### PR TITLE
Add more detailed Debug for MapSource

### DIFF
--- a/moq-warp/src/model/segment.rs
+++ b/moq-warp/src/model/segment.rs
@@ -49,7 +49,7 @@ impl Deref for Publisher {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Subscriber {
 	pub info: Arc<Info>,
 

--- a/moq-warp/src/model/track.rs
+++ b/moq-warp/src/model/track.rs
@@ -51,7 +51,7 @@ impl fmt::Debug for Publisher {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Subscriber {
 	pub name: String,
 
@@ -69,12 +69,6 @@ impl Subscriber {
 			}),
 			Some(res) => res,
 		}
-	}
-}
-
-impl fmt::Debug for Subscriber {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "track subscriber: {:?}", self.name)
 	}
 }
 

--- a/moq-warp/src/model/watch.rs
+++ b/moq-warp/src/model/watch.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::collections::VecDeque;
 use tokio::sync::watch;
 
@@ -5,6 +6,18 @@ use tokio::sync::watch;
 struct State<T> {
 	queue: VecDeque<T>,
 	drained: usize,
+}
+
+impl<T> fmt::Debug for State<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(
+			f,
+			"State<{}> ( queue.len(): {}, drained: {} )",
+			std::any::type_name::<T>(),
+			&self.queue.len(),
+			&self.drained
+		)
+	}
 }
 
 impl<T> State<T> {
@@ -85,7 +98,7 @@ impl<T: Clone> Default for Publisher<T> {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Subscriber<T: Clone> {
 	state: watch::Receiver<State<T>>,
 	index: usize,


### PR DESCRIPTION
and everything it contains.

Stop short of printing all of the bytes in a State's VecDeque, but expose most everything else for easier troubleshooting.