### PR TITLE
moq-transport: Make Messages and Objects Clone

### DIFF
--- a/moq-transport/src/message/announce.rs
+++ b/moq-transport/src/message/announce.rs
@@ -2,7 +2,7 @@ use crate::coding::{decode_string, encode_string, DecodeError, EncodeError};
 
 use webtransport_generic::{RecvStream, SendStream};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Announce {
 	// The track namespace
 	pub track_namespace: String,

--- a/moq-transport/src/message/announce_error.rs
+++ b/moq-transport/src/message/announce_error.rs
@@ -2,7 +2,7 @@ use crate::coding::{decode_string, encode_string, DecodeError, EncodeError, VarI
 
 use webtransport_generic::{RecvStream, SendStream};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AnnounceError {
 	// Echo back the namespace that was announced.
 	// TODO Propose using an ID to save bytes.

--- a/moq-transport/src/message/announce_ok.rs
+++ b/moq-transport/src/message/announce_ok.rs
@@ -2,7 +2,7 @@ use crate::coding::{decode_string, encode_string, DecodeError, EncodeError};
 
 use webtransport_generic::{RecvStream, SendStream};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AnnounceOk {
 	// Echo back the namespace that was announced.
 	// TODO Propose using an ID to save bytes.

--- a/moq-transport/src/message/go_away.rs
+++ b/moq-transport/src/message/go_away.rs
@@ -2,7 +2,7 @@ use crate::coding::{decode_string, encode_string, DecodeError, EncodeError};
 
 use webtransport_generic::{RecvStream, SendStream};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GoAway {
 	pub url: String,
 }

--- a/moq-transport/src/message/mod.rs
+++ b/moq-transport/src/message/mod.rs
@@ -36,6 +36,7 @@ use webtransport_generic::{RecvStream, SendStream};
 // This implements a decode/encode method that uses the specified type.
 macro_rules! message_types {
     {$($name:ident = $val:expr,)*} => {
+		#[derive(Clone)]
 		pub enum Message {
 			$($name($name)),*
 		}

--- a/moq-transport/src/message/subscribe.rs
+++ b/moq-transport/src/message/subscribe.rs
@@ -2,7 +2,7 @@ use crate::coding::{decode_string, encode_string, DecodeError, EncodeError, VarI
 
 use webtransport_generic::{RecvStream, SendStream};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Subscribe {
 	// An ID we choose so we can map to the track_name.
 	// Proposal: https://github.com/moq-wg/moq-transport/issues/209

--- a/moq-transport/src/message/subscribe_error.rs
+++ b/moq-transport/src/message/subscribe_error.rs
@@ -2,7 +2,7 @@ use crate::coding::{decode_string, encode_string, DecodeError, EncodeError, VarI
 
 use webtransport_generic::{RecvStream, SendStream};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SubscribeError {
 	// NOTE: No full track name because of this proposal: https://github.com/moq-wg/moq-transport/issues/209
 

--- a/moq-transport/src/message/subscribe_ok.rs
+++ b/moq-transport/src/message/subscribe_ok.rs
@@ -2,7 +2,7 @@ use crate::coding::{DecodeError, EncodeError, VarInt};
 
 use webtransport_generic::{RecvStream, SendStream};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SubscribeOk {
 	// NOTE: No full track name because of this proposal: https://github.com/moq-wg/moq-transport/issues/209
 

--- a/moq-transport/src/object/mod.rs
+++ b/moq-transport/src/object/mod.rs
@@ -9,7 +9,7 @@ use crate::coding::{DecodeError, EncodeError, VarInt};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use webtransport_generic::{RecvStream, SendStream};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Object {
 	// An ID for this track.
 	// Proposal: https://github.com/moq-wg/moq-transport/issues/209


### PR DESCRIPTION
This is useful if you want to build channels to send/recv these internally.