### PR TITLE
Better read/write error messages

### DIFF
--- a/moq-transport/src/model/broadcast.rs
+++ b/moq-transport/src/model/broadcast.rs
@@ -45,7 +45,7 @@ impl State {
 	}
 
 	pub fn insert(&mut self, track: track::Subscriber) -> Result<(), Error> {
-		self.closed?;
+		self.closed.clone()?;
 
 		match self.tracks.entry(track.name.clone()) {
 			hash_map::Entry::Occupied(_) => return Err(Error::Duplicate),
@@ -56,7 +56,7 @@ impl State {
 	}
 
 	pub fn request(&mut self, name: &str) -> Result<track::Subscriber, Error> {
-		self.closed?;
+		self.closed.clone()?;
 
 		// Create a new track.
 		let (publisher, subscriber) = track::new(name);
@@ -76,7 +76,7 @@ impl State {
 			return Ok(true);
 		}
 
-		self.closed?;
+		self.closed.clone()?;
 		Ok(false)
 	}
 
@@ -86,7 +86,7 @@ impl State {
 	}
 
 	pub fn close(&mut self, err: Error) -> Result<(), Error> {
-		self.closed?;
+		self.closed.clone()?;
 		self.closed = Err(err);
 		Ok(())
 	}

--- a/moq-transport/src/model/segment.rs
+++ b/moq-transport/src/model/segment.rs
@@ -50,7 +50,7 @@ struct State {
 
 impl State {
 	pub fn close(&mut self, err: Error) -> Result<(), Error> {
-		self.closed?;
+		self.closed.clone()?;
 		self.closed = Err(err);
 		Ok(())
 	}
@@ -99,7 +99,7 @@ impl Publisher {
 	/// Write a new chunk of bytes.
 	pub fn write_chunk(&mut self, data: Bytes) -> Result<(), Error> {
 		let mut state = self.state.lock_mut();
-		state.closed?;
+		state.closed.clone()?;
 		state.data.push(data);
 		Ok(())
 	}
@@ -167,9 +167,9 @@ impl Subscriber {
 					return Ok(Some(chunk));
 				}
 
-				match state.closed {
+				match &state.closed {
 					Err(Error::Closed) => return Ok(None),
-					Err(err) => return Err(err),
+					Err(err) => return Err(err.clone()),
 					Ok(()) => state.changed(),
 				}
 			};

--- a/moq-transport/src/model/track.rs
+++ b/moq-transport/src/model/track.rs
@@ -54,13 +54,13 @@ struct State {
 
 impl State {
 	pub fn close(&mut self, err: Error) -> Result<(), Error> {
-		self.closed?;
+		self.closed.clone()?;
 		self.closed = Err(err);
 		Ok(())
 	}
 
 	pub fn insert(&mut self, segment: segment::Subscriber) -> Result<(), Error> {
-		self.closed?;
+		self.closed.clone()?;
 
 		let entry = match self.lookup.entry(segment.sequence) {
 			indexmap::map::Entry::Occupied(_entry) => return Err(Error::Duplicate),
@@ -236,9 +236,9 @@ impl Subscriber {
 				}
 
 				// Otherwise check if we need to return an error.
-				match state.closed {
+				match &state.closed {
 					Err(Error::Closed) => return Ok(None),
-					Err(err) => return Err(err),
+					Err(err) => return Err(err.clone()),
 					Ok(()) => state.changed(),
 				}
 			};

--- a/moq-transport/src/session/control.rs
+++ b/moq-transport/src/session/control.rs
@@ -24,12 +24,19 @@ impl Control {
 	pub async fn send<T: Into<Message> + fmt::Debug>(&self, msg: T) -> Result<(), Error> {
 		let mut stream = self.send.lock().await;
 		log::info!("sending message: {:?}", msg);
-		msg.into().encode(&mut *stream).await.map_err(|_e| Error::Write)
+		msg.into()
+			.encode(&mut *stream)
+			.await
+			.map_err(|e| Error::Unknown(e.to_string()))?;
+		Ok(())
 	}
 
 	// It's likely a mistake to call this from two different tasks, but it's easier to just support it.
 	pub async fn recv(&self) -> Result<Message, Error> {
 		let mut stream = self.recv.lock().await;
-		Message::decode(&mut *stream).await.map_err(|_e| Error::Read)
+		let msg = Message::decode(&mut *stream)
+			.await
+			.map_err(|e| Error::Unknown(e.to_string()))?;
+		Ok(msg)
 	}
 }


### PR DESCRIPTION
Still need to properly support encode/decode though. The problem there is that encode/decode uses AsyncRead, which means we get io::Error instead of quinn::ReadError and quinn::WriteError. The io::Error type is not clonable so we just can't use it, well unless it's wrapped in an Arc or something gross.