### PR TITLE
(DO NOT MERGE) Quick fix to use local webtransport crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,8 +2119,6 @@ dependencies = [
 [[package]]
 name = "webtransport-generic"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df712317d761312996f654739debeb3838eb02c6fd9146d9efdfd08a46674e45"
 dependencies = [
  "bytes",
  "tokio",
@@ -2129,8 +2127,6 @@ dependencies = [
 [[package]]
 name = "webtransport-proto"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fefb5728651d507b444659853b47896116179ea8fd0348d02de080250892c7"
 dependencies = [
  "bytes",
  "http",
@@ -2140,8 +2136,6 @@ dependencies = [
 [[package]]
 name = "webtransport-quinn"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cfc3592022726f4e8e5a536e68fb1ecb0b077e6b5435bd7ac3b9c97670c18c"
 dependencies = [
  "async-std",
  "bytes",

--- a/moq-pub/Cargo.toml
+++ b/moq-pub/Cargo.toml
@@ -18,8 +18,8 @@ moq-transport = { path = "../moq-transport" }
 
 # QUIC
 quinn = "0.10"
-webtransport-quinn = "0.5"
-webtransport-generic = "0.5"
+webtransport-generic = {path = "../../webtransport-rs/webtransport-generic", version = "0.5"}
+webtransport-quinn = {path = "../../webtransport-rs/webtransport-quinn", version = "0.5.3"}
 http = "0.2.9"
 
 # Crypto

--- a/moq-relay/Cargo.toml
+++ b/moq-relay/Cargo.toml
@@ -16,8 +16,8 @@ moq-transport = { path = "../moq-transport" }
 
 # QUIC
 quinn = "0.10"
-webtransport-generic = "0.5"
-webtransport-quinn = "0.5"
+webtransport-generic = {path = "../../webtransport-rs/webtransport-generic", version = "0.5"}
+webtransport-quinn = {path = "../../webtransport-rs/webtransport-quinn", version = "0.5.3"}
 
 # Crypto
 ring = "0.16.20"

--- a/moq-transport/Cargo.toml
+++ b/moq-transport/Cargo.toml
@@ -23,4 +23,4 @@ log = "0.4"
 indexmap = "2"
 
 quinn = "0.10"
-webtransport-quinn = "0.5.3"
+webtransport-quinn = {path = "../../webtransport-rs/webtransport-quinn", version = "0.5.3"}


### PR DESCRIPTION
Until a new version of webtransport-proto can be pushed to crates.io