### PR TITLE
Fix a panic when --fingerprint was not provided, and rename it to --dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Notable arguments:
 -   `--listen <ADDR>` Listen on this address, default: `[::]:4443`
 -   `--cert <CERT>` Use the certificate file at this path
 -   `--key <KEY>` Use the private key at this path
--   `--fingerprint` Listen via HTTPS as well, serving the `/fingerprint` of the self-signed certificate. (dev only)
+-   `--dev` Listen via HTTPS as well, serving the `/fingerprint` of the self-signed certificate. (dev only)
 
 This listens for WebTransport connections on `UDP https://localhost:4443` by default.
 You need a client to connect to that address, to both publish and consume media.

--- a/dev/relay
+++ b/dev/relay
@@ -34,4 +34,4 @@ fi
 echo "Publish URL: https://quic.video/publish/?server=localhost:${PORT}"
 
 # Run the relay and forward any arguments
-cargo run --bin moq-relay -- --listen "$LISTEN" --cert "$CERT" --key "$KEY" --fingerprint $ARGS -- "$@"
+cargo run --bin moq-relay -- --listen "$LISTEN" --cert "$CERT" --key "$KEY" --dev $ARGS -- "$@"

--- a/moq-relay/src/config.rs
+++ b/moq-relay/src/config.rs
@@ -26,7 +26,7 @@ pub struct Config {
 
 	/// Listen on HTTPS and serve /fingerprint, for self-signed certificates
 	#[arg(long, action)]
-	pub fingerprint: bool,
+	pub dev: bool,
 
 	/// Optional: Use the moq-api via HTTP to store origin information.
 	#[arg(long)]


### PR DESCRIPTION
The tokio behavior is quite misleading. The fact that the branch still gets executed even when the precondition is false just seems like a bug, but it's well documented.