### PR TITLE
feat: expose moq-pub as library with generic input

### DIFF
--- a/moq-pub/src/lib.rs
+++ b/moq-pub/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod media;

--- a/moq-pub/src/main.rs
+++ b/moq-pub/src/main.rs
@@ -6,10 +6,8 @@ use clap::Parser;
 mod cli;
 use cli::*;
 
-mod media;
-use media::*;
-
 use moq_transport::cache::broadcast;
+use moq_pub::media::Media;
 
 // TODO: clap complete
 
@@ -24,9 +22,11 @@ async fn main() -> anyhow::Result<()> {
 	tracing::subscriber::set_global_default(tracer).unwrap();
 
 	let config = Config::parse();
+	log::debug!("config {config:?}");
 
+	let input = tokio::io::stdin();
 	let (publisher, subscriber) = broadcast::new("");
-	let mut media = Media::new(&config, publisher).await?;
+	let mut media = Media::new(input, publisher).await?;
 
 	// Create a list of acceptable root certificates.
 	let mut roots = rustls::RootCertStore::empty();

--- a/moq-pub/src/main.rs
+++ b/moq-pub/src/main.rs
@@ -6,8 +6,8 @@ use clap::Parser;
 mod cli;
 use cli::*;
 
-use moq_transport::cache::broadcast;
 use moq_pub::media::Media;
+use moq_transport::cache::broadcast;
 
 // TODO: clap complete
 
@@ -22,7 +22,6 @@ async fn main() -> anyhow::Result<()> {
 	tracing::subscriber::set_global_default(tracer).unwrap();
 
 	let config = Config::parse();
-	log::debug!("config {config:?}");
 
 	let input = tokio::io::stdin();
 	let (publisher, subscriber) = broadcast::new("");

--- a/moq-pub/src/media.rs
+++ b/moq-pub/src/media.rs
@@ -1,4 +1,3 @@
-use crate::cli::Config;
 use anyhow::{self, Context};
 use moq_transport::cache::{broadcast, fragment, segment, track};
 use moq_transport::VarInt;
@@ -8,9 +7,9 @@ use std::cmp::max;
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::time;
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
-pub struct Media {
+pub struct Media<I> {
 	// We hold on to publisher so we don't close then while media is still being published.
 	_broadcast: broadcast::Publisher,
 	_catalog: track::Publisher,
@@ -18,15 +17,15 @@ pub struct Media {
 
 	// Tracks based on their track ID.
 	tracks: HashMap<u32, Track>,
+	input: I
 }
 
-impl Media {
-	pub async fn new(_config: &Config, mut broadcast: broadcast::Publisher) -> anyhow::Result<Self> {
-		let mut stdin = tokio::io::stdin();
-		let ftyp = read_atom(&mut stdin).await?;
+impl<I: AsyncRead + Send + Unpin + 'static> Media<I> {
+	pub async fn new(mut input: I, mut broadcast: broadcast::Publisher) -> anyhow::Result<Self> {
+		let ftyp = read_atom(&mut input).await?;
 		anyhow::ensure!(&ftyp[4..8] == b"ftyp", "expected ftyp atom");
 
-		let moov = read_atom(&mut stdin).await?;
+		let moov = read_atom(&mut input).await?;
 		anyhow::ensure!(&moov[4..8] == b"moov", "expected moov atom");
 
 		let mut init = ftyp;
@@ -77,16 +76,16 @@ impl Media {
 			_catalog: catalog,
 			_init: init_track,
 			tracks,
+			input
 		})
 	}
 
 	pub async fn run(&mut self) -> anyhow::Result<()> {
-		let mut stdin = tokio::io::stdin();
 		// The current track name
 		let mut current = None;
 
 		loop {
-			let atom = read_atom(&mut stdin).await?;
+			let atom = read_atom(&mut self.input).await?;
 
 			let mut reader = Cursor::new(&atom);
 			let header = mp4::BoxHeader::read(&mut reader)?;

--- a/moq-pub/src/media.rs
+++ b/moq-pub/src/media.rs
@@ -17,7 +17,7 @@ pub struct Media<I> {
 
 	// Tracks based on their track ID.
 	tracks: HashMap<u32, Track>,
-	input: I
+	input: I,
 }
 
 impl<I: AsyncRead + Send + Unpin + 'static> Media<I> {
@@ -76,7 +76,7 @@ impl<I: AsyncRead + Send + Unpin + 'static> Media<I> {
 			_catalog: catalog,
 			_init: init_track,
 			tracks,
-			input
+			input,
 		})
 	}
 


### PR DESCRIPTION
This PR has two changes, which allow to reuse the code in `moq-pub` from other libraries or apps:
* adds a `lib.rs` to `moq-pub` to expose the `media` module
* lets the `Media` struct accept an `input: impl AsyncRead` argument instead of being hardcoded to `stdin`