### PR TITLE
check if objectreader index is in range before iterating

### DIFF
--- a/moq-transport/src/serve/object.rs
+++ b/moq-transport/src/serve/object.rs
@@ -136,7 +136,7 @@ impl ObjectsReader {
 					}
 				} else {
 					for object in &state.objects[..state.objects.len()] {
-						self.pending.push(object.clone())
+						self.pending.push(object.clone());
 					}
 				}
 

--- a/moq-transport/src/serve/object.rs
+++ b/moq-transport/src/serve/object.rs
@@ -130,9 +130,16 @@ impl ObjectsReader {
 		loop {
 			let notify = {
 				let state = self.state.lock();
-				for object in &state.objects[self.index..] {
-					self.pending.push(object.clone());
+				if self.index <= state.objects.len() {
+					for object in &state.objects[self.index..] {
+						self.pending.push(object.clone());
+					}
+				} else {
+					for object in &state.objects[..state.objects.len()] {
+						self.pending.push(object.clone())
+					}
 				}
+
 				self.index = state.objects.len();
 
 				if let Some(object) = self.pending.pop() {


### PR DESCRIPTION
I'm getting a panic when I create an single object stream with a group_id that is 1 higher than the previous object stream: 
```
thread 'main' panicked at /moq-rs-amadeus/moq-transport/src/serve/object.rs:133:45:
range start index 100 out of range for slice of length 1
```
This PR adds a check to make sure we're not trying to read objects that are out of range when the `state.objects` have been cleared in the `ObjectsWriter`. And in case the objects have been cleared, all new `ObjectReader`s are pushed to pending.