### PR TITLE
Correctly encode the subscribe location.

### DIFF
--- a/moq-transport/src/message/subscribe.rs
+++ b/moq-transport/src/message/subscribe.rs
@@ -73,7 +73,7 @@ impl Encode for Subscribe {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SubscribePair {
 	pub group: SubscribeLocation,
 	pub object: SubscribeLocation,
@@ -140,11 +140,5 @@ impl SubscribeLocation {
 			Self::Latest(_) => 2,
 			Self::Future(_) => 3,
 		}
-	}
-}
-
-impl Default for SubscribeLocation {
-	fn default() -> Self {
-		Self::None
 	}
 }

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -1,7 +1,8 @@
 use std::ops;
 
 use crate::{
-	data, message,
+	data,
+	message::{self, SubscribeLocation, SubscribePair},
 	serve::{self, ServeError, TrackWriter, TrackWriterMode},
 };
 
@@ -47,8 +48,14 @@ impl Subscribe {
 			track_namespace: track.namespace.clone(),
 			track_name: track.name.clone(),
 			// TODO add these to the publisher.
-			start: Default::default(),
-			end: Default::default(),
+			start: SubscribePair {
+				group: SubscribeLocation::Latest(0),
+				object: SubscribeLocation::Absolute(0),
+			},
+			end: SubscribePair {
+				group: SubscribeLocation::None,
+				object: SubscribeLocation::None,
+			},
 			params: Default::default(),
 		});
 


### PR DESCRIPTION
None is not a valid start.