### PR TITLE
filter DNS query results to only include addresses that our quic endpoint can use

### DIFF
--- a/moq-native/src/quic.rs
+++ b/moq-native/src/quic.rs
@@ -197,7 +197,7 @@ impl Client {
 		let addr = tokio::net::lookup_host((host.clone(), port))
 			.await
 			.context("failed DNS lookup")?
-			.filter(|s| own_protocol_ipv4 == s.is_ipv4())
+			.filter(|s| own_protocol_ipv4 == s.ip().to_canonical().is_ipv4())
 			.next()
 			.context("no DNS entries")?;
 

--- a/moq-native/src/quic.rs
+++ b/moq-native/src/quic.rs
@@ -190,10 +190,14 @@ impl Client {
 		let host = url.host().context("invalid DNS name")?.to_string();
 		let port = url.port().unwrap_or(443);
 
+		let local_addr = self.quic.local_addr()?.ip();
+		let own_protocol_ipv4 = local_addr.to_canonical().is_ipv4();
+
 		// Look up the DNS entry.
 		let addr = tokio::net::lookup_host((host.clone(), port))
 			.await
 			.context("failed DNS lookup")?
+			.filter(|s| own_protocol_ipv4 == s.is_ipv4())
 			.next()
 			.context("no DNS entries")?;
 

--- a/moq-native/src/quic.rs
+++ b/moq-native/src/quic.rs
@@ -197,9 +197,8 @@ impl Client {
 		let addr = tokio::net::lookup_host((host.clone(), port))
 			.await
 			.context("failed DNS lookup")?
-			.filter(|s| own_protocol_ipv4 == s.ip().to_canonical().is_ipv4())
-			.next()
-			.context("no DNS entries")?;
+			.find(|s| own_protocol_ipv4 == s.ip().to_canonical().is_ipv4())
+			.context("no DNS entries with matching IP version")?;
 
 		let connection = self.quic.connect_with(config, addr, &host)?.await?;
 


### PR DESCRIPTION
Minor bug fix. Without this change it's possible that the connection will attempt to use an IP address which the internal `quinn::Endpoint` can't actually connect to. 