### PR TITLE
Add sslkeylogfile envvar for debugging

### DIFF
--- a/moq-native/src/quic.rs
+++ b/moq-native/src/quic.rs
@@ -59,10 +59,13 @@ impl Endpoint {
 
 		let server_config = config.tls.server.map(|mut server| {
 			server.alpn_protocols = vec![web_transport_quinn::ALPN.to_vec(), moq_transport::setup::ALPN.to_vec()];
+			server.key_log = Arc::new(rustls::KeyLogFile::new());
 			let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(server));
 			server_config.transport_config(transport.clone());
 			server_config
 		});
+
+
 
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = quinn::default_runtime().context("no async runtime")?;
@@ -183,7 +186,7 @@ impl Client {
 			"moqt" => moq_transport::setup::ALPN.to_vec(),
 			_ => anyhow::bail!("url scheme must be 'https' or 'moqt'"),
 		}];
-
+		config.key_log = Arc::new(rustls::KeyLogFile::new());
 		let mut config = quinn::ClientConfig::new(Arc::new(config));
 		config.transport_config(self.transport.clone());
 

--- a/moq-native/src/quic.rs
+++ b/moq-native/src/quic.rs
@@ -65,8 +65,6 @@ impl Endpoint {
 			server_config
 		});
 
-
-
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = quinn::default_runtime().context("no async runtime")?;
 		let endpoint_config = quinn::EndpointConfig::default();


### PR DESCRIPTION
While trying to inspect the traffic more closely I have found out that with these two lines we can use the SSLKEYLOGFILE environment variable to later decrypt pcap files and see more of the QUIC and WebTransport traffic. It might not be useful. 

About envvar from the quinn repo:

> If the SSLKEYLOGFILE environment variable is set, the tests will emit UDP packets for inspection using external protocol analyzers like Wireshark, and NSS-compatible key logs for the client side of each connection will be written to the path specified in the variable.