### PR TITLE
really small correction with url.join

### DIFF
--- a/moq-api/src/client.rs
+++ b/moq-api/src/client.rs
@@ -17,7 +17,7 @@ impl Client {
 	}
 
 	pub async fn get_origin(&self, namespace: &str) -> Result<Option<Origin>, ApiError> {
-		let url = self.url.join("origin/")?.join(namespace)?;
+		let url = self.url.join(&format!("origin/{namespace}"))?;
 		let resp = self.client.get(url).send().await?;
 		if resp.status() == reqwest::StatusCode::NOT_FOUND {
 			return Ok(None);
@@ -28,7 +28,7 @@ impl Client {
 	}
 
 	pub async fn set_origin(&self, namespace: &str, origin: Origin) -> Result<(), ApiError> {
-		let url = self.url.join("origin/")?.join(namespace)?;
+		let url = self.url.join(&format!("origin/{namespace}"))?;
 
 		let resp = self.client.post(url).json(&origin).send().await?;
 		resp.error_for_status()?;
@@ -37,7 +37,7 @@ impl Client {
 	}
 
 	pub async fn delete_origin(&self, namespace: &str) -> Result<(), ApiError> {
-		let url = self.url.join("origin/")?.join(namespace)?;
+		let url = self.url.join(&format!("origin/{namespace}"))?;
 
 		let resp = self.client.delete(url).send().await?;
 		resp.error_for_status()?;
@@ -46,7 +46,7 @@ impl Client {
 	}
 
 	pub async fn patch_origin(&self, namespace: &str, origin: Origin) -> Result<(), ApiError> {
-		let url = self.url.join("origin/")?.join(namespace)?;
+		let url = self.url.join(&format!("origin/{namespace}"))?;
 
 		let resp = self.client.patch(url).json(&origin).send().await?;
 		resp.error_for_status()?;


### PR DESCRIPTION
I know this is not an important change, but I came across it while changing the api for my own project and it might help others who want to do the same.

The url's join method overwrites the previous join. So e.g. url.join("origin/").join("vaj") won't make an url like kiscica.hu/origin/vaj, but kiscica.hu/vaj.