### PR TITLE
add flake.nix, export moq packages, overlay and nixosModule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 logs/
 *.mp4
+result

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ See the published [crate](https://crates.io/crates/moq-transfork) and [documenta
 [moq-clock](moq-clock) is a simple client that can publish or subscribe to the current time.
 It's meant to demonstate that [moq-transfork](moq-transfork) can be used for more than just media.
 
+## nix/nixos
+
+moq also has nix support see [`nix/README.md`](nix/README.md)
+
 
 # License
 

--- a/dev/pub
+++ b/dev/pub
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Change directory to the root of the project

--- a/dev/sub
+++ b/dev/sub
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Change directory to the root of the project

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729880355,
+        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  description = "MoQ";
+
+  inputs = {
+    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url  = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs@{ flake-utils, ... }:
+    flake-utils.lib.meld inputs [
+      ./nix/modules
+      ./nix/packages/moq.nix
+      ./nix/overlay.nix
+      ./nix/shell.nix
+    ];
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,58 @@
+# moq nix
+
+## dev shell
+
+To get a dev shell with cargo and ffmpeg run `nix develop`
+
+## nix build moq binaries
+
+To build `moq-relay`, `moq-karp` and `moq-clock` run `nix build
+.#moq-relay`
+
+## NixOS module and overlay
+
+The moq nix flake also exports a `nixosModule` for the `moq-relay`
+server and a nix overlay with the moq packages. Here is an example
+NixOS configuration that uses this overlay and nixosModule:
+
+```
+{
+  description = "My configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    moq = {
+      url = "github:kixelated/moq-rs";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, moq, ... }: {
+    nixosConfigurations = {
+      hostname = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ./configuration.nix # Your system configuration.
+          ({ pkgs, ... }: {
+            nixpkgs.overlays = [ moq.overlays.default ];
+            environment.systemPackages = [ pkgs.moq.moq-relay ];
+          })
+          moq.nixosModules.moq-relay
+          {
+             services.moq-relay = {
+               enable = true;
+               port = 4443;
+               user = "moq-relay";
+               group = "moq-relay";
+               tls = {
+                 certPath = "<cert path>";
+                 keyPath = "<key path>";
+               };
+            };
+          }
+        ];
+      };
+    };
+  };
+}
+```

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -1,0 +1,6 @@
+inputs:
+{
+  nixosModules = {
+    moq-relay = import ./moq-relay.nix;
+  };
+}

--- a/nix/modules/moq-relay.nix
+++ b/nix/modules/moq-relay.nix
@@ -1,0 +1,100 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.moq-relay;
+in
+{
+  options.services.moq-relay = {
+    enable = lib.mkEnableOption "moq-relay";
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 443;
+      description = "Relay server port";
+    };
+    user = lib.mkOption {
+      type = with lib.types; uniq str;
+      description = ''
+        User account that runs moq-relay.
+
+        ::: {.note}
+        This user must have access to the TLS certificate and key.
+        :::
+      '';
+    };
+    group = lib.mkOption {
+      type = with lib.types; uniq str;
+      description = ''
+        Group account that runs moq-relay.
+
+        ::: {.note}
+        This group must have access to the TLS certificate and key.
+        :::
+      '';
+    };
+    tls = {
+      keyPath = lib.mkOption {
+        type = lib.types.path;
+        example = "/var/lib/acme/moq-relay.example.org/key.pem";
+        description = ''
+          Path to TLS private key
+        '';
+      };
+      certPath = lib.mkOption {
+        type = lib.types.path;
+        example = "/var/lib/acme/moq-relay.example.org/cert.pem";
+        description = ''
+          Path to TLS certificate
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.moq-relay = {
+      description = "Media over QUIC relay server";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${pkgs.moq.moq-relay}/bin/moq-relay --bind [::]:${builtins.toString cfg.port} --tls-cert ${cfg.tls.certPath} --tls-key ${cfg.tls.keyPath}";
+        Restart = "on-failure";
+        RestartSec = "1";
+
+        # hardening
+        RemoveIPC = true;
+        CapabilityBoundingSet = [ "" ];
+        DynamicUser = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        ProtectClock = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "@system-service";
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        ProtectHostname = true;
+        LockPersonality = true;
+        ProtectKernelTunables = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictRealtime = true;
+        ProtectSystem = "strict";
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        ProtectHome = true;
+        PrivateUsers = true;
+        PrivateTmp = true;
+      };
+    };
+  };
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,8 @@
+{ self, ... }:
+{
+  overlays = {
+    default = final: _prev: {
+      moq = self.packages.${final.system};
+    };
+  };
+}

--- a/nix/packages/moq.nix
+++ b/nix/packages/moq.nix
@@ -1,20 +1,22 @@
 { self, nixpkgs, flake-utils, ... }:
 flake-utils.lib.eachDefaultSystem (system:
   let
-    pkgs = import nixpkgs {
-      inherit system;
-    };
+    pkgs = nixpkgs.legacyPackages.${system};
+    moq-relay-version = (pkgs.lib.importTOML ../../moq-relay/Cargo.toml).package.version;
   in
     with pkgs;
     {
       packages = rec {
         moq-relay = rustPlatform.buildRustPackage rec {
           pname = "moq-relay";
-          version = "0.6.7";
+          version = moq-relay-version;
 
           src = ../../.;
 
-          cargoHash = "sha256-kOAulF1OqR1VBKSy15RURJEk2ZpgZIFxPwrr03RbvPk=";
+          cargoLock = {
+            lockFile = ../../Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
 
           nativeBuildInputs = [ pkg-config ];
 

--- a/nix/packages/moq.nix
+++ b/nix/packages/moq.nix
@@ -1,0 +1,32 @@
+{ self, nixpkgs, flake-utils, ... }:
+flake-utils.lib.eachDefaultSystem (system:
+  let
+    pkgs = import nixpkgs {
+      inherit system;
+    };
+  in
+    with pkgs;
+    {
+      packages = rec {
+        moq-relay = rustPlatform.buildRustPackage rec {
+          pname = "moq-relay";
+          version = "0.6.7";
+
+          src = ../../.;
+
+          cargoHash = "sha256-kOAulF1OqR1VBKSy15RURJEk2ZpgZIFxPwrr03RbvPk=";
+
+          nativeBuildInputs = [ pkg-config ];
+
+          buildInputs = [ libressl ];
+
+          meta = {
+            description = "Media Over QUIC relay server";
+            mainProgram = "moq-relay";
+            homepage = "https://quic.video/";
+            changelog = "https://github.com/kixelated/moq-rs/releases/tag/moq-relay-v${version}";
+          };
+        };
+      };
+    }
+)

--- a/nix/packages/moq.nix
+++ b/nix/packages/moq.nix
@@ -20,8 +20,11 @@ flake-utils.lib.eachDefaultSystem (system:
 
           nativeBuildInputs = [ pkg-config ];
 
-          buildInputs = [ libressl ];
-
+          buildInputs = [ libressl ]
+                        ++ lib.optionals stdenv.isDarwin [
+                          darwin.apple_sdk.frameworks.Security
+                          darwin.apple_sdk.frameworks.SystemConfiguration
+                        ];
           meta = {
             description = "Media Over QUIC relay server";
             mainProgram = "moq-relay";

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,9 +1,7 @@
 { self, nixpkgs, flake-utils, ... }:
 flake-utils.lib.eachDefaultSystem (system:
   let
-    pkgs = import nixpkgs {
-      inherit system;
-    };
+    pkgs = nixpkgs.legacyPackages.${system};
   in
     with pkgs;
     {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,20 @@
+{ self, nixpkgs, flake-utils, ... }:
+flake-utils.lib.eachDefaultSystem (system:
+  let
+    pkgs = import nixpkgs {
+      inherit system;
+    };
+  in
+    with pkgs;
+    {
+      devShells.default = mkShell {
+        nativeBuildInputs = [
+          pkg-config
+          libressl
+          cargo
+          ffmpeg
+        ];
+        LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+      };
+    }
+)


### PR DESCRIPTION
For people who use nix this provides a nix dev shell, nix moq packages and a nixosModule for the relay server so you can run the relay server on a nixos system pretty easily. 