### PR TITLE
Have moq-native return web_transport_quinn.

### DIFF
--- a/moq-relay/src/cluster.rs
+++ b/moq-relay/src/cluster.rs
@@ -101,7 +101,7 @@ impl Cluster {
 				let root = Url::parse(&format!("https://{}", root)).context("invalid root URL")?;
 				let root = self.client.connect(root).await.context("failed to connect to root")?;
 
-				let mut root = moq_transfork::Session::connect(root)
+				let mut root = moq_transfork::Session::connect(root.into())
 					.await
 					.context("failed to establish root session")?;
 
@@ -191,7 +191,7 @@ impl Cluster {
 		// Connect to the remote node.
 		let conn = self.client.connect(url).await.context("failed to connect to remote")?;
 
-		let mut session = moq_transfork::Session::connect(conn)
+		let mut session = moq_transfork::Session::connect(conn.into())
 			.await
 			.context("failed to establish session")?;
 

--- a/moq-relay/src/cluster.rs
+++ b/moq-relay/src/cluster.rs
@@ -101,7 +101,7 @@ impl Cluster {
 				let root = Url::parse(&format!("https://{}", root)).context("invalid root URL")?;
 				let root = self.client.connect(root).await.context("failed to connect to root")?;
 
-				let mut root = moq_transfork::Session::connect(root.into())
+				let mut root = moq_transfork::Session::connect(root)
 					.await
 					.context("failed to establish root session")?;
 
@@ -191,7 +191,7 @@ impl Cluster {
 		// Connect to the remote node.
 		let conn = self.client.connect(url).await.context("failed to connect to remote")?;
 
-		let mut session = moq_transfork::Session::connect(conn.into())
+		let mut session = moq_transfork::Session::connect(conn)
 			.await
 			.context("failed to establish session")?;
 

--- a/moq-relay/src/main.rs
+++ b/moq-relay/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
 	let mut conn_id = 0;
 
 	while let Some(conn) = server.accept().await {
-		let session = Connection::new(conn_id, conn, cluster.clone());
+		let session = Connection::new(conn_id, conn.into(), cluster.clone());
 		conn_id += 1;
 
 		tokio::spawn(async move {

--- a/moq-transfork/src/session/mod.rs
+++ b/moq-transfork/src/session/mod.rs
@@ -53,7 +53,8 @@ impl Session {
 	}
 
 	/// Perform the MoQ handshake as a client.
-	pub async fn connect(mut session: web_transport::Session) -> Result<Self, Error> {
+	pub async fn connect<T: Into<web_transport::Session>>(session: T) -> Result<Self, Error> {
+		let mut session = session.into();
 		let mut stream = Stream::open(&mut session, message::ControlType::Session).await?;
 		Self::connect_setup(&mut stream).await.or_close(&mut stream)?;
 		Ok(Self::new(session, stream))
@@ -74,7 +75,8 @@ impl Session {
 	}
 
 	/// Perform the MoQ handshake as a server
-	pub async fn accept(mut session: web_transport::Session) -> Result<Self, Error> {
+	pub async fn accept<T: Into<web_transport::Session>>(session: T) -> Result<Self, Error> {
+		let mut session = session.into();
 		let mut stream = Stream::accept(&mut session).await?;
 		let kind = stream.reader.decode().await?;
 


### PR DESCRIPTION
A few folks have been asking.