### PR TITLE
Remove the leading slash in broadcast names.

### DIFF
--- a/moq-karp-cli/src/client.rs
+++ b/moq-karp-cli/src/client.rs
@@ -21,7 +21,7 @@ impl<T: AsyncRead + Unpin> BroadcastClient<T> {
 
 	pub async fn run(&mut self) -> anyhow::Result<()> {
 		let url = Url::parse(&self.url).context("invalid URL")?;
-		let path = url.path().to_string();
+		let path = url.path().strip_prefix('/').unwrap().to_string();
 
 		let session = self.connect(url).await?;
 

--- a/moq-web/src/connection/connect.rs
+++ b/moq-web/src/connection/connect.rs
@@ -22,7 +22,7 @@ pub struct Connect {
 
 impl Connect {
 	pub fn new(mut addr: Url) -> Self {
-		let path = addr.path().to_string();
+		let path = addr.path().strip_prefix('/').unwrap().to_string();
 
 		// Connect using the base of the URL.
 		addr.set_fragment(None);


### PR DESCRIPTION
Unintentional when switching from `path_segments()` to `path()`.