### PR TITLE
Fix JS using the wrong type for priority.

### DIFF
--- a/js/moq/src/wire/subscribe.ts
+++ b/js/moq/src/wire/subscribe.ts
@@ -8,11 +8,11 @@ export class SubscribeUpdate {
 	}
 
 	async encode(w: Writer) {
-		await w.u53(this.priority);
+		await w.u8(this.priority);
 	}
 
 	static async decode(r: Reader): Promise<SubscribeUpdate> {
-		const priority = await r.u53();
+		const priority = await r.u8();
 		return new SubscribeUpdate(priority);
 	}
 


### PR DESCRIPTION
Would cause a subscription to hang if a Rust client was first to subscribe to a Javascript publisher. We currently pass along the priority of the first subscriber only; there's currently no SUBSCRIBE_UPDATE.

When Rust subscribes, it uses priority = 100 for the catalog. This is >64 which triggered JS thinking it's a 2-byte VarInt and hang waiting for additional bytes to arrive. This is actually a very good reason to have an explicit size prefix for messages, as it would catch this encoding issue.