### PR TITLE
Another simpler fix for now-or-never

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -1592,7 +1592,6 @@ dependencies = [
  "axum",
  "bytes",
  "clap",
- "futures",
  "http-body",
  "hyper-serve",
  "moq-lite",

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -16,7 +16,6 @@ anyhow = { version = "1", features = ["backtrace"] }
 axum = { version = "0.8", features = ["tokio"] }
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
-futures = "0.3"
 http-body = "1"
 hyper-serve = { version = "0.6", features = [
 	"tls-rustls",

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -13,7 +13,6 @@ use axum::{
 	Router,
 };
 use bytes::Bytes;
-use futures::FutureExt;
 use hyper_serve::accept::DefaultAcceptor;
 use moq_lite::OriginUpdate;
 use std::future::Future;
@@ -81,7 +80,7 @@ async fn serve_announced(Path(prefix): Path<String>, cluster: Cluster) -> impl I
 	let mut origin = cluster.combined.consume_prefix(&prefix);
 	let mut broadcasts = Vec::new();
 
-	while let Some(Some(OriginUpdate { suffix, active })) = origin.next().now_or_never() {
+	while let Some(OriginUpdate { suffix, active }) = origin.try_next() {
 		if active.is_some() {
 			broadcasts.push(suffix);
 		}

--- a/rs/moq/src/model/origin.rs
+++ b/rs/moq/src/model/origin.rs
@@ -325,12 +325,21 @@ pub struct OriginConsumer {
 impl OriginConsumer {
 	/// Returns the next (un)announced broadcast and the absolute path.
 	///
-	/// The broadcast will only be None if it was previously Some.
+	/// The broadcast will only be announced if it was previously unannounced.
 	/// The same path won't be announced/unannounced twice, instead it will toggle.
+	/// Returns None if the consumer is closed.
 	///
 	/// Note: The returned path is absolute and will always match this consumer's prefix.
 	pub async fn next(&mut self) -> Option<OriginUpdate> {
 		self.updates.recv().await
+	}
+
+	/// Returns the next (un)announced broadcast and the absolute path without blocking.
+	///
+	/// Returns None if there is no update available; NOT because the consumer is closed.
+	/// You have to use `is_closed` to check if the consumer is closed.
+	pub fn try_next(&mut self) -> Option<OriginUpdate> {
+		self.updates.try_recv().ok()
 	}
 
 	/// Get a specific broadcast by path.
@@ -389,6 +398,10 @@ impl OriginConsumer {
 	pub fn prefix(&self) -> &Path {
 		&self.prefix
 	}
+
+	pub fn is_closed(&self) -> bool {
+		self.updates.is_closed()
+	}
 }
 
 impl Clone for OriginConsumer {
@@ -404,6 +417,12 @@ use futures::FutureExt;
 impl OriginConsumer {
 	pub fn assert_next(&mut self, path: &str, broadcast: &BroadcastConsumer) {
 		let next = self.next().now_or_never().expect("next blocked").expect("no next");
+		assert_eq!(next.suffix.as_str(), path, "wrong path");
+		assert!(next.active.unwrap().is_clone(broadcast), "should be the same broadcast");
+	}
+
+	pub fn assert_try_next(&mut self, path: &str, broadcast: &BroadcastConsumer) {
+		let next = self.try_next().expect("no next");
 		assert_eq!(next.suffix.as_str(), path, "wrong path");
 		assert!(next.active.unwrap().is_clone(broadcast), "should be the same broadcast");
 	}
@@ -557,5 +576,37 @@ mod tests {
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 		assert!(producer.consume("test").is_none());
+	}
+	// There was a tokio bug where only the first 127 broadcasts would be received instantly.
+	#[tokio::test]
+	#[should_panic]
+	async fn test_128() {
+		let mut producer = OriginProducer::default();
+		let mut consumer = producer.consume_all();
+		let broadcast = BroadcastProducer::new();
+
+		for i in 0..256 {
+			producer.publish(format!("test{i}"), broadcast.consume());
+		}
+
+		for i in 0..256 {
+			consumer.assert_next(&format!("test{i}"), &broadcast.consume());
+		}
+	}
+
+	#[tokio::test]
+	async fn test_128_fix() {
+		let mut producer = OriginProducer::default();
+		let mut consumer = producer.consume_all();
+		let broadcast = BroadcastProducer::new();
+
+		for i in 0..256 {
+			producer.publish(format!("test{i}"), broadcast.consume());
+		}
+
+		for i in 0..256 {
+			// try_next does not have the same issue because it's synchronous.
+			consumer.assert_try_next(&format!("test{i}"), &broadcast.consume());
+		}
 	}
 }

--- a/rs/moq/src/session/publisher.rs
+++ b/rs/moq/src/session/publisher.rs
@@ -1,4 +1,3 @@
-use futures::FutureExt;
 use web_async::FuturesExt;
 
 use crate::{
@@ -82,8 +81,8 @@ impl Publisher {
 		let mut init = Vec::new();
 
 		// Send ANNOUNCE_INIT as the first message with all currently active paths
-		// We use `now_or_never` so `announced` keeps track of what has been sent for us.
-		while let Some(Some(OriginUpdate { suffix, active })) = announced.next().now_or_never() {
+		// We use `try_next()` to synchronously get the initial updates.
+		while let Some(OriginUpdate { suffix, active }) = announced.try_next() {
 			let full = self.origin.root().join(&prefix).join(&suffix);
 			if active.is_some() {
 				tracing::debug!(broadcast = %full, "announce");


### PR DESCRIPTION
I think this is better than #525 and #524. The tokio documentation states that try_recv won't spuriously return `Empty`.