### PR TITLE
Change some of the default latency/TTL values.

### DIFF
--- a/js/hang/src/publish/audio/captions.ts
+++ b/js/hang/src/publish/audio/captions.ts
@@ -29,7 +29,7 @@ export class Captions {
 
 	constructor(audio: Audio, props?: CaptionsProps) {
 		this.audio = audio;
-		this.#ttl = props?.ttl ?? 5000;
+		this.#ttl = props?.ttl ?? 10000;
 		this.enabled = new Signal(props?.enabled ?? false);
 
 		this.signals.effect(this.#run.bind(this));

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -2601,9 +2601,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable audio buffering latency option (default 100 ms) to control frame grouping, enabling tuning between smoother playback with potential lag and more aggressive catch-up with possible drops.
  - Extended default caption display duration to 10 seconds when no custom timeout is provided, improving readability for longer phrases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->