### PR TITLE
Support Webpack and fixes

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -38,11 +38,12 @@
 		"release": "tsx ../scripts/release.ts"
 	},
 	"dependencies": {
+		"@huggingface/transformers": "^3.7.0",
 		"@kixelated/moq": "workspace:^",
 		"@kixelated/signals": "workspace:^",
-		"zod": "^4.0.0",
+		"async-mutex": "^0.5.0",
 		"comlink": "^4.4.2",
-		"@huggingface/transformers": "^3.7.0"
+		"zod": "^4.0.0"
 	},
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.77",

--- a/js/hang/src/publish/audio/captions.ts
+++ b/js/hang/src/publish/audio/captions.ts
@@ -1,8 +1,9 @@
 import * as Moq from "@kixelated/moq";
 import { Effect, Signal } from "@kixelated/signals";
+import type { Audio } from ".";
 import type * as Catalog from "../../catalog";
 import { u8 } from "../../catalog";
-import type { Audio } from ".";
+import { loadAudioWorklet } from "../../util/hacks";
 import type { Request, Result } from "./captions-worker";
 
 export type CaptionsProps = {
@@ -92,14 +93,11 @@ export class Captions {
 
 		// The workload needs to be loaded asynchronously, unfortunately, but it should be instant.
 		effect.spawn(async () => {
-			// Hacky workaround to support Webpack and Vite:
-			// https://github.com/webpack/webpack/issues/11543#issuecomment-2045809214
-
-			const { register } = navigator.serviceWorker;
-			// @ts-ignore hack to make webpack believe that it is registering a worker
-			navigator.serviceWorker.register = (url: URL) => ctx.audioWorklet.addModule(url);
-			await navigator.serviceWorker.register(new URL("./capture-worklet", import.meta.url));
-			navigator.serviceWorker.register = register;
+			await ctx.audioWorklet.addModule(
+				await loadAudioWorklet(() =>
+					navigator.serviceWorker.register(new URL("./capture-worklet", import.meta.url)),
+				),
+			);
 
 			// Create the worklet.
 			const worklet = new AudioWorkletNode(ctx, "capture", {

--- a/js/hang/src/publish/audio/captions.ts
+++ b/js/hang/src/publish/audio/captions.ts
@@ -1,9 +1,9 @@
 import * as Moq from "@kixelated/moq";
 import { Effect, Signal } from "@kixelated/signals";
-import type { Audio } from ".";
 import type * as Catalog from "../../catalog";
 import { u8 } from "../../catalog";
 import { loadAudioWorklet } from "../../util/hacks";
+import type { Audio } from ".";
 import type { Request, Result } from "./captions-worker";
 
 export type CaptionsProps = {

--- a/js/hang/src/publish/audio/index.ts
+++ b/js/hang/src/publish/audio/index.ts
@@ -1,7 +1,7 @@
 import * as Moq from "@kixelated/moq";
 import { Effect, type Getter, Signal } from "@kixelated/signals";
 import type * as Catalog from "../../catalog";
-import { u53, u8 } from "../../catalog/integers";
+import { u8, u53 } from "../../catalog/integers";
 import * as Container from "../../container";
 import { loadAudioWorklet } from "../../util/hacks";
 import { Captions, type CaptionsProps } from "./captions";

--- a/js/hang/src/publish/audio/speaking.ts
+++ b/js/hang/src/publish/audio/speaking.ts
@@ -1,10 +1,10 @@
 import * as Moq from "@kixelated/moq";
 import { Effect, Signal } from "@kixelated/signals";
-import type { Audio } from ".";
 import type * as Catalog from "../../catalog";
 import { u8 } from "../../catalog";
 import { BoolProducer } from "../../container/bool";
 import { loadAudioWorklet } from "../../util/hacks";
+import type { Audio } from ".";
 import type { Request, Result } from "./speaking-worker";
 
 export type SpeakingProps = {

--- a/js/hang/src/publish/audio/speaking.ts
+++ b/js/hang/src/publish/audio/speaking.ts
@@ -4,7 +4,6 @@ import type * as Catalog from "../../catalog";
 import { u8 } from "../../catalog";
 import { BoolProducer } from "../../container/bool";
 import type { Audio } from ".";
-import CaptureWorklet from "./capture-worklet?worker&url";
 import type { Request, Result } from "./speaking-worker";
 
 export type SpeakingProps = {
@@ -85,7 +84,14 @@ export class Speaking {
 
 		// The workload needs to be loaded asynchronously, unfortunately, but it should be instant.
 		effect.spawn(async () => {
-			await ctx.audioWorklet.addModule(CaptureWorklet);
+			// Hacky workaround to support Webpack and Vite:
+			// https://github.com/webpack/webpack/issues/11543#issuecomment-2045809214
+
+			const { register } = navigator.serviceWorker;
+			// @ts-ignore hack to make webpack believe that it is registering a worker
+			navigator.serviceWorker.register = (url: URL) => ctx.audioWorklet.addModule(url);
+			await navigator.serviceWorker.register(new URL("./capture-worklet", import.meta.url));
+			navigator.serviceWorker.register = register;
 
 			// Create the worklet.
 			const worklet = new AudioWorkletNode(ctx, "capture", {

--- a/js/hang/src/publish/video/detection.ts
+++ b/js/hang/src/publish/video/detection.ts
@@ -4,8 +4,6 @@ import * as Comlink from "comlink";
 import * as Catalog from "../../catalog";
 import type { Video } from ".";
 import type { DetectionWorker } from "./detection-worker";
-// Vite-specific import for worker
-import WorkerUrl from "./detection-worker?worker&url";
 
 export type DetectionProps = {
 	enabled?: boolean;
@@ -52,8 +50,7 @@ export class Detection {
 			track: { name: this.#track.name, priority: Catalog.u8(this.#track.priority) },
 		});
 
-		// Initialize worker
-		const worker = new Worker(WorkerUrl, { type: "module" });
+		const worker = new Worker(new URL("./detection-worker", import.meta.url), { type: "module" });
 		effect.cleanup(() => worker.terminate());
 
 		const api = Comlink.wrap<DetectionWorker>(worker);

--- a/js/hang/src/support/element.ts
+++ b/js/hang/src/support/element.ts
@@ -302,7 +302,7 @@ export default class HangSupport extends HTMLElement {
 			if (mode !== "publish") {
 				addRow("Rendering", "Audio", binary(support.audio.render));
 				addRow("", "Video", binary(support.video.render));
-				addRow("Decoding", "Audio", binary(support.audio.decoding?.opus));
+				addRow("Decoding", "Opus", binary(support.audio.decoding?.opus));
 				addRow("", "AAC", binary(support.audio.decoding?.aac));
 				addRow("", "AV1", hardware(support.video.decoding?.av1));
 				addRow("", "H.265", hardware(support.video.decoding?.h265));

--- a/js/hang/src/util/hacks.ts
+++ b/js/hang/src/util/hacks.ts
@@ -1,5 +1,29 @@
+import { Mutex } from "async-mutex";
+
 // https://issues.chromium.org/issues/40504498
 export const isChrome = navigator.userAgent.toLowerCase().includes("chrome");
 
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
 export const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+
+// Hacky workaround to support Webpack and Vite
+// https://github.com/webpack/webpack/issues/11543#issuecomment-2045809214
+
+// Note that Webpack needs to see `navigator.serviceWorker.register(new URL("literal"), ...)` for this to work
+
+const loadAudioWorkletMutex = new Mutex();
+
+export async function loadAudioWorklet(registerFn: () => Promise<ServiceWorkerRegistration>) {
+	return await loadAudioWorkletMutex.runExclusive(async () => {
+		const { register } = navigator.serviceWorker;
+
+		// @ts-ignore hack to make webpack believe that it is registering a worker
+		navigator.serviceWorker.register = (url: URL) => Promise.resolve(url);
+
+		try {
+			return (await registerFn()) as unknown as URL;
+		} finally {
+			navigator.serviceWorker.register = register;
+		}
+	});
+}

--- a/js/package.json
+++ b/js/package.json
@@ -9,9 +9,10 @@
 		"concurrently": "^9.1.2",
 		"cpy-cli": "^5.0.0",
 		"knip": "^5.60.2",
+		"prettier": "^3.6.2",
 		"rimraf": "^6.0.1",
-		"typescript": "^5.8.3",
-		"tsx": "^4.20.1"
+		"tsx": "^4.20.1",
+		"typescript": "^5.8.3"
 	},
 	"packageManager": "pnpm@10.12.1"
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       knip:
         specifier: ^5.60.2
         version: 5.60.2(@types/node@24.0.1)(typescript@5.8.3)
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -1539,6 +1542,11 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   protobufjs@7.5.3:
     resolution: {integrity: sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==}
     engines: {node: '>=12.0.0'}
@@ -3011,6 +3019,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prettier@3.6.2: {}
 
   protobufjs@7.5.3:
     dependencies:

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@kixelated/signals':
         specifier: workspace:^
         version: link:../signals
+      async-mutex:
+        specifier: ^0.5.0
+        version: 0.5.0
       comlink:
         specifier: ^4.4.2
         version: 4.4.2


### PR DESCRIPTION
On Next.js there is still some problems with the transformers library being loaded as node module somehow...

```
 ⚠ ./node_modules/.pnpm/@huggingface+transformers@3.7.2/node_modules/@huggingface/transformers/dist/transformers.node.mjs
Critical dependency: Accessing import.meta directly is unsupported (only property access or destructuring is supported)

Import trace for requested module:
./node_modules/.pnpm/@huggingface+transformers@3.7.2/node_modules/@huggingface/transformers/dist/transformers.node.mjs
./node_modules/.pnpm/@kixelated+hang@file+..+..+..+forks+moq+js+hang+dist+kixelated-hang-0.3.13.tgz_@types+react@19.1.11_react@19.1.1/node_modules/@kixelated/hang/publish/audio/captions-worker.js
```
but its not blocking anything.

Also turbopack just gives up without any error message and return code 0 :smile: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added speaking capability to Audio for integrated speaking state.
  - Improved multi-channel audio handling with explicit channel count support.

- Bug Fixes
  - Improved compatibility for audio and video worklet loading across build environments, reducing initialization failures.
  - Corrected support panel label from “Audio” to “Opus” for decoding details.

- Chores
  - Added Prettier and an async utility dependency to development/package tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->