### PR TITLE
Fix stereo audio

### DIFF
--- a/js/hang/src/support/element.ts
+++ b/js/hang/src/support/element.ts
@@ -302,7 +302,7 @@ export default class HangSupport extends HTMLElement {
 			if (mode !== "publish") {
 				addRow("Rendering", "Audio", binary(support.audio.render));
 				addRow("", "Video", binary(support.video.render));
-				addRow("Decoding", "Audio", binary(support.audio.decoding?.opus));
+				addRow("Decoding", "Opus", binary(support.audio.decoding?.opus));
 				addRow("", "AAC", binary(support.audio.decoding?.aac));
 				addRow("", "AV1", hardware(support.video.decoding?.av1));
 				addRow("", "H.265", hardware(support.video.decoding?.h265));

--- a/js/hang/src/watch/audio/index.ts
+++ b/js/hang/src/watch/audio/index.ts
@@ -97,7 +97,10 @@ export class Audio {
 			await context.audioWorklet.addModule(RenderWorklet);
 
 			// Create the worklet node
-			const worklet = new AudioWorkletNode(context, "render");
+			const worklet = new AudioWorkletNode(context, "render", {
+				channelCount,
+				channelCountMode: "explicit",
+			});
 			effect.cleanup(() => worklet.disconnect());
 
 			// Listen for buffer status updates (optional, for monitoring)


### PR DESCRIPTION
Fixes the audio sounding like shit. No idea why this parameter is needed...

Fixes 1/2 of #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Audio processing now respects the exact number of input channels, improving multi‑channel accuracy and consistency across devices and browsers.
- Style
  - Updated the support details label: the decoding row now shows header “Opus” instead of “Audio” for clearer codec-specific information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->