### PR TITLE
Skip erroring groups in TrackConsumer.

### DIFF
--- a/rs/hang/src/model/track.rs
+++ b/rs/hang/src/model/track.rs
@@ -139,14 +139,15 @@ impl TrackConsumer {
 				Some(res) = async { Some(self.current.as_mut()?.read().await) } => {
 					drop(buffering);
 
-					match res? {
+					match res {
 						// Got the next frame.
-						Some(frame) => {
+						Ok(Some(frame)) => {
 							self.max_timestamp = frame.timestamp;
 							return Ok(Some(frame));
 						}
-						None => {
-							// Group ended cleanly, instantly move to the next group.
+						Ok(None) | Err(_) => {
+							// Group ended, instantly move to the next group.
+							// We don't care about errors, which will happen if the group is closed early.
 							self.current = self.pending.pop_front();
 							continue;
 						}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of early stream/group termination, treating it as normal completion instead of an error.
  * Reduced spurious error messages and interruptions during playback/consumption when groups end or switch.
  * Increased resilience to transient read failures, preventing crashes and ensuring smoother continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->