### PR TITLE
Fix hidden lifetime warnings

### DIFF
--- a/rs/moq/src/model/origin.rs
+++ b/rs/moq/src/model/origin.rs
@@ -422,16 +422,16 @@ impl OriginProducer {
 	}
 
 	/// Returns the root that is automatically stripped from all paths.
-	pub fn root(&self) -> &Path {
+	pub fn root(&self) -> &Path<'_> {
 		&self.root
 	}
 
-	pub fn allowed(&self) -> impl Iterator<Item = &Path> {
+	pub fn allowed(&self) -> impl Iterator<Item = &Path<'_>> {
 		self.nodes.nodes.iter().map(|(root, _)| root)
 	}
 
 	/// Converts a relative path to an absolute path.
-	pub fn absolute(&self, path: impl AsPath) -> Path {
+	pub fn absolute(&self, path: impl AsPath) -> Path<'_> {
 		self.root.join(path)
 	}
 }
@@ -512,16 +512,16 @@ impl OriginConsumer {
 	}
 
 	/// Returns the prefix that is automatically stripped from all paths.
-	pub fn root(&self) -> &Path {
+	pub fn root(&self) -> &Path<'_> {
 		&self.root
 	}
 
-	pub fn allowed(&self) -> impl Iterator<Item = &Path> {
+	pub fn allowed(&self) -> impl Iterator<Item = &Path<'_>> {
 		self.nodes.nodes.iter().map(|(root, _)| root)
 	}
 
 	/// Converts a relative path to an absolute path.
-	pub fn absolute(&self, path: impl AsPath) -> Path {
+	pub fn absolute(&self, path: impl AsPath) -> Path<'_> {
 		self.root.join(path)
 	}
 }

--- a/rs/moq/src/session/subscriber.rs
+++ b/rs/moq/src/session/subscriber.rs
@@ -298,7 +298,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	fn log_path(&self, path: impl AsPath) -> Path {
+	fn log_path(&self, path: impl AsPath) -> Path<'_> {
 		self.origin.as_ref().unwrap().root().join(path)
 	}
 }


### PR DESCRIPTION
Fix the following warning:

> warning: hiding a lifetime that's elided elsewhere is confusing
> help: the same lifetime is referred to in inconsistent ways, making the signature confusing
> help: use `'_` for type paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refined internal API type signatures for improved code clarity and maintainability. No functional changes or impact on behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->