### PR TITLE
Always run the VAD model when enabled.

### DIFF
--- a/js/hang/src/publish/audio/speaking.ts
+++ b/js/hang/src/publish/audio/speaking.ts
@@ -31,8 +31,6 @@ export class Speaking {
 	}
 
 	#runCatalog(effect: Effect): void {
-		console.log("run catalog", effect.get(this.enabled));
-
 		const enabled = effect.get(this.enabled);
 		if (!enabled) return;
 


### PR DESCRIPTION
Was set to only run when requested, but it makes the signal useless. TODO: Figure out a good API to request stuff run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new method for handling audio active state signaling

* **Refactor**
  * Optimized audio component initialization flow and worker lifecycle management
  * Simplified state propagation patterns for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->