### PR TITLE
Remove Sync constraint

### DIFF
--- a/rs/moq/src/ietf/session.rs
+++ b/rs/moq/src/ietf/session.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::{Publisher, Subscriber};
 
-pub(crate) async fn start<S: web_transport_trait::Session + Sync>(
+pub(crate) async fn start<S: web_transport_trait::Session>(
 	session: S,
 	setup: Stream<S>,
 	publish: Option<OriginConsumer>,
@@ -32,7 +32,7 @@ pub(crate) async fn start<S: web_transport_trait::Session + Sync>(
 	Ok(())
 }
 
-async fn run<S: web_transport_trait::Session + Sync>(
+async fn run<S: web_transport_trait::Session>(
 	session: S,
 	setup: Stream<S>,
 	publish: Option<OriginConsumer>,
@@ -51,7 +51,7 @@ async fn run<S: web_transport_trait::Session + Sync>(
 	}
 }
 
-async fn run_control_read<S: web_transport_trait::Session + Sync>(
+async fn run_control_read<S: web_transport_trait::Session>(
 	mut control: Reader<S::RecvStream>,
 	mut publisher: Publisher<S>,
 	mut subscriber: Subscriber<S>,
@@ -117,7 +117,7 @@ async fn run_control_read<S: web_transport_trait::Session + Sync>(
 	}
 }
 
-async fn run_control_write<S: web_transport_trait::Session + Sync>(
+async fn run_control_write<S: web_transport_trait::Session>(
 	mut control: Writer<S::SendStream>,
 	mut rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
 ) -> Result<(), Error> {

--- a/rs/moq/src/lite/session.rs
+++ b/rs/moq/src/lite/session.rs
@@ -4,7 +4,7 @@ use crate::{coding::Stream, lite::SessionInfo, Error, OriginConsumer, OriginProd
 
 use super::{Publisher, Subscriber};
 
-pub(crate) async fn start<S: web_transport_trait::Session + Sync>(
+pub(crate) async fn start<S: web_transport_trait::Session>(
 	session: S,
 	// The stream used to setup the session, after exchanging setup messages.
 	setup: Stream<S>,
@@ -51,7 +51,7 @@ pub(crate) async fn start<S: web_transport_trait::Session + Sync>(
 }
 
 // TODO do something useful with this
-async fn run_session<S: web_transport_trait::Session + Sync>(mut stream: Stream<S>) -> Result<(), Error> {
+async fn run_session<S: web_transport_trait::Session>(mut stream: Stream<S>) -> Result<(), Error> {
 	while let Some(_info) = stream.reader.decode_maybe::<SessionInfo>().await? {}
 	Err(Error::Cancel)
 }


### PR DESCRIPTION
The `web_transport_trait::Session` trait already inherits `MaybeSync`. Adding `Sync` makes it fail on WASM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Simplified type constraints in session handling functions to support a broader range of session implementations without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->