### PR TITLE
Have release-plz version crates together.

### DIFF
--- a/rs/.release-plz.toml
+++ b/rs/.release-plz.toml
@@ -1,3 +1,31 @@
 [workspace]
 dependencies_update = true
 git_release_enable = false
+
+[[package]]
+name = "hang"
+version_group = "hang"
+
+[[package]]
+name = "hang-cli"
+version_group = "hang"
+
+[[package]]
+name = "moq-lite"
+version_group = "moq"
+
+[[package]]
+name = "moq-clock"
+version_group = "moq"
+
+[[package]]
+name = "moq-relay"
+version_group = "moq"
+
+[[package]]
+name = "moq-token"
+version_group = "token"
+
+[[package]]
+name = "moq-token-cli"
+version_group = "token"


### PR DESCRIPTION
ex. moq-relay is bumped when moq-lite is bumped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace package configuration to include additional package entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->