### PR TITLE
Also rename back to --cluster-root

### DIFF
--- a/rs/nix/modules/moq-relay.nix
+++ b/rs/nix/modules/moq-relay.nix
@@ -225,7 +225,7 @@ in
         MOQ_AUTH_PUBLIC = cfg.auth.publicPath;
       } // lib.optionalAttrs (cfg.cluster.rootUrl != null) {
         # Cluster configuration
-        MOQ_CLUSTER_CONNECT = cfg.cluster.rootUrl;
+        MOQ_CLUSTER_ROOT = cfg.cluster.rootUrl;
       } // lib.optionalAttrs (cfg.cluster.mode != "none") {
         MOQ_CLUSTER_TOKEN = if cfg.cluster.tokenFile != null then cfg.cluster.tokenFile else "${cfg.stateDir}/cluster.jwt";
       } // lib.optionalAttrs (cfg.cluster.nodeUrl != null) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cluster root configuration parameter renamed from "connect" to "root" across command-line arguments and environment variables.
  * Backward compatibility maintained—previous parameter names remain functional through configuration aliases for seamless upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->