### PR TITLE
Fix an arg collision with --tls-root and --cluster-root

### DIFF
--- a/rs/hang-cli/src/server.rs
+++ b/rs/hang-cli/src/server.rs
@@ -19,7 +19,7 @@ pub async fn server<T: AsyncRead + Unpin>(
 	format: ImportType,
 	input: &mut T,
 ) -> anyhow::Result<()> {
-	let mut listen = config.listen.unwrap_or("[::]:443".parse().unwrap());
+	let mut listen = config.bind.unwrap_or("[::]:443".parse().unwrap());
 	listen = tokio::net::lookup_host(listen)
 		.await
 		.context("invalid listen address")?

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -14,7 +14,7 @@ pub struct ClientTls {
 	/// This value can be provided multiple times for multiple roots.
 	/// If this is empty, system roots will be used instead
 	#[serde(skip_serializing_if = "Vec::is_empty")]
-	#[arg(long = "tls-root", env = "MOQ_CLIENT_TLS_ROOT")]
+	#[arg(id = "tls-root", long = "tls-root", env = "MOQ_CLIENT_TLS_ROOT")]
 	pub root: Vec<PathBuf>,
 
 	/// Danger: Disable TLS certificate verification.
@@ -22,7 +22,11 @@ pub struct ClientTls {
 	/// Fine for local development and between relays, but should be used in caution in production.
 	// This is an Option<bool> so clap skips over it when not provided, otherwise it is set to false.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[arg(long = "tls-disable-verify", env = "MOQ_CLIENT_TLS_DISABLE_VERIFY")]
+	#[arg(
+		id = "tls-disable-verify",
+		long = "tls-disable-verify",
+		env = "MOQ_CLIENT_TLS_DISABLE_VERIFY"
+	)]
 	pub disable_verify: Option<bool>,
 }
 
@@ -30,7 +34,12 @@ pub struct ClientTls {
 #[serde(deny_unknown_fields, default)]
 pub struct ClientConfig {
 	/// Listen for UDP packets on the given address.
-	#[arg(long, id = "client-bind", default_value = "[::]:0", env = "MOQ_CLIENT_BIND")]
+	#[arg(
+		id = "client-bind",
+		long = "client-bind",
+		default_value = "[::]:0",
+		env = "MOQ_CLIENT_BIND"
+	)]
 	pub bind: net::SocketAddr,
 
 	#[command(flatten)]

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -63,8 +63,9 @@ pub struct ServerTlsConfig {
 pub struct ServerConfig {
 	/// Listen for UDP packets on the given address.
 	/// Defaults to `[::]:443` if not provided.
-	#[arg(long, env = "MOQ_SERVER_LISTEN")]
-	pub listen: Option<net::SocketAddr>,
+	#[serde(alias = "listen")]
+	#[arg(id = "server-bind", long = "server-bind", alias = "listen", env = "MOQ_SERVER_BIND")]
+	pub bind: Option<net::SocketAddr>,
 
 	#[command(flatten)]
 	#[serde(default)]
@@ -133,7 +134,7 @@ impl Server {
 		let runtime = quinn::default_runtime().context("no async runtime")?;
 		let endpoint_config = quinn::EndpointConfig::default();
 
-		let listen = config.listen.unwrap_or("[::]:443".parse().unwrap());
+		let listen = config.bind.unwrap_or("[::]:443".parse().unwrap());
 		let socket = std::net::UdpSocket::bind(listen).context("failed to bind UDP socket")?;
 
 		// Create the generic QUIC endpoint.

--- a/rs/moq-relay/fly.toml
+++ b/rs/moq-relay/fly.toml
@@ -16,7 +16,7 @@ port = 443
 # Environment variables
 [env]
 # NOTE: A dedicated IPv4 address is required for UDP.
-MOQ_SERVER_LISTEN = "fly-global-services:443"
+MOQ_SERVER_BIND = "fly-global-services:443"
 
 # Resource allocation per region
 [[vm]]

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -14,18 +14,28 @@ use crate::AuthToken;
 pub struct ClusterConfig {
 	/// Connect to this hostname in order to discover other nodes.
 	#[serde(alias = "connect")]
-	#[arg(long = "cluster-root", env = "MOQ_CLUSTER_ROOT", alias = "cluster-connect")]
+	#[arg(
+		id = "cluster-root",
+		long = "cluster-root",
+		env = "MOQ_CLUSTER_ROOT",
+		alias = "cluster-connect"
+	)]
 	pub root: Option<String>,
 
 	/// Use the token in this file when connecting to other nodes.
-	#[arg(long = "cluster-token", env = "MOQ_CLUSTER_TOKEN")]
+	#[arg(id = "cluster-token", long = "cluster-token", env = "MOQ_CLUSTER_TOKEN")]
 	pub token: Option<PathBuf>,
 
 	/// Our hostname which we advertise to other nodes.
 	///
 	// TODO Remove alias once we've migrated to the new name.
 	#[serde(alias = "advertise")]
-	#[arg(long = "cluster-node", env = "MOQ_CLUSTER_NODE", alias = "cluster-advertise")]
+	#[arg(
+		id = "cluster-node",
+		long = "cluster-node",
+		env = "MOQ_CLUSTER_NODE",
+		alias = "cluster-advertise"
+	)]
 	pub node: Option<String>,
 
 	/// The prefix to use for cluster announcements.
@@ -33,6 +43,7 @@ pub struct ClusterConfig {
 	///
 	/// WARNING: This should not be accessible by users unless authentication is disabled (YOLO).
 	#[arg(
+		id = "cluster-prefix",
 		long = "cluster-prefix",
 		default_value = "internal/origins",
 		env = "MOQ_CLUSTER_PREFIX"

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -14,7 +14,7 @@ pub use web::*;
 async fn main() -> anyhow::Result<()> {
 	let config = Config::load()?;
 
-	let addr = config.server.listen.unwrap_or("[::]:443".parse().unwrap());
+	let addr = config.server.bind.unwrap_or("[::]:443".parse().unwrap());
 	let mut server = config.server.init()?;
 	let client = config.client.init()?;
 	let auth = config.auth.init()?;

--- a/rs/nix/modules/moq-relay.nix
+++ b/rs/nix/modules/moq-relay.nix
@@ -208,7 +208,7 @@ in
         MOQ_LOG_LEVEL = lib.mkDefault cfg.logLevel;
 
         # Server configuration
-        MOQ_SERVER_LISTEN = "[::]:${toString cfg.port}";
+        MOQ_SERVER_BIND = "[::]:${toString cfg.port}";
 
         MOQ_CLIENT_TLS_DISABLE_VERIFY = lib.boolToString cfg.cluster.disableTlsVerify;
       } // lib.optionalAttrs (cfg.tls.generate != [ ]) {


### PR DESCRIPTION
And rename --listen to --server-bind

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server configuration naming convention from `listen` to `bind` across multiple modules. Environment variable changed from `MOQ_SERVER_LISTEN` to `MOQ_SERVER_BIND`. Users must update deployment configurations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->