### PR TITLE
Fix cluster prefix removal.

### DIFF
--- a/rs/moq/src/model/origin.rs
+++ b/rs/moq/src/model/origin.rs
@@ -512,6 +512,15 @@ impl OriginConsumer {
 		Some(OriginConsumer::new(self.root.clone(), self.nodes.select(prefixes)?))
 	}
 
+	/// Returns a new OriginConsumer that automatically strips out the provided prefix.
+	///
+	/// Returns None if the provided root is not authorized; when consume_only was already used without a wildcard.
+	pub fn with_root(&self, prefix: impl AsPath) -> Option<Self> {
+		let prefix = prefix.as_path();
+
+		Some(Self::new(self.root.join(&prefix).to_owned(), self.nodes.root(&prefix)?))
+	}
+
 	/// Returns the prefix that is automatically stripped from all paths.
 	pub fn root(&self) -> &Path<'_> {
 		&self.root


### PR DESCRIPTION
I don't know when this broke. The new cluster I'm setting up was trying to connect to `internal/origins/usw.moq.hang.live`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved remote discovery and cluster orchestration through enhanced origin consumption mechanisms
  * Enhanced prefix and root handling for origin subscriptions, enabling more flexible path management in the relay infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->