### PR TITLE
Allow --tls-disable-verify without false.

### DIFF
--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -20,12 +20,12 @@ pub struct ClientTls {
 	/// Danger: Disable TLS certificate verification.
 	///
 	/// Fine for local development and between relays, but should be used in caution in production.
-	// This is an Option<bool> so clap skips over it when not provided, otherwise it is set to false.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "tls-disable-verify",
 		long = "tls-disable-verify",
-		env = "MOQ_CLIENT_TLS_DISABLE_VERIFY"
+		env = "MOQ_CLIENT_TLS_DISABLE_VERIFY",
+		action = clap::ArgAction::SetTrue
 	)]
 	pub disable_verify: Option<bool>,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved command-line flag handling for TLS verification settings to support explicit boolean control with enhanced consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->