### PR TITLE
IETF: Fix group order = 0x0

### DIFF
--- a/js/moq/src/ietf/subscribe.ts
+++ b/js/moq/src/ietf/subscribe.ts
@@ -48,8 +48,8 @@ export class Subscribe {
 		const subscriberPriority = await r.u8();
 
 		const groupOrder = await r.u8();
-		if (groupOrder !== 0 && groupOrder !== GROUP_ORDER) {
-			throw new Error(`unsupported group order: ${groupOrder}`);
+		if (groupOrder > 2) {
+			throw new Error(`unknown group order: ${groupOrder}`);
 		}
 
 		const forward = await r.u8();

--- a/rs/moq/src/ietf/group.rs
+++ b/rs/moq/src/ietf/group.rs
@@ -6,6 +6,7 @@ const SUBGROUP_ID: u8 = 0x0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
 #[repr(u8)]
 pub enum GroupOrder {
+	Any = 0x0,
 	Ascending = 0x1,
 	Descending = 0x2,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new group ordering mode, expanding available configuration options and providing users with enhanced flexibility in how they organize and manage grouped data across the system.

* **Improvements**
  * Enhanced validation framework to properly support the new ordering mode alongside existing options, with improved error handling and clearer error messages for invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->