### PR TITLE
IETF: Allow subgroup and warn instead or error

### DIFF
--- a/js/moq/src/ietf/object.ts
+++ b/js/moq/src/ietf/object.ts
@@ -14,21 +14,25 @@ export interface GroupFlags {
  * Used for stream-per-group delivery mode.
  */
 export class Group {
+	flags: GroupFlags;
 	trackAlias: bigint;
 	groupId: number;
-	flags: GroupFlags;
+	subGroupId: number;
+	publisherPriority: number;
 
-	constructor(trackAlias: bigint, groupId: number, flags: GroupFlags) {
-		if (flags.hasSubgroup && flags.hasSubgroupObject) {
-			throw new Error("hasSubgroup and hasSubgroupObject cannot be true at the same time");
-		}
-
+	constructor(trackAlias: bigint, groupId: number, subGroupId: number, publisherPriority: number, flags: GroupFlags) {
+		this.flags = flags;
 		this.trackAlias = trackAlias;
 		this.groupId = groupId;
-		this.flags = flags;
+		this.subGroupId = subGroupId;
+		this.publisherPriority = publisherPriority;
 	}
 
 	async encode(w: Writer): Promise<void> {
+		if (!this.flags.hasSubgroup && this.subGroupId !== 0) {
+			throw new Error(`Subgroup ID must be 0 if hasSubgroup is false: ${this.subGroupId}`);
+		}
+
 		let id = 0x10;
 		if (this.flags.hasExtensions) {
 			id |= 0x01;
@@ -46,7 +50,7 @@ export class Group {
 		await w.u62(this.trackAlias);
 		await w.u53(this.groupId);
 		if (this.flags.hasSubgroup) {
-			await w.u53(0); // subgroup id = 0
+			await w.u53(this.subGroupId);
 		}
 		await w.u8(0); // publisher priority
 	}
@@ -66,14 +70,10 @@ export class Group {
 
 		const trackAlias = await r.u62();
 		const groupId = await r.u53();
+		const subGroupId = flags.hasSubgroup ? await r.u53() : 0;
+		const publisherPriority = await r.u8(); // Don't care about publisher priority
 
-		if (flags.hasSubgroup) {
-			await r.u53(); // Don't care about subgroup id
-		}
-
-		await r.u8(); // Don't care about publisher priority
-
-		return new Group(trackAlias, groupId, flags);
+		return new Group(trackAlias, groupId, subGroupId, publisherPriority, flags);
 	}
 }
 
@@ -109,16 +109,12 @@ export class Frame {
 	static async decode(r: Reader, flags: GroupFlags): Promise<Frame> {
 		const delta = await r.u53();
 		if (delta !== 0) {
-			throw new Error(`Unsupported delta: ${delta}`);
+			console.warn(`object ID delta is not supported, ignoring: ${delta}`);
 		}
 
 		if (flags.hasExtensions) {
 			const extensionsLength = await r.u53();
-			if (extensionsLength > 0) {
-				throw new Error(`Unsupported extensions length: ${extensionsLength}`);
-			}
-
-			// Don't care about extensions
+			// We don't care about extensions
 			await r.read(extensionsLength);
 		}
 

--- a/js/moq/src/ietf/publisher.ts
+++ b/js/moq/src/ietf/publisher.ts
@@ -142,7 +142,7 @@ export class Publisher {
 			const stream = await Writer.open(this.#quic);
 
 			// Write STREAM_HEADER_SUBGROUP
-			const header = new GroupMessage(requestId, group.sequence, {
+			const header = new GroupMessage(requestId, group.sequence, 0, 0, {
 				hasExtensions: false,
 				hasSubgroup: false,
 				hasSubgroupObject: false,

--- a/js/moq/src/ietf/subscriber.ts
+++ b/js/moq/src/ietf/subscriber.ts
@@ -184,11 +184,16 @@ export class Subscriber {
 	async handleGroup(group: GroupMessage, stream: Reader) {
 		const producer = new Group(group.groupId);
 
+		if (group.subGroupId !== 0) {
+			console.warn("subgroup ID is not supported, ignoring");
+		}
+
 		try {
 			let requestId = this.#trackAliases.get(group.trackAlias);
 			if (requestId === undefined) {
 				// Just hope the track alias is the request ID
 				requestId = group.trackAlias;
+				console.warn("unknown track alias, using request ID");
 			}
 
 			const track = this.#subscribes.get(requestId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added publisher priority field support for enhanced media object group tracking.
  * Enhanced subgroup ID handling and validation across publishers and subscribers.

* **Bug Fixes**
  * Improved error handling: non-critical issues now emit warnings instead of failures.
  * Better handling of unknown track aliases with graceful fallbacks.
  * Extensions parsing is now more lenient and continues without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->