### PR TITLE
IETF: Don't return an error when the control stream is closed.

### DIFF
--- a/rs/moq/src/ietf/session.rs
+++ b/rs/moq/src/ietf/session.rs
@@ -62,7 +62,11 @@ async fn run_control_read<S: web_transport_trait::Session>(
 	mut subscriber: Subscriber<S>,
 ) -> Result<(), Error> {
 	loop {
-		let id: u64 = reader.decode().await?;
+		let id: u64 = match reader.decode_maybe().await? {
+			Some(id) => id,
+			None => return Ok(()),
+		};
+
 		let size: u16 = reader.decode::<u16>().await?;
 		tracing::trace!(id, size, "reading control message");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced control-read path to gracefully handle cases with missing identifiers, allowing proper loop termination without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->