### PR TITLE
IETF: Use the correct error message.

### DIFF
--- a/rs/moq/src/ietf/publisher.rs
+++ b/rs/moq/src/ietf/publisher.rs
@@ -112,9 +112,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		web_async::spawn(async move {
 			if let Err(err) = Self::run_track(session, track, request_id, rx).await {
 				control
-					.send(ietf::SubscribeError {
+					.send(ietf::PublishDone {
 						request_id,
-						error_code: 500,
+						status_code: 500,
 						reason_phrase: err.to_string().into(),
 					})
 					.ok();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured error handling to use consistent PublishDone messages for both success and failure scenarios instead of separate error message types.
  * Renamed status field for improved clarity in error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->