### PR TITLE
Log when no track is supported.

### DIFF
--- a/js/hang/src/watch/video/source.ts
+++ b/js/hang/src/watch/video/source.ts
@@ -115,6 +115,10 @@ export class Source {
 				if (valid) supported[name] = rendition;
 			}
 
+			if (Object.keys(supported).length === 0 && Object.keys(renditions).length > 0) {
+				console.warn("no supported renditions found, available: ", renditions);
+			}
+
 			this.#supported.set(supported);
 		});
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime warning when no supported video renditions are found during playback initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->