### PR TITLE
fix: prevent canvas pixelation on Chrome

### DIFF
--- a/js/hang/src/meet/element.ts
+++ b/js/hang/src/meet/element.ts
@@ -209,8 +209,27 @@ class HangMeetInstance {
 				width: "100%",
 				height: "100%",
 				objectFit: "contain",
+				display: "block", // Prevents extra spacing
 			},
-		});
+		}) as HTMLCanvasElement;
+
+		// FIX: Prevent pixelation by syncing canvas buffer to display size
+		const resizeCanvas = () => {
+			const parent = canvas.parentElement;
+			if (!parent) return;
+
+			const rect = parent.getBoundingClientRect();
+			const w = Math.round(rect.width);
+			const h = Math.round(rect.height);
+
+			if (canvas.width !== w || canvas.height !== h) {
+				canvas.width = w;
+				canvas.height = h;
+			}
+		};
+
+		resizeCanvas();
+		new ResizeObserver(resizeCanvas).observe(canvas.parentElement!);
 
 		const renderer = new Watch.Video.Renderer(broadcast.video, { canvas });
 		const emitter = new Watch.Audio.Emitter(broadcast.audio);


### PR DESCRIPTION
- Canvas defaults to 300x150 → stretched by CSS → pixelated
- Now syncs canvas.width/height to parent size via ResizeObserver
- Crisp rendering, tested on Chrome 130 (Windows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote video rendering quality by fixing pixelation issues. Remote video now displays clearly and adjusts automatically when the window is resized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->