### PR TITLE
Add support for multiple versions

### DIFF
--- a/js/moq/src/connection/connect.ts
+++ b/js/moq/src/connection/connect.ts
@@ -82,7 +82,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	params.setVarint(Ietf.Parameter.MaxRequestId, 42069n); // Allow a ton of request IDs.
 	params.setBytes(Ietf.Parameter.Implementation, encoder.encode("moq-lite-js")); // Put the implementation name in the parameters.
 
-	const client = new Ietf.ClientSetup([Lite.CURRENT_VERSION, Ietf.CURRENT_VERSION], params);
+	const client = new Ietf.ClientSetup([Lite.Version.DRAFT_02, Lite.Version.DRAFT_01, Ietf.Version.DRAFT_14], params);
 	console.debug(url.toString(), "sending client setup", client);
 	await client.encode(stream.writer);
 
@@ -95,10 +95,10 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	const server = await Ietf.ServerSetup.decode(stream.reader);
 	console.debug(url.toString(), "received server setup", server);
 
-	if (server.version === Lite.CURRENT_VERSION) {
+	if (Object.values(Lite.Version).includes(server.version as Lite.Version)) {
 		console.debug(url.toString(), "moq-lite session established");
-		return new Lite.Connection(url, quic, stream);
-	} else if (server.version === Ietf.CURRENT_VERSION) {
+		return new Lite.Connection(url, quic, stream, server.version as Lite.Version);
+	} else if (Object.values(Ietf.Version).includes(server.version as Ietf.Version)) {
 		const maxRequestId = server.parameters.getVarint(Ietf.Parameter.MaxRequestId) ?? 0n;
 		console.debug(url.toString(), "moq-ietf session established");
 		return new Ietf.Connection(url, quic, stream, maxRequestId);

--- a/js/moq/src/ietf/version.ts
+++ b/js/moq/src/ietf/version.ts
@@ -16,8 +16,3 @@ export const Version = {
 } as const;
 
 export type Version = (typeof Version)[keyof typeof Version];
-
-/**
- * The current/default version used by this implementation
- */
-export const CURRENT_VERSION = Version.DRAFT_14;

--- a/js/moq/src/lite/connection.ts
+++ b/js/moq/src/lite/connection.ts
@@ -10,6 +10,7 @@ import { SessionInfo } from "./session.ts";
 import { StreamId } from "./stream.ts";
 import { Subscribe } from "./subscribe.ts";
 import { Subscriber } from "./subscriber.ts";
+import type { Version } from "./version.ts";
 
 /**
  * Represents a connection to a MoQ server.
@@ -19,6 +20,9 @@ import { Subscriber } from "./subscriber.ts";
 export class Connection implements Established {
 	// The URL of the connection.
 	readonly url: URL;
+
+	// The version of the connection.
+	readonly version: Version;
 
 	// The established WebTransport session.
 	#quic: WebTransport;
@@ -43,13 +47,14 @@ export class Connection implements Established {
 	 *
 	 * @internal
 	 */
-	constructor(url: URL, quic: WebTransport, session: Stream) {
+	constructor(url: URL, quic: WebTransport, session: Stream, version: Version) {
 		this.url = url;
 		this.#quic = quic;
 		this.#session = session;
+		this.version = version;
 
-		this.#publisher = new Publisher(this.#quic);
-		this.#subscriber = new Subscriber(this.#quic);
+		this.#publisher = new Publisher(this.#quic, this.version);
+		this.#subscriber = new Subscriber(this.#quic, this.version);
 
 		this.#run();
 	}

--- a/js/moq/src/lite/index.ts
+++ b/js/moq/src/lite/index.ts
@@ -4,3 +4,4 @@ export * from "./group.ts";
 export * from "./session.ts";
 export * from "./stream.ts";
 export * from "./subscribe.ts";
+export * from "./version.ts";

--- a/js/moq/src/lite/publisher.ts
+++ b/js/moq/src/lite/publisher.ts
@@ -8,6 +8,7 @@ import { error } from "../util/error.ts";
 import { Announce, AnnounceInit, type AnnounceInterest } from "./announce.ts";
 import { Group as GroupMessage } from "./group.ts";
 import { type Subscribe, SubscribeOk, SubscribeUpdate } from "./subscribe.ts";
+import type { Version } from "./version.ts";
 
 /**
  * Handles publishing broadcasts and managing their lifecycle.
@@ -15,6 +16,9 @@ import { type Subscribe, SubscribeOk, SubscribeUpdate } from "./subscribe.ts";
  * @internal
  */
 export class Publisher {
+	// The version of the connection.
+	readonly version: Version;
+
 	#quic: WebTransport;
 
 	// Our published broadcasts.
@@ -27,8 +31,9 @@ export class Publisher {
 	 *
 	 * @internal
 	 */
-	constructor(quic: WebTransport) {
+	constructor(quic: WebTransport, version: Version) {
 		this.#quic = quic;
+		this.version = version;
 	}
 
 	/**
@@ -136,7 +141,7 @@ export class Publisher {
 		const track = broadcast.subscribe(msg.track, msg.priority);
 
 		try {
-			const info = new SubscribeOk(msg.priority);
+			const info = new SubscribeOk({ version: this.version, priority: msg.priority });
 			await info.encode(stream.writer);
 
 			console.debug(`publish ok: broadcast=${msg.broadcast} track=${track.name}`);

--- a/js/moq/src/lite/session.ts
+++ b/js/moq/src/lite/session.ts
@@ -1,22 +1,6 @@
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
 
-export const Version = {
-	DRAFT_00: 0xff000000,
-	DRAFT_01: 0xff000001,
-	DRAFT_02: 0xff000002,
-	DRAFT_03: 0xff000003,
-	FORK_00: 0xff0bad00,
-	FORK_01: 0xff0bad01,
-	FORK_02: 0xff0bad02,
-	FORK_03: 0xff0bad03,
-	FORK_04: 0xff0bad04,
-	LITE_00: 0xff0dad00,
-	LITE_01: 0xff0dad01,
-} as const;
-
-export const CURRENT_VERSION = Version.LITE_01;
-
 export class Extensions {
 	entries: Map<bigint, Uint8Array>;
 

--- a/js/moq/src/lite/subscriber.ts
+++ b/js/moq/src/lite/subscriber.ts
@@ -9,6 +9,7 @@ import { Announce, AnnounceInit, AnnounceInterest } from "./announce.ts";
 import type { Group as GroupMessage } from "./group.ts";
 import { StreamId } from "./stream.ts";
 import { Subscribe, SubscribeOk } from "./subscribe.ts";
+import type { Version } from "./version.ts";
 
 /**
  * Handles subscribing to broadcasts and managing their lifecycle.
@@ -17,6 +18,9 @@ import { Subscribe, SubscribeOk } from "./subscribe.ts";
  */
 export class Subscriber {
 	#quic: WebTransport;
+
+	// The version of the connection.
+	readonly version: Version;
 
 	// Our subscribed tracks.
 	#subscribes = new Map<bigint, Track>();
@@ -28,8 +32,9 @@ export class Subscriber {
 	 *
 	 * @internal
 	 */
-	constructor(quic: WebTransport) {
+	constructor(quic: WebTransport, version: Version) {
 		this.#quic = quic;
+		this.version = version;
 	}
 
 	/**
@@ -113,7 +118,7 @@ export class Subscriber {
 		await msg.encode(stream.writer);
 
 		try {
-			await SubscribeOk.decode(stream.reader);
+			await SubscribeOk.decode(stream.reader, this.version);
 			console.debug(`subscribe ok: id=${id} broadcast=${broadcast} track=${request.track.name}`);
 
 			await Promise.race([stream.reader.closed, request.track.closed]);

--- a/js/moq/src/lite/version.ts
+++ b/js/moq/src/lite/version.ts
@@ -1,0 +1,6 @@
+export const Version = {
+	DRAFT_01: 0xff0dad01,
+	DRAFT_02: 0xff0dad02,
+} as const;
+
+export type Version = (typeof Version)[keyof typeof Version];

--- a/rs/hang/src/model/group.rs
+++ b/rs/hang/src/model/group.rs
@@ -4,6 +4,7 @@ use crate::model::{Frame, Timestamp};
 use crate::Result;
 
 use moq_lite::coding::Decode;
+use moq_lite::lite;
 
 /// A consumer for a group of frames.
 ///
@@ -64,7 +65,7 @@ impl GroupConsumer {
 			None => return Ok(None),
 		};
 
-		let micros = u64::decode(&mut payload)?;
+		let micros = u64::decode(&mut payload, lite::Version::Draft02)?;
 		let timestamp = Timestamp::from_micros(micros);
 
 		let frame = Frame {

--- a/rs/hang/src/model/track.rs
+++ b/rs/hang/src/model/track.rs
@@ -4,7 +4,7 @@ use crate::model::{Frame, GroupConsumer, Timestamp};
 use crate::Error;
 use futures::{stream::FuturesUnordered, StreamExt};
 
-use moq_lite::coding::*;
+use moq_lite::{coding::*, lite};
 
 /// A producer for media tracks.
 ///
@@ -41,7 +41,7 @@ impl TrackProducer {
 	pub fn write(&mut self, frame: Frame) {
 		let timestamp = frame.timestamp.as_micros() as u64;
 		let mut header = BytesMut::new();
-		timestamp.encode(&mut header);
+		timestamp.encode(&mut header, lite::Version::Draft02);
 
 		if frame.keyframe {
 			if let Some(group) = self.group.take() {

--- a/rs/moq/src/coding/decode.rs
+++ b/rs/moq/src/coding/decode.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, string::FromUtf8Error};
 use thiserror::Error;
 
-pub trait Decode: Sized {
-	fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, DecodeError>;
+pub trait Decode<V>: Sized {
+	fn decode<B: bytes::Buf>(buf: &mut B, version: V) -> Result<Self, DecodeError>;
 }
 
 /// A decode error.
@@ -48,9 +48,9 @@ pub enum DecodeError {
 	Unsupported,
 }
 
-impl Decode for bool {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		match u8::decode(r)? {
+impl<V> Decode<V> for bool {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		match u8::decode(r, version)? {
 			0 => Ok(false),
 			1 => Ok(true),
 			_ => Err(DecodeError::InvalidValue),
@@ -58,8 +58,8 @@ impl Decode for bool {
 	}
 }
 
-impl Decode for u8 {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+impl<V> Decode<V> for u8 {
+	fn decode<R: bytes::Buf>(r: &mut R, _: V) -> Result<Self, DecodeError> {
 		match r.has_remaining() {
 			true => Ok(r.get_u8()),
 			false => Err(DecodeError::Short),
@@ -67,8 +67,8 @@ impl Decode for u8 {
 	}
 }
 
-impl Decode for u16 {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+impl<V> Decode<V> for u16 {
+	fn decode<R: bytes::Buf>(r: &mut R, _: V) -> Result<Self, DecodeError> {
 		match r.remaining() >= 2 {
 			true => Ok(r.get_u16()),
 			false => Err(DecodeError::Short),
@@ -76,19 +76,19 @@ impl Decode for u16 {
 	}
 }
 
-impl Decode for String {
+impl<V> Decode<V> for String {
 	/// Decode a string with a varint length prefix.
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let v = Vec::<u8>::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		let v = Vec::<u8>::decode(r, version)?;
 		let str = String::from_utf8(v)?;
 
 		Ok(str)
 	}
 }
 
-impl Decode for Vec<u8> {
-	fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, DecodeError> {
-		let size = usize::decode(buf)?;
+impl<V> Decode<V> for Vec<u8> {
+	fn decode<B: bytes::Buf>(buf: &mut B, version: V) -> Result<Self, DecodeError> {
+		let size = usize::decode(buf, version)?;
 
 		if buf.remaining() < size {
 			return Err(DecodeError::Short);
@@ -99,15 +99,8 @@ impl Decode for Vec<u8> {
 	}
 }
 
-impl Decode for std::time::Duration {
-	fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, DecodeError> {
-		let ms = u64::decode(buf)?;
-		Ok(std::time::Duration::from_micros(ms))
-	}
-}
-
-impl Decode for i8 {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+impl<V> Decode<V> for i8 {
+	fn decode<R: bytes::Buf>(r: &mut R, _: V) -> Result<Self, DecodeError> {
 		if !r.has_remaining() {
 			return Err(DecodeError::Short);
 		}
@@ -119,9 +112,9 @@ impl Decode for i8 {
 	}
 }
 
-impl Decode for bytes::Bytes {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let len = usize::decode(r)?;
+impl<V> Decode<V> for bytes::Bytes {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		let len = usize::decode(r, version)?;
 		if r.remaining() < len {
 			return Err(DecodeError::Short);
 		}
@@ -131,9 +124,9 @@ impl Decode for bytes::Bytes {
 }
 
 // TODO Support borrowed strings.
-impl<'a> Decode for Cow<'a, str> {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let s = String::decode(r)?;
+impl<'a, V> Decode<V> for Cow<'a, str> {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		let s = String::decode(r, version)?;
 		Ok(Cow::Owned(s))
 	}
 }

--- a/rs/moq/src/coding/stream.rs
+++ b/rs/moq/src/coding/stream.rs
@@ -3,30 +3,43 @@ use std::sync::Arc;
 use crate::coding::{Reader, Writer};
 use crate::Error;
 
-pub struct Stream<S: web_transport_trait::Session> {
-	pub writer: Writer<S::SendStream>,
-	pub reader: Reader<S::RecvStream>,
+pub struct Stream<S: web_transport_trait::Session, V> {
+	pub writer: Writer<S::SendStream, V>,
+	pub reader: Reader<S::RecvStream, V>,
 }
 
-impl<S: web_transport_trait::Session> Stream<S> {
-	pub async fn open(session: &S) -> Result<Self, Error> {
+impl<S: web_transport_trait::Session, V> Stream<S, V> {
+	pub async fn open(session: &S, version: V) -> Result<Self, Error>
+	where
+		V: Clone,
+	{
 		let (send, recv) = session.open_bi().await.map_err(|err| Error::Transport(Arc::new(err)))?;
 
-		let writer = Writer::new(send);
-		let reader = Reader::new(recv);
+		let writer = Writer::new(send, version.clone());
+		let reader = Reader::new(recv, version);
 
 		Ok(Stream { writer, reader })
 	}
 
-	pub async fn accept(session: &S) -> Result<Self, Error> {
+	pub async fn accept(session: &S, version: V) -> Result<Self, Error>
+	where
+		V: Clone,
+	{
 		let (send, recv) = session
 			.accept_bi()
 			.await
 			.map_err(|err| Error::Transport(Arc::new(err)))?;
 
-		let writer = Writer::new(send);
-		let reader = Reader::new(recv);
+		let writer = Writer::new(send, version.clone());
+		let reader = Reader::new(recv, version);
 
 		Ok(Stream { writer, reader })
+	}
+
+	pub fn with_version<O: Clone>(self, version: O) -> Stream<S, O> {
+		Stream {
+			writer: self.writer.with_version(version.clone()),
+			reader: self.reader.with_version(version),
+		}
 	}
 }

--- a/rs/moq/src/coding/varint.rs
+++ b/rs/moq/src/coding/varint.rs
@@ -157,9 +157,9 @@ impl fmt::Display for VarInt {
 	}
 }
 
-impl Decode for VarInt {
+impl<V> Decode<V> for VarInt {
 	/// Decode a varint from the given reader.
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+	fn decode<R: bytes::Buf>(r: &mut R, _: V) -> Result<Self, DecodeError> {
 		if !r.has_remaining() {
 			return Err(DecodeError::Short);
 		}
@@ -200,9 +200,9 @@ impl Decode for VarInt {
 	}
 }
 
-impl Encode for VarInt {
+impl<V> Encode<V> for VarInt {
 	/// Encode a varint to the given writer.
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, _: V) {
 		if self.0 < (1u64 << 6) {
 			w.put_u8(self.0 as u8);
 		} else if self.0 < (1u64 << 14) {
@@ -215,45 +215,45 @@ impl Encode for VarInt {
 	}
 }
 
-impl Encode for u64 {
+impl<V> Encode<V> for u64 {
 	/// Encode a varint to the given writer.
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
 		// TODO use VarInt everywhere instead of u64
 		let v = VarInt::try_from(*self).expect("u64 too large");
-		v.encode(w)
+		v.encode(w, version)
 	}
 }
 
-impl Decode for u64 {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		VarInt::decode(r).map(|v| v.into_inner())
+impl<V> Decode<V> for u64 {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		VarInt::decode(r, version).map(|v| v.into_inner())
 	}
 }
 
-impl Encode for usize {
+impl<V> Encode<V> for usize {
 	/// Encode a varint to the given writer.
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
 		// TODO use VarInt everywhere instead of usize
 		let v = VarInt::try_from(*self).expect("usize too large");
-		v.encode(w)
+		v.encode(w, version)
 	}
 }
 
-impl Decode for usize {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		VarInt::decode(r).map(|v| v.into_inner() as usize)
+impl<V> Decode<V> for usize {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		VarInt::decode(r, version).map(|v| v.into_inner() as usize)
 	}
 }
 
-impl Encode for u32 {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		VarInt::from(*self).encode(w)
+impl<V> Encode<V> for u32 {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
+		VarInt::from(*self).encode(w, version)
 	}
 }
 
-impl Decode for u32 {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let v = VarInt::decode(r)?;
+impl<V> Decode<V> for u32 {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		let v = VarInt::decode(r, version)?;
 		let v = v.try_into().map_err(|_| DecodeError::BoundsExceeded)?;
 		Ok(v)
 	}

--- a/rs/moq/src/ietf/goaway.rs
+++ b/rs/moq/src/ietf/goaway.rs
@@ -2,7 +2,10 @@
 
 use std::borrow::Cow;
 
-use crate::{coding::*, ietf::Message};
+use crate::{
+	coding::*,
+	ietf::{Message, Version},
+};
 
 /// GoAway message (0x10)
 #[derive(Clone, Debug)]
@@ -13,12 +16,12 @@ pub struct GoAway<'a> {
 impl<'a> Message for GoAway<'a> {
 	const ID: u64 = 0x10;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.new_session_uri.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		self.new_session_uri.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let new_session_uri = Cow::<str>::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let new_session_uri = Cow::<str>::decode(r, version)?;
 		Ok(Self { new_session_uri })
 	}
 }
@@ -30,13 +33,13 @@ mod tests {
 
 	fn encode_message<M: Message>(msg: &M) -> Vec<u8> {
 		let mut buf = BytesMut::new();
-		msg.encode(&mut buf);
+		msg.encode(&mut buf, Version::Draft14);
 		buf.to_vec()
 	}
 
 	fn decode_message<M: Message>(bytes: &[u8]) -> Result<M, DecodeError> {
 		let mut buf = bytes::Bytes::from(bytes.to_vec());
-		M::decode(&mut buf)
+		M::decode(&mut buf, Version::Draft14)
 	}
 
 	#[test]

--- a/rs/moq/src/ietf/location.rs
+++ b/rs/moq/src/ietf/location.rs
@@ -6,17 +6,17 @@ pub struct Location {
 	pub object: u64,
 }
 
-impl Encode for Location {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.group.encode(w);
-		self.object.encode(w);
+impl<V: Clone> Encode<V> for Location {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
+		self.group.encode(w, version.clone());
+		self.object.encode(w, version);
 	}
 }
 
-impl Decode for Location {
-	fn decode<B: bytes::Buf>(buf: &mut B) -> Result<Self, DecodeError> {
-		let group = u64::decode(buf)?;
-		let object = u64::decode(buf)?;
+impl<V: Clone> Decode<V> for Location {
+	fn decode<B: bytes::Buf>(buf: &mut B, version: V) -> Result<Self, DecodeError> {
+		let group = u64::decode(buf, version.clone())?;
+		let object = u64::decode(buf, version)?;
 		Ok(Self { group, object })
 	}
 }

--- a/rs/moq/src/ietf/message.rs
+++ b/rs/moq/src/ietf/message.rs
@@ -1,4 +1,5 @@
-use crate::coding::{DecodeError, Sizer};
+use crate::coding::{self, DecodeError, Sizer};
+use crate::ietf::Version;
 use std::fmt::Debug;
 
 use bytes::{Buf, BufMut};
@@ -13,14 +14,32 @@ pub trait Message: Sized + Debug {
 	const ID: u64;
 
 	/// Encode this message with a size prefix.
-	fn encode<W: BufMut>(&self, w: &mut W);
-
-	fn encode_size(&self) -> u16 {
-		let mut sizer = Sizer::default();
-		self.encode(&mut sizer);
-		sizer.size.try_into().expect("message too large")
-	}
+	fn encode<W: BufMut>(&self, w: &mut W, version: Version);
 
 	/// Decode a size-prefixed message, ensuring exact size consumption.
-	fn decode<B: Buf>(buf: &mut B) -> Result<Self, DecodeError>;
+	fn decode<B: Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError>;
+}
+
+impl<T: Message> coding::Encode<Version> for T {
+	fn encode<W: BufMut>(&self, w: &mut W, version: Version) {
+		// TODO Always encode 2 bytes for the size, then go back and populate it later.
+		// That way we can avoid calculating the size upfront.
+		let mut sizer = Sizer::default();
+		self.encode(&mut sizer, version);
+		let size: u16 = sizer.size.try_into().expect("message too large");
+		size.encode(w, version);
+		self.encode(w, version);
+	}
+}
+
+impl<T: Message> coding::Decode<Version> for T {
+	fn decode<B: Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
+		let size = u16::decode(buf, version)?;
+		let mut limited = buf.take(size as usize);
+		let result = Self::decode(&mut limited, version)?;
+		if limited.remaining() > 0 {
+			return Err(DecodeError::Long);
+		}
+		Ok(result)
+	}
 }

--- a/rs/moq/src/ietf/mod.rs
+++ b/rs/moq/src/ietf/mod.rs
@@ -16,6 +16,7 @@ mod subscribe;
 mod subscribe_namespace;
 mod subscriber;
 mod track;
+mod version;
 
 use control::*;
 pub use fetch::*;
@@ -34,5 +35,4 @@ pub use subscribe::*;
 pub use subscribe_namespace::*;
 use subscriber::*;
 pub use track::*;
-
-pub const ALPN: &str = crate::coding::Alpn::IETF_LATEST.0;
+pub use version::*;

--- a/rs/moq/src/ietf/namespace.rs
+++ b/rs/moq/src/ietf/namespace.rs
@@ -1,23 +1,23 @@
 use crate::{coding::*, Path};
 
 /// Helper function to encode namespace as tuple of strings
-pub fn encode_namespace<W: bytes::BufMut>(w: &mut W, namespace: &Path) {
+pub fn encode_namespace<W: bytes::BufMut, V: Clone>(w: &mut W, namespace: &Path, version: V) {
 	// Split the path by '/' to get individual parts
 	let path_str = namespace.as_str();
 	if path_str.is_empty() {
-		0u64.encode(w);
+		0u64.encode(w, version);
 	} else {
 		let parts: Vec<&str> = path_str.split('/').collect();
-		(parts.len() as u64).encode(w);
+		(parts.len() as u64).encode(w, version.clone());
 		for part in parts {
-			part.encode(w);
+			part.encode(w, version.clone());
 		}
 	}
 }
 
 /// Helper function to decode namespace from tuple of strings
-pub fn decode_namespace<R: bytes::Buf>(r: &mut R) -> Result<Path<'static>, DecodeError> {
-	let count = u64::decode(r)? as usize;
+pub fn decode_namespace<R: bytes::Buf, V: Clone>(r: &mut R, version: V) -> Result<Path<'static>, DecodeError> {
+	let count = u64::decode(r, version.clone())? as usize;
 
 	if count == 0 {
 		return Ok(Path::from(String::new()));
@@ -25,7 +25,7 @@ pub fn decode_namespace<R: bytes::Buf>(r: &mut R) -> Result<Path<'static>, Decod
 
 	let mut parts = Vec::with_capacity(count.min(16));
 	for _ in 0..count {
-		let part = String::decode(r)?;
+		let part = String::decode(r, version.clone())?;
 		parts.push(part);
 	}
 

--- a/rs/moq/src/ietf/request.rs
+++ b/rs/moq/src/ietf/request.rs
@@ -1,6 +1,6 @@
 use crate::{
 	coding::{Decode, DecodeError, Encode},
-	ietf::Message,
+	ietf::{Message, Version},
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -20,15 +20,15 @@ impl std::fmt::Display for RequestId {
 	}
 }
 
-impl Encode for RequestId {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.0.encode(w);
+impl<V> Encode<V> for RequestId {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
+		self.0.encode(w, version);
 	}
 }
 
-impl Decode for RequestId {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let request_id = u64::decode(r)?;
+impl<V> Decode<V> for RequestId {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		let request_id = u64::decode(r, version)?;
 		Ok(Self(request_id))
 	}
 }
@@ -41,12 +41,12 @@ pub struct MaxRequestId {
 impl Message for MaxRequestId {
 	const ID: u64 = 0x15;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.request_id.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let request_id = RequestId::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}
 }
@@ -59,12 +59,12 @@ pub struct RequestsBlocked {
 impl Message for RequestsBlocked {
 	const ID: u64 = 0x1a;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.request_id.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let request_id = RequestId::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}
 }

--- a/rs/moq/src/ietf/setup.rs
+++ b/rs/moq/src/ietf/setup.rs
@@ -1,6 +1,6 @@
 use crate::{
 	coding::*,
-	ietf::{Message, Parameters},
+	ietf::{Message, Parameters, Version as IetfVersion},
 };
 
 /// Sent by the client to setup the session.
@@ -17,17 +17,17 @@ impl Message for ClientSetup {
 	const ID: u64 = 0x20;
 
 	/// Decode a client setup message.
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let versions = Versions::decode(r)?;
-		let parameters = Parameters::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: IetfVersion) -> Result<Self, DecodeError> {
+		let versions = Versions::decode(r, version)?;
+		let parameters = Parameters::decode(r, version)?;
 
 		Ok(Self { versions, parameters })
 	}
 
 	/// Encode a client setup message.
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.versions.encode(w);
-		self.parameters.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: IetfVersion) {
+		self.versions.encode(w, version);
+		self.parameters.encode(w, version);
 	}
 }
 
@@ -44,14 +44,14 @@ pub struct ServerSetup {
 impl Message for ServerSetup {
 	const ID: u64 = 0x21;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.version.encode(w);
-		self.parameters.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: IetfVersion) {
+		self.version.encode(w, version);
+		self.parameters.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let version = Version::decode(r)?;
-		let parameters = Parameters::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: IetfVersion) -> Result<Self, DecodeError> {
+		let version = Version::decode(r, version)?;
+		let parameters = Parameters::decode(r, version)?;
 
 		Ok(Self { version, parameters })
 	}

--- a/rs/moq/src/ietf/subscribe_namespace.rs
+++ b/rs/moq/src/ietf/subscribe_namespace.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use crate::{
 	coding::*,
-	ietf::{Message, Parameters, RequestId},
+	ietf::{Message, Parameters, RequestId, Version},
 	Path,
 };
 
@@ -20,18 +20,18 @@ pub struct SubscribeNamespace<'a> {
 impl<'a> Message for SubscribeNamespace<'a> {
 	const ID: u64 = 0x11;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.request_id.encode(w);
-		encode_namespace(w, &self.namespace);
-		0u8.encode(w); // no parameters
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		self.request_id.encode(w, version);
+		encode_namespace(w, &self.namespace, version);
+		0u8.encode(w, version); // no parameters
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let request_id = RequestId::decode(r)?;
-		let namespace = decode_namespace(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let request_id = RequestId::decode(r, version)?;
+		let namespace = decode_namespace(r, version)?;
 
 		// Ignore parameters, who cares.
-		let _params = Parameters::decode(r)?;
+		let _params = Parameters::decode(r, version)?;
 
 		Ok(Self { namespace, request_id })
 	}
@@ -46,12 +46,12 @@ pub struct SubscribeNamespaceOk {
 impl Message for SubscribeNamespaceOk {
 	const ID: u64 = 0x12;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.request_id.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let request_id = RequestId::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}
 }
@@ -66,16 +66,16 @@ pub struct SubscribeNamespaceError<'a> {
 impl<'a> Message for SubscribeNamespaceError<'a> {
 	const ID: u64 = 0x13;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.request_id.encode(w);
-		self.error_code.encode(w);
-		self.reason_phrase.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		self.request_id.encode(w, version);
+		self.error_code.encode(w, version);
+		self.reason_phrase.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let request_id = RequestId::decode(r)?;
-		let error_code = u64::decode(r)?;
-		let reason_phrase = Cow::<str>::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let request_id = RequestId::decode(r, version)?;
+		let error_code = u64::decode(r, version)?;
+		let reason_phrase = Cow::<str>::decode(r, version)?;
 
 		Ok(Self {
 			request_id,
@@ -94,12 +94,12 @@ pub struct UnsubscribeNamespace {
 impl Message for UnsubscribeNamespace {
 	const ID: u64 = 0x14;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.request_id.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let request_id = RequestId::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}
 }

--- a/rs/moq/src/ietf/subscriber.rs
+++ b/rs/moq/src/ietf/subscriber.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
 	coding::Reader,
-	ietf::{self, Control, FetchHeader, FilterType, GroupFlags, GroupOrder, RequestId},
+	ietf::{self, Control, FetchHeader, FilterType, GroupFlags, GroupOrder, RequestId, Version},
 	model::BroadcastProducer,
 	Broadcast, Error, Frame, FrameProducer, Group, GroupProducer, OriginProducer, Path, PathOwned, Track,
 	TrackProducer,
@@ -47,15 +47,18 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	origin: Option<OriginProducer>,
 	state: Lock<State>,
 	control: Control,
+
+	version: Version,
 }
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
-	pub fn new(session: S, origin: Option<OriginProducer>, control: Control) -> Self {
+	pub fn new(session: S, origin: Option<OriginProducer>, control: Control, version: Version) -> Self {
 		Self {
 			session,
 			origin,
 			state: Default::default(),
 			control,
+			version,
 		}
 	}
 
@@ -187,7 +190,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				.await
 				.map_err(|err| Error::Transport(Arc::new(err)))?;
 
-			let stream = Reader::new(stream);
+			let stream = Reader::new(stream, self.version);
 			let this = self.clone();
 
 			web_async::spawn(async move {
@@ -198,7 +201,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 	}
 
-	async fn run_uni_stream(mut self, mut stream: Reader<S::RecvStream>) -> Result<(), Error> {
+	async fn run_uni_stream(mut self, mut stream: Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		let kind: u64 = stream.decode_peek().await?;
 
 		match kind {
@@ -281,7 +284,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream>) -> Result<(), Error> {
+	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		let group: ietf::GroupHeader = stream.decode().await?;
 		tracing::trace!(?group, "received group header");
 
@@ -332,7 +335,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	async fn run_group(
 		&mut self,
 		group: ietf::GroupHeader,
-		stream: &mut Reader<S::RecvStream>,
+		stream: &mut Reader<S::RecvStream, Version>,
 		mut producer: GroupProducer,
 	) -> Result<(), Error> {
 		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
@@ -379,7 +382,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	async fn run_frame(&mut self, stream: &mut Reader<S::RecvStream>, mut frame: FrameProducer) -> Result<(), Error> {
+	async fn run_frame(
+		&mut self,
+		stream: &mut Reader<S::RecvStream, Version>,
+		mut frame: FrameProducer,
+	) -> Result<(), Error> {
 		let mut remain = frame.info.size;
 
 		tracing::trace!(size = %frame.info.size, "reading frame");

--- a/rs/moq/src/ietf/version.rs
+++ b/rs/moq/src/ietf/version.rs
@@ -1,0 +1,33 @@
+use crate::coding;
+
+pub const ALPN: &str = "moq-00";
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[repr(u64)]
+pub enum Version {
+	Draft14 = 0xff00000e,
+}
+
+impl TryFrom<coding::Version> for Version {
+	type Error = ();
+
+	fn try_from(value: coding::Version) -> Result<Self, Self::Error> {
+		if value == Self::Draft14.into() {
+			Ok(Self::Draft14)
+		} else {
+			Err(())
+		}
+	}
+}
+
+impl From<Version> for coding::Version {
+	fn from(value: Version) -> Self {
+		Self(value as u64)
+	}
+}
+
+impl Version {
+	pub const fn coding(self) -> coding::Version {
+		coding::Version(self as u64)
+	}
+}

--- a/rs/moq/src/lite/group.rs
+++ b/rs/moq/src/lite/group.rs
@@ -1,4 +1,7 @@
-use crate::{coding::*, lite::Message};
+use crate::{
+	coding::*,
+	lite::{Message, Version},
+};
 
 #[derive(Clone, Debug)]
 pub struct Group {
@@ -10,15 +13,15 @@ pub struct Group {
 }
 
 impl Message for Group {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		Ok(Self {
-			subscribe: u64::decode(r)?,
-			sequence: u64::decode(r)?,
+			subscribe: u64::decode(r, version)?,
+			sequence: u64::decode(r, version)?,
 		})
 	}
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.subscribe.encode(w);
-		self.sequence.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		self.subscribe.encode(w, version);
+		self.sequence.encode(w, version);
 	}
 }

--- a/rs/moq/src/lite/info.rs
+++ b/rs/moq/src/lite/info.rs
@@ -1,4 +1,7 @@
-use crate::{coding::*, lite::Message};
+use crate::{
+	coding::*,
+	lite::{Message, Version},
+};
 
 #[derive(Clone, Debug)]
 pub struct SessionInfo {
@@ -6,8 +9,8 @@ pub struct SessionInfo {
 }
 
 impl Message for SessionInfo {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let bitrate = match u64::decode(r)? {
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let bitrate = match u64::decode(r, version)? {
 			0 => None,
 			bitrate => Some(bitrate),
 		};
@@ -15,7 +18,7 @@ impl Message for SessionInfo {
 		Ok(Self { bitrate })
 	}
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.bitrate.unwrap_or(0).encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		self.bitrate.unwrap_or(0).encode(w, version);
 	}
 }

--- a/rs/moq/src/lite/message.rs
+++ b/rs/moq/src/lite/message.rs
@@ -1,6 +1,9 @@
 use bytes::{Buf, BufMut};
 
-use crate::coding::{Decode, DecodeError, Encode, Sizer};
+use crate::{
+	coding::{Decode, DecodeError, Encode, Sizer},
+	lite::Version,
+};
 
 /// A trait for messages that are automatically size-prefixed during encoding/decoding.
 ///
@@ -10,27 +13,27 @@ use crate::coding::{Decode, DecodeError, Encode, Sizer};
 /// - Ensuring no bytes are left over or missing after decoding
 pub trait Message: Sized {
 	/// Encode this message with a size prefix.
-	fn encode<W: BufMut>(&self, w: &mut W);
+	fn encode<W: BufMut>(&self, w: &mut W, version: Version);
 
 	/// Decode a size-prefixed message, ensuring exact size consumption.
-	fn decode<B: Buf>(buf: &mut B) -> Result<Self, DecodeError>;
+	fn decode<B: Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError>;
 }
 
 // Blanket implementation for all types that implement Encode + Decode
-impl<T: Message> Encode for T {
-	fn encode<W: BufMut>(&self, w: &mut W) {
+impl<T: Message> Encode<Version> for T {
+	fn encode<W: BufMut>(&self, w: &mut W, version: Version) {
 		let mut sizer = Sizer::default();
-		Message::encode(self, &mut sizer);
-		sizer.size.encode(w);
-		Message::encode(self, w);
+		Message::encode(self, &mut sizer, version);
+		sizer.size.encode(w, version);
+		Message::encode(self, w, version);
 	}
 }
 
-impl<T: Message> Decode for T {
-	fn decode<B: Buf>(buf: &mut B) -> Result<Self, DecodeError> {
-		let size = usize::decode(buf)?;
+impl<T: Message> Decode<Version> for T {
+	fn decode<B: Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
+		let size = usize::decode(buf, version)?;
 		let mut limited = buf.take(size);
-		let result = Message::decode(&mut limited)?;
+		let result = Message::decode(&mut limited, version)?;
 		if limited.remaining() > 0 {
 			return Err(DecodeError::Long);
 		}

--- a/rs/moq/src/lite/mod.rs
+++ b/rs/moq/src/lite/mod.rs
@@ -10,6 +10,7 @@ mod setup;
 mod stream;
 mod subscribe;
 mod subscriber;
+mod version;
 
 pub use announce::*;
 pub use group::*;
@@ -22,5 +23,4 @@ pub use setup::*;
 pub use stream::*;
 pub use subscribe::*;
 use subscriber::*;
-
-pub const ALPN: &str = crate::coding::Alpn::LITE_LATEST.0;
+pub use version::*;

--- a/rs/moq/src/lite/parameters.rs
+++ b/rs/moq/src/lite/parameters.rs
@@ -7,23 +7,23 @@ const MAX_PARAMS: u64 = 64;
 #[derive(Default, Debug, Clone)]
 pub struct Parameters(HashMap<u64, Vec<u8>>);
 
-impl Decode for Parameters {
-	fn decode<R: bytes::Buf>(mut r: &mut R) -> Result<Self, DecodeError> {
+impl<V: Clone> Decode<V> for Parameters {
+	fn decode<R: bytes::Buf>(mut r: &mut R, version: V) -> Result<Self, DecodeError> {
 		let mut map = HashMap::new();
 
 		// I hate this encoding so much; let me encode my role and get on with my life.
-		let count = u64::decode(r)?;
+		let count = u64::decode(r, version.clone())?;
 		if count > MAX_PARAMS {
 			return Err(DecodeError::TooMany);
 		}
 
 		for _ in 0..count {
-			let kind = u64::decode(r)?;
+			let kind = u64::decode(r, version.clone())?;
 			if map.contains_key(&kind) {
 				return Err(DecodeError::Duplicate);
 			}
 
-			let data = Vec::<u8>::decode(&mut r)?;
+			let data = Vec::<u8>::decode(&mut r, version.clone())?;
 			map.insert(kind, data);
 		}
 
@@ -31,13 +31,13 @@ impl Decode for Parameters {
 	}
 }
 
-impl Encode for Parameters {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.0.len().encode(w);
+impl<V: Clone> Encode<V> for Parameters {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
+		self.0.len().encode(w, version.clone());
 
 		for (kind, value) in self.0.iter() {
-			kind.encode(w);
-			value.encode(w);
+			kind.encode(w, version.clone());
+			value.encode(w, version.clone());
 		}
 	}
 }

--- a/rs/moq/src/lite/setup.rs
+++ b/rs/moq/src/lite/setup.rs
@@ -1,6 +1,6 @@
 use crate::{
 	coding::*,
-	lite::{Message, Parameters},
+	lite::{self, Message, Parameters},
 };
 
 /// Sent by the client to setup the session.
@@ -15,17 +15,17 @@ pub struct ClientSetup {
 
 impl Message for ClientSetup {
 	/// Decode a client setup message.
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let versions = Versions::decode(r)?;
-		let parameters = Parameters::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: lite::Version) -> Result<Self, DecodeError> {
+		let versions = Versions::decode(r, version)?;
+		let parameters = Parameters::decode(r, version)?;
 
 		Ok(Self { versions, parameters })
 	}
 
 	/// Encode a client setup message.
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.versions.encode(w);
-		self.parameters.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: lite::Version) {
+		self.versions.encode(w, version);
+		self.parameters.encode(w, version);
 	}
 }
 
@@ -40,14 +40,14 @@ pub struct ServerSetup {
 }
 
 impl Message for ServerSetup {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.version.encode(w);
-		self.parameters.encode(w);
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: lite::Version) {
+		self.version.encode(w, version);
+		self.parameters.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let version = Version::decode(r)?;
-		let parameters = Parameters::decode(r)?;
+	fn decode<R: bytes::Buf>(r: &mut R, version: lite::Version) -> Result<Self, DecodeError> {
+		let version = Version::decode(r, version)?;
+		let parameters = Parameters::decode(r, version)?;
 
 		Ok(Self { version, parameters })
 	}

--- a/rs/moq/src/lite/stream.rs
+++ b/rs/moq/src/lite/stream.rs
@@ -18,17 +18,17 @@ pub enum ControlType {
 	ServerCompatV14 = 0x21,
 }
 
-impl Decode for ControlType {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let t = u64::decode(r)?;
+impl<V> Decode<V> for ControlType {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		let t = u64::decode(r, version)?;
 		t.try_into().map_err(|_| DecodeError::InvalidValue)
 	}
 }
 
-impl Encode for ControlType {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
+impl<V> Encode<V> for ControlType {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
 		let v: u64 = (*self).into();
-		v.encode(w)
+		v.encode(w, version)
 	}
 }
 
@@ -38,16 +38,16 @@ pub enum DataType {
 	Group = 0,
 }
 
-impl Decode for DataType {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		let t = u64::decode(r)?;
+impl<V> Decode<V> for DataType {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		let t = u64::decode(r, version)?;
 		t.try_into().map_err(|_| DecodeError::InvalidValue)
 	}
 }
 
-impl Encode for DataType {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
+impl<V> Encode<V> for DataType {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
 		let v: u64 = (*self).into();
-		v.encode(w)
+		v.encode(w, version)
 	}
 }

--- a/rs/moq/src/lite/subscriber.rs
+++ b/rs/moq/src/lite/subscriber.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
 	coding::{Reader, Stream},
-	lite,
+	lite::{self, Version},
 	model::BroadcastProducer,
 	AsPath, Broadcast, Error, Frame, FrameProducer, Group, GroupProducer, OriginProducer, Path, PathOwned,
 	TrackProducer,
@@ -21,15 +21,17 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	origin: Option<OriginProducer>,
 	subscribes: Lock<HashMap<u64, TrackProducer>>,
 	next_id: Arc<atomic::AtomicU64>,
+	version: Version,
 }
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
-	pub fn new(session: S, origin: Option<OriginProducer>) -> Self {
+	pub fn new(session: S, origin: Option<OriginProducer>, version: Version) -> Self {
 		Self {
 			session,
 			origin,
 			subscribes: Default::default(),
 			next_id: Default::default(),
+			version,
 		}
 	}
 
@@ -49,7 +51,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				.await
 				.map_err(|err| Error::Transport(Arc::new(err)))?;
 
-			let stream = Reader::new(stream);
+			let stream = Reader::new(stream, self.version);
 			let this = self.clone();
 
 			web_async::spawn(async move {
@@ -60,7 +62,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 	}
 
-	async fn run_uni_stream(mut self, mut stream: Reader<S::RecvStream>) -> Result<(), Error> {
+	async fn run_uni_stream(mut self, mut stream: Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		let kind = stream.decode().await?;
 
 		let res = match kind {
@@ -81,7 +83,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Ok(());
 		}
 
-		let mut stream = Stream::open(&self.session).await?;
+		let mut stream = Stream::open(&self.session, self.version).await?;
 		stream.writer.encode(&lite::ControlType::Announce).await?;
 
 		tracing::trace!(root = %self.log_path(""), "announced start");
@@ -205,7 +207,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	async fn run_track(&mut self, msg: lite::Subscribe<'_>) -> Result<(), Error> {
-		let mut stream = Stream::open(&self.session).await?;
+		let mut stream = Stream::open(&self.session, self.version).await?;
 		stream.writer.encode(&lite::ControlType::Subscribe).await?;
 
 		if let Err(err) = self.run_track_stream(&mut stream, msg).await {
@@ -217,7 +219,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		stream.writer.closed().await
 	}
 
-	async fn run_track_stream(&mut self, stream: &mut Stream<S>, msg: lite::Subscribe<'_>) -> Result<(), Error> {
+	async fn run_track_stream(
+		&mut self,
+		stream: &mut Stream<S, Version>,
+		msg: lite::Subscribe<'_>,
+	) -> Result<(), Error> {
 		stream.writer.encode(&msg).await?;
 
 		// TODO use the response correctly populate the track info
@@ -229,7 +235,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream>) -> Result<(), Error> {
+	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		let hdr: lite::Group = stream.decode().await?;
 
 		let group = {
@@ -263,7 +269,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	async fn run_group(&mut self, stream: &mut Reader<S::RecvStream>, mut group: GroupProducer) -> Result<(), Error> {
+	async fn run_group(
+		&mut self,
+		stream: &mut Reader<S::RecvStream, Version>,
+		mut group: GroupProducer,
+	) -> Result<(), Error> {
 		while let Some(size) = stream.decode_maybe::<u64>().await? {
 			let frame = group.create_frame(Frame { size });
 
@@ -283,7 +293,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	async fn run_frame(&mut self, stream: &mut Reader<S::RecvStream>, mut frame: FrameProducer) -> Result<(), Error> {
+	async fn run_frame(
+		&mut self,
+		stream: &mut Reader<S::RecvStream, Version>,
+		mut frame: FrameProducer,
+	) -> Result<(), Error> {
 		let mut remain = frame.info.size;
 
 		tracing::trace!(size = %frame.info.size, "reading frame");

--- a/rs/moq/src/lite/version.rs
+++ b/rs/moq/src/lite/version.rs
@@ -1,0 +1,40 @@
+use crate::coding;
+
+/// The ALPN string for the Lite protocol.
+///
+/// NOTE: The version is still negotiated via the setup message.
+/// In the future we'll use ALPN instead.
+pub const ALPN: &str = "moql";
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[repr(u64)]
+pub enum Version {
+	Draft01 = 0xff0dad01,
+	Draft02 = 0xff0dad02,
+}
+
+impl TryFrom<coding::Version> for Version {
+	type Error = ();
+
+	fn try_from(value: coding::Version) -> Result<Self, Self::Error> {
+		if value == Self::Draft01.coding() {
+			Ok(Self::Draft01)
+		} else if value == Self::Draft02.coding() {
+			Ok(Self::Draft02)
+		} else {
+			Err(())
+		}
+	}
+}
+
+impl From<Version> for coding::Version {
+	fn from(value: Version) -> Self {
+		value.coding()
+	}
+}
+
+impl Version {
+	pub const fn coding(self) -> coding::Version {
+		coding::Version(self as u64)
+	}
+}

--- a/rs/moq/src/path.rs
+++ b/rs/moq/src/path.rs
@@ -288,15 +288,15 @@ impl<'a> Display for Path<'a> {
 	}
 }
 
-impl<'a> Decode for Path<'a> {
-	fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-		Ok(String::decode(r)?.into())
+impl<'a, V> Decode<V> for Path<'a> {
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		Ok(String::decode(r, version)?.into())
 	}
 }
 
-impl<'a> Encode for Path<'a> {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W) {
-		self.as_str().encode(w)
+impl<'a, V> Encode<V> for Path<'a> {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
+		self.as_str().encode(w, version)
 	}
 }
 


### PR DESCRIPTION
Now it's muuuuch easier to support different message encodings in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple protocol versions, including Lite DRAFT_02 and DRAFT_01, alongside IETF DRAFT_14.
  * Implemented protocol version negotiation for enhanced compatibility across different client and server versions.

* **Improvements**
  * Enhanced version compatibility validation to ensure seamless session establishment across supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->