### PR TITLE
Fix IETF encoding.

### DIFF
--- a/rs/moq/src/ietf/fetch.rs
+++ b/rs/moq/src/ietf/fetch.rs
@@ -113,7 +113,7 @@ pub struct Fetch<'a> {
 impl<'a> Message for Fetch<'a> {
 	const ID: u64 = 0x16;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.subscriber_priority.encode(w, version);
 		self.group_order.encode(w, version);
@@ -122,7 +122,7 @@ impl<'a> Message for Fetch<'a> {
 		0u8.encode(w, version);
 	}
 
-	fn decode<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(buf, version)?;
 		let subscriber_priority = u8::decode(buf, version)?;
 		let group_order = GroupOrder::decode(buf, version)?;
@@ -149,7 +149,7 @@ pub struct FetchOk {
 impl Message for FetchOk {
 	const ID: u64 = 0x18;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.group_order.encode(w, version);
 		self.end_of_track.encode(w, version);
@@ -158,7 +158,7 @@ impl Message for FetchOk {
 		0u8.encode(w, version);
 	}
 
-	fn decode<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(buf, version)?;
 		let group_order = GroupOrder::decode(buf, version)?;
 		let end_of_track = bool::decode(buf, version)?;
@@ -184,13 +184,13 @@ pub struct FetchError<'a> {
 impl<'a> Message for FetchError<'a> {
 	const ID: u64 = 0x19;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.error_code.encode(w, version);
 		self.reason_phrase.encode(w, version);
 	}
 
-	fn decode<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(buf, version)?;
 		let error_code = u64::decode(buf, version)?;
 		let reason_phrase = Cow::<str>::decode(buf, version)?;
@@ -209,11 +209,11 @@ pub struct FetchCancel {
 impl Message for FetchCancel {
 	const ID: u64 = 0x17;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 	}
 
-	fn decode<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(buf, version)?;
 		Ok(Self { request_id })
 	}

--- a/rs/moq/src/ietf/goaway.rs
+++ b/rs/moq/src/ietf/goaway.rs
@@ -16,11 +16,11 @@ pub struct GoAway<'a> {
 impl<'a> Message for GoAway<'a> {
 	const ID: u64 = 0x10;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.new_session_uri.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let new_session_uri = Cow::<str>::decode(r, version)?;
 		Ok(Self { new_session_uri })
 	}
@@ -33,13 +33,13 @@ mod tests {
 
 	fn encode_message<M: Message>(msg: &M) -> Vec<u8> {
 		let mut buf = BytesMut::new();
-		msg.encode(&mut buf, Version::Draft14);
+		msg.encode_msg(&mut buf, Version::Draft14);
 		buf.to_vec()
 	}
 
 	fn decode_message<M: Message>(bytes: &[u8]) -> Result<M, DecodeError> {
 		let mut buf = bytes::Bytes::from(bytes.to_vec());
-		M::decode(&mut buf, Version::Draft14)
+		M::decode_msg(&mut buf, Version::Draft14)
 	}
 
 	#[test]

--- a/rs/moq/src/ietf/publish.rs
+++ b/rs/moq/src/ietf/publish.rs
@@ -127,14 +127,14 @@ pub struct PublishDone<'a> {
 impl<'a> Message for PublishDone<'a> {
 	const ID: u64 = 0x0b;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.status_code.encode(w, version);
 		self.stream_count.encode(w, version);
 		self.reason_phrase.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let status_code = u64::decode(r, version)?;
 		let stream_count = u64::decode(r, version)?;
@@ -164,7 +164,7 @@ pub struct Publish<'a> {
 impl<'a> Message for Publish<'a> {
 	const ID: u64 = 0x1D;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		encode_namespace(w, &self.track_namespace, version);
 		self.track_name.encode(w, version);
@@ -182,7 +182,7 @@ impl<'a> Message for Publish<'a> {
 		0u8.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let track_namespace = decode_namespace(r, version)?;
 		let track_name = Cow::<str>::decode(r, version)?;
@@ -221,7 +221,7 @@ pub struct PublishOk {
 impl Message for PublishOk {
 	const ID: u64 = 0x1E;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.forward.encode(w, version);
 		self.subscriber_priority.encode(w, version);
@@ -235,7 +235,7 @@ impl Message for PublishOk {
 		0u8.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let forward = bool::decode(r, version)?;
 		let subscriber_priority = u8::decode(r, version)?;
@@ -274,13 +274,13 @@ pub struct PublishError<'a> {
 impl<'a> Message for PublishError<'a> {
 	const ID: u64 = 0x1F;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.error_code.encode(w, version);
 		self.reason_phrase.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let error_code = u64::decode(r, version)?;
 		let reason_phrase = Cow::<str>::decode(r, version)?;

--- a/rs/moq/src/ietf/publish_namespace.rs
+++ b/rs/moq/src/ietf/publish_namespace.rs
@@ -21,13 +21,13 @@ pub struct PublishNamespace<'a> {
 impl<'a> Message for PublishNamespace<'a> {
 	const ID: u64 = 0x06;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		encode_namespace(w, &self.track_namespace, version);
 		0u8.encode(w, version); // number of parameters
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let track_namespace = decode_namespace(r, version)?;
 
@@ -50,11 +50,11 @@ pub struct PublishNamespaceOk {
 impl Message for PublishNamespaceOk {
 	const ID: u64 = 0x07;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}
@@ -71,13 +71,13 @@ pub struct PublishNamespaceError<'a> {
 impl<'a> Message for PublishNamespaceError<'a> {
 	const ID: u64 = 0x08;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.error_code.encode(w, version);
 		self.reason_phrase.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let error_code = u64::decode(r, version)?;
 		let reason_phrase = Cow::<str>::decode(r, version)?;
@@ -98,11 +98,11 @@ pub struct PublishNamespaceDone<'a> {
 impl<'a> Message for PublishNamespaceDone<'a> {
 	const ID: u64 = 0x09;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		encode_namespace(w, &self.track_namespace, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let track_namespace = decode_namespace(r, version)?;
 		Ok(Self { track_namespace })
 	}
@@ -119,13 +119,13 @@ pub struct PublishNamespaceCancel<'a> {
 impl<'a> Message for PublishNamespaceCancel<'a> {
 	const ID: u64 = 0x0c;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		encode_namespace(w, &self.track_namespace, version);
 		self.error_code.encode(w, version);
 		self.reason_phrase.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let track_namespace = decode_namespace(r, version)?;
 		let error_code = u64::decode(r, version)?;
 		let reason_phrase = Cow::<str>::decode(r, version)?;
@@ -144,13 +144,13 @@ mod tests {
 
 	fn encode_message<M: Message>(msg: &M) -> Vec<u8> {
 		let mut buf = BytesMut::new();
-		msg.encode(&mut buf, Version::Draft14);
+		msg.encode_msg(&mut buf, Version::Draft14);
 		buf.to_vec()
 	}
 
 	fn decode_message<M: Message>(bytes: &[u8]) -> Result<M, DecodeError> {
 		let mut buf = bytes::Bytes::from(bytes.to_vec());
-		M::decode(&mut buf, Version::Draft14)
+		M::decode_msg(&mut buf, Version::Draft14)
 	}
 
 	#[test]

--- a/rs/moq/src/ietf/request.rs
+++ b/rs/moq/src/ietf/request.rs
@@ -41,11 +41,11 @@ pub struct MaxRequestId {
 impl Message for MaxRequestId {
 	const ID: u64 = 0x15;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}
@@ -59,11 +59,11 @@ pub struct RequestsBlocked {
 impl Message for RequestsBlocked {
 	const ID: u64 = 0x1a;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}

--- a/rs/moq/src/ietf/session.rs
+++ b/rs/moq/src/ietf/session.rs
@@ -87,122 +87,122 @@ async fn run_control_read<S: web_transport_trait::Session>(
 
 		match id {
 			ietf::Subscribe::ID => {
-				let msg = ietf::Subscribe::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::Subscribe::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_subscribe(msg)?;
 			}
 			ietf::SubscribeUpdate::ID => {
-				let msg = ietf::SubscribeUpdate::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::SubscribeUpdate::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_subscribe_update(msg)?;
 			}
 			ietf::SubscribeOk::ID => {
-				let msg = ietf::SubscribeOk::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::SubscribeOk::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_subscribe_ok(msg)?;
 			}
 			ietf::SubscribeError::ID => {
-				let msg = ietf::SubscribeError::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::SubscribeError::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_subscribe_error(msg)?;
 			}
 			ietf::PublishNamespace::ID => {
-				let msg = ietf::PublishNamespace::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::PublishNamespace::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_publish_namespace(msg)?;
 			}
 			ietf::PublishNamespaceOk::ID => {
-				let msg = ietf::PublishNamespaceOk::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::PublishNamespaceOk::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_publish_namespace_ok(msg)?;
 			}
 			ietf::PublishNamespaceError::ID => {
-				let msg = ietf::PublishNamespaceError::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::PublishNamespaceError::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_publish_namespace_error(msg)?;
 			}
 			ietf::PublishNamespaceDone::ID => {
-				let msg = ietf::PublishNamespaceDone::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::PublishNamespaceDone::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_publish_namespace_done(msg)?;
 			}
 			ietf::Unsubscribe::ID => {
-				let msg = ietf::Unsubscribe::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::Unsubscribe::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_unsubscribe(msg)?;
 			}
 			ietf::PublishDone::ID => {
-				let msg = ietf::PublishDone::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::PublishDone::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_publish_done(msg)?;
 			}
 			ietf::PublishNamespaceCancel::ID => {
-				let msg = ietf::PublishNamespaceCancel::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::PublishNamespaceCancel::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_publish_namespace_cancel(msg)?;
 			}
 			ietf::TrackStatus::ID => {
-				let msg = ietf::TrackStatus::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::TrackStatus::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_track_status(msg)?;
 			}
 			ietf::GoAway::ID => {
-				let msg = ietf::GoAway::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::GoAway::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				return Err(Error::Unsupported);
 			}
 			ietf::SubscribeNamespace::ID => {
-				let msg = ietf::SubscribeNamespace::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::SubscribeNamespace::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_subscribe_namespace(msg)?;
 			}
 			ietf::SubscribeNamespaceOk::ID => {
-				let msg = ietf::SubscribeNamespaceOk::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::SubscribeNamespaceOk::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_subscribe_namespace_ok(msg)?;
 			}
 			ietf::SubscribeNamespaceError::ID => {
-				let msg = ietf::SubscribeNamespaceError::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::SubscribeNamespaceError::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_subscribe_namespace_error(msg)?;
 			}
 			ietf::UnsubscribeNamespace::ID => {
-				let msg = ietf::UnsubscribeNamespace::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::UnsubscribeNamespace::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_unsubscribe_namespace(msg)?;
 			}
 			ietf::MaxRequestId::ID => {
-				let msg = ietf::MaxRequestId::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::MaxRequestId::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				control.max_request_id(msg.request_id);
 			}
 			ietf::RequestsBlocked::ID => {
-				let msg = ietf::RequestsBlocked::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::RequestsBlocked::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				tracing::warn!(?msg, "ignoring requests blocked");
 			}
 			ietf::Fetch::ID => {
-				let msg = ietf::Fetch::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::Fetch::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_fetch(msg)?;
 			}
 			ietf::FetchCancel::ID => {
-				let msg = ietf::FetchCancel::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::FetchCancel::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				publisher.recv_fetch_cancel(msg)?;
 			}
 			ietf::FetchOk::ID => {
-				let msg = ietf::FetchOk::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::FetchOk::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_fetch_ok(msg)?;
 			}
 			ietf::FetchError::ID => {
-				let msg = ietf::FetchError::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::FetchError::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_fetch_error(msg)?;
 			}
 			ietf::Publish::ID => {
-				let msg = ietf::Publish::decode(&mut data, ietf::Version::Draft14)?;
+				let msg = ietf::Publish::decode_msg(&mut data, ietf::Version::Draft14)?;
 				tracing::debug!(message = ?msg, "received control message");
 				subscriber.recv_publish(msg)?;
 			}

--- a/rs/moq/src/ietf/setup.rs
+++ b/rs/moq/src/ietf/setup.rs
@@ -17,7 +17,7 @@ impl Message for ClientSetup {
 	const ID: u64 = 0x20;
 
 	/// Decode a client setup message.
-	fn decode<R: bytes::Buf>(r: &mut R, version: IetfVersion) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: IetfVersion) -> Result<Self, DecodeError> {
 		let versions = Versions::decode(r, version)?;
 		let parameters = Parameters::decode(r, version)?;
 
@@ -25,7 +25,7 @@ impl Message for ClientSetup {
 	}
 
 	/// Encode a client setup message.
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: IetfVersion) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: IetfVersion) {
 		self.versions.encode(w, version);
 		self.parameters.encode(w, version);
 	}
@@ -44,12 +44,12 @@ pub struct ServerSetup {
 impl Message for ServerSetup {
 	const ID: u64 = 0x21;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: IetfVersion) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: IetfVersion) {
 		self.version.encode(w, version);
 		self.parameters.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: IetfVersion) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: IetfVersion) -> Result<Self, DecodeError> {
 		let version = Version::decode(r, version)?;
 		let parameters = Parameters::decode(r, version)?;
 

--- a/rs/moq/src/ietf/subscribe.rs
+++ b/rs/moq/src/ietf/subscribe.rs
@@ -48,7 +48,7 @@ pub struct Subscribe<'a> {
 impl<'a> Message for Subscribe<'a> {
 	const ID: u64 = 0x03;
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 
 		// Decode namespace (tuple of strings)
@@ -89,7 +89,7 @@ impl<'a> Message for Subscribe<'a> {
 		})
 	}
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		encode_namespace(w, &self.track_namespace, version);
 		self.track_name.encode(w, version);
@@ -117,7 +117,7 @@ pub struct SubscribeOk {
 impl Message for SubscribeOk {
 	const ID: u64 = 0x04;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.track_alias.encode(w, version);
 		0u64.encode(w, version); // expires = 0
@@ -126,7 +126,7 @@ impl Message for SubscribeOk {
 		0u8.encode(w, version); // no parameters
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let track_alias = u64::decode(r, version)?;
 
@@ -165,12 +165,12 @@ pub struct SubscribeError<'a> {
 impl<'a> Message for SubscribeError<'a> {
 	const ID: u64 = 0x05;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.error_code.encode(w, version);
 		self.reason_phrase.encode(w, version);
 	}
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let error_code = u64::decode(r, version)?;
 		let reason_phrase = Cow::<str>::decode(r, version)?;
@@ -192,11 +192,11 @@ pub struct Unsubscribe {
 impl Message for Unsubscribe {
 	const ID: u64 = 0x0a;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}
@@ -228,7 +228,7 @@ pub struct SubscribeUpdate {
 impl Message for SubscribeUpdate {
 	const ID: u64 = 0x02;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.subscription_request_id.encode(w, version);
 		self.start_location.encode(w, version);
@@ -238,7 +238,7 @@ impl Message for SubscribeUpdate {
 		0u8.encode(w, version); // no parameters
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let subscription_request_id = RequestId::decode(r, version)?;
 		let start_location = Location::decode(r, version)?;
@@ -265,13 +265,13 @@ mod tests {
 
 	fn encode_message<M: Message>(msg: &M) -> Vec<u8> {
 		let mut buf = BytesMut::new();
-		msg.encode(&mut buf, Version::Draft14);
+		msg.encode_msg(&mut buf, Version::Draft14);
 		buf.to_vec()
 	}
 
 	fn decode_message<M: Message>(bytes: &[u8]) -> Result<M, DecodeError> {
 		let mut buf = bytes::Bytes::from(bytes.to_vec());
-		M::decode(&mut buf, Version::Draft14)
+		M::decode_msg(&mut buf, Version::Draft14)
 	}
 
 	#[test]

--- a/rs/moq/src/ietf/subscribe_namespace.rs
+++ b/rs/moq/src/ietf/subscribe_namespace.rs
@@ -20,13 +20,13 @@ pub struct SubscribeNamespace<'a> {
 impl<'a> Message for SubscribeNamespace<'a> {
 	const ID: u64 = 0x11;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		encode_namespace(w, &self.namespace, version);
 		0u8.encode(w, version); // no parameters
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let namespace = decode_namespace(r, version)?;
 
@@ -46,11 +46,11 @@ pub struct SubscribeNamespaceOk {
 impl Message for SubscribeNamespaceOk {
 	const ID: u64 = 0x12;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}
@@ -66,13 +66,13 @@ pub struct SubscribeNamespaceError<'a> {
 impl<'a> Message for SubscribeNamespaceError<'a> {
 	const ID: u64 = 0x13;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		self.error_code.encode(w, version);
 		self.reason_phrase.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let error_code = u64::decode(r, version)?;
 		let reason_phrase = Cow::<str>::decode(r, version)?;
@@ -94,11 +94,11 @@ pub struct UnsubscribeNamespace {
 impl Message for UnsubscribeNamespace {
 	const ID: u64 = 0x14;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		Ok(Self { request_id })
 	}

--- a/rs/moq/src/ietf/track.rs
+++ b/rs/moq/src/ietf/track.rs
@@ -23,7 +23,7 @@ pub struct TrackStatus<'a> {
 impl<'a> Message for TrackStatus<'a> {
 	const ID: u64 = 0x0d;
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.request_id.encode(w, version);
 		encode_namespace(w, &self.track_namespace, version);
 		self.track_name.encode(w, version);
@@ -34,7 +34,7 @@ impl<'a> Message for TrackStatus<'a> {
 		0u8.encode(w, version); // no parameters
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let request_id = RequestId::decode(r, version)?;
 		let track_namespace = decode_namespace(r, version)?;
 		let track_name = Cow::<str>::decode(r, version)?;

--- a/rs/moq/src/lite/announce.rs
+++ b/rs/moq/src/lite/announce.rs
@@ -22,7 +22,7 @@ pub enum Announce<'a> {
 }
 
 impl<'a> Message for Announce<'a> {
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		Ok(match AnnounceStatus::decode(r, version)? {
 			AnnounceStatus::Active => Self::Active {
 				suffix: Path::decode(r, version)?,
@@ -33,7 +33,7 @@ impl<'a> Message for Announce<'a> {
 		})
 	}
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		match self {
 			Self::Active { suffix } => {
 				AnnounceStatus::Active.encode(w, version);
@@ -55,12 +55,12 @@ pub struct AnnouncePlease<'a> {
 }
 
 impl<'a> Message for AnnouncePlease<'a> {
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let prefix = Path::decode(r, version)?;
 		Ok(Self { prefix })
 	}
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.prefix.encode(w, version)
 	}
 }
@@ -96,7 +96,7 @@ pub struct AnnounceInit<'a> {
 }
 
 impl<'a> Message for AnnounceInit<'a> {
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let count = u64::decode(r, version)?;
 
 		// Don't allocate more than 1024 elements upfront
@@ -109,7 +109,7 @@ impl<'a> Message for AnnounceInit<'a> {
 		Ok(Self { suffixes: paths })
 	}
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		(self.suffixes.len() as u64).encode(w, version);
 		for path in &self.suffixes {
 			path.encode(w, version);

--- a/rs/moq/src/lite/group.rs
+++ b/rs/moq/src/lite/group.rs
@@ -13,14 +13,14 @@ pub struct Group {
 }
 
 impl Message for Group {
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		Ok(Self {
 			subscribe: u64::decode(r, version)?,
 			sequence: u64::decode(r, version)?,
 		})
 	}
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.subscribe.encode(w, version);
 		self.sequence.encode(w, version);
 	}

--- a/rs/moq/src/lite/info.rs
+++ b/rs/moq/src/lite/info.rs
@@ -9,7 +9,7 @@ pub struct SessionInfo {
 }
 
 impl Message for SessionInfo {
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let bitrate = match u64::decode(r, version)? {
 			0 => None,
 			bitrate => Some(bitrate),
@@ -18,7 +18,7 @@ impl Message for SessionInfo {
 		Ok(Self { bitrate })
 	}
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.bitrate.unwrap_or(0).encode(w, version);
 	}
 }

--- a/rs/moq/src/lite/message.rs
+++ b/rs/moq/src/lite/message.rs
@@ -13,19 +13,19 @@ use crate::{
 /// - Ensuring no bytes are left over or missing after decoding
 pub trait Message: Sized {
 	/// Encode this message with a size prefix.
-	fn encode<W: BufMut>(&self, w: &mut W, version: Version);
+	fn encode_msg<W: BufMut>(&self, w: &mut W, version: Version);
 
 	/// Decode a size-prefixed message, ensuring exact size consumption.
-	fn decode<B: Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError>;
+	fn decode_msg<B: Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError>;
 }
 
 // Blanket implementation for all types that implement Encode + Decode
 impl<T: Message> Encode<Version> for T {
 	fn encode<W: BufMut>(&self, w: &mut W, version: Version) {
 		let mut sizer = Sizer::default();
-		Message::encode(self, &mut sizer, version);
+		Message::encode_msg(self, &mut sizer, version);
 		sizer.size.encode(w, version);
-		Message::encode(self, w, version);
+		Message::encode_msg(self, w, version);
 	}
 }
 
@@ -33,7 +33,7 @@ impl<T: Message> Decode<Version> for T {
 	fn decode<B: Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
 		let size = usize::decode(buf, version)?;
 		let mut limited = buf.take(size);
-		let result = Message::decode(&mut limited, version)?;
+		let result = Message::decode_msg(&mut limited, version)?;
 		if limited.remaining() > 0 {
 			return Err(DecodeError::Long);
 		}

--- a/rs/moq/src/lite/setup.rs
+++ b/rs/moq/src/lite/setup.rs
@@ -15,7 +15,7 @@ pub struct ClientSetup {
 
 impl Message for ClientSetup {
 	/// Decode a client setup message.
-	fn decode<R: bytes::Buf>(r: &mut R, version: lite::Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: lite::Version) -> Result<Self, DecodeError> {
 		let versions = Versions::decode(r, version)?;
 		let parameters = Parameters::decode(r, version)?;
 
@@ -23,7 +23,7 @@ impl Message for ClientSetup {
 	}
 
 	/// Encode a client setup message.
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: lite::Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: lite::Version) {
 		self.versions.encode(w, version);
 		self.parameters.encode(w, version);
 	}
@@ -40,12 +40,12 @@ pub struct ServerSetup {
 }
 
 impl Message for ServerSetup {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: lite::Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: lite::Version) {
 		self.version.encode(w, version);
 		self.parameters.encode(w, version);
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: lite::Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: lite::Version) -> Result<Self, DecodeError> {
 		let version = Version::decode(r, version)?;
 		let parameters = Parameters::decode(r, version)?;
 

--- a/rs/moq/src/lite/subscribe.rs
+++ b/rs/moq/src/lite/subscribe.rs
@@ -18,7 +18,7 @@ pub struct Subscribe<'a> {
 }
 
 impl<'a> Message for Subscribe<'a> {
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let id = u64::decode(r, version)?;
 		let broadcast = Path::decode(r, version)?;
 		let track = Cow::<str>::decode(r, version)?;
@@ -32,7 +32,7 @@ impl<'a> Message for Subscribe<'a> {
 		})
 	}
 
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		self.id.encode(w, version);
 		self.broadcast.encode(w, version);
 		self.track.encode(w, version);
@@ -46,13 +46,13 @@ pub struct SubscribeOk {
 }
 
 impl Message for SubscribeOk {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
 		if version == Version::Draft01 {
 			self.priority.encode(w, version);
 		}
 	}
 
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let priority = if version == Version::Draft01 {
 			u8::decode(r, version)?
 		} else {

--- a/rs/moq/src/session.rs
+++ b/rs/moq/src/session.rs
@@ -64,7 +64,7 @@ impl<S: web_transport_trait::Session> Session<S> {
 		// Decode server setup manually
 		let size: u16 = stream.reader.decode().await?;
 		let mut buf = stream.reader.read_exact(size as usize).await?;
-		let server = ietf::ServerSetup::decode(&mut buf, ietf::Version::Draft14)?;
+		let server = ietf::ServerSetup::decode_msg(&mut buf, ietf::Version::Draft14)?;
 		if !buf.is_empty() {
 			return Err(Error::WrongSize);
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal protocol message handling method naming conventions across multiple message types for consistency.
  * Updated server setup configuration structure field naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->