### PR TITLE
feat: avoid unnecessary/unwanted canvas resize on path change

### DIFF
--- a/js/hang/src/watch/video/renderer.ts
+++ b/js/hang/src/watch/video/renderer.ts
@@ -39,8 +39,10 @@ export class Renderer {
 		if (!canvas) return;
 
 		const display = effect.get(this.source.display);
-		canvas.width = display?.width ?? 1;
-		canvas.height = display?.height ?? 1;
+		if (!display) return; // Keep current canvas size until we have new dimensions
+
+		canvas.width = display.width;
+		canvas.height = display.height;
 	}
 
 	// Detect when video should be downloaded.


### PR DESCRIPTION
When the path is changed currently the canvas shortly changes size to a 1:1 aspect ratio because display is undefined. With this change the size is only set when we actually have one.