### PR TITLE
Add latency slider to watch demo

### DIFF
--- a/js/hang-demo/src/index.html
+++ b/js/hang-demo/src/index.html
@@ -28,7 +28,9 @@
 
 	-->
 	<hang-watch url="%VITE_RELAY_URL%" path="bbb" muted controls>
-		<canvas style="width: 100%; height: auto; border-radius: 4px; margin: 0 auto;"></canvas>
+		<div id="watch-container" style="width: 100%; height: auto; border-radius: 4px; margin: 0 auto; position: relative">
+			<canvas style="width: 100%; height: auto;"></canvas>
+		</div>
 	</hang-watch>
 
 	<h3>Other demos:</h3>

--- a/js/hang/src/watch/element.ts
+++ b/js/hang/src/watch/element.ts
@@ -510,6 +510,9 @@ export class HangWatchInstance {
 	}
 
 	#renderBuffering(effect: Effect) {
+		const container = this.parent.querySelector("#watch-container") as HTMLElement;
+		if (!container) return;
+
 		if (!document.getElementById("buffer-spinner-animation")) {
 			const style = document.createElement("style");
 			style.id = "buffer-spinner-animation";
@@ -522,7 +525,7 @@ export class HangWatchInstance {
 			document.head.appendChild(style);
 		}
 
-		const container = DOM.create("div", {
+		const overlay = DOM.create("div", {
 			style: {
 				position: "absolute",
 				display: "none",
@@ -535,7 +538,7 @@ export class HangWatchInstance {
 				zIndex: "1",
 				backgroundColor: "rgba(0, 0, 0, 0.4)",
 				backdropFilter: "blur(2px)",
-				pointerEvents: "auto",
+				pointerEvents: "none",
 			},
 		});
 
@@ -550,20 +553,26 @@ export class HangWatchInstance {
 			},
 		});
 
-		container.appendChild(spinner);
+		overlay.appendChild(spinner);
+		container.appendChild(overlay);
 
 		effect.effect((effect) => {
 			const syncStatus = effect.get(this.video.source.syncStatus);
 			const bufferStatus = effect.get(this.video.source.bufferStatus);
 			const shouldShow = syncStatus.state === "wait" || bufferStatus.state === "empty";
+
 			if (shouldShow) {
-				container.style.display = "flex";
+				overlay.style.display = "flex";
 			} else {
-				container.style.display = "none";
+				overlay.style.display = "none";
 			}
 		});
 
-		DOM.render(effect, this.parent, container);
+		effect.cleanup(() => {
+			if (overlay.parentNode) {
+				overlay.parentNode.removeChild(overlay);
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
This PR addresses #688 by adding a latency slider to the demo page. 

To address this, we created a new method - `renderLatency` - which handles creating the slider and adding the slider to the DOM. We add an event listener to the slider, which fires every time the slider input value changes, and updates the latency signal on the parent.

<img width="640" height="360" alt="Screenshot 2025-11-29 at 10 10 02 AM" src="https://github.com/user-attachments/assets/d60cead7-1924-4ed5-b7ac-f4ed3d2b70fe" />

We can definitely update the look of the slider.

A user can adjust the latency from 0ms to 20,000ms (we can update this).

This PR also makes one other UI change to limit the BufferRenderer / spinner to the canvas element, rather than cover the entirety of the hang-watch element (including controls). We wrap the canvas in a new element - `watch-container` - that encapsulates the canvas and the buffering element.

Testing:
- [ ] You should be able to set the latency on the demo page, and see the latency take affect
- [ ] The buffer spinner / blur should appear over the canvas element when updating the latency

