### PR TITLE
Apply fix to center buffering container

### DIFF
--- a/js/hang-ui/src/Components/watch/styles.css
+++ b/js/hang-ui/src/Components/watch/styles.css
@@ -45,6 +45,7 @@
 
 .bufferingContainer {
 	position: absolute;
+	display: flex;
 	justify-content: center;
 	align-items: center;
 	width: 100%;


### PR DESCRIPTION
Quick little fix to center the `.bufferingContainer` element by applying `display: flex` CSS rule, which was left out when moving `hang-ui` to its own package. 