### PR TITLE
frame caching for rendering on pause

### DIFF
--- a/js/hang/src/watch/video/renderer.ts
+++ b/js/hang/src/watch/video/renderer.ts
@@ -46,7 +46,7 @@ export class Renderer {
 
 		// Only update if dimensions actually changed (setting canvas.width/height clears the canvas)
 		// TODO I thought the signals library would prevent this, but I'm too lazy to investigate.
-		if (canvas.width !== display.width && canvas.height !== display.height) {
+		if (canvas.width !== display.width || canvas.height !== display.height) {
 			canvas.width = display.width;
 			canvas.height = display.height;
 		}


### PR DESCRIPTION
- Added `#lastFrame` signal to cache the most recent frame
- When not paused: updates cache with new frames and renders them
- When paused: uses the cached frame for rendering
- Fixes #765 