### PR TITLE
target_link_libraries

### DIFF
--- a/rs/libmoq/CMakeLists.txt
+++ b/rs/libmoq/CMakeLists.txt
@@ -48,8 +48,9 @@ file(MAKE_DIRECTORY ${RUST_TARGET_DIR}/include)
 add_library(moq INTERFACE)
 target_include_directories(moq INTERFACE ${RUST_TARGET_DIR}/include)
 
-# Force absolute path to be used in linker command
-target_link_options(moq INTERFACE "$<LINK_ONLY:${RUST_LIB}>")
+# Link the static library - must use target_link_libraries so it appears
+# after object files in the link command (linker order matters for static libs)
+target_link_libraries(moq INTERFACE "${RUST_LIB}")
 
 # Link required system frameworks on macOS
 if(APPLE)


### PR DESCRIPTION
✍🏼  Dear Diary,
I ran into this problem when trying to build `obs-moq` where `libmoq` was not ending up in the final `obs-moq.so` file in Linux.  Changing this CMakeLists.txt setting did the trick.

# Problem:
When building projects that link against libmoq (like obs-moq), the Rust static library was not being properly linked into the final binary. This resulted in:
Dramatically smaller output files (~310KB instead of ~31MB)
Runtime errors: undefined symbol: moq_origin_consume and other moq API functions

# Root Cause:
The original code used:
```target_link_options(moq INTERFACE "$<LINK_ONLY:${RUST_LIB}>")```

This approach has issues:
target_link_options is not designed for libraries - it's meant for linker flags (like -Wl,--as-needed), not library files
The `$<LINK_ONLY:...>` generator expression doesn't reliably work with INTERFACE targets in all CMake configurations
CMake's dependency tracking doesn't properly recognize the static library as a link dependency, so it may be silently omitted during the link phase

# Solution:
Using target_link_libraries is the canonical CMake approach for linking libraries:
```target_link_libraries(moq INTERFACE "${RUST_LIB}")```