### PR TITLE
fix: Safari compatibility - replace toArray() with spread operator

### DIFF
--- a/js/lite/src/lite/publisher.ts
+++ b/js/lite/src/lite/publisher.ts
@@ -77,7 +77,7 @@ export class Publisher {
 			active.add(suffix);
 		}
 
-		const init = new AnnounceInit(active.values().toArray());
+		const init = new AnnounceInit([...active]);
 		await init.encode(stream.writer);
 
 		// Wait for updates to the broadcasts.


### PR DESCRIPTION
## Summary

Safari doesn't support `Iterator.prototype.toArray()` yet, causing a crash:

```
TypeError: r.values().toArray is not a function
```

This PR replaces `active.values().toArray()` with `[...active]` (spread operator) which is equivalent and works in Safari.

## Changes

- `js/lite/src/lite/publisher.ts` line 80: `active.values().toArray()` → `[...active]`

## Testing

Tested with Safari 18 using WebSocket fallback via cdn.moq.dev/anon.