### PR TITLE
Integrate time and delivery into model + update protocol layer

### DIFF
--- a/js/lite/src/broadcast.ts
+++ b/js/lite/src/broadcast.ts
@@ -1,15 +1,5 @@
 import { Signal } from "@moq/signals";
-import { Track } from "./track.ts";
-
-export interface TrackRequest {
-	track: Track;
-	priority: number;
-}
-
-export class BroadcastState {
-	requested = new Signal<TrackRequest[]>([]);
-	closed = new Signal<boolean | Error>(false);
-}
+import { Track, type TrackProps } from "./track.js";
 
 /**
  * Handles writing and managing tracks in a broadcast.
@@ -17,13 +7,14 @@ export class BroadcastState {
  * @public
  */
 export class Broadcast {
-	state = new BroadcastState();
+	#requested = new Signal<Track[]>([]);
+	#closed = new Signal<boolean | Error>(false);
 
 	readonly closed: Promise<Error | undefined>;
 
 	constructor() {
 		this.closed = new Promise((resolve) => {
-			const dispose = this.state.closed.subscribe((closed) => {
+			const dispose = this.#closed.subscribe((closed) => {
 				if (!closed) return;
 				resolve(closed instanceof Error ? closed : undefined);
 				dispose();
@@ -34,33 +25,38 @@ export class Broadcast {
 	/**
 	 * A track requested over the network.
 	 */
-	async requested(): Promise<TrackRequest | undefined> {
+	async requested(): Promise<Track | undefined> {
 		for (;;) {
 			// We use pop instead of shift because it's slightly more efficient.
-			const track = this.state.requested.peek().pop();
+			const track = this.#requested.peek().pop();
 			if (track) return track;
 
-			const closed = this.state.closed.peek();
+			const closed = this.#closed.peek();
 			if (closed instanceof Error) throw closed;
 			if (closed) return undefined;
 
-			await Signal.race(this.state.requested, this.state.closed);
+			await Signal.race(this.#requested, this.#closed);
 		}
+	}
+
+	/**
+	 * Creates a new track and serves it over the network.
+	 */
+	subscribe(track: TrackProps): Track {
+		const t = new Track(track);
+		this.serve(t);
+		return t;
 	}
 
 	/**
 	 * Populates the provided track over the network.
 	 */
-	subscribe(name: string, priority: number): Track {
-		const track = new Track(name);
-
-		if (this.state.closed.peek()) {
-			throw new Error(`broadcast is closed: ${this.state.closed.peek()}`);
+	serve(track: Track) {
+		if (this.#closed.peek()) {
+			throw new Error(`broadcast is closed: ${this.#closed.peek()}`);
 		}
-		this.state.requested.mutate((requested) => {
-			requested.push({ track, priority });
-			// Sort the tracks by priority in ascending order (we will pop)
-			requested.sort((a, b) => a.priority - b.priority);
+		this.#requested.mutate((requested) => {
+			requested.push(track);
 		});
 
 		return track;
@@ -72,11 +68,11 @@ export class Broadcast {
 	 * @param abort - If provided, throw this exception instead of returning undefined.
 	 */
 	close(abort?: Error) {
-		this.state.closed.set(abort ?? true);
-		for (const { track } of this.state.requested.peek()) {
+		this.#closed.set(abort ?? true);
+		for (const track of this.#requested.peek()) {
 			track.close(abort);
 		}
-		this.state.requested.mutate((requested) => {
+		this.#requested.mutate((requested) => {
 			requested.length = 0;
 		});
 	}

--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -2,8 +2,11 @@ import WebTransportWs from "@moq/web-transport-ws";
 import * as Ietf from "../ietf/index.ts";
 import * as Lite from "../lite/index.ts";
 import { Stream } from "../stream.ts";
+import type * as Time from "../time.ts";
 import * as Hex from "../util/hex.ts";
 import type { Established } from "./established.ts";
+
+const SUPPORTED = [Lite.Version.DRAFT_03, Lite.Version.DRAFT_02, Lite.Version.DRAFT_01, Ietf.Version.DRAFT_14];
 
 export interface WebSocketOptions {
 	// If true (default), enable the WebSocket fallback.
@@ -13,9 +16,9 @@ export interface WebSocketOptions {
 	// By default, `https` => `wss` and `http` => `ws`.
 	url?: URL;
 
-	// The delay in milliseconds before attempting the WebSocket fallback. (default: 200)
+	// The delay in milliseconds before attempting the WebSocket fallback. (default: 500)
 	// If WebSocket won the previous race for a given URL, this will be 0.
-	delay?: DOMHighResTimeStamp;
+	delay?: Time.Milli;
 }
 
 export interface ConnectProps {
@@ -44,9 +47,9 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 
 	const webtransport = globalThis.WebTransport ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
 
-	// Give QUIC a 200ms head start to connect before trying WebSocket, unless WebSocket has won in the past.
+	// Give QUIC a 500ms head start to connect before trying WebSocket, unless WebSocket has won in the past.
 	// NOTE that QUIC should be faster because it involves 1/2 fewer RTTs.
-	const headstart = !webtransport || websocketWon.has(url.toString()) ? 0 : (props?.websocket?.delay ?? 200);
+	const headstart = !webtransport || websocketWon.has(url.toString()) ? 0 : (props?.websocket?.delay ?? 500);
 	const websocket =
 		props?.websocket?.enabled !== false
 			? connectWebSocket(props?.websocket?.url ?? url, headstart, cancel)
@@ -82,7 +85,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	params.setVarint(Ietf.Parameter.MaxRequestId, 42069n); // Allow a ton of request IDs.
 	params.setBytes(Ietf.Parameter.Implementation, encoder.encode("moq-lite-js")); // Put the implementation name in the parameters.
 
-	const client = new Ietf.ClientSetup([Lite.Version.DRAFT_02, Lite.Version.DRAFT_01, Ietf.Version.DRAFT_14], params);
+	const client = new Ietf.ClientSetup(SUPPORTED, params);
 	console.debug(url.toString(), "sending client setup", client);
 	await client.encode(stream.writer);
 

--- a/js/lite/src/connection/reload.ts
+++ b/js/lite/src/connection/reload.ts
@@ -1,11 +1,12 @@
 import { Effect, Signal } from "@moq/signals";
+import type * as Time from "../time.ts";
 import { type ConnectProps, connect, type WebSocketOptions } from "./connect.ts";
 import type { Established } from "./established.ts";
 
 export type ReloadDelay = {
 	// The delay in milliseconds before reconnecting.
 	// default: 1000
-	initial: DOMHighResTimeStamp;
+	initial: Time.Milli;
 
 	// The multiplier for the delay.
 	// default: 2
@@ -13,7 +14,7 @@ export type ReloadDelay = {
 
 	// The maximum delay in milliseconds.
 	// default: 30000
-	max: DOMHighResTimeStamp;
+	max: Time.Milli;
 };
 
 export type ReloadProps = ConnectProps & {
@@ -48,7 +49,7 @@ export class Reload {
 
 	signals = new Effect();
 
-	#delay: DOMHighResTimeStamp;
+	#delay: Time.Milli;
 
 	// Increased by 1 each time to trigger a reload.
 	#tick = new Signal(0);
@@ -56,7 +57,7 @@ export class Reload {
 	constructor(props?: ReloadProps) {
 		this.url = Signal.from(props?.url);
 		this.enabled = Signal.from(props?.enabled ?? false);
-		this.delay = props?.delay ?? { initial: 1000, multiplier: 2, max: 30000 };
+		this.delay = props?.delay ?? { initial: 1000 as Time.Milli, multiplier: 2, max: 30000 as Time.Milli };
 		this.webtransport = props?.webtransport;
 		this.websocket = props?.websocket;
 
@@ -103,7 +104,7 @@ export class Reload {
 				const tick = this.#tick.peek() + 1;
 				effect.timer(() => this.#tick.update((prev) => Math.max(prev, tick)), this.#delay);
 
-				this.#delay = Math.min(this.#delay * this.delay.multiplier, this.delay.max);
+				this.#delay = Math.min(this.#delay * this.delay.multiplier, this.delay.max) as Time.Milli;
 			}
 		});
 	}

--- a/js/lite/src/frame.ts
+++ b/js/lite/src/frame.ts
@@ -1,0 +1,38 @@
+import * as Time from "./time";
+
+export class Frame {
+	instant: Time.Milli;
+	payload: Uint8Array;
+
+	constructor({ payload, instant = Time.Milli.now() }: { payload: Uint8Array; instant?: Time.Milli }) {
+		this.instant = instant;
+		this.payload = payload;
+	}
+
+	static fromString(str: string, instant = Time.Milli.now()) {
+		return new Frame({ payload: new TextEncoder().encode(str), instant });
+	}
+
+	static fromJson(json: unknown, instant = Time.Milli.now()) {
+		return new Frame({ payload: new TextEncoder().encode(JSON.stringify(json)), instant });
+	}
+
+	static fromBool(bool: boolean, instant = Time.Milli.now()) {
+		return new Frame({ payload: new Uint8Array([bool ? 1 : 0]), instant });
+	}
+
+	toString() {
+		return new TextDecoder().decode(this.payload);
+	}
+
+	toJson() {
+		return JSON.parse(this.toString());
+	}
+
+	toBool() {
+		if (this.payload.byteLength !== 1) throw new Error("invalid bool frame");
+		if (this.payload[0] === 0) return false;
+		if (this.payload[0] === 1) return true;
+		throw new Error("invalid bool frame");
+	}
+}

--- a/js/lite/src/group.ts
+++ b/js/lite/src/group.ts
@@ -1,7 +1,8 @@
 import { Signal } from "@moq/signals";
+import type { Frame } from "./frame";
 
 export class GroupState {
-	frames = new Signal<Uint8Array[]>([]);
+	frames = new Signal<Frame[]>([]);
 	closed = new Signal<boolean | Error>(false);
 	total = new Signal<number>(0); // The total number of frames in the group thus far
 }
@@ -29,7 +30,7 @@ export class Group {
 	 * Writes a frame to the group.
 	 * @param frame - The frame to write
 	 */
-	writeFrame(frame: Uint8Array) {
+	writeFrame(frame: Frame) {
 		if (this.state.closed.peek()) throw new Error("group is closed");
 
 		this.state.frames.mutate((frames) => {
@@ -39,23 +40,11 @@ export class Group {
 		this.state.total.update((total) => total + 1);
 	}
 
-	writeString(str: string) {
-		this.writeFrame(new TextEncoder().encode(str));
-	}
-
-	writeJson(json: unknown) {
-		this.writeString(JSON.stringify(json));
-	}
-
-	writeBool(bool: boolean) {
-		this.writeFrame(new Uint8Array([bool ? 1 : 0]));
-	}
-
 	/**
 	 * Reads the next frame from the group.
 	 * @returns A promise that resolves to the next frame or undefined
 	 */
-	async readFrame(): Promise<Uint8Array | undefined> {
+	async readFrame(): Promise<Frame | undefined> {
 		for (;;) {
 			const frames = this.state.frames.peek();
 			const frame = frames.shift();
@@ -69,11 +58,11 @@ export class Group {
 		}
 	}
 
-	async readFrameSequence(): Promise<{ sequence: number; data: Uint8Array } | undefined> {
+	async readFrameSequence(): Promise<{ sequence: number; frame: Frame } | undefined> {
 		for (;;) {
 			const frames = this.state.frames.peek();
 			const frame = frames.shift();
-			if (frame) return { sequence: this.state.total.peek() - frames.length - 1, data: frame };
+			if (frame) return { sequence: this.state.total.peek() - frames.length - 1, frame };
 
 			const closed = this.state.closed.peek();
 			if (closed instanceof Error) throw closed;
@@ -81,21 +70,6 @@ export class Group {
 
 			await Signal.race(this.state.frames, this.state.closed);
 		}
-	}
-
-	async readString(): Promise<string | undefined> {
-		const frame = await this.readFrame();
-		return frame ? new TextDecoder().decode(frame) : undefined;
-	}
-
-	async readJson(): Promise<unknown | undefined> {
-		const frame = await this.readString();
-		return frame ? JSON.parse(frame) : undefined;
-	}
-
-	async readBool(): Promise<boolean | undefined> {
-		const frame = await this.readFrame();
-		return frame ? frame[0] === 1 : undefined;
 	}
 
 	close(abort?: Error) {

--- a/js/lite/src/ietf/subscriber.ts
+++ b/js/lite/src/ietf/subscriber.ts
@@ -1,12 +1,13 @@
 import { Announced } from "../announced.ts";
-import { Broadcast, type TrackRequest } from "../broadcast.ts";
+import { Broadcast } from "../broadcast.ts";
+import { Frame } from "../frame.ts";
 import { Group } from "../group.ts";
 import * as Path from "../path.ts";
 import type { Reader } from "../stream.ts";
 import type { Track } from "../track.ts";
 import { error } from "../util/error.ts";
 import type * as Control from "./control.ts";
-import { Frame, type Group as GroupMessage } from "./object.ts";
+import { Frame as FrameMessage, type Group as GroupMessage } from "./object.ts";
 import { type Publish, type PublishDone, PublishError } from "./publish.ts";
 import type { PublishNamespace, PublishNamespaceDone } from "./publish_namespace.ts";
 import { Subscribe, type SubscribeError, type SubscribeOk, Unsubscribe } from "./subscribe.ts";
@@ -114,15 +115,15 @@ export class Subscriber {
 		return broadcast;
 	}
 
-	async #runSubscribe(broadcast: Path.Valid, request: TrackRequest) {
+	async #runSubscribe(broadcast: Path.Valid, track: Track) {
 		const requestId = await this.#control.nextRequestId();
 		if (requestId === undefined) return;
 
-		this.#subscribes.set(requestId, request.track);
+		this.#subscribes.set(requestId, track);
 
-		console.debug(`subscribe start: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+		console.debug(`subscribe start: id=${requestId} broadcast=${broadcast} track=${track.name}`);
 
-		const msg = new Subscribe(requestId, broadcast, request.track.name, request.priority);
+		const msg = new Subscribe(requestId, broadcast, track.name, track.priority.peek());
 
 		// Send SUBSCRIBE message on control stream and wait for response
 		const responsePromise = new Promise<SubscribeOk>((resolve, reject) => {
@@ -134,23 +135,23 @@ export class Subscriber {
 		try {
 			const ok = await responsePromise;
 			this.#trackAliases.set(ok.trackAlias, requestId);
-			console.debug(`subscribe ok: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+			console.debug(`subscribe ok: id=${requestId} broadcast=${broadcast} track=${track.name}`);
 
 			try {
-				await request.track.closed;
+				await track.closed;
 
 				const msg = new Unsubscribe(requestId);
 				await this.#control.write(msg);
-				console.debug(`unsubscribe: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+				console.debug(`unsubscribe: id=${requestId} broadcast=${broadcast} track=${track.name}`);
 			} finally {
 				this.#trackAliases.delete(ok.trackAlias);
 			}
 		} catch (err) {
 			const e = error(err);
-			request.track.close(e);
+			track.close(e);
 
 			console.warn(
-				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
+				`subscribe error: id=${requestId} broadcast=${broadcast} track=${track.name} error=${e.message}`,
 			);
 		} finally {
 			this.#subscribes.delete(requestId);
@@ -225,11 +226,14 @@ export class Subscriber {
 				const done = await Promise.race([stream.done(), producer.closed, track.closed]);
 				if (done !== false) break;
 
-				const frame = await Frame.decode(stream, group.flags);
-				if (frame.payload === undefined) break;
+				const msg = await FrameMessage.decode(stream, group.flags);
+				if (msg.payload === undefined) break;
+
+				// TODO support timestamps
+				const frame = new Frame({ payload: msg.payload });
 
 				// Treat each object payload as a frame
-				producer.writeFrame(frame.payload);
+				producer.writeFrame(frame);
 			}
 
 			producer.close();

--- a/js/lite/src/index.ts
+++ b/js/lite/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./announced.ts";
 export * from "./broadcast.ts";
 export * as Connection from "./connection/index.ts";
+export * from "./frame.ts";
 export * from "./group.ts";
 export * as Path from "./path.ts";
 export * as Time from "./time.ts";

--- a/js/lite/src/lite/announce.ts
+++ b/js/lite/src/lite/announce.ts
@@ -29,10 +29,6 @@ export class Announce {
 	static async decode(r: Reader): Promise<Announce> {
 		return Message.decode(r, Announce.#decode);
 	}
-
-	static async decodeMaybe(r: Reader): Promise<Announce | undefined> {
-		return Message.decodeMaybe(r, Announce.#decode);
-	}
 }
 
 export class AnnounceInterest {

--- a/js/lite/src/lite/connection.ts
+++ b/js/lite/src/lite/connection.ts
@@ -125,10 +125,10 @@ export class Connection implements Established {
 	async #runSession() {
 		try {
 			// Receive messages until the connection is closed.
-			for (;;) {
-				const msg = await SessionInfo.decodeMaybe(this.#session.reader);
-				if (!msg) break;
-				// TODO use the session info
+			while (!(await this.#session.reader.done())) {
+				const msg = await SessionInfo.decode(this.#session.reader);
+				// TODO use SessionInfo
+				console.debug("session info", msg);
 			}
 		} finally {
 			console.warn("session stream closed");
@@ -162,7 +162,7 @@ export class Connection implements Established {
 			await this.#publisher.runAnnounce(msg, stream);
 			return;
 		} else if (typ === StreamId.Subscribe) {
-			const msg = await Subscribe.decode(stream.reader);
+			const msg = await Subscribe.decode(stream.reader, this.version);
 			await this.#publisher.runSubscribe(msg, stream);
 			return;
 		} else {
@@ -184,6 +184,7 @@ export class Connection implements Established {
 					stream.stop(new Error("cancel"));
 				})
 				.catch((err: unknown) => {
+					console.warn("error running uni stream", err);
 					stream.stop(err);
 				});
 		}

--- a/js/lite/src/lite/frame.ts
+++ b/js/lite/src/lite/frame.ts
@@ -1,0 +1,61 @@
+import type { Reader, Writer } from "../stream";
+import * as Time from "../time.ts";
+import * as Message from "./message.ts";
+import { Version } from "./version.js";
+
+export class Frame {
+	delta: Time.Milli;
+	payload: Uint8Array;
+
+	constructor({ payload, delta }: { delta: Time.Milli; payload: Uint8Array }) {
+		this.payload = payload;
+		this.delta = delta;
+	}
+
+	async #encode(w: Writer, version: Version) {
+		switch (version) {
+			case Version.DRAFT_03:
+				await w.u53(this.delta);
+				break;
+			case Version.DRAFT_01:
+			case Version.DRAFT_02:
+				break;
+			default: {
+				const v: never = version;
+				throw new Error(`unsupported version: ${v}`);
+			}
+		}
+
+		await w.write(this.payload);
+	}
+
+	static async #decode(r: Reader, version: Version): Promise<Frame> {
+		let delta: Time.Milli;
+
+		switch (version) {
+			case Version.DRAFT_03:
+				delta = (await r.u53()) as Time.Milli;
+				break;
+			case Version.DRAFT_01:
+			case Version.DRAFT_02:
+				// NOTE: The caller is responsible for calling Time.Milli.now()
+				delta = Time.Milli.zero;
+				break;
+			default: {
+				const v: never = version;
+				throw new Error(`unsupported version: ${v}`);
+			}
+		}
+
+		const payload = await r.readAll();
+		return new Frame({ delta, payload });
+	}
+
+	async encode(w: Writer, v: Version): Promise<void> {
+		return Message.encode(w, (w) => this.#encode(w, v));
+	}
+
+	static async decode(r: Reader, v: Version): Promise<Frame> {
+		return Message.decode(r, (r) => Frame.#decode(r, v));
+	}
+}

--- a/js/lite/src/lite/group.ts
+++ b/js/lite/src/lite/group.ts
@@ -26,10 +26,6 @@ export class Group {
 	static async decode(r: Reader): Promise<Group> {
 		return Message.decode(r, Group.#decode);
 	}
-
-	static async decodeMaybe(r: Reader): Promise<Group | undefined> {
-		return Message.decodeMaybe(r, Group.#decode);
-	}
 }
 
 export class GroupDrop {
@@ -59,34 +55,5 @@ export class GroupDrop {
 
 	static async decode(r: Reader): Promise<GroupDrop> {
 		return Message.decode(r, GroupDrop.#decode);
-	}
-
-	static async decodeMaybe(r: Reader): Promise<GroupDrop | undefined> {
-		return Message.decodeMaybe(r, GroupDrop.#decode);
-	}
-}
-
-export class Frame {
-	payload: Uint8Array;
-
-	constructor(payload: Uint8Array) {
-		this.payload = payload;
-	}
-
-	async #encode(w: Writer) {
-		await w.write(this.payload);
-	}
-
-	static async #decode(r: Reader): Promise<Frame> {
-		const payload = await r.readAll();
-		return new Frame(payload);
-	}
-
-	async encode(w: Writer): Promise<void> {
-		return Message.encode(w, this.#encode.bind(this));
-	}
-
-	static async decode(r: Reader): Promise<Frame> {
-		return Message.decode(r, Frame.#decode);
 	}
 }

--- a/js/lite/src/lite/message.ts
+++ b/js/lite/src/lite/message.ts
@@ -52,8 +52,3 @@ export async function decode<T>(reader: Reader, f: (r: Reader) => Promise<T>): P
 
 	return msg;
 }
-
-export async function decodeMaybe<T>(reader: Reader, f: (r: Reader) => Promise<T>): Promise<T | undefined> {
-	if (await reader.done()) return;
-	return await decode(reader, f);
-}

--- a/js/lite/src/lite/session.ts
+++ b/js/lite/src/lite/session.ts
@@ -141,8 +141,4 @@ export class SessionInfo {
 	static async decode(r: Reader): Promise<SessionInfo> {
 		return Message.decode(r, SessionInfo.#decode);
 	}
-
-	static async decodeMaybe(r: Reader): Promise<SessionInfo | undefined> {
-		return Message.decodeMaybe(r, SessionInfo.#decode);
-	}
 }

--- a/js/lite/src/lite/subscribe.ts
+++ b/js/lite/src/lite/subscribe.ts
@@ -1,34 +1,68 @@
 import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
+import * as Time from "../time.ts";
 import * as Message from "./message.ts";
 import { Version } from "./version.ts";
 
 export class SubscribeUpdate {
 	priority: number;
+	ordered: boolean;
+	maxLatency: Time.Milli;
 
-	constructor(priority: number) {
+	constructor({ priority, maxLatency, ordered }: { priority: number; maxLatency: Time.Milli; ordered: boolean }) {
 		this.priority = priority;
+		this.maxLatency = maxLatency;
+		this.ordered = ordered;
 	}
 
-	async #encode(w: Writer) {
-		await w.u8(this.priority);
+	async #encode(w: Writer, version: Version) {
+		switch (version) {
+			case Version.DRAFT_01:
+			case Version.DRAFT_02:
+				await w.u8(this.priority);
+				break;
+			case Version.DRAFT_03:
+				await w.u8(this.priority);
+				await w.bool(this.ordered);
+				await w.u53(this.maxLatency);
+				break;
+			default: {
+				const v: never = version;
+				throw new Error(`unsupported version: ${v}`);
+			}
+		}
 	}
 
-	static async #decode(r: Reader): Promise<SubscribeUpdate> {
-		const priority = await r.u8();
-		return new SubscribeUpdate(priority);
+	static async #decode(r: Reader, version: Version): Promise<SubscribeUpdate> {
+		let priority: number;
+		let maxLatency = Time.Milli.zero;
+		let ordered = false;
+
+		switch (version) {
+			case Version.DRAFT_01:
+			case Version.DRAFT_02:
+				priority = await r.u8();
+				break;
+			case Version.DRAFT_03:
+				priority = await r.u8();
+				ordered = await r.bool();
+				maxLatency = (await r.u53()) as Time.Milli;
+				break;
+			default: {
+				const v: never = version;
+				throw new Error(`unsupported version: ${v}`);
+			}
+		}
+
+		return new SubscribeUpdate({ priority, maxLatency, ordered });
 	}
 
-	async encode(w: Writer): Promise<void> {
-		return Message.encode(w, this.#encode.bind(this));
+	async encode(w: Writer, version: Version): Promise<void> {
+		return Message.encode(w, (w) => this.#encode(w, version));
 	}
 
-	static async decode(r: Reader): Promise<SubscribeUpdate> {
-		return Message.decode(r, SubscribeUpdate.#decode);
-	}
-
-	static async decodeMaybe(r: Reader): Promise<SubscribeUpdate | undefined> {
-		return Message.decodeMaybe(r, SubscribeUpdate.#decode);
+	static async decode(r: Reader, version: Version): Promise<SubscribeUpdate> {
+		return Message.decode(r, (r) => SubscribeUpdate.#decode(r, version));
 	}
 }
 
@@ -37,78 +71,148 @@ export class Subscribe {
 	broadcast: Path.Valid;
 	track: string;
 	priority: number;
+	ordered: boolean;
+	maxLatency: Time.Milli;
 
-	constructor(id: bigint, broadcast: Path.Valid, track: string, priority: number) {
+	constructor({
+		id,
+		broadcast,
+		track,
+		priority,
+		ordered,
+		maxLatency,
+	}: {
+		id: bigint;
+		broadcast: Path.Valid;
+		track: string;
+		priority: number;
+		ordered: boolean;
+		maxLatency: Time.Milli;
+	}) {
 		this.id = id;
 		this.broadcast = broadcast;
 		this.track = track;
 		this.priority = priority;
+		this.ordered = ordered;
+		this.maxLatency = maxLatency;
 	}
 
-	async #encode(w: Writer) {
+	async #encode(w: Writer, version: Version) {
 		await w.u62(this.id);
 		await w.string(this.broadcast);
 		await w.string(this.track);
 		await w.u8(this.priority);
+
+		switch (version) {
+			case Version.DRAFT_03:
+				await w.bool(this.ordered);
+				await w.u53(this.maxLatency);
+				break;
+			case Version.DRAFT_01:
+			case Version.DRAFT_02:
+				break;
+			default: {
+				const v: never = version;
+				throw new Error(`unsupported version: ${v}`);
+			}
+		}
 	}
 
-	static async #decode(r: Reader): Promise<Subscribe> {
+	static async #decode(r: Reader, version: Version): Promise<Subscribe> {
 		const id = await r.u62();
 		const broadcast = Path.from(await r.string());
 		const track = await r.string();
 		const priority = await r.u8();
-		return new Subscribe(id, broadcast, track, priority);
+		let maxLatency = Time.Milli.zero;
+		let ordered = false;
+
+		switch (version) {
+			case Version.DRAFT_03:
+				ordered = await r.bool();
+				maxLatency = (await r.u53()) as Time.Milli;
+				break;
+			case Version.DRAFT_01:
+			case Version.DRAFT_02:
+				break;
+			default: {
+				const v: never = version;
+				throw new Error(`unsupported version: ${v}`);
+			}
+		}
+
+		return new Subscribe({ id, broadcast, track, priority, maxLatency, ordered });
 	}
 
-	async encode(w: Writer): Promise<void> {
-		return Message.encode(w, this.#encode.bind(this));
+	async encode(w: Writer, version: Version): Promise<void> {
+		return Message.encode(w, (w) => this.#encode(w, version));
 	}
 
-	static async decode(r: Reader): Promise<Subscribe> {
-		return Message.decode(r, Subscribe.#decode);
+	static async decode(r: Reader, version: Version): Promise<Subscribe> {
+		return Message.decode(r, (r) => Subscribe.#decode(r, version));
 	}
 }
 
 export class SubscribeOk {
-	// The version
-	readonly version: Version;
-	priority?: number;
+	priority: number;
+	ordered: boolean;
+	maxLatency: Time.Milli;
 
-	constructor({ version, priority = undefined }: { version: Version; priority?: number }) {
-		this.version = version;
+	constructor({ priority, maxLatency, ordered }: { priority: number; maxLatency: Time.Milli; ordered: boolean }) {
 		this.priority = priority;
+		this.maxLatency = maxLatency;
+		this.ordered = ordered;
 	}
 
-	async #encode(w: Writer) {
-		if (this.version === Version.DRAFT_02) {
-			// noop
-		} else if (this.version === Version.DRAFT_01) {
-			await w.u8(this.priority ?? 0);
-		} else {
-			const version: never = this.version;
-			throw new Error(`unsupported version: ${version}`);
+	async #encode(version: Version, w: Writer) {
+		switch (version) {
+			case Version.DRAFT_01:
+				await w.u8(this.priority);
+				break;
+			case Version.DRAFT_02:
+				break;
+			case Version.DRAFT_03:
+				await w.u8(this.priority);
+				await w.bool(this.ordered);
+				await w.u53(this.maxLatency);
+				break;
+			default: {
+				const v: never = version;
+				throw new Error(`unsupported version: ${v}`);
+			}
 		}
 	}
 
 	static async #decode(version: Version, r: Reader): Promise<SubscribeOk> {
-		let priority: number | undefined;
-		if (version === Version.DRAFT_02) {
-			// noop
-		} else if (version === Version.DRAFT_01) {
-			priority = await r.u8();
-		} else {
-			const v: never = version;
-			throw new Error(`unsupported version: ${v}`);
+		let priority = 0;
+		let ordered = false;
+		let maxLatency = Time.Milli.zero;
+
+		switch (version) {
+			case Version.DRAFT_01:
+				priority = await r.u8();
+				break;
+			case Version.DRAFT_02:
+				// noop
+				break;
+			case Version.DRAFT_03:
+				priority = await r.u8();
+				ordered = await r.bool();
+				maxLatency = (await r.u53()) as Time.Milli;
+				break;
+			default: {
+				const v: never = version;
+				throw new Error(`unsupported version: ${v}`);
+			}
 		}
 
-		return new SubscribeOk({ version, priority });
+		return new SubscribeOk({ priority, maxLatency, ordered });
 	}
 
-	async encode(w: Writer): Promise<void> {
-		return Message.encode(w, this.#encode.bind(this));
+	async encode(w: Writer, version: Version): Promise<void> {
+		return Message.encode(w, this.#encode.bind(this, version));
 	}
 
 	static async decode(r: Reader, version: Version): Promise<SubscribeOk> {
-		return Message.decode(r, SubscribeOk.#decode.bind(SubscribeOk, version));
+		return Message.decode(r, (r) => SubscribeOk.#decode(version, r));
 	}
 }

--- a/js/lite/src/lite/version.ts
+++ b/js/lite/src/lite/version.ts
@@ -1,6 +1,7 @@
 export const Version = {
 	DRAFT_01: 0xff0dad01,
 	DRAFT_02: 0xff0dad02,
+	DRAFT_03: 0xff0dad03,
 } as const;
 
 export type Version = (typeof Version)[keyof typeof Version];

--- a/js/lite/src/stream.ts
+++ b/js/lite/src/stream.ts
@@ -250,7 +250,8 @@ export class Writer {
 		await this.write(setInt32(this.#scratch, v));
 	}
 
-	async u53(v: number) {
+	// Returns the number of bytes written
+	async u53(v: number): Promise<number> {
 		if (v < 0) {
 			throw new Error(`underflow, value is negative: ${v.toString()}`);
 		}
@@ -258,10 +259,14 @@ export class Writer {
 			throw new Error(`overflow, value larger than 53-bits: ${v.toString()}`);
 		}
 
-		await this.write(setVint53(this.#scratch, v));
+		const buffer = setVint53(this.#scratch, v);
+
+		await this.write(buffer);
+		return buffer.byteLength;
 	}
 
-	async u62(v: bigint) {
+	// Returns the number of bytes written
+	async u62(v: bigint): Promise<number> {
 		if (v < 0) {
 			throw new Error(`underflow, value is negative: ${v.toString()}`);
 		}
@@ -271,17 +276,21 @@ export class Writer {
 		}
 		*/
 
-		await this.write(setVint62(this.#scratch, v));
+		const buffer = setVint62(this.#scratch, v);
+		await this.write(buffer);
+		return buffer.byteLength;
 	}
 
 	async write(v: Uint8Array) {
 		await this.#writer.write(v);
 	}
 
-	async string(str: string) {
+	// Returns the number of bytes written
+	async string(str: string): Promise<number> {
 		const data = new TextEncoder().encode(str);
-		await this.u53(data.byteLength);
+		const length = await this.u53(data.byteLength);
 		await this.write(data);
+		return length + data.byteLength;
 	}
 
 	close() {

--- a/js/lite/src/zod.ts
+++ b/js/lite/src/zod.ts
@@ -1,16 +1,17 @@
 // Helper containers for Zod-validated track encoding/decoding.
 
 import type * as z from "zod";
+import { Frame } from "./frame.ts";
 import type { Group } from "./group.ts";
 import type { Track } from "./track.ts";
 
 export async function read<T = unknown>(source: Track | Group, schema: z.ZodSchema<T>): Promise<T | undefined> {
-	const next = await source.readJson();
-	if (next === undefined) return undefined; // only treat undefined as EOF, not other falsy values
-	return schema.parse(next);
+	const next = await source.readFrame();
+	if (next === undefined) return; // only treat undefined as EOF, not other falsy values
+	return schema.parse(next.toJson());
 }
 
 export function write<T = unknown>(source: Track | Group, value: T, schema: z.ZodSchema<T>) {
 	const valid = schema.parse(value);
-	source.writeJson(valid);
+	source.writeFrame(Frame.fromJson(valid));
 }

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -153,6 +153,16 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 		for (const fn of dispose) fn();
 		return result;
 	}
+
+	// Spawn a promise that resolves when the signal changes.
+	promise(): Promise<T> {
+		return new Promise<T>((resolve) => {
+			const dispose = this.changed((value) => {
+				resolve(value);
+				dispose();
+			});
+		});
+	}
 }
 
 type SetterType<S> = S extends Setter<infer T> ? T : never;

--- a/rs/moq-lite/src/coding/writer.rs
+++ b/rs/moq-lite/src/coding/writer.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::sync::Arc;
 
 use crate::{coding::*, Error};
 
@@ -18,7 +18,7 @@ impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
 		}
 	}
 
-	pub async fn encode<T: Encode<V> + Debug>(&mut self, msg: &T) -> Result<(), Error>
+	pub async fn encode<T: Encode<V>>(&mut self, msg: &T) -> Result<(), Error>
 	where
 		V: Clone,
 	{
@@ -55,7 +55,7 @@ impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
 		Ok(())
 	}
 
-	/// A clean termination of the stream, waiting for the peer to close.
+	/// Mark the clean termination of the stream.
 	pub fn finish(&mut self) -> Result<(), Error> {
 		self.stream
 			.as_mut()

--- a/rs/moq-lite/src/ietf/parameters.rs
+++ b/rs/moq-lite/src/ietf/parameters.rs
@@ -1,40 +1,18 @@
 use std::collections::{hash_map, HashMap};
 
-use num_enum::{FromPrimitive, IntoPrimitive};
-
 use crate::coding::*;
 
 const MAX_PARAMS: u64 = 64;
 
-#[derive(Debug, Copy, Clone, FromPrimitive, IntoPrimitive, Eq, Hash, PartialEq)]
-#[repr(u64)]
-pub enum ParameterVarInt {
-	MaxRequestId = 2,
-	MaxAuthTokenCacheSize = 4,
-	#[num_enum(catch_all)]
-	Unknown(u64),
-}
-
-#[derive(Debug, Copy, Clone, FromPrimitive, IntoPrimitive, Eq, Hash, PartialEq)]
-#[repr(u64)]
-pub enum ParameterBytes {
-	Path = 1,
-	AuthorizationToken = 3,
-	Authority = 5,
-	Implementation = 7,
-	#[num_enum(catch_all)]
-	Unknown(u64),
-}
-
 #[derive(Default, Debug, Clone)]
 pub struct Parameters {
-	vars: HashMap<ParameterVarInt, u64>,
-	bytes: HashMap<ParameterBytes, Vec<u8>>,
+	ints: HashMap<u64, u64>,
+	bytes: HashMap<u64, Vec<u8>>,
 }
 
 impl<V: Clone> Decode<V> for Parameters {
 	fn decode<R: bytes::Buf>(mut r: &mut R, version: V) -> Result<Self, DecodeError> {
-		let mut vars = HashMap::new();
+		let mut ints = HashMap::new();
 		let mut bytes = HashMap::new();
 
 		// I hate this encoding so much; let me encode my role and get on with my life.
@@ -48,13 +26,11 @@ impl<V: Clone> Decode<V> for Parameters {
 			let kind = u64::decode(r, version.clone())?;
 
 			if kind % 2 == 0 {
-				let kind = ParameterVarInt::from(kind);
-				match vars.entry(kind) {
+				match ints.entry(kind) {
 					hash_map::Entry::Occupied(_) => return Err(DecodeError::Duplicate),
 					hash_map::Entry::Vacant(entry) => entry.insert(u64::decode(&mut r, version.clone())?),
 				};
 			} else {
-				let kind = ParameterBytes::from(kind);
 				match bytes.entry(kind) {
 					hash_map::Entry::Occupied(_) => return Err(DecodeError::Duplicate),
 					hash_map::Entry::Vacant(entry) => entry.insert(Vec::<u8>::decode(&mut r, version.clone())?),
@@ -62,40 +38,44 @@ impl<V: Clone> Decode<V> for Parameters {
 			}
 		}
 
-		Ok(Parameters { vars, bytes })
+		Ok(Parameters { ints, bytes })
 	}
 }
 
 impl<V: Clone> Encode<V> for Parameters {
 	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) {
-		(self.vars.len() + self.bytes.len()).encode(w, version.clone());
+		(self.ints.len() + self.bytes.len()).encode(w, version.clone());
 
-		for (kind, value) in self.vars.iter() {
-			u64::from(*kind).encode(w, version.clone());
+		for (kind, value) in self.ints.iter() {
+			kind.encode(w, version.clone());
 			value.encode(w, version.clone());
 		}
 
 		for (kind, value) in self.bytes.iter() {
-			u64::from(*kind).encode(w, version.clone());
+			kind.encode(w, version.clone());
 			value.encode(w, version.clone());
 		}
 	}
 }
 
 impl Parameters {
-	pub fn get_varint(&self, kind: ParameterVarInt) -> Option<u64> {
-		self.vars.get(&kind).copied()
+	pub fn get_int(&self, kind: u64) -> Option<u64> {
+		assert!(kind.is_multiple_of(2));
+		self.ints.get(&kind).copied()
 	}
 
-	pub fn set_varint(&mut self, kind: ParameterVarInt, value: u64) {
-		self.vars.insert(kind, value);
+	pub fn set_int(&mut self, kind: u64, value: u64) {
+		assert!(kind.is_multiple_of(2));
+		self.ints.insert(kind, value);
 	}
 
-	pub fn get_bytes(&self, kind: ParameterBytes) -> Option<&[u8]> {
+	pub fn get_bytes(&self, kind: u64) -> Option<&[u8]> {
+		assert!(!kind.is_multiple_of(2));
 		self.bytes.get(&kind).map(|v| v.as_slice())
 	}
 
-	pub fn set_bytes(&mut self, kind: ParameterBytes, value: Vec<u8>) {
+	pub fn set_bytes(&mut self, kind: u64, value: Vec<u8>) {
+		assert!(!kind.is_multiple_of(2));
 		self.bytes.insert(kind, value);
 	}
 }

--- a/rs/moq-lite/src/ietf/request.rs
+++ b/rs/moq-lite/src/ietf/request.rs
@@ -3,7 +3,7 @@ use crate::{
 	ietf::{Message, Version},
 };
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct RequestId(pub u64);
 
 impl RequestId {

--- a/rs/moq-lite/src/ietf/setup.rs
+++ b/rs/moq-lite/src/ietf/setup.rs
@@ -2,6 +2,18 @@ use crate::{
 	coding::*,
 	ietf::{Message, Parameters, Version as IetfVersion},
 };
+use num_enum::IntoPrimitive;
+
+#[derive(Debug, Copy, Clone, IntoPrimitive, Eq, Hash, PartialEq)]
+#[repr(u64)]
+pub enum SetupParameter {
+	Path = 1,
+	MaxRequestId = 2,
+	AuthorizationToken = 3,
+	MaxAuthTokenCacheSize = 4,
+	Authority = 5,
+	Implementation = 7,
+}
 
 /// Sent by the client to setup the session.
 #[derive(Debug, Clone)]

--- a/rs/moq-lite/src/lite/frame.rs
+++ b/rs/moq-lite/src/lite/frame.rs
@@ -1,0 +1,64 @@
+use bytes::Buf;
+
+use crate::{
+	coding::{Decode, DecodeError, Encode},
+	lite::Version,
+	Time,
+};
+
+#[derive(Clone, Debug)]
+pub struct FrameHeader {
+	/// The timestamp delta (in milliseconds) since the previous frame in the group.
+	pub delta: Time,
+
+	// NOTE: This is the size of the payload that still needs to be read/written.
+	// We do not encode/decode here so we can perform chunking.
+	pub size: usize,
+}
+
+// NOTE: We do not implement Message so we can perform chunking.
+// The caller is expected to read/write `size` bytes immediately afterwards.
+impl Decode<Version> for FrameHeader {
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		// NOTE: This is the message size.
+		let size = usize::decode(r, version)?;
+		if size > r.remaining() {
+			return Err(DecodeError::Short);
+		}
+
+		let r = &mut r.take(size);
+
+		let delta = match version {
+			Version::Draft03 => Time::decode(r, version)?,
+			// If no timestamp is provided for this protocol version, we use the current (receive) time.
+			// NOTE: The (correct) media timestamp is still in the payload for backwards compatibility.
+			Version::Draft02 | Version::Draft01 => Time::now(),
+		};
+
+		let size = r.remaining();
+
+		Ok(Self { delta, size })
+	}
+}
+
+impl Encode<Version> for FrameHeader {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) {
+		// Unfortunately, we need to know the size of the header to calculate the message size.
+		// Encode the timestamp to the maximum buffer size first.
+		let mut tmp = [0u8; 8];
+		let mut buf = &mut tmp[..];
+
+		match version {
+			Version::Draft03 => self.delta.encode(&mut buf, version),
+			Version::Draft02 | Version::Draft01 => {}
+		}
+
+		// Compute the number of bytes used for the timestamp and write it.
+		let size = 8 - buf.len();
+
+		// Encode the total size of the timestamp and payload.
+		(self.size + size).encode(w, version);
+
+		w.put(&tmp[..size]);
+	}
+}

--- a/rs/moq-lite/src/lite/mod.rs
+++ b/rs/moq-lite/src/lite/mod.rs
@@ -1,4 +1,5 @@
 mod announce;
+mod frame;
 mod group;
 mod info;
 mod message;
@@ -13,6 +14,7 @@ mod subscriber;
 mod version;
 
 pub use announce::*;
+pub use frame::*;
 pub use group::*;
 pub use info::*;
 pub use message::*;

--- a/rs/moq-lite/src/lite/session.rs
+++ b/rs/moq-lite/src/lite/session.rs
@@ -1,3 +1,4 @@
+use futures::FutureExt;
 use tokio::sync::oneshot;
 
 use crate::{
@@ -24,28 +25,7 @@ pub(crate) async fn start<S: web_transport_trait::Session>(
 
 	let init = oneshot::channel();
 
-	web_async::spawn(async move {
-		let res = tokio::select! {
-			res = run_session(setup) => res,
-			res = publisher.run() => res,
-			res = subscriber.run(init.0) => res,
-		};
-
-		match res {
-			Err(Error::Transport(_)) => {
-				tracing::info!("session terminated");
-				session.close(1, "");
-			}
-			Err(err) => {
-				tracing::warn!(%err, "session error");
-				session.close(err.to_code(), err.to_string().as_ref());
-			}
-			_ => {
-				tracing::info!("session closed");
-				session.close(0, "");
-			}
-		}
-	});
+	web_async::spawn(run(session, setup, publisher, subscriber, init.0).boxed());
 
 	// Wait until receiving the initial announcements to prevent some race conditions.
 	// Otherwise, `consume()` might return not found if we don't wait long enough, so just wait.
@@ -54,6 +34,35 @@ pub(crate) async fn start<S: web_transport_trait::Session>(
 	init.1.await.map_err(|_| Error::Cancel)?;
 
 	Ok(())
+}
+
+async fn run<S: web_transport_trait::Session>(
+	session: S,
+	setup: Stream<S, Version>,
+	publisher: Publisher<S>,
+	subscriber: Subscriber<S>,
+	init: oneshot::Sender<()>,
+) {
+	let res = tokio::select! {
+		res = run_session(setup) => res,
+		res = publisher.run() => res,
+		res = subscriber.run(init) => res,
+	};
+
+	match res {
+		Err(Error::Transport(_)) => {
+			tracing::info!("session terminated");
+			session.close(1, "");
+		}
+		Err(err) => {
+			tracing::warn!(%err, "session error");
+			session.close(err.to_code(), err.to_string().as_ref());
+		}
+		_ => {
+			tracing::info!("session closed");
+			session.close(0, "");
+		}
+	}
 }
 
 // TODO do something useful with this

--- a/rs/moq-lite/src/lite/version.rs
+++ b/rs/moq-lite/src/lite/version.rs
@@ -11,6 +11,7 @@ pub const ALPN: &str = "moql";
 pub enum Version {
 	Draft01 = 0xff0dad01,
 	Draft02 = 0xff0dad02,
+	Draft03 = 0xff0dad03,
 }
 
 impl TryFrom<coding::Version> for Version {
@@ -21,6 +22,8 @@ impl TryFrom<coding::Version> for Version {
 			Ok(Self::Draft01)
 		} else if value == Self::Draft02.coding() {
 			Ok(Self::Draft02)
+		} else if value == Self::Draft03.coding() {
+			Ok(Self::Draft03)
 		} else {
 			Err(())
 		}

--- a/rs/moq-lite/src/model/broadcast.rs
+++ b/rs/moq-lite/src/model/broadcast.rs
@@ -1,50 +1,43 @@
-use std::{
-	collections::HashMap,
-	future::Future,
-	sync::{
-		atomic::{AtomicUsize, Ordering},
-		Arc,
-	},
-};
+use std::{collections::HashMap, future::Future};
 
-use crate::{Error, Produce, TrackConsumer, TrackProducer};
+use crate::{Delivery, Error, Produce, Track, TrackConsumer, TrackProducer};
 use tokio::sync::watch;
 use web_async::Lock;
 
-use super::Track;
-
+#[derive(Default)]
 struct State {
-	// When explicitly publishing, we hold a reference to the consumer.
-	// This prevents the track from being marked as "unused".
-	published: HashMap<String, TrackConsumer>,
+	// Explicitly published tracks.
+	// NOTE: These will be `unused` when there's no active subscribers, but won't be removed.
+	producers: HashMap<String, TrackProducer>,
 
-	// When requesting, we hold a reference to the producer for dynamic tracks.
-	// The track will be marked as "unused" when the last consumer is dropped.
+	// Tracks requested over the network.
+	// NOTE: These will be removed on `unused`.
 	requested: HashMap<String, TrackProducer>,
 }
 
-#[derive(Clone, Default)]
-pub struct Broadcast {
-	// NOTE: Broadcasts have no names because they're often relative.
-}
+pub struct Broadcast {}
 
 impl Broadcast {
 	pub fn produce() -> Produce<BroadcastProducer, BroadcastConsumer> {
 		let producer = BroadcastProducer::new();
-		let consumer = producer.consume();
-		Produce { producer, consumer }
+		Produce {
+			consumer: producer.consume(),
+			producer,
+		}
 	}
 }
 
 /// Receive broadcast/track requests and return if we can fulfill them.
+#[derive(Clone)]
 pub struct BroadcastProducer {
 	state: Lock<State>,
-	closed: watch::Sender<bool>,
+
+	closed: watch::Sender<Option<Result<(), Error>>>,
 	requested: (
+		// We need the sender so we can clone new consumers
 		async_channel::Sender<TrackProducer>,
 		async_channel::Receiver<TrackProducer>,
 	),
-	cloned: Arc<AtomicUsize>,
 }
 
 impl Default for BroadcastProducer {
@@ -54,43 +47,42 @@ impl Default for BroadcastProducer {
 }
 
 impl BroadcastProducer {
-	fn new() -> Self {
+	pub fn new() -> Self {
 		Self {
-			state: Lock::new(State {
-				published: HashMap::new(),
-				requested: HashMap::new(),
-			}),
+			state: Default::default(),
 			closed: Default::default(),
 			requested: async_channel::unbounded(),
-			cloned: Default::default(),
 		}
 	}
 
-	/// Return the next requested track.
+	/// Return the next requested track, or None if there are no Consumers active.
 	pub async fn requested_track(&mut self) -> Option<TrackProducer> {
-		self.requested.1.recv().await.ok()
+		tokio::select! {
+			request = self.requested.1.recv() => request.ok(),
+			_ = self.closed.closed() => None,
+		}
 	}
 
 	/// Produce a new track and insert it into the broadcast.
-	pub fn create_track(&mut self, track: Track) -> TrackProducer {
-		let track = track.clone().produce();
-		self.insert_track(track.consumer);
-		track.producer
+	pub fn create_track<T: Into<Track>>(&mut self, track: T, delivery: Delivery) -> TrackProducer {
+		let track = TrackProducer::new(track.into(), delivery);
+		self.publish_track(track.clone());
+		track
 	}
 
-	/// Insert a track into the lookup, returning true if it was unique.
-	pub fn insert_track(&mut self, track: TrackConsumer) -> bool {
-		let mut state = self.state.lock();
-		let unique = state.published.insert(track.info.name.clone(), track.clone()).is_none();
-		let removed = state.requested.remove(&track.info.name).is_some();
+	/// Insert a track into the broadcast.
+	pub fn publish_track(&mut self, track: TrackProducer) {
+		let name = track.name.to_string();
 
-		unique && !removed
+		let mut state = self.state.lock();
+		state.producers.insert(name, track);
 	}
 
 	/// Remove a track from the lookup.
-	pub fn remove_track(&mut self, name: &str) -> bool {
+	pub fn remove_track(&mut self, name: &str) {
 		let mut state = self.state.lock();
-		state.published.remove(name).is_some() || state.requested.remove(name).is_some()
+		state.producers.remove(name);
+		state.requested.remove(name);
 	}
 
 	pub fn consume(&self) -> BroadcastConsumer {
@@ -101,16 +93,47 @@ impl BroadcastProducer {
 		}
 	}
 
-	pub fn close(&mut self) {
-		self.closed.send_modify(|closed| *closed = true);
+	pub fn close(&mut self) -> Result<(), Error> {
+		let mut result = Ok(());
+
+		self.closed.send_if_modified(|closed| {
+			if let Some(closed) = closed.clone() {
+				result = Err(closed.err().unwrap_or(Error::Cancel));
+				return false;
+			}
+
+			*closed = Some(Ok(()));
+			true
+		});
+
+		result
+	}
+
+	pub fn abort(&mut self, err: Error) -> Result<(), Error> {
+		let mut result = Ok(());
+
+		self.closed.send_if_modified(|closed| {
+			if let Some(Err(err)) = closed.clone() {
+				result = Err(err);
+				return false;
+			}
+
+			*closed = Some(Err(err));
+			true
+		});
+
+		result
 	}
 
 	/// Block until there are no more consumers.
 	///
 	/// A new consumer can be created by calling [Self::consume] and this will block again.
+	// We don't use the `async` keyword so we don't borrow &self across the await.
 	pub fn unused(&self) -> impl Future<Output = ()> {
 		let closed = self.closed.clone();
-		async move { closed.closed().await }
+		async move {
+			closed.closed().await;
+		}
 	}
 
 	pub fn is_clone(&self, other: &Self) -> bool {
@@ -118,124 +141,58 @@ impl BroadcastProducer {
 	}
 }
 
-impl Clone for BroadcastProducer {
-	fn clone(&self) -> Self {
-		self.cloned.fetch_add(1, Ordering::Relaxed);
-		Self {
-			state: self.state.clone(),
-			closed: self.closed.clone(),
-			requested: self.requested.clone(),
-			cloned: self.cloned.clone(),
-		}
-	}
-}
-
-impl Drop for BroadcastProducer {
-	fn drop(&mut self) {
-		if self.cloned.fetch_sub(1, Ordering::Relaxed) > 0 {
-			return;
-		}
-
-		// Cleanup any lingering state when the last producer is dropped.
-
-		// Close the sender so consumers can't send any more requests.
-		self.requested.0.close();
-
-		// Drain any remaining requests.
-		while let Ok(producer) = self.requested.1.try_recv() {
-			producer.abort(Error::Cancel);
-		}
-
-		let mut state = self.state.lock();
-
-		// Cleanup any published tracks.
-		state.published.clear();
-		state.requested.clear();
-	}
-}
-
-#[cfg(test)]
-use futures::FutureExt;
-
-#[cfg(test)]
-impl BroadcastProducer {
-	pub fn assert_used(&self) {
-		assert!(self.unused().now_or_never().is_none(), "should be used");
-	}
-
-	pub fn assert_unused(&self) {
-		assert!(self.unused().now_or_never().is_some(), "should be unused");
-	}
-
-	pub fn assert_request(&mut self) -> TrackProducer {
-		self.requested_track()
-			.now_or_never()
-			.expect("should not have blocked")
-			.expect("should be a request")
-	}
-
-	pub fn assert_no_request(&mut self) {
-		assert!(self.requested_track().now_or_never().is_none(), "should have blocked");
-	}
-}
-
 /// Subscribe to abitrary broadcast/tracks.
 #[derive(Clone)]
 pub struct BroadcastConsumer {
 	state: Lock<State>,
-	closed: watch::Receiver<bool>,
+	closed: watch::Receiver<Option<Result<(), Error>>>,
 	requested: async_channel::Sender<TrackProducer>,
 }
 
 impl BroadcastConsumer {
-	pub fn subscribe_track(&self, track: &Track) -> TrackConsumer {
+	/// Starts fetches the Track over the network, using the given settings.
+	///
+	/// This is synchronous and cannot fail.
+	/// However, the returned [TrackConsumer] will be aborted if the track can't be found.
+	pub fn subscribe_track(&self, track: impl Into<Track>, delivery: Delivery) -> TrackConsumer {
+		let track = track.into();
+
 		let mut state = self.state.lock();
 
-		// Return any explictly published track.
-		if let Some(consumer) = state.published.get(&track.name).cloned() {
-			return consumer;
+		// If the track is already published, return it.
+		if let Some(existing) = state.producers.get(track.name.as_ref()) {
+			return existing.subscribe(delivery);
 		}
 
-		// Return any requested tracks.
-		if let Some(producer) = state.requested.get(&track.name) {
-			return producer.consume();
+		if let Some(existing) = state.requested.get(track.name.as_ref()) {
+			return existing.subscribe(delivery);
 		}
 
-		// Otherwise we have never seen this track before and need to create a new producer.
-		let track = track.clone().produce();
-		let producer = track.producer;
-		let consumer = track.consumer;
+		// Create a new track producer using this first request's delivery information.
+		// The publisher SHOULD replace them with their own settigns on OK.
+		let track = TrackProducer::new(track, delivery);
 
-		// Insert the producer into the lookup so we will deduplicate requests.
-		// This is not a subscriber so it doesn't count towards "used" subscribers.
-		match self.requested.try_send(producer.clone()) {
-			Ok(()) => {}
-			Err(_) => {
-				// If the BroadcastProducer is closed, immediately close the track.
-				// This is a bit more ergonomic than returning None.
-				producer.abort(Error::Cancel);
-				return consumer;
-			}
-		}
+		let consumer = track.subscribe(delivery);
 
-		// Insert the producer into the lookup so we will deduplicate requests.
-		state.requested.insert(producer.info.name.clone(), producer.clone());
+		state.requested.insert(track.name.to_string(), track.clone());
 
-		// Remove the track from the lookup when it's unused.
 		let state = self.state.clone();
+		let requested = self.requested.clone();
+
 		web_async::spawn(async move {
-			producer.unused().await;
-			state.lock().requested.remove(&producer.info.name);
+			if requested.send(track.clone()).await.is_ok() {
+				track.unused().await;
+			}
+			state.lock().requested.remove(track.name.as_ref());
 		});
 
 		consumer
 	}
 
-	pub fn closed(&self) -> impl Future<Output = ()> {
-		// A hacky way to check if the broadcast is closed.
-		let mut closed = self.closed.clone();
-		async move {
-			closed.wait_for(|closed| *closed).await.ok();
+	pub async fn closed(&self) -> Result<(), Error> {
+		match self.closed.clone().wait_for(|closed| closed.is_some()).await {
+			Ok(closed) => closed.clone().unwrap(),
+			Err(_) => Err(Error::Cancel),
 		}
 	}
 
@@ -244,216 +201,5 @@ impl BroadcastConsumer {
 	/// Duplicate names are allowed in the case of resumption.
 	pub fn is_clone(&self, other: &Self) -> bool {
 		self.closed.same_channel(&other.closed)
-	}
-}
-
-#[cfg(test)]
-impl BroadcastConsumer {
-	pub fn assert_not_closed(&self) {
-		assert!(self.closed().now_or_never().is_none(), "should not be closed");
-	}
-
-	pub fn assert_closed(&self) {
-		assert!(self.closed().now_or_never().is_some(), "should be closed");
-	}
-}
-
-#[cfg(test)]
-mod test {
-	use super::*;
-
-	#[tokio::test]
-	async fn insert() {
-		let mut producer = BroadcastProducer::new();
-		let mut track1 = Track::new("track1").produce();
-
-		// Make sure we can insert before a consumer is created.
-		producer.insert_track(track1.consumer);
-		track1.producer.append_group();
-
-		let consumer = producer.consume();
-
-		let mut track1_sub = consumer.subscribe_track(&track1.producer.info);
-		track1_sub.assert_group();
-
-		let mut track2 = Track::new("track2").produce();
-		producer.insert_track(track2.consumer);
-
-		let consumer2 = producer.consume();
-		let mut track2_consumer = consumer2.subscribe_track(&track2.producer.info);
-		track2_consumer.assert_no_group();
-
-		track2.producer.append_group();
-
-		track2_consumer.assert_group();
-	}
-
-	#[tokio::test]
-	async fn unused() {
-		let producer = BroadcastProducer::new();
-		producer.assert_unused();
-
-		// Create a new consumer.
-		let consumer1 = producer.consume();
-		producer.assert_used();
-
-		// It's also valid to clone the consumer.
-		let consumer2 = consumer1.clone();
-		producer.assert_used();
-
-		// Dropping one consumer doesn't make it unused.
-		drop(consumer1);
-		producer.assert_used();
-
-		drop(consumer2);
-		producer.assert_unused();
-
-		// Even though it's unused, we can still create a new consumer.
-		let consumer3 = producer.consume();
-		producer.assert_used();
-
-		let track1 = consumer3.subscribe_track(&Track::new("track1"));
-
-		// It doesn't matter if a subscription is alive, we only care about the broadcast handle.
-		// TODO is this the right behavior?
-		drop(consumer3);
-		producer.assert_unused();
-
-		drop(track1);
-	}
-
-	#[tokio::test]
-	async fn closed() {
-		let mut producer = BroadcastProducer::new();
-
-		let consumer = producer.consume();
-		consumer.assert_not_closed();
-
-		// Create a new track and insert it into the broadcast.
-		let mut track1 = Track::new("track1").produce();
-		track1.producer.append_group();
-		producer.insert_track(track1.consumer);
-
-		let mut track1c = consumer.subscribe_track(&track1.producer.info);
-		let track2 = consumer.subscribe_track(&Track::new("track2"));
-
-		drop(producer);
-		consumer.assert_closed();
-
-		// The requested TrackProducer should have been dropped, so the track should be closed.
-		track2.assert_closed();
-
-		// But track1 is still open because we currently don't cascade the closed state.
-		track1c.assert_group();
-		track1c.assert_no_group();
-		track1c.assert_not_closed();
-
-		// TODO: We should probably cascade the closed state.
-		drop(track1.producer);
-		track1c.assert_closed();
-	}
-
-	#[tokio::test]
-	async fn select() {
-		let mut producer = BroadcastProducer::new();
-
-		// Make sure this compiles; it's actually more involved than it should be.
-		tokio::select! {
-			_ = producer.unused() => {}
-			_ = producer.requested_track() => {}
-		}
-	}
-
-	#[tokio::test]
-	async fn requests() {
-		let mut producer = BroadcastProducer::new();
-
-		let consumer = producer.consume();
-		let consumer2 = consumer.clone();
-
-		let mut track1 = consumer.subscribe_track(&Track::new("track1"));
-		track1.assert_not_closed();
-		track1.assert_no_group();
-
-		// Make sure we deduplicate requests while track1 is still active.
-		let mut track2 = consumer2.subscribe_track(&Track::new("track1"));
-		track2.assert_is_clone(&track1);
-
-		// Get the requested track, and there should only be one.
-		let mut track3 = producer.assert_request();
-		producer.assert_no_request();
-
-		// Make sure the consumer is the same.
-		track3.consume().assert_is_clone(&track1);
-
-		// Append a group and make sure they all get it.
-		track3.append_group();
-		track1.assert_group();
-		track2.assert_group();
-
-		// Make sure that tracks are cancelled when the producer is dropped.
-		let track4 = consumer.subscribe_track(&Track::new("track2"));
-		drop(producer);
-
-		// Make sure the track is errored, not closed.
-		track4.assert_error();
-
-		let track5 = consumer2.subscribe_track(&Track::new("track3"));
-		track5.assert_error();
-	}
-
-	#[tokio::test]
-	async fn requested_unused() {
-		let mut broadcast = Broadcast::produce();
-
-		// Subscribe to a track that doesn't exist - this creates a request
-		let consumer1 = broadcast.consumer.subscribe_track(&Track::new("unknown_track"));
-
-		// Get the requested track producer
-		let producer1 = broadcast.producer.assert_request();
-
-		// The track producer should NOT be unused yet because there's a consumer
-		assert!(
-			producer1.unused().now_or_never().is_none(),
-			"track producer should be used"
-		);
-
-		// Making a new consumer will keep the producer alive
-		let consumer2 = broadcast.consumer.subscribe_track(&Track::new("unknown_track"));
-		consumer2.assert_is_clone(&consumer1);
-
-		// Drop the consumer subscription
-		drop(consumer1);
-
-		// The track producer should NOT be unused yet because there's a consumer
-		assert!(
-			producer1.unused().now_or_never().is_none(),
-			"track producer should be used"
-		);
-
-		// Drop the second consumer, now the producer should be unused
-		drop(consumer2);
-
-		// BUG: The track producer should become unused after dropping the consumer,
-		// but it won't because the broadcast keeps a reference in the lookup HashMap
-		// This assertion will fail, demonstrating the bug
-		assert!(
-			producer1.unused().now_or_never().is_some(),
-			"track producer should be unused after consumer is dropped"
-		);
-
-		// TODO Unfortunately, we need to sleep for a little bit to detect when unused.
-		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-
-		// Now the cleanup task should have run and we can subscribe again to the unknown track.
-		let consumer3 = broadcast.consumer.subscribe_track(&Track::new("unknown_track"));
-		let producer2 = broadcast.producer.assert_request();
-
-		// Drop the consumer, now the producer should be unused
-		drop(consumer3);
-		assert!(
-			producer2.unused().now_or_never().is_some(),
-			"track producer should be unused after consumer is dropped"
-		);
 	}
 }

--- a/rs/moq-lite/src/model/origin.rs
+++ b/rs/moq-lite/src/model/origin.rs
@@ -19,6 +19,18 @@ impl ConsumerId {
 	}
 }
 
+pub struct Origin {}
+
+impl Origin {
+	pub fn produce() -> Produce<OriginProducer, OriginConsumer> {
+		let producer = OriginProducer::new();
+		Produce {
+			consumer: producer.consume(),
+			producer,
+		}
+	}
+}
+
 // If there are multiple broadcasts with the same path, we use the most recent one but keep the others around.
 struct OriginBroadcast {
 	path: PathOwned,
@@ -334,16 +346,6 @@ impl Default for OriginNodes {
 /// A broadcast path and its associated consumer, or None if closed.
 pub type OriginAnnounce = (PathOwned, Option<BroadcastConsumer>);
 
-pub struct Origin {}
-
-impl Origin {
-	pub fn produce() -> Produce<OriginProducer, OriginConsumer> {
-		let producer = OriginProducer::default();
-		let consumer = producer.consume();
-		Produce { producer, consumer }
-	}
-}
-
 /// Announces broadcasts to consumers over the network.
 #[derive(Clone, Default)]
 pub struct OriginProducer {
@@ -356,6 +358,10 @@ pub struct OriginProducer {
 }
 
 impl OriginProducer {
+	pub fn new() -> Self {
+		Self::default()
+	}
+
 	/// Publish a broadcast, announcing it to all consumers.
 	///
 	/// The broadcast will be unannounced when it is closed.
@@ -378,7 +384,7 @@ impl OriginProducer {
 		let root = root.clone();
 
 		web_async::spawn(async move {
-			broadcast.closed().await;
+			broadcast.closed().await.ok();
 			root.lock().remove(&full, broadcast, &rest);
 		});
 
@@ -594,42 +600,42 @@ impl OriginConsumer {
 
 #[cfg(test)]
 mod tests {
-	use crate::Broadcast;
+	use crate::BroadcastProducer;
 
 	use super::*;
 
 	#[tokio::test]
 	async fn test_announce() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
 
-		let mut consumer1 = origin.consumer;
+		let mut consumer1 = origin.consume();
 		// Make a new consumer that should get it.
 		consumer1.assert_next_wait();
 
 		// Publish the first broadcast.
-		origin.producer.publish_broadcast("test1", broadcast1.consumer);
+		origin.publish_broadcast("test1", broadcast1.consume());
 
-		consumer1.assert_next("test1", &broadcast1.producer.consume());
+		consumer1.assert_next("test1", &broadcast1.consume());
 		consumer1.assert_next_wait();
 
 		// Make a new consumer that should get the existing broadcast.
 		// But we don't consume it yet.
-		let mut consumer2 = origin.producer.consume();
+		let mut consumer2 = origin.consume();
 
 		// Publish the second broadcast.
-		origin.producer.publish_broadcast("test2", broadcast2.consumer);
+		origin.publish_broadcast("test2", broadcast2.consume());
 
-		consumer1.assert_next("test2", &broadcast2.producer.consume());
+		consumer1.assert_next("test2", &broadcast2.consume());
 		consumer1.assert_next_wait();
 
-		consumer2.assert_next("test1", &broadcast1.producer.consume());
-		consumer2.assert_next("test2", &broadcast2.producer.consume());
+		consumer2.assert_next("test1", &broadcast1.consume());
+		consumer2.assert_next("test2", &broadcast2.consume());
 		consumer2.assert_next_wait();
 
 		// Close the first broadcast.
-		drop(broadcast1.producer);
+		drop(broadcast1);
 
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
@@ -641,12 +647,12 @@ mod tests {
 		consumer2.assert_next_wait();
 
 		// And a new consumer only gets the last broadcast.
-		let mut consumer3 = origin.producer.consume();
-		consumer3.assert_next("test2", &broadcast2.producer.consume());
+		let mut consumer3 = origin.consume();
+		consumer3.assert_next("test2", &broadcast2.consume());
 		consumer3.assert_next_wait();
 
 		// Close the other producer and make sure it cleans up
-		drop(broadcast2.producer);
+		drop(broadcast2);
 
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
@@ -664,275 +670,267 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_duplicate() {
-		let mut origin = Origin::produce();
+		let origin = OriginProducer::new();
 
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
-		let broadcast3 = Broadcast::produce();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
+		let broadcast3 = BroadcastProducer::new();
 
-		let consumer1 = broadcast1.consumer;
-		let consumer2 = broadcast2.consumer;
-		let consumer3 = broadcast3.consumer;
+		let consumer1 = broadcast1.consume();
+		let consumer2 = broadcast2.consume();
+		let consumer3 = broadcast3.consume();
 
-		origin.producer.publish_broadcast("test", consumer1.clone());
-		origin.producer.publish_broadcast("test", consumer2.clone());
-		origin.producer.publish_broadcast("test", consumer3.clone());
+		origin.publish_broadcast("test", consumer1.clone());
+		origin.publish_broadcast("test", consumer2.clone());
+		origin.publish_broadcast("test", consumer3.clone());
 
-		assert!(origin.consumer.consume_broadcast("test").is_some());
+		let mut consumer = origin.consume();
+		assert!(consumer.consume_broadcast("test").is_some());
 
-		origin.consumer.assert_next("test", &consumer1);
-		origin.consumer.assert_next_none("test");
-		origin.consumer.assert_next("test", &consumer2);
-		origin.consumer.assert_next_none("test");
-		origin.consumer.assert_next("test", &consumer3);
+		consumer.assert_next("test", &consumer1);
+		consumer.assert_next_none("test");
+		consumer.assert_next("test", &consumer2);
+		consumer.assert_next_none("test");
+		consumer.assert_next("test", &consumer3);
 
 		// Drop the backup, nothing should change.
-		drop(broadcast2.producer);
+		drop(broadcast2);
 
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 
-		assert!(origin.consumer.consume_broadcast("test").is_some());
-		origin.consumer.assert_next_wait();
+		assert!(consumer.consume_broadcast("test").is_some());
+		consumer.assert_next_wait();
 
 		// Drop the active, we should reannounce.
-		drop(broadcast3.producer);
+		drop(broadcast3);
 
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 
-		assert!(origin.consumer.consume_broadcast("test").is_some());
-		origin.consumer.assert_next_none("test");
-		origin.consumer.assert_next("test", &consumer1);
+		assert!(consumer.consume_broadcast("test").is_some());
+		consumer.assert_next_none("test");
+		consumer.assert_next("test", &consumer1);
 
 		// Drop the final broadcast, we should unannounce.
-		drop(broadcast1.producer);
+		drop(broadcast1);
 
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-		assert!(origin.consumer.consume_broadcast("test").is_none());
+		assert!(consumer.consume_broadcast("test").is_none());
 
-		origin.consumer.assert_next_none("test");
-		origin.consumer.assert_next_wait();
+		consumer.assert_next_none("test");
+		consumer.assert_next_wait();
 	}
 
 	#[tokio::test]
 	async fn test_duplicate_reverse() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let consumer = origin.consume();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
 
-		origin.producer.publish_broadcast("test", broadcast1.consumer);
-		origin.producer.publish_broadcast("test", broadcast2.consumer);
-		assert!(origin.consumer.consume_broadcast("test").is_some());
+		origin.publish_broadcast("test", broadcast1.consume());
+		origin.publish_broadcast("test", broadcast2.consume());
+		assert!(consumer.consume_broadcast("test").is_some());
 
 		// This is harder, dropping the new broadcast first.
-		drop(broadcast2.producer);
+		drop(broadcast2);
 
 		// Wait for the cleanup async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-		assert!(origin.consumer.consume_broadcast("test").is_some());
+		assert!(consumer.consume_broadcast("test").is_some());
 
-		drop(broadcast1.producer);
+		drop(broadcast1);
 
 		// Wait for the cleanup async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-		assert!(origin.consumer.consume_broadcast("test").is_none());
+		assert!(consumer.consume_broadcast("test").is_none());
 	}
 
 	#[tokio::test]
 	async fn test_double_publish() {
-		let origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let consumer = origin.consume();
+		let broadcast = BroadcastProducer::new();
 
 		// Ensure it doesn't crash.
-		origin.producer.publish_broadcast("test", broadcast.producer.consume());
-		origin.producer.publish_broadcast("test", broadcast.producer.consume());
+		origin.publish_broadcast("test", broadcast.consume());
+		origin.publish_broadcast("test", broadcast.consume());
 
-		assert!(origin.consumer.consume_broadcast("test").is_some());
+		assert!(consumer.consume_broadcast("test").is_some());
 
-		drop(broadcast.producer);
+		drop(broadcast);
 
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-		assert!(origin.consumer.consume_broadcast("test").is_none());
+		assert!(consumer.consume_broadcast("test").is_none());
 	}
 	// There was a tokio bug where only the first 127 broadcasts would be received instantly.
 	#[tokio::test]
 	#[should_panic]
 	async fn test_128() {
-		let mut origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast = BroadcastProducer::new();
 
 		for i in 0..256 {
-			origin
-				.producer
-				.publish_broadcast(format!("test{i}"), broadcast.consumer.clone());
+			origin.publish_broadcast(format!("test{i}"), broadcast.consume());
 		}
 
+		let mut consumer = origin.consume();
 		for i in 0..256 {
-			origin.consumer.assert_next(format!("test{i}"), &broadcast.consumer);
+			consumer.assert_next(format!("test{i}"), &broadcast.consume());
 		}
 	}
 
 	#[tokio::test]
 	async fn test_128_fix() {
-		let mut origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast = BroadcastProducer::new();
 
 		for i in 0..256 {
-			origin
-				.producer
-				.publish_broadcast(format!("test{i}"), broadcast.consumer.clone());
+			origin.publish_broadcast(format!("test{i}"), broadcast.consume());
 		}
 
+		let mut consumer = origin.consume();
 		for i in 0..256 {
 			// try_next does not have the same issue because it's synchronous.
-			origin.consumer.assert_try_next(format!("test{i}"), &broadcast.consumer);
+			consumer.assert_try_next(format!("test{i}"), &broadcast.consume());
 		}
 	}
 
 	#[tokio::test]
 	async fn test_with_root_basic() {
-		let mut origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let mut consumer = origin.consume();
+
+		let broadcast = BroadcastProducer::new();
 
 		// Create a producer with root "/foo"
-		let foo_producer = origin.producer.with_root("foo").expect("should create root");
+		let foo_producer = origin.with_root("foo").expect("should create root");
 		assert_eq!(foo_producer.root().as_str(), "foo");
 
 		// When publishing to "bar/baz", it should actually publish to "foo/bar/baz"
-		assert!(foo_producer.publish_broadcast("bar/baz", broadcast.consumer.clone()));
+		assert!(foo_producer.publish_broadcast("bar/baz", broadcast.consume()));
 
 		// The original consumer should see the full path
-		origin.consumer.assert_next("foo/bar/baz", &broadcast.consumer);
+		consumer.assert_next("foo/bar/baz", &broadcast.consume());
 
 		// A consumer created from the rooted producer should see the stripped path
 		let mut foo_consumer = foo_producer.consume();
-		foo_consumer.assert_next("bar/baz", &broadcast.consumer);
+		foo_consumer.assert_next("bar/baz", &broadcast.consume());
 	}
 
 	#[tokio::test]
 	async fn test_with_root_nested() {
-		let mut origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let mut consumer = origin.consume();
+		let broadcast = BroadcastProducer::new();
 
 		// Create nested roots
-		let foo_producer = origin.producer.with_root("foo").expect("should create foo root");
+		let foo_producer = origin.with_root("foo").expect("should create foo root");
 		let foo_bar_producer = foo_producer.with_root("bar").expect("should create bar root");
 		assert_eq!(foo_bar_producer.root().as_str(), "foo/bar");
 
 		// Publishing to "baz" should actually publish to "foo/bar/baz"
-		assert!(foo_bar_producer.publish_broadcast("baz", broadcast.consumer.clone()));
+		assert!(foo_bar_producer.publish_broadcast("baz", broadcast.consume()));
 
 		// The original consumer sees the full path
-		origin.consumer.assert_next("foo/bar/baz", &broadcast.consumer);
+		consumer.assert_next("foo/bar/baz", &broadcast.consume());
 
 		// Consumer from foo_bar_producer sees just "baz"
 		let mut foo_bar_consumer = foo_bar_producer.consume();
-		foo_bar_consumer.assert_next("baz", &broadcast.consumer);
+		foo_bar_consumer.assert_next("baz", &broadcast.consume());
 	}
 
 	#[tokio::test]
 	async fn test_publish_only_allows() {
-		let origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast = BroadcastProducer::new();
 
 		// Create a producer that can only publish to "allowed" paths
 		let limited_producer = origin
-			.producer
 			.publish_only(&["allowed/path1".into(), "allowed/path2".into()])
 			.expect("should create limited producer");
 
 		// Should be able to publish to allowed paths
-		assert!(limited_producer.publish_broadcast("allowed/path1", broadcast.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("allowed/path1/nested", broadcast.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("allowed/path2", broadcast.consumer.clone()));
+		assert!(limited_producer.publish_broadcast("allowed/path1", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast("allowed/path1/nested", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast("allowed/path2", broadcast.consume()));
 
 		// Should not be able to publish to disallowed paths
-		assert!(!limited_producer.publish_broadcast("notallowed", broadcast.consumer.clone()));
-		assert!(!limited_producer.publish_broadcast("allowed", broadcast.consumer.clone())); // Parent of allowed path
-		assert!(!limited_producer.publish_broadcast("other/path", broadcast.consumer.clone()));
+		assert!(!limited_producer.publish_broadcast("notallowed", broadcast.consume()));
+		assert!(!limited_producer.publish_broadcast("allowed", broadcast.consume())); // Parent of allowed path
+		assert!(!limited_producer.publish_broadcast("other/path", broadcast.consume()));
 	}
 
 	#[tokio::test]
 	async fn test_publish_only_empty() {
-		let origin = Origin::produce();
+		let origin = OriginProducer::new();
 
 		// Creating a producer with no allowed paths should return None
-		assert!(origin.producer.publish_only(&[]).is_none());
+		assert!(origin.publish_only(&[]).is_none());
 	}
 
 	#[tokio::test]
 	async fn test_consume_only_filters() {
-		let mut origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
-		let broadcast3 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
+		let broadcast3 = BroadcastProducer::new();
 
 		// Publish to different paths
-		origin
-			.producer
-			.publish_broadcast("allowed", broadcast1.consumer.clone());
-		origin
-			.producer
-			.publish_broadcast("allowed/nested", broadcast2.consumer.clone());
-		origin
-			.producer
-			.publish_broadcast("notallowed", broadcast3.consumer.clone());
+		origin.publish_broadcast("allowed", broadcast1.consume());
+		origin.publish_broadcast("allowed/nested", broadcast2.consume());
+		origin.publish_broadcast("notallowed", broadcast3.consume());
 
 		// Create a consumer that only sees "allowed" paths
 		let mut limited_consumer = origin
-			.consumer
+			.consume()
 			.consume_only(&["allowed".into()])
 			.expect("should create limited consumer");
 
 		// Should only receive broadcasts under "allowed"
-		limited_consumer.assert_next("allowed", &broadcast1.consumer);
-		limited_consumer.assert_next("allowed/nested", &broadcast2.consumer);
+		limited_consumer.assert_next("allowed", &broadcast1.consume());
+		limited_consumer.assert_next("allowed/nested", &broadcast2.consume());
 		limited_consumer.assert_next_wait(); // Should not see "notallowed"
 
 		// Original consumer should see all
-		origin.consumer.assert_next("allowed", &broadcast1.consumer);
-		origin.consumer.assert_next("allowed/nested", &broadcast2.consumer);
-		origin.consumer.assert_next("notallowed", &broadcast3.consumer);
+		let mut consumer = origin.consume();
+		consumer.assert_next("allowed", &broadcast1.consume());
+		consumer.assert_next("allowed/nested", &broadcast2.consume());
+		consumer.assert_next("notallowed", &broadcast3.consume());
 	}
 
 	#[tokio::test]
 	async fn test_consume_only_multiple_prefixes() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
-		let broadcast3 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
+		let broadcast3 = BroadcastProducer::new();
 
-		origin
-			.producer
-			.publish_broadcast("foo/test", broadcast1.consumer.clone());
-		origin
-			.producer
-			.publish_broadcast("bar/test", broadcast2.consumer.clone());
-		origin
-			.producer
-			.publish_broadcast("baz/test", broadcast3.consumer.clone());
+		origin.publish_broadcast("foo/test", broadcast1.consume());
+		origin.publish_broadcast("bar/test", broadcast2.consume());
+		origin.publish_broadcast("baz/test", broadcast3.consume());
 
 		// Consumer that only sees "foo" and "bar" paths
 		let mut limited_consumer = origin
-			.consumer
+			.consume()
 			.consume_only(&["foo".into(), "bar".into()])
 			.expect("should create limited consumer");
 
-		limited_consumer.assert_next("foo/test", &broadcast1.consumer);
-		limited_consumer.assert_next("bar/test", &broadcast2.consumer);
+		limited_consumer.assert_next("foo/test", &broadcast1.consume());
+		limited_consumer.assert_next("bar/test", &broadcast2.consume());
 		limited_consumer.assert_next_wait(); // Should not see "baz/test"
 	}
 
 	#[tokio::test]
 	async fn test_with_root_and_publish_only() {
-		let mut origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast = BroadcastProducer::new();
 
 		// User connects to /foo root
-		let foo_producer = origin.producer.with_root("foo").expect("should create foo root");
+		let foo_producer = origin.with_root("foo").expect("should create foo root");
 
 		// Limit them to publish only to "bar" and "goop/pee" within /foo
 		let limited_producer = foo_producer
@@ -940,43 +938,38 @@ mod tests {
 			.expect("should create limited producer");
 
 		// Should be able to publish to foo/bar and foo/goop/pee (but user sees as bar and goop/pee)
-		assert!(limited_producer.publish_broadcast("bar", broadcast.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("bar/nested", broadcast.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("goop/pee", broadcast.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("goop/pee/nested", broadcast.consumer.clone()));
+		assert!(limited_producer.publish_broadcast("bar", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast("bar/nested", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast("goop/pee", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast("goop/pee/nested", broadcast.consume()));
 
 		// Should not be able to publish outside allowed paths
-		assert!(!limited_producer.publish_broadcast("baz", broadcast.consumer.clone()));
-		assert!(!limited_producer.publish_broadcast("goop", broadcast.consumer.clone())); // Parent of allowed
-		assert!(!limited_producer.publish_broadcast("goop/other", broadcast.consumer.clone()));
+		assert!(!limited_producer.publish_broadcast("baz", broadcast.consume()));
+		assert!(!limited_producer.publish_broadcast("goop", broadcast.consume())); // Parent of allowed
+		assert!(!limited_producer.publish_broadcast("goop/other", broadcast.consume()));
 
 		// Original consumer sees full paths
-		origin.consumer.assert_next("foo/bar", &broadcast.consumer);
-		origin.consumer.assert_next("foo/bar/nested", &broadcast.consumer);
-		origin.consumer.assert_next("foo/goop/pee", &broadcast.consumer);
-		origin.consumer.assert_next("foo/goop/pee/nested", &broadcast.consumer);
+		let mut consumer = origin.consume();
+		consumer.assert_next("foo/bar", &broadcast.consume());
+		consumer.assert_next("foo/bar/nested", &broadcast.consume());
+		consumer.assert_next("foo/goop/pee", &broadcast.consume());
+		consumer.assert_next("foo/goop/pee/nested", &broadcast.consume());
 	}
 
 	#[tokio::test]
 	async fn test_with_root_and_consume_only() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
-		let broadcast3 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
+		let broadcast3 = BroadcastProducer::new();
 
 		// Publish broadcasts
-		origin
-			.producer
-			.publish_broadcast("foo/bar/test", broadcast1.consumer.clone());
-		origin
-			.producer
-			.publish_broadcast("foo/goop/pee/test", broadcast2.consumer.clone());
-		origin
-			.producer
-			.publish_broadcast("foo/other/test", broadcast3.consumer.clone());
+		origin.publish_broadcast("foo/bar/test", broadcast1.consume());
+		origin.publish_broadcast("foo/goop/pee/test", broadcast2.consume());
+		origin.publish_broadcast("foo/other/test", broadcast3.consume());
 
 		// User connects to /foo root
-		let foo_producer = origin.producer.with_root("foo").expect("should create foo root");
+		let foo_producer = origin.with_root("foo").expect("should create foo root");
 
 		// Create consumer limited to "bar" and "goop/pee" within /foo
 		let mut limited_consumer = foo_producer
@@ -984,18 +977,17 @@ mod tests {
 			.expect("should create limited consumer");
 
 		// Should only see allowed paths (without foo prefix)
-		limited_consumer.assert_next("bar/test", &broadcast1.consumer);
-		limited_consumer.assert_next("goop/pee/test", &broadcast2.consumer);
+		limited_consumer.assert_next("bar/test", &broadcast1.consume());
+		limited_consumer.assert_next("goop/pee/test", &broadcast2.consume());
 		limited_consumer.assert_next_wait(); // Should not see "other/test"
 	}
 
 	#[tokio::test]
 	async fn test_with_root_unauthorized() {
-		let origin = Origin::produce();
+		let origin = OriginProducer::new();
 
 		// First limit the producer to specific paths
 		let limited_producer = origin
-			.producer
 			.publish_only(&["allowed".into()])
 			.expect("should create limited producer");
 
@@ -1011,15 +1003,15 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_wildcard_permission() {
-		let origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast = BroadcastProducer::new();
 
 		// Producer with root access (empty string means wildcard)
-		let root_producer = origin.producer.clone();
+		let root_producer = origin.clone();
 
 		// Should be able to publish anywhere
-		assert!(root_producer.publish_broadcast("any/path", broadcast.consumer.clone()));
-		assert!(root_producer.publish_broadcast("other/path", broadcast.consumer.clone()));
+		assert!(root_producer.publish_broadcast("any/path", broadcast.consume()));
+		assert!(root_producer.publish_broadcast("other/path", broadcast.consume()));
 
 		// Can create any root
 		let foo_producer = root_producer.with_root("foo").expect("should create any root");
@@ -1028,119 +1020,108 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_consume_broadcast_with_permissions() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
 
-		origin
-			.producer
-			.publish_broadcast("allowed/test", broadcast1.consumer.clone());
-		origin
-			.producer
-			.publish_broadcast("notallowed/test", broadcast2.consumer.clone());
+		origin.publish_broadcast("allowed/test", broadcast1.consume());
+		origin.publish_broadcast("notallowed/test", broadcast2.consume());
 
 		// Create limited consumer
 		let limited_consumer = origin
-			.consumer
+			.consume()
 			.consume_only(&["allowed".into()])
 			.expect("should create limited consumer");
 
 		// Should be able to get allowed broadcast
 		let result = limited_consumer.consume_broadcast("allowed/test");
 		assert!(result.is_some());
-		assert!(result.unwrap().is_clone(&broadcast1.consumer));
+		assert!(result.unwrap().is_clone(&broadcast1.consume()));
 
 		// Should not be able to get disallowed broadcast
 		assert!(limited_consumer.consume_broadcast("notallowed/test").is_none());
 
 		// Original consumer can get both
-		assert!(origin.consumer.consume_broadcast("allowed/test").is_some());
-		assert!(origin.consumer.consume_broadcast("notallowed/test").is_some());
+		assert!(limited_consumer.consume_broadcast("allowed/test").is_some());
+		assert!(limited_consumer.consume_broadcast("notallowed/test").is_some());
 	}
 
 	#[tokio::test]
 	async fn test_nested_paths_with_permissions() {
-		let origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast = BroadcastProducer::new();
 
 		// Create producer limited to "a/b/c"
 		let limited_producer = origin
-			.producer
 			.publish_only(&["a/b/c".into()])
 			.expect("should create limited producer");
 
 		// Should be able to publish to exact path and nested paths
-		assert!(limited_producer.publish_broadcast("a/b/c", broadcast.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("a/b/c/d", broadcast.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("a/b/c/d/e", broadcast.consumer.clone()));
+		assert!(limited_producer.publish_broadcast("a/b/c", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast("a/b/c/d", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast("a/b/c/d/e", broadcast.consume()));
 
 		// Should not be able to publish to parent or sibling paths
-		assert!(!limited_producer.publish_broadcast("a", broadcast.consumer.clone()));
-		assert!(!limited_producer.publish_broadcast("a/b", broadcast.consumer.clone()));
-		assert!(!limited_producer.publish_broadcast("a/b/other", broadcast.consumer.clone()));
+		assert!(!limited_producer.publish_broadcast("a", broadcast.consume()));
+		assert!(!limited_producer.publish_broadcast("a/b", broadcast.consume()));
+		assert!(!limited_producer.publish_broadcast("a/b/other", broadcast.consume()));
 	}
 
 	#[tokio::test]
 	async fn test_multiple_consumers_with_different_permissions() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
-		let broadcast3 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
+		let broadcast3 = BroadcastProducer::new();
 
 		// Publish to different paths
-		origin
-			.producer
-			.publish_broadcast("foo/test", broadcast1.consumer.clone());
-		origin
-			.producer
-			.publish_broadcast("bar/test", broadcast2.consumer.clone());
-		origin
-			.producer
-			.publish_broadcast("baz/test", broadcast3.consumer.clone());
+		origin.publish_broadcast("foo/test", broadcast1.consume());
+		origin.publish_broadcast("bar/test", broadcast2.consume());
+		origin.publish_broadcast("baz/test", broadcast3.consume());
 
 		// Create consumers with different permissions
 		let mut foo_consumer = origin
-			.consumer
+			.consume()
 			.consume_only(&["foo".into()])
 			.expect("should create foo consumer");
 
 		let mut bar_consumer = origin
-			.consumer
+			.consume()
 			.consume_only(&["bar".into()])
 			.expect("should create bar consumer");
 
 		let mut foobar_consumer = origin
-			.consumer
+			.consume()
 			.consume_only(&["foo".into(), "bar".into()])
 			.expect("should create foobar consumer");
 
 		// Each consumer should only see their allowed paths
-		foo_consumer.assert_next("foo/test", &broadcast1.consumer);
+		foo_consumer.assert_next("foo/test", &broadcast1.consume());
 		foo_consumer.assert_next_wait();
 
-		bar_consumer.assert_next("bar/test", &broadcast2.consumer);
+		bar_consumer.assert_next("bar/test", &broadcast2.consume());
 		bar_consumer.assert_next_wait();
 
-		foobar_consumer.assert_next("foo/test", &broadcast1.consumer);
-		foobar_consumer.assert_next("bar/test", &broadcast2.consumer);
+		foobar_consumer.assert_next("foo/test", &broadcast1.consume());
+		foobar_consumer.assert_next("bar/test", &broadcast2.consume());
 		foobar_consumer.assert_next_wait();
 	}
 
 	#[tokio::test]
 	async fn test_select_with_empty_prefix() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
 
 		// User with root "demo" allowed to subscribe to "worm-node" and "foobar"
-		let demo_producer = origin.producer.with_root("demo").expect("should create demo root");
+		let demo_producer = origin.with_root("demo").expect("should create demo root");
 		let limited_producer = demo_producer
 			.publish_only(&["worm-node".into(), "foobar".into()])
 			.expect("should create limited producer");
 
 		// Publish some broadcasts
-		assert!(limited_producer.publish_broadcast("worm-node/test", broadcast1.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("foobar/test", broadcast2.consumer.clone()));
+		assert!(limited_producer.publish_broadcast("worm-node/test", broadcast1.consume()));
+		assert!(limited_producer.publish_broadcast("foobar/test", broadcast2.consume()));
 
 		// consume_only with empty prefix should keep the exact same "worm-node" and "foobar" nodes
 		let mut consumer = limited_producer
@@ -1148,28 +1129,28 @@ mod tests {
 			.expect("should create consumer with empty prefix");
 
 		// Should still see both broadcasts
-		consumer.assert_next("worm-node/test", &broadcast1.consumer);
-		consumer.assert_next("foobar/test", &broadcast2.consumer);
+		consumer.assert_next("worm-node/test", &broadcast1.consume());
+		consumer.assert_next("foobar/test", &broadcast2.consume());
 		consumer.assert_next_wait();
 	}
 
 	#[tokio::test]
 	async fn test_select_narrowing_scope() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
-		let broadcast3 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
+		let broadcast3 = BroadcastProducer::new();
 
 		// User with root "demo" allowed to subscribe to "worm-node" and "foobar"
-		let demo_producer = origin.producer.with_root("demo").expect("should create demo root");
+		let demo_producer = origin.with_root("demo").expect("should create demo root");
 		let limited_producer = demo_producer
 			.publish_only(&["worm-node".into(), "foobar".into()])
 			.expect("should create limited producer");
 
 		// Publish broadcasts at different levels
-		assert!(limited_producer.publish_broadcast("worm-node", broadcast1.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("worm-node/foo", broadcast2.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("foobar/bar", broadcast3.consumer.clone()));
+		assert!(limited_producer.publish_broadcast("worm-node", broadcast1.consume()));
+		assert!(limited_producer.publish_broadcast("worm-node/foo", broadcast2.consume()));
+		assert!(limited_producer.publish_broadcast("foobar/bar", broadcast3.consume()));
 
 		// Test 1: consume_only("worm-node") should result in a single "" node with contents of "worm-node" ONLY
 		let mut worm_consumer = limited_producer
@@ -1177,8 +1158,8 @@ mod tests {
 			.expect("should create worm-node consumer");
 
 		// Should see worm-node content with paths stripped to ""
-		worm_consumer.assert_next("worm-node", &broadcast1.consumer);
-		worm_consumer.assert_next("worm-node/foo", &broadcast2.consumer);
+		worm_consumer.assert_next("worm-node", &broadcast1.consume());
+		worm_consumer.assert_next("worm-node/foo", &broadcast2.consume());
 		worm_consumer.assert_next_wait(); // Should NOT see foobar content
 
 		// Test 2: consume_only("worm-node/foo") should result in a "" node with contents of "worm-node/foo"
@@ -1186,27 +1167,26 @@ mod tests {
 			.consume_only(&["worm-node/foo".into()])
 			.expect("should create worm-node/foo consumer");
 
-		foo_consumer.assert_next("worm-node/foo", &broadcast2.consumer);
+		foo_consumer.assert_next("worm-node/foo", &broadcast2.consume());
 		foo_consumer.assert_next_wait(); // Should NOT see other content
 	}
 
 	#[tokio::test]
 	async fn test_select_multiple_roots_with_empty_prefix() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
-		let broadcast3 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
+		let broadcast3 = BroadcastProducer::new();
 
 		// Producer with multiple allowed roots
 		let limited_producer = origin
-			.producer
 			.publish_only(&["app1".into(), "app2".into(), "shared".into()])
 			.expect("should create limited producer");
 
 		// Publish to each root
-		assert!(limited_producer.publish_broadcast("app1/data", broadcast1.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("app2/config", broadcast2.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("shared/resource", broadcast3.consumer.clone()));
+		assert!(limited_producer.publish_broadcast("app1/data", broadcast1.consume()));
+		assert!(limited_producer.publish_broadcast("app2/config", broadcast2.consume()));
+		assert!(limited_producer.publish_broadcast("shared/resource", broadcast3.consume()));
 
 		// consume_only with empty prefix should maintain all roots
 		let mut consumer = limited_producer
@@ -1214,20 +1194,19 @@ mod tests {
 			.expect("should create consumer with empty prefix");
 
 		// Should see all broadcasts from all roots
-		consumer.assert_next("app1/data", &broadcast1.consumer);
-		consumer.assert_next("app2/config", &broadcast2.consumer);
-		consumer.assert_next("shared/resource", &broadcast3.consumer);
+		consumer.assert_next("app1/data", &broadcast1.consume());
+		consumer.assert_next("app2/config", &broadcast2.consume());
+		consumer.assert_next("shared/resource", &broadcast3.consume());
 		consumer.assert_next_wait();
 	}
 
 	#[tokio::test]
 	async fn test_publish_only_with_empty_prefix() {
-		let origin = Origin::produce();
-		let broadcast = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast = BroadcastProducer::new();
 
 		// Producer with specific allowed paths
 		let limited_producer = origin
-			.producer
 			.publish_only(&["services/api".into(), "services/web".into()])
 			.expect("should create limited producer");
 
@@ -1237,36 +1216,35 @@ mod tests {
 			.expect("should create producer with empty prefix");
 
 		// Should still have the same publishing restrictions
-		assert!(same_producer.publish_broadcast("services/api", broadcast.consumer.clone()));
-		assert!(same_producer.publish_broadcast("services/web", broadcast.consumer.clone()));
-		assert!(!same_producer.publish_broadcast("services/db", broadcast.consumer.clone()));
-		assert!(!same_producer.publish_broadcast("other", broadcast.consumer.clone()));
+		assert!(same_producer.publish_broadcast("services/api", broadcast.consume()));
+		assert!(same_producer.publish_broadcast("services/web", broadcast.consume()));
+		assert!(!same_producer.publish_broadcast("services/db", broadcast.consume()));
+		assert!(!same_producer.publish_broadcast("other", broadcast.consume()));
 	}
 
 	#[tokio::test]
 	async fn test_select_narrowing_to_deeper_path() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
-		let broadcast3 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
+		let broadcast3 = BroadcastProducer::new();
 
 		// Producer with broad permission
 		let limited_producer = origin
-			.producer
 			.publish_only(&["org".into()])
 			.expect("should create limited producer");
 
 		// Publish at various depths
-		assert!(limited_producer.publish_broadcast("org/team1/project1", broadcast1.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("org/team1/project2", broadcast2.consumer.clone()));
-		assert!(limited_producer.publish_broadcast("org/team2/project1", broadcast3.consumer.clone()));
+		assert!(limited_producer.publish_broadcast("org/team1/project1", broadcast1.consume()));
+		assert!(limited_producer.publish_broadcast("org/team1/project2", broadcast2.consume()));
+		assert!(limited_producer.publish_broadcast("org/team2/project1", broadcast3.consume()));
 
 		// Narrow down to team1 only
 		let mut team1_consumer = limited_producer
 			.consume_only(&["org/team2".into()])
 			.expect("should create team1 consumer");
 
-		team1_consumer.assert_next("org/team2/project1", &broadcast3.consumer);
+		team1_consumer.assert_next("org/team2/project1", &broadcast3.consume());
 		team1_consumer.assert_next_wait(); // Should NOT see team1 content
 
 		// Further narrow down to team1/project1
@@ -1275,17 +1253,16 @@ mod tests {
 			.expect("should create project1 consumer");
 
 		// Should only see project1 content at root
-		project1_consumer.assert_next("org/team1/project1", &broadcast1.consumer);
+		project1_consumer.assert_next("org/team1/project1", &broadcast1.consume());
 		project1_consumer.assert_next_wait();
 	}
 
 	#[tokio::test]
 	async fn test_select_with_non_matching_prefix() {
-		let origin = Origin::produce();
+		let origin = OriginProducer::new();
 
 		// Producer with specific allowed paths
 		let limited_producer = origin
-			.producer
 			.publish_only(&["allowed/path".into()])
 			.expect("should create limited producer");
 
@@ -1298,19 +1275,19 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_maintains_access_with_wider_prefix() {
-		let origin = Origin::produce();
-		let broadcast1 = Broadcast::produce();
-		let broadcast2 = Broadcast::produce();
+		let origin = OriginProducer::new();
+		let broadcast1 = BroadcastProducer::new();
+		let broadcast2 = BroadcastProducer::new();
 
 		// Setup: user with root "demo" allowed to subscribe to specific paths
-		let demo_producer = origin.producer.with_root("demo").expect("should create demo root");
+		let demo_producer = origin.with_root("demo").expect("should create demo root");
 		let user_producer = demo_producer
 			.publish_only(&["worm-node".into(), "foobar".into()])
 			.expect("should create user producer");
 
 		// Publish some data
-		assert!(user_producer.publish_broadcast("worm-node/data", broadcast1.consumer.clone()));
-		assert!(user_producer.publish_broadcast("foobar", broadcast2.consumer.clone()));
+		assert!(user_producer.publish_broadcast("worm-node/data", broadcast1.consume()));
+		assert!(user_producer.publish_broadcast("foobar", broadcast2.consume()));
 
 		// Key test: consume_only with "" should maintain access to allowed roots
 		let mut consumer = user_producer
@@ -1318,8 +1295,8 @@ mod tests {
 			.expect("consume_only with empty prefix should not fail when user has specific permissions");
 
 		// Should still receive broadcasts from allowed paths
-		consumer.assert_next("worm-node/data", &broadcast1.consumer);
-		consumer.assert_next("foobar", &broadcast2.consumer);
+		consumer.assert_next("worm-node/data", &broadcast1.consume());
+		consumer.assert_next("foobar", &broadcast2.consume());
 		consumer.assert_next_wait();
 
 		// Also test that we can still narrow the scope
@@ -1327,7 +1304,7 @@ mod tests {
 			.consume_only(&["worm-node".into()])
 			.expect("should be able to narrow scope to worm-node");
 
-		narrow_consumer.assert_next("worm-node/data", &broadcast1.consumer);
+		narrow_consumer.assert_next("worm-node/data", &broadcast1.consume());
 		narrow_consumer.assert_next_wait(); // Should not see foobar
 	}
 }

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -13,125 +13,301 @@
 //! The track is closed with [Error] when all writers or readers are dropped.
 
 use tokio::sync::watch;
-
-use crate::{Error, Produce, Result};
+use web_async::FuturesExt;
 
 use super::{Group, GroupConsumer, GroupProducer};
+use crate::{
+	Delivery, DeliveryConsumer, DeliveryProducer, Error, ExpiresConsumer, ExpiresProducer, Produce, Result, Subscriber,
+	Subscribers,
+};
 
-use std::{cmp::Ordering, future::Future};
+use std::{
+	borrow::Cow,
+	collections::VecDeque,
+	fmt,
+	future::Future,
+	ops::{Deref, DerefMut},
+	sync::Arc,
+};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// Static information about a track
+///
+/// Only used to make accessing the name easy/fast.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Track {
-	pub name: String,
-	pub priority: u8,
+	pub name: Arc<String>,
+}
+
+impl fmt::Display for Track {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.name)
+	}
 }
 
 impl Track {
-	pub fn new<T: Into<String>>(name: T) -> Self {
+	pub fn new<T: ToString>(name: T) -> Self {
 		Self {
-			name: name.into(),
-			priority: 0,
+			name: Arc::new(name.to_string()),
 		}
 	}
 
-	pub fn produce(self) -> Produce<TrackProducer, TrackConsumer> {
-		let producer = TrackProducer::new(self);
-		let consumer = producer.consume();
-		Produce { producer, consumer }
+	pub fn as_str(&self) -> &str {
+		&self.name
 	}
 }
 
-#[derive(Default)]
-struct TrackState {
-	latest: Option<GroupConsumer>,
+impl From<&str> for Track {
+	fn from(name: &str) -> Self {
+		Self {
+			name: Arc::new(name.to_string()),
+		}
+	}
+}
+
+impl From<String> for Track {
+	fn from(name: String) -> Self {
+		Self { name: Arc::new(name) }
+	}
+}
+
+impl From<&String> for Track {
+	fn from(name: &String) -> Self {
+		Self {
+			name: Arc::new(name.clone()),
+		}
+	}
+}
+
+impl From<&Track> for Track {
+	fn from(track: &Track) -> Self {
+		track.clone()
+	}
+}
+
+impl From<Cow<'_, str>> for Track {
+	fn from(name: Cow<'_, str>) -> Self {
+		Self {
+			name: Arc::new(name.into_owned()),
+		}
+	}
+}
+
+impl From<Arc<String>> for Track {
+	fn from(name: Arc<String>) -> Self {
+		Self { name }
+	}
+}
+
+impl AsRef<str> for Track {
+	fn as_ref(&self) -> &str {
+		&self.name
+	}
+}
+
+#[derive(Debug, Default)]
+struct State {
+	// Groups in order of arrival.
+	// If None, the group has expired but was not in the front of the queue.
+	groups: VecDeque<Option<Produce<GroupProducer, GroupConsumer>>>,
+
+	// +1 every time we remove a group from the front.
+	offset: usize,
+
+	// Some if the track is closed
 	closed: Option<Result<()>>,
+
+	// The highest sequence number received.
+	max: Option<u64>,
+}
+
+impl State {
+	fn create_group(&mut self, info: Group, expires: ExpiresProducer) -> Result<GroupProducer> {
+		if let Some(closed) = self.closed.clone() {
+			return Err(closed.err().unwrap_or(Error::Cancel));
+		}
+
+		let group = GroupProducer::new(info.clone(), expires);
+
+		// As a sanity check, make sure this is not a duplicate.
+		if self
+			.groups
+			.iter()
+			.filter_map(|g| g.as_ref())
+			.any(|g| g.producer.sequence == group.sequence)
+		{
+			return Err(Error::Duplicate);
+		}
+
+		self.max = Some(self.max.unwrap_or_default().max(group.sequence));
+
+		self.groups.push_back(Some(Produce {
+			consumer: group.consume(),
+			producer: group.clone(),
+		}));
+
+		Ok(group)
+	}
+
+	fn append_group(&mut self, expires: ExpiresProducer) -> Result<GroupProducer> {
+		if let Some(closed) = self.closed.clone() {
+			return Err(closed.err().unwrap_or(Error::Cancel));
+		}
+
+		let sequence = match self.max {
+			Some(sequence) => sequence + 1,
+			None => 0,
+		};
+		self.max = Some(sequence);
+
+		let group = GroupProducer::new(Group { sequence }, expires);
+
+		self.groups.push_back(Some(Produce {
+			consumer: group.consume(),
+			producer: group.clone(),
+		}));
+
+		Ok(group)
+	}
+
+	fn abort(&mut self, err: Error) -> Result<()> {
+		if let Some(Err(err)) = self.closed.clone() {
+			return Err(err);
+		}
+
+		self.closed = Some(Err(err));
+
+		Ok(())
+	}
+
+	fn close(&mut self) -> Result<()> {
+		if let Some(closed) = self.closed.clone() {
+			return Err(closed.err().unwrap_or(Error::Cancel));
+		}
+
+		self.closed = Some(Ok(()));
+
+		Ok(())
+	}
 }
 
 /// A producer for a track, used to create new groups.
 #[derive(Clone)]
 pub struct TrackProducer {
-	pub info: Track,
-	state: watch::Sender<TrackState>,
+	info: Track,
+	state: watch::Sender<State>,
+	subscribers: Subscribers,
+	delivery: DeliveryProducer,
+	expires: ExpiresProducer,
+}
+
+impl fmt::Debug for TrackProducer {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("TrackProducer")
+			.field("info", &self.info)
+			.field("state", &self.state.borrow().deref())
+			.field("subscribers", &self.subscribers)
+			.finish()
+	}
 }
 
 impl TrackProducer {
-	fn new(info: Track) -> Self {
+	pub fn new<T: Into<Track>>(info: T, delivery: Delivery) -> Self {
+		let info = info.into();
+
+		let delivery = DeliveryProducer::new(delivery);
+
 		Self {
+			state: watch::Sender::new(State::default()),
+			expires: ExpiresProducer::new(delivery.consume()),
+			delivery,
+			subscribers: Default::default(),
 			info,
-			state: Default::default(),
 		}
 	}
 
-	/// Insert a group into the track, returning true if this is the latest group.
-	pub fn insert_group(&mut self, group: GroupConsumer) -> bool {
-		self.state.send_if_modified(|state| {
-			assert!(state.closed.is_none());
-
-			if let Some(latest) = &state.latest {
-				match group.info.cmp(&latest.info) {
-					Ordering::Less => return false,
-					Ordering::Equal => return false,
-					Ordering::Greater => (),
-				}
-			}
-
-			state.latest = Some(group.clone());
-			true
-		})
+	pub fn info(&self) -> Track {
+		self.info.clone()
 	}
 
-	/// Create a new group with the given sequence number.
+	/// A handle to update the delivery information.
+	pub fn delivery(&mut self) -> &mut DeliveryProducer {
+		&mut self.delivery
+	}
+
+	/// Information about all of the subscribers of this track.
+	pub fn subscribers(&mut self) -> &mut Subscribers {
+		&mut self.subscribers
+	}
+
+	/// Return a handle controlling when groups are expired.
+	pub fn expires(&mut self) -> &mut ExpiresProducer {
+		&mut self.expires
+	}
+
+	/// Create a new [GroupProducer] with the given info.
 	///
-	/// If the sequence number is not the latest, this method will return None.
-	pub fn create_group(&mut self, info: Group) -> Option<GroupProducer> {
-		let group = info.produce();
-		self.insert_group(group.consumer).then_some(group.producer)
+	/// Returns an error if the track is closed.
+	pub fn create_group<T: Into<Group>>(&mut self, info: T) -> Result<GroupProducer> {
+		let mut result = Err(Error::Cancel);
+
+		self.state.send_if_modified(|state| {
+			result = state.create_group(info.into(), self.expires.clone());
+			result.is_ok()
+		});
+
+		result
 	}
 
 	/// Create a new group with the next sequence number.
-	pub fn append_group(&mut self) -> GroupProducer {
-		let mut producer = None;
+	pub fn append_group(&mut self) -> Result<GroupProducer> {
+		let mut result = Err(Error::Cancel);
 
 		self.state.send_if_modified(|state| {
-			assert!(state.closed.is_none());
-
-			let sequence = state.latest.as_ref().map_or(0, |group| group.info.sequence + 1);
-			let group = Group { sequence }.produce();
-			state.latest = Some(group.consumer);
-			producer = Some(group.producer);
-
-			true
+			result = state.append_group(self.expires.clone());
+			result.is_ok()
 		});
 
-		producer.unwrap()
+		result
 	}
 
-	/// Create a group with a single frame.
-	pub fn write_frame<B: Into<bytes::Bytes>>(&mut self, frame: B) {
-		let mut group = self.append_group();
-		group.write_frame(frame.into());
-		group.close();
+	pub fn close(&mut self) -> Result<()> {
+		let mut result = Ok(());
+
+		self.state.send_if_modified(|state| {
+			result = state.close();
+			result.is_ok()
+		});
+
+		result
 	}
 
-	pub fn close(self) {
-		self.state.send_modify(|state| state.closed = Some(Ok(())));
-	}
+	pub fn abort(&mut self, err: Error) -> Result<()> {
+		let mut result = Ok(());
 
-	pub fn abort(self, err: Error) {
-		self.state.send_modify(|state| state.closed = Some(Err(err)));
+		self.state.send_if_modified(|state| {
+			result = state.abort(err);
+			result.is_ok()
+		});
+
+		result
 	}
 
 	/// Create a new consumer for the track.
-	pub fn consume(&self) -> TrackConsumer {
+	pub fn subscribe(&self, delivery: Delivery) -> TrackConsumer {
 		TrackConsumer {
 			info: self.info.clone(),
 			state: self.state.subscribe(),
-			prev: None,
+			subscriber: self.subscribers.subscribe(delivery),
+			index: 0,
+			expires: self.expires.consume(),
+			delivery: self.delivery.consume(),
 		}
 	}
 
 	/// Block until there are no active consumers.
+	// We don't use the `async` keyword so we don't borrow &self across the await.
 	pub fn unused(&self) -> impl Future<Output = ()> {
 		let state = self.state.clone();
 		async move {
@@ -145,60 +321,134 @@ impl TrackProducer {
 	}
 }
 
-impl From<Track> for TrackProducer {
-	fn from(info: Track) -> Self {
-		TrackProducer::new(info)
+impl Deref for TrackProducer {
+	type Target = Track;
+
+	fn deref(&self) -> &Self::Target {
+		&self.info
 	}
 }
 
 /// A consumer for a track, used to read groups.
-#[derive(Clone)]
+///
+/// If the consumer is cloned, it will receive a copy of all unread groups.
+//#[derive(Clone)]
 pub struct TrackConsumer {
-	pub info: Track,
-	state: watch::Receiver<TrackState>,
-	prev: Option<u64>, // The previous sequence number
+	info: Track,
+
+	state: watch::Receiver<State>,
+
+	subscriber: Subscriber,
+
+	expires: ExpiresConsumer,
+
+	// We last returned this group, factoring in offset
+	index: usize,
+
+	delivery: DeliveryConsumer,
+}
+
+impl fmt::Debug for TrackConsumer {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("TrackConsumer")
+			.field("name", &self.name)
+			.field("state", &self.state.borrow().deref())
+			.field("subscriber", &self.subscriber)
+			.field("index", &self.index)
+			.field("delivery", &self.delivery)
+			.finish()
+	}
 }
 
 impl TrackConsumer {
-	/// Return the next group in order.
+	pub fn info(&self) -> Track {
+		self.info.clone()
+	}
+
+	/// Return the next group received over the network, in any order.
 	///
-	/// NOTE: This can have gaps if the reader is too slow or there were network slowdowns.
+	/// See [TrackConsumerOrdered] if you're willing to buffer groups in order.
+	///
+	/// NOTE: This can have gaps due to congestion.
 	pub async fn next_group(&mut self) -> Result<Option<GroupConsumer>> {
-		// Wait until there's a new latest group or the track is closed.
-		let state = match self
-			.state
-			.wait_for(|state| {
-				state.latest.as_ref().map(|group| group.info.sequence) > self.prev || state.closed.is_some()
-			})
-			.await
-		{
-			Ok(state) => state,
-			Err(_) => return Err(Error::Cancel),
-		};
+		loop {
+			// Wait until there's a new latest group or the track is closed.
+			let state = self
+				.state
+				.wait_for(|state| state.closed.is_some() || self.index < state.offset + state.groups.len())
+				.await
+				.map_err(|_| Error::Cancel)?;
 
-		match &state.closed {
-			Some(Ok(_)) => return Ok(None),
-			Some(Err(err)) => return Err(err.clone()),
-			_ => {}
+			for i in self.index.saturating_sub(state.offset)..state.groups.len() {
+				// If None, the group has expired out of order.
+				if let Some(group) = &state.groups[i] {
+					self.index = state.offset + i + 1;
+
+					let info = self.subscriber.current();
+					if self.expires.is_expired(group.consumer.sequence, info.max_latency) {
+						// Skip expired groups for this consumer
+						continue;
+					}
+
+					// TODO skip if expired
+					return Ok(Some(group.consumer.clone()));
+				}
+			}
+
+			match &state.closed {
+				Some(Ok(_)) => return Ok(None),
+				Some(Err(err)) => return Err(err.clone()),
+				// There must have been a new None group
+				// This can happen if an immediately expired group is received, or just a race.
+				_ => {}
+			}
 		}
-
-		// If there's a new latest group, return it.
-		let group = state.latest.clone().unwrap();
-		self.prev = Some(group.info.sequence);
-
-		Ok(Some(group))
 	}
 
 	/// Block until the track is closed.
-	pub async fn closed(&self) -> Result<()> {
-		match self.state.clone().wait_for(|state| state.closed.is_some()).await {
-			Ok(state) => state.closed.clone().unwrap(),
-			Err(_) => Err(Error::Cancel),
+	pub fn closed(&self) -> impl Future<Output = Result<()>> {
+		let mut state = self.state.clone();
+
+		async move {
+			match state.wait_for(|state| state.closed.is_some()).await {
+				Ok(state) => state.closed.clone().unwrap(),
+				Err(_) => Err(Error::Cancel),
+			}
 		}
 	}
 
 	pub fn is_clone(&self, other: &Self) -> bool {
 		self.state.same_channel(&other.state)
+	}
+
+	/// Return a handle allowing you to update the subscriber's priority/max_latency.
+	pub fn subscriber(&mut self) -> &mut Subscriber {
+		&mut self.subscriber
+	}
+
+	/// Return a handle to detect when groups are expired.
+	///
+	/// This is used internally, but worth exporting I guess.
+	pub fn expires(&mut self) -> &mut ExpiresConsumer {
+		&mut self.expires
+	}
+
+	/// Return a handle to update the delivery information.
+	pub fn delivery(&mut self) -> &mut DeliveryConsumer {
+		&mut self.delivery
+	}
+
+	/// Convert to a helper that returns groups in order, if possible.
+	pub fn ordered(self) -> TrackConsumerOrdered {
+		TrackConsumerOrdered::new(self)
+	}
+}
+
+impl Deref for TrackConsumer {
+	type Target = Track;
+
+	fn deref(&self) -> &Self::Target {
+		&self.info
 	}
 }
 
@@ -244,5 +494,94 @@ impl TrackConsumer {
 
 	pub fn assert_not_clone(&self, other: &Self) {
 		assert!(!self.is_clone(other), "should not be clone");
+	}
+}
+
+/// A [TrackConsumer] that returns groups in creation order, if possible.
+///
+/// It's recommended to set [Delivery::ordered] too if you REALLY want head-of-line blocking.
+/// The user experience would be to buffer rather than skip any groups, except in severe congestion.
+///
+/// With [Delivery::ordered] not set, we will try our best to return groups in order up to `max_latency`.
+/// This produces a hybrid experience where we'll buffer up until a point then skip ahead to newer groups.
+//
+// TODO: There's no group dropped message (yet), so we guess based on min/max timestamps.
+pub struct TrackConsumerOrdered {
+	track: TrackConsumer,
+	expected: u64,
+	pending: VecDeque<GroupConsumer>,
+}
+
+impl TrackConsumerOrdered {
+	pub fn new(track: TrackConsumer) -> Self {
+		Self {
+			track,
+			expected: 0,
+			pending: VecDeque::new(),
+		}
+	}
+
+	pub async fn next_group(&mut self) -> Result<Option<GroupConsumer>> {
+		let mut expires = self.track.expires().clone();
+
+		loop {
+			tokio::select! {
+				// Get the next group from the track.
+				Some(group) = self.track.next_group().transpose() => {
+					let group = group?;
+
+					// If we're looking for this sequence number, return it.
+					if group.sequence == self.expected {
+						self.expected += 1;
+						return Ok(Some(group));
+					}
+
+					// If it's old, skip it.
+					if group.sequence < self.expected {
+						continue;
+					}
+
+					// If it's new, insert it into the buffered queue based on the sequence number ascending.
+					let index = self.pending.partition_point(|g| g.sequence < group.sequence);
+					self.pending.insert(index, group);
+				}
+				Some(next) = async {
+					loop {
+						// Get the oldest group in the buffered queue.
+						let first = self.pending.front()?;
+
+						// Wait until it has a timestamp available. (TODO would be nice to make this required)
+						let Ok(instant) = first.instant().await else {
+							self.pending.pop_front();
+							continue;
+						};
+
+						// Wait until the first frame of the group would have been expired.
+						// This doesn't mean the entire group is expired, because that uses the max_timestamp.
+						// But even if the group has one frame this will still unstuck the consumer.
+						expires.wait_expired(first.sequence, instant).await;
+						return self.pending.pop_front()
+					}
+				} => {
+					// We found the next group in order, so update the expected sequence number.
+					self.expected = next.sequence + 1;
+					return Ok(Some(next));
+				}
+			}
+		}
+	}
+}
+
+impl Deref for TrackConsumerOrdered {
+	type Target = TrackConsumer;
+
+	fn deref(&self) -> &Self::Target {
+		&self.track
+	}
+}
+
+impl DerefMut for TrackConsumerOrdered {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.track
 	}
 }


### PR DESCRIPTION
## Summary

This PR combines the model refactoring with protocol layer updates (originally planned as separate PRs #3 and #4, but they're too tightly coupled to separate). The model now supports temporal awareness and latency-aware delivery, and the protocol layer is updated to support the new subscribe parameters.

## Rust (moq-lite) Model Changes

### Frame
- Added `instant: Time` field for presentation timestamp
- Frame size changed from `u64` to `usize`
- State machine now tracks time alongside data

### Group
- Integrates with `ExpiresProducer` for expiration tracking
- Calls `expires.create_frame()` when appending frames
- Tracks `max_instant` for latest timestamp in group

### Track (Major Refactoring)
**TrackProducer** now internally manages:
- `delivery: DeliveryProducer` - for updating track-level delivery preferences
- `subscribers: Subscribers` - tracks all connected consumers and their demands
- `expires: ExpiresProducer` - manages group/frame expiration

**TrackConsumer** now has:
- `subscriber: Subscriber` - declares its own delivery preferences
- `expires: ExpiresConsumer` - can check if groups are expired
- `delivery: DeliveryConsumer` - can react to delivery changes
- Filters expired groups transparently before returning them

**Breaking change**: Priority removed from Track, now per-subscriber via `Delivery`

### Broadcast
- Simplified from ~450 to ~200 lines
- Stores `TrackProducer` instead of `TrackConsumer`
- Separates explicit publishes (`producers`) from dynamic requests (`requested`)
- Cleaner ownership model

## Rust (moq-lite) Protocol Layer Changes

### IETF Protocol
- Added `delivery_timeout` parameter to Subscribe and Publish messages
- Added `group_order` field to SubscribeOk
- Renamed parameter methods: `get_int`/`set_int` → `get_varint`/`set_varint`
- Added `Default` derive for `RequestId`

### Lite Protocol
- Added **DRAFT_03** version
- Added `max_latency` and `ordered` fields to Subscribe/SubscribeOk/SubscribeUpdate
- New `lite/frame.rs` for frame encoding with timestamp deltas
- Version-gated: Draft01/Draft02 still work, Draft03 adds new fields

## TypeScript (lite) Changes

### Core Types
- **New `Frame` class** with `instant: Time.Milli` and `payload: Uint8Array`
- **Tracks now have reactive properties** using Signals:
  - `priority: Signal<number>`
  - `maxLatency: Signal<Time.Milli>`
  - `ordered: Signal<boolean>`
- Groups and Broadcasts updated to work with new Frame type

### Protocol Layer
- Added **DRAFT_03** version matching Rust
- Subscribe messages now include `maxLatency` and `ordered` fields
- Frame encoding with delta timestamps
- Version-gated protocol changes
- Reactive updates: when track properties change, `SubscribeUpdate` messages are sent

### Signals
- Added Signal utilities for reactive track properties
- Enables dynamic priority/latency negotiation mid-stream

## Breaking Changes

⚠️ **Track API**: `priority` removed from Track, now per-subscriber via `Delivery`  
⚠️ **Frame size**: Changed from `u64` to `usize` in Rust  
⚠️ **Frame type**: TypeScript now uses `Frame` objects instead of raw `Uint8Array`  
⚠️ **Subscribe API**: Now requires `Delivery` parameter  

## Compatibility

✅ **Version gating**: Draft01/Draft02 clients continue to work  
✅ **Draft03**: New version includes max_latency and ordered fields  
✅ **Backward compatible**: Older versions negotiate down gracefully  

## Known Issues

- hang crate will fail to compile (fixed in PR #5)
- moq-relay and moq-clock need updates (fixed in PR #6)
- These are expected and won't block this PR

## Test Plan

- [x] moq-lite (Rust) compiles successfully
- [x] @moq/lite (TypeScript) compiles successfully
- [ ] hang crate fails as expected (will be fixed in PR #5)
- [ ] Integration tests (will pass after PR #5)

## Dependencies

- **Depends on**: PR #2 (Delivery & Expiration)
- **Depended on by**: PR #5 (Hang Simplification)

## Notes

Originally planned as two separate PRs (Model Refactoring + Protocol Layer), but they're too tightly coupled:
- Model changes require protocol support for new fields
- Protocol changes are meaningless without model integration
- Splitting them creates non-compiling intermediate states

This combined PR ensures the model and protocol stay synchronized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)