### PR TITLE
docs: add comprehensive documentation outline

### DIFF
--- a/DOCUMENTATION_OUTLINE.md
+++ b/DOCUMENTATION_OUTLINE.md
@@ -1,0 +1,624 @@
+# MoQ Documentation Outline
+
+This document provides a comprehensive outline for the MoQ project documentation, including both existing content and suggested additions.
+
+---
+
+## 1. Getting Started
+
+### 1.1 Introduction (`/doc/index.md` - ROOT)
+**Status:** ✅ Exists
+**TODO:**
+- Project overview and value proposition
+- Key benefits (real-time latency, massive scale, QUIC advantages)
+- Quick comparison to WebRTC, HLS, RTMP
+- Link to quick start guide
+- Link to demo/playground
+
+### 1.2 Quick Start (`/doc/setup/index.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Installation instructions (Nix and manual)
+- Running first example in < 5 minutes
+- Verify setup is working
+- Next steps guidance
+
+### 1.3 Development Setup (`/doc/setup/development.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Prerequisites (Rust, Bun, Just)
+- Cloning and building the project
+- Common development commands (`just check`, `just fix`, `just dev`)
+- IDE setup recommendations
+- Troubleshooting common setup issues
+
+### 1.4 Production Deployment (`/doc/setup/production.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Deployment overview
+- Relay server configuration
+- Web client deployment
+- Native client deployment
+- Environment variables and configuration
+- Security considerations
+
+---
+
+## 2. Core Concepts
+
+### 2.1 MoQ Overview (`/doc/concepts/index.md`)
+**Status:** ✅ Exists
+**TODO:**
+- What is MoQ and why it exists
+- Key abstractions: Broadcasts, Tracks, Groups, Frames
+- When to use MoQ vs other protocols
+- Real-world use cases
+
+### 2.2 Architecture (`/doc/concepts/architecture.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Layered protocol stack (QUIC → WebTransport → moq-lite → hang → app)
+- Separation of concerns (CDN doesn't know about media)
+- Publisher → Relay → Subscriber flow
+- Clustering and fan-out architecture
+- Why QUIC matters for live streaming
+
+### 2.3 Protocol Specification (`/doc/concepts/protocol.md`)
+**Status:** ✅ Exists
+**TODO:**
+- moq-lite protocol details
+- hang protocol details
+- Wire format and message types
+- Track naming conventions
+- Priority and ordering guarantees
+- Relationship to IETF MoQ working group
+
+### 2.4 Authentication & Authorization (`/doc/concepts/authentication.md`)
+**Status:** ✅ Exists
+**TODO:**
+- JWT token structure
+- Issuer and verification flow
+- Path-based authorization (pub/sub permissions)
+- Anonymous access configuration
+- Token generation examples
+- Security best practices
+
+### 2.5 Deployment Architecture (`/doc/concepts/deployment.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Single relay deployment
+- Multi-relay clustering
+- Geographic distribution with GeoDNS
+- Load balancing strategies
+- Monitoring and observability
+- Scaling considerations
+
+### 2.6 Performance & Optimization (`/doc/concepts/performance.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Latency characteristics and tuning
+- Bandwidth management and adaptive bitrate
+- QUIC congestion control
+- Group and frame sizing best practices
+- Client-side buffering strategies
+- Measuring and monitoring performance
+- Benchmarking results
+
+---
+
+## 3. Rust Documentation
+
+### 3.1 Rust Overview (`/doc/rust/index.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Overview of all Rust crates
+- Package hierarchy and dependencies
+- When to use each crate
+- Installation and dependency management
+- Links to docs.rs for API reference
+
+### 3.2 moq-lite Library (`/doc/rust/moq-lite.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Core pub/sub protocol API
+- Creating publishers and subscribers
+- Working with broadcasts, tracks, groups, frames
+- Connection management
+- Error handling
+- Performance considerations
+- Code examples
+
+### 3.3 hang Library (`/doc/rust/hang.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Media encoding/decoding layer
+- Catalog format and usage
+- Supported codecs (H.264, H.265, VP8/9, AV1, Opus, AAC)
+- Container format
+- Timestamp handling
+- Integration with moq-lite
+- Code examples
+
+### 3.4 moq-relay Server (`/doc/rust/moq-relay.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Relay server architecture
+- Configuration options
+- Running the relay
+- Clustering setup
+- Monitoring and metrics
+- Performance tuning
+- Deployment strategies
+
+### 3.5 moq-token Library (`/doc/rust/moq-token.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- JWT token generation and verification
+- Integration with moq-relay
+- Custom claims and scopes
+- Token validation
+- Security best practices
+- Code examples
+
+### 3.6 moq-native Library (`/doc/rust/moq-native.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Quinn QUIC helper utilities
+- Native QUIC connection setup
+- Certificate management
+- Use cases for native vs WebTransport
+- Code examples
+
+### 3.7 libmoq FFI (`/doc/rust/libmoq.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- C FFI bindings overview
+- Using libmoq from C/C++
+- Memory management
+- Error handling in FFI context
+- Integration examples (Python, Go, etc.)
+
+### 3.8 Rust Examples (`/doc/rust/examples.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Simple chat application
+- Clock synchronization
+- Video publisher
+- Video subscriber
+- Custom protocol on top of moq-lite
+- Advanced patterns and best practices
+
+### 3.9 Rust API Reference (`/doc/rust/api.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Link to docs.rs for each crate
+- API stability guarantees
+- Breaking change policy
+- Deprecation notices
+
+---
+
+## 4. TypeScript/JavaScript Documentation
+
+### 4.1 TypeScript Overview (`/doc/typescript/index.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Overview of all npm packages
+- Browser compatibility
+- WebTransport requirements
+- Installation and setup
+- Package hierarchy
+
+### 4.2 @moq/lite Package (`/doc/typescript/lite.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Core protocol for browsers
+- Creating publishers and subscribers
+- WebTransport connection setup
+- Working with tracks and groups
+- Error handling
+- TypeScript types
+- Code examples
+
+### 4.3 @moq/hang Package (`/doc/typescript/hang.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Media layer for browsers
+- Catalog handling
+- WebCodecs integration
+- Audio/video encoding and decoding
+- Integration with @moq/lite
+- Code examples
+
+### 4.4 Web Components (`/doc/typescript/web-components.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Overview of Web Components
+- `<hang-publish>` - Camera/screen publishing
+- `<hang-watch>` - Video player
+- `<hang-meet>` - Video conferencing
+- `<hang-support>` - Feature detection
+- Attributes and properties
+- Events and callbacks
+- Styling and customization
+- Full integration examples
+
+### 4.5 @moq/hang-ui Package (`/doc/typescript/hang-ui.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- SolidJS UI components
+- Component library overview
+- Using with existing apps
+- Customization options
+- Examples and demos
+
+### 4.6 TypeScript Examples (`/doc/typescript/examples.md`)
+**Status:** ✅ Exists
+**TODO:**
+- Video player implementation
+- Camera publisher
+- Screen sharing
+- Text chat
+- Video conferencing app
+- Custom media pipeline
+- React integration example
+- Vue integration example
+
+### 4.7 TypeScript API Reference (`/doc/typescript/api.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Link to generated API docs
+- Key interfaces and types
+- API stability guarantees
+- Breaking change policy
+
+---
+
+## 5. Command-Line Tools
+
+### 5.1 CLI Tools Overview (`/doc/cli/index.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Overview of available CLI tools
+- Installation instructions
+- Common use cases
+
+### 5.2 hang CLI (`/doc/cli/hang.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Publishing video files
+- Transcoding options
+- Supported formats
+- Command-line options
+- Examples and recipes
+- Integration with workflows
+
+### 5.3 moq-token CLI (`/doc/cli/moq-token.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Generating JWT tokens
+- Token customization
+- Testing authentication
+- Command-line options
+- Examples
+
+### 5.4 Just Commands (`/doc/cli/just.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Overview of justfile commands
+- Development workflow
+- Testing and linting
+- Building and running
+- Deployment helpers
+- Custom task creation
+
+---
+
+## 6. Guides & Tutorials
+
+### 6.1 Building a Video Streaming App (`/doc/guides/video-streaming.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Step-by-step tutorial
+- Publisher setup (camera or file)
+- Relay configuration
+- Player implementation
+- Adding adaptive bitrate
+- Testing and debugging
+
+### 6.2 Building a Video Conference App (`/doc/guides/conferencing.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Multi-party communication architecture
+- Managing multiple publishers
+- Selective forwarding unit (SFU) pattern
+- UI layout and controls
+- Audio/video quality management
+- Screen sharing integration
+
+### 6.3 Migrating from WebRTC (`/doc/guides/webrtc-migration.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Key differences between MoQ and WebRTC
+- Architecture changes needed
+- Signaling comparison
+- API mapping guide
+- Performance expectations
+- Migration checklist
+
+### 6.4 Migrating from HLS/DASH (`/doc/guides/hls-migration.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Key differences between MoQ and HLS/DASH
+- Latency improvements
+- Chunking vs frame-based delivery
+- Player implementation differences
+- Adaptive bitrate strategies
+- Migration checklist
+
+### 6.5 Building Custom Protocols (`/doc/guides/custom-protocol.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Using moq-lite for non-media use cases
+- Designing track hierarchy
+- Serialization strategies
+- Priority and ordering
+- Example: Chat application
+- Example: Sensor data streaming
+- Example: Collaborative editing
+
+### 6.6 Testing & Debugging (`/doc/guides/testing.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Unit testing strategies
+- Integration testing
+- Load testing and benchmarking
+- Debugging QUIC issues
+- Network simulation and testing
+- Common issues and solutions
+
+### 6.7 Security Best Practices (`/doc/guides/security.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Authentication setup
+- Token security
+- HTTPS/TLS requirements
+- Certificate management
+- Rate limiting and abuse prevention
+- Content validation
+- Privacy considerations
+
+---
+
+## 7. Deployment
+
+### 7.1 Cloud Deployment (`/doc/deployment/cloud.md`)
+**Status:** 🆕 Suggested New Page (content exists in setup/production.md)
+**TODO:**
+- AWS deployment guide
+- GCP deployment guide
+- Azure deployment guide
+- DigitalOcean deployment guide
+- Linode deployment guide
+- Cost optimization
+
+### 7.2 Infrastructure as Code (`/doc/deployment/iac.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- OpenTofu/Terraform examples
+- Ansible playbooks
+- Docker and Kubernetes
+- Systemd service configuration
+- Automated deployment pipelines
+
+### 7.3 Clustering & Scaling (`/doc/deployment/clustering.md`)
+**Status:** 🆕 Suggested New Page (content exists in concepts)
+**TODO:**
+- Cluster architecture
+- Setting up multi-relay clusters
+- Geographic distribution
+- Load balancing
+- Health checks and failover
+- Scaling strategies
+
+### 7.4 Monitoring & Observability (`/doc/deployment/monitoring.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Metrics and logging
+- Prometheus integration (when available)
+- Grafana dashboards
+- Alerting strategies
+- Performance monitoring
+- Debugging production issues
+
+### 7.5 Certificate Management (`/doc/deployment/certificates.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Let's Encrypt integration
+- Certificate rotation
+- Custom certificate authorities
+- Development certificates
+- WebTransport certificate requirements
+
+---
+
+## 8. Reference
+
+### 8.1 Configuration Reference (`/doc/reference/configuration.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- moq-relay configuration options
+- Environment variables
+- Command-line arguments
+- Configuration file format
+- Default values
+- Configuration validation
+
+### 8.2 Error Codes (`/doc/reference/errors.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Protocol error codes
+- Application error codes
+- Troubleshooting by error code
+- Common error scenarios
+
+### 8.3 Protocol Messages (`/doc/reference/messages.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Complete message format reference
+- Wire format details
+- Message flow diagrams
+- Version compatibility
+
+### 8.4 Codec Support (`/doc/reference/codecs.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Supported video codecs (H.264, H.265, VP8, VP9, AV1)
+- Supported audio codecs (Opus, AAC)
+- Browser compatibility matrix
+- Codec selection guidance
+- Quality and performance tradeoffs
+
+### 8.5 Browser Compatibility (`/doc/reference/browser-compatibility.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- WebTransport browser support
+- WebCodecs browser support
+- Feature detection
+- Polyfills and fallbacks
+- Testing across browsers
+
+### 8.6 Glossary (`/doc/reference/glossary.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Technical terms and definitions
+- Protocol-specific terminology
+- Acronym expansions
+
+---
+
+## 9. Community & Contributing
+
+### 9.1 Contributing Guide (`/doc/community/contributing.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- How to contribute
+- Code style guidelines
+- Pull request process
+- Issue reporting
+- Feature requests
+- Community guidelines
+
+### 9.2 Development Roadmap (`/doc/community/roadmap.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Current development status
+- Planned features
+- Known limitations
+- Future directions
+- Release schedule
+
+### 9.3 FAQ (`/doc/community/faq.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Common questions and answers
+- "Why MoQ instead of X?"
+- Performance questions
+- Compatibility questions
+- Troubleshooting common issues
+
+### 9.4 Changelog (`/doc/community/changelog.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Release history
+- Breaking changes
+- New features
+- Bug fixes
+- Migration guides between versions
+
+### 9.5 License & Legal (`/doc/community/license.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- License information
+- Third-party licenses
+- Patent information
+- Contribution licensing
+
+---
+
+## 10. Advanced Topics
+
+### 10.1 Protocol Extensions (`/doc/advanced/extensions.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Extending moq-lite protocol
+- Custom message types
+- Backwards compatibility
+- Extension registration
+
+### 10.2 Performance Tuning (`/doc/advanced/tuning.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- QUIC parameter tuning
+- Congestion control algorithms
+- Buffer management
+- OS-level optimizations
+- Profiling and benchmarking
+
+### 10.3 Internals & Architecture (`/doc/advanced/internals.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Implementation details
+- Memory management
+- Concurrency model
+- State management
+- Design decisions and tradeoffs
+
+### 10.4 Research & Papers (`/doc/advanced/research.md`)
+**Status:** 🆕 Suggested New Page
+**TODO:**
+- Related academic papers
+- IETF MoQ working group
+- Performance studies
+- Comparison studies
+
+---
+
+## Documentation Maintenance
+
+### High Priority Additions
+1. **Performance & Optimization Guide** - Critical for production users
+2. **Testing & Debugging Guide** - Essential for developers
+3. **Monitoring & Observability** - Important for operations
+4. **Migration Guides** - Help users transition from other technologies
+5. **Security Best Practices** - Critical for production deployment
+
+### Medium Priority Additions
+1. **CLI Tools Documentation** - Improve usability
+2. **Browser Compatibility Matrix** - Help with planning
+3. **Error Code Reference** - Aid troubleshooting
+4. **FAQ** - Reduce support burden
+5. **Changelog** - Keep users informed
+
+### Low Priority Additions
+1. **Research & Papers** - Nice to have for academic users
+2. **Protocol Extensions** - For advanced users
+3. **Internals & Architecture** - For contributors
+
+### Content Improvements for Existing Pages
+1. Add more code examples to all guides
+2. Include troubleshooting sections
+3. Add diagrams and visual aids
+4. Create video tutorials or screencasts
+5. Add "Next Steps" to each page
+6. Improve search and navigation
+7. Add copy buttons to code blocks
+8. Include "Edit on GitHub" links
+
+### Documentation Infrastructure
+- **Generator:** VitePress (already in use)
+- **API Docs:** docs.rs for Rust, TypeDoc or similar for TypeScript
+- **Versioning:** Need version selector for different releases
+- **Search:** VitePress built-in search or Algolia
+- **Analytics:** Consider adding usage analytics
+- **Feedback:** Add feedback mechanism on each page


### PR DESCRIPTION
Add detailed outline for MoQ documentation structure covering:
- Existing documentation inventory across all sections
- Suggested new pages to fill content gaps
- TODO summaries for each page with content guidance
- Priority levels for documentation improvements

The outline covers 10 major sections from getting started to advanced
topics, identifying ~30 existing pages and ~30 suggested additions.