### PR TITLE
refactor: simplify match statements using let-else syntax

### DIFF
--- a/rs/hang/src/import/annexb.rs
+++ b/rs/hang/src/import/annexb.rs
@@ -18,10 +18,12 @@ impl<'a, T: Buf + AsRef<[u8]> + 'a> NalIterator<'a, T> {
 	pub fn flush(self) -> anyhow::Result<Option<Bytes>> {
 		let start = match self.start {
 			Some(start) => start,
-			None => match after_start_code(self.buf.as_ref())? {
-				Some(start) => start,
-				None => return Ok(None),
-			},
+			None => {
+				let Some(start) = after_start_code(self.buf.as_ref())? else {
+					return Ok(None);
+				};
+				start
+			}
 		};
 
 		self.buf.advance(start);

--- a/rs/hang/src/model/group.rs
+++ b/rs/hang/src/model/group.rs
@@ -60,10 +60,10 @@ impl GroupConsumer {
 	}
 
 	async fn read_unbuffered(&mut self) -> Result<Option<Frame>> {
-		let payload = match self.group.next_frame().await? {
-			Some(mut frame) => frame.read_chunks().await?,
-			None => return Ok(None),
+		let Some(mut frame) = self.group.next_frame().await? else {
+			return Ok(None);
 		};
+		let payload = frame.read_chunks().await?;
 
 		let mut payload = BufList::from_iter(payload);
 

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -79,16 +79,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		tracing::info!(id = %request_id, broadcast = %absolute, %track, "subscribed started");
 
-		let broadcast = match self.origin.consume_broadcast(&msg.track_namespace) {
-			Some(consumer) => consumer,
-			None => {
-				self.control.send(ietf::SubscribeError {
-					request_id,
-					error_code: 404,
-					reason_phrase: "Broadcast not found".into(),
-				})?;
-				return Ok(());
-			}
+		let Some(broadcast) = self.origin.consume_broadcast(&msg.track_namespace) else {
+			self.control.send(ietf::SubscribeError {
+				request_id,
+				error_code: 404,
+				reason_phrase: "Broadcast not found".into(),
+			})?;
+			return Ok(());
 		};
 
 		let track = Track {

--- a/rs/moq-lite/src/ietf/subscriber.rs
+++ b/rs/moq-lite/src/ietf/subscriber.rs
@@ -76,9 +76,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	fn start_announce(&mut self, path: PathOwned) -> Result<BroadcastProducer, Error> {
-		let origin = match &self.origin {
-			Some(origin) => origin,
-			None => return Err(Error::InvalidRole),
+		let Some(origin) = &self.origin else {
+			return Err(Error::InvalidRole);
 		};
 
 		let mut state = self.state.lock();
@@ -114,9 +113,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	fn stop_announce(&mut self, path: PathOwned) -> Result<(), Error> {
-		let origin = match &self.origin {
-			Some(origin) => origin,
-			None => return Err(Error::InvalidRole),
+		let Some(origin) = &self.origin else {
+			return Err(Error::InvalidRole);
 		};
 
 		let mut state = self.state.lock();

--- a/rs/moq-lite/src/model/frame.rs
+++ b/rs/moq-lite/src/model/frame.rs
@@ -163,15 +163,12 @@ impl FrameConsumer {
 	pub async fn read_chunks(&mut self) -> Result<Vec<Bytes>> {
 		// Wait until the writer is done before even attempting to read.
 		// That way this function can be cancelled without consuming half of the frame.
-		let state = match self.state.wait_for(|state| state.closed.is_some()).await {
-			Ok(state) => {
-				if let Some(Err(err)) = &state.closed {
-					return Err(err.clone());
-				}
-				state
-			}
-			Err(_) => return Err(Error::Cancel),
+		let Ok(state) = self.state.wait_for(|state| state.closed.is_some()).await else {
+			return Err(Error::Cancel);
 		};
+		if let Some(Err(err)) = &state.closed {
+			return Err(err.clone());
+		}
 
 		// Get all of the remaining chunks.
 		let chunks = state.chunks[self.index..].to_vec();
@@ -184,15 +181,12 @@ impl FrameConsumer {
 	pub async fn read_all(&mut self) -> Result<Bytes> {
 		// Wait until the writer is done before even attempting to read.
 		// That way this function can be cancelled without consuming half of the frame.
-		let state = match self.state.wait_for(|state| state.closed.is_some()).await {
-			Ok(state) => {
-				if let Some(Err(err)) = &state.closed {
-					return Err(err.clone());
-				}
-				state
-			}
-			Err(_) => return Err(Error::Cancel),
+		let Ok(state) = self.state.wait_for(|state| state.closed.is_some()).await else {
+			return Err(Error::Cancel);
 		};
+		if let Some(Err(err)) = &state.closed {
+			return Err(err.clone());
+		}
 
 		// Get all of the remaining chunks.
 		let chunks = &state.chunks[self.index..];

--- a/rs/moq-lite/src/model/group.rs
+++ b/rs/moq-lite/src/model/group.rs
@@ -179,10 +179,10 @@ impl GroupConsumer {
 		};
 
 		// Read the frame in one go, which is cancel safe.
-		let frame = match self.active.as_mut() {
-			Some(frame) => frame.read_all().await?,
-			None => return Ok(None),
+		let Some(frame) = self.active.as_mut() else {
+			return Ok(None);
 		};
+		let frame = frame.read_all().await?;
 
 		self.active = None;
 

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -165,15 +165,14 @@ impl TrackConsumer {
 	/// NOTE: This can have gaps if the reader is too slow or there were network slowdowns.
 	pub async fn next_group(&mut self) -> Result<Option<GroupConsumer>> {
 		// Wait until there's a new latest group or the track is closed.
-		let state = match self
+		let Ok(state) = self
 			.state
 			.wait_for(|state| {
 				state.latest.as_ref().map(|group| group.info.sequence) > self.prev || state.closed.is_some()
 			})
 			.await
-		{
-			Ok(state) => state,
-			Err(_) => return Err(Error::Cancel),
+		else {
+			return Err(Error::Cancel);
 		};
 
 		match &state.closed {

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -116,15 +116,17 @@ impl Cluster {
 	}
 
 	pub async fn run(self) -> anyhow::Result<()> {
-		let root = match self.config.root.clone() {
-			// If we're using a root node, then we have to connect to it.
-			Some(connect) if Some(&connect) != self.config.node.as_ref() => connect,
-			// Otherwise, we're the root node so we wait for other nodes to connect to us.
-			_ => {
-				tracing::info!("running as root, accepting leaf nodes");
-				self.run_combined().await?;
-				anyhow::bail!("combined connection closed");
-			}
+		// If we're using a root node, then we have to connect to it.
+		// Otherwise, we're the root node so we wait for other nodes to connect to us.
+		let Some(root) = self
+			.config
+			.root
+			.clone()
+			.filter(|connect| Some(connect) != self.config.node.as_ref())
+		else {
+			tracing::info!("running as root, accepting leaf nodes");
+			self.run_combined().await?;
+			anyhow::bail!("combined connection closed");
 		};
 
 		// Subscribe to available origins.
@@ -199,13 +201,10 @@ impl Cluster {
 				continue;
 			}
 
-			let origin = match origin {
-				Some(origin) => origin,
-				None => {
-					tracing::info!(%node, "origin cancelled");
-					active.remove(node.as_str()).unwrap().abort();
-					continue;
-				}
+			let Some(origin) = origin else {
+				tracing::info!(%node, "origin cancelled");
+				active.remove(node.as_str()).unwrap().abort();
+				continue;
 			};
 
 			tracing::info!(%node, "discovered origin");


### PR DESCRIPTION
Replaced verbose match statements that extract a value and early return
on the alternative branch with the more concise let-else syntax.

Changes include:
- moq-relay: Simplified Option and Result matching in web.rs, auth.rs,
  cluster.rs
- moq-lite: Simplified error handling patterns in model (track.rs,
  frame.rs, group.rs) and ietf modules (subscriber.rs, publisher.rs)
- hang: Simplified nested matches in annexb.rs and group.rs

This improves code readability while maintaining the same behavior.
All tests pass.