### PR TITLE
Fix link to auth docs

### DIFF
--- a/rs/moq-token/README.md
+++ b/rs/moq-token/README.md
@@ -3,7 +3,7 @@
 A simple JWT and JWK based authentication scheme for moq-relay.
 
 For comprehensive documentation including token structure, authorization rules, and examples, see:
-**[Authentication Documentation](../../docs/auth.md)**
+**[Authentication Documentation](../../doc/concepts/authentication.md)**
 
 ## Quick Usage (symmetric keys)
 ```bash


### PR DESCRIPTION
Currently links to a non-existent file, fixes the link to the actual correct page