### PR TITLE
rs: moq-native: Implement QUIC-LB compatible CID generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,7 +2632,6 @@ name = "moq-native"
 version = "0.11.0"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
  "bytes",
  "clap",
  "console-subscriber",

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -20,7 +20,6 @@ tokio-console = ["dep:console-subscriber"]
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
 console-subscriber = { version = "0.5", optional = true }
 futures = "0.3"
@@ -43,7 +42,7 @@ rustls-native-certs = "0.8"
 rustls-pemfile = "2"
 rustls-webpki = { version = "0.103", features = ["aws-lc-rs"] }
 serde = { version = "1", features = ["derive"] }
-serde_with = { version = "3", features = ["base64"] }
+serde_with = { version = "3", features = ["hex"] }
 time = "0.3"
 tokio = { workspace = true, features = ["full"] }
 tracing = "0.1"


### PR DESCRIPTION
This implementation was developed by trial-and-error testing against AWS's Network Load Balancer with QUIC support. They seem to have some internal requirements that go beyond what's specified by the draft RFC; in particular the resulting Connection ID must be EXACTLY 16 bytes in length or else it will not work.