### PR TITLE
Add #[non_exhaustive] to moq-native configuration.

### DIFF
--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -4,10 +4,7 @@ use moq_lite::coding::Bytes;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// Optional: Use moq_native to configure a logger.
-	moq_native::Log {
-		level: tracing::Level::DEBUG,
-	}
-	.init();
+	moq_native::Log::new(tracing::Level::DEBUG).init();
 
 	// Create an origin that we can publish to and the session can consume from.
 	let origin = moq_lite::Origin::produce();

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -95,9 +95,7 @@ pub unsafe extern "C" fn moq_log_level(level: *const c_char, level_len: usize) -
 	ffi::enter(move || {
 		match unsafe { ffi::parse_str(level, level_len)? } {
 			"" => moq_native::Log::default(),
-			level => moq_native::Log {
-				level: Level::from_str(level)?,
-			},
+			level => moq_native::Log::new(Level::from_str(level)?),
 		}
 		.init();
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -3,10 +3,7 @@
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// Optional: Use moq_native to configure a logger.
-	moq_native::Log {
-		level: tracing::Level::DEBUG,
-	}
-	.init();
+	moq_native::Log::new(tracing::Level::DEBUG).init();
 
 	// Create an origin that we can publish to and the session can consume from.
 	let origin = moq_lite::Origin::produce();

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -17,6 +17,7 @@ static WEBSOCKET_WON: LazyLock<Mutex<HashSet<(String, u16)>>> = LazyLock::new(||
 /// TLS configuration for the client.
 #[derive(Clone, Default, Debug, clap::Args, serde::Serialize, serde::Deserialize)]
 #[serde(default, deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ClientTls {
 	/// Use the TLS root at this path, encoded as PEM.
 	///
@@ -42,6 +43,7 @@ pub struct ClientTls {
 /// WebSocket configuration for the client.
 #[derive(Clone, Debug, clap::Args, serde::Serialize, serde::Deserialize)]
 #[serde(default, deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ClientWebSocket {
 	/// Delay in milliseconds before attempting WebSocket fallback (default: 200)
 	/// If WebSocket won the previous race for a given server, this will be 0.
@@ -68,6 +70,7 @@ impl Default for ClientWebSocket {
 /// Configuration for the MoQ client.
 #[derive(Clone, Debug, clap::Parser, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
 pub struct ClientConfig {
 	/// Listen for UDP packets on the given address.
 	#[arg(

--- a/rs/moq-native/src/iroh.rs
+++ b/rs/moq-native/src/iroh.rs
@@ -10,6 +10,7 @@ pub use iroh::Endpoint as IrohEndpoint;
 
 #[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
 pub struct IrohEndpointConfig {
 	/// Whether to enable iroh support.
 	///

--- a/rs/moq-native/src/log.rs
+++ b/rs/moq-native/src/log.rs
@@ -11,6 +11,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 #[serde_with::serde_as]
 #[derive(Clone, clap::Parser, Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
 pub struct Log {
 	/// The level filter to use.
 	#[serde_as(as = "DisplayFromStr")]
@@ -25,6 +26,10 @@ impl Default for Log {
 }
 
 impl Log {
+	pub fn new(level: Level) -> Self {
+		Self { level }
+	}
+
 	pub fn level(&self) -> LevelFilter {
 		LevelFilter::from_level(self.level)
 	}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -28,6 +28,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 /// Alternatively, you can generate a self-signed certificate given a list of hostnames.
 #[derive(clap::Args, Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct ServerTlsConfig {
 	/// Load the given certificate from disk.
 	#[arg(long = "tls-cert", id = "tls-cert", env = "MOQ_SERVER_TLS_CERT")]
@@ -54,6 +55,7 @@ pub struct ServerTlsConfig {
 /// Configuration for the MoQ server.
 #[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
 pub struct ServerConfig {
 	/// Listen for UDP packets on the given address.
 	/// Defaults to `[::]:443` if not provided.


### PR DESCRIPTION
Avoids a semver bump every time we add a new field.