### PR TITLE
Update @moq/lite docs with server-side usage

### DIFF
--- a/js/lite/README.md
+++ b/js/lite/README.md
@@ -30,7 +30,7 @@ yarn add @moq/lite
 
 `@moq/lite` works on both browsers and servers, however in JS/TS server environments (Node, Bun, Deno) WebTransport is not yet available, so `@moq/lite` will default to WebSockets communication with the relay.
 
-Deno and Bun both have `WebSockets` built in, however Node does not, so for Node you will need the WebSockets polyfill to use `@moq/lite`
+Deno and Bun and Node v21+ have `WebSockets` built in, but older versions of Node do not, so for older versions of Node you will need the WebSockets polyfill to use `@moq/lite`
 
 ```javascript
 import WebSocket from 'ws';


### PR DESCRIPTION
`@moq/lite` works in server JS/TS environments like Node, Bun, Deno but needs some additional setup for Node. Adding some extra docs and a link to an example for server-side usage of `@moq/lite`