### PR TITLE
Add universal build for macos (needed for obs-studio)

### DIFF
--- a/.github/workflows/libmoq.yml
+++ b/.github/workflows/libmoq.yml
@@ -25,6 +25,8 @@ jobs:
             os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: universal-apple-darwin
+            os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
 

--- a/rs/libmoq/build.sh
+++ b/rs/libmoq/build.sh
@@ -43,29 +43,70 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Detect target if not specified
-if [[ -z "$TARGET" ]]; then
-    TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
-    echo "Detected target: $TARGET"
-fi
-
 # Get version from Cargo.toml if not specified
 if [[ -z "$VERSION" ]]; then
     VERSION=$(grep '^version' "$SCRIPT_DIR/Cargo.toml" | head -1 | sed 's/.*"\(.*\)".*/\1/')
     echo "Detected version: $VERSION"
 fi
 
-echo "Building libmoq for $TARGET..."
+if [[ "$TARGET" == "universal-apple-darwin" ]]; then
+    if [[ "$(uname)" != "Darwin" ]]; then
+        echo "Error: Universal builds are only supported on macOS" >&2
+        exit 1
+    fi
+    
+    echo "Building libmoq for $TARGET..."
 
-# Set up cross-compilation for Linux ARM64
-if [[ "$TARGET" == "aarch64-unknown-linux-gnu" ]]; then
-	export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+    # Build x86_64
+    echo "Building for x86_64-apple-darwin..."
+    cargo build --release --package libmoq --target x86_64-apple-darwin --manifest-path "$WORKSPACE_DIR/Cargo.toml"
+
+    # Build arm64
+    echo "Building for aarch64-apple-darwin..."
+    cargo build --release --package libmoq --target aarch64-apple-darwin --manifest-path "$WORKSPACE_DIR/Cargo.toml"
+
+    # Define sources for packaging
+    # Use arm64 as the reference for headers/pkgconfig (they should be identical)
+    REF_TARGET="aarch64-apple-darwin"
+    INCLUDE_SOURCE="$WORKSPACE_DIR/target/$REF_TARGET/include/moq.h"
+    PKGCONFIG_SOURCE="$WORKSPACE_DIR/target/$REF_TARGET/pkgconfig/moq.pc"
+    
+    # Libraries to combine
+    LIB_X86="$WORKSPACE_DIR/target/x86_64-apple-darwin/release/libmoq.a"
+    LIB_ARM64="$WORKSPACE_DIR/target/aarch64-apple-darwin/release/libmoq.a"
+    LIB_FILE="libmoq.a"
+
+else
+    # Detect target if not specified
+    if [[ -z "$TARGET" ]]; then
+        TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
+        echo "Detected target: $TARGET"
+    fi
+
+    echo "Building libmoq for $TARGET..."
+
+    # Set up cross-compilation for Linux ARM64
+    if [[ "$TARGET" == "aarch64-unknown-linux-gnu" ]]; then
+        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+    fi
+
+    cargo build --release --package libmoq --target "$TARGET" --manifest-path "$WORKSPACE_DIR/Cargo.toml"
+
+    # Define sources for packaging
+    INCLUDE_SOURCE="$WORKSPACE_DIR/target/$TARGET/include/moq.h"
+    PKGCONFIG_SOURCE="$WORKSPACE_DIR/target/$TARGET/pkgconfig/moq.pc"
+    
+    TARGET_DIR="$WORKSPACE_DIR/target/$TARGET/release"
+    if [[ "$TARGET" == *"-windows-"* ]]; then
+        LIB_SOURCE="$TARGET_DIR/moq.lib"
+        LIB_FILE="moq.lib"
+    else
+        LIB_SOURCE="$TARGET_DIR/libmoq.a"
+        LIB_FILE="libmoq.a"
+    fi
 fi
 
-cargo build --release --package libmoq --target "$TARGET" --manifest-path "$WORKSPACE_DIR/Cargo.toml"
-
 # Determine paths
-TARGET_DIR="$WORKSPACE_DIR/target/$TARGET/release"
 NAME="moq-${VERSION}-${TARGET}"
 PACKAGE_DIR="$OUTPUT_DIR/$NAME"
 
@@ -75,35 +116,25 @@ echo "Packaging $NAME..."
 rm -rf "$PACKAGE_DIR"
 mkdir -p "$PACKAGE_DIR/include" "$PACKAGE_DIR/lib"
 
-# Copy header (generated in target/$TARGET/include/ by build.rs)
-cp "$WORKSPACE_DIR/target/$TARGET/include/moq.h" "$PACKAGE_DIR/include/"
+# Copy header
+cp "$INCLUDE_SOURCE" "$PACKAGE_DIR/include/"
 
 # Copy static library
-case "$TARGET" in
-    *-windows-*)
-        cp "$TARGET_DIR/moq.lib" "$PACKAGE_DIR/lib/"
-        ;;
-    *)
-        # Unix-like (macOS, Linux, etc.)
-        cp "$TARGET_DIR/libmoq.a" "$PACKAGE_DIR/lib/"
-        ;;
-esac
+if [[ "$TARGET" == "universal-apple-darwin" ]]; then
+    echo "Creating universal binary..."
+    lipo -create "$LIB_X86" "$LIB_ARM64" -output "$PACKAGE_DIR/lib/$LIB_FILE"
+else
+    cp "$LIB_SOURCE" "$PACKAGE_DIR/lib/"
+fi
 
 # Copy pkg-config file (generated in target/$TARGET/pkgconfig/ by build.rs, not for Windows)
 if [[ "$TARGET" != *"-windows-"* ]]; then
     mkdir -p "$PACKAGE_DIR/lib/pkgconfig"
-    cp "$WORKSPACE_DIR/target/$TARGET/pkgconfig/moq.pc" "$PACKAGE_DIR/lib/pkgconfig/"
+    cp "$PKGCONFIG_SOURCE" "$PACKAGE_DIR/lib/pkgconfig/"
 fi
 
 # Generate CMake config files from templates
 mkdir -p "$PACKAGE_DIR/lib/cmake/moq"
-
-# Determine library filename
-if [[ "$TARGET" == *"-windows-"* ]]; then
-    LIB_FILE="moq.lib"
-else
-    LIB_FILE="libmoq.a"
-fi
 
 # Extract major version
 MAJOR_VERSION="${VERSION%%.*}"


### PR DESCRIPTION
In order to build the moqbs fork properly for macos, we need a unified build for macos that support both architectures.