### PR TITLE
moq-lite: Close session on drop

### DIFF
--- a/rs/moq-lite/src/session.rs
+++ b/rs/moq-lite/src/session.rs
@@ -43,6 +43,12 @@ impl Session {
 	}
 }
 
+impl Drop for Session {
+	fn drop(&mut self) {
+		self.session.close(Error::Cancel.to_code(), "dropped");
+	}
+}
+
 // We use a wrapper type that is dyn-compatible to remove the generic bounds from Session.
 trait SessionInner: Send + Sync {
 	fn close(&self, code: u32, reason: &str);


### PR DESCRIPTION
## Summary
- Implement `Drop` for `Session` to automatically close the underlying transport when dropped
- Closes with error code 0 (`Cancel`) and reason "dropped"
- Fixes issue where old sessions remained active after reconnection, causing stale events (like announced broadcasts) to be replayed

## Test plan
- [x] `just check` passes
- [ ] Manual testing with client reconnection scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)