### PR TITLE
moq-relay: Skip jwt query param when no token configured

### DIFF
--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -231,7 +231,10 @@ impl Cluster {
 
 	#[tracing::instrument("remote", skip_all, err, fields(%node))]
 	async fn run_remote(mut self, node: &str, token: String, origin: BroadcastConsumer) -> anyhow::Result<()> {
-		let url = Url::parse(&format!("https://{node}/?jwt={token}"))?;
+		let url = match token.is_empty() {
+			true => Url::parse(&format!("https://{node}/"))?,
+			false => Url::parse(&format!("https://{node}/?jwt={token}"))?,
+		};
 		let mut backoff = 1;
 
 		loop {


### PR DESCRIPTION
## Summary
- Don't append `?jwt=` to cluster URLs when no token is configured
- Results in cleaner URLs without an empty query parameter

## Test plan
- [ ] Verify relay starts without `--cluster-token` and connects to other nodes without `?jwt=` in URL
- [ ] Verify relay with `--cluster-token` still includes the JWT in the query parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)