### PR TITLE
Fix REFRESH_ERROR_INTERVAL constant to use correct duration

### DIFF
--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -68,7 +68,7 @@ pub struct AuthToken {
 	pub cluster: bool,
 }
 
-const REFRESH_ERROR_INTERVAL: Duration = Duration::from_mins(5);
+const REFRESH_ERROR_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Clone)]
 pub struct Auth {


### PR DESCRIPTION
## Summary
Fixed the `REFRESH_ERROR_INTERVAL` constant in the auth module to use the correct duration value. The constant was using an invalid `from_mins()` method that doesn't exist in the Rust standard library.

## Changes
- Replaced `Duration::from_mins(5)` with `Duration::from_secs(5 * 60)` to correctly represent a 5-minute interval
- This maintains the intended 5-minute duration while using the correct standard library API

## Details
The `Duration` type in Rust's standard library provides `from_secs()`, `from_millis()`, and similar methods, but not `from_mins()`. The change converts the 5-minute duration to 300 seconds, which is functionally equivalent and uses the correct API.

https://claude.ai/code/session_01JTZURBozqfxJbmmvz4qWmN