### PR TITLE
fix: just recipe 'install' error

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,6 +2,8 @@
 
 # Using Just: https://github.com/casey/just?tab=readme-ov-file#installation
 
+set windows-shell := ["C:\\Program Files\\Git\\bin\\sh.exe","-c"]
+
 set quiet
 
 # List all of the available commands.


### PR DESCRIPTION
When I run just install in the terminal, I get the error.
`error: Recipe "install" could not be run because just could not find the shell: program not found`

I fixed this by adding the line `set windows-shell := ["C:\\Program Files\\Git\\bin\\sh.exe","-c"]` in the Justfile.
