### PR TITLE
fix: README dev URL (http, port) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ just install
 just dev
 ```
 
-Then visit [https://localhost:8080](https://localhost:8080) to see the demo.
+Then visit [http://localhost:5173](http://localhost:5173) to see the demo.
 
 
 ## Architecture


### PR DESCRIPTION
When I run `just dev` in the terminal, the dev page url is different from what is documented in the README.

Difference found in the `## full-setup` section:
  - https -> http
  - 8080 -> 5173

Update the README to reflect the correct development URL.
