### PR TITLE
Remove hang-meet references from documentation

### DIFF
--- a/doc/typescript/examples.md
+++ b/doc/typescript/examples.md
@@ -121,38 +121,6 @@ for await (const group of chatTrack) {
 </html>
 ```
 
-### Video Conference
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-    <script type="module">
-        import "@moq/hang/meet/element";
-    </script>
-    <style>
-        hang-meet {
-            display: block;
-            width: 100%;
-            height: 100vh;
-        }
-    </style>
-</head>
-<body>
-    <hang-meet
-        url="https://relay.example.com/anon"
-        path="conference/room-123"
-        audio video controls>
-        <!-- Publish your own camera -->
-        <hang-publish
-            path="conference/room-123/alice"
-            audio video>
-        </hang-publish>
-    </hang-meet>
-</body>
-</html>
-```
-
 ### Dynamic Controls
 
 ```html

--- a/doc/typescript/hang.md
+++ b/doc/typescript/hang.md
@@ -64,20 +64,6 @@ The fastest way to add MoQ to your web page. See [Web Components](/typescript/we
 </hang-watch>
 ```
 
-### Video Conferencing
-
-```html
-<script type="module">
-    import "@moq/hang/meet/element";
-</script>
-
-<hang-meet
-    url="https://relay.example.com/anon"
-    path="room123"
-    audio video controls>
-</hang-meet>
-```
-
 [Learn more about Web Components →](/typescript/web-components)
 
 ## JavaScript API

--- a/doc/typescript/web-components.md
+++ b/doc/typescript/web-components.md
@@ -74,35 +74,6 @@ Subscribe to and render a MoQ broadcast.
 </hang-watch>
 ```
 
-### `<hang-meet>`
-
-Video conferencing component that discovers and renders multiple broadcasts.
-
-**Attributes:**
-- `url` (required) - Relay server URL
-- `path` (required) - Room path prefix
-- `audio` - Enable audio (boolean)
-- `video` - Enable video (boolean)
-- `controls` - Show controls (boolean)
-
-**Example:**
-
-```html
-<script type="module">
-    import "@moq/hang/meet/element";
-</script>
-
-<hang-meet
-    url="https://relay.example.com/anon"
-    path="room123"
-    audio video controls>
-    <!-- Optional: add local publish component -->
-    <hang-publish path="room123/me" audio video></hang-publish>
-</hang-meet>
-```
-
-This discovers any broadcasts starting with `room123/` and renders them in a grid.
-
 ### `<hang-support>`
 
 Display browser support information.
@@ -268,7 +239,7 @@ import "@moq/hang";
 Full TypeScript support with type definitions:
 
 ```typescript
-import type { HangWatch, HangPublish, HangMeet } from "@moq/hang";
+import type { HangWatch, HangPublish } from "@moq/hang";
 
 const watch: HangWatch = document.querySelector("hang-watch")!;
 const publish: HangPublish = document.querySelector("hang-publish")!;


### PR DESCRIPTION
## Summary
- Remove all `hang-meet` / `<hang-meet>` references from TypeScript documentation
- The component no longer exists so these references were outdated

## Test plan
- [ ] Verify documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)