### PR TITLE
docs: native client integration guide

### DIFF
--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
 								{ text: "Configuration", link: "/app/relay/config" },
 								{ text: "Authentication", link: "/app/relay/auth" },
 								{ text: "Clustering", link: "/app/relay/cluster" },
+								{ text: "HTTP", link: "/app/relay/http" },
 								{ text: "Production", link: "/app/relay/production" },
 							],
 						},

--- a/doc/app/relay/index.md
+++ b/doc/app/relay/index.md
@@ -74,39 +74,7 @@ moq-relay relay.toml
 
 ## HTTP Endpoints
 
-For debugging, the relay exposes HTTP endpoints on the same bind address (TCP instead of UDP):
-
-### GET /certificate.sha256
-
-Returns the fingerprint of the TLS certificate:
-
-```bash
-curl http://localhost:4443/certificate.sha256
-```
-
-### GET /announced/*prefix
-
-Returns all announced tracks with the given prefix:
-
-```bash
-# All announced broadcasts
-curl http://localhost:4443/announced/
-
-# Broadcasts under "demo/"
-curl http://localhost:4443/announced/demo
-```
-
-### GET /fetch/*path
-
-Returns the latest group of the given track:
-
-```bash
-curl http://localhost:4443/fetch/demo/video
-```
-
-::: warning
-The HTTP server listens on TCP, not HTTPS. It's intended for local debugging only.
-:::
+The relay exposes HTTP/HTTPS endpoints for debugging, health checks, and late-join. See [HTTP](/app/relay/http) for details.
 
 ## TLS Setup
 
@@ -147,7 +115,7 @@ Metrics (Prometheus format) are planned but not yet implemented.
 
 Current visibility:
 - Check logs for connection count
-- Use HTTP endpoints for track inspection
+- Use [HTTP endpoints](/app/relay/http) for track inspection
 - Monitor system resources (CPU, memory, bandwidth)
 
 ## Performance

--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -92,31 +92,17 @@ Unfortunately, fMP4 is not quite designed for real-time streaming and incurs eit
 - Minimal size (HLS): GoP sized fragments introduce a GoP's worth of latency.
 - Mixed latency/size (LL-HLS): 500ms sized fragments introduce a 500ms latency, with some additional overhead.
 
-## Video `description` Field
+## `description`
+The `description` field in audio/video renditions contains codec-specific initialization data based on the [WebCodecs codec registration](https://www.w3.org/TR/webcodecs-codec-registry/).
 
-The `description` field in a video rendition controls how codec initialization data (e.g. H.264 SPS/PPS) is delivered.
-This follows the [WebCodecs AVC codec registration](https://w3c.github.io/webcodecs/avc_codec_registration.html).
+For example, the `description` field for [H.264](https://www.w3.org/TR/webcodecs-avc-codec-registration/) can be:
+- **present**: the `description` is an `avcC` box, containing the SPS/PPS and other information.
+- **absent**: the SPS/PPS NALUs are delivered **inline** before each keyframe.
 
-### With `description` (AVCC format)
+There's no "right format" and both exist in the wild.
+Inlining the SPS/PPS marginally increases the overhead of each frame, but it means the decoder can be reinitialized (ex. resolution change).
 
-When `description` contains a hex-encoded value, the codec data is in AVCC format:
-- The description contains the `avcC` box (SPS/PPS for H.264, VPS/SPS/PPS for H.265).
-- NAL units in each frame payload are **length-prefixed** (4-byte big-endian length).
-- The decoder is initialized once using the description, before any frames arrive.
-
-This is the format used in the [Big Buck Bunny example](#example) above.
-
-### Without `description` (Annex B format)
-
-When `description` is absent or null, the codec data is in Annex B format:
-- SPS/PPS are delivered **inline** in the bitstream before each keyframe.
-- NAL units use start codes (`00 00 00 01`) as delimiters.
-- The decoder extracts parameters from the bitstream itself.
-
-::: tip
-A missing `description` is **not** an error — it simply means the publisher is using Annex B.
-Your decoder should handle both formats.
-:::
+Unfortunately, your decoder should handle both.
 
 ## Groups and Keyframes
 
@@ -125,7 +111,7 @@ A new group starts with a keyframe (IDR frame) that can be decoded independently
 
 This has important implications:
 - **Skipping a group means skipping an entire GoP.** The relay can drop old groups without corrupting the decoder state.
-- **Late-join viewers** need the first frame of a group (the keyframe) to start decoding. Joining mid-group produces corrupted output until the next group boundary.
-- **Audio groups** typically align with video groups but may contain multiple audio frames per group.
+- **Late-join viewers** start at the beginning of a group (the keyframe), since it's not possible to join mid-group.
+- **Audio groups** don't need to align with video groups and can contain any number of frames.
 
 The relay uses group boundaries for partial reliability: if congestion occurs, entire groups are dropped rather than individual frames, keeping the decoder in a consistent state.

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -1,0 +1,93 @@
+// cargo run --example subscribe
+
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+	// Optional: Use moq_native to configure a logger.
+	moq_native::Log::new(tracing::Level::DEBUG).init();
+
+	// Create an origin that the session can publish incoming broadcasts to.
+	let origin = moq_lite::Origin::produce();
+	let consumer = origin.consume();
+
+	// Run the subscription and the session in parallel.
+	tokio::select! {
+		res = run_session(origin) => res,
+		res = run_subscribe(consumer) => res,
+	}
+}
+
+// Connect to the server and subscribe to broadcasts.
+async fn run_session(origin: moq_lite::OriginProducer) -> anyhow::Result<()> {
+	// Optional: Use moq_native to make a QUIC client.
+	let client = moq_native::ClientConfig::default().init()?;
+
+	// For local development, use: http://localhost:4443/anon/video-example
+	// The "anon" path is usually configured to bypass authentication; be careful!
+	let url = url::Url::parse("https://cdn.moq.dev/anon/video-example").unwrap();
+
+	// Establish a WebTransport/QUIC connection and MoQ handshake for subscribing.
+	// with_consume() registers an OriginProducer for incoming data.
+	// Use with_publish() if you also want to publish from the session.
+	let session = client.with_consume(origin).connect(url).await?;
+
+	// Wait until the session is closed.
+	session.closed().await.map_err(Into::into)
+}
+
+// Subscribe to a broadcast and read media frames.
+async fn run_subscribe(mut consumer: moq_lite::OriginConsumer) -> anyhow::Result<()> {
+	// Wait for a broadcast to be announced.
+	let (path, broadcast) = consumer
+		.announced()
+		.await
+		.ok_or_else(|| anyhow::anyhow!("origin closed"))?;
+
+	let broadcast = broadcast.ok_or_else(|| anyhow::anyhow!("broadcast unannounced: {path}"))?;
+
+	tracing::info!(%path, "broadcast announced");
+
+	// Read the catalog to discover available tracks.
+	let catalog_track = broadcast.subscribe_track(&hang::Catalog::default_track());
+	let mut catalog = hang::CatalogConsumer::new(catalog_track);
+
+	let info = catalog.next().await?.ok_or_else(|| anyhow::anyhow!("no catalog"))?;
+
+	// Find the first video track.
+	let (name, config) = info
+		.video
+		.renditions
+		.iter()
+		.next()
+		.ok_or_else(|| anyhow::anyhow!("no video renditions"))?;
+
+	tracing::info!(
+		%name,
+		codec = %config.codec,
+		width = ?config.coded_width,
+		height = ?config.coded_height,
+		"subscribing to video track"
+	);
+
+	// Subscribe to the video track.
+	let track = moq_lite::Track {
+		name: name.clone(),
+		priority: 1,
+	};
+
+	let track_consumer = broadcast.subscribe_track(&track);
+	let mut ordered = hang::container::OrderedConsumer::new(track_consumer, Duration::from_millis(500));
+
+	// Read frames in presentation order.
+	while let Some(frame) = ordered.read().await? {
+		tracing::info!(
+			timestamp = ?frame.timestamp,
+			keyframe = frame.keyframe,
+			bytes = frame.payload.num_bytes(),
+			"received frame"
+		);
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary

- **`doc/rs/env/native.md`**: Fill in the empty file with a guide for building native MoQ clients in Rust — connecting, publishing, subscribing, reading catalogs/frames, platform decoders, and common pitfalls.
- **`doc/concept/layer/hang.md`**: Add video `description` field semantics (AVCC vs Annex B) and group-to-keyframe relationship.
- **`doc/app/relay/http.md`**: Add late-join pattern using HTTP group fetch (`?group=N`).

Written from experience integrating MoQ into a native Rust video player. All code examples reference the current API (`OrderedConsumer`, `CatalogConsumer`, `Origin::produce()`, etc.).