### PR TITLE
Rename query parameter from 'path' to 'broadcast'

### DIFF
--- a/js/hang-demo/src/index.html
+++ b/js/hang-demo/src/index.html
@@ -151,7 +151,7 @@ just pub bbb
 			href="publish.html">publish demo</a>.
 		For example,
 		Try running <code class="language-bash">just pub tos</code> in a new terminal and then <a
-			href="index.html?path=tos" target="_blank">watch robots bang</a>.
+			href="index.html?broadcast=tos" target="_blank">watch robots bang</a>.
 		This command uses ffmpeg to produce a fragmented MP4 file piped over stdout and then sent over the network.
 		Yeah it's pretty gross.
 	</p>

--- a/js/hang-demo/src/index.ts
+++ b/js/hang-demo/src/index.ts
@@ -13,7 +13,7 @@ if (!watch) throw new Error("unable to find <hang-watch> element");
 
 // If query params are provided, use them.
 const urlParams = new URLSearchParams(window.location.search);
-const path = urlParams.get("path");
+const path = urlParams.get("broadcast") ?? urlParams.get("path");
 const url = urlParams.get("url");
 
 if (path) {

--- a/js/hang-demo/src/publish.html
+++ b/js/hang-demo/src/publish.html
@@ -30,7 +30,7 @@
 
 	<h3>Other demos:</h3>
 	<ul>
-		<li><a href="index.html?path=me" target="_blank" rel="noreferrer" id="watch">Watch your broadcast: <span
+		<li><a href="index.html?broadcast=me" target="_blank" rel="noreferrer" id="watch">Watch your broadcast: <span
 					id="watch-name"></span></a></li>
 		<li><a href="mse.html">Watch a broadcast (MSE).</a></li>
 		<li><a href="support.html">Check browser support.</a></li>
@@ -39,7 +39,7 @@
 	<h3>Tips:</h3>
 	<p>
 		This page creates a broadcast called `me` by default.
-		You can use <a href="index.html?&path=notme">query parameters</a> to use a different path and create
+		You can use <a href="index.html?broadcast=notme">query parameters</a> to use a different broadcast name and create
 		multiple broadcasts.
 	</p>
 	<p>
@@ -69,7 +69,7 @@ publish.broadcast.audio.enabled.set(true);</code></pre>
 	<p>
 		You're not limited to web publishing either.
 		Try running <code class="language-bash">just pub tos</code> in a new terminal and then <a
-			href="index.html?path=tos" target="_blank">watch robots bang</a>.
+			href="index.html?broadcast=tos" target="_blank">watch robots bang</a>.
 		This uses ffmpeg to produce a fragmented MP4 file piped over stdout then sent over the network.
 		Yeah it's pretty gross.
 	</p>

--- a/js/hang-demo/src/publish.ts
+++ b/js/hang-demo/src/publish.ts
@@ -12,9 +12,9 @@ const watch = document.getElementById("watch") as HTMLAnchorElement;
 const watchName = document.getElementById("watch-name") as HTMLSpanElement;
 
 const urlParams = new URLSearchParams(window.location.search);
-const path = urlParams.get("path");
+const path = urlParams.get("broadcast") ?? urlParams.get("path");
 if (path) {
 	publish.setAttribute("path", path);
-	watch.href = `index.html?path=${path}`;
+	watch.href = `index.html?broadcast=${path}`;
 	watchName.textContent = path;
 }


### PR DESCRIPTION
## Summary
Renamed the `path` query parameter to `broadcast` across the hang-demo application to better reflect its purpose. The old `path` parameter is still supported for backward compatibility.

## Changes
- Updated all query parameter references from `?path=` to `?broadcast=` in HTML links and documentation
- Modified TypeScript code to check for the new `broadcast` parameter first, falling back to `path` for backward compatibility
- Updated user-facing text to refer to "broadcast name" instead of "path" for clarity
- Updated all demo links in both `index.html` and `publish.html` to use the new parameter name

## Implementation Details
- The fallback logic (`urlParams.get("broadcast") ?? urlParams.get("path")`) ensures existing links and bookmarks using the old `path` parameter will continue to work
- Changes were made consistently across both the index and publish demo pages
- Documentation and example commands were updated to reflect the new terminology

https://claude.ai/code/session_01JVFEnpupZUk77uPbLvEf5R