### PR TITLE
Fix stale TrackProducer returned from cache

### DIFF
--- a/rs/moq-lite/src/model/broadcast.rs
+++ b/rs/moq-lite/src/model/broadcast.rs
@@ -193,7 +193,11 @@ impl BroadcastConsumer {
 		let mut state = self.state.lock();
 
 		if let Some(producer) = state.producers.get(&track.name) {
-			return producer.consume();
+			if !producer.is_closed() {
+				return producer.consume();
+			}
+			// Remove the stale entry
+			state.producers.remove(&track.name);
 		}
 
 		// Otherwise we have never seen this track before and need to create a new producer.
@@ -393,6 +397,35 @@ mod test {
 
 		let track5 = consumer2.subscribe_track(&Track::new("track3"));
 		track5.assert_error();
+	}
+
+	#[tokio::test]
+	async fn stale_producer() {
+		let mut broadcast = Broadcast::produce();
+		let consumer = broadcast.consume();
+
+		// Subscribe to a track, creating a request
+		let track1 = consumer.subscribe_track(&Track::new("track1"));
+
+		// Get the requested producer and close it (simulating publisher disconnect)
+		let mut producer1 = broadcast.assert_request();
+		producer1.append_group();
+		producer1.close();
+
+		// The consumer should see the track as closed
+		track1.assert_closed();
+
+		// Subscribe again to the same track - should get a NEW producer, not the stale one
+		let mut track2 = consumer.subscribe_track(&Track::new("track1"));
+		track2.assert_not_closed();
+		track2.assert_not_clone(&track1);
+
+		// There should be a new request for the track
+		let mut producer2 = broadcast.assert_request();
+		producer2.append_group();
+
+		// The new consumer should receive the new group
+		track2.assert_group();
 	}
 
 	#[tokio::test]

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -160,6 +160,11 @@ impl TrackProducer {
 		}
 	}
 
+	/// Return true if the track has been closed or aborted.
+	pub fn is_closed(&self) -> bool {
+		self.state.borrow().closed.is_some()
+	}
+
 	/// Return true if this is the same track.
 	pub fn is_clone(&self, other: &Self) -> bool {
 		self.state.same_channel(&other.state)


### PR DESCRIPTION
## Summary
- Adds `TrackProducer::is_closed()` to check if a track has been closed/aborted
- `BroadcastConsumer::subscribe_track()` now checks liveness before returning a cached producer, and removes stale entries so a fresh request is issued
- Adds a `stale_producer` test verifying late-joining subscribers get a new producer after publisher disconnect

Fixes #941

## Test plan
- [x] `cargo test -p moq-lite` — all 142 tests pass including new `stale_producer` test
- [x] `just check` — full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)