### PR TITLE
Fix AsPath for String not normalizing paths

### DIFF
--- a/rs/moq-lite/src/path.rs
+++ b/rs/moq-lite/src/path.rs
@@ -35,13 +35,13 @@ impl AsPath for Path<'_> {
 
 impl AsPath for String {
 	fn as_path(&self) -> Path<'_> {
-		Path(Cow::Borrowed(self))
+		Path::new(self)
 	}
 }
 
 impl<'a> AsPath for &'a String {
 	fn as_path(&self) -> Path<'a> {
-		Path(Cow::Borrowed(self))
+		Path::new(self)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #910 — `OriginConsumer::announced` panics if prefix does not match
- `AsPath for String` and `AsPath for &String` bypassed `Path::new()` and directly borrowed the raw string, so trailing slashes (e.g. `"some_prefix/"`) were preserved without normalization
- This caused `OriginConsumerNotify::announce/reannounce/unannounce` to panic when `strip_prefix` failed on the unnormalized root
- Fixed by routing both impls through `Path::new()`, matching the `&str` impl behavior

## Test plan
- [x] Added `test_with_root_trailing_slash_consumer` — consumer with trailing-slash String root receives announcements
- [x] Added `test_with_root_trailing_slash_producer` — producer with trailing-slash String root publishes correctly
- [x] Added `test_with_root_trailing_slash_unannounce` — unannounce also works with trailing-slash root
- [x] All 145 existing moq-lite tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)