### PR TITLE
Send estimated bitrate over the session stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6565,9 +6565,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quinn"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f91486ee9d3065c017f13f4ff901928e78b2d3a124268dff821bd1caed6ca"
+checksum = "96b195557749e84091d7b912a25e190e9606283b5121d041faf538b0b55f40d7"
 dependencies = [
  "bytes",
  "futures",
@@ -6585,9 +6585,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-trait"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2615c30ed29953bb3727391850279a25c948c0b7a4ed2343d3a78e1d3cce2f7c"
+checksum = "802d6aa508f2c63c9050ceabc17265bbf90ed4d6f4e4357e987583883628e79c"
 dependencies = [
  "bytes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ tokio = "1.48"
 web-async = { version = "0.1.1", features = ["tracing"] }
 web-transport-iroh = "0.1.1"
 web-transport-quiche = "0.2"
-web-transport-quinn = "0.11"
-web-transport-trait = "0.3.2"
+web-transport-quinn = "0.11.4"
+web-transport-trait = "0.3.3"
 web-transport-ws = "0.2.2"
 
 [profile.dev]

--- a/js/lite/src/lite/connection.ts
+++ b/js/lite/src/lite/connection.ts
@@ -132,7 +132,7 @@ export class Connection implements Established {
 			for (;;) {
 				const msg = await SessionInfo.decodeMaybe(this.#session.reader);
 				if (!msg) break;
-				this.bitrate.set(msg.bitrate || undefined);
+				this.bitrate.set(msg.bitrate ?? undefined);
 			}
 		} finally {
 			console.debug("session stream closed");

--- a/js/lite/src/lite/connection.ts
+++ b/js/lite/src/lite/connection.ts
@@ -1,3 +1,4 @@
+import { Signal } from "@moq/signals";
 import type { Announced } from "../announced.ts";
 import type { Broadcast } from "../broadcast.ts";
 import type { Established } from "../connection/established.ts";
@@ -35,6 +36,9 @@ export class Connection implements Established {
 
 	// Module for distributing tracks.
 	#subscriber: Subscriber;
+
+	// Estimated send bitrate reported by the server, in bits per second.
+	bitrate = new Signal<number | undefined>(undefined);
 
 	// Just to avoid logging when `close()` is called.
 	#closed = false;
@@ -128,7 +132,7 @@ export class Connection implements Established {
 			for (;;) {
 				const msg = await SessionInfo.decodeMaybe(this.#session.reader);
 				if (!msg) break;
-				// TODO use the session info
+				this.bitrate.set(msg.bitrate || undefined);
 			}
 		} finally {
 			console.debug("session stream closed");

--- a/rs/moq-lite/Cargo.toml
+++ b/rs/moq-lite/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { workspace = true, features = [
 	"io-util",
 	"sync",
 	"test-util",
+	"time",
 ] }
 tracing = "0.1"
 web-async = { workspace = true }

--- a/rs/moq-lite/src/lite/session.rs
+++ b/rs/moq-lite/src/lite/session.rs
@@ -70,7 +70,7 @@ async fn recv_session_info<S: web_transport_trait::Session>(
 //   0% change  → wait MAX_SEND_INTERVAL
 //   ≥SEND_CHANGE_THRESHOLD change → wait MIN_SEND_INTERVAL
 const MIN_SEND_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
-const MAX_SEND_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+const MAX_SEND_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 const SEND_CHANGE_THRESHOLD: f64 = 0.25;
 const SEND_CHECK_INTERVAL: std::time::Duration = MIN_SEND_INTERVAL;
 

--- a/rs/moq-lite/src/lite/session.rs
+++ b/rs/moq-lite/src/lite/session.rs
@@ -72,21 +72,17 @@ async fn recv_session_info<S: web_transport_trait::Session>(
 const MIN_SEND_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 const MAX_SEND_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 const SEND_CHANGE_THRESHOLD: f64 = 0.25;
-const SEND_CHECK_INTERVAL: std::time::Duration = MIN_SEND_INTERVAL;
-
 async fn send_session_info<S: web_transport_trait::Session>(
 	session: &S,
 	mut writer: Writer<S::SendStream, Version>,
 ) -> Result<(), Error> {
 	use web_transport_trait::Stats;
 
-	let mut interval = tokio::time::interval(SEND_CHECK_INTERVAL);
 	let mut last_sent: Option<u64> = None;
 	let mut last_sent_at = tokio::time::Instant::now();
 
 	loop {
-		// Poll frequently so we detect sudden bitrate changes quickly.
-		interval.tick().await;
+		tokio::time::sleep(MIN_SEND_INTERVAL).await;
 
 		let bitrate = session.stats().estimated_send_rate();
 

--- a/rs/moq-lite/src/lite/session.rs
+++ b/rs/moq-lite/src/lite/session.rs
@@ -2,7 +2,7 @@ use tokio::sync::oneshot;
 
 use crate::{
 	Error, OriginConsumer, OriginProducer,
-	coding::Stream,
+	coding::{Stream, Writer},
 	lite::{SessionInfo, Version},
 };
 
@@ -24,9 +24,12 @@ pub(crate) async fn start<S: web_transport_trait::Session>(
 
 	let init = oneshot::channel();
 
+	let session2 = session.clone();
+
 	web_async::spawn(async move {
 		let res = tokio::select! {
-			res = run_session(setup) => res,
+			res = recv_session_info::<S>(setup.reader) => res,
+			res = send_session_info::<S>(&session2, setup.writer) => res,
 			res = publisher.run() => res,
 			res = subscriber.run(init.0) => res,
 		};
@@ -56,8 +59,58 @@ pub(crate) async fn start<S: web_transport_trait::Session>(
 	Ok(())
 }
 
-// TODO do something useful with this
-async fn run_session<S: web_transport_trait::Session>(mut stream: Stream<S, Version>) -> Result<(), Error> {
-	while let Some(_info) = stream.reader.decode_maybe::<SessionInfo>().await? {}
+async fn recv_session_info<S: web_transport_trait::Session>(
+	mut reader: crate::coding::Reader<S::RecvStream, Version>,
+) -> Result<(), Error> {
+	while let Some(_info) = reader.decode_maybe::<SessionInfo>().await? {}
 	Err(Error::Cancel)
+}
+
+// Send interval scales linearly with the relative change in bitrate:
+//   0% change  → wait MAX_SEND_INTERVAL
+//   ≥SEND_CHANGE_THRESHOLD change → wait MIN_SEND_INTERVAL
+const MIN_SEND_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+const MAX_SEND_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+const SEND_CHANGE_THRESHOLD: f64 = 0.25;
+const SEND_CHECK_INTERVAL: std::time::Duration = MIN_SEND_INTERVAL;
+
+async fn send_session_info<S: web_transport_trait::Session>(
+	session: &S,
+	mut writer: Writer<S::SendStream, Version>,
+) -> Result<(), Error> {
+	use web_transport_trait::Stats;
+
+	let mut interval = tokio::time::interval(SEND_CHECK_INTERVAL);
+	let mut last_sent: Option<u64> = None;
+	let mut last_sent_at = tokio::time::Instant::now();
+
+	loop {
+		// Poll frequently so we detect sudden bitrate changes quickly.
+		interval.tick().await;
+
+		let bitrate = session.stats().estimated_send_rate();
+
+		let Some(bitrate) = bitrate else {
+			continue;
+		};
+
+		// Only send updates when the bitrate has changed significantly.
+		// Small changes wait longer (up to MAX), large changes send sooner (down to MIN).
+		let should_send = match last_sent {
+			None => true,
+			Some(prev) => {
+				let change = (bitrate as f64 - prev as f64).abs() / prev.max(1) as f64;
+				let t = (change / SEND_CHANGE_THRESHOLD).min(1.0);
+				let required = MAX_SEND_INTERVAL.mul_f64(1.0 - t) + MIN_SEND_INTERVAL.mul_f64(t);
+				last_sent_at.elapsed() >= required
+			}
+		};
+
+		if should_send {
+			let info = SessionInfo { bitrate: Some(bitrate) };
+			writer.encode(&info).await?;
+			last_sent = Some(bitrate);
+			last_sent_at = tokio::time::Instant::now();
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- The server periodically sends `SessionInfo` messages containing the estimated send bitrate over the session stream
- Send frequency adapts to the magnitude of change: large bitrate swings trigger fast updates (100ms), while small drifts wait longer (up to 1s)
- The JS client exposes this as a reactive `bitrate` signal on `Connection`
- Bumps `web-transport-quinn` to 0.11.4 and `web-transport-trait` to 0.3.3 for the new `Stats` trait

## Test plan
- [ ] Verify bitrate signal updates in the browser client during playback
- [ ] Confirm send interval adapts correctly to varying network conditions
- [ ] Check that the session stream gracefully handles missing bitrate data

🤖 Generated with [Claude Code](https://claude.com/claude-code)