### PR TITLE
Fix Vite sourcemap warnings by inlining sources in TypeScript sourcemaps

### DIFF
--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -10,6 +10,7 @@
 		"declarationMap": true,
 		"isolatedModules": true,
 		"sourceMap": true,
+		"inlineSources": true,
 
 		// https://www.typescriptlang.org/tsconfig/#Type_Checking_6248
 		"allowUnreachableCode": false,


### PR DESCRIPTION
TypeScript's tsc generates sourcemaps with `sources` pointing to relative
paths (e.g., `../src/index.ts`) but without `sourcesContent`. When Vite
processes these files, it tries to read the source files from disk and
warns if they're missing. This happens with stale build artifacts and
also when packages are consumed from npm (where src/ isn't published).

Adding `inlineSources: true` embeds the original source content directly
in the `.map` files, making them self-contained.

https://claude.ai/code/session_011xkF5jMLomBaNyojmtAvE8