### PR TITLE
Rename Effect.effect() calls to Effect.run() across codebase

### DIFF
--- a/js/hang/src/util/latency.ts
+++ b/js/hang/src/util/latency.ts
@@ -28,7 +28,7 @@ export class Latency {
 		this.buffer = props.buffer;
 		this.config = props.config;
 
-		this.signals.effect(this.#run.bind(this));
+		this.signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect): void {

--- a/js/lite/src/connection/reload.ts
+++ b/js/lite/src/connection/reload.ts
@@ -63,7 +63,7 @@ export class Reload {
 		this.#delay = this.delay.initial;
 
 		// Create a reactive root so cleanup is easier.
-		this.signals.effect(this.#connect.bind(this));
+		this.signals.run(this.#connect.bind(this));
 	}
 
 	#connect(effect: Effect): void {

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -62,10 +62,10 @@ export class Encoder {
 		this.volume = Signal.from(props?.volume ?? 1);
 		this.maxLatency = props?.maxLatency ?? (100 as Time.Milli); // Default is a group every 100ms
 
-		this.#signals.effect(this.#runSource.bind(this));
-		this.#signals.effect(this.#runConfig.bind(this));
-		this.#signals.effect(this.#runGain.bind(this));
-		this.#signals.effect(this.#runCatalog.bind(this));
+		this.#signals.run(this.#runSource.bind(this));
+		this.#signals.run(this.#runConfig.bind(this));
+		this.#signals.run(this.#runGain.bind(this));
+		this.#signals.run(this.#runCatalog.bind(this));
 	}
 
 	#runSource(effect: Effect): void {

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -49,7 +49,7 @@ export class Broadcast {
 		this.preview = new Preview(props?.preview);
 		this.user = new User.Info(props?.user);
 
-		this.signals.effect(this.#run.bind(this));
+		this.signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect) {
@@ -75,7 +75,7 @@ export class Broadcast {
 
 			effect.cleanup(() => request.track.close());
 
-			effect.effect((effect) => {
+			effect.run((effect) => {
 				if (effect.get(request.track.state.closed)) return;
 
 				switch (request.track.name) {

--- a/js/publish/src/chat/index.ts
+++ b/js/publish/src/chat/index.ts
@@ -24,7 +24,7 @@ export class Root {
 		this.message = new Message(props?.message);
 		this.typing = new Typing(props?.typing);
 
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			this.#catalog.set({
 				message: effect.get(this.message.catalog),
 				typing: effect.get(this.typing.catalog),

--- a/js/publish/src/chat/message.ts
+++ b/js/publish/src/chat/message.ts
@@ -23,7 +23,7 @@ export class Message {
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.latest = new Signal<string>("");
 
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const enabled = effect.get(this.enabled);
 			if (!enabled) return;
 

--- a/js/publish/src/chat/typing.ts
+++ b/js/publish/src/chat/typing.ts
@@ -23,7 +23,7 @@ export class Typing {
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.active = new Signal<boolean>(false);
 
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const enabled = effect.get(this.enabled);
 			if (!enabled) return;
 

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -61,7 +61,7 @@ export default class MoqPublish extends HTMLElement {
 		this.#audioEnabled = new Signal(false);
 		this.#eitherEnabled = new Signal(false);
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const muted = effect.get(this.muted);
 			const invisible = effect.get(this.invisible);
 			this.#videoEnabled.set(!invisible);
@@ -94,7 +94,7 @@ export default class MoqPublish extends HTMLElement {
 		this.signals.cleanup(() => observer.disconnect());
 		setPreview();
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const preview = effect.get(this.#preview);
 			if (!preview) return;
 
@@ -112,7 +112,7 @@ export default class MoqPublish extends HTMLElement {
 			});
 		});
 
-		this.signals.effect(this.#runSource.bind(this));
+		this.signals.run(this.#runSource.bind(this));
 	}
 
 	connectedCallback() {
@@ -152,13 +152,13 @@ export default class MoqPublish extends HTMLElement {
 
 		if (source === "camera") {
 			const video = new Source.Camera({ enabled: this.#videoEnabled });
-			this.signals.effect((effect) => {
+			this.signals.run((effect) => {
 				const source = effect.get(video.source);
 				this.broadcast.video.source.set(source);
 			});
 
 			const audio = new Source.Microphone({ enabled: this.#audioEnabled });
-			this.signals.effect((effect) => {
+			this.signals.run((effect) => {
 				const source = effect.get(audio.source);
 				this.broadcast.audio.source.set(source);
 			});
@@ -179,7 +179,7 @@ export default class MoqPublish extends HTMLElement {
 				enabled: this.#eitherEnabled,
 			});
 
-			this.signals.effect((effect) => {
+			this.signals.run((effect) => {
 				const source = effect.get(screen.source);
 				if (!source) return;
 
@@ -205,7 +205,7 @@ export default class MoqPublish extends HTMLElement {
 				enabled: this.#eitherEnabled,
 			});
 
-			this.signals.effect((effect) => {
+			this.signals.run((effect) => {
 				const source = effect.get(fileSource.source);
 				this.broadcast.video.source.set(source.video);
 				this.broadcast.audio.source.set(source.audio);

--- a/js/publish/src/location/index.ts
+++ b/js/publish/src/location/index.ts
@@ -22,7 +22,7 @@ export class Root {
 		this.window = new Window(props?.window);
 		this.peers = new Peers(props?.peers);
 
-		this.signals.effect(this.#run.bind(this));
+		this.signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect): void {

--- a/js/publish/src/location/peers.ts
+++ b/js/publish/src/location/peers.ts
@@ -22,7 +22,7 @@ export class Peers {
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.positions = Signal.from(props?.positions ?? {});
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const enabled = effect.get(this.enabled);
 			if (!enabled) return;
 

--- a/js/publish/src/location/window.ts
+++ b/js/publish/src/location/window.ts
@@ -31,7 +31,7 @@ export class Window {
 		this.position = Signal.from(props?.position ?? undefined);
 		this.handle = Signal.from(props?.handle ?? undefined);
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const enabled = effect.get(this.enabled);
 			if (!enabled) return;
 

--- a/js/publish/src/preview.ts
+++ b/js/publish/src/preview.ts
@@ -22,7 +22,7 @@ export class Preview {
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.info = Signal.from(props?.info);
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			if (!effect.get(this.enabled)) return;
 			effect.set(this.catalog, { name: Preview.TRACK });
 		});

--- a/js/publish/src/source/camera.ts
+++ b/js/publish/src/source/camera.ts
@@ -22,7 +22,7 @@ export class Camera {
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.constraints = Signal.from(props?.constraints);
 
-		this.signals.effect(this.#run.bind(this));
+		this.signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect): void {

--- a/js/publish/src/source/device.ts
+++ b/js/publish/src/source/device.ts
@@ -34,12 +34,12 @@ export class Device<Kind extends "audio" | "video"> {
 		this.kind = kind;
 		this.preferred = Signal.from(props?.preferred);
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			effect.spawn(this.#run.bind(this, effect));
 			effect.event(navigator.mediaDevices, "devicechange", () => effect.reload());
 		});
 
-		this.signals.effect(this.#runRequested.bind(this));
+		this.signals.run(this.#runRequested.bind(this));
 	}
 
 	async #run(effect: Effect) {

--- a/js/publish/src/source/file.ts
+++ b/js/publish/src/source/file.ts
@@ -18,7 +18,7 @@ export class File {
 		this.enabled = Signal.from(config.enabled ?? false);
 		this.file = Signal.from(config.file);
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const values = effect.getAll([this.file, this.enabled]);
 			if (!values) return;
 			const [file] = values;

--- a/js/publish/src/source/microphone.ts
+++ b/js/publish/src/source/microphone.ts
@@ -25,7 +25,7 @@ export class Microphone {
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.constraints = Signal.from(props?.constraints);
 
-		this.signals.effect(this.#run.bind(this));
+		this.signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect): void {

--- a/js/publish/src/source/screen.ts
+++ b/js/publish/src/source/screen.ts
@@ -23,7 +23,7 @@ export class Screen {
 		this.video = Signal.from(props?.video);
 		this.audio = Signal.from(props?.audio);
 
-		this.signals.effect(this.#run.bind(this));
+		this.signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect): void {

--- a/js/publish/src/support/element.ts
+++ b/js/publish/src/support/element.ts
@@ -35,7 +35,7 @@ export default class MoqPublishSupport extends HTMLElement {
 
 	connectedCallback() {
 		this.#signals = new Effect();
-		this.#signals.effect(this.#render.bind(this));
+		this.#signals.run(this.#render.bind(this));
 	}
 
 	disconnectedCallback() {
@@ -161,7 +161,7 @@ export default class MoqPublishSupport extends HTMLElement {
 			this.#details.update((prev) => !prev);
 		});
 
-		effect.effect((effect) => {
+		effect.run((effect) => {
 			detailsButton.textContent = effect.get(this.#details) ? "Details ➖" : "Details ➕";
 		});
 

--- a/js/publish/src/ui/context.tsx
+++ b/js/publish/src/ui/context.tsx
@@ -76,7 +76,7 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 		publish.invisible.set(true);
 		publish.source.set(undefined);
 
-		publish.signals.effect((effect) => {
+		publish.signals.run((effect) => {
 			const clearCameraDevices = () => setCameraMediaDevices([]);
 			const video = effect.get(publish.video);
 
@@ -94,7 +94,7 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 			setCameraMediaDevices(devices);
 		});
 
-		publish.signals.effect((effect) => {
+		publish.signals.run((effect) => {
 			const clearMicrophoneDevices = () => setMicrophoneMediaDevices([]);
 			const audio = effect.get(publish.audio);
 
@@ -118,7 +118,7 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 			setMicrophoneMediaDevices(devices);
 		});
 
-		publish.signals.effect((effect) => {
+		publish.signals.run((effect) => {
 			const source = effect.get(publish.source);
 			const muted = effect.get(publish.muted);
 			const invisible = effect.get(publish.invisible);
@@ -126,12 +126,12 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 			setNothingActive(source === undefined && muted && invisible);
 		});
 
-		publish.signals.effect((effect) => {
+		publish.signals.run((effect) => {
 			const audioActive = !effect.get(publish.muted);
 			setMicrophoneActive(audioActive);
 		});
 
-		publish.signals.effect((effect) => {
+		publish.signals.run((effect) => {
 			const videoSource = effect.get(publish.source);
 			const videoActive = effect.get(publish.video);
 
@@ -147,7 +147,7 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 			}
 		});
 
-		publish.signals.effect((effect) => {
+		publish.signals.run((effect) => {
 			const video = effect.get(publish.video);
 
 			if (!video || !("device" in video)) return;
@@ -156,7 +156,7 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 			setSelectedCameraSource(requested);
 		});
 
-		publish.signals.effect((effect) => {
+		publish.signals.run((effect) => {
 			const audio = effect.get(publish.audio);
 
 			if (!audio || !("device" in audio)) return;
@@ -165,7 +165,7 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 			setSelectedMicrophoneSource(requested);
 		});
 
-		publish.signals.effect((effect) => {
+		publish.signals.run((effect) => {
 			const url = effect.get(publish.connection.url);
 			const status = effect.get(publish.connection.status);
 			const audioSource = effect.get(publish.broadcast.audio.source);
@@ -193,7 +193,7 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 			}
 		});
 
-		publish.signals.effect((effect) => {
+		publish.signals.run((effect) => {
 			const selectedSource = effect.get(publish.source);
 			setFileActive(selectedSource instanceof File);
 		});

--- a/js/publish/src/user.ts
+++ b/js/publish/src/user.ts
@@ -28,7 +28,7 @@ export class Info {
 		this.avatar = Signal.from(props?.avatar);
 		this.color = Signal.from(props?.color);
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			if (!effect.get(this.enabled)) return;
 
 			effect.set(this.catalog, {

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -63,9 +63,9 @@ export class Encoder {
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.config = Signal.from(props?.config);
 
-		this.#signals.effect(this.#runCatalog.bind(this));
-		this.#signals.effect(this.#runConfig.bind(this));
-		this.#signals.effect(this.#runDimensions.bind(this));
+		this.#signals.run(this.#runCatalog.bind(this));
+		this.#signals.run(this.#runConfig.bind(this));
+		this.#signals.run(this.#runDimensions.bind(this));
 	}
 
 	serve(track: Moq.Track, effect: Effect): void {
@@ -94,14 +94,14 @@ export class Encoder {
 
 			effect.cleanup(() => encoder.close());
 
-			effect.effect(() => {
+			effect.run(() => {
 				const config = effect.get(this.#config);
 				if (!config) return;
 
 				encoder.configure(config);
 			});
 
-			effect.effect((effect) => {
+			effect.run((effect) => {
 				const frame = effect.get(this.frame);
 				if (!frame) return;
 

--- a/js/publish/src/video/index.ts
+++ b/js/publish/src/video/index.ts
@@ -39,8 +39,8 @@ export class Root {
 
 		this.flip = Signal.from(props?.flip ?? false);
 
-		this.signals.effect(this.#runCatalog.bind(this));
-		this.signals.effect(this.#runFrame.bind(this));
+		this.signals.run(this.#runCatalog.bind(this));
+		this.signals.run(this.#runFrame.bind(this));
 	}
 
 	#runFrame(effect: Effect) {

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -458,7 +458,7 @@ export class Effect {
 			return;
 		}
 
-		this.effect((effect) => {
+		this.run((effect) => {
 			const value = effect.get(signal);
 			fn(value);
 		});

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -63,10 +63,10 @@ export class Decoder {
 
 		this.enabled = Signal.from(props?.enabled ?? false);
 
-		this.#signals.effect(this.#runWorklet.bind(this));
-		this.#signals.effect(this.#runEnabled.bind(this));
-		this.#signals.effect(this.#runLatency.bind(this));
-		this.#signals.effect(this.#runDecoder.bind(this));
+		this.#signals.run(this.#runWorklet.bind(this));
+		this.#signals.run(this.#runEnabled.bind(this));
+		this.#signals.run(this.#runLatency.bind(this));
+		this.#signals.run(this.#runDecoder.bind(this));
 	}
 
 	#runWorklet(effect: Effect): void {
@@ -187,7 +187,7 @@ export class Decoder {
 		effect.cleanup(() => consumer.close());
 
 		// Combine network jitter buffer with decode buffer
-		effect.effect((inner) => {
+		effect.run((inner) => {
 			const network = inner.get(consumer.buffered);
 			const decode = inner.get(this.#decodeBuffered);
 			this.#buffered.update(() => mergeBufferedRanges(network, decode));
@@ -239,7 +239,7 @@ export class Decoder {
 
 		// For CMAF, just use decode buffer (no network jitter buffer yet)
 		// TODO: Add CMAF consumer wrapper for latency control
-		effect.effect((inner) => {
+		effect.run((inner) => {
 			const decode = inner.get(this.#decodeBuffered);
 			this.#buffered.update(() => decode);
 		});

--- a/js/watch/src/audio/emitter.ts
+++ b/js/watch/src/audio/emitter.ts
@@ -35,7 +35,7 @@ export class Emitter {
 		this.paused = Signal.from(props?.paused ?? props?.muted ?? false);
 
 		// Set the volume to 0 when muted.
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const muted = effect.get(this.muted);
 			if (muted) {
 				this.#unmuteVolume = this.volume.peek() || 0.5;
@@ -45,18 +45,18 @@ export class Emitter {
 			}
 		});
 
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const enabled = !effect.get(this.paused) && !effect.get(this.muted);
 			this.source.enabled.set(enabled);
 		});
 
 		// Set unmute when the volume is non-zero.
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const volume = effect.get(this.volume);
 			this.muted.set(volume === 0);
 		});
 
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const root = effect.get(this.source.root);
 			if (!root) return;
 
@@ -65,7 +65,7 @@ export class Emitter {
 
 			effect.set(this.#gain, gain);
 
-			effect.effect(() => {
+			effect.run(() => {
 				// We only connect/disconnect when enabled to save power.
 				// Otherwise the worklet keeps running in the background returning 0s.
 				const enabled = effect.get(this.source.enabled);
@@ -76,7 +76,7 @@ export class Emitter {
 			});
 		});
 
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const gain = effect.get(this.#gain);
 			if (!gain) return;
 

--- a/js/watch/src/audio/mse.ts
+++ b/js/watch/src/audio/mse.ts
@@ -35,8 +35,8 @@ export class Mse implements Backend {
 		this.volume = Signal.from(props?.volume ?? 0.5);
 		this.muted = Signal.from(props?.muted ?? false);
 
-		this.#signals.effect(this.#runMedia.bind(this));
-		this.#signals.effect(this.#runVolume.bind(this));
+		this.#signals.run(this.#runMedia.bind(this));
+		this.#signals.run(this.#runVolume.bind(this));
 	}
 
 	#runMedia(effect: Effect): void {

--- a/js/watch/src/audio/source.ts
+++ b/js/watch/src/audio/source.ts
@@ -58,9 +58,9 @@ export class Source {
 		this.target = Signal.from(props?.target);
 		this.supported = Signal.from(props?.supported);
 
-		this.#signals.effect(this.#runCatalog.bind(this));
-		this.#signals.effect(this.#runSupported.bind(this));
-		this.#signals.effect(this.#runSelected.bind(this));
+		this.#signals.run(this.#runCatalog.bind(this));
+		this.#signals.run(this.#runSupported.bind(this));
+		this.#signals.run(this.#runSelected.bind(this));
 	}
 
 	#runCatalog(effect: Effect): void {

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -131,7 +131,7 @@ export class MultiBackend implements Backend {
 
 		this.paused = Signal.from(props?.paused ?? false);
 
-		this.signals.effect(this.#runElement.bind(this));
+		this.signals.run(this.#runElement.bind(this));
 	}
 
 	#runElement(effect: Effect): void {

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -43,9 +43,9 @@ export class Broadcast {
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.reload = Signal.from(props?.reload ?? false);
 
-		this.signals.effect(this.#runReload.bind(this));
-		this.signals.effect(this.#runBroadcast.bind(this));
-		this.signals.effect(this.#runCatalog.bind(this));
+		this.signals.run(this.#runReload.bind(this));
+		this.signals.run(this.#runBroadcast.bind(this));
+		this.signals.run(this.#runCatalog.bind(this));
 	}
 
 	#runReload(effect: Effect): void {

--- a/js/watch/src/chat/index.ts
+++ b/js/watch/src/chat/index.ts
@@ -25,7 +25,7 @@ export class Chat {
 		this.typing = new Typing(broadcast, catalog, props?.typing);
 
 		// Grab the chat section from the catalog (if it's changed).
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const message = effect.get(this.message.catalog);
 			const typing = effect.get(this.typing.catalog);
 			if (!message && !typing) return;

--- a/js/watch/src/chat/message.ts
+++ b/js/watch/src/chat/message.ts
@@ -30,12 +30,12 @@ export class Message {
 		this.enabled = Signal.from(props?.enabled ?? false);
 
 		// Grab the chat section from the catalog (if it's changed).
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			if (!effect.get(this.enabled)) return;
 			this.#catalog.set(effect.get(catalog)?.chat?.message);
 		});
 
-		this.#signals.effect(this.#run.bind(this));
+		this.#signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect) {

--- a/js/watch/src/chat/typing.ts
+++ b/js/watch/src/chat/typing.ts
@@ -28,12 +28,12 @@ export class Typing {
 		this.enabled = Signal.from(props?.enabled ?? false);
 
 		// Grab the chat section from the catalog (if it's changed).
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			if (!effect.get(this.enabled)) return;
 			this.#catalog.set(effect.get(catalog)?.chat?.typing);
 		});
 
-		this.#signals.effect(this.#run.bind(this));
+		this.#signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect) {

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -79,7 +79,7 @@ export default class MoqWatch extends HTMLElement implements Backend {
 		// This is kind of dangerous because it can create loops.
 		// NOTE: This only runs when the element is connected to the DOM, which is not obvious.
 		// This is because there's no destructor for web components to clean up our effects.
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const url = effect.get(this.url);
 			if (url) {
 				this.setAttribute("url", url.toString());
@@ -88,7 +88,7 @@ export default class MoqWatch extends HTMLElement implements Backend {
 			}
 		});
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const broadcast = effect.get(this.path);
 			if (broadcast) {
 				this.setAttribute("path", broadcast.toString());
@@ -97,7 +97,7 @@ export default class MoqWatch extends HTMLElement implements Backend {
 			}
 		});
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const muted = effect.get(this.audio.muted);
 			if (muted) {
 				this.setAttribute("muted", "");
@@ -106,7 +106,7 @@ export default class MoqWatch extends HTMLElement implements Backend {
 			}
 		});
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const paused = effect.get(this.paused);
 			if (paused) {
 				this.setAttribute("paused", "true");
@@ -115,12 +115,12 @@ export default class MoqWatch extends HTMLElement implements Backend {
 			}
 		});
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const volume = effect.get(this.audio.volume);
 			this.setAttribute("volume", volume.toString());
 		});
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const jitter = Math.floor(effect.get(this.jitter));
 			this.setAttribute("jitter", jitter.toString());
 		});

--- a/js/watch/src/location/peers.ts
+++ b/js/watch/src/location/peers.ts
@@ -24,11 +24,11 @@ export class Peers {
 		this.broadcast = broadcast;
 		this.enabled = Signal.from(props?.enabled ?? false);
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			this.#catalog.set(effect.get(catalog)?.location?.peers);
 		});
 
-		this.signals.effect(this.#run.bind(this));
+		this.signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect) {

--- a/js/watch/src/location/window.ts
+++ b/js/watch/src/location/window.ts
@@ -30,20 +30,20 @@ export class Window {
 		this.broadcast = broadcast;
 		this.enabled = Signal.from(props?.enabled ?? false);
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			this.#catalog.set(effect.get(catalog)?.location);
 		});
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			if (!effect.get(this.enabled)) return;
 			this.#position.set(effect.get(this.#catalog)?.initial);
 		});
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			this.#handle.set(effect.get(this.#catalog)?.handle);
 		});
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			const broadcast = effect.get(this.broadcast);
 			if (!broadcast) return;
 

--- a/js/watch/src/mse.ts
+++ b/js/watch/src/mse.ts
@@ -28,11 +28,11 @@ export class Muxer {
 		this.paused = Signal.from(props?.paused ?? false);
 		this.#sync = sync;
 
-		this.#signals.effect(this.#runMediaSource.bind(this));
-		this.#signals.effect(this.#runSkip.bind(this));
-		this.#signals.effect(this.#runTrim.bind(this));
-		this.#signals.effect(this.#runPaused.bind(this));
-		this.#signals.effect(this.#runSync.bind(this));
+		this.#signals.run(this.#runMediaSource.bind(this));
+		this.#signals.run(this.#runSkip.bind(this));
+		this.#signals.run(this.#runTrim.bind(this));
+		this.#signals.run(this.#runPaused.bind(this));
+		this.#signals.run(this.#runSync.bind(this));
 	}
 
 	#runMediaSource(effect: Effect): void {

--- a/js/watch/src/preview.ts
+++ b/js/watch/src/preview.ts
@@ -23,11 +23,11 @@ export class Preview {
 		this.broadcast = broadcast;
 		this.enabled = Signal.from(props?.enabled ?? false);
 
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			this.#catalog.set(effect.get(catalog)?.preview);
 		});
 
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const values = effect.getAll([this.enabled, this.broadcast, this.#catalog]);
 			if (!values) return;
 			const [_, broadcast, catalog] = values;

--- a/js/watch/src/support/element.ts
+++ b/js/watch/src/support/element.ts
@@ -35,7 +35,7 @@ export default class MoqWatchSupport extends HTMLElement {
 
 	connectedCallback() {
 		this.#signals = new Effect();
-		this.#signals.effect(this.#render.bind(this));
+		this.#signals.run(this.#render.bind(this));
 	}
 
 	disconnectedCallback() {
@@ -160,7 +160,7 @@ export default class MoqWatchSupport extends HTMLElement {
 			this.#details.update((prev) => !prev);
 		});
 
-		effect.effect((effect) => {
+		effect.run((effect) => {
 			detailsButton.textContent = effect.get(this.#details) ? "Details ➖" : "Details ➕";
 		});
 

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -41,7 +41,7 @@ export class Sync {
 			this.#resolve = resolve;
 		});
 
-		this.signals.effect(this.#runLatency.bind(this));
+		this.signals.run(this.#runLatency.bind(this));
 	}
 
 	#runLatency(effect: Effect): void {

--- a/js/watch/src/ui/context.tsx
+++ b/js/watch/src/ui/context.tsx
@@ -119,7 +119,7 @@ export default function WatchUIContextProvider(props: WatchUIContextProviderProp
 	const watch = props.moqWatch;
 	const signals = new Signals.Effect();
 
-	signals.effect((effect) => {
+	signals.run((effect) => {
 		const url = effect.get(watch.connection.url);
 		const connection = effect.get(watch.connection.status);
 		const broadcast = effect.get(watch.broadcast.status);
@@ -141,32 +141,32 @@ export default function WatchUIContextProvider(props: WatchUIContextProviderProp
 		}
 	});
 
-	signals.effect((effect) => {
+	signals.run((effect) => {
 		const paused = effect.get(watch.paused);
 		setIsPlaying(!paused);
 	});
 
-	signals.effect((effect) => {
+	signals.run((effect) => {
 		const volume = effect.get(watch.audio.volume);
 		setCurrentVolume(volume * 100);
 	});
 
-	signals.effect((effect) => {
+	signals.run((effect) => {
 		const muted = effect.get(watch.audio.muted);
 		setIsMuted(muted);
 	});
 
-	signals.effect((effect) => {
+	signals.run((effect) => {
 		const stalled = effect.get(watch.video.stalled);
 		setBuffering(stalled);
 	});
 
-	signals.effect((effect) => {
+	signals.run((effect) => {
 		const jitter = effect.get(watch.jitter);
 		setJitter(jitter);
 	});
 
-	signals.effect((effect) => {
+	signals.run((effect) => {
 		const videoCatalog = effect.get(watch.video.source.catalog);
 		const renditions = videoCatalog?.renditions ?? {};
 
@@ -179,7 +179,7 @@ export default function WatchUIContextProvider(props: WatchUIContextProviderProp
 		setAvailableRenditions(renditionsList);
 	});
 
-	signals.effect((effect) => {
+	signals.run((effect) => {
 		const selected = effect.get(watch.video.source.track);
 		setActiveRendition(selected);
 	});

--- a/js/watch/src/user.ts
+++ b/js/watch/src/user.ts
@@ -18,7 +18,7 @@ export class Info {
 	constructor(catalog: Signal<Catalog.Root | undefined>, props?: Props) {
 		this.enabled = Signal.from(props?.enabled ?? false);
 
-		this.signals.effect((effect) => {
+		this.signals.run((effect) => {
 			if (!effect.get(this.enabled)) return;
 
 			this.#id.set(effect.get(catalog)?.user?.id);

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -58,10 +58,10 @@ export class Decoder implements Backend {
 		this.source = source;
 		this.source.supported.set(supported); // super hacky
 
-		this.#signals.effect(this.#runPending.bind(this));
-		this.#signals.effect(this.#runActive.bind(this));
-		this.#signals.effect(this.#runDisplay.bind(this));
-		this.#signals.effect(this.#runBuffering.bind(this));
+		this.#signals.run(this.#runPending.bind(this));
+		this.#signals.run(this.#runActive.bind(this));
+		this.#signals.run(this.#runDisplay.bind(this));
+		this.#signals.run(this.#runBuffering.bind(this));
 	}
 
 	#runPending(effect: Effect): void {
@@ -83,7 +83,7 @@ export class Decoder implements Backend {
 
 		effect.cleanup(() => pending?.close());
 
-		effect.effect((effect) => {
+		effect.run((effect) => {
 			if (!pending) return;
 
 			const active = effect.get(this.#active);
@@ -200,7 +200,7 @@ class DecoderTrack {
 		this.config = requiredConfig;
 		this.stats = props.stats;
 
-		this.signals.effect(this.#run.bind(this));
+		this.signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect): void {
@@ -268,7 +268,7 @@ class DecoderTrack {
 		effect.cleanup(() => consumer.close());
 
 		// Combine network jitter buffer with decode buffer
-		effect.effect((inner) => {
+		effect.run((inner) => {
 			const network = inner.get(consumer.buffered);
 			const decode = inner.get(this.#buffered);
 			this.buffered.update(() => mergeBufferedRanges(network, decode));
@@ -348,7 +348,7 @@ class DecoderTrack {
 		});
 
 		// Use decode buffer directly (no network jitter buffer for CMAF yet)
-		effect.effect((inner) => {
+		effect.run((inner) => {
 			const decode = inner.get(this.#buffered);
 			this.buffered.update(() => decode);
 		});

--- a/js/watch/src/video/mse.ts
+++ b/js/watch/src/video/mse.ts
@@ -35,9 +35,9 @@ export class Mse implements Backend {
 		this.source = source;
 		this.source.supported.set(supported); // super hacky
 
-		this.signals.effect(this.#runMedia.bind(this));
-		this.signals.effect(this.#runStalled.bind(this));
-		this.signals.effect(this.#runTimestamp.bind(this));
+		this.signals.run(this.#runMedia.bind(this));
+		this.signals.run(this.#runStalled.bind(this));
+		this.signals.run(this.#runTimestamp.bind(this));
 	}
 
 	#runMedia(effect: Effect): void {

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -27,14 +27,14 @@ export class Renderer {
 		this.canvas = Signal.from(props?.canvas);
 		this.paused = Signal.from(props?.paused ?? false);
 
-		this.#signals.effect((effect) => {
+		this.#signals.run((effect) => {
 			const canvas = effect.get(this.canvas);
 			this.#ctx.set(canvas?.getContext("2d") ?? undefined);
 		});
 
-		this.#signals.effect(this.#runEnabled.bind(this));
-		this.#signals.effect(this.#runRender.bind(this));
-		this.#signals.effect(this.#runResize.bind(this));
+		this.#signals.run(this.#runEnabled.bind(this));
+		this.#signals.run(this.#runRender.bind(this));
+		this.#signals.run(this.#runResize.bind(this));
 	}
 
 	#runResize(effect: Effect) {

--- a/js/watch/src/video/source.ts
+++ b/js/watch/src/video/source.ts
@@ -57,9 +57,9 @@ export class Source {
 		this.sync = sync;
 		this.supported = Signal.from(props?.supported);
 
-		this.#signals.effect(this.#runCatalog.bind(this));
-		this.#signals.effect(this.#runSupported.bind(this));
-		this.#signals.effect(this.#runSelected.bind(this));
+		this.#signals.run(this.#runCatalog.bind(this));
+		this.#signals.run(this.#runSupported.bind(this));
+		this.#signals.run(this.#runSelected.bind(this));
 	}
 
 	#runCatalog(effect: Effect): void {


### PR DESCRIPTION
The method was renamed from effect() to run() with a backwards-compat
alias. This updates all 45 consumer files to use the new name directly.

https://claude.ai/code/session_01BjY8jXi5sY2YbWKgqZwqEz