### PR TITLE
Fix npm publish auth by adding --provenance flag for OIDC trusted publishing

### DIFF
--- a/js/common/release.ts
+++ b/js/common/release.ts
@@ -25,7 +25,7 @@ execSync("bun run build", { stdio: "inherit" });
 
 console.log(`🚀 Publishing ${name}@${version}...`);
 // Use npm for publishing to support OIDC trusted publishing
-execSync("npm publish --access public", {
+execSync("npm publish --provenance --access public", {
 	stdio: "inherit",
 	cwd: "dist",
 });


### PR DESCRIPTION
The release workflow has id-token: write permission and setup-node with
registry-url configured for OIDC trusted publishing, but npm publish was
missing the --provenance flag. Without it, npm doesn't initiate the OIDC
token exchange and instead tries to use the unset NODE_AUTH_TOKEN, causing
"Access token expired or revoked" errors.

https://claude.ai/code/session_01R9XxJoV5zz97yvipaA627c