### PR TITLE
bump @moq/lite

### DIFF
--- a/js/lite/package.json
+++ b/js/lite/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/lite",
 	"type": "module",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",


### PR DESCRIPTION
## Summary
- Bumps `@moq/lite` from 0.1.4 to 0.1.4 to trigger a release with `inlineSources` in sourcemaps
- Fixes Vite warnings about sourcemaps pointing to missing source files

## Test plan
- [ ] Verify `just check` passes
- [ ] After release, confirm Vite no longer warns about missing sourcemap sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)