### PR TITLE
Revert back to get/set properties.

### DIFF
--- a/js/publish/src/ui/components/CameraSourceButton.tsx
+++ b/js/publish/src/ui/components/CameraSourceButton.tsx
@@ -6,12 +6,12 @@ import MediaSourceSourceSelector from "./MediaSourceSelector";
 export default function CameraSourceButton() {
 	const context = usePublishUIContext();
 	const onClick = () => {
-		if (context.moqPublish.source.peek() === "camera") {
+		if (context.moqPublish.source === "camera") {
 			// Camera already selected, toggle video.
-			context.moqPublish.invisible.update((invisible) => !invisible);
+			context.moqPublish.invisible = !context.moqPublish.invisible;
 		} else {
-			context.moqPublish.source.set("camera");
-			context.moqPublish.invisible.set(false);
+			context.moqPublish.source = "camera";
+			context.moqPublish.invisible = false;
 		}
 	};
 

--- a/js/publish/src/ui/components/MicrophoneSourceButton.tsx
+++ b/js/publish/src/ui/components/MicrophoneSourceButton.tsx
@@ -6,12 +6,12 @@ import MediaSourceSourceSelector from "./MediaSourceSelector";
 export default function MicrophoneSourceButton() {
 	const context = usePublishUIContext();
 	const onClick = () => {
-		if (context.moqPublish.source.peek() === "camera") {
+		if (context.moqPublish.source === "camera") {
 			// Camera already selected, toggle audio.
-			context.moqPublish.muted.update((muted) => !muted);
+			context.moqPublish.muted = !context.moqPublish.muted;
 		} else {
-			context.moqPublish.source.set("camera");
-			context.moqPublish.muted.set(false);
+			context.moqPublish.source = "camera";
+			context.moqPublish.muted = false;
 		}
 	};
 

--- a/js/publish/src/ui/components/NothingSourceButton.tsx
+++ b/js/publish/src/ui/components/NothingSourceButton.tsx
@@ -4,9 +4,9 @@ import usePublishUIContext from "../hooks/use-publish-ui";
 export default function NothingSourceButton() {
 	const context = usePublishUIContext();
 	const onClick = () => {
-		context.moqPublish.source.set(undefined);
-		context.moqPublish.muted.set(true);
-		context.moqPublish.invisible.set(true);
+		context.moqPublish.source = undefined;
+		context.moqPublish.muted = true;
+		context.moqPublish.invisible = true;
 	};
 
 	return (

--- a/js/publish/src/ui/components/ScreenSourceButton.tsx
+++ b/js/publish/src/ui/components/ScreenSourceButton.tsx
@@ -4,9 +4,9 @@ import usePublishUIContext from "../hooks/use-publish-ui";
 export default function ScreenSourceButton() {
 	const context = usePublishUIContext();
 	const onClick = () => {
-		context.moqPublish.source.set("screen");
-		context.moqPublish.invisible.set(false);
-		context.moqPublish.muted.set(true);
+		context.moqPublish.source = "screen";
+		context.moqPublish.invisible = false;
+		context.moqPublish.muted = true;
 	};
 
 	return (

--- a/js/publish/src/ui/context.tsx
+++ b/js/publish/src/ui/context.tsx
@@ -48,9 +48,9 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 	const [publishStatus, setPublishStatus] = createSignal<PublishStatus>("no-url");
 
 	const setFile = (file: File) => {
-		props.moqPublish.source.set(file);
-		props.moqPublish.invisible.set(false);
-		props.moqPublish.muted.set(true);
+		props.moqPublish.source = file;
+		props.moqPublish.invisible = false;
+		props.moqPublish.muted = true;
 	};
 
 	const value: PublishUIContextValue = {
@@ -72,9 +72,9 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 		const publish = props.moqPublish;
 
 		// Initialize with "nothing" active on page load
-		publish.muted.set(true);
-		publish.invisible.set(true);
-		publish.source.set(undefined);
+		publish.muted = true;
+		publish.invisible = true;
+		publish.source = undefined;
 
 		publish.signals.run((effect) => {
 			const clearCameraDevices = () => setCameraMediaDevices([]);
@@ -119,20 +119,20 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 		});
 
 		publish.signals.run((effect) => {
-			const source = effect.get(publish.source);
-			const muted = effect.get(publish.muted);
-			const invisible = effect.get(publish.invisible);
+			const source = effect.get(publish.state.source);
+			const muted = effect.get(publish.state.muted);
+			const invisible = effect.get(publish.state.invisible);
 
 			setNothingActive(source === undefined && muted && invisible);
 		});
 
 		publish.signals.run((effect) => {
-			const audioActive = !effect.get(publish.muted);
+			const audioActive = !effect.get(publish.state.muted);
 			setMicrophoneActive(audioActive);
 		});
 
 		publish.signals.run((effect) => {
-			const videoSource = effect.get(publish.source);
+			const videoSource = effect.get(publish.state.source);
 			const videoActive = effect.get(publish.video);
 
 			if (videoActive && videoSource === "camera") {
@@ -170,8 +170,8 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 			const status = effect.get(publish.connection.status);
 			const audioSource = effect.get(publish.broadcast.audio.source);
 			const videoSource = effect.get(publish.broadcast.video.source);
-			const muted = effect.get(publish.muted);
-			const invisible = effect.get(publish.invisible);
+			const muted = effect.get(publish.state.muted);
+			const invisible = effect.get(publish.state.invisible);
 
 			const audio = audioSource && !muted;
 			const video = videoSource && !invisible;
@@ -194,7 +194,7 @@ export default function PublishUIContextProvider(props: PublishUIContextProvider
 		});
 
 		publish.signals.run((effect) => {
-			const selectedSource = effect.get(publish.source);
+			const selectedSource = effect.get(publish.state.source);
 			setFileActive(selectedSource instanceof File);
 		});
 	});

--- a/js/watch/src/ui/context.tsx
+++ b/js/watch/src/ui/context.tsx
@@ -47,17 +47,17 @@ export const WatchUIContext = createContext<WatchUIContextValues>();
 export default function WatchUIContextProvider(props: WatchUIContextProviderProps) {
 	const [watchStatus, setWatchStatus] = createSignal<WatchStatus>("no-url");
 	const [isPlaying, setIsPlaying] = createSignal<boolean>(false);
-	const isMuted = createAccessor(props.moqWatch.audio.muted);
+	const isMuted = createAccessor(props.moqWatch.backend.audio.muted);
 	const [currentVolume, setCurrentVolume] = createSignal<number>(0);
-	const buffering = createAccessor(props.moqWatch.video.stalled);
-	const jitter = createAccessor(props.moqWatch.jitter);
+	const buffering = createAccessor(props.moqWatch.backend.video.stalled);
+	const jitter = createAccessor(props.moqWatch.backend.jitter);
 	const [availableRenditions, setAvailableRenditions] = createSignal<Rendition[]>([]);
-	const activeRendition = createAccessor(props.moqWatch.video.source.track);
+	const activeRendition = createAccessor(props.moqWatch.backend.video.source.track);
 	const [isStatsPanelVisible, setIsStatsPanelVisible] = createSignal<boolean>(false);
 	const [isFullscreen, setIsFullscreen] = createSignal<boolean>(!!document.fullscreenElement);
 
 	const togglePlayback = () => {
-		props.moqWatch.paused.set(!props.moqWatch.paused.get());
+		props.moqWatch.paused = !props.moqWatch.paused;
 	};
 
 	const toggleFullscreen = () => {
@@ -69,27 +69,27 @@ export default function WatchUIContextProvider(props: WatchUIContextProviderProp
 	};
 
 	const setVolume = (volume: number) => {
-		props.moqWatch.audio.volume.set(volume / 100);
+		props.moqWatch.backend.audio.volume.set(volume / 100);
 	};
 
 	const toggleMuted = () => {
-		props.moqWatch.audio.muted.update((muted) => !muted);
+		props.moqWatch.backend.audio.muted.update((muted) => !muted);
 	};
 
 	const setJitter = (latency: Moq.Time.Milli) => {
-		props.moqWatch.jitter.set(latency);
+		props.moqWatch.jitter = latency;
 	};
 
 	const setActiveRenditionValue = (name: string | undefined) => {
-		props.moqWatch.video.source.target.update((prev) => ({
+		props.moqWatch.backend.video.source.target.update((prev) => ({
 			...prev,
 			name: name,
 		}));
 	};
 
-	const timestamp = createAccessor(props.moqWatch.video.timestamp);
-	const videoBuffered = createAccessor(props.moqWatch.video.buffered);
-	const audioBuffered = createAccessor(props.moqWatch.audio.buffered);
+	const timestamp = createAccessor(props.moqWatch.backend.video.timestamp);
+	const videoBuffered = createAccessor(props.moqWatch.backend.video.buffered);
+	const audioBuffered = createAccessor(props.moqWatch.backend.audio.buffered);
 
 	const value: WatchUIContextValues = {
 		moqWatch: props.moqWatch,
@@ -141,17 +141,17 @@ export default function WatchUIContextProvider(props: WatchUIContextProviderProp
 	});
 
 	signals.run((effect) => {
-		const paused = effect.get(watch.paused);
+		const paused = effect.get(watch.backend.paused);
 		setIsPlaying(!paused);
 	});
 
 	signals.run((effect) => {
-		const volume = effect.get(watch.audio.volume);
+		const volume = effect.get(watch.backend.audio.volume);
 		setCurrentVolume(volume * 100);
 	});
 
 	signals.run((effect) => {
-		const videoCatalog = effect.get(watch.video.source.catalog);
+		const videoCatalog = effect.get(watch.backend.video.source.catalog);
 		const renditions = videoCatalog?.renditions ?? {};
 
 		const renditionsList: Rendition[] = Object.entries(renditions).map(([name, config]) => ({

--- a/js/watch/src/ui/element.tsx
+++ b/js/watch/src/ui/element.tsx
@@ -21,8 +21,8 @@ export function WatchUI(props: { watch: MoqWatch }) {
 						<Show when={context.isStatsPanelVisible()}>
 							<Stats
 								context={WatchUIContext}
-								getElement={(ctx): MoqWatch | undefined => {
-									return ctx?.moqWatch;
+								getElement={(ctx) => {
+									return ctx?.moqWatch.backend;
 								}}
 							/>
 						</Show>


### PR DESCRIPTION
Apparently React 19 will only use properties, with no support for attributes. So we should to go back to exposing get/set methods instead of signals.

Power users can access stuff like .backend or .state directly for signal access. IDK if we should put everything in there or not. We'll bump to version 0.2.0 after this.

@pzanella now I understand some of the changes in #932. I can confirm this fixes your vite-7 branch but is much simpler than full blown React components.