### PR TITLE
Fix IETF subscriber race cancelling groups before consumers attach

### DIFF
--- a/rs/moq-lite/src/ietf/subscriber.rs
+++ b/rs/moq-lite/src/ietf/subscriber.rs
@@ -375,12 +375,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			track.producer.create_group(group)?
 		};
 
-		let res = tokio::select! {
-			_ = producer.unused() => Err(Error::Cancel),
-			res = self.run_group(group, stream, producer.clone()) => res,
-		};
-
-		match res {
+		// NOTE: We don't check `producer.unused()` because it's being written to a cache.
+		match self.run_group(group, stream, producer.clone()).await {
 			Err(Error::Cancel) => {
 				tracing::trace!(group = %producer.info.sequence, "group cancelled");
 				let _ = producer.close(Error::Cancel);
@@ -432,12 +428,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			} else {
 				let mut frame = producer.create_frame(Frame { size })?;
 
-				let res = tokio::select! {
-					_ = frame.unused() => Err(Error::Cancel),
-					res = self.run_frame(stream, frame.clone()) => res,
-				};
-
-				if let Err(err) = res {
+				if let Err(err) = self.run_frame(stream, frame.clone()).await {
 					let _ = frame.close(err.clone());
 					return Err(err);
 				}


### PR DESCRIPTION
## Summary
- The `Producer/Consumer` refactor (`a0f55d06`) made `unused()` fire immediately when `consumers == 0`, which is the initial state for `GroupProducer` and `FrameProducer`
- The IETF subscriber's `tokio::select!` with `unused()` was a race condition: groups were randomly cancelled before any downstream publisher could call `next_group()` to create a consumer
- This broke cross-version relay forwarding (e.g. IETF Draft14 publisher → relay → moq-lite-03 subscriber), with `catalog.json` groups being silently dropped
- Removed the `group.unused()` and `frame.unused()` checks from the IETF subscriber, matching the lite subscriber which already skips them ("written to a cache")

## Test plan
- [ ] Run `just dev` with publisher using moq-transport-14 and subscriber using moq-lite-03 — catalog.json should reliably reach the subscriber
- [ ] Run `just check` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)