### PR TITLE
Fix race condition in IETF subscriber unused() checks

### DIFF
--- a/rs/moq-lite/src/ietf/subscriber.rs
+++ b/rs/moq-lite/src/ietf/subscriber.rs
@@ -375,10 +375,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			track.producer.create_group(group)?
 		};
 
-		let res = tokio::select! {
-			_ = producer.unused() => Err(Error::Cancel),
-			res = self.run_group(group, stream, producer.clone()) => res,
-		};
+		// NOTE: We don't check group.unused() because it's being written to a cache.
+		// This matches the lite subscriber behavior — the publisher task creates
+		// GroupConsumers asynchronously via next_group(), so checking unused() here
+		// would race and cancel groups before consumers can attach.
+		let res = self.run_group(group, stream, producer.clone()).await;
 
 		match res {
 			Err(Error::Cancel) => {
@@ -432,12 +433,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			} else {
 				let mut frame = producer.create_frame(Frame { size })?;
 
-				let res = tokio::select! {
-					_ = frame.unused() => Err(Error::Cancel),
-					res = self.run_frame(stream, frame.clone()) => res,
-				};
-
-				if let Err(err) = res {
+				// NOTE: Don't check frame.unused() for the same reason as group.unused() above.
+				if let Err(err) = self.run_frame(stream, frame.clone()).await {
 					let _ = frame.close(err.clone());
 					return Err(err);
 				}


### PR DESCRIPTION
## Problem

The IETF subscriber uses `tokio::select!` to race `run_group()`/`run_frame()` against `producer.unused()`/`frame.unused()`. The intent is to cancel processing if nobody is consuming the data. However, this doesn't work correctly because the relay writes incoming data to a cache, and consumers (`GroupConsumer`) are created asynchronously via `next_group()`.

What actually happens:

1. A new group arrives from the publisher
2. The subscriber starts `run_group()` and simultaneously checks `unused()`
3. `unused()` returns immediately because no consumer has attached yet, they haven't had time to call `next_group()`
4. `tokio::select!` picks the `unused()` branch and cancels the group with `Error::Cancel`
5. The consumer eventually calls `next_group()`, but the group is already gone

This causes intermittent data loss where groups and frames are silently dropped depending on timing. The race is particularly visible under load or when consumers are slightly delayed in attaching.

## Fix

Remove the `unused()` checks entirely, matching the lite subscriber behavior. Since data goes through a cache, groups and frames should always be fully received regardless of whether a consumer is currently attached. The cache handles expiration separately via group eviction by age.

```rust
// Before: race that cancels if no consumer is attached yet
let res = tokio::select! {
    _ = producer.unused() => Err(Error::Cancel),
    res = self.run_group(group, stream, producer.clone()) => res,
};

// After: always receive the full group
let res = self.run_group(group, stream, producer.clone()).await;
```

Same pattern removed for frames within `run_group()`.

## Test plan

Verify IETF browser client (moq-encoder-player) subscribes and receives all groups without intermittent drops. Test multiple subscribers attaching at staggered times to confirm they all receive complete data. Check no regression in lite subscriber path and that relay memory stays bounded since cache eviction still works independently.