### PR TITLE
fix: `Fmp4::init_audio()` doesn't populate description for AAC, causing downstream format mismatch

### DIFF
--- a/rs/moq-mux/src/import/fmp4.rs
+++ b/rs/moq-mux/src/import/fmp4.rs
@@ -395,16 +395,20 @@ impl Fmp4 {
 				}
 
 				let bitrate = desc.avg_bitrate.max(desc.max_bitrate);
+				let profile = desc.dec_specific.profile;
+				let sample_rate = mp4a.audio.sample_rate.integer() as u32;
+				let channel_count = mp4a.audio.channel_count as u32;
+
+				// Build the AudioSpecificConfig (ISO 14496-3 §1.6.2.1)
+				// This is what GStreamer/WebCodecs need as codec_data.
+				let description = build_aac_audio_specific_config(profile, sample_rate, channel_count);
 
 				AudioConfig {
-					codec: AAC {
-						profile: desc.dec_specific.profile,
-					}
-					.into(),
-					sample_rate: mp4a.audio.sample_rate.integer() as _,
-					channel_count: mp4a.audio.channel_count as _,
+					codec: AAC { profile }.into(),
+					sample_rate,
+					channel_count,
 					bitrate: Some(bitrate.into()),
-					description: None, // TODO?
+					description: Some(description),
 					container,
 					jitter: None,
 				}
@@ -668,5 +672,50 @@ impl Drop for Fmp4 {
 				TrackKind::Audio => catalog.audio.remove_track(&track.producer.info).is_some(),
 			};
 		}
+	}
+}
+
+/// Reconstruct the AudioSpecificConfig from parsed fields.
+///
+/// Layout (ISO 14496-3):
+///   audioObjectType      (5 bits)  — the AAC profile (2 = AAC-LC)
+///   samplingFreqIndex    (4 bits)  — index into the standard table, or 0xF
+///   [samplingFrequency  (24 bits)] — only if index == 0xF
+///   channelConfiguration (4 bits)
+///
+/// For standard sample rates this produces exactly 2 bytes (e.g. 0x12 0x10
+/// for AAC-LC / 44100 Hz / stereo).
+fn build_aac_audio_specific_config(profile: u8, sample_rate: u32, channels: u32) -> Bytes {
+	let freq_index: u8 = match sample_rate {
+		96000 => 0,
+		88200 => 1,
+		64000 => 2,
+		48000 => 3,
+		44100 => 4,
+		32000 => 5,
+		24000 => 6,
+		22050 => 7,
+		16000 => 8,
+		12000 => 9,
+		11025 => 10,
+		8000 => 11,
+		7350 => 12,
+		_ => 0xF, // explicit 24-bit frequency follows
+	};
+
+	if freq_index != 0xF {
+		// 5 + 4 + 4 = 13 bits → 2 bytes (3 bits padding)
+		let b0 = (profile << 3) | (freq_index >> 1);
+		let b1 = ((freq_index & 1) << 7) | ((channels as u8 & 0x0F) << 3);
+		Bytes::from(vec![b0, b1])
+	} else {
+		// 5 + 4 + 24 + 4 = 37 bits → 5 bytes (3 bits padding)
+		let mut bits: u64 = 0;
+		bits |= (profile as u64) << 35;
+		bits |= 0xF_u64 << 31;
+		bits |= (sample_rate as u64) << 7;
+		bits |= ((channels as u64) & 0xF) << 3;
+		let all = bits.to_be_bytes();
+		Bytes::copy_from_slice(&all[3..8])
 	}
 }


### PR DESCRIPTION
In `rs/moq-mux/src/import/fmp4.rs`, `init_audio()` sets description: None for AAC tracks (marked with `// TODO?`):

```rust
mp4_atom::Codec::Mp4a(mp4a) => {
    // ...
    AudioConfig {
         codec: AAC { profile: desc.dec_specific.profile }.into(),
         sample_rate: mp4a.audio.sample_rate.integer() as _,
         channel_count: mp4a.audio.channel_count as _,
         bitrate: Some(bitrate.into()),
         container,
         jitter: None,
         description: None, // TODO?
    }
```

**The problem:** `Fmp4::extract()` writes raw AAC frames (no ADTS headers) into the track — that's correct for fMP4, where frames are always raw. But without description, consumers have no `AudioSpecificConfig` to initialize their decoder. They're forced to assume ADTS framing (which includes the config inline), but the actual payload is headerless raw AAC. The decoder either fails or produces silence/garbage.

**The fix:** Build the AudioSpecificConfig from the already-parsed ESDS fields. This is a 2-byte blob for standard sample rates (e.g. 0x12 0x10 for AAC-LC / 44100 Hz / stereo):

```rust
mp4_atom::Codec::Mp4a(mp4a) => {
    let desc = &mp4a.esds.es_desc.dec_config;

    if desc.object_type_indication != 0x40 {
        anyhow::bail!("unsupported codec: MPEG2");
    }

    let bitrate = desc.avg_bitrate.max(desc.max_bitrate);
    let profile = desc.dec_specific.profile;
    let sample_rate = mp4a.audio.sample_rate.integer() as u32;
    let channel_count = mp4a.audio.channel_count as u32;

    AudioConfig {
        codec: AAC { profile }.into(),
        sample_rate,
        channel_count,
        bitrate: Some(bitrate.into()),
        description: Some(build_audio_specific_config(profile, sample_rate, channel_count)),
    }
}

/// ISO 14496-3 §1.6.2.1 AudioSpecificConfig
fn build_audio_specific_config(profile: u8, sample_rate: u32, channels: u32) -> Bytes {
    let freq_index: u8 = match sample_rate {
        96000 => 0, 88200 => 1, 64000 => 2, 48000 => 3,
        44100 => 4, 32000 => 5, 24000 => 6, 22050 => 7,
        16000 => 8, 12000 => 9, 11025 => 10, 8000 => 11,
        7350 => 12, _ => 0xF,
    };

    if freq_index != 0xF {
        // 5 + 4 + 4 = 13 bits → 2 bytes
        let b0 = (profile << 3) | (freq_index >> 1);
        let b1 = ((freq_index & 1) << 7) | ((channels as u8 & 0x0F) << 3);
        Bytes::from(vec![b0, b1])
    } else {
        // 5 + 4 + 24 + 4 = 37 bits → 5 bytes
        let mut bits: u64 = 0;
        bits |= (profile as u64) << 35;
        bits |= 0xF_u64 << 31;
        bits |= (sample_rate as u64) << 7;
        bits |= ((channels as u64) & 0xF) << 3;
        Bytes::copy_from_slice(&bits.to_be_bytes()[3..8])
    }
}
```

**Note:** The same `// TODO?` exists for Opus. Opus doesn't strictly need it (the essential config is in the codec string + sample rate + channels), but for completeness it could carry the OpusHead bytes.

**Comparison with video:** `init_video` already does this correctly — it calls `avcc.encode_body()` to populate description for H.264. Audio just needs the equivalent treatment.
