### PR TITLE
Cache and re-insert parameter sets before keyframes in H.264/H.265

### DIFF
--- a/rs/moq-mux/src/import/avc3.rs
+++ b/rs/moq-mux/src/import/avc3.rs
@@ -195,6 +195,12 @@ impl Avc3 {
 				let sps = h264_parser::Sps::parse(&rbsp)?;
 				self.init(&sps)?;
 
+				// PPS is tied to SPS context; drop cached PPS when SPS changes.
+				if self.cached_sps.as_ref().is_some_and(|cached| cached != &nal) {
+					self.cached_pps = None;
+					self.current.contains_pps = false;
+				}
+
 				self.cached_sps = Some(nal.clone());
 				self.current.contains_sps = true;
 			}
@@ -214,12 +220,14 @@ impl Avc3 {
 				{
 					self.current.chunks.push_chunk(START_CODE.clone());
 					self.current.chunks.push_chunk(sps.clone());
+					self.current.contains_sps = true;
 				}
 				if !self.current.contains_pps
 					&& let Some(pps) = &self.cached_pps
 				{
 					self.current.chunks.push_chunk(START_CODE.clone());
 					self.current.chunks.push_chunk(pps.clone());
+					self.current.contains_pps = true;
 				}
 
 				self.current.contains_idr = true;

--- a/rs/moq-mux/src/import/hev1.rs
+++ b/rs/moq-mux/src/import/hev1.rs
@@ -197,6 +197,12 @@ impl Hev1 {
 				let sps = SpsNALUnit::parse(&mut &nal[..]).context("failed to parse SPS NAL unit")?;
 				self.init(&sps)?;
 
+				// PPS is tied to SPS context; drop cached PPS when SPS changes.
+				if self.cached_sps.as_ref().is_some_and(|cached| cached != &nal) {
+					self.cached_pps = None;
+					self.current.contains_pps = false;
+				}
+
 				self.cached_sps = Some(nal.clone());
 				self.current.contains_sps = true;
 			}
@@ -222,18 +228,21 @@ impl Hev1 {
 				{
 					self.current.chunks.push_chunk(START_CODE.clone());
 					self.current.chunks.push_chunk(vps.clone());
+					self.current.contains_vps = true;
 				}
 				if !self.current.contains_sps
 					&& let Some(sps) = &self.cached_sps
 				{
 					self.current.chunks.push_chunk(START_CODE.clone());
 					self.current.chunks.push_chunk(sps.clone());
+					self.current.contains_sps = true;
 				}
 				if !self.current.contains_pps
 					&& let Some(pps) = &self.cached_pps
 				{
 					self.current.chunks.push_chunk(START_CODE.clone());
 					self.current.chunks.push_chunk(pps.clone());
+					self.current.contains_pps = true;
 				}
 
 				self.current.contains_idr = true;


### PR DESCRIPTION
## Summary
This change improves H.264 (AVC3) and H.265 (HEV1) video stream handling by caching parameter set NALs (SPS/PPS for H.264, VPS/SPS/PPS for H.265) and automatically re-inserting them before keyframes when they're not already present in the frame. This ensures that decoders can properly initialize when seeking to keyframes, even if the parameter sets were only transmitted earlier in the stream.

## Key Changes

**HEV1 (H.265) decoder:**
- Added caching fields for VPS, SPS, and PPS NAL units
- Track presence of parameter sets in current frame with `contains_vps`, `contains_sps`, `contains_pps` flags
- Explicitly handle VPS NAL units (previously ignored, now cached)
- Extract PPS handling into dedicated match arm with caching
- Before keyframes, re-insert cached parameter sets if not already present in the current frame
- Reset parameter set presence flags when finishing a frame
- Updated documentation to clarify that VPS is cached but not parsed

**AVC3 (H.264) decoder:**
- Added caching fields for SPS and PPS NAL units
- Track presence of parameter sets in current frame with `contains_sps`, `contains_pps` flags
- Extract PPS handling into dedicated match arm with caching
- Before keyframes, re-insert cached SPS/PPS if not already present in the current frame
- Reset parameter set presence flags when finishing a frame
- Minor refactor: renamed `nal` to `rbsp` for clarity in SPS parsing

## Implementation Details
- Parameter sets are cached as `Option<Bytes>` and cloned when re-inserted
- Re-insertion uses the existing `START_CODE` constant to properly delimit NAL units
- The presence tracking prevents duplicate parameter sets in frames that already contain them
- This approach maintains backward compatibility while improving robustness for seeking and stream switching scenarios

https://claude.ai/code/session_01DecABSHDcyvYj7E8j6ZfMd