### PR TITLE
Fix potential null reference in Consumer group shifting logic

### DIFF
--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -224,7 +224,8 @@ export class Consumer {
 			const latency = max - min;
 			if (latency <= threshold) break;
 
-			const first = this.#groups.shift()!;
+			const first = this.#groups.shift();
+			if (!first) break;
 			this.#active = this.#groups[0]?.consumer.sequence;
 			console.warn(`skipping slow group: ${first.consumer.sequence} -> ${this.#active}`);
 


### PR DESCRIPTION
## Summary
Added null safety check when shifting groups from the queue to prevent potential runtime errors when the groups array becomes empty.

## Key Changes
- Changed `this.#groups.shift()!` to `this.#groups.shift()` to remove the non-null assertion
- Added explicit null check with early exit: `if (!first) break;` to safely handle the case when no groups are available

## Implementation Details
The original code used a non-null assertion operator (`!`) which could mask cases where `shift()` returns `undefined`. The updated code explicitly checks for this condition and breaks out of the loop, providing safer and more defensive error handling. This prevents potential issues where the code might attempt to access properties on a null/undefined value in subsequent operations.

https://claude.ai/code/session_01H2XHJUweYxQtdxBs3ZVs38