### PR TITLE
cdn: simplify nix packaging and fix deploy

### DIFF
--- a/cdn/common/memory-alert.service.tftpl
+++ b/cdn/common/memory-alert.service.tftpl
@@ -4,7 +4,7 @@ Description=Alert when system memory is low
 [Service]
 Type=simple
 Environment=MEMORY_ALERT_WEBHOOK=${webhook}
-Environment=PATH=/var/lib/moq/jq/bin:/usr/bin:/bin
+Environment=PATH=/var/lib/moq/pkg/bin:/usr/bin:/bin
 ExecStart=/etc/systemd/system/memory-alert.sh
 Restart=on-failure
 RestartSec=10

--- a/cdn/justfile
+++ b/cdn/justfile
@@ -5,6 +5,11 @@ mod pub
 default:
   just --list
 
+deploy:
+	tofu apply
+	just relay::deploy-all
+	just pub::deploy
+
 # Pin relay and pub to their latest release tags
 pin:
 	just relay::pin
@@ -12,8 +17,8 @@ pin:
 
 # Update all flake inputs to latest
 update:
-	nix flake update --flake relay
-	nix flake update --flake pub
+	just relay::update
+	just pub::update
 
 # Run health checks against all relay nodes
 health:

--- a/cdn/pub/demo-bbb-prepare.service
+++ b/cdn/pub/demo-bbb-prepare.service
@@ -10,9 +10,9 @@ WorkingDirectory=/var/lib/moq
 
 ExecStart=/bin/bash -c '\
   # Download the video \
-  /nix/var/nix/profiles/default/bin/nix shell nixpkgs#wget -c wget -nv http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4 -O /var/lib/moq/tmp.mp4 && \
+  /var/lib/moq/pkg/bin/wget -nv http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4 -O /var/lib/moq/tmp.mp4 && \
   # Fragment the video using ffmpeg from flake \
-  /var/lib/moq/ffmpeg/bin/ffmpeg \
+  /var/lib/moq/pkg/bin/ffmpeg \
     -y -loglevel error -i /var/lib/moq/tmp.mp4 \
     -c copy \
     -f mp4 -movflags cmaf+separate_moof+delay_moov+skip_trailer+frag_every_frame \

--- a/cdn/pub/demo-bbb.service.tftpl
+++ b/cdn/pub/demo-bbb.service.tftpl
@@ -12,7 +12,7 @@ Environment="RUST_LOG=info"
 
 # Stream fragmented video in a loop and pipe to hang publish
 ExecStart=/bin/bash -c '\
-  /var/lib/moq/ffmpeg/bin/ffmpeg \
+  /var/lib/moq/pkg/bin/ffmpeg \
     -stream_loop -1 \
     -hide_banner \
     -v quiet \
@@ -22,9 +22,10 @@ ExecStart=/bin/bash -c '\
     -f mp4 \
     -movflags cmaf+separate_moof+delay_moov+skip_trailer+frag_every_frame \
     - | \
-  /var/lib/moq/moq-cli/bin/moq-cli publish \
+  /var/lib/moq/pkg/bin/moq-cli publish \
     --url "https://${domain}/demo?jwt=$(cat /var/lib/moq/demo-pub.jwt)" \
-    --name bbb'
+    --name bbb \
+    fmp4'
 
 # Restart with exponential backoff
 Restart=always

--- a/cdn/pub/flake.lock
+++ b/cdn/pub/flake.lock
@@ -37,15 +37,17 @@
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1772401057,
-        "narHash": "sha256-OToXgocdPxGZ8/4vuARgF8yxe8FYdYOLVYIJZHD/9Yg=",
+        "lastModified": 1772567574,
+        "narHash": "sha256-c3QrX5CiOuVMn+eOL+WxvBUrh1z0bxYerAaC7zzu6Rw=",
         "owner": "moq-dev",
         "repo": "moq",
-        "rev": "378a7c7fd536169c79eb6087ad1ab8714ec051d0",
+        "rev": "8165c5690bfb436522daac372eb4a4f0ad197a58",
         "type": "github"
       },
       "original": {
@@ -56,27 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772173633,
-        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
+        "lastModified": 1772542754,
+        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
         "type": "github"
       },
       "original": {
@@ -89,7 +75,7 @@
     "root": {
       "inputs": {
         "moq": "moq",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-overlay": {

--- a/cdn/pub/flake.nix
+++ b/cdn/pub/flake.nix
@@ -23,9 +23,15 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          moq-cli = moq.packages.${system}.moq;
-          ffmpeg = pkgs.ffmpeg;
-          jq = pkgs.jq;
+          default = pkgs.symlinkJoin {
+            name = "moq-pub";
+            paths = [
+              moq.packages.${system}.moq-cli
+              pkgs.ffmpeg
+              pkgs.wget
+              pkgs.jq
+            ];
+          };
         };
     };
 }

--- a/cdn/pub/justfile
+++ b/cdn/pub/justfile
@@ -48,7 +48,7 @@ deploy:
 	rsync -az --exclude='.gitignore' ../common/gen/ root@$HOST:/etc/systemd/system/
 
 	echo "  Building and caching packages..."
-	ssh root@$HOST "cd /var/lib/moq && nix build .#ffmpeg -o ffmpeg && nix build .#moq-cli -o moq-cli && nix build .#jq -o jq"
+	ssh root@$HOST "cd /var/lib/moq && nix build -o pkg"
 
 	echo "  Enabling and starting services..."
 	ssh root@$HOST "\

--- a/cdn/relay/certbot-renew.service
+++ b/cdn/relay/certbot-renew.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 # Renew certificates if they're close to expiration
-ExecStart=/var/lib/moq/cert/bin/certbot renew
+ExecStart=/var/lib/moq/pkg/bin/certbot renew
 
 StandardOutput=journal
 StandardError=journal

--- a/cdn/relay/flake.lock
+++ b/cdn/relay/flake.lock
@@ -37,15 +37,17 @@
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1772401057,
-        "narHash": "sha256-OToXgocdPxGZ8/4vuARgF8yxe8FYdYOLVYIJZHD/9Yg=",
+        "lastModified": 1772567574,
+        "narHash": "sha256-c3QrX5CiOuVMn+eOL+WxvBUrh1z0bxYerAaC7zzu6Rw=",
         "owner": "moq-dev",
         "repo": "moq",
-        "rev": "378a7c7fd536169c79eb6087ad1ab8714ec051d0",
+        "rev": "8165c5690bfb436522daac372eb4a4f0ad197a58",
         "type": "github"
       },
       "original": {
@@ -56,27 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772173633,
-        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
+        "lastModified": 1772542754,
+        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
         "type": "github"
       },
       "original": {
@@ -89,7 +75,7 @@
     "root": {
       "inputs": {
         "moq": "moq",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-overlay": {

--- a/cdn/relay/flake.nix
+++ b/cdn/relay/flake.nix
@@ -23,10 +23,15 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          moq-relay = moq.packages.${system}.moq-relay;
-          certbot = pkgs.certbot.withPlugins (ps: [ ps.certbot-dns-google ]);
-          jq = pkgs.jq;
-          perf = pkgs.linuxPackages.perf;
+          default = pkgs.symlinkJoin {
+            name = "moq-relay";
+            paths = [
+              moq.packages.${system}.moq-relay
+              (pkgs.certbot.withPlugins (ps: [ ps.certbot-dns-google ]))
+              pkgs.jq
+              pkgs.perf
+            ];
+          };
         };
     };
 }

--- a/cdn/relay/justfile
+++ b/cdn/relay/justfile
@@ -58,7 +58,7 @@ deploy node:
 	rsync -az --exclude='.gitignore' ../common/gen/ root@$HOST:/etc/systemd/system/
 
 	echo "  Building and caching packages..."
-	ssh root@$HOST "cd /var/lib/moq && nix build .#moq-relay -o relay && nix build .#certbot -o cert && nix build .#jq -o jq"
+	ssh root@$HOST "cd /var/lib/moq && nix build -o pkg"
 
 	echo "  Enabling and starting services..."
 	ssh root@$HOST "\
@@ -98,9 +98,8 @@ perf node *args:
 	set -euo pipefail
 	HOST=$(just host {{node}})
 	echo "Building perf on $HOST..."
-	ssh root@$HOST "cd /var/lib/moq && nix build .#perf -o perf"
 	echo "Recording on $HOST... (Ctrl+C to stop)"
-	ssh -t root@$HOST "/var/lib/moq/perf/bin/perf record -g -p \$(pidof moq-relay) {{args}}"
+	ssh -t root@$HOST "/var/lib/moq/pkg/bin/perf record -g -p \$(pidof moq-relay) {{args}}"
 	echo "Copying perf.data..."
 	scp root@$HOST:~/perf.data .
 	echo "Run 'perf report -i perf.data' to analyze."

--- a/cdn/relay/moq-cert.service.tftpl
+++ b/cdn/relay/moq-cert.service.tftpl
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=oneshot
 RemainAfterExit=yes
 # Obtain initial certificate
-ExecStart=/bin/sh -c '/var/lib/moq/cert/bin/certbot certonly \
+ExecStart=/bin/sh -c '/var/lib/moq/pkg/bin/certbot certonly \
   --dns-google \
   --dns-google-credentials /var/lib/moq/gcp.json \
   --non-interactive \

--- a/cdn/relay/moq-relay.service.tftpl
+++ b/cdn/relay/moq-relay.service.tftpl
@@ -11,7 +11,7 @@ WorkingDirectory=/var/lib/moq
 Environment="RUST_LOG=info"
 Environment="RUST_BACKTRACE=1"
 
-ExecStart=/var/lib/moq/relay/bin/moq-relay \
+ExecStart=/var/lib/moq/pkg/bin/moq-relay \
   --listen [::]:443 \
   --tls-cert /etc/letsencrypt/live/${domain}/fullchain.pem \
   --tls-key /etc/letsencrypt/live/${domain}/privkey.pem \


### PR DESCRIPTION
## Summary
- Bundle all nix dependencies into a single `default` package using `symlinkJoin`, replacing multiple `nix build .#foo -o foo` calls with a single `nix build -o pkg`
- Fix broken `nix shell nixpkgs#wget -c` in demo-bbb-prepare.service by adding wget to the pub flake
- Add top-level `just deploy` recipe, fix `just update` delegation, add `fmp4` format arg to moq-cli publish
- Update flake.lock inputs

## Test plan
- [ ] `just pub::deploy` succeeds
- [ ] `just relay::deploy-all` succeeds
- [ ] demo-bbb-prepare and demo-bbb services start correctly
- [ ] certbot and moq-relay services start correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)