### PR TITLE
Log transport and version in relay connection

### DIFF
--- a/rs/moq-lite/src/client.rs
+++ b/rs/moq-lite/src/client.rs
@@ -77,9 +77,7 @@ impl Client {
 					lite::Version::Lite03,
 				)?;
 
-				tracing::debug!(version = ?Version::Lite(lite::Version::Lite03), "connected");
-
-				return Ok(Session::new(session));
+				return Ok(Session::new(session, lite::Version::Lite03.into()));
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -149,9 +147,7 @@ impl Client {
 			}
 		}
 
-		tracing::debug!(version = ?server.version, "connected");
-
-		Ok(Session::new(session))
+		Ok(Session::new(session, version))
 	}
 }
 

--- a/rs/moq-lite/src/server.rs
+++ b/rs/moq-lite/src/server.rs
@@ -75,9 +75,7 @@ impl Server {
 					lite::Version::Lite03,
 				)?;
 
-				tracing::debug!(version = ?Version::Lite(lite::Version::Lite03), "connected");
-
-				return Ok(Session::new(session));
+				return Ok(Session::new(session, lite::Version::Lite03.into()));
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -147,8 +145,6 @@ impl Server {
 			}
 		};
 
-		tracing::debug!(?version, "connected");
-
-		Ok(Session::new(session))
+		Ok(Session::new(session, version))
 	}
 }

--- a/rs/moq-lite/src/session.rs
+++ b/rs/moq-lite/src/session.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, pin::Pin};
 
-use crate::Error;
+use crate::{Error, Version};
 
 /// A MoQ transport session, wrapping a WebTransport connection.
 ///
@@ -9,15 +9,22 @@ use crate::Error;
 /// - [`crate::Server::accept`] for servers.
 pub struct Session {
 	session: Box<dyn SessionInner>,
+	version: Version,
 	closed: bool,
 }
 
 impl Session {
-	pub(super) fn new<S: web_transport_trait::Session>(session: S) -> Self {
+	pub(super) fn new<S: web_transport_trait::Session>(session: S, version: Version) -> Self {
 		Self {
 			session: Box::new(session),
+			version,
 			closed: false,
 		}
+	}
+
+	/// Returns the negotiated protocol version.
+	pub fn version(&self) -> Version {
+		self.version
 	}
 
 	/// Close the underlying transport session.

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -422,6 +422,18 @@ impl Request {
 		}
 	}
 
+	/// Returns the transport type as a string (e.g. "quic", "iroh").
+	pub fn transport(&self) -> &'static str {
+		match self.kind {
+			#[cfg(feature = "quinn")]
+			RequestKind::Quinn(_) => "quic",
+			#[cfg(feature = "quiche")]
+			RequestKind::Quiche(_) => "quic",
+			#[cfg(feature = "iroh")]
+			RequestKind::Iroh(_) => "iroh",
+		}
+	}
+
 	/// Returns the URL provided by the client.
 	pub fn url(&self) -> Option<&Url> {
 		#[cfg(not(any(feature = "quinn", feature = "quiche", feature = "iroh")))]

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -31,16 +31,17 @@ impl Connection {
 		let publish = self.cluster.publisher(&token);
 		let subscribe = self.cluster.subscriber(&token);
 		let registration = self.cluster.register(&token);
+		let transport = self.request.transport();
 
 		match (&publish, &subscribe) {
 			(Some(publish), Some(subscribe)) => {
-				tracing::info!(root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "session accepted");
+				tracing::info!(transport, root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "session accepted");
 			}
 			(Some(publish), None) => {
-				tracing::info!(root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "publisher accepted");
+				tracing::info!(transport, root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "publisher accepted");
 			}
 			(None, Some(subscribe)) => {
-				tracing::info!(root = %token.root, subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "subscriber accepted")
+				tracing::info!(transport, root = %token.root, subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "subscriber accepted")
 			}
 			_ => anyhow::bail!("invalid session; no allowed paths"),
 		}
@@ -57,6 +58,8 @@ impl Connection {
 			// .with_stats(stats)
 			.ok()
 			.await?;
+
+		tracing::info!(version = %session.version(), transport, "negotiated");
 
 		// Wait until the session is closed.
 		// Keep registration alive so the cluster node stays announced.


### PR DESCRIPTION
## Summary
- Expose negotiated protocol version from `moq_lite::Session` via `session.version()`
- Add `Request::transport()` to `moq-native` returning `"quic"` or `"iroh"`
- Log transport in the relay's "session accepted" line and version after negotiation

## Test plan
- [x] `cargo check` passes
- [ ] Verify log output includes transport and version fields when connecting to relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)