### PR TITLE
Add missing props and re-export dependencies

### DIFF
--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/src/index.ts
+++ b/js/publish/src/index.ts
@@ -1,3 +1,5 @@
+export * as Lite from "@moq/lite";
+export * as Signals from "@moq/signals";
 export * as Audio from "./audio";
 export * from "./broadcast";
 export * as Chat from "./chat";

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -185,6 +185,30 @@ export default class MoqWatch extends HTMLElement {
 		this.backend.paused.set(value);
 	}
 
+	get volume(): number {
+		return this.backend.audio.volume.peek();
+	}
+
+	set volume(value: number) {
+		this.backend.audio.volume.set(value);
+	}
+
+	get muted(): boolean {
+		return this.backend.audio.muted.peek();
+	}
+
+	set muted(value: boolean) {
+		this.backend.audio.muted.set(value);
+	}
+
+	get reload(): boolean {
+		return this.broadcast.reload.peek();
+	}
+
+	set reload(value: boolean) {
+		this.broadcast.reload.set(value);
+	}
+
 	get jitter(): Time.Milli {
 		return this.backend.jitter.peek();
 	}

--- a/js/watch/src/index.ts
+++ b/js/watch/src/index.ts
@@ -1,3 +1,5 @@
+export * as Lite from "@moq/lite";
+export * as Signals from "@moq/signals";
 export * as Audio from "./audio";
 export * from "./backend";
 export * from "./broadcast";


### PR DESCRIPTION
## Summary
- Add `volume`, `muted`, and `reload` getter/setter properties to `MoqWatch` element so all observed attributes have corresponding props for type-safe Solid.js usage
- Re-export `@moq/lite` as `Lite` and `@moq/signals` as `Signals` from both `@moq/watch` and `@moq/publish`
- Bump both packages to 0.2.2

## Test plan
- Verify `prop:muted`, `prop:volume`, `prop:reload` work on `<moq-watch>` in Solid.js
- Verify `import { Lite, Signals } from "@moq/watch"` and `"@moq/publish"` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)