### PR TITLE
Fix trun sample duration fallback to trex default

### DIFF
--- a/js/hang/src/catalog/container.ts
+++ b/js/hang/src/catalog/container.ts
@@ -20,6 +20,8 @@ export const ContainerSchema = z
 			timescale: u53Schema,
 			// Track ID used in the moof/mdat fragments
 			trackId: u53Schema,
+			// Default sample duration from trex (fallback when trun/tfhd omit per-sample durations)
+			defaultSampleDuration: u53Schema.optional(),
 		}),
 	])
 	.default({ kind: "legacy" });

--- a/js/hang/src/container/cmaf/decode.ts
+++ b/js/hang/src/container/cmaf/decode.ts
@@ -80,6 +80,8 @@ export interface InitSegment {
 	timescale: number;
 	/** Track ID from the init segment */
 	trackId: number;
+	/** Default sample duration from trex box (fallback when trun/tfhd omit it) */
+	defaultSampleDuration?: number;
 }
 
 /**
@@ -105,6 +107,31 @@ function toArrayBuffer(data: Uint8Array): ArrayBuffer {
 // Type guard for finding boxes by type
 function isBoxType<T extends ParsedIsoBox>(type: string) {
 	return (box: ParsedIsoBox): box is T => box.type === type;
+}
+
+/**
+ * Manually scan for a trex box in raw MP4 data and extract default_sample_duration.
+ * trex layout: version(1) + flags(3) + track_ID(4) + default_sample_description_index(4) + default_sample_duration(4) + ...
+ */
+function parseDefaultSampleDuration(data: Uint8Array): number | undefined {
+	const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+	for (let i = 0; i + 8 <= data.length; ) {
+		const size = view.getUint32(i);
+		if (size < 8 || i + size > data.length) break;
+		const type = String.fromCharCode(data[i + 4], data[i + 5], data[i + 6], data[i + 7]);
+		if (type === "trex" && size >= 8 + 16) {
+			// Content starts at i+8: version(1) + flags(3) + track_ID(4) + default_desc_idx(4) + default_duration(4)
+			const duration = view.getUint32(i + 8 + 12);
+			return duration > 0 ? duration : undefined;
+		}
+		// Recurse into container boxes
+		if (type === "moov" || type === "mvex") {
+			const inner = parseDefaultSampleDuration(data.subarray(i + 8, i + size));
+			if (inner !== undefined) return inner;
+		}
+		i += size;
+	}
+	return undefined;
 }
 
 /**
@@ -138,10 +165,15 @@ export function decodeInitSegment(init: Uint8Array): InitSegment {
 	const entry = stsd.entries[0];
 	const description = extractDescription(entry);
 
+	// Extract default_sample_duration from trex box.
+	// Parse manually from the raw init bytes since the library may not have readTrex.
+	const defaultSampleDuration = parseDefaultSampleDuration(init) || undefined;
+
 	return {
 		description,
 		timescale: mdhd.timescale,
 		trackId,
+		defaultSampleDuration,
 	};
 }
 
@@ -221,9 +253,10 @@ export function decodeTimestamp(segment: Uint8Array, timescale: number): Time.Mi
  *
  * @param segment - The moof + mdat data
  * @param timescale - Time units per second (from init segment)
+ * @param defaultSampleDuration - Default sample duration from trex (fallback when trun/tfhd omit it)
  * @returns Array of decoded samples
  */
-export function decodeDataSegment(segment: Uint8Array, timescale: number): Sample[] {
+export function decodeDataSegment(segment: Uint8Array, timescale: number, defaultSampleDuration?: number): Sample[] {
 	// Cast to ParsedIsoBox[] since the library's return type changes with readers
 	const boxes = readIsoBoxes(toArrayBuffer(segment), { readers: DATA_READERS }) as ParsedIsoBox[];
 
@@ -233,7 +266,7 @@ export function decodeDataSegment(segment: Uint8Array, timescale: number): Sampl
 
 	// Find moof > traf > tfhd for default sample values
 	const tfhd = findBox(boxes, isBoxType<TrackFragmentHeaderBox & ParsedIsoBox>("tfhd"));
-	const defaultDuration = tfhd?.defaultSampleDuration ?? 0;
+	const defaultDuration = tfhd?.defaultSampleDuration ?? defaultSampleDuration ?? 0;
 	const defaultSize = tfhd?.defaultSampleSize ?? 0;
 	const defaultFlags = tfhd?.defaultSampleFlags ?? 0;
 

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -244,7 +244,7 @@ export class Decoder {
 	#runCmafDecoder(effect: Effect, sub: Moq.Track, config: Catalog.AudioConfig): void {
 		if (config.container.kind !== "cmaf") return; // just to help typescript
 
-		const { timescale } = config.container;
+		const { timescale, defaultSampleDuration } = config.container;
 		const description = config.description ? Util.Hex.toBytes(config.description) : undefined;
 
 		// For CMAF, just use decode buffer (no network jitter buffer yet)
@@ -284,7 +284,7 @@ export class Decoder {
 							const segment = await group.readFrame();
 							if (!segment) break;
 
-							const samples = Container.Cmaf.decodeDataSegment(segment, timescale);
+							const samples = Container.Cmaf.decodeDataSegment(segment, timescale, defaultSampleDuration);
 
 							for (const sample of samples) {
 								this.#stats.update((stats) => ({

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -355,7 +355,7 @@ class DecoderTrack {
 	#runCmaf(effect: Effect, sub: Moq.Track, decoder: VideoDecoder): void {
 		if (this.config.container.kind !== "cmaf") return;
 
-		const { timescale } = this.config.container;
+		const { timescale, defaultSampleDuration } = this.config.container;
 		const description = this.config.description ? Util.Hex.toBytes(this.config.description) : undefined;
 
 		// Configure decoder with description from catalog
@@ -388,7 +388,7 @@ class DecoderTrack {
 							const segment = await Promise.race([group.readFrame(), effect.cancel]);
 							if (!segment) break;
 
-							const samples = Container.Cmaf.decodeDataSegment(segment, timescale);
+							const samples = Container.Cmaf.decodeDataSegment(segment, timescale, defaultSampleDuration);
 
 							for (const sample of samples) {
 								const chunk = new EncodedVideoChunk({


### PR DESCRIPTION
## Summary

- CMAF encoders (e.g. GPAC with `cdur=0.033`) may omit per-sample duration in `trun`, relying on `default_sample_duration` from the `trex` box in the init segment
- The decoder now falls back to the trex default when neither trun nor tfhd provide a sample duration, instead of throwing `Invalid sample duration 0`

## Changes

- Parse `default_sample_duration` from `trex` in `decodeInitSegment()` (manual box scan, no new library dependency)
- Add `defaultSampleDuration` to `InitSegment` interface and CMAF container schema
- Add optional `defaultSampleDuration` param to `decodeDataSegment()`
- Pass `defaultSampleDuration` through in video/audio decoders (`@moq/watch`)

## Context

Testing with a CMAF publisher using GPAC DASH-IF ingest (1s segments, 30 chunks/sec). GPAC sets `default_sample_duration=512` in `trex` (timescale 15360 = 33.3ms per frame) but does not set the `TR_SAMPLE_DURATION` flag in `trun` entries. The `tfhd` also omits `defaultSampleDuration`, so the only source of truth is `trex`.

## Test plan

- [ ] Verify streams from GPAC CMAF ingest no longer throw `Invalid sample duration 0`
- [ ] Verify streams that include per-sample duration in trun still work (no regression)
- [ ] Verify the trex parser handles init segments without a trex box (returns undefined)