### PR TITLE
Add warning for Cloudflare relay reload feature limitation

### DIFF
--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -68,10 +68,23 @@ export class Broadcast {
 		const announced = conn.announced(name);
 		effect.cleanup(() => announced.close());
 
+		// Warn if the relay doesn't support announcements (e.g. Cloudflare)
+		let warnTimer: ReturnType<typeof setTimeout> | undefined;
+		if (conn.url.hostname.endsWith("mediaoverquic.com")) {
+			warnTimer = setTimeout(() => {
+				console.warn(
+					"Cloudflare relay does not support the reload feature yet. Remove the `reload` attribute to connect without waiting for announcements.",
+				);
+			}, 1000);
+			effect.cleanup(() => clearTimeout(warnTimer));
+		}
+
 		effect.spawn(async () => {
 			for (;;) {
 				const update = await announced.next();
 				if (!update) break;
+
+				clearTimeout(warnTimer);
 
 				// Require full equality
 				if (update.path !== name) {


### PR DESCRIPTION
## Summary
Added a warning message to inform users when connecting to Cloudflare relays that don't support the reload/announcement feature yet.

## Key Changes
- Added a timer-based warning that displays after 1 second if a Cloudflare relay (mediaoverquic.com) is detected
- The warning message instructs users to remove the `reload` attribute if they want to connect without waiting for announcements
- The warning timer is cleared once an announcement is successfully received, preventing unnecessary console spam
- Proper cleanup of the timer is ensured through the effect cleanup mechanism

## Implementation Details
- The detection is based on checking if the relay hostname ends with "mediaoverquic.com"
- A 1-second delay is used before showing the warning to avoid alerting users on fast connections
- The timer is automatically cleared when the first announcement arrives, indicating the relay supports the feature or the connection is working as expected

https://claude.ai/code/session_01GNKSpPhpqY6oAC3Y3M3omS