### PR TITLE
Make Log::init() fallible

### DIFF
--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// Optional: Use moq_native to configure a logger.
-	moq_native::Log::new(tracing::Level::DEBUG).init();
+	moq_native::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that the session can publish incoming broadcasts to.
 	let origin = moq_lite::Origin::produce();

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// Optional: Use moq_native to configure a logger.
-	moq_native::Log::new(tracing::Level::DEBUG).init();
+	moq_native::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that we can publish to and the session can consume from.
 	let origin = moq_lite::Origin::produce();

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -97,7 +97,8 @@ pub unsafe extern "C" fn moq_log_level(level: *const c_char, level_len: usize) -
 			"" => moq_native::Log::default(),
 			level => moq_native::Log::new(Level::from_str(level)?),
 		}
-		.init();
+		.init()
+		.map_err(|_| crate::error::Error::LogInit)?;
 
 		Ok(())
 	})

--- a/rs/libmoq/src/error.rs
+++ b/rs/libmoq/src/error.rs
@@ -99,6 +99,10 @@ pub enum Error {
 	#[error("level error: {0}")]
 	Level(Arc<tracing::metadata::ParseLevelError>),
 
+	/// Log initialization failed.
+	#[error("log init failed")]
+	LogInit,
+
 	/// Invalid error code conversion.
 	#[error("invalid code")]
 	InvalidCode,
@@ -153,6 +157,7 @@ impl ffi::ReturnCode for Error {
 			Error::Hang(_) => -18,
 			Error::NoIndex => -19,
 			Error::NulError(_) => -20,
+			Error::LogInit => -29,
 			Error::SessionNotFound => -21,
 			Error::OriginNotFound => -22,
 			Error::AnnouncementNotFound => -23,

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -81,7 +81,7 @@ async fn main() -> anyhow::Result<()> {
 		.expect("failed to install default crypto provider");
 
 	let cli = Cli::parse();
-	cli.log.init();
+	cli.log.init()?;
 
 	let publish = Publish::new(match &cli.command {
 		Command::Serve { format, .. } => format,

--- a/rs/moq-clock/src/main.rs
+++ b/rs/moq-clock/src/main.rs
@@ -47,7 +47,7 @@ pub enum Command {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	let config = Config::parse();
-	config.log.init();
+	config.log.init()?;
 
 	let client = config.client.init()?;
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -3,7 +3,7 @@
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// Optional: Use moq_native to configure a logger.
-	moq_native::Log::new(tracing::Level::DEBUG).init();
+	moq_native::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that we can publish to and the session can consume from.
 	let origin = moq_lite::Origin::produce();

--- a/rs/moq-native/src/log.rs
+++ b/rs/moq-native/src/log.rs
@@ -34,7 +34,7 @@ impl Log {
 		LevelFilter::from_level(self.level)
 	}
 
-	pub fn init(&self) {
+	pub fn init(&self) -> anyhow::Result<()> {
 		let filter = EnvFilter::builder()
 			.with_default_directive(self.level().into()) // Default to our -q/-v args
 			.from_env_lossy() // Allow overriding with RUST_LOG
@@ -57,17 +57,19 @@ impl Log {
 			tracing_subscriber::registry()
 				.with(fmt_layer)
 				.with(console_layer)
-				.init();
+				.try_init()?;
 		}
 
 		#[cfg(not(feature = "tokio-console"))]
 		{
-			tracing_subscriber::registry().with(fmt_layer).init();
+			tracing_subscriber::registry().with(fmt_layer).try_init()?;
 		}
 
 		// Start deadlock detection thread (only in debug builds)
 		#[cfg(debug_assertions)]
 		std::thread::spawn(Self::deadlock_detector);
+
+		Ok(())
 	}
 
 	#[cfg(debug_assertions)]

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -58,7 +58,7 @@ impl Config {
 			config.update_from(std::env::args());
 		}
 
-		config.log.init();
+		config.log.init()?;
 		tracing::trace!(?config, "final config");
 
 		Ok(config)


### PR DESCRIPTION
## Summary
- Changed `Log::init()` to return `anyhow::Result<()>` instead of panicking when called twice
- Uses `try_init()` instead of `init()` for tracing subscriber setup
- Added `LogInit` error variant to libmoq's FFI error enum
- Updated all callers to propagate the error with `?`

## Test plan
- [x] `just check` passes
- [x] All callers updated to handle the `Result`

🤖 Generated with [Claude Code](https://claude.com/claude-code)