### PR TITLE
Skip WebSocket fallback for non-HTTP URL schemes (moqt://, moql://)

### DIFF
--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -53,6 +53,14 @@ pub(crate) async fn race_handle(
 	if !config.enabled {
 		return None;
 	}
+
+	// Only attempt WebSocket for HTTP-based schemes.
+	// Custom protocols (moqt://, moql://) use raw QUIC and don't support WebSocket.
+	match url.scheme() {
+		"http" | "https" | "ws" | "wss" => {}
+		_ => return None,
+	}
+
 	let res = connect(config, tls, url).await;
 	if let Err(err) = &res {
 		tracing::warn!(%err, "WebSocket connection failed");


### PR DESCRIPTION
When the URL scheme is a raw QUIC protocol like moqt:// or moql://, don't attempt the WebSocket fallback at all. This avoids the unnecessary 200ms delay and spurious warning log before the inevitable failure.

https://claude.ai/code/session_01NpqD9fDepXPcbocD8NWcK1