### PR TITLE
Set MSRV to 1.85 (edition 2024)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.85"
+
 [workspace.dependencies]
 conducer = { version = "0.3", path = "rs/conducer" }
 hang = { version = "0.15", path = "rs/hang" }

--- a/rs/conducer/Cargo.toml
+++ b/rs/conducer/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.3.0"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["async", "producer", "consumer", "state", "sync"]
 categories = ["asynchronous", "concurrency"]

--- a/rs/hang/Cargo.toml
+++ b/rs/hang/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.15.1"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.2.11"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.7.9"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/moq-clock/Cargo.toml
+++ b/rs/moq-clock/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.10.7"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/moq-lite/Cargo.toml
+++ b/rs/moq-lite/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.15.0"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/moq-msf/Cargo.toml
+++ b/rs/moq-msf/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.3.1"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.13.2"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.10.7"
 edition = "2024"
+rust-version.workspace = true
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/moq-token-cli/Cargo.toml
+++ b/rs/moq-token-cli/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.5.12"
 edition = "2024"
+rust-version.workspace = true
 
 [[bin]]
 name = "moq-token"

--- a/rs/moq-token/Cargo.toml
+++ b/rs/moq-token/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 version = "0.5.9"
 edition = "2024"
+rust-version.workspace = true
 
 [features]
 jwks-loader = ["reqwest"]


### PR DESCRIPTION
## Summary
- Used `cargo-msrv` to determine MSRV is **1.85** (required by edition 2024)
- Added `rust-version = "1.85"` to `[workspace.package]`
- All 12 crates now inherit `rust-version.workspace = true`

## Test plan
- [x] `cargo check` passes
- [x] `just fix` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)