### PR TITLE
Switch from web-transport-ws to qmux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1443,7 +1443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2228,7 +2228,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2261,7 +2261,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2553,7 +2553,7 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2616,7 +2616,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2658,9 +2658,9 @@ checksum = "f981dadd5a072a9e0efcd24bdcc388e570073f7e51b33505ceb1ef4668c80c86"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2705,7 +2705,7 @@ dependencies = [
  "tracing",
  "url",
  "vergen-gitcl",
- "webpki-roots 1.0.6",
+ "webpki-roots",
  "ws_stream_wasm",
  "z32",
 ]
@@ -2718,7 +2718,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3151,6 +3151,7 @@ dependencies = [
  "humantime-serde",
  "moq-lite",
  "parking_lot",
+ "qmux",
  "quinn",
  "rand 0.9.2",
  "rcgen",
@@ -3169,10 +3170,9 @@ dependencies = [
  "tracing-test",
  "url",
  "web-transport-iroh",
- "web-transport-proto",
+ "web-transport-proto 0.5.4",
  "web-transport-quiche",
  "web-transport-quinn",
- "web-transport-ws",
 ]
 
 [[package]]
@@ -3189,6 +3189,7 @@ dependencies = [
  "moq-lite",
  "moq-native",
  "moq-token",
+ "qmux",
  "rustls",
  "sd-notify",
  "serde",
@@ -3200,7 +3201,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
- "web-transport-ws",
 ]
 
 [[package]]
@@ -3511,7 +3511,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4316,6 +4316,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "qmux"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7501d231269d77ad5e6ee965e9ddcaf2ea61f8466f36232ff7aa6e46c1bd38bb"
+dependencies = [
+ "bytes",
+ "futures",
+ "rustls",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "web-transport-proto 0.6.0",
+ "web-transport-trait",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4374,7 +4390,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4414,7 +4430,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4627,7 +4643,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4771,7 +4787,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4839,7 +4855,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5034,7 +5050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5617,7 +5633,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5626,7 +5642,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5842,11 +5858,11 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tungstenite 0.24.0",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6556,7 +6572,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "web-transport-proto",
+ "web-transport-proto 0.5.4",
  "web-transport-trait",
 ]
 
@@ -6565,6 +6581,20 @@ name = "web-transport-proto"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5afe275c02f899650c5497b946552fcc04f3f378bd2c3bc1e8005ff915772b97"
+dependencies = [
+ "bytes",
+ "http",
+ "sfv",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "web-transport-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0225d295c8ac00a2e9a498aefeaf3f3c6186da12a251c938189b15b82ea22808"
 dependencies = [
  "bytes",
  "http",
@@ -6591,7 +6621,7 @@ dependencies = [
  "tokio-quiche",
  "tracing",
  "url",
- "web-transport-proto",
+ "web-transport-proto 0.5.4",
  "web-transport-trait",
 ]
 
@@ -6611,32 +6641,17 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "web-transport-proto",
+ "web-transport-proto 0.5.4",
  "web-transport-trait",
 ]
 
 [[package]]
 name = "web-transport-trait"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802d6aa508f2c63c9050ceabc17265bbf90ed4d6f4e4357e987583883628e79c"
+checksum = "cb67841c4a481ca3c1412ee4c9f463987401991e1ddc000903df2124f3dc85e9"
 dependencies = [
  "bytes",
-]
-
-[[package]]
-name = "web-transport-ws"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488d9dfc229815aa7739c60748dd2324ad48b50e753491b7049f7a1ce146c165"
-dependencies = [
- "bytes",
- "futures",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite 0.24.0",
- "web-transport-proto",
- "web-transport-trait",
 ]
 
 [[package]]
@@ -6646,15 +6661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6694,7 +6700,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ moq-msf = { version = "0.1", path = "rs/moq-msf" }
 moq-mux = { version = "0.3", path = "rs/moq-mux" }
 moq-native = { version = "0.13", path = "rs/moq-native", default-features = false }
 moq-token = { version = "0.5", path = "rs/moq-token" }
+qmux = { version = "0.0.3", default-features = false }
 
 serde = { version = "1", features = ["derive"] }
 tokio = "1.48"
@@ -34,8 +35,7 @@ web-transport-iroh = "0.2"
 web-transport-proto = "0.5"
 web-transport-quiche = "0.2"
 web-transport-quinn = "0.11"
-web-transport-trait = "0.3.2"
-web-transport-ws = "0.3.0"
+web-transport-trait = "0.3.4"
 
 [profile.dev]
 panic = "abort"

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -24,7 +24,7 @@ quinn = [
 quiche = ["dep:web-transport-quiche", "dep:rcgen"]
 aws-lc-rs = ["rustls/aws-lc-rs", "rcgen?/aws_lc_rs", "quinn?/rustls-aws-lc-rs"]
 iroh = ["dep:web-transport-iroh", "dep:web-transport-proto"]
-websocket = ["dep:web-transport-ws"]
+websocket = ["dep:qmux"]
 ring = ["rustls/ring", "rcgen?/ring", "quinn?/rustls-ring"]
 tokio-console = ["dep:console-subscriber"]
 
@@ -39,6 +39,7 @@ humantime-serde = "1.1"
 
 moq-lite = { workspace = true, features = ["serde"] }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
+qmux = { workspace = true, features = ["wss"], optional = true }
 quinn = { version = "0.11", default-features = false, features = [
 	"platform-verifier",
 	"runtime-tokio",
@@ -62,9 +63,6 @@ web-transport-iroh = { workspace = true, optional = true }
 web-transport-proto = { workspace = true, optional = true }
 web-transport-quiche = { workspace = true, optional = true }
 web-transport-quinn = { workspace = true, optional = true }
-web-transport-ws = { workspace = true, features = [
-	"rustls-tls-webpki-roots",
-], optional = true }
 
 [dev-dependencies]
 anyhow = "1"

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -184,7 +184,7 @@ impl Server {
 	///
 	/// This is useful for simple applications that want WebSocket on a dedicated port.
 	/// For applications that need WebSocket on the same HTTP port (e.g. moq-relay),
-	/// use `web_transport_ws::Session::accept()` with your own HTTP framework instead.
+	/// use `qmux::Session::accept()` with your own HTTP framework instead.
 	#[cfg(feature = "websocket")]
 	pub fn with_websocket(mut self, websocket: Option<crate::websocket::WebSocketListener>) -> Self {
 		self.websocket = websocket;
@@ -402,7 +402,7 @@ pub(crate) enum RequestKind {
 	#[cfg(feature = "iroh")]
 	Iroh(crate::iroh::IrohRequest),
 	#[cfg(feature = "websocket")]
-	WebSocket(web_transport_ws::Session),
+	WebSocket(qmux::Session),
 }
 
 /// An incoming MoQ session that can be accepted or rejected.

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -1,9 +1,9 @@
 use anyhow::Context;
+use qmux::tokio_tungstenite;
 use std::collections::HashSet;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::{net, time};
 use url::Url;
-use web_transport_ws::tokio_tungstenite;
 
 // Track servers (hostname:port) where WebSocket won the race, so we won't give QUIC a headstart next time
 static WEBSOCKET_WON: LazyLock<Mutex<HashSet<(String, u16)>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
@@ -49,7 +49,7 @@ pub(crate) async fn race_handle(
 	config: &ClientWebSocket,
 	tls: &rustls::ClientConfig,
 	url: Url,
-) -> Option<anyhow::Result<web_transport_ws::Session>> {
+) -> Option<anyhow::Result<qmux::Session>> {
 	if !config.enabled {
 		return None;
 	}
@@ -72,7 +72,7 @@ pub(crate) async fn connect(
 	config: &ClientWebSocket,
 	tls: &rustls::ClientConfig,
 	mut url: Url,
-) -> anyhow::Result<web_transport_ws::Session> {
+) -> anyhow::Result<qmux::Session> {
 	anyhow::ensure!(config.enabled, "WebSocket support is disabled");
 
 	let host = url.host_str().context("missing hostname")?.to_string();
@@ -119,8 +119,8 @@ pub(crate) async fn connect(
 		tokio_tungstenite::Connector::Plain
 	};
 
-	let session = web_transport_ws::Client::new()
-		.with_config(web_transport_ws::tungstenite::protocol::WebSocketConfig {
+	let session = qmux::Client::new()
+		.with_config(qmux::tungstenite::protocol::WebSocketConfig {
 			max_message_size: Some(64 << 20), // 64 MB
 			max_frame_size: Some(16 << 20),   // 16 MB
 			accept_unmasked_frames: false,
@@ -143,13 +143,13 @@ pub(crate) async fn connect(
 /// alongside QUIC connections on a separate port.
 pub struct WebSocketListener {
 	listener: tokio::net::TcpListener,
-	server: web_transport_ws::Server,
+	server: qmux::Server,
 }
 
 impl WebSocketListener {
 	pub async fn bind(addr: net::SocketAddr) -> anyhow::Result<Self> {
 		let listener = tokio::net::TcpListener::bind(addr).await?;
-		let server = web_transport_ws::Server::new();
+		let server = qmux::Server::new();
 		Ok(Self { listener, server })
 	}
 
@@ -157,7 +157,7 @@ impl WebSocketListener {
 		Ok(self.listener.local_addr()?)
 	}
 
-	pub async fn accept(&self) -> Option<anyhow::Result<web_transport_ws::Session>> {
+	pub async fn accept(&self) -> Option<anyhow::Result<qmux::Session>> {
 		match self.listener.accept().await {
 			Ok((stream, addr)) => {
 				tracing::debug!(%addr, "accepted WebSocket TCP connection");

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -22,7 +22,7 @@ default = ["iroh", "quinn", "websocket"]
 iroh = ["moq-native/iroh"]
 quinn = ["moq-native/quinn"]
 quiche = ["moq-native/quiche"]
-websocket = ["moq-native/websocket", "dep:web-transport-ws", "axum/ws"]
+websocket = ["moq-native/websocket", "dep:qmux", "axum/ws"]
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
@@ -37,6 +37,7 @@ moq-native = { workspace = true, default-features = false, features = [
 	"aws-lc-rs",
 ] }
 moq-token = { workspace = true, features = ["jwks-loader"] }
+qmux = { workspace = true, features = ["ws"], optional = true }
 rustls = { version = "0.23", features = [
 	"aws-lc-rs",
 ], default-features = false }
@@ -48,7 +49,6 @@ toml = "0.9"
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
 url = { version = "2", features = ["serde"] }
-web-transport-ws = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 sd-notify = "0.4"

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -1,10 +1,10 @@
 use futures::{SinkExt, StreamExt};
+use qmux::tungstenite;
 use std::{
 	future::Future,
 	pin::Pin,
 	sync::{Arc, atomic::Ordering},
 };
-use web_transport_ws::tungstenite;
 
 use axum::{
 	extract::{Path, Query, State, WebSocketUpgrade},
@@ -71,7 +71,7 @@ where
 		+ 'static,
 {
 	// Wrap the WebSocket in a WebTransport compatibility layer.
-	let ws = web_transport_ws::Session::accept(socket, None);
+	let ws = qmux::ws::accept(socket, None);
 	let session = moq_lite::Server::new()
 		.with_publish(subscribe)
 		.with_consume(publish)


### PR DESCRIPTION
## Summary
- Replace `web-transport-ws` with the new `qmux` crate for WebSocket transport
- `qmux` supports both the legacy `webtransport` wire format and the new QMux protocol (draft-ietf-quic-qmux-00)
- Bump `web-transport-trait` to 0.3.4 for compatibility

## Test plan
- [x] `just check` passes (all tests and linting)
- [ ] Verify WebSocket fallback still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)