### PR TITLE
Fix iroh test and add noq backend tests

### DIFF
--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -129,6 +129,8 @@ pub struct Client {
 	quiche: Option<crate::quiche::QuicheClient>,
 	#[cfg(feature = "iroh")]
 	iroh: Option<web_transport_iroh::iroh::Endpoint>,
+	#[cfg(feature = "iroh")]
+	iroh_addrs: Vec<std::net::SocketAddr>,
 }
 
 impl Client {
@@ -236,12 +238,24 @@ impl Client {
 			quiche,
 			#[cfg(feature = "iroh")]
 			iroh: None,
+			#[cfg(feature = "iroh")]
+			iroh_addrs: Vec::new(),
 		})
 	}
 
 	#[cfg(feature = "iroh")]
 	pub fn with_iroh(mut self, iroh: Option<web_transport_iroh::iroh::Endpoint>) -> Self {
 		self.iroh = iroh;
+		self
+	}
+
+	/// Set direct IP addresses for connecting to iroh peers.
+	///
+	/// This is useful when the peer's IP addresses are known ahead of time,
+	/// bypassing the need for peer discovery (e.g. in tests or local networks).
+	#[cfg(feature = "iroh")]
+	pub fn with_iroh_addrs(mut self, addrs: Vec<std::net::SocketAddr>) -> Self {
+		self.iroh_addrs = addrs;
 		self
 	}
 
@@ -265,7 +279,7 @@ impl Client {
 		#[cfg(feature = "iroh")]
 		if url.scheme() == "iroh" {
 			let endpoint = self.iroh.as_ref().context("Iroh support is not enabled")?;
-			let session = crate::iroh::connect(endpoint, url).await?;
+			let session = crate::iroh::connect(endpoint, url, self.iroh_addrs.iter().copied()).await?;
 			let session = self.moq.connect(session).await?;
 			return Ok(session);
 		}

--- a/rs/moq-native/src/iroh.rs
+++ b/rs/moq-native/src/iroh.rs
@@ -152,9 +152,19 @@ impl IrohRequest {
 	}
 }
 
-pub(crate) async fn connect(endpoint: &IrohEndpoint, url: Url) -> anyhow::Result<web_transport_iroh::Session> {
+pub(crate) async fn connect(
+	endpoint: &IrohEndpoint,
+	url: Url,
+	addrs: impl IntoIterator<Item = std::net::SocketAddr>,
+) -> anyhow::Result<web_transport_iroh::Session> {
 	let host = url.host().context("Invalid URL: missing host")?.to_string();
 	let endpoint_id: iroh::EndpointId = host.parse().context("Invalid URL: host is not an iroh endpoint id")?;
+
+	// Build an EndpointAddr with any direct IP addresses provided.
+	let mut endpoint_addr = iroh::EndpointAddr::new(endpoint_id);
+	for addr in addrs {
+		endpoint_addr = endpoint_addr.with_ip_addr(addr);
+	}
 
 	// We need to use this API to provide multiple ALPNs.
 	// H3 is last because it requires WebTransport framing which not all H3 endpoints support.
@@ -166,7 +176,7 @@ pub(crate) async fn connect(endpoint: &IrohEndpoint, url: Url) -> anyhow::Result
 	additional.push(b"h3".to_vec());
 	let opts = iroh::endpoint::ConnectOptions::new().with_additional_alpns(additional);
 
-	let mut connecting = endpoint.connect_with_opts(endpoint_id, alpn, opts).await?;
+	let mut connecting = endpoint.connect_with_opts(endpoint_addr, alpn, opts).await?;
 	let alpn = connecting.alpn().await?;
 	let alpn = String::from_utf8(alpn).context("failed to decode ALPN")?;
 

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -11,7 +11,7 @@ const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Publish a broadcast on the server, subscribe on the client, and verify
 /// the data arrives correctly using the specified QUIC backend and URL scheme.
-#[cfg(any(feature = "quinn", feature = "quiche"))]
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
 async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::produce();
@@ -132,7 +132,6 @@ async fn quiche_webtransport() {
 #[cfg(feature = "iroh")]
 #[tracing_test::traced_test]
 #[tokio::test]
-#[ignore = "iroh peer discovery requires network; needs direct addressing support in moq-native"]
 async fn iroh_connect() {
 	use moq_native::IrohEndpointConfig;
 
@@ -155,6 +154,10 @@ async fn iroh_connect() {
 		.await
 		.expect("failed to bind server iroh endpoint")
 		.expect("server iroh endpoint not enabled");
+
+	// Get the server's direct addresses before moving it into the server.
+	let server_addr = server_endpoint.addr();
+	let server_addrs: Vec<std::net::SocketAddr> = server_addr.ip_addrs().copied().collect();
 
 	let server_endpoint_id = server_endpoint.id();
 
@@ -187,7 +190,8 @@ async fn iroh_connect() {
 	let client = client_config
 		.init()
 		.expect("failed to init client")
-		.with_iroh(Some(client_endpoint));
+		.with_iroh(Some(client_endpoint))
+		.with_iroh_addrs(server_addrs);
 
 	let url: url::Url = format!("iroh://{server_endpoint_id}").parse().unwrap();
 
@@ -240,4 +244,20 @@ async fn iroh_connect() {
 		.await
 		.expect("server task panicked")
 		.expect("server task failed");
+}
+
+// ── Noq backend ─────────────────────────────────────────────────────
+
+#[cfg(feature = "noq")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn noq_raw_quic() {
+	backend_test("moqt", moq_native::QuicBackend::Noq).await;
+}
+
+#[cfg(feature = "noq")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn noq_webtransport() {
+	backend_test("https", moq_native::QuicBackend::Noq).await;
 }


### PR DESCRIPTION
## Summary
- Enable `iroh::connect()` to accept direct socket addresses via `EndpointAddr`, bypassing peer discovery for local/test connections
- Add `with_iroh_addrs()` builder method to `Client` for passing known peer addresses
- Remove `#[ignore]` from `iroh_connect` test now that direct addressing works
- Add `noq_raw_quic` and `noq_webtransport` backend tests

## Test plan
- [x] `cargo test -p moq-native --test backend --all-features` — 6 passed, 1 ignored (quiche raw QUIC)
- [x] `cargo test -p moq-native --all-features` — 39 passed
- [x] `just check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)