### PR TITLE
Fix unused Result warning in moq-ffi log init

### DIFF
--- a/rs/moq-ffi/src/log.rs
+++ b/rs/moq-ffi/src/log.rs
@@ -21,7 +21,7 @@ pub fn moq_log_level(level: String) -> Result<(), MoqError> {
 		return Err(MoqError::Log("logging already initialized".into()));
 	}
 
-	log.init();
+	log.init().map_err(|e| MoqError::Log(e.to_string()))?;
 
 	Ok(())
 }


### PR DESCRIPTION
## Summary
- Propagate the error from `log.init()` in `moq-ffi` instead of silently ignoring the `Result`, fixing a compiler warning.

## Test plan
- [x] `just fix` passes with no changes
- [x] `cargo check -p moq-ffi` compiles with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)