### PR TITLE
Fix draft-17 SETUP handshake: remove duplicate 0x2F00 stream type

### DIFF
--- a/rs/moq-lite/src/client.rs
+++ b/rs/moq-lite/src/client.rs
@@ -64,9 +64,7 @@ impl Client {
 				let send_fut = async {
 					let send = session.open_uni().await.map_err(Error::from_transport)?;
 					let mut writer: Writer<S::SendStream, Version> = Writer::new(send, v);
-					// Write stream type 0x2F00
-					writer.encode(&0x2F00u64).await?;
-					// Write SETUP message
+					// Write SETUP message (includes stream type 0x2F00)
 					writer.encode(&client_setup).await?;
 					Ok::<_, Error>(writer)
 				};
@@ -74,12 +72,7 @@ impl Client {
 				let recv_fut = async {
 					let recv = session.accept_uni().await.map_err(Error::from_transport)?;
 					let mut reader: Reader<S::RecvStream, Version> = Reader::new(recv, v);
-					// Read stream type
-					let stream_type: u64 = reader.decode().await?;
-					if stream_type != 0x2F00 {
-						return Err(Error::UnexpectedStream);
-					}
-					// Read SETUP message
+					// Read SETUP message (includes stream type 0x2F00)
 					let server: setup::Server = reader.decode().await?;
 					Ok::<_, Error>((reader, server))
 				};

--- a/rs/moq-lite/src/server.rs
+++ b/rs/moq-lite/src/server.rs
@@ -62,12 +62,7 @@ impl Server {
 				let recv_fut = async {
 					let recv = session.accept_uni().await.map_err(Error::from_transport)?;
 					let mut reader: Reader<S::RecvStream, Version> = Reader::new(recv, v);
-					// Read stream type
-					let stream_type: u64 = reader.decode().await?;
-					if stream_type != 0x2F00 {
-						return Err(Error::UnexpectedStream);
-					}
-					// Read client SETUP message
+					// Read client SETUP message (includes stream type 0x2F00)
 					let _client: setup::Client = reader.decode().await?;
 					Ok::<_, Error>(reader)
 				};
@@ -75,9 +70,7 @@ impl Server {
 				let send_fut = async {
 					let send = session.open_uni().await.map_err(Error::from_transport)?;
 					let mut writer: Writer<S::SendStream, Version> = Writer::new(send, v);
-					// Write stream type 0x2F00
-					writer.encode(&0x2F00u64).await?;
-					// Write SETUP message
+					// Write SETUP message (includes stream type 0x2F00)
 					writer.encode(&server_setup).await?;
 					Ok::<_, Error>(writer)
 				};


### PR DESCRIPTION
## Summary
- The SETUP message encoding in `setup.rs` already includes `Type(0x2F00)` as part of the wire format, but `client.rs` and `server.rs` were also writing/reading `0x2F00` as a separate stream type prefix
- This caused the value to appear twice on the wire, breaking interoperability with spec-compliant draft-17 peers (decode error: `invalid value`)
- Removed the redundant stream type write/read from the draft-17 handshake paths in both client and server

## Test plan
- [ ] Verify `cargo check -p moq-lite` passes (confirmed locally)
- [ ] Test draft-17 handshake against a spec-compliant peer
- [ ] Verify older draft versions (14-16) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)