### PR TITLE
Use Promise.withResolvers()

### DIFF
--- a/js/lite/src/ietf/control.ts
+++ b/js/lite/src/ietf/control.ts
@@ -147,8 +147,7 @@ export class Stream {
 
 	#maxRequestId: bigint;
 
-	#maxRequestIdPromise?: Promise<void>; // unblocks when there's a new max request id
-	#maxRequestIdResolve!: () => void; // resolves the max request id promise
+	#maxRequestIdUpdate?: PromiseWithResolvers<void>;
 
 	#writeLock = new Mutex();
 	#readLock = new Mutex();
@@ -168,9 +167,7 @@ export class Stream {
 		this.stream.reader.version = version;
 		this.stream.writer.version = version;
 		this.#maxRequestId = maxRequestId;
-		this.#maxRequestIdPromise = new Promise((resolve) => {
-			this.#maxRequestIdResolve = resolve;
-		});
+		this.#maxRequestIdUpdate = Promise.withResolvers();
 	}
 
 	/**
@@ -231,10 +228,8 @@ export class Stream {
 		}
 
 		this.#maxRequestId = max;
-		this.#maxRequestIdResolve();
-		this.#maxRequestIdPromise = new Promise((resolve) => {
-			this.#maxRequestIdResolve = resolve;
-		});
+		this.#maxRequestIdUpdate?.resolve();
+		this.#maxRequestIdUpdate = Promise.withResolvers();
 	}
 
 	async nextRequestId(): Promise<bigint | undefined> {
@@ -252,17 +247,17 @@ export class Stream {
 				return id;
 			}
 
-			if (!this.#maxRequestIdPromise) {
+			if (!this.#maxRequestIdUpdate) {
 				return undefined;
 			}
 
 			console.warn("blocked on max request id");
-			await this.#maxRequestIdPromise;
+			await this.#maxRequestIdUpdate.promise;
 		}
 	}
 
 	close(): void {
-		this.#maxRequestIdResolve();
-		this.#maxRequestIdPromise = undefined;
+		this.#maxRequestIdUpdate?.resolve();
+		this.#maxRequestIdUpdate = undefined;
 	}
 }

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -194,11 +194,8 @@ export class Effect {
 	#stack?: string;
 	#scheduled = false;
 
-	#stop!: () => void;
-	#stopped: Promise<void>;
-
-	#close!: () => void;
-	#closed: Promise<void>;
+	#stopped: PromiseWithResolvers<void>;
+	#closed: PromiseWithResolvers<void>;
 
 	#abort: AbortController = new AbortController();
 
@@ -215,13 +212,8 @@ export class Effect {
 			this.#stack = new Error().stack;
 		}
 
-		this.#stopped = new Promise((resolve) => {
-			this.#stop = resolve;
-		});
-
-		this.#closed = new Promise((resolve) => {
-			this.#close = resolve;
-		});
+		this.#stopped = Promise.withResolvers();
+		this.#closed = Promise.withResolvers();
 
 		if (fn) {
 			this.#schedule();
@@ -243,13 +235,11 @@ export class Effect {
 	async #run(): Promise<void> {
 		if (this.#dispose === undefined) return; // closed, no error because this is a microtask
 
-		this.#stop();
+		this.#stopped.resolve();
 		this.#abort.abort();
 		this.#abort = new AbortController();
 
-		this.#stopped = new Promise((resolve) => {
-			this.#stop = resolve;
-		});
+		this.#stopped = Promise.withResolvers();
 
 		// Unsubscribe from all signals.
 		for (const unwatch of this.#unwatch) unwatch();
@@ -588,8 +578,8 @@ export class Effect {
 			return;
 		}
 
-		this.#close();
-		this.#stop();
+		this.#closed.resolve();
+		this.#stopped.resolve();
 		this.#abort.abort();
 
 		for (const fn of this.#dispose) fn();
@@ -606,11 +596,11 @@ export class Effect {
 	}
 
 	get closed(): Promise<void> {
-		return this.#closed;
+		return this.#closed.promise;
 	}
 
 	get cancel(): Promise<void> {
-		return this.#stopped;
+		return this.#stopped.promise;
 	}
 
 	get abort(): AbortSignal {

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -27,8 +27,7 @@ export class Sync {
 
 	// A ghetto way to learn when the reference/latency changes.
 	// There's probably a way to use Effect, but lets keep it simple for now.
-	#update: Promise<void>;
-	#resolve!: () => void;
+	#update: PromiseWithResolvers<void>;
 
 	signals = new Effect();
 
@@ -37,9 +36,7 @@ export class Sync {
 		this.audio = Signal.from(props?.audio);
 		this.video = Signal.from(props?.video);
 
-		this.#update = new Promise((resolve) => {
-			this.#resolve = resolve;
-		});
+		this.#update = Promise.withResolvers();
 
 		this.signals.run(this.#runLatency.bind(this));
 	}
@@ -52,11 +49,8 @@ export class Sync {
 		const latency = Time.Milli.add(Time.Milli.max(video, audio), jitter);
 		this.#latency.set(latency);
 
-		this.#resolve();
-
-		this.#update = new Promise((resolve) => {
-			this.#resolve = resolve;
-		});
+		this.#update.resolve();
+		this.#update = Promise.withResolvers();
 	}
 
 	// Update the reference if this is the earliest frame we've seen, relative to its timestamp.
@@ -68,11 +62,8 @@ export class Sync {
 			return;
 		}
 		this.#reference.set(ref);
-		this.#resolve();
-
-		this.#update = new Promise((resolve) => {
-			this.#resolve = resolve;
-		});
+		this.#update.resolve();
+		this.#update = Promise.withResolvers();
 	}
 
 	// Sleep until it's time to render this frame.
@@ -95,7 +86,7 @@ export class Sync {
 			if (sleep <= 0) return;
 			const wait = new Promise((resolve) => setTimeout(resolve, sleep)).then(() => true);
 
-			const ok = await Promise.race([this.#update, wait]);
+			const ok = await Promise.race([this.#update.promise, wait]);
 			if (ok) return;
 		}
 	}


### PR DESCRIPTION
## Summary
- Replaces manual `new Promise(resolve => { this.#x = resolve })` patterns with `Promise.withResolvers()` across 3 files
- Eliminates `!` non-null assertion operators on resolver fields by storing the whole `PromiseWithResolvers` object
- Net removal of 24 lines

## Test plan
- [x] `just check` passes
- [x] `just fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)