### PR TITLE
Fix race where subscribe_track returns NotFound

### DIFF
--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -137,13 +137,19 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			Entry::Vacant(entry) => entry.insert(broadcast.clone()),
 		};
 
+		// Create the dynamic handler BEFORE publishing, so that consumers
+		// see dynamic >= 1 immediately when they receive the announcement.
+		// Otherwise there's a race on multi-threaded runtimes where a consumer
+		// can call subscribe_track() before dynamic is incremented, getting NotFound.
+		let dynamic = broadcast.dynamic();
+
 		// Run the broadcast in the background until all consumers are dropped.
 		self.origin
 			.as_mut()
 			.unwrap()
 			.publish_broadcast(path.clone(), broadcast.consume());
 
-		web_async::spawn(self.clone().run_broadcast(path, broadcast.dynamic()));
+		web_async::spawn(self.clone().run_broadcast(path, dynamic));
 
 		Ok(())
 	}


### PR DESCRIPTION
## Summary

- Fix race condition in `subscriber.rs::start_announce()` where `publish_broadcast()` announces to consumers **before** `broadcast.dynamic()` increments the dynamic counter
- On multi-threaded tokio runtimes, a consumer can receive the announcement and call `subscribe_track()` while `dynamic` is still 0, getting `NotFound`
- Fix: create the `BroadcastDynamic` before publishing the broadcast, so consumers always see `dynamic >= 1`

## Context

Reported by users hitting intermittent `NotFound` errors when calling `subscribe_track()` on a `BroadcastConsumer` obtained via `announced()`. The race window is between `publish_broadcast` (which sends to MPSC channel, waking consumers) and `broadcast.dynamic()` (which increments the counter). On a multi-threaded runtime, another thread can poll the woken consumer task and call `subscribe_track` in that gap.

## Test plan

- [ ] `cargo check -p moq-lite` passes
- [ ] Manual testing by reporters to confirm intermittent NotFound is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)