### PR TITLE
Add with_origin convenience method to Client and Server

### DIFF
--- a/rs/moq-lite/src/client.rs
+++ b/rs/moq-lite/src/client.rs
@@ -28,6 +28,14 @@ impl Client {
 		self
 	}
 
+	/// Set both publish and consume from an `OriginProducer`.
+	///
+	/// This is equivalent to calling `with_publish(origin.consume())` and `with_consume(origin)`.
+	pub fn with_origin(self, origin: OriginProducer) -> Self {
+		let consumer = origin.consume();
+		self.with_publish(consumer).with_consume(origin)
+	}
+
 	pub fn with_versions(mut self, versions: Versions) -> Self {
 		self.versions = versions;
 		self

--- a/rs/moq-lite/src/server.rs
+++ b/rs/moq-lite/src/server.rs
@@ -28,6 +28,14 @@ impl Server {
 		self
 	}
 
+	/// Set both publish and consume from an `OriginProducer`.
+	///
+	/// This is equivalent to calling `with_publish(origin.consume())` and `with_consume(origin)`.
+	pub fn with_origin(self, origin: OriginProducer) -> Self {
+		let consumer = origin.consume();
+		self.with_publish(consumer).with_consume(origin)
+	}
+
 	pub fn with_versions(mut self, versions: Versions) -> Self {
 		self.versions = versions;
 		self


### PR DESCRIPTION
## Summary
Added a new `with_origin()` convenience method to both `Client` and `Server` that simplifies the common pattern of setting both publish and consume from an `OriginProducer`.

## Key Changes
- Added `with_origin()` method to `Client` that accepts an `OriginProducer` and configures both publish and consume in a single call
- Added identical `with_origin()` method to `Server` for consistency
- Both implementations extract the consumer from the origin producer and chain the existing `with_publish()` and `with_consume()` methods

## Implementation Details
The `with_origin()` method is a convenience wrapper that:
1. Calls `origin.consume()` to extract the consumer
2. Chains `with_publish(consumer)` and `with_consume(origin)` to configure both directions

This eliminates the need for callers to manually extract the consumer and make two separate method calls, improving API ergonomics.

https://claude.ai/code/session_01BR7nZNehx4JkvZrKfaiaAt