### PR TITLE
Make SUBSCRIBE_NAMESPACE errors non-fatal

### DIFF
--- a/rs/moq-lite/src/ietf/session.rs
+++ b/rs/moq-lite/src/ietf/session.rs
@@ -52,7 +52,10 @@ pub fn start<S: web_transport_trait::Session>(
 							}
 							_ => Stream::open(&sub_ns_adapter, version).await?,
 						};
-						sub_ns.run_subscribe_namespace(stream).await
+						if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
+						tracing::warn!(%err, "subscribe_namespace failed, continuing without");
+					}
+					Ok(())
 					} => Err(err),
 				}
 			}
@@ -83,7 +86,10 @@ pub fn start<S: web_transport_trait::Session>(
 							return Ok(());
 						}
 						let stream = Stream::open(&sub_ns_session, version).await?;
-						sub_ns.run_subscribe_namespace(stream).await
+						if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
+							tracing::warn!(%err, "subscribe_namespace failed, continuing without");
+						}
+						Ok(())
 					} => Err(err),
 				}
 			}


### PR DESCRIPTION
## Summary
- When the peer rejects our `SUBSCRIBE_NAMESPACE` request, log a warning and continue the session instead of tearing it down
- The session can still function via unsolicited `PUBLISH_NAMESPACE` messages from the peer
- Fixes the issue where clients responding with `DOES_NOT_EXIST` or `UNINTERESTED` to `SUBSCRIBE_NAMESPACE` would cause the relay to drop the session

## Test plan
- [ ] Connect a draft-17 client that rejects `SUBSCRIBE_NAMESPACE` — session should stay alive
- [ ] Verify that `PUBLISH_NAMESPACE` announcements still flow after `SUBSCRIBE_NAMESPACE` is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)