### PR TITLE
Add landing page for non-MoQ clients accessing relay

### DIFF
--- a/rs/moq-relay/src/landing.html
+++ b/rs/moq-relay/src/landing.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>moq-relay</title>
+		<style>
+			:root {
+				color-scheme: light dark;
+			}
+			html,
+			body {
+				margin: 0;
+				padding: 0;
+				height: 100%;
+				font-family:
+					system-ui,
+					-apple-system,
+					Segoe UI,
+					Roboto,
+					Ubuntu,
+					sans-serif;
+			}
+			body {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				padding: 2rem;
+				box-sizing: border-box;
+				background: #0b0d10;
+				color: #e5e7eb;
+			}
+			main {
+				max-width: 40rem;
+				text-align: center;
+			}
+			h1 {
+				font-size: 1.5rem;
+				margin: 0 0 1rem;
+			}
+			p {
+				margin: 0 0 1rem;
+				line-height: 1.5;
+			}
+			a {
+				color: #60a5fa;
+			}
+			code {
+				background: rgba(255, 255, 255, 0.08);
+				padding: 0.1rem 0.35rem;
+				border-radius: 0.25rem;
+				font-size: 0.95em;
+			}
+		</style>
+	</head>
+	<body>
+		<main>
+			<h1>moq-relay</h1>
+			<p>
+				This is a <code>moq-relay</code> instance, and you're not a MoQ client.
+			</p>
+			<p>
+				See <a href="https://moq.dev">https://moq.dev</a> for more info.
+			</p>
+		</main>
+	</body>
+</html>

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -11,7 +11,7 @@ use axum::{
 	body::Body,
 	extract::{Path, Query, State},
 	http::{Method, StatusCode},
-	response::{IntoResponse, Response},
+	response::{Html, IntoResponse, Response},
 	routing::get,
 };
 use bytes::Bytes;
@@ -109,6 +109,7 @@ impl Web {
 		};
 
 		let app = app
+			.fallback(serve_landing)
 			.layer(CorsLayer::new().allow_origin(Any).allow_methods([Method::GET]))
 			.with_state(Arc::new(self.state))
 			.into_make_service();
@@ -158,6 +159,23 @@ async fn reload_certs(config: axum_server::tls_rustls::RustlsConfig, cert: PathB
 			tracing::warn!(%err, "failed to reload web certificate");
 		}
 	}
+}
+
+/// HTML landing page served when a plain browser hits the relay directly.
+///
+/// MoQ clients speak WebTransport or WebSocket, so a GET request from a
+/// regular browser isn't something we can service. Rather than exposing an
+/// internal error (e.g. the "Request method must be `CONNECT`" rejection
+/// from axum's WebSocket extractor), we render a short informational page.
+pub(crate) const LANDING_PAGE: &str = include_str!("landing.html");
+
+pub(crate) fn landing_response() -> Response {
+	(StatusCode::NOT_FOUND, Html(LANDING_PAGE)).into_response()
+}
+
+/// Axum fallback handler for any unmatched route.
+async fn serve_landing() -> Response {
+	landing_response()
 }
 
 async fn serve_fingerprint(State(state): State<Arc<WebState>>) -> String {

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -7,20 +7,30 @@ use std::{
 };
 
 use axum::{
-	extract::{Path, Query, State, WebSocketUpgrade},
+	extract::{
+		Path, Query, State, WebSocketUpgrade,
+		rejection::{PathRejection, QueryRejection},
+		ws::rejection::WebSocketUpgradeRejection,
+	},
 	http::StatusCode,
 	response::Response,
 };
 use moq_lite::{OriginConsumer, OriginProducer};
 
-use crate::{AuthParams, WebState, web::AuthQuery};
+use crate::{AuthParams, WebState, web::AuthQuery, web::landing_response};
 
 pub(crate) async fn serve_ws(
-	ws: WebSocketUpgrade,
-	Path(path): Path<String>,
-	Query(query): Query<AuthQuery>,
+	ws: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
+	path: Result<Path<String>, PathRejection>,
+	query: Result<Query<AuthQuery>, QueryRejection>,
 	State(state): State<Arc<WebState>>,
 ) -> axum::response::Result<Response> {
+	// If this isn't a WebSocket upgrade (e.g. a plain browser visit), serve
+	// the informational landing page instead of an error response.
+	let (Ok(ws), Ok(Path(path)), Ok(Query(query))) = (ws, path, query) else {
+		return Ok(landing_response());
+	};
+
 	let ws = ws.protocols(["webtransport"]);
 
 	let params = AuthParams {


### PR DESCRIPTION
## Summary
This PR adds a user-friendly landing page that is served when a regular web browser or non-MoQ client accesses the relay directly, replacing generic error responses with informative guidance.

## Key Changes
- **New landing page**: Added `landing.html` with styled informational content explaining that the relay is a MoQ service and directing users to https://moq.dev for more information
- **Web server fallback**: Configured the Axum router with a fallback handler (`serve_landing`) that catches all unmatched routes and serves the landing page with a 404 status code
- **WebSocket error handling**: Updated `serve_ws` to gracefully handle extraction failures (WebSocket upgrade, path, and query rejections) by serving the landing page instead of exposing internal error messages
- **Response helper**: Added `landing_response()` utility function to generate consistent landing page responses

## Implementation Details
- The landing page includes responsive design with dark mode support and links to the MoQ specification
- The fallback handler is registered at the router level to catch any requests that don't match defined routes
- WebSocket handler now accepts `Result` types for its extractors, allowing it to detect when a plain HTTP request arrives and serve the landing page instead of letting Axum's WebSocket extractor reject the request with a technical error message
- The landing page HTML is embedded at compile time using `include_str!()` for efficient serving

https://claude.ai/code/session_01FMvy3oWhasZwmxnCcch8tN