### PR TITLE
Move buffer slider from Controls to StatsPanel

### DIFF
--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": {

--- a/js/moq-boy/src/ui/components/Controls.tsx
+++ b/js/moq-boy/src/ui/components/Controls.tsx
@@ -1,13 +1,12 @@
-import { createAccessor, createPair } from "@moq/signals/solid";
+import { createPair } from "@moq/signals/solid";
 import { For } from "solid-js";
 import { useGameUI } from "../hooks/use-boy-ui";
 
-/** All game controls: D-pad, A/B, Start/Select, Mute, Reset, Jitter slider, Key hints. */
+/** All game controls: D-pad, A/B, Start/Select, Mute, Reset, Key hints. */
 export default function Controls() {
 	const ctx = useGameUI();
 	const game = ctx.game;
 
-	const jitter = createAccessor(game.sync.jitter);
 	const [userMuted, setUserMuted] = createPair(game.userMuted);
 
 	const toggleMute = (e: MouseEvent) => {
@@ -18,11 +17,6 @@ export default function Controls() {
 	const onReset = (e: MouseEvent) => {
 		e.stopPropagation();
 		game.sendCommand({ type: "reset" });
-	};
-
-	const onJitterInput = (e: Event) => {
-		const el = e.currentTarget as HTMLInputElement;
-		game.latency.set(Number.parseInt(el.value, 10) as import("@moq/lite").Time.Milli);
 	};
 
 	return (
@@ -44,19 +38,6 @@ export default function Controls() {
 					Reset
 				</button>
 			</div>
-
-			<label class="boy__jitter">
-				<span class="boy__jitter-label">Buffer: {jitter()}ms</span>
-				<input
-					type="range"
-					class="boy__jitter-slider"
-					min="0"
-					max="500"
-					value={jitter()}
-					onInput={onJitterInput}
-					onClick={(e) => e.stopPropagation()}
-				/>
-			</label>
 
 			<div class="boy__key-hints">
 				<div>Arrows: D-pad</div>

--- a/js/moq-boy/src/ui/components/StatsPanel.tsx
+++ b/js/moq-boy/src/ui/components/StatsPanel.tsx
@@ -1,9 +1,18 @@
+import { createAccessor } from "@moq/signals/solid";
 import { For, Show } from "solid-js";
 import { useGameUI } from "../hooks/use-boy-ui";
 
-/** Right-side panel showing location, encoding stats, and per-viewer latency. */
+/** Right-side panel showing location, encoding stats, buffer slider, and per-viewer latency. */
 export default function StatsPanel() {
 	const ctx = useGameUI();
+	const game = ctx.game;
+
+	const jitter = createAccessor(game.sync.jitter);
+
+	const onJitterInput = (e: Event) => {
+		const el = e.currentTarget as HTMLInputElement;
+		game.latency.set(Number.parseInt(el.value, 10) as import("@moq/lite").Time.Milli);
+	};
 
 	const location = () => ctx.status()?.location;
 	const stats = () => ctx.status()?.stats;
@@ -39,6 +48,19 @@ export default function StatsPanel() {
 					<div class="boy__location-value">{location()}</div>
 				</div>
 			</Show>
+
+			<label class="boy__jitter">
+				<span class="boy__jitter-label">Buffer: {jitter()}ms</span>
+				<input
+					type="range"
+					class="boy__jitter-slider"
+					min="0"
+					max="500"
+					value={jitter()}
+					onInput={onJitterInput}
+					onClick={(e) => e.stopPropagation()}
+				/>
+			</label>
 
 			<Show when={stats()}>
 				<div class="boy__stats-list">

--- a/js/moq-boy/src/ui/styles/card.css
+++ b/js/moq-boy/src/ui/styles/card.css
@@ -80,12 +80,7 @@
 }
 
 .boy__panel--left {
-	border-right: 1px solid var(--boy-border);
 	order: -1;
-}
-
-.boy__panel--right {
-	border-left: 1px solid var(--boy-border);
 }
 
 /* On narrow screens, stack panels below video instead of side-by-side. */

--- a/js/moq-boy/src/ui/styles/card.css
+++ b/js/moq-boy/src/ui/styles/card.css
@@ -72,7 +72,7 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	width: 240px;
+	width: 200px;
 	background: var(--boy-bg-card);
 	flex-shrink: 0;
 	padding: var(--spacing-16);


### PR DESCRIPTION
## Summary
Relocates the jitter/buffer slider UI component from the Controls panel to the StatsPanel, reorganizing the layout to better group related functionality.

## Key Changes
- **Moved buffer slider component** from `Controls.tsx` to `StatsPanel.tsx`
  - Includes the jitter accessor and `onJitterInput` handler
  - Updates component documentation to reflect new contents
- **Removed jitter-related imports** from Controls.tsx (`createAccessor`)
- **Adjusted panel width** in `card.css` from 240px to 200px to accommodate the new layout
- **Removed panel borders** (border-right from left panel, border-left from right panel) for a cleaner visual separation
- **Version bump** from 0.2.3 to 0.2.4

## Implementation Details
The buffer slider functionality remains unchanged—it still controls `game.latency` through the same input handler. The move is purely organizational, placing the buffer control alongside other statistics and status information in the right-side panel rather than with game controls.

https://claude.ai/code/session_01HXFoYxCAnP3umAKK7y3PJy