### PR TITLE
fix(moq-lite): exit run_send_bandwidth when the session closes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "moq-lite"
-version = "0.15.10"
+version = "0.15.11"
 dependencies = [
  "bytes",
  "conducer",

--- a/rs/moq-lite/Cargo.toml
+++ b/rs/moq-lite/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.15.10"
+version = "0.15.11"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-lite/src/session.rs
+++ b/rs/moq-lite/src/session.rs
@@ -92,27 +92,31 @@ impl Drop for Session {
 }
 
 /// Polls the QUIC congestion controller for estimated send rate.
-/// Only active when at least one consumer exists.
+///
+/// Exits as soon as the session closes so we don't pin the underlying connection
+/// after the wrapping [`Session`] is dropped.
 async fn run_send_bandwidth<S: web_transport_trait::Session>(session: &S, producer: BandwidthProducer) {
+	tokio::select! {
+		_ = session.closed() => {}
+		_ = producer.closed() => {}
+		_ = run_send_bandwidth_inner(session, &producer) => {}
+	}
+}
+
+/// Toggles between waiting for a consumer and polling stats while one exists.
+/// Returns when the producer channel errors (closed by the consumer side).
+async fn run_send_bandwidth_inner<S: web_transport_trait::Session>(session: &S, producer: &BandwidthProducer) {
 	const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 	loop {
-		tokio::select! {
-			biased;
-			_ = producer.closed() => return,
-			res = producer.used() => {
-				if res.is_err() {
-					return;
-				}
-			}
+		if producer.used().await.is_err() {
+			return;
 		}
 
 		let mut interval = tokio::time::interval(POLL_INTERVAL);
-
 		loop {
 			tokio::select! {
 				biased;
-				_ = producer.closed() => return,
 				res = producer.unused() => {
 					if res.is_err() {
 						return;


### PR DESCRIPTION
## Summary

- `run_send_bandwidth` (introduced in #1208) spawns a detached task that clones the underlying `web_transport_trait::Session`, but its `select!` arms only wait on `producer.closed()` / `producer.used()` / `producer.unused()`. None of those fire when the wrapping `moq_lite::Session` drops — the task is the sole `Producer`, so `producer.closed()` can never transition, and the outer loop's `producer.used()` sits forever waiting for a new consumer on a dead session.
- Net effect: every accepted quinn-backed session leaks a task that permanently pins the cloned session, the underlying `quinn::Connection`, and its `StreamsState` (HashMaps sized to `max_concurrent_*_streams`). On `moq-relay` with `DEFAULT_MAX_STREAMS = 10_000`, that's ~1.5–3 MB of live heap per connection accumulating unboundedly.
- Confirmed via jemalloc heap profiles on `use.cdn.moq.dev`: ~484 MB retained after 53 min / 328 accepted connections, 79% of it in `quinn_proto::endpoint::Endpoint::accept → hashbrown::HashMap::insert → RawTable::reserve_rehash` inside `StreamsState::new`.

## Fix

Wrap the existing polling logic in an outer `select!` that also listens on `session.closed()`, so the task exits as soon as the transport dies. Extract the polling loop into `run_send_bandwidth_inner` so all termination conditions live in one place.

Bumps `moq-lite` to `0.15.11`.

## Test plan

- [x] `just check` passes locally
- [ ] Deploy to a single relay node and watch RSS over several hours
- [ ] Confirm with a follow-up heap dump that `quinn_proto::Connection::new` is no longer dominant

🤖 Generated with [Claude Code](https://claude.com/claude-code)