### PR TITLE
feat(moq-lite,moq-relay): per-category task profiling via tokio-metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "moq-lite"
-version = "0.15.11"
+version = "0.15.12"
 dependencies = [
  "bytes",
  "conducer",
@@ -3644,6 +3644,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-metrics",
  "tracing",
  "web-async",
  "web-transport-trait",
@@ -6524,6 +6525,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e81d53caf955549b1dec7af4ac2149e94cc25ed97b4a545151140281e2f528"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/rs/moq-lite/Cargo.toml
+++ b/rs/moq-lite/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.15.11"
+version = "0.15.12"
 edition = "2024"
 rust-version.workspace = true
 
@@ -24,6 +24,7 @@ rand = "0.9.2"
 serde = { workspace = true, optional = true, features = ["rc"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["macros", "io-util", "sync", "test-util", "time"] }
+tokio-metrics = "0.5"
 tracing = "0.1"
 web-async = { workspace = true }
 web-transport-trait = { workspace = true }

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -46,7 +46,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received subscribe");
-				web_async::spawn(async move {
+				crate::task::IETF_PUB_SUBSCRIBE.spawn(async move {
 					if let Err(err) = this.run_subscribe_stream(stream, msg).await {
 						tracing::debug!(%err, "subscribe stream error");
 					}
@@ -58,7 +58,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received fetch");
-				web_async::spawn(async move {
+				crate::task::IETF_PUB_FETCH.spawn(async move {
 					if let Err(err) = this.run_fetch_stream(stream, msg).await {
 						tracing::debug!(%err, "fetch stream error");
 					}
@@ -70,7 +70,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received subscribe_namespace");
-				web_async::spawn(async move {
+				crate::task::IETF_PUB_SUB_NAMESPACE.spawn(async move {
 					if let Err(err) = this.run_subscribe_namespace_stream(stream, msg).await {
 						tracing::debug!(%err, "subscribe_namespace stream error");
 					}

--- a/rs/moq-lite/src/ietf/session.rs
+++ b/rs/moq-lite/src/ietf/session.rs
@@ -16,7 +16,7 @@ pub fn start<S: web_transport_trait::Session>(
 	subscribe: Option<OriginProducer>,
 	version: Version,
 ) -> Result<(), Error> {
-	web_async::spawn(async move {
+	crate::task::IETF_SESSION.spawn(async move {
 		let res = match version {
 			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
 				let Some(setup) = setup else {
@@ -61,7 +61,7 @@ pub fn start<S: web_transport_trait::Session>(
 			}
 			_ => {
 				// Spawn SETUP sender (keeps stream alive for GOAWAY).
-				web_async::spawn({
+				crate::task::IETF_SETUP.spawn({
 					let session = session.clone();
 					async move {
 						if let Err(err) = run_setup(session).await {
@@ -155,7 +155,7 @@ async fn run_unis<S: web_transport_trait::Session>(
 		// We accept it in the background without blocking, since there are no
 		// extensions that require waiting on the SETUP before proceeding.
 		if kind == setup::SETUP_V17 {
-			web_async::spawn(async move {
+			crate::task::IETF_SETUP.spawn(async move {
 				// Decode and discard the unified SETUP message.
 				if let Err(err) = reader.decode::<setup::Setup>().await {
 					tracing::warn!(%err, "setup decode error");
@@ -173,7 +173,7 @@ async fn run_unis<S: web_transport_trait::Session>(
 
 		// Group data — spawn a handler for each stream.
 		let mut sub = subscriber.clone();
-		web_async::spawn(async move {
+		crate::task::IETF_UNI_STREAM.spawn(async move {
 			let mut reader = reader.with_version(version);
 			if let Err(err) = run_uni_group(&mut sub, &mut reader).await {
 				tracing::debug!(%err, "uni stream error");

--- a/rs/moq-lite/src/ietf/subscriber.rs
+++ b/rs/moq-lite/src/ietf/subscriber.rs
@@ -154,7 +154,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received publish");
-				web_async::spawn(async move {
+				crate::task::IETF_SUB_PUBLISH.spawn(async move {
 					if let Err(err) = this.run_publish_stream(stream, msg).await {
 						tracing::debug!(%err, "publish stream error");
 					}
@@ -166,7 +166,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received publish_namespace");
-				web_async::spawn(async move {
+				crate::task::IETF_SUB_PUB_NAMESPACE.spawn(async move {
 					if let Err(err) = this.run_publish_namespace_stream(stream, msg).await {
 						tracing::debug!(%err, "publish_namespace stream error");
 					}
@@ -428,7 +428,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let this = self.clone();
 		let producer = broadcast.clone();
 
-		web_async::spawn(async move {
+		crate::task::IETF_SUB_BROADCAST.spawn(async move {
 			if let Err(err) = this.run_broadcast(path.clone(), producer.dynamic()).await {
 				tracing::debug!(%err, "error running broadcast");
 			}
@@ -513,7 +513,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let mut this = self.clone();
 
 			let path = path.to_owned();
-			web_async::spawn(async move {
+			crate::task::IETF_SUB_TRACK.spawn(async move {
 				this.run_subscribe(path, track).await;
 			});
 		}

--- a/rs/moq-lite/src/lib.rs
+++ b/rs/moq-lite/src/lib.rs
@@ -25,6 +25,7 @@ mod path;
 mod server;
 mod session;
 mod setup;
+pub mod task;
 mod version;
 
 pub use client::*;

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -65,7 +65,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let session = self.session.clone();
 		let version = self.version;
 
-		web_async::spawn(async move {
+		crate::task::LITE_PROBE.spawn(async move {
 			if let Err(err) = Self::run_probe(&session, &mut stream, version).await {
 				match &err {
 					Error::Cancel | Error::Transport(_) => {
@@ -131,7 +131,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			.ok_or(Error::Unauthorized)?;
 
 		let version = self.version;
-		web_async::spawn(async move {
+		crate::task::LITE_ANNOUNCE.spawn(async move {
 			if let Err(err) = Self::run_announce(&mut stream, &mut origin, &prefix, version).await {
 				match &err {
 					Error::Cancel | Error::Transport(_) => {
@@ -228,7 +228,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let version = self.version;
 
 		let session = self.session.clone();
-		web_async::spawn(async move {
+		crate::task::LITE_SUBSCRIBE.spawn(async move {
 			if let Err(err) = Self::run_subscribe(session, &mut stream, &subscribe, broadcast, priority, version).await
 			{
 				match &err {

--- a/rs/moq-lite/src/lite/session.rs
+++ b/rs/moq-lite/src/lite/session.rs
@@ -30,7 +30,7 @@ pub fn start<S: web_transport_trait::Session>(
 	let publisher = Publisher::new(session.clone(), publish, version);
 	let subscriber = Subscriber::new(session.clone(), subscribe, recv_bw_for_sub, version);
 
-	web_async::spawn(async move {
+	crate::task::LITE_SESSION.spawn(async move {
 		let res = tokio::select! {
 			Err(res) = run_session(setup) => Err(res),
 			res = publisher.run() => res,

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -61,7 +61,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let stream = Reader::new(stream, self.version);
 			let this = self.clone();
 
-			web_async::spawn(async move {
+			crate::task::LITE_UNI_STREAM.spawn(async move {
 				if let Err(err) = this.run_uni_stream(stream).await {
 					tracing::debug!(%err, "error running uni stream");
 				}
@@ -222,7 +222,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			.unwrap()
 			.publish_broadcast(path.clone(), broadcast.consume());
 
-		web_async::spawn(self.clone().run_broadcast(path, dynamic));
+		crate::task::LITE_BROADCAST.spawn(self.clone().run_broadcast(path, dynamic));
 
 		Ok(())
 	}
@@ -247,7 +247,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let mut this = self.clone();
 
 			let path = path.clone();
-			web_async::spawn(async move {
+			crate::task::LITE_TRACK.spawn(async move {
 				this.run_subscribe(id, path, track).await;
 				this.subscribes.lock().remove(&id);
 			});

--- a/rs/moq-lite/src/model/broadcast.rs
+++ b/rs/moq-lite/src/model/broadcast.rs
@@ -308,7 +308,7 @@ impl BroadcastConsumer {
 
 		// Remove the track from the lookup when it's unused.
 		let consumer_state = self.state.clone();
-		web_async::spawn(async move {
+		crate::task::BROADCAST_DEDUP.spawn(async move {
 			let _ = weak.unused().await;
 
 			let Some(producer) = consumer_state.produce() else {

--- a/rs/moq-lite/src/model/origin.rs
+++ b/rs/moq-lite/src/model/origin.rs
@@ -385,7 +385,7 @@ impl OriginProducer {
 		root.lock().publish(&full, &broadcast, &rest);
 		let root = root.clone();
 
-		web_async::spawn(async move {
+		crate::task::ORIGIN_CLEANUP.spawn(async move {
 			broadcast.closed().await;
 			root.lock().remove(&full, broadcast, &rest);
 		});

--- a/rs/moq-lite/src/session.rs
+++ b/rs/moq-lite/src/session.rs
@@ -30,7 +30,7 @@ impl Session {
 			let consumer = producer.consume();
 
 			let session = session.clone();
-			web_async::spawn(async move {
+			crate::task::BANDWIDTH.spawn(async move {
 				run_send_bandwidth(&session, producer).await;
 			});
 

--- a/rs/moq-lite/src/task.rs
+++ b/rs/moq-lite/src/task.rs
@@ -1,0 +1,241 @@
+//! Task categorisation and profiling.
+//!
+//! Every detached task spawned by moq-lite (and moq-relay) is attributed to a
+//! typed [`Category`]. Each category owns a lazily-initialised
+//! [`tokio_metrics::TaskMonitor`], so we can ask "which class of task is not
+//! dying?" without rebuilding the process.
+//!
+//! Call sites look like:
+//!
+//! ```ignore
+//! moq_lite::task::LITE_SESSION.spawn(async move { /* ... */ });
+//! ```
+//!
+//! A snapshot of every category's metrics is available via [`snapshot`].
+
+use std::future::Future;
+use std::sync::{Mutex, OnceLock};
+
+use tokio::task::JoinHandle;
+use tokio_metrics::{TaskMetrics, TaskMonitor};
+
+/// A task category: a name plus a lazily-initialised [`TaskMonitor`].
+///
+/// Define each category as a `pub static` constant and call
+/// [`Category::spawn`] on it. Typos fail at compile time and there's no hash
+/// lookup on the spawn hot path after the first call per category.
+pub struct Category {
+	name: &'static str,
+	monitor: OnceLock<TaskMonitor>,
+}
+
+impl Category {
+	pub const fn new(name: &'static str) -> Self {
+		Self {
+			name,
+			monitor: OnceLock::new(),
+		}
+	}
+
+	pub fn name(&self) -> &'static str {
+		self.name
+	}
+
+	/// Spawn a tracked detached task under this category.
+	///
+	/// Returns a [`JoinHandle`] so call sites that need `abort_handle()` (e.g.
+	/// `moq_relay::cluster`) still work.
+	#[track_caller]
+	pub fn spawn<F>(&'static self, f: F) -> JoinHandle<()>
+	where
+		F: Future<Output = ()> + Send + 'static,
+	{
+		let f = tracing::Instrument::in_current_span(f);
+		tokio::task::spawn(self.monitor().instrument(f))
+	}
+
+	/// Returns the monitor, initialising it on first call and registering
+	/// `self` in the global registry so [`snapshot`] can find it.
+	///
+	/// Hot path (after first init) is a single `OnceLock::get()` — lock-free.
+	fn monitor(&'static self) -> &'static TaskMonitor {
+		self.monitor.get_or_init(|| {
+			REGISTRY.lock().unwrap().push(self);
+			TaskMonitor::new()
+		})
+	}
+
+	fn cumulative(&self) -> TaskMetrics {
+		// The registry only contains categories whose monitor has been
+		// initialised, but be defensive so snapshot() can't panic.
+		self.monitor.get().map(TaskMonitor::cumulative).unwrap_or_default()
+	}
+}
+
+static REGISTRY: Mutex<Vec<&'static Category>> = Mutex::new(Vec::new());
+
+/// A flat, leak-focused projection of [`TaskMetrics`] for logging.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct TaskSnapshot {
+	pub name: &'static str,
+	/// `instrumented_count - dropped_count` — tasks currently live.
+	pub live: u64,
+	pub spawned: u64,
+	pub dropped: u64,
+	pub slow_polls: u64,
+	pub mean_poll_us: u64,
+}
+
+impl std::fmt::Display for TaskSnapshot {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(
+			f,
+			"{:40} live={:>5} spawned={:>8} dropped={:>8} slow={:>4} poll_us={:>5}",
+			self.name, self.live, self.spawned, self.dropped, self.slow_polls, self.mean_poll_us,
+		)
+	}
+}
+
+/// Per-category snapshot, sorted by category name.
+///
+/// Only includes categories whose [`Category::spawn`] has been called at least
+/// once (they register themselves lazily).
+pub fn snapshot() -> Vec<TaskSnapshot> {
+	let mut registry = REGISTRY.lock().unwrap().clone();
+	registry.sort_by_key(|c| c.name);
+	registry
+		.iter()
+		.map(|c| {
+			let m = c.cumulative();
+			let live = m.instrumented_count.saturating_sub(m.dropped_count);
+			let mean_poll_us = if m.total_poll_count > 0 {
+				(m.total_poll_duration.as_micros() as u64) / m.total_poll_count
+			} else {
+				0
+			};
+			TaskSnapshot {
+				name: c.name,
+				live,
+				spawned: m.instrumented_count,
+				dropped: m.dropped_count,
+				slow_polls: m.total_slow_poll_count,
+				mean_poll_us,
+			}
+		})
+		.collect()
+}
+
+/// Raw metrics escape hatch for anyone who wants the full [`TaskMetrics`].
+pub fn snapshot_raw() -> Vec<(&'static str, TaskMetrics)> {
+	let mut registry = REGISTRY.lock().unwrap().clone();
+	registry.sort_by_key(|c| c.name);
+	registry.iter().map(|c| (c.name, c.cumulative())).collect()
+}
+
+// ─── moq-lite categories ────────────────────────────────────────────────────
+//
+// Add new categories here rather than inline at spawn sites — keeps the full
+// list discoverable in one place.
+
+/// Periodic send-bandwidth sampling task (`Session::new`).
+pub static BANDWIDTH: Category = Category::new("moq-lite/bandwidth");
+
+/// The moq-lite (draft lite-*) session driver task (`lite::start`).
+pub static LITE_SESSION: Category = Category::new("moq-lite/lite-session");
+
+/// Per-PROBE-stream task on the publisher side.
+pub static LITE_PROBE: Category = Category::new("moq-lite/lite-probe");
+
+/// Per-ANNOUNCE-stream task on the publisher side.
+pub static LITE_ANNOUNCE: Category = Category::new("moq-lite/lite-announce");
+
+/// Per-SUBSCRIBE-stream task on the publisher side.
+pub static LITE_SUBSCRIBE: Category = Category::new("moq-lite/lite-subscribe");
+
+/// Per-incoming-uni-stream task on the subscriber side (group data).
+pub static LITE_UNI_STREAM: Category = Category::new("moq-lite/lite-uni-stream");
+
+/// Per-broadcast driver task on the subscriber side (`run_broadcast`).
+pub static LITE_BROADCAST: Category = Category::new("moq-lite/lite-broadcast");
+
+/// Per-track driver task on the subscriber side (`run_subscribe`).
+pub static LITE_TRACK: Category = Category::new("moq-lite/lite-track");
+
+/// The IETF (draft-14+) session driver task (`ietf::start`).
+pub static IETF_SESSION: Category = Category::new("moq-lite/ietf-session");
+
+/// IETF SETUP sender / GOAWAY watcher task.
+pub static IETF_SETUP: Category = Category::new("moq-lite/ietf-setup");
+
+/// Per-incoming-uni-stream task on the IETF session (group data).
+pub static IETF_UNI_STREAM: Category = Category::new("moq-lite/ietf-uni-stream");
+
+/// Per-incoming-SUBSCRIBE handler task on the IETF publisher side.
+pub static IETF_PUB_SUBSCRIBE: Category = Category::new("moq-lite/ietf-pub-subscribe");
+
+/// Per-incoming-FETCH handler task on the IETF publisher side.
+pub static IETF_PUB_FETCH: Category = Category::new("moq-lite/ietf-pub-fetch");
+
+/// Per-incoming-SUBSCRIBE_NAMESPACE handler task on the IETF publisher side.
+pub static IETF_PUB_SUB_NAMESPACE: Category = Category::new("moq-lite/ietf-pub-sub-namespace");
+
+/// Per-incoming-PUBLISH handler task on the IETF subscriber side.
+pub static IETF_SUB_PUBLISH: Category = Category::new("moq-lite/ietf-sub-publish");
+
+/// Per-incoming-PUBLISH_NAMESPACE handler task on the IETF subscriber side.
+pub static IETF_SUB_PUB_NAMESPACE: Category = Category::new("moq-lite/ietf-sub-pub-namespace");
+
+/// Per-broadcast driver task on the IETF subscriber side.
+pub static IETF_SUB_BROADCAST: Category = Category::new("moq-lite/ietf-sub-broadcast");
+
+/// Per-track driver task on the IETF subscriber side (`run_subscribe`).
+pub static IETF_SUB_TRACK: Category = Category::new("moq-lite/ietf-sub-track");
+
+/// Cleanup task that removes a broadcast from an origin when it closes.
+pub static ORIGIN_CLEANUP: Category = Category::new("moq-lite/origin-cleanup");
+
+/// Per-track dedup cleanup task inside `crate::model::broadcast`.
+pub static BROADCAST_DEDUP: Category = Category::new("moq-lite/broadcast-dedup");
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::time::Duration;
+
+	static TEST_BLOCKER: Category = Category::new("test/blocker");
+	static TEST_INSTANT: Category = Category::new("test/instant");
+
+	#[tokio::test]
+	async fn snapshot_tracks_live_count() {
+		let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+		TEST_BLOCKER.spawn(async move {
+			let _ = rx.await;
+		});
+		TEST_INSTANT.spawn(async {});
+
+		// Give the runtime time to poll both tasks once so the instant one
+		// actually completes and gets counted as dropped.
+		tokio::time::sleep(Duration::from_millis(20)).await;
+
+		let snap = snapshot();
+		let blocker = snap
+			.iter()
+			.find(|s| s.name == "test/blocker")
+			.expect("blocker category should be registered");
+		let instant = snap
+			.iter()
+			.find(|s| s.name == "test/instant")
+			.expect("instant category should be registered");
+
+		assert_eq!(blocker.live, 1, "blocker should still be live");
+		assert_eq!(blocker.spawned, 1);
+		assert_eq!(blocker.dropped, 0);
+
+		assert_eq!(instant.live, 0, "instant task should already be dropped");
+		assert_eq!(instant.spawned, 1);
+		assert_eq!(instant.dropped, 1);
+
+		let _ = tx.send(());
+	}
+}

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -239,7 +239,7 @@ impl Cluster {
 			let token = token.clone();
 			let node2 = node.clone();
 
-			let handle = tokio::spawn(
+			let handle = crate::task::CLUSTER_REMOTE.spawn(
 				async move {
 					match this.run_remote(node2.as_str(), None, token, origin).await {
 						Ok(()) => tracing::info!(%node2, "origin closed"),

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -13,6 +13,7 @@ mod config;
 mod connection;
 #[cfg(feature = "jemalloc")]
 pub mod jemalloc;
+pub mod task;
 mod web;
 #[cfg(feature = "websocket")]
 mod websocket;

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -57,11 +57,14 @@ async fn main() -> anyhow::Result<()> {
 	#[cfg(not(feature = "jemalloc"))]
 	let jemalloc = std::future::pending::<anyhow::Result<()>>();
 
+	let task_profiler = task::run();
+
 	tokio::select! {
 		Err(err) = cluster.clone().run() => return Err(err).context("cluster failed"),
 		Err(err) = web.run() => return Err(err).context("web server failed"),
 		Err(err) = serve(server, cluster, auth) => return Err(err).context("server failed"),
 		Err(err) = jemalloc => return Err(err).context("jemalloc profiler failed"),
+		Err(err) = task_profiler => return Err(err).context("task profiler failed"),
 		else => Ok(()),
 	}
 }
@@ -78,7 +81,7 @@ async fn serve(mut server: moq_native::Server, cluster: Cluster, auth: Auth) -> 
 		};
 
 		conn_id += 1;
-		tokio::spawn(async move {
+		task::CONNECTION.spawn(async move {
 			if let Err(err) = conn.run().await {
 				tracing::warn!(%err, "connection closed");
 			}

--- a/rs/moq-relay/src/task.rs
+++ b/rs/moq-relay/src/task.rs
@@ -1,0 +1,59 @@
+//! Relay-side task categories and the SIGUSR2 snapshot handler.
+//!
+//! New categories for detached tasks spawned by `moq-relay` live here. The
+//! [`run`] future listens for `SIGUSR2` and logs a snapshot of every tracked
+//! category (both moq-lite and moq-relay), and also passively logs the same
+//! snapshot every 10 minutes so slow leaks are visible from the journal
+//! without operator intervention.
+//!
+//! Trigger an on-demand dump with:
+//!
+//! ```sh
+//! systemctl kill -s SIGUSR2 moq-relay
+//! # or
+//! kill -USR2 $(pidof moq-relay)
+//! ```
+
+use std::time::Duration;
+
+use moq_lite::task::Category;
+
+/// The accept-loop task spawned per incoming QUIC/WebTransport connection.
+pub static CONNECTION: Category = Category::new("moq-relay/connection");
+
+/// Per-remote-cluster-node connection task (`Cluster::run_remote`).
+pub static CLUSTER_REMOTE: Category = Category::new("moq-relay/cluster-remote");
+
+/// Background TLS certificate reload watcher (`Web::reload_certs`).
+pub static CERT_RELOAD: Category = Category::new("moq-relay/cert-reload");
+
+/// Listen for SIGUSR2 and log the current task snapshot. Also logs the
+/// snapshot passively every 10 minutes.
+pub async fn run() -> anyhow::Result<()> {
+	let mut sig = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined2())?;
+
+	// 10 minutes between passive dumps — cheap enough to leave on, noisy
+	// enough to catch a leak within an alert window.
+	let mut ticker = tokio::time::interval(Duration::from_secs(600));
+	// `interval` fires immediately on the first tick; we want the first
+	// passive dump to land 10 minutes after startup, not at t=0.
+	ticker.tick().await;
+
+	loop {
+		tokio::select! {
+			_ = sig.recv() => {
+				tracing::info!("task snapshot requested (SIGUSR2)");
+				log_snapshot();
+			}
+			_ = ticker.tick() => {
+				log_snapshot();
+			}
+		}
+	}
+}
+
+fn log_snapshot() {
+	for entry in moq_lite::task::snapshot() {
+		tracing::info!(target: "task_snapshot", %entry);
+	}
+}

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -126,7 +126,7 @@ impl Web {
 			let config = axum_server::tls_rustls::RustlsConfig::from_pem_file(cert.clone(), key.clone()).await?;
 
 			#[cfg(unix)]
-			tokio::spawn(reload_certs(config.clone(), cert, key));
+			crate::task::CERT_RELOAD.spawn(reload_certs(config.clone(), cert, key));
 
 			let server = axum_server::bind_rustls(listen, config);
 			Some(server.serve(app))


### PR DESCRIPTION
## Summary

Adds diagnostic task-category profiling so we can answer "which class of detached task is piling up?" without eyeballing a jemalloc heap dump. This is the proactive follow-up to PR #1286 — that one fixed a specific `run_send_bandwidth` leak; this one makes the next such leak obvious within minutes instead of hours.

- New `moq_lite::task` module exposes a typed `Category` handle plus `spawn` / `snapshot` / `snapshot_raw` / `TaskSnapshot`.
- Each `Category` is a `pub static` with a lazily-initialised `tokio_metrics::TaskMonitor`. The typed handle means typos fail at compile time and there's no per-spawn hash lookup — first use registers self in a global `Mutex<Vec<&'static Category>>`, subsequent spawns are lock-free.
- `moq_relay::task::run()` listens for `SIGUSR2` and logs the snapshot on demand, and also logs passively every 10 minutes so slow leaks are visible from the journal without operator intervention. Wired into `main.rs` alongside the existing `SIGUSR1` jemalloc handler.
- All 21 `web_async::spawn` sites in `rs/moq-lite/src/` migrated to `crate::task::<CATEGORY>.spawn(...)`. The 3 `tokio::spawn` sites in moq-relay (connection loop, cluster remote, cert reload) are migrated to their own relay-side categories.
- No ``RUSTFLAGS=\"--cfg tokio_unstable\"`` needed — ``TaskMonitor::instrument`` works on stable tokio. (That was the pitfall that killed ``web-async``'s earlier ``spawn_named`` attempt.)
- ``web-async`` itself is untouched — ``Lock<T>`` and ``FuturesExt`` are still used inside moq-lite.

Bumps ``moq-lite`` ``0.15.11 → 0.15.12``. Adds ``tokio-metrics = \"0.5\"`` as a direct dep on moq-lite.

### Output shape

A snapshot line looks like (one per category):

\`\`\`
moq-lite/bandwidth                       live=   42 spawned=    1203 dropped=    1161 slow=   2 poll_us=   12
moq-lite/lite-session                    live=   42 spawned=    1203 dropped=    1161 slow=   0 poll_us=   18
moq-relay/connection                     live=   42 spawned=    1203 dropped=    1161 slow=   0 poll_us=    9
...
\`\`\`

On a memory alert the operator runs \`journalctl -u moq-relay | grep task_snapshot | tail\` — any category whose \`live\` is monotonically climbing is the leak.

## Out of scope

- Test-only \`tokio::spawn\` sites in \`moq-native\`, \`moq-lite/lite/priority\` tests, \`hang\`/\`moq-mux\` per-group finishers. They're noise for leak detection; add in a follow-up if ever needed.
- Removing \`web-async\` entirely. Out of scope because \`Lock<T>\` and \`FuturesExt\` are still used.
- \`console-subscriber\` / tokio-console live inspection. Layer on later if cumulative snapshots aren't enough.

## Test plan

- [x] \`cargo test -p moq-lite task::\` — \`snapshot_tracks_live_count\` passes (live count = 1 for a blocked task, 0 for an instantly-finished one)
- [x] \`just check\` passes (rustdoc intra-doc links, clippy, biome, etc.)
- [ ] Local smoke: run \`moq-relay\` + \`moq-clock pub\` + \`moq-clock sub\`, \`kill -USR2 \$(pgrep moq-relay)\`, eyeball \`task_snapshot\` lines in stderr showing \`moq-lite/bandwidth live=2\`, \`moq-lite/lite-session live=2\`, \`moq-relay/connection live=2\`. Kill the clock processes and re-signal, confirm they drop to 0.
- [ ] Deploy to one cdn relay via \`just deploy use\`, wait 10 min, \`ssh root@use.cdn.moq.dev journalctl -u moq-relay | grep task_snapshot\`, eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)