### PR TITLE
Refactor publish stats logging to use structured logging

### DIFF
--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -151,15 +151,25 @@ impl Publish {
 		let delta = &current - prev;
 		let secs = elapsed.as_secs_f64();
 
-		let fps = (delta.frames as f64 / secs).round() as u64;
-		let bps = (delta.bytes as f64 * 8.0 / secs).round() as u64;
-		let drift_ms = delta
-			.drift
-			.mean()
-			.map(|d| d.as_secs_f64() * 1000.0)
-			.unwrap_or(f64::NAN);
+		let fps = delta.frames as f64 / secs;
+		let bps = delta.bytes as f64 * 8.0 / secs;
 
-		tracing::info!(fps, bps, drift_ms, "stats");
+		let frames = format!("{:.0}/s", fps);
+
+		let bitrate = if bps >= 1_000_000.0 {
+			format!("{:.1} Mbps", bps / 1_000_000.0)
+		} else if bps >= 1_000.0 {
+			format!("{:.1} Kbps", bps / 1_000.0)
+		} else {
+			format!("{:.0} bps", bps)
+		};
+
+		let drift = match delta.drift.mean() {
+			Some(mean) => format!("{:.1}ms", mean.as_secs_f64() * 1000.0),
+			None => "n/a".to_string(),
+		};
+
+		tracing::info!(frames, bitrate, drift, "stats");
 
 		*prev = current;
 	}

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -151,23 +151,15 @@ impl Publish {
 		let delta = &current - prev;
 		let secs = elapsed.as_secs_f64();
 
-		let fps = delta.frames as f64 / secs;
-		let bps = delta.bytes as f64 * 8.0 / secs;
+		let fps = (delta.frames as f64 / secs).round() as u64;
+		let bps = (delta.bytes as f64 * 8.0 / secs).round() as u64;
+		let drift_ms = delta
+			.drift
+			.mean()
+			.map(|d| d.as_secs_f64() * 1000.0)
+			.unwrap_or(f64::NAN);
 
-		let drift_str = match delta.drift.mean() {
-			Some(mean) => format!("μ={:.1}ms", mean.as_secs_f64() * 1000.0),
-			None => "n/a".to_string(),
-		};
-
-		let bitrate_str = if bps >= 1_000_000.0 {
-			format!("{:.1} Mbps", bps / 1_000_000.0)
-		} else if bps >= 1_000.0 {
-			format!("{:.1} Kbps", bps / 1_000.0)
-		} else {
-			format!("{:.0} bps", bps)
-		};
-
-		eprintln!("frames: {:.0}/s  bitrate: {}  drift: {}", fps, bitrate_str, drift_str);
+		tracing::info!(fps, bps, drift_ms, "stats");
 
 		*prev = current;
 	}


### PR DESCRIPTION
## Summary
Refactored the statistics logging in the publish module to use structured logging via the `tracing` crate instead of manual string formatting and `eprintln!`.

## Key Changes
- Replaced manual string formatting for FPS, bitrate, and drift statistics with direct numeric values
- Changed from `eprintln!` to `tracing::info!` for structured logging output
- Simplified bitrate calculation by removing multi-unit formatting (Mbps/Kbps/bps) in favor of raw bps value
- Converted floating-point calculations to rounded integers for cleaner numeric output
- Replaced conditional drift formatting with `map().unwrap_or(f64::NAN)` for consistency

## Implementation Details
- FPS and BPS are now rounded to integers before logging
- Drift is logged as milliseconds (f64) with NaN as the fallback value when unavailable
- The structured logging approach allows for better filtering and processing of metrics by logging infrastructure

https://claude.ai/code/session_01VRQxcZwpWp9hHC6cpf28an