### PR TITLE
chore(@moq/watch): bump patch to 0.2.6

### DIFF
--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",


### PR DESCRIPTION
## Summary
- Bump `@moq/watch` from 0.2.5 to 0.2.6 to release the audio ring-buffer fixes, jitter overhead, and sync revert that landed in #1291.

## Test plan
- [ ] CI green