### PR TITLE
use generated name if no sink pad name provided

### DIFF
--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -234,7 +234,7 @@ impl ElementImpl for MoqSink {
 		let pad = if let Some(name) = name {
 			pad_builder.name(name).build()
 		} else {
-			pad_builder.build()
+			pad_builder.generated_name().build()
 		};
 
 		self.obj().add_pad(&pad).ok()?;


### PR DESCRIPTION
This lets you construct pipelines without specifying the pad name on moqsink(eg. `mux.sink_0` in the `demo/pub` Justfile).

eg. 

```
gst-launch-1.0 -v -e videotestsrc ! video/x-raw,width=1280,height=720,framerate=60/1,format=I420 ! x264enc ! moqsink name=mux url="https://cdn.moq.dev/anon" broadcast="videotestsrc"
```

Without this, the above pipeline will panic.

```
thread '<unnamed>' panicked at rs/moq-gst/src/sink/imp.rs:237:25:
Attempt to build a Pad from a wildcard-name template or with a target Pad with an incompatible name. Make sure to define a specific name using PadBuilder or opt-in to keep the automatically generated name.
```