### PR TITLE
fix: add `sideEffects` to some js libraries

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -5,6 +5,7 @@
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",
+	"sideEffects": false,
 	"exports": {
 		".": "./src/index.ts",
 		"./catalog": "./src/catalog/index.ts",

--- a/js/lite/package.json
+++ b/js/lite/package.json
@@ -5,6 +5,7 @@
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",
+	"sideEffects": false,
 	"exports": {
 		".": "./src/index.ts",
 		"./zod": "./src/zod.ts"

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -5,6 +5,7 @@
 	"description": "Reactive and safe signals",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",
+	"sideEffects": false,
 	"exports": {
 		".": "./src/index.ts",
 		"./solid": "./src/solid.ts",
@@ -28,6 +29,9 @@
 		"solid-js": "^1.9.7"
 	},
 	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		},
 		"react": {
 			"optional": true
 		},

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -5,6 +5,7 @@
 	"description": "Media over QUIC - Token Generation and Validation",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",
+	"sideEffects": false,
 	"exports": {
 		".": "./src/index.ts"
 	},


### PR DESCRIPTION
i saw that `@moq/lite` was missing this flag, causing rolldown to bundle 60kb of extra code that can be pruned if it knows it has no side effects.

i also added it to other libraries that from what i can tell have no side effects