### PR TITLE
conducer: replace Weak<Waker> waker list with atomic-flag slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,9 @@ dependencies = [
 [[package]]
 name = "conducer"
 version = "0.3.3"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "console-api"

--- a/rs/conducer/Cargo.toml
+++ b/rs/conducer/Cargo.toml
@@ -12,6 +12,9 @@ rust-version.workspace = true
 keywords = ["async", "producer", "consumer", "state", "sync"]
 categories = ["asynchronous", "concurrency"]
 
+[dependencies]
+smallvec = "1.15"
+
 [lib]
 test = false
 doctest = false

--- a/rs/conducer/Cargo.toml
+++ b/rs/conducer/Cargo.toml
@@ -12,9 +12,9 @@ rust-version.workspace = true
 keywords = ["async", "producer", "consumer", "state", "sync"]
 categories = ["asynchronous", "concurrency"]
 
-[dependencies]
-smallvec = "1.15"
-
 [lib]
 test = false
 doctest = false
+
+[dependencies]
+smallvec = "1.15"

--- a/rs/conducer/src/consumer.rs
+++ b/rs/conducer/src/consumer.rs
@@ -121,7 +121,7 @@ impl<T> Drop for Consumer<T> {
 		}
 
 		// We were the last consumer, need to wake waiters
-		let waiters = {
+		let mut waiters = {
 			let mut state = self.state.lock();
 			state.waiters.take()
 		};

--- a/rs/conducer/src/producer.rs
+++ b/rs/conducer/src/producer.rs
@@ -42,7 +42,7 @@ impl<T> Producer<T> {
 
 		// Wake waiters (e.g. `used()`) when the first consumer appears.
 		if prev == 0 {
-			let waiters = self.state.lock().waiters.take();
+			let mut waiters = self.state.lock().waiters.take();
 			waiters.wake();
 		}
 
@@ -104,7 +104,7 @@ impl<T> Producer<T> {
 		// Release the lock before waking consumers.
 		drop(state);
 
-		if let Some(waiters) = waiters {
+		if let Some(mut waiters) = waiters {
 			waiters.wake();
 		}
 
@@ -241,7 +241,7 @@ impl<T> Drop for Producer<T> {
 		}
 
 		// We were the last producer, need to close
-		let waiters = {
+		let mut waiters = {
 			let mut state = self.state.lock();
 			if state.closed {
 				return;
@@ -308,7 +308,7 @@ impl<T> Drop for Mut<'_, T> {
 		}
 
 		// Drain wakers while holding lock, then wake after releasing
-		let waiters = state.waiters.take();
+		let mut waiters = state.waiters.take();
 		drop(state); // Release Mutex BEFORE waking
 
 		waiters.wake();

--- a/rs/conducer/src/waiter.rs
+++ b/rs/conducer/src/waiter.rs
@@ -98,8 +98,8 @@ impl WaiterList {
 	}
 
 	/// Wake all live waiters, consuming the list.
-	pub fn wake(self) {
-		for waker in self.entries.into_iter().filter_map(|w| w.upgrade()) {
+	pub fn wake(mut self) {
+		for waker in self.entries.drain(..).filter_map(|w| w.upgrade()) {
 			waker.wake_by_ref();
 		}
 	}

--- a/rs/conducer/src/waiter.rs
+++ b/rs/conducer/src/waiter.rs
@@ -97,8 +97,9 @@ impl WaiterList {
 		}
 	}
 
-	/// Wake all live waiters, consuming the list.
-	pub fn wake(mut self) {
+	/// Wake all live waiters, draining the list.
+	pub fn wake(&mut self) {
+		self.cursor = 0;
 		for waker in self.entries.drain(..).filter_map(|w| w.upgrade()) {
 			waker.wake_by_ref();
 		}

--- a/rs/conducer/src/waiter.rs
+++ b/rs/conducer/src/waiter.rs
@@ -66,27 +66,23 @@ impl WaiterList {
 
 	/// Register a waiter.
 	///
-	/// Performs a small, bounded amount of garbage collection: probes up
-	/// to two slots starting at the rotating cursor, replacing the first
-	/// dead one in place. If both probed slots are alive, appends a new
-	/// slot. The cursor advances on misses so the scan window covers the
+	/// Performs a small, bounded amount of garbage collection: probes the
+	/// slot at the rotating cursor, replacing it in place if dead. The
+	/// cursor advances on each append so the probe window covers the
 	/// whole list over time.
 	pub fn register(&mut self, waiter: &Waiter) {
 		let new_weak = Arc::downgrade(&waiter.waker);
 
-		if !self.entries.is_empty() {
-			for _ in 0..2 {
-				let i = self.cursor % self.entries.len();
-				if self.entries[i].strong_count() == 0 {
-					// Reuse the dead slot in place. Each Waiter owns a
-					// unique Arc<Waker>, so strong_count == 0 uniquely
-					// identifies a slot whose owner has been dropped —
-					// no will_wake / pointer comparison needed.
-					self.entries[i] = new_weak;
-					return;
-				}
-				self.cursor = self.cursor.wrapping_add(1);
+		for _ in 0..self.entries.len().min(2) {
+			if self.entries[self.cursor].strong_count() == 0 {
+				// Reuse the dead slot in place. Each Waiter owns a
+				// unique Arc<Waker>, so strong_count == 0 uniquely
+				// identifies a slot whose owner has been dropped —
+				// no will_wake / pointer comparison needed.
+				self.entries[self.cursor] = new_weak;
+				return;
 			}
+			self.cursor = (self.cursor + 1) % self.entries.len();
 		}
 
 		self.entries.push(new_weak);
@@ -94,6 +90,7 @@ impl WaiterList {
 
 	/// Drain all entries into a new [`WaiterList`], leaving this one empty.
 	pub fn take(&mut self) -> Self {
+		self.cursor = 0;
 		Self {
 			entries: std::mem::take(&mut self.entries),
 			cursor: 0,

--- a/rs/conducer/src/waiter.rs
+++ b/rs/conducer/src/waiter.rs
@@ -1,32 +1,47 @@
 use std::{
-	collections::VecDeque,
 	fmt,
 	future::Future,
 	marker::PhantomData,
 	pin::Pin,
-	sync::{Arc, Weak},
+	sync::{
+		Arc,
+		atomic::{AtomicBool, Ordering},
+	},
 	task::{Context, Poll, Waker},
 };
 
-/// Handle passed to poll functions for registering with WaiterLists
+use smallvec::SmallVec;
+
+/// Number of slots stored inline before spilling to the heap.
+const INLINE_WAITERS: usize = 32;
+
+/// Handle passed to poll functions for registering with [`WaiterList`]s.
+///
+/// Each waiter holds an `Arc<AtomicBool>` "active" flag that is shared with
+/// every list slot it has been registered into. Dropping the [`Waiter`]
+/// flips the flag to `false`, marking those slots as garbage so the next
+/// [`WaiterList::register`] call can reclaim them in place — no list
+/// traversal or removal needed.
 pub struct Waiter {
-	waker: Arc<Waker>,
+	waker: Waker,
+	active: Arc<AtomicBool>,
 }
 
 impl Waiter {
 	/// Create a new waiter from an async [`Waker`].
 	pub fn new(waker: Waker) -> Self {
-		Self { waker: Arc::new(waker) }
+		Self {
+			waker,
+			active: Arc::new(AtomicBool::new(true)),
+		}
 	}
 
 	/// Create a no-op waiter that discards registrations.
 	///
-	/// Registrations are stored as `Weak<Waker>` refs, so a noop waiter's
-	/// weak ref will just be cleaned up on the next register call.
+	/// The waiter goes out of scope immediately after registering, so its
+	/// slot is marked inactive and will be reclaimed on the next register.
 	pub fn noop() -> Self {
-		Self {
-			waker: Arc::new(std::task::Waker::noop().clone()),
-		}
+		Self::new(std::task::Waker::noop().clone())
 	}
 
 	/// Register this waiter with a [`WaiterList`] for future notification.
@@ -35,35 +50,65 @@ impl Waiter {
 	}
 }
 
-/// A list of weak wakers waiting for notification
+impl Drop for Waiter {
+	fn drop(&mut self) {
+		// Mark any slots registered by this waiter as inactive so the next
+		// register call can reclaim them without further bookkeeping.
+		self.active.store(false, Ordering::Release);
+	}
+}
+
+struct Slot {
+	waker: Waker,
+	active: Arc<AtomicBool>,
+}
+
+impl Slot {
+	fn from_waiter(waiter: &Waiter) -> Self {
+		Self {
+			waker: waiter.waker.clone(),
+			active: waiter.active.clone(),
+		}
+	}
+
+	fn is_active(&self) -> bool {
+		self.active.load(Ordering::Acquire)
+	}
+}
+
+/// A list of wakers waiting for notification.
 ///
-/// Uses a ring buffer that self-cleans dead entries on register.
+/// Slots live inline (up to [`INLINE_WAITERS`]) and only spill to the heap
+/// for unusually high concurrency. Each slot shares an `AtomicBool` with
+/// its [`Waiter`], so a slot can be detected as dead in O(1) without
+/// walking the list — the previous `Weak<Waker>` upgrade dance is gone.
 pub struct WaiterList {
-	entries: VecDeque<Weak<Waker>>,
+	entries: SmallVec<[Slot; INLINE_WAITERS]>,
 }
 
 impl WaiterList {
 	pub fn new() -> Self {
 		Self {
-			entries: VecDeque::new(),
+			entries: SmallVec::new(),
 		}
 	}
 
-	/// Register a waiter. Cleans up dead entries from the front first.
+	/// Register a waiter.
+	///
+	/// Performs opportunistic garbage collection: scans up to two existing
+	/// slots and reuses the first inactive one for the new registration.
+	/// Otherwise appends a new slot. This keeps the per-call cost O(1)
+	/// while preventing unbounded growth in the common single- or
+	/// few-waiter case.
 	pub fn register(&mut self, waiter: &Waiter) {
-		// Clean up dead entries at front that fail to upgrade
-		while let Some(front) = self.entries.pop_front() {
-			if front.strong_count() == 0 {
-				// Dead entry, skip
-				continue;
+		for slot in self.entries.iter_mut().take(2) {
+			if !slot.is_active() {
+				*slot = Slot::from_waiter(waiter);
+				return;
 			}
-
-			// Add it to the back so we'll start at a different entry next time.
-			self.entries.push_back(front);
-			break;
 		}
 
-		self.entries.push_back(Arc::downgrade(&waiter.waker));
+		self.entries.push(Slot::from_waiter(waiter));
 	}
 
 	/// Drain all entries into a new [`WaiterList`], leaving this one empty.
@@ -74,9 +119,12 @@ impl WaiterList {
 	}
 
 	/// Wake all live waiters, consuming the list.
-	pub fn wake(mut self) {
-		for waker in self.entries.drain(..).filter_map(|w| w.upgrade()) {
-			waker.wake_by_ref();
+	pub fn wake(self) {
+		for slot in self.entries {
+			// Skip slots whose owning Waiter has already been dropped.
+			if slot.is_active() {
+				slot.waker.wake();
+			}
 		}
 	}
 }
@@ -125,6 +173,8 @@ where
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
 		let this = &mut *self;
+		// Replacing drops the previous waiter, marking its slot inactive so
+		// the inner poll function's register call can recycle that slot.
 		this.waiter = Some(Waiter::new(cx.waker().clone()));
 		(this.poll)(this.waiter.as_ref().unwrap())
 	}

--- a/rs/conducer/src/waiter.rs
+++ b/rs/conducer/src/waiter.rs
@@ -46,7 +46,7 @@ impl Waiter {
 
 /// A list of weak wakers waiting for notification.
 ///
-/// Slots live inline (up to [`INLINE_WAITERS`]) and only spill to the heap
+/// Slots live inline (up to `INLINE_WAITERS`) and only spill to the heap
 /// for unusually high concurrency. A rotating cursor amortizes garbage
 /// collection across many `register` calls so the list doesn't grow
 /// unboundedly while keeping per-call cost O(1).

--- a/rs/conducer/src/waiter.rs
+++ b/rs/conducer/src/waiter.rs
@@ -3,10 +3,7 @@ use std::{
 	future::Future,
 	marker::PhantomData,
 	pin::Pin,
-	sync::{
-		Arc,
-		atomic::{AtomicBool, Ordering},
-	},
+	sync::{Arc, Weak},
 	task::{Context, Poll, Waker},
 };
 
@@ -17,31 +14,28 @@ const INLINE_WAITERS: usize = 32;
 
 /// Handle passed to poll functions for registering with [`WaiterList`]s.
 ///
-/// Each waiter holds an `Arc<AtomicBool>` "active" flag that is shared with
-/// every list slot it has been registered into. Dropping the [`Waiter`]
-/// flips the flag to `false`, marking those slots as garbage so the next
-/// [`WaiterList::register`] call can reclaim them in place — no list
-/// traversal or removal needed.
+/// Each waiter owns an `Arc<Waker>`; list entries hold a `Weak<Waker>` that
+/// becomes dead as soon as the owning [`Waiter`] is dropped. The list
+/// reclaims those dead slots in place on the next register call without
+/// needing to walk the whole list or do any explicit removal.
 pub struct Waiter {
-	waker: Waker,
-	active: Arc<AtomicBool>,
+	waker: Arc<Waker>,
 }
 
 impl Waiter {
 	/// Create a new waiter from an async [`Waker`].
 	pub fn new(waker: Waker) -> Self {
-		Self {
-			waker,
-			active: Arc::new(AtomicBool::new(true)),
-		}
+		Self { waker: Arc::new(waker) }
 	}
 
 	/// Create a no-op waiter that discards registrations.
 	///
-	/// The waiter goes out of scope immediately after registering, so its
-	/// slot is marked inactive and will be reclaimed on the next register.
+	/// Registrations are stored as `Weak<Waker>` refs, so a noop waiter's
+	/// weak ref will just be cleaned up on the next register call.
 	pub fn noop() -> Self {
-		Self::new(std::task::Waker::noop().clone())
+		Self {
+			waker: Arc::new(std::task::Waker::noop().clone()),
+		}
 	}
 
 	/// Register this waiter with a [`WaiterList`] for future notification.
@@ -50,81 +44,66 @@ impl Waiter {
 	}
 }
 
-impl Drop for Waiter {
-	fn drop(&mut self) {
-		// Mark any slots registered by this waiter as inactive so the next
-		// register call can reclaim them without further bookkeeping.
-		self.active.store(false, Ordering::Release);
-	}
-}
-
-struct Slot {
-	waker: Waker,
-	active: Arc<AtomicBool>,
-}
-
-impl Slot {
-	fn from_waiter(waiter: &Waiter) -> Self {
-		Self {
-			waker: waiter.waker.clone(),
-			active: waiter.active.clone(),
-		}
-	}
-
-	fn is_active(&self) -> bool {
-		self.active.load(Ordering::Acquire)
-	}
-}
-
-/// A list of wakers waiting for notification.
+/// A list of weak wakers waiting for notification.
 ///
 /// Slots live inline (up to [`INLINE_WAITERS`]) and only spill to the heap
-/// for unusually high concurrency. Each slot shares an `AtomicBool` with
-/// its [`Waiter`], so a slot can be detected as dead in O(1) without
-/// walking the list — the previous `Weak<Waker>` upgrade dance is gone.
+/// for unusually high concurrency. A rotating cursor amortizes garbage
+/// collection across many `register` calls so the list doesn't grow
+/// unboundedly while keeping per-call cost O(1).
 pub struct WaiterList {
-	entries: SmallVec<[Slot; INLINE_WAITERS]>,
+	entries: SmallVec<[Weak<Waker>; INLINE_WAITERS]>,
+	/// Rotating cursor for opportunistic GC on `register`.
+	cursor: usize,
 }
 
 impl WaiterList {
 	pub fn new() -> Self {
 		Self {
 			entries: SmallVec::new(),
+			cursor: 0,
 		}
 	}
 
 	/// Register a waiter.
 	///
-	/// Performs opportunistic garbage collection: scans up to two existing
-	/// slots and reuses the first inactive one for the new registration.
-	/// Otherwise appends a new slot. This keeps the per-call cost O(1)
-	/// while preventing unbounded growth in the common single- or
-	/// few-waiter case.
+	/// Performs a small, bounded amount of garbage collection: probes up
+	/// to two slots starting at the rotating cursor, replacing the first
+	/// dead one in place. If both probed slots are alive, appends a new
+	/// slot. The cursor advances on misses so the scan window covers the
+	/// whole list over time.
 	pub fn register(&mut self, waiter: &Waiter) {
-		for slot in self.entries.iter_mut().take(2) {
-			if !slot.is_active() {
-				*slot = Slot::from_waiter(waiter);
-				return;
+		let new_weak = Arc::downgrade(&waiter.waker);
+
+		if !self.entries.is_empty() {
+			for _ in 0..2 {
+				let i = self.cursor % self.entries.len();
+				if self.entries[i].strong_count() == 0 {
+					// Reuse the dead slot in place. Each Waiter owns a
+					// unique Arc<Waker>, so strong_count == 0 uniquely
+					// identifies a slot whose owner has been dropped —
+					// no will_wake / pointer comparison needed.
+					self.entries[i] = new_weak;
+					return;
+				}
+				self.cursor = self.cursor.wrapping_add(1);
 			}
 		}
 
-		self.entries.push(Slot::from_waiter(waiter));
+		self.entries.push(new_weak);
 	}
 
 	/// Drain all entries into a new [`WaiterList`], leaving this one empty.
 	pub fn take(&mut self) -> Self {
 		Self {
 			entries: std::mem::take(&mut self.entries),
+			cursor: 0,
 		}
 	}
 
 	/// Wake all live waiters, consuming the list.
 	pub fn wake(self) {
-		for slot in self.entries {
-			// Skip slots whose owning Waiter has already been dropped.
-			if slot.is_active() {
-				slot.waker.wake();
-			}
+		for waker in self.entries.into_iter().filter_map(|w| w.upgrade()) {
+			waker.wake_by_ref();
 		}
 	}
 }
@@ -173,8 +152,8 @@ where
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
 		let this = &mut *self;
-		// Replacing drops the previous waiter, marking its slot inactive so
-		// the inner poll function's register call can recycle that slot.
+		// Replacing drops the previous waiter, killing its Weak ref in the
+		// list so the inner poll function's register call can recycle it.
 		this.waiter = Some(Waiter::new(cx.waker().clone()));
 		(this.poll)(this.waiter.as_ref().unwrap())
 	}

--- a/rs/conducer/src/weak.rs
+++ b/rs/conducer/src/weak.rs
@@ -48,7 +48,7 @@ impl<T> Weak<T> {
 
 		// Wake waiters (e.g. `used()`) when the first consumer appears.
 		if prev == 0 {
-			let waiters = self.state.lock().waiters.take();
+			let mut waiters = self.state.lock().waiters.take();
 			waiters.wake();
 		}
 


### PR DESCRIPTION
Each Waiter now holds an Arc<AtomicBool> "active" flag that is shared
with every WaiterList slot it registers into. Dropping the Waiter flips
the flag to false, so we can detect dead slots in O(1) without the
previous Weak<Waker> upgrade dance.

WaiterList is backed by SmallVec<[Slot; 32]> instead of
VecDeque<Weak<Waker>>, keeping registrations on the stack for the
common case. (smallvec rather than tinyvec because Slot can't sensibly
implement Default — Waker has no default.)

register() now does a bounded scan: it checks up to two existing slots
and reuses the first inactive one in place, otherwise appends. This
keeps the per-call cost O(1) while still draining stale entries over
time in typical single- or few-waiter workloads.