### PR TITLE
Add macOS to Cachix build matrix

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -9,10 +9,16 @@ on:
 
 jobs:
   cache:
-    name: Build and push to Cachix
-    runs-on: ubuntu-latest
+    name: Build and push to Cachix (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Extended the Cachix CI workflow to build and cache artifacts on multiple operating systems, adding macOS support alongside the existing Ubuntu builds.

## Key Changes
- Modified the `cache` job to use a matrix strategy with `ubuntu-latest` and `macos-latest`
- Updated the job name to dynamically display the OS being tested: `Build and push to Cachix (${{ matrix.os }})`
- Changed `runs-on` from a static `ubuntu-latest` to use the matrix variable `${{ matrix.os }}`
- Added `fail-fast: false` to ensure all matrix jobs complete even if one fails

## Implementation Details
- The matrix strategy allows the same workflow job to run on multiple operating systems in parallel
- This enables building and caching Nix packages for both Linux and macOS environments
- The `fail-fast: false` setting ensures comprehensive testing across all platforms regardless of individual failures

https://claude.ai/code/session_01Urh4XGFQDLsJHQbtitUfWv