### PR TITLE
fix: Safari/Firefox moq-boy compatibility

### DIFF
--- a/demo/boy/src/index.ts
+++ b/demo/boy/src/index.ts
@@ -9,7 +9,7 @@ if (boy) boy.url = url;
 const about = document.getElementById("about");
 if (boy && about) {
 	const effect = new Effect();
-	effect.run(() => {
-		about.hidden = effect.get(boy.expanded) !== undefined;
+	effect.run((inner) => {
+		about.hidden = inner.get(boy.expanded) !== undefined;
 	});
 }

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": {

--- a/js/moq-boy/src/ui/styles/card.css
+++ b/js/moq-boy/src/ui/styles/card.css
@@ -5,8 +5,9 @@
 	border-radius: var(--spacing-8);
 	overflow: hidden;
 	cursor: pointer;
-	transition: all 0.3s ease;
+	transition: border-color 0.3s ease;
 	width: 320px;
+	height: auto;
 	aspect-ratio: 10 / 9;
 }
 

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.6",
+	"version": "0.2.7",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -102,10 +102,13 @@ export class Decoder {
 			// Ensure the context is running before creating the worklet
 			if (context.state === "closed") return;
 
-			// Create the worklet node
+			// Create the worklet node. outputChannelCount must be set explicitly
+			// so the process() callback receives a matching channel layout —
+			// Firefox defaults differently than Chrome otherwise.
 			const worklet = new AudioWorkletNode(context, "render", {
 				channelCount,
 				channelCountMode: "explicit",
+				outputChannelCount: [channelCount],
 			});
 			effect.cleanup(() => worklet.disconnect());
 

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -345,8 +345,11 @@ export class Decoder {
 		// Add to decode buffer
 		this.#addDecodeBuffered(timestampMilli, end);
 
+		// Firefox's Opus decoder sometimes outputs more channels than requested
+		// (e.g. 6 for stereo). Clamp to the ring's channel count.
+		const channels = Math.min(sample.numberOfChannels, ring.channels);
 		const channelData: Float32Array[] = [];
-		for (let channel = 0; channel < sample.numberOfChannels; channel++) {
+		for (let channel = 0; channel < channels; channel++) {
 			const data = new Float32Array(sample.numberOfFrames);
 			sample.copyTo(data, { format: "f32-planar", planeIndex: channel });
 			channelData.push(data);

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -500,5 +500,23 @@ async function supported(config: Catalog.VideoConfig): Promise<boolean> {
 		optimizeForLatency: config.optimizeForLatency ?? true,
 	});
 
-	return supported ?? false;
+	if (supported) return true;
+
+	// Safari rejects `avc3.*` codec strings even though its H.264 decoder handles
+	// inline SPS/PPS. Rewrite to `avc1.*` and retry; mutate config.codec so the
+	// later `decoder.configure()` call uses the accepted string too.
+	if (config.codec.startsWith("avc3.")) {
+		const avc1 = `avc1.${config.codec.slice("avc3.".length)}`;
+		const retry = await VideoDecoder.isConfigSupported({
+			codec: avc1,
+			description,
+			optimizeForLatency: config.optimizeForLatency ?? true,
+		});
+		if (retry.supported) {
+			config.codec = avc1;
+			return true;
+		}
+	}
+
+	return false;
 }


### PR DESCRIPTION
## Summary
- **Safari WebCodecs:** `VideoDecoder.isConfigSupported` rejects `avc3.*` codec strings. Retry with `avc1.*` and rewrite `config.codec` so `configure()` uses the accepted form. moq-boy's H.264 stream now plays on Safari.
- **Safari grid resize:** `transition: all 0.3s ease` on `.boy__card` left Safari stuck mid-transition on `height`/`aspect-ratio` when collapsing an expanded game. Narrow the transition to `border-color` and pin `height: auto`.
- **Firefox Opus:** Firefox's `AudioDecoder` occasionally emits 6-channel `AudioData` for a stereo Opus stream. Clamp to the ring's channel count (keeps L/R from the surround layout).
- **Effect closure:** Boy demo's expanded-watcher captured the outer `Effect` inside its callback; use the inner one.

## Test plan
- [ ] Safari: open moq-boy demo, confirm video plays (previously "No supported video renditions found")
- [ ] Safari: expand a game then collapse — card returns to grid size (previously stuck at height 100%)
- [ ] Firefox: audio plays without `wrong number of channels 6` errors
- [ ] Chrome: regression check — video + audio still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)