### PR TITLE
fix: disable WebTransport on Firefox, force WebSocket fallback

### DIFF
--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -33,6 +33,11 @@ export interface ConnectProps {
 // Save if WebSocket won the last race, so we won't give QUIC a head start next time.
 const websocketWon = new Set<string>();
 
+// Firefox's WebTransport implementation drops server-initiated bidi streams,
+// breaking publish (the relay opens a subscribe bidi back to us). Force WebSocket.
+// TODO: remove once Firefox fixes incoming bidi delivery.
+const isFirefox = typeof navigator !== "undefined" && navigator.userAgent.toLowerCase().includes("firefox");
+
 /**
  * Establishes a connection to a MOQ server.
  *
@@ -50,7 +55,8 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 		done = resolve;
 	});
 
-	const webtransport = globalThis.WebTransport ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
+	const webtransport =
+		globalThis.WebTransport && !isFirefox ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
 
 	// Give QUIC a 200ms head start to connect before trying WebSocket, unless WebSocket has won in the past.
 	// NOTE that QUIC should be faster because it involves 1/2 fewer RTTs.

--- a/js/publish/src/support/index.ts
+++ b/js/publish/src/support/index.ts
@@ -83,7 +83,9 @@ async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 
 export async function isSupported(): Promise<Full> {
 	return {
-		webtransport: typeof WebTransport !== "undefined" ? "full" : "partial",
+		// Firefox's WebTransport drops server-initiated bidi streams, so we force the
+		// WebSocket fallback. Report "partial" to surface the degraded path in UI.
+		webtransport: typeof WebTransport !== "undefined" ? (isFirefox ? "partial" : "full") : "partial",
 		audio: {
 			capture: typeof AudioWorkletNode !== "undefined",
 			encoding: {

--- a/js/watch/src/support/index.ts
+++ b/js/watch/src/support/index.ts
@@ -79,7 +79,9 @@ async function videoDecoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 
 export async function isSupported(): Promise<Full> {
 	return {
-		webtransport: typeof WebTransport !== "undefined" ? "full" : "partial",
+		// Firefox's WebTransport drops server-initiated bidi streams, so we force the
+		// WebSocket fallback. Report "partial" to surface the degraded path in UI.
+		webtransport: typeof WebTransport !== "undefined" ? (isFirefox ? "partial" : "full") : "partial",
 		audio: {
 			decoding: {
 				aac: await audioDecoderSupported("aac"),


### PR DESCRIPTION
## Summary
- Firefox's WebTransport drops server-initiated bidirectional streams, so the relay's subscribe-back path never reaches the client and publishes silently fail (e.g. moq-boy button input in production).
- Locally the bug is masked because Firefox falls back to WebSocket when the self-signed cert is rejected by WebTransport — only the prod (real cert) path exercises the broken transport.
- Force the WebSocket fallback for Firefox in `js/lite/src/connection/connect.ts` until upstream is fixed.
- Report `webtransport: "partial"` in the `@moq/watch` and `@moq/publish` capability checks so the degraded path is surfaced in UI.

Related Firefox bugs (similar pattern of neqo events not making it up to the WebTransport JS layer): [1872496](https://bugzilla.mozilla.org/show_bug.cgi?id=1872496), [1899812](https://bugzilla.mozilla.org/show_bug.cgi?id=1899812), [1814712](https://bugzilla.mozilla.org/show_bug.cgi?id=1814712). A focused minimal repro + new Bugzilla is the proper next step.

## Test plan
- [ ] Verify Firefox at moq.dev/boy: keyboard input now controls the game.
- [ ] Verify Chrome at moq.dev/boy: still uses WebTransport (no regression).
- [ ] Verify watch/publish UI shows the degraded WebTransport status on Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)