### PR TITLE
moq-token: default to base64url encoding for JWK output

### DIFF
--- a/rs/moq-token-cli/src/main.rs
+++ b/rs/moq-token-cli/src/main.rs
@@ -18,7 +18,7 @@ enum Commands {
 	/// Generate a new signing key.
 	///
 	/// A random key ID is assigned unless --id is specified.
-	/// Output is JSON by default; use --base64 for base64url encoding.
+	/// Output is base64url-encoded JSON.
 	Generate {
 		/// The algorithm to use.
 		#[arg(long, default_value = "HS256")]
@@ -43,10 +43,6 @@ enum Commands {
 		/// Write the public key to a directory as {kid}.jwk (asymmetric algorithms only).
 		#[arg(long, conflicts_with = "public")]
 		public_dir: Option<PathBuf>,
-
-		/// Output as base64url instead of JSON.
-		#[arg(long)]
-		base64: bool,
 	},
 
 	/// Sign a token, writing it to stdout.
@@ -88,12 +84,8 @@ enum Commands {
 	},
 }
 
-fn write_key(key: &moq_token::Key, path: &std::path::Path, base64: bool) -> anyhow::Result<()> {
-	if base64 {
-		Ok(key.to_file_base64url(path)?)
-	} else {
-		Ok(key.to_file(path)?)
-	}
+fn write_key(key: &moq_token::Key, path: &std::path::Path) -> anyhow::Result<()> {
+	Ok(key.to_file(path)?)
 }
 
 fn main() -> anyhow::Result<()> {
@@ -107,7 +99,6 @@ fn main() -> anyhow::Result<()> {
 			out_dir,
 			public,
 			public_dir,
-			base64,
 		} => {
 			let id = match id {
 				Some(id) => moq_token::KeyId::decode(&id)?,
@@ -118,19 +109,19 @@ fn main() -> anyhow::Result<()> {
 
 			if let Some(dir) = public_dir {
 				let path = dir.join(format!("{id}.jwk"));
-				write_key(&key.to_public()?, &path, base64)?;
+				write_key(&key.to_public()?, &path)?;
 			} else if let Some(path) = public {
-				write_key(&key.to_public()?, &path, base64)?;
+				write_key(&key.to_public()?, &path)?;
 			}
 
 			if let Some(dir) = out_dir {
 				let path = dir.join(format!("{id}.jwk"));
-				write_key(&key, &path, base64)?;
+				write_key(&key, &path)?;
 			} else if let Some(path) = out {
-				write_key(&key, &path, base64)?;
+				write_key(&key, &path)?;
 			} else {
-				let json = key.to_str()?;
-				println!("{json}");
+				let encoded = key.to_str()?;
+				println!("{encoded}");
 			}
 		}
 

--- a/rs/moq-token/src/key.rs
+++ b/rs/moq-token/src/key.rs
@@ -208,34 +208,30 @@ impl fmt::Debug for Key {
 }
 
 impl Key {
+	/// Parse a key from a string, auto-detecting JSON or base64url encoding.
 	#[allow(clippy::should_implement_trait)]
 	pub fn from_str(s: &str) -> crate::Result<Self> {
-		Ok(serde_json::from_str(s)?)
+		let s = s.trim();
+		if s.starts_with('{') {
+			Ok(serde_json::from_str(s)?)
+		} else {
+			let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(s)?;
+			let json = String::from_utf8(decoded)?;
+			Ok(serde_json::from_str(&json)?)
+		}
 	}
 
 	/// Load a key from a file, auto-detecting JSON or base64url encoding.
 	pub fn from_file<P: AsRef<StdPath>>(path: P) -> crate::Result<Self> {
 		let contents = std::fs::read_to_string(&path)?;
-		Self::from_encoded(&contents)
+		Self::from_str(&contents)
 	}
 
 	/// Async version of [`from_file`](Self::from_file), using `tokio::fs`.
 	#[cfg(feature = "tokio")]
 	pub async fn from_file_async<P: AsRef<StdPath>>(path: P) -> crate::Result<Self> {
 		let contents = tokio::fs::read_to_string(path).await?;
-		Self::from_encoded(&contents)
-	}
-
-	/// Parse a key from a string, auto-detecting JSON or base64url encoding.
-	fn from_encoded(contents: &str) -> crate::Result<Self> {
-		let contents = contents.trim();
-		if contents.starts_with('{') {
-			Ok(serde_json::from_str(contents)?)
-		} else {
-			let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(contents)?;
-			let json = String::from_utf8(decoded)?;
-			Ok(serde_json::from_str(&json)?)
-		}
+		Self::from_str(&contents)
 	}
 
 	/// Encode the key as base64url-encoded JSON.
@@ -577,16 +573,14 @@ mod tests {
 			panic!("Expected OCT key");
 		}
 
-		let key_str = key.to_str();
-		assert!(key_str.is_ok());
-		let key_str = key_str.unwrap();
+		let key_str = key.to_str().unwrap();
 
-		// After serializing again it must contain the kty
-		assert!(key_str.contains("\"alg\":\"HS256\""));
-		assert!(key_str.contains("\"key_ops\""));
-		assert!(key_str.contains("\"sign\""));
-		assert!(key_str.contains("\"verify\""));
-		assert!(key_str.contains("\"kty\":\"oct\""));
+		// Round-trip through from_str and verify fields
+		let loaded = Key::from_str(&key_str).unwrap();
+		assert_eq!(loaded.algorithm, Algorithm::HS256);
+		assert!(loaded.operations.contains(&KeyOperation::Sign));
+		assert!(loaded.operations.contains(&KeyOperation::Verify));
+		assert!(matches!(loaded.key, KeyType::OCT { .. }));
 	}
 
 	#[test]
@@ -598,13 +592,17 @@ mod tests {
 	#[test]
 	fn test_key_to_str() {
 		let key = create_test_key();
-		let json = key.to_str().unwrap();
-		assert!(json.contains("\"alg\":\"HS256\""));
-		assert!(json.contains("\"key_ops\""));
-		assert!(json.contains("\"sign\""));
-		assert!(json.contains("\"verify\""));
-		assert!(json.contains("\"kid\":\"test-key-1\""));
-		assert!(json.contains("\"kty\":\"oct\""));
+		let encoded = key.to_str().unwrap();
+
+		// Should be base64url, not raw JSON
+		assert!(!encoded.contains('{'));
+
+		// Round-trip through from_str
+		let loaded = Key::from_str(&encoded).unwrap();
+		assert_eq!(loaded.algorithm, Algorithm::HS256);
+		assert_eq!(loaded.kid, key.kid);
+		assert!(loaded.operations.contains(&KeyOperation::Sign));
+		assert!(loaded.operations.contains(&KeyOperation::Verify));
 	}
 
 	#[test]
@@ -1428,6 +1426,41 @@ mod tests {
 		let _: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
 		// Read key back from file
+		let loaded_key = Key::from_file(&temp_path).unwrap();
+		assert_eq!(loaded_key.algorithm, key.algorithm);
+		assert_eq!(loaded_key.operations, key.operations);
+		assert_eq!(loaded_key.kid, key.kid);
+
+		if let (
+			KeyType::OCT {
+				secret: original_secret,
+			},
+			KeyType::OCT { secret: loaded_secret },
+		) = (&key.key, &loaded_key.key)
+		{
+			assert_eq!(loaded_secret, original_secret);
+		} else {
+			panic!("Expected both keys to be OCT variant");
+		}
+
+		// Clean up
+		std::fs::remove_file(temp_path).ok();
+	}
+
+	#[test]
+	fn test_file_io_raw_json() {
+		let key = create_test_key();
+		let temp_dir = std::env::temp_dir();
+		let temp_path = temp_dir.join("test_jwk_raw_json.key");
+
+		// Write key as raw JSON (backwards compat format)
+		let json = serde_json::to_string(&key).unwrap();
+		std::fs::write(&temp_path, &json).unwrap();
+
+		// Verify it looks like JSON
+		assert!(json.starts_with('{'));
+
+		// Load via from_file (should auto-detect JSON)
 		let loaded_key = Key::from_file(&temp_path).unwrap();
 		assert_eq!(loaded_key.algorithm, key.algorithm);
 		assert_eq!(loaded_key.operations, key.operations);

--- a/rs/moq-token/src/key.rs
+++ b/rs/moq-token/src/key.rs
@@ -238,21 +238,15 @@ impl Key {
 		}
 	}
 
+	/// Encode the key as base64url-encoded JSON.
 	pub fn to_str(&self) -> crate::Result<String> {
-		Ok(serde_json::to_string(self)?)
-	}
-
-	/// Write the key to a file as JSON.
-	pub fn to_file<P: AsRef<StdPath>>(&self, path: P) -> crate::Result<()> {
-		let json = serde_json::to_string_pretty(self)?;
-		std::fs::write(path, json)?;
-		Ok(())
+		let json = serde_json::to_string(self)?;
+		Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes()))
 	}
 
 	/// Write the key to a file as base64url-encoded JSON.
-	pub fn to_file_base64url<P: AsRef<StdPath>>(&self, path: P) -> crate::Result<()> {
-		let json = serde_json::to_string(self)?;
-		let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes());
+	pub fn to_file<P: AsRef<StdPath>>(&self, path: P) -> crate::Result<()> {
+		let encoded = self.to_str()?;
 		std::fs::write(path, encoded)?;
 		Ok(())
 	}
@@ -1416,7 +1410,7 @@ mod tests {
 		let temp_path = temp_dir.join("test_jwk.key");
 
 		// Write key to file as base64url
-		key.to_file_base64url(&temp_path).unwrap();
+		key.to_file(&temp_path).unwrap();
 
 		// Read file contents
 		let contents = std::fs::read_to_string(&temp_path).unwrap();


### PR DESCRIPTION
## Summary
- `Key::to_str()` and `Key::to_file()` now output base64url-encoded JSON instead of raw JSON
- Removed `to_file_base64url()` (redundant, `to_file()` does this now)
- Removed `--base64` CLI flag from `moq-token-cli generate` since base64url is now the default
- Loading via `Key::from_file()` still auto-detects both JSON and base64url for backwards compatibility

## Test plan
- [ ] `cargo test -p moq-token` passes (existing tests cover file I/O round-trip)
- [ ] `moq-token-cli generate` outputs base64url-encoded key
- [ ] Existing raw JSON key files can still be loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)