### PR TITLE
Fix keyboard input handling in GameCard component

### DIFF
--- a/js/moq-boy/src/ui/components/GameCard.tsx
+++ b/js/moq-boy/src/ui/components/GameCard.tsx
@@ -32,13 +32,13 @@ function GameCardInner() {
 
 	const onKeyDown = (e: KeyboardEvent) => {
 		if (!isActive()) return;
-		if (e.repeat) return;
 
 		const button = KEY_MAP[e.key];
 		if (button) {
+			e.preventDefault();
+			if (e.repeat) return;
 			game.heldButtons.add(button);
 			game.sendButtons();
-			e.preventDefault();
 		} else if (e.key === "Escape" && ctx.expanded()) {
 			game.expanded.set(undefined);
 			e.preventDefault();


### PR DESCRIPTION
## Summary
Improved the keyboard event handling logic in the GameCard component to prevent repeated key events from being processed and to call `preventDefault()` at the appropriate time.

## Key Changes
- Moved the `e.repeat` check to occur **after** validating that a button mapping exists for the key, rather than checking it first
- Moved `e.preventDefault()` call to execute **before** adding the button to `heldButtons`, ensuring the default action is prevented before any game state is modified
- This ensures that only valid game button inputs trigger event prevention, and that prevention happens at the earliest point in the input processing pipeline

## Implementation Details
The reordering ensures that:
1. Invalid keys (those without a mapping) don't trigger early returns that skip the repeat check
2. The default browser behavior is prevented before any game state mutations occur
3. Repeated key events are still filtered out for valid button inputs, preventing duplicate button presses from being registered

https://claude.ai/code/session_011GbwsaqGaUq6T9GYjKpVcd