### PR TITLE
chore: bump patch versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "moq-boy"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "boytacean",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "moq-native"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.10.20"
+version = "0.10.21"
 dependencies = [
  "anyhow",
  "axum",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "moq-token"
-version = "0.5.15"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "moq-token-cli"
-version = "0.5.20"
+version = "0.5.21"
 dependencies = [
  "anyhow",
  "clap",

--- a/rs/moq-boy/Cargo.toml
+++ b/rs/moq-boy/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["moq", "gameboy", "streaming", "emulator", "live"]
 categories = ["multimedia::video", "emulators", "network-programming"]
 
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.13.11"
+version = "0.13.12"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.10.20"
+version = "0.10.21"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-token-cli/Cargo.toml
+++ b/rs/moq-token-cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.5.20"
+version = "0.5.21"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-token/Cargo.toml
+++ b/rs/moq-token/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.5.15"
+version = "0.5.16"
 edition = "2024"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary
- `moq-native` 0.13.11 → 0.13.12 — `--identity` replaced with `--cert`/`--key` (#1308)
- `moq-relay` 0.10.20 → 0.10.21 — non-MoQ landing page (#1280), auth refactor + HTTP client tests (#1311)
- `moq-token` 0.5.15 → 0.5.16 — default to base64url JWK output (#1309)
- `moq-token-cli` 0.5.20 → 0.5.21 — sync with `moq-token`
- `moq-boy` 0.2.5 → 0.2.6

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)