### PR TITLE
chore: bump JS patch versions

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/lite/package.json
+++ b/js/lite/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/lite",
 	"type": "module",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/signals",
 	"type": "module",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "Reactive and safe signals",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/token",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Media over QUIC - Token Generation and Validation",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",


### PR DESCRIPTION
## Summary
- Bump patch versions for `@moq/lite` (0.2.0 → 0.2.1), `@moq/watch` (0.2.7 → 0.2.8), `@moq/publish` (0.2.4 → 0.2.5), `@moq/hang` (0.2.2 → 0.2.3), `@moq/signals` (0.1.5 → 0.1.6), and `@moq/token` (0.2.1 → 0.2.2).
- These packages have shipped changes since their last published version and are due for a release.

## Unreleased changes covered by these bumps
- `@moq/lite`, `@moq/watch`, `@moq/publish`: #1306 (disable WebTransport on Firefox, force WebSocket fallback)
- `@moq/lite`, `@moq/hang`, `@moq/signals`, `@moq/token`: #1298 (add `sideEffects: false` for better tree-shaking)
- `@moq/lite`, `@moq/watch`: #1291 (miscellaneous fixes in `connection/reload.ts` and watch sync/element)

`@moq/boy` is already at 0.2.6 from #1313, and `@moq/clock` / `@moq/ui-core` have no source changes since their last bump.

## Test plan
- [ ] `just check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)