### PR TITLE
Clarify group delivery semantics with recv_group and next_group_ordered

### DIFF
--- a/doc/rs/index.md
+++ b/doc/rs/index.md
@@ -253,7 +253,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut track = broadcast.subscribe("chat").await?;
 
     // Read groups and frames
-    while let Some(group) = track.next_group().await? {
+    while let Some(group) = track.recv_group().await? {
         while let Some(frame) = group.read().await? {
             println!("Received: {:?}", frame);
         }

--- a/js/clock/src/main.ts
+++ b/js/clock/src/main.ts
@@ -147,7 +147,7 @@ async function subscribe(config: Config) {
 
 	// Handle groups and frames like the Rust implementation
 	for (;;) {
-		const group = await track.nextGroup();
+		const group = await track.recvGroup();
 		if (!group) {
 			console.log("❌ Connection ended");
 			break;

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -109,7 +109,7 @@ export class Consumer {
 	async #run() {
 		// Start fetching groups in the background
 		for (;;) {
-			const consumer = await this.#track.nextGroup();
+			const consumer = await this.#track.recvGroup();
 			if (!consumer) break;
 
 			// To improve TTV, we always start with the first group.

--- a/js/lite/examples/subscribe.ts
+++ b/js/lite/examples/subscribe.ts
@@ -12,7 +12,7 @@ async function main() {
 
 	// Read data as it arrives
 	for (;;) {
-		const group = await track.nextGroup();
+		const group = await track.recvGroup();
 		if (!group) break;
 
 		for (;;) {

--- a/js/lite/src/ietf/publisher.ts
+++ b/js/lite/src/ietf/publisher.ts
@@ -161,7 +161,7 @@ export class Publisher {
 			// Serve track groups, racing with stream close (= Unsubscribe)
 			const serving = (async () => {
 				for (;;) {
-					const group = await track.nextGroup();
+					const group = await track.recvGroup();
 					if (!group) return;
 					void this.#runGroup(msg.requestId, group);
 				}

--- a/js/lite/src/lite/publisher.ts
+++ b/js/lite/src/lite/publisher.ts
@@ -201,7 +201,7 @@ export class Publisher {
 	async #runTrack(sub: bigint, broadcast: Path.Valid, track: Track, stream: Writer) {
 		try {
 			for (;;) {
-				const next = track.nextGroup();
+				const next = track.recvGroup();
 				const group = await Promise.race([next, stream.closed]);
 				if (!group) {
 					next.then((group) => group?.close()).catch(() => {});

--- a/js/lite/src/track.test.ts
+++ b/js/lite/src/track.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { Group } from "./group.ts";
+import { Track } from "./track.ts";
+
+test("nextGroupOrdered skips late arrivals", async () => {
+	const track = new Track("test");
+
+	track.writeGroup(new Group(5));
+
+	const first = await track.nextGroupOrdered();
+	expect(first?.sequence).toBe(5);
+
+	// Late arrivals with sequence <= last returned are skipped.
+	track.writeGroup(new Group(3));
+	track.writeGroup(new Group(4));
+	track.writeGroup(new Group(7));
+
+	const next = await track.nextGroupOrdered();
+	expect(next?.sequence).toBe(7);
+});
+
+test("nextGroupOrdered returns buffered groups in sequence", async () => {
+	const track = new Track("test");
+
+	track.writeGroup(new Group(3));
+	track.writeGroup(new Group(5));
+
+	expect((await track.nextGroupOrdered())?.sequence).toBe(3);
+	expect((await track.nextGroupOrdered())?.sequence).toBe(5);
+});
+
+test("recvGroup after nextGroupOrdered still returns late arrivals", async () => {
+	const track = new Track("test");
+
+	track.writeGroup(new Group(5));
+
+	// Ordered returns seq 5, advancing its cursor.
+	const ordered = await track.nextGroupOrdered();
+	expect(ordered?.sequence).toBe(5);
+
+	// recvGroup is independent of the ordered cursor: a late seq 3 still surfaces.
+	track.writeGroup(new Group(3));
+	const recv = await track.recvGroup();
+	expect(recv?.sequence).toBe(3);
+});
+
+test("nextGroupOrdered returns undefined when track closes", async () => {
+	const track = new Track("test");
+	track.close();
+	expect(await track.nextGroupOrdered()).toBeUndefined();
+});

--- a/js/lite/src/track.ts
+++ b/js/lite/src/track.ts
@@ -11,6 +11,7 @@ export class Track {
 
 	state = new TrackState();
 	#next?: number;
+	#orderedSequence?: number;
 
 	readonly closed: Promise<Error | undefined>;
 
@@ -91,7 +92,14 @@ export class Track {
 		group.close();
 	}
 
-	async nextGroup(): Promise<Group | undefined> {
+	/**
+	 * Receive the next group available on this track, in arrival order.
+	 *
+	 * Groups may arrive out of order or with gaps due to network conditions.
+	 * Use {@link nextGroupOrdered} if you need groups in sequence order,
+	 * skipping those that arrive too late.
+	 */
+	async recvGroup(): Promise<Group | undefined> {
 		for (;;) {
 			const groups = this.state.groups.peek();
 			if (groups.length > 0) {
@@ -103,6 +111,33 @@ export class Track {
 			if (closed) return undefined;
 
 			await Signal.race(this.state.groups, this.state.closed);
+		}
+	}
+
+	/**
+	 * @deprecated Use {@link recvGroup} for arrival order, or {@link nextGroupOrdered} for sequence order.
+	 */
+	async nextGroup(): Promise<Group | undefined> {
+		return this.recvGroup();
+	}
+
+	/**
+	 * Return the next group with a strictly-greater sequence number than the last returned.
+	 *
+	 * Late arrivals (with a sequence number at or below the last one returned) are silently skipped.
+	 *
+	 * NOTE: This will be renamed to `nextGroup` in the next major version.
+	 */
+	async nextGroupOrdered(): Promise<Group | undefined> {
+		for (;;) {
+			const group = await this.recvGroup();
+			if (!group) return undefined;
+			if (this.#orderedSequence !== undefined && group.sequence <= this.#orderedSequence) {
+				group.close();
+				continue;
+			}
+			this.#orderedSequence = group.sequence;
+			return group;
 		}
 	}
 

--- a/js/lite/src/track.ts
+++ b/js/lite/src/track.ts
@@ -11,7 +11,7 @@ export class Track {
 
 	state = new TrackState();
 	#next?: number;
-	#orderedSequence?: number;
+	#nextSequence = 0;
 
 	readonly closed: Promise<Error | undefined>;
 
@@ -132,11 +132,11 @@ export class Track {
 		for (;;) {
 			const group = await this.recvGroup();
 			if (!group) return undefined;
-			if (this.#orderedSequence !== undefined && group.sequence <= this.#orderedSequence) {
+			if (group.sequence < this.#nextSequence) {
 				group.close();
 				continue;
 			}
-			this.#orderedSequence = group.sequence;
+			this.#nextSequence = group.sequence + 1;
 			return group;
 		}
 	}

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -292,7 +292,7 @@ export class Decoder {
 			// Process data segments
 			// TODO: Use a consumer wrapper for CMAF to support latency control
 			for (;;) {
-				const group = await sub.nextGroup();
+				const group = await sub.recvGroup();
 				if (!group) break;
 
 				effect.spawn(async () => {

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -380,7 +380,7 @@ class DecoderTrack {
 			// Process data segments
 			// TODO: Use a consumer wrapper for CMAF to support latency control
 			for (;;) {
-				const group = await Promise.race([sub.nextGroup(), effect.cancel]);
+				const group = await Promise.race([sub.recvGroup(), effect.cancel]);
 				if (!group) break;
 
 				effect.spawn(async () => {

--- a/rs/hang/src/catalog/consumer.rs
+++ b/rs/hang/src/catalog/consumer.rs
@@ -24,7 +24,7 @@ impl CatalogConsumer {
 	pub async fn next(&mut self) -> Result<Option<Catalog>> {
 		loop {
 			tokio::select! {
-				res = self.track.next_group() => {
+				res = self.track.recv_group() => {
 					match res? {
 						Some(group) => {
 							// Use the new group.

--- a/rs/hang/src/container/consumer.rs
+++ b/rs/hang/src/container/consumer.rs
@@ -192,7 +192,7 @@ impl OrderedConsumer {
 	// Returns Pending until all groups have been consumed.
 	fn poll_read_finish(&mut self, waiter: &conducer::Waiter) -> Poll<Result<(), Error>> {
 		loop {
-			let Some(group) = ready!(self.track.poll_next_group(waiter)?) else {
+			let Some(group) = ready!(self.track.poll_recv_group(waiter)?) else {
 				// Track is finished.
 				return Poll::Ready(Ok(()));
 			};
@@ -861,7 +861,7 @@ mod tests {
 		let finisher = tokio::spawn(async move {
 			// After consumer has buffered group 1's frames via buffer_until...
 			tokio::time::sleep(Duration::from_millis(20)).await;
-			// Write group 2: next_group fires, drops current buffer_until for group 1
+			// Write group 2: recv_group fires, drops current buffer_until for group 1
 			write_group(&mut track, 2, &[ts(200_000)]);
 			// Then finish group 0: consumer proceeds, re-creates buffer_until for group 1
 			tokio::time::sleep(Duration::from_millis(20)).await;

--- a/rs/moq-boy/src/input.rs
+++ b/rs/moq-boy/src/input.rs
@@ -106,7 +106,7 @@ async fn handle_viewer_commands(
 
 	let mut track = broadcast.subscribe_track(&command_track)?;
 
-	while let Some(mut group) = track.next_group().await? {
+	while let Some(mut group) = track.recv_group().await? {
 		while let Some(frame) = group.read_frame().await? {
 			let text = std::str::from_utf8(&frame).context("invalid UTF-8 in command")?;
 			match serde_json::from_str::<RawCommand>(text) {

--- a/rs/moq-clock/src/clock.rs
+++ b/rs/moq-clock/src/clock.rs
@@ -80,7 +80,7 @@ impl Subscriber {
 	}
 
 	pub async fn run(mut self) -> anyhow::Result<()> {
-		while let Some(mut group) = self.track.next_group().await? {
+		while let Some(mut group) = self.track.recv_group().await? {
 			let base = group
 				.read_frame()
 				.await

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -225,7 +225,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					while tasks.next().await.is_some() {}
 					false
 				} => unreachable!(),
-				Some(group) = track.next_group().transpose() => group,
+				Some(group) = track.recv_group().transpose() => group,
 				else => return Ok(()),
 			}?;
 

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -307,7 +307,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					while tasks.next().await.is_some() {}
 					false
 				} => unreachable!(),
-				Some(group) = track.next_group().transpose() => group,
+				Some(group) = track.recv_group().transpose() => group,
 				else => return Ok(()),
 			}?;
 

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -462,12 +462,7 @@ impl TrackConsumer {
 		self.recv_group().await
 	}
 
-	/// Poll for the next group with a strictly-greater sequence number than the last returned, without blocking.
-	///
-	/// Implemented as a thin wrapper over [`Self::poll_recv_group`] that discards
-	/// late arrivals (sequence at or below the last returned by this method).
-	/// Shares the arrival-order cursor with [`Self::poll_recv_group`], so a discarded
-	/// group is also consumed from its perspective.
+	/// A helper that calls [`Self::poll_recv_group`] but only returns groups with a sequence number higher than any previously returned.
 	///
 	/// NOTE: This will be renamed to `poll_next_group` in the next major version.
 	pub fn poll_next_group_ordered(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -286,7 +286,6 @@ impl TrackProducer {
 			info: self.info.clone(),
 			state: self.state.consume(),
 			index: 0,
-			ordered_sequence: None,
 			min_sequence: 0,
 		}
 	}
@@ -376,7 +375,6 @@ impl TrackWeak {
 			info: self.info.clone(),
 			state: self.state.consume(),
 			index: 0,
-			ordered_sequence: None,
 			min_sequence: 0,
 		}
 	}
@@ -400,9 +398,8 @@ pub struct TrackConsumer {
 	state: conducer::Consumer<State>,
 	/// Arrival-order cursor used by [`Self::recv_group`].
 	index: usize,
-	/// Highest sequence returned by [`Self::next_group_ordered`], or None if not yet called.
-	ordered_sequence: Option<u64>,
-
+	/// Minimum sequence to return. Advanced by [`Self::next_group_ordered`]
+	/// past each returned group, and set directly by [`Self::start_at`].
 	min_sequence: u64,
 }
 
@@ -463,23 +460,16 @@ impl TrackConsumer {
 
 	/// Poll for the next group with a strictly-greater sequence number than the last returned, without blocking.
 	///
-	/// Walks arriving groups in order of receipt (like [`Self::poll_recv_group`]) but silently
-	/// skips any whose sequence is not greater than the last one returned by this method.
+	/// Advances [`Self::start_at`] past each returned group, so late arrivals with a lower
+	/// sequence are filtered out by [`Self::poll_recv_group`] on subsequent calls.
 	///
 	/// NOTE: This will be renamed to `poll_next_group` in the next major version.
 	pub fn poll_next_group_ordered(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
-		loop {
-			let Some(group) = ready!(self.poll_recv_group(waiter)?) else {
-				return Poll::Ready(Ok(None));
-			};
-			if let Some(last) = self.ordered_sequence
-				&& group.info.sequence <= last
-			{
-				continue;
-			}
-			self.ordered_sequence = Some(group.info.sequence);
-			return Poll::Ready(Ok(Some(group)));
-		}
+		let Some(group) = ready!(self.poll_recv_group(waiter)?) else {
+			return Poll::Ready(Ok(None));
+		};
+		self.min_sequence = group.info.sequence.saturating_add(1);
+		Poll::Ready(Ok(Some(group)))
 	}
 
 	/// Return the next group with a strictly-greater sequence number than the last returned.

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -59,10 +59,10 @@ struct State {
 }
 
 impl State {
-	/// Find the next non-tombstoned group at or after `index`.
+	/// Find the next non-tombstoned group at or after `index` in arrival order.
 	///
 	/// Returns the group and its absolute index so the consumer can advance past it.
-	fn poll_next_group(&self, index: usize, min_sequence: u64) -> Poll<Result<Option<(GroupConsumer, usize)>>> {
+	fn poll_recv_group(&self, index: usize, min_sequence: u64) -> Poll<Result<Option<(GroupConsumer, usize)>>> {
 		let start = index.saturating_sub(self.offset);
 		for (i, slot) in self.groups.iter().enumerate().skip(start) {
 			if let Some((group, _)) = slot
@@ -286,6 +286,7 @@ impl TrackProducer {
 			info: self.info.clone(),
 			state: self.state.consume(),
 			index: 0,
+			ordered_sequence: None,
 			min_sequence: 0,
 		}
 	}
@@ -375,6 +376,7 @@ impl TrackWeak {
 			info: self.info.clone(),
 			state: self.state.consume(),
 			index: 0,
+			ordered_sequence: None,
 			min_sequence: 0,
 		}
 	}
@@ -396,7 +398,10 @@ impl TrackWeak {
 pub struct TrackConsumer {
 	pub info: Track,
 	state: conducer::Consumer<State>,
+	/// Arrival-order cursor used by [`Self::recv_group`].
 	index: usize,
+	/// Highest sequence returned by [`Self::next_group_ordered`], or None if not yet called.
+	ordered_sequence: Option<u64>,
 
 	min_sequence: u64,
 }
@@ -414,15 +419,19 @@ impl TrackConsumer {
 		})
 	}
 
-	/// Poll for the next group without blocking.
+	/// Poll for the next group received over the network, in arrival order, without blocking.
+	///
+	/// Groups may arrive out of order or with gaps due to network conditions.
+	/// Use [`Self::next_group_ordered`] if you need groups in sequence order,
+	/// skipping those that arrive too late.
 	///
 	/// Returns `Poll::Ready(Ok(Some(group)))` when a group is available,
 	/// `Poll::Ready(Ok(None))` when the track is finished,
 	/// `Poll::Ready(Err(e))` when the track has been aborted, or
 	/// `Poll::Pending` when no group is available yet.
-	pub fn poll_next_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+	pub fn poll_recv_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
 		let Some((consumer, found_index)) =
-			ready!(self.poll(waiter, |state| state.poll_next_group(self.index, self.min_sequence))?)
+			ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, self.min_sequence))?)
 		else {
 			return Poll::Ready(Ok(None));
 		};
@@ -431,11 +440,56 @@ impl TrackConsumer {
 		Poll::Ready(Ok(Some(consumer)))
 	}
 
-	/// Return the next group in order.
+	/// Receive the next group available on this track, in arrival order.
 	///
-	/// NOTE: This can have gaps if the reader is too slow or there were network slowdowns.
+	/// Groups may arrive out of order or with gaps due to network conditions.
+	/// Use [`Self::next_group_ordered`] if you need groups in sequence order,
+	/// skipping those that arrive too late.
+	pub async fn recv_group(&mut self) -> Result<Option<GroupConsumer>> {
+		conducer::wait(|waiter| self.poll_recv_group(waiter)).await
+	}
+
+	/// Deprecated alias for [`Self::poll_recv_group`].
+	#[deprecated(note = "use poll_recv_group for arrival order, or poll_next_group_ordered for sequence order")]
+	pub fn poll_next_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+		self.poll_recv_group(waiter)
+	}
+
+	/// Deprecated alias for [`Self::recv_group`].
+	#[deprecated(note = "use recv_group for arrival order, or next_group_ordered for sequence order")]
 	pub async fn next_group(&mut self) -> Result<Option<GroupConsumer>> {
-		conducer::wait(|waiter| self.poll_next_group(waiter)).await
+		self.recv_group().await
+	}
+
+	/// Poll for the next group with a strictly-greater sequence number than the last returned, without blocking.
+	///
+	/// Walks arriving groups in order of receipt (like [`Self::poll_recv_group`]) but silently
+	/// skips any whose sequence is not greater than the last one returned by this method.
+	///
+	/// NOTE: This will be renamed to `poll_next_group` in the next major version.
+	pub fn poll_next_group_ordered(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+		loop {
+			let Some(group) = ready!(self.poll_recv_group(waiter)?) else {
+				return Poll::Ready(Ok(None));
+			};
+			if let Some(last) = self.ordered_sequence
+				&& group.info.sequence <= last
+			{
+				continue;
+			}
+			self.ordered_sequence = Some(group.info.sequence);
+			return Poll::Ready(Ok(Some(group)));
+		}
+	}
+
+	/// Return the next group with a strictly-greater sequence number than the last returned.
+	///
+	/// Groups that arrive late (with a sequence number at or below the last one returned)
+	/// are silently skipped.
+	///
+	/// NOTE: This will be renamed to `next_group` in the next major version.
+	pub async fn next_group_ordered(&mut self) -> Result<Option<GroupConsumer>> {
+		conducer::wait(|waiter| self.poll_next_group_ordered(waiter)).await
 	}
 
 	/// Poll for the group with the given sequence, without blocking.
@@ -518,7 +572,7 @@ use futures::FutureExt;
 #[cfg(test)]
 impl TrackConsumer {
 	pub fn assert_group(&mut self) -> GroupConsumer {
-		self.next_group()
+		self.recv_group()
 			.now_or_never()
 			.expect("group would have blocked")
 			.expect("would have errored")
@@ -527,8 +581,8 @@ impl TrackConsumer {
 
 	pub fn assert_no_group(&mut self) {
 		assert!(
-			self.next_group().now_or_never().is_none(),
-			"next group would not have blocked"
+			self.recv_group().now_or_never().is_none(),
+			"recv_group would not have blocked"
 		);
 	}
 
@@ -786,7 +840,7 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn next_group_finishes_without_waiting_for_gaps() {
+	async fn recv_group_finishes_without_waiting_for_gaps() {
 		let mut producer = Track::new("test").produce();
 		producer.create_group(Group { sequence: 1 }).unwrap();
 		producer.finish_at(1).unwrap();
@@ -795,11 +849,74 @@ mod test {
 		assert_eq!(consumer.assert_group().info.sequence, 1);
 
 		let done = consumer
-			.next_group()
+			.recv_group()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored");
 		assert!(done.is_none(), "track should finish without waiting for gaps");
+	}
+
+	#[tokio::test]
+	async fn next_group_ordered_skips_late_arrivals() {
+		let mut producer = Track::new("test").produce();
+		let mut consumer = producer.consume();
+
+		// Seq 5 arrives first.
+		producer.create_group(Group { sequence: 5 }).unwrap();
+		let group = consumer
+			.next_group_ordered()
+			.now_or_never()
+			.expect("should not block")
+			.expect("would have errored")
+			.expect("track should not be closed");
+		assert_eq!(group.info.sequence, 5);
+
+		// Seq 3 arrives late — skipped because 3 <= 5.
+		producer.create_group(Group { sequence: 3 }).unwrap();
+		// Seq 4 arrives late — also skipped.
+		producer.create_group(Group { sequence: 4 }).unwrap();
+		// Seq 7 arrives — returned.
+		producer.create_group(Group { sequence: 7 }).unwrap();
+
+		let group = consumer
+			.next_group_ordered()
+			.now_or_never()
+			.expect("should not block")
+			.expect("would have errored")
+			.expect("track should not be closed");
+		assert_eq!(group.info.sequence, 7);
+
+		// No more groups — would block.
+		assert!(
+			consumer.next_group_ordered().now_or_never().is_none(),
+			"should block waiting for a higher sequence"
+		);
+	}
+
+	#[tokio::test]
+	async fn next_group_ordered_returns_arrivals_in_order() {
+		let mut producer = Track::new("test").produce();
+		let mut consumer = producer.consume();
+
+		// Seq 3 arrives first, then seq 5 — both should be returned in arrival order.
+		producer.create_group(Group { sequence: 3 }).unwrap();
+		producer.create_group(Group { sequence: 5 }).unwrap();
+
+		let group = consumer
+			.next_group_ordered()
+			.now_or_never()
+			.expect("should not block")
+			.expect("would have errored")
+			.expect("track should not be closed");
+		assert_eq!(group.info.sequence, 3);
+
+		let group = consumer
+			.next_group_ordered()
+			.now_or_never()
+			.expect("should not block")
+			.expect("would have errored")
+			.expect("track should not be closed");
+		assert_eq!(group.info.sequence, 5);
 	}
 
 	#[tokio::test]

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -287,6 +287,7 @@ impl TrackProducer {
 			state: self.state.consume(),
 			index: 0,
 			min_sequence: 0,
+			next_sequence: 0,
 		}
 	}
 
@@ -376,6 +377,7 @@ impl TrackWeak {
 			state: self.state.consume(),
 			index: 0,
 			min_sequence: 0,
+			next_sequence: 0,
 		}
 	}
 
@@ -398,9 +400,11 @@ pub struct TrackConsumer {
 	state: conducer::Consumer<State>,
 	/// Arrival-order cursor used by [`Self::recv_group`].
 	index: usize,
-	/// Minimum sequence to return. Advanced by [`Self::next_group_ordered`]
-	/// past each returned group, and set directly by [`Self::start_at`].
+	/// Minimum sequence to return from any `recv` method. Set by [`Self::start_at`].
 	min_sequence: u64,
+	/// One past the highest sequence returned by [`Self::next_group_ordered`].
+	/// Used only by that method to skip late arrivals; does not affect [`Self::recv_group`].
+	next_sequence: u64,
 }
 
 impl TrackConsumer {
@@ -460,16 +464,24 @@ impl TrackConsumer {
 
 	/// Poll for the next group with a strictly-greater sequence number than the last returned, without blocking.
 	///
-	/// Advances [`Self::start_at`] past each returned group, so late arrivals with a lower
-	/// sequence are filtered out by [`Self::poll_recv_group`] on subsequent calls.
+	/// Implemented as a thin wrapper over [`Self::poll_recv_group`] that discards
+	/// late arrivals (sequence at or below the last returned by this method).
+	/// Shares the arrival-order cursor with [`Self::poll_recv_group`], so a discarded
+	/// group is also consumed from its perspective.
 	///
 	/// NOTE: This will be renamed to `poll_next_group` in the next major version.
 	pub fn poll_next_group_ordered(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
-		let Some(group) = ready!(self.poll_recv_group(waiter)?) else {
-			return Poll::Ready(Ok(None));
-		};
-		self.min_sequence = group.info.sequence.saturating_add(1);
-		Poll::Ready(Ok(Some(group)))
+		loop {
+			let Some(group) = ready!(self.poll_recv_group(waiter)?) else {
+				return Poll::Ready(Ok(None));
+			};
+			if group.info.sequence < self.next_sequence {
+				// Late arrival; discard and keep looking.
+				continue;
+			}
+			self.next_sequence = group.info.sequence.saturating_add(1);
+			return Poll::Ready(Ok(Some(group)));
+		}
 	}
 
 	/// Return the next group with a strictly-greater sequence number than the last returned.
@@ -907,6 +919,28 @@ mod test {
 			.expect("would have errored")
 			.expect("track should not be closed");
 		assert_eq!(group.info.sequence, 5);
+	}
+
+	#[tokio::test]
+	async fn recv_group_after_next_group_ordered_sees_late_arrivals() {
+		let mut producer = Track::new("test").produce();
+		let mut consumer = producer.consume();
+
+		producer.create_group(Group { sequence: 5 }).unwrap();
+		producer.create_group(Group { sequence: 3 }).unwrap();
+
+		// Ordered returns seq 5 and advances its internal cursor past it.
+		let group = consumer
+			.next_group_ordered()
+			.now_or_never()
+			.expect("should not block")
+			.expect("would have errored")
+			.expect("track should not be closed");
+		assert_eq!(group.info.sequence, 5);
+
+		// Intermixing: recv_group on the same consumer still returns the late seq 3.
+		// The ordered cursor is separate from the recv_group filter.
+		assert_eq!(consumer.assert_group().info.sequence, 3);
 	}
 
 	#[tokio::test]

--- a/rs/moq-mux/src/ordered/consumer.rs
+++ b/rs/moq-mux/src/ordered/consumer.rs
@@ -189,7 +189,7 @@ impl<F: Container> Consumer<F> {
 	// Returns Pending until all groups have been consumed.
 	fn poll_read_finish(&mut self, waiter: &conducer::Waiter) -> Poll<Result<(), F::Error>> {
 		loop {
-			let Some(group) = ready!(self.track.poll_next_group(waiter)?) else {
+			let Some(group) = ready!(self.track.poll_recv_group(waiter)?) else {
 				// Track is finished.
 				return Poll::Ready(Ok(()));
 			};

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -73,10 +73,10 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 		.subscribe_track(&Track::new("video"))
 		.expect("subscribe_track failed");
 
-	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.next_group())
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
-		.expect("next_group timed out")
-		.expect("next_group failed")
+		.expect("recv_group timed out")
+		.expect("recv_group failed")
 		.expect("track closed prematurely");
 
 	let frame = tokio::time::timeout(TIMEOUT, group_sub.read_frame())
@@ -225,10 +225,10 @@ async fn iroh_connect() {
 		.subscribe_track(&Track::new("video"))
 		.expect("subscribe_track failed");
 
-	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.next_group())
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
-		.expect("next_group timed out")
-		.expect("next_group failed")
+		.expect("recv_group timed out")
+		.expect("recv_group failed")
 		.expect("track closed prematurely");
 
 	let frame = tokio::time::timeout(TIMEOUT, group_sub.read_frame())

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -92,10 +92,10 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 		.expect("subscribe_track failed");
 
 	// Read one group.
-	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.next_group())
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
-		.expect("next_group timed out")
-		.expect("next_group failed")
+		.expect("recv_group timed out")
+		.expect("recv_group failed")
 		.expect("track closed prematurely");
 
 	// Read one frame and verify the payload.
@@ -432,10 +432,10 @@ async fn broadcast_websocket() {
 		.expect("subscribe_track failed");
 
 	// Read one group.
-	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.next_group())
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
-		.expect("next_group timed out")
-		.expect("next_group failed")
+		.expect("recv_group timed out")
+		.expect("recv_group failed")
 		.expect("track closed prematurely");
 
 	// Read one frame and verify the payload.
@@ -538,10 +538,10 @@ async fn broadcast_websocket_fallback() {
 		.subscribe_track(&Track::new("video"))
 		.expect("subscribe_track failed");
 
-	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.next_group())
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
-		.expect("next_group timed out")
-		.expect("next_group failed")
+		.expect("recv_group timed out")
+		.expect("recv_group failed")
 		.expect("track closed prematurely");
 
 	let frame = tokio::time::timeout(TIMEOUT, group_sub.read_frame())

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -340,7 +340,7 @@ async fn serve_fetch(
 		let group = match params.group {
 			FetchGroup::Latest => match track.latest() {
 				Some(sequence) => track.get_group(sequence).await,
-				None => track.next_group().await,
+				None => track.recv_group().await,
 			},
 			FetchGroup::Num(sequence) => track.get_group(sequence).await,
 		};


### PR DESCRIPTION
## Summary

This PR clarifies the semantics of group delivery in MOQ tracks by introducing explicit methods for two distinct use cases:
- `recv_group()` for receiving groups in arrival order (may have gaps/out-of-order due to network)
- `next_group_ordered()` for receiving groups in strict sequence order (skips late arrivals)

The previous `next_group()` method was ambiguous about which semantics it provided. This change makes the intent explicit while maintaining backward compatibility through deprecation.

## Key Changes

- **Rust (`rs/moq-lite/src/model/track.rs`)**:
  - Renamed internal `poll_next_group()` → `poll_recv_group()` to clarify it returns groups in arrival order
  - Added `recv_group()` async method for arrival-order group consumption
  - Added `poll_next_group_ordered()` and `next_group_ordered()` for sequence-ordered consumption with late-arrival skipping
  - Added `ordered_sequence` field to `TrackConsumer` to track the highest sequence returned by ordered methods
  - Deprecated `poll_next_group()` and `next_group()` with guidance to use the new explicit methods
  - Added comprehensive tests for both delivery semantics

- **JavaScript (`js/lite/src/track.ts`)**:
  - Renamed `nextGroup()` → `recvGroup()` for arrival-order semantics
  - Added `nextGroupOrdered()` for sequence-ordered consumption
  - Added `#orderedSequence` field to track highest sequence in ordered mode
  - Deprecated `nextGroup()` with guidance to use explicit methods

- **Test and Example Updates**:
  - Updated all test files and examples across Rust and JavaScript to use `recv_group()` for arrival-order consumption
  - Updated documentation examples to reflect the new API

## Implementation Details

- The `next_group_ordered()` implementation loops through arriving groups via `recv_group()` and silently skips any with sequence ≤ the last returned sequence
- Both methods coexist without conflict; consumers can choose their delivery semantics
- The deprecation path allows gradual migration of existing code
- New tests verify both semantics work correctly, including edge cases like out-of-order arrivals and gaps

https://claude.ai/code/session_012wTum3MYQzh2U5peWrUHq3