### PR TITLE
Add back button to game controls UI

### DIFF
--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.2.6",
+	"version": "0.2.7",
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": {

--- a/js/moq-boy/src/ui/components/Controls.tsx
+++ b/js/moq-boy/src/ui/components/Controls.tsx
@@ -26,8 +26,16 @@ export default function Controls() {
 		game.sendCommand({ type: "reset" });
 	};
 
+	const onBack = (e: MouseEvent) => {
+		e.stopPropagation();
+		game.expanded.set(undefined);
+	};
+
 	return (
 		<div class="boy__controls">
+			<button type="button" class="boy__back-btn" onClick={onBack}>
+				← Back
+			</button>
 			<Dpad />
 			<ABButtons />
 			<MetaButtons />
@@ -64,7 +72,7 @@ export default function Controls() {
 				<div>Arrows: D-pad</div>
 				<div>Z: B &nbsp; X: A</div>
 				<div>Enter: Start &nbsp; Shift: Select</div>
-				<div>Esc: Collapse</div>
+				<div>Esc: Back</div>
 			</div>
 		</div>
 	);

--- a/js/moq-boy/src/ui/components/Controls.tsx
+++ b/js/moq-boy/src/ui/components/Controls.tsx
@@ -34,7 +34,7 @@ export default function Controls() {
 	return (
 		<div class="boy__controls">
 			<button type="button" class="boy__back-btn" onClick={onBack}>
-				← Back
+				<span aria-hidden="true">←</span> Back
 			</button>
 			<Dpad />
 			<ABButtons />

--- a/js/moq-boy/src/ui/styles/controls.css
+++ b/js/moq-boy/src/ui/styles/controls.css
@@ -5,6 +5,28 @@
 	gap: 1.5rem;
 }
 
+/* Back button */
+.boy__back-btn {
+	width: 100%;
+	background: var(--color-white-alpha-05);
+	color: var(--boy-text-muted);
+	border: 1px solid var(--boy-border);
+	padding: 0.5rem;
+	border-radius: 6px;
+	cursor: pointer;
+	font-size: 0.75rem;
+	transition: all 0.15s;
+}
+
+.boy__back-btn:hover {
+	border-color: var(--boy-accent);
+	color: var(--boy-text);
+}
+
+.boy__back-btn:active {
+	transform: scale(0.98);
+}
+
 /* D-pad grid */
 .boy__dpad {
 	display: grid;


### PR DESCRIPTION
## Summary
Added a "Back" button to the game controls interface that allows users to collapse/close the expanded controls view.

## Key Changes
- **New back button component**: Added styled `.boy__back-btn` button to the controls section with hover and active states
- **Back button functionality**: Implemented `onBack` handler that clears the expanded state when clicked
- **Updated keyboard shortcut label**: Changed the Esc key description from "Collapse" to "Back" for consistency with the new button label
- **Version bump**: Updated package version from 0.2.6 to 0.2.7

## Implementation Details
- The back button is positioned at the top of the controls container (before D-pad and other buttons)
- Uses `stopPropagation()` to prevent event bubbling
- Styled with semi-transparent white background, muted text color, and smooth transitions
- Includes hover state that highlights the border with accent color
- Active state includes a subtle scale animation (0.98) for tactile feedback
- Button spans full width of the controls container

https://claude.ai/code/session_016Ycf7L6p7wHdpnmc5TcHNv