### PR TITLE
Add MSF catalog format support with format negotiation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.8.8",
@@ -99,7 +99,7 @@
     },
     "js/lite": {
       "name": "@moq/lite",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@moq/qmux": "^0.0.6",
         "@moq/signals": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "js/moq-boy": {
       "name": "@moq/boy",
-      "version": "0.2.4",
+      "version": "0.2.7",
       "dependencies": {
         "@moq/lite": "workspace:^",
         "@moq/signals": "workspace:^",
@@ -137,9 +137,21 @@
         "vite-plugin-solid": "^2.11.10",
       },
     },
+    "js/msf": {
+      "name": "@moq/msf",
+      "version": "0.1.0",
+      "dependencies": {
+        "@moq/lite": "workspace:^",
+        "zod": "^4.1.5",
+      },
+      "devDependencies": {
+        "rimraf": "^6.0.1",
+        "typescript": "^6.0.0",
+      },
+    },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/lite": "workspace:^",
@@ -160,7 +172,7 @@
     },
     "js/signals": {
       "name": "@moq/signals",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "devDependencies": {
         "@types/react": "^19.1.8",
         "rimraf": "^6.0.1",
@@ -180,7 +192,7 @@
     },
     "js/token": {
       "name": "@moq/token",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "bin": {
         "moq-token": "./src/cli.ts",
       },
@@ -215,12 +227,14 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/lite": "workspace:^",
+        "@moq/msf": "workspace:^",
         "@moq/signals": "workspace:^",
         "@moq/ui-core": "workspace:^",
+        "zod": "^4.1.5",
       },
       "devDependencies": {
         "@types/audioworklet": "^0.0.77",
@@ -501,6 +515,8 @@
     "@moq/hang": ["@moq/hang@workspace:js/hang"],
 
     "@moq/lite": ["@moq/lite@workspace:js/lite"],
+
+    "@moq/msf": ["@moq/msf@workspace:js/msf"],
 
     "@moq/publish": ["@moq/publish@workspace:js/publish"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -227,7 +227,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/lite": "workspace:^",

--- a/bun.lock
+++ b/bun.lock
@@ -234,7 +234,6 @@
         "@moq/msf": "workspace:^",
         "@moq/signals": "workspace:^",
         "@moq/ui-core": "workspace:^",
-        "zod": "^4.1.5",
       },
       "devDependencies": {
         "@types/audioworklet": "^0.0.77",

--- a/js/msf/README.md
+++ b/js/msf/README.md
@@ -1,0 +1,29 @@
+# @moq/msf
+
+Zod schemas and helpers for the [MSF (MOQT Streaming Format)](https://datatracker.ietf.org/doc/draft-ietf-moq-streaming-format/) catalog.
+
+This package provides types for decoding the MSF catalog track delivered over `moq-lite`. It is consumed by `@moq/watch` when the player is configured with `catalogFormat: "msf"`.
+
+## Installation
+
+```bash
+npm add @moq/msf
+```
+
+## Usage
+
+```typescript
+import * as Msf from "@moq/msf";
+
+// Fetch and decode a catalog from a moq-lite track
+const catalog = await Msf.fetch(track);
+if (catalog) {
+	for (const t of catalog.tracks) {
+		console.log(t.name, t.role, t.codec);
+	}
+}
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@moq/msf",
+	"type": "module",
+	"version": "0.1.0",
+	"description": "MSF (MOQT Streaming Format) catalog types for MoQ",
+	"license": "(MIT OR Apache-2.0)",
+	"repository": "github:moq-dev/moq",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"sideEffects": false,
+	"scripts": {
+		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"check": "tsc --noEmit",
+		"release": "bun ../common/release.ts"
+	},
+	"dependencies": {
+		"@moq/lite": "workspace:^",
+		"zod": "^4.1.5"
+	},
+	"devDependencies": {
+		"rimraf": "^6.0.1",
+		"typescript": "^6.0.0"
+	}
+}

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -1,0 +1,61 @@
+import type * as Moq from "@moq/lite";
+import { z } from "zod";
+
+export const PackagingSchema = z.enum(["loc", "cmaf", "legacy", "mediatimeline", "eventtimeline"]).or(z.string());
+
+export type Packaging = z.infer<typeof PackagingSchema>;
+
+export const RoleSchema = z
+	.enum(["video", "audio", "audiodescription", "caption", "subtitle", "signlanguage"])
+	.or(z.string());
+
+export type Role = z.infer<typeof RoleSchema>;
+
+export const TrackSchema = z.object({
+	name: z.string(),
+	packaging: PackagingSchema,
+	isLive: z.boolean(),
+	role: RoleSchema.optional(),
+	codec: z.string().optional(),
+	width: z.number().optional(),
+	height: z.number().optional(),
+	framerate: z.number().optional(),
+	samplerate: z.number().optional(),
+	channelConfig: z.string().optional(),
+	bitrate: z.number().optional(),
+	initData: z.string().optional(),
+	renderGroup: z.number().optional(),
+	altGroup: z.number().optional(),
+});
+
+export type Track = z.infer<typeof TrackSchema>;
+
+export const CatalogSchema = z.object({
+	version: z.literal(1),
+	tracks: z.array(TrackSchema),
+});
+
+export type Catalog = z.infer<typeof CatalogSchema>;
+
+export function encode(catalog: Catalog): Uint8Array {
+	const encoder = new TextEncoder();
+	return encoder.encode(JSON.stringify(catalog));
+}
+
+export function decode(raw: Uint8Array): Catalog {
+	const decoder = new TextDecoder();
+	const str = decoder.decode(raw);
+	try {
+		const json = JSON.parse(str);
+		return CatalogSchema.parse(json);
+	} catch (error) {
+		console.warn("invalid MSF catalog", str);
+		throw error;
+	}
+}
+
+export async function fetch(track: Moq.Track): Promise<Catalog | undefined> {
+	const frame = await track.readFrame();
+	if (!frame) return undefined;
+	return decode(frame);
+}

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -1,13 +1,17 @@
 import type * as Moq from "@moq/lite";
-import { z } from "zod";
+import * as z from "zod/mini";
 
-export const PackagingSchema = z.enum(["loc", "cmaf", "legacy", "mediatimeline", "eventtimeline"]).or(z.string());
+export const PackagingSchema = z.union([
+	z.enum(["loc", "cmaf", "legacy", "mediatimeline", "eventtimeline"]),
+	z.string(),
+]);
 
 export type Packaging = z.infer<typeof PackagingSchema>;
 
-export const RoleSchema = z
-	.enum(["video", "audio", "audiodescription", "caption", "subtitle", "signlanguage"])
-	.or(z.string());
+export const RoleSchema = z.union([
+	z.enum(["video", "audio", "audiodescription", "caption", "subtitle", "signlanguage"]),
+	z.string(),
+]);
 
 export type Role = z.infer<typeof RoleSchema>;
 
@@ -15,17 +19,17 @@ export const TrackSchema = z.object({
 	name: z.string(),
 	packaging: PackagingSchema,
 	isLive: z.boolean(),
-	role: RoleSchema.optional(),
-	codec: z.string().optional(),
-	width: z.number().optional(),
-	height: z.number().optional(),
-	framerate: z.number().optional(),
-	samplerate: z.number().optional(),
-	channelConfig: z.string().optional(),
-	bitrate: z.number().optional(),
-	initData: z.string().optional(),
-	renderGroup: z.number().optional(),
-	altGroup: z.number().optional(),
+	role: z.optional(RoleSchema),
+	codec: z.optional(z.string()),
+	width: z.optional(z.number()),
+	height: z.optional(z.number()),
+	framerate: z.optional(z.number()),
+	samplerate: z.optional(z.number()),
+	channelConfig: z.optional(z.string()),
+	bitrate: z.optional(z.number()),
+	initData: z.optional(z.string()),
+	renderGroup: z.optional(z.number()),
+	altGroup: z.optional(z.number()),
 });
 
 export type Track = z.infer<typeof TrackSchema>;

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -30,6 +30,11 @@ export const TrackSchema = z.object({
 	initData: z.optional(z.string()),
 	renderGroup: z.optional(z.number()),
 	altGroup: z.optional(z.number()),
+
+	// Non-standard: maximum delay (ms) between consecutive frames on this track.
+	// The player's buffer must be at least this large to avoid underruns.
+	// Mirrors the `jitter` field in the hang catalog.
+	jitter: z.optional(z.number()),
 });
 
 export type Track = z.infer<typeof TrackSchema>;

--- a/js/msf/src/index.ts
+++ b/js/msf/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./catalog";

--- a/js/msf/tsconfig.json
+++ b/js/msf/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"]
+}

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -28,8 +28,7 @@
 		"@moq/lite": "workspace:^",
 		"@moq/msf": "workspace:^",
 		"@moq/signals": "workspace:^",
-		"@moq/ui-core": "workspace:^",
-		"zod": "^4.1.5"
+		"@moq/ui-core": "workspace:^"
 	},
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.77",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -26,8 +26,10 @@
 	"dependencies": {
 		"@moq/hang": "workspace:^",
 		"@moq/lite": "workspace:^",
+		"@moq/msf": "workspace:^",
 		"@moq/signals": "workspace:^",
-		"@moq/ui-core": "workspace:^"
+		"@moq/ui-core": "workspace:^",
+		"zod": "^4.1.5"
 	},
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.77",

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -3,18 +3,10 @@ import type * as Moq from "@moq/lite";
 import { Path } from "@moq/lite";
 import * as Msf from "@moq/msf";
 import { Effect, type Getter, Signal } from "@moq/signals";
-import { z } from "zod";
 
 import { toHang } from "./msf";
 
-export const catalogFormatSchema = z.enum(["hang", "msf"]);
-export type CatalogFormat = z.infer<typeof catalogFormatSchema>;
-
-export const catalogAttrSchema = z.enum(["hang", "msf", "auto"]);
-export type CatalogAttr = z.infer<typeof catalogAttrSchema>;
-
-/** Delay (ms) before attempting MSF catalog fetch, giving hang format a headstart. */
-const HANG_HEADSTART_MS = 100;
+export type CatalogFormat = "hang" | "msf";
 
 export interface BroadcastProps {
 	connection?: Moq.Connection.Established | Signal<Moq.Connection.Established | undefined>;
@@ -33,8 +25,8 @@ export interface BroadcastProps {
 	// Defaults to false; pass true to wait for an announcement before subscribing.
 	reload?: boolean | Signal<boolean>;
 
-	// Which catalog formats to try. Default: ["hang"]
-	catalog?: CatalogFormat[] | Signal<CatalogFormat[]>;
+	// Which catalog format to use. Default: "hang"
+	catalog?: CatalogFormat | Signal<CatalogFormat>;
 }
 
 // A catalog source that (optionally) reloads automatically when live/offline.
@@ -46,7 +38,7 @@ export class Broadcast {
 	status = new Signal<"offline" | "loading" | "live">("offline");
 	reload: Signal<boolean>;
 
-	catalogFormats: Signal<CatalogFormat[]>;
+	catalogFormat: Signal<CatalogFormat>;
 
 	#active = new Signal<Moq.Broadcast | undefined>(undefined);
 	readonly active: Getter<Moq.Broadcast | undefined> = this.#active;
@@ -64,7 +56,7 @@ export class Broadcast {
 		this.name = Signal.from(props?.name ?? Path.empty());
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.reload = Signal.from(props?.reload ?? false);
-		this.catalogFormats = Signal.from(props?.catalog ?? (["hang"] as CatalogFormat[]));
+		this.catalogFormat = Signal.from(props?.catalog ?? "hang");
 
 		this.#announced = props?.announced ?? new Signal(new Set());
 
@@ -103,75 +95,31 @@ export class Broadcast {
 		if (!values) return;
 		const [_, broadcast] = values;
 
-		const formats = effect.get(this.catalogFormats);
+		const format = effect.get(this.catalogFormat);
 		this.status.set("loading");
 
-		const hangTrack = formats.includes("hang")
-			? broadcast.subscribe("catalog.json", Catalog.PRIORITY.catalog)
-			: undefined;
-		const msfTrack = formats.includes("msf") ? broadcast.subscribe("catalog", Catalog.PRIORITY.catalog) : undefined;
+		const trackName = format === "hang" ? "catalog.json" : "catalog";
+		const track = broadcast.subscribe(trackName, Catalog.PRIORITY.catalog);
+		effect.cleanup(() => track.close());
 
-		if (hangTrack) effect.cleanup(() => hangTrack.close());
-		if (msfTrack) effect.cleanup(() => msfTrack.close());
+		const fetchNext =
+			format === "hang"
+				? async () => Catalog.fetch(track)
+				: async () => {
+						const update = await Msf.fetch(track);
+						return update ? toHang(update) : undefined;
+					};
 
 		effect.spawn(async () => {
 			try {
-				// Race the first catalog fetch, giving hang a headstart.
-				// Wrap each fetch so undefined results reject, ensuring only
-				// successful fetches compete (via Promise.any).
-				const hangFetch = hangTrack
-					? Catalog.fetch(hangTrack).then((r) => {
-							if (r) return { kind: "hang" as const, root: r };
-							throw new Error("hang catalog empty");
-						})
-					: undefined;
-
-				const msfFetch = msfTrack
-					? new Promise((r) => setTimeout(r, HANG_HEADSTART_MS))
-							.then(() => Msf.fetch(msfTrack))
-							.then((c) => {
-								if (c) return { kind: "msf" as const, root: toHang(c) };
-								throw new Error("msf catalog empty");
-							})
-					: undefined;
-
-				const candidates = [hangFetch, msfFetch].filter((c): c is NonNullable<typeof c> => c != null);
-				if (candidates.length === 0) return;
-
-				const first = await Promise.race([effect.cancel.then(() => undefined), Promise.any(candidates)]);
-				if (!first) return;
-
-				// Close the loser
-				if (first.kind === "hang") {
-					msfTrack?.close();
-				} else {
-					hangTrack?.close();
-				}
-
-				console.debug("received catalog", first.kind, this.name.peek(), first.root);
-				this.#catalog.set(first.root);
-				this.status.set("live");
-
-				// Continue reading updates from the winner
-				const fetchNext =
-					first.kind === "hang"
-						? async () => {
-								const update = await Promise.race([
-									effect.cancel,
-									Catalog.fetch(hangTrack as Moq.Track),
-								]);
-								return update;
-							}
-						: async () => {
-								const update = await Promise.race([effect.cancel, Msf.fetch(msfTrack as Moq.Track)]);
-								return update ? toHang(update) : undefined;
-							};
-
 				for (;;) {
-					const root = await fetchNext();
-					if (!root) break;
-					console.debug("received catalog", first.kind, this.name.peek(), root);
-					this.#catalog.set(root);
+					const update = await Promise.race([effect.cancel, fetchNext()]);
+					if (!update) break;
+
+					console.debug("received catalog", format, this.name.peek(), update);
+
+					this.#catalog.set(update);
+					this.status.set("live");
 				}
 			} catch (err) {
 				console.warn("error fetching catalog", this.name.peek(), err);

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -1,7 +1,20 @@
 import * as Catalog from "@moq/hang/catalog";
 import type * as Moq from "@moq/lite";
 import { Path } from "@moq/lite";
+import * as Msf from "@moq/msf";
 import { Effect, type Getter, Signal } from "@moq/signals";
+import { z } from "zod";
+
+import { toHang } from "./msf";
+
+export const catalogFormatSchema = z.enum(["hang", "msf"]);
+export type CatalogFormat = z.infer<typeof catalogFormatSchema>;
+
+export const catalogAttrSchema = z.enum(["hang", "msf", "auto"]);
+export type CatalogAttr = z.infer<typeof catalogAttrSchema>;
+
+/** Delay (ms) before attempting MSF catalog fetch, giving hang format a headstart. */
+const HANG_HEADSTART_MS = 100;
 
 export interface BroadcastProps {
 	connection?: Moq.Connection.Established | Signal<Moq.Connection.Established | undefined>;
@@ -19,6 +32,9 @@ export interface BroadcastProps {
 	// Whether to reload the broadcast when it goes offline.
 	// Defaults to false; pass true to wait for an announcement before subscribing.
 	reload?: boolean | Signal<boolean>;
+
+	// Which catalog formats to try. Default: ["hang"]
+	catalog?: CatalogFormat[] | Signal<CatalogFormat[]>;
 }
 
 // A catalog source that (optionally) reloads automatically when live/offline.
@@ -29,6 +45,8 @@ export class Broadcast {
 	name: Signal<Moq.Path.Valid>;
 	status = new Signal<"offline" | "loading" | "live">("offline");
 	reload: Signal<boolean>;
+
+	catalogFormats: Signal<CatalogFormat[]>;
 
 	#active = new Signal<Moq.Broadcast | undefined>(undefined);
 	readonly active: Getter<Moq.Broadcast | undefined> = this.#active;
@@ -46,6 +64,7 @@ export class Broadcast {
 		this.name = Signal.from(props?.name ?? Path.empty());
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.reload = Signal.from(props?.reload ?? false);
+		this.catalogFormats = Signal.from(props?.catalog ?? (["hang"] as CatalogFormat[]));
 
 		this.#announced = props?.announced ?? new Signal(new Set());
 
@@ -84,21 +103,75 @@ export class Broadcast {
 		if (!values) return;
 		const [_, broadcast] = values;
 
+		const formats = effect.get(this.catalogFormats);
 		this.status.set("loading");
 
-		const catalog = broadcast.subscribe("catalog.json", Catalog.PRIORITY.catalog);
-		effect.cleanup(() => catalog.close());
+		const hangTrack = formats.includes("hang")
+			? broadcast.subscribe("catalog.json", Catalog.PRIORITY.catalog)
+			: undefined;
+		const msfTrack = formats.includes("msf") ? broadcast.subscribe("catalog", Catalog.PRIORITY.catalog) : undefined;
+
+		if (hangTrack) effect.cleanup(() => hangTrack.close());
+		if (msfTrack) effect.cleanup(() => msfTrack.close());
 
 		effect.spawn(async () => {
 			try {
+				// Race the first catalog fetch, giving hang a headstart.
+				// Wrap each fetch so undefined results reject, ensuring only
+				// successful fetches compete (via Promise.any).
+				const hangFetch = hangTrack
+					? Catalog.fetch(hangTrack).then((r) => {
+							if (r) return { kind: "hang" as const, root: r };
+							throw new Error("hang catalog empty");
+						})
+					: undefined;
+
+				const msfFetch = msfTrack
+					? new Promise((r) => setTimeout(r, HANG_HEADSTART_MS))
+							.then(() => Msf.fetch(msfTrack))
+							.then((c) => {
+								if (c) return { kind: "msf" as const, root: toHang(c) };
+								throw new Error("msf catalog empty");
+							})
+					: undefined;
+
+				const candidates = [hangFetch, msfFetch].filter((c): c is NonNullable<typeof c> => c != null);
+				if (candidates.length === 0) return;
+
+				const first = await Promise.race([effect.cancel.then(() => undefined), Promise.any(candidates)]);
+				if (!first) return;
+
+				// Close the loser
+				if (first.kind === "hang") {
+					msfTrack?.close();
+				} else {
+					hangTrack?.close();
+				}
+
+				console.debug("received catalog", first.kind, this.name.peek(), first.root);
+				this.#catalog.set(first.root);
+				this.status.set("live");
+
+				// Continue reading updates from the winner
+				const fetchNext =
+					first.kind === "hang"
+						? async () => {
+								const update = await Promise.race([
+									effect.cancel,
+									Catalog.fetch(hangTrack as Moq.Track),
+								]);
+								return update;
+							}
+						: async () => {
+								const update = await Promise.race([effect.cancel, Msf.fetch(msfTrack as Moq.Track)]);
+								return update ? toHang(update) : undefined;
+							};
+
 				for (;;) {
-					const update = await Promise.race([effect.cancel, Catalog.fetch(catalog)]);
-					if (!update) break;
-
-					console.debug("received catalog", this.name.peek(), update);
-
-					this.#catalog.set(update);
-					this.status.set("live");
+					const root = await fetchNext();
+					if (!root) break;
+					console.debug("received catalog", first.kind, this.name.peek(), root);
+					this.#catalog.set(root);
 				}
 			} catch (err) {
 				console.warn("error fetching catalog", this.name.peek(), err);

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -26,7 +26,7 @@ export interface BroadcastProps {
 	reload?: boolean | Signal<boolean>;
 
 	// Which catalog format to use. Default: "hang"
-	catalog?: CatalogFormat | Signal<CatalogFormat>;
+	catalogFormat?: CatalogFormat | Signal<CatalogFormat>;
 }
 
 // A catalog source that (optionally) reloads automatically when live/offline.
@@ -56,7 +56,7 @@ export class Broadcast {
 		this.name = Signal.from(props?.name ?? Path.empty());
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.reload = Signal.from(props?.reload ?? false);
-		this.catalogFormat = Signal.from(props?.catalog ?? "hang");
+		this.catalogFormat = Signal.from(props?.catalogFormat ?? "hang");
 
 		this.#announced = props?.announced ?? new Signal(new Set());
 

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -5,11 +5,11 @@ import { MultiBackend } from "./backend";
 import { Broadcast, type CatalogFormat } from "./broadcast";
 import type { Latency } from "./sync";
 
-function parseCatalog(value: string | null): CatalogFormat {
+function parseCatalogFormat(value: string | null): CatalogFormat {
 	return value === "msf" ? "msf" : "hang";
 }
 
-const OBSERVED = ["url", "name", "paused", "volume", "muted", "reload", "latency", "jitter", "catalog"] as const;
+const OBSERVED = ["url", "name", "paused", "volume", "muted", "reload", "latency", "jitter", "catalog-format"] as const;
 type Observed = (typeof OBSERVED)[number];
 
 // Close everything when this element is garbage collected.
@@ -179,8 +179,8 @@ export default class MoqWatch extends HTMLElement {
 		} else if (name === "jitter") {
 			// Deprecated: use latency="<number>" instead.
 			this.#setLatencyNumber(newValue);
-		} else if (name === "catalog") {
-			this.broadcast.catalogFormat.set(parseCatalog(newValue));
+		} else if (name === "catalog-format") {
+			this.broadcast.catalogFormat.set(parseCatalogFormat(newValue));
 		} else {
 			const exhaustive: never = name;
 			throw new Error(`Invalid attribute: ${exhaustive}`);
@@ -253,11 +253,11 @@ export default class MoqWatch extends HTMLElement {
 		this.backend.latency.set(value as Time.Milli);
 	}
 
-	get catalog(): CatalogFormat {
+	get catalogFormat(): CatalogFormat {
 		return this.broadcast.catalogFormat.peek();
 	}
 
-	set catalog(value: CatalogFormat) {
+	set catalogFormat(value: CatalogFormat) {
 		this.broadcast.catalogFormat.set(value);
 	}
 }

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -2,14 +2,11 @@ import type { Time } from "@moq/lite";
 import * as Moq from "@moq/lite";
 import { Effect, Signal } from "@moq/signals";
 import { MultiBackend } from "./backend";
-import { Broadcast, type CatalogAttr, type CatalogFormat, catalogAttrSchema } from "./broadcast";
+import { Broadcast, type CatalogFormat } from "./broadcast";
 import type { Latency } from "./sync";
 
-function parseCatalogAttr(value: string | null): CatalogFormat[] {
-	const parsed = catalogAttrSchema.safeParse(value);
-	if (!parsed.success) return ["hang"];
-	if (parsed.data === "auto") return ["hang", "msf"];
-	return [parsed.data];
+function parseCatalog(value: string | null): CatalogFormat {
+	return value === "msf" ? "msf" : "hang";
 }
 
 const OBSERVED = ["url", "name", "paused", "volume", "muted", "reload", "latency", "jitter", "catalog"] as const;
@@ -183,7 +180,7 @@ export default class MoqWatch extends HTMLElement {
 			// Deprecated: use latency="<number>" instead.
 			this.#setLatencyNumber(newValue);
 		} else if (name === "catalog") {
-			this.broadcast.catalogFormats.set(parseCatalogAttr(newValue));
+			this.broadcast.catalogFormat.set(parseCatalog(newValue));
 		} else {
 			const exhaustive: never = name;
 			throw new Error(`Invalid attribute: ${exhaustive}`);
@@ -256,16 +253,12 @@ export default class MoqWatch extends HTMLElement {
 		this.backend.latency.set(value as Time.Milli);
 	}
 
-	get catalog(): CatalogFormat[] {
-		return this.broadcast.catalogFormats.peek();
+	get catalog(): CatalogFormat {
+		return this.broadcast.catalogFormat.peek();
 	}
 
-	set catalog(value: CatalogAttr | CatalogFormat[]) {
-		if (typeof value === "string") {
-			this.broadcast.catalogFormats.set(parseCatalogAttr(value));
-		} else {
-			this.broadcast.catalogFormats.set(value);
-		}
+	set catalog(value: CatalogFormat) {
+		this.broadcast.catalogFormat.set(value);
 	}
 }
 

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -2,10 +2,17 @@ import type { Time } from "@moq/lite";
 import * as Moq from "@moq/lite";
 import { Effect, Signal } from "@moq/signals";
 import { MultiBackend } from "./backend";
-import { Broadcast } from "./broadcast";
+import { Broadcast, type CatalogAttr, type CatalogFormat, catalogAttrSchema } from "./broadcast";
 import type { Latency } from "./sync";
 
-const OBSERVED = ["url", "name", "paused", "volume", "muted", "reload", "latency", "jitter"] as const;
+function parseCatalogAttr(value: string | null): CatalogFormat[] {
+	const parsed = catalogAttrSchema.safeParse(value);
+	if (!parsed.success) return ["hang"];
+	if (parsed.data === "auto") return ["hang", "msf"];
+	return [parsed.data];
+}
+
+const OBSERVED = ["url", "name", "paused", "volume", "muted", "reload", "latency", "jitter", "catalog"] as const;
 type Observed = (typeof OBSERVED)[number];
 
 // Close everything when this element is garbage collected.
@@ -175,6 +182,8 @@ export default class MoqWatch extends HTMLElement {
 		} else if (name === "jitter") {
 			// Deprecated: use latency="<number>" instead.
 			this.#setLatencyNumber(newValue);
+		} else if (name === "catalog") {
+			this.broadcast.catalogFormats.set(parseCatalogAttr(newValue));
 		} else {
 			const exhaustive: never = name;
 			throw new Error(`Invalid attribute: ${exhaustive}`);
@@ -245,6 +254,18 @@ export default class MoqWatch extends HTMLElement {
 	/** @deprecated Use `latency = <number>` instead. */
 	set jitter(value: number) {
 		this.backend.latency.set(value as Time.Milli);
+	}
+
+	get catalog(): CatalogFormat[] {
+		return this.broadcast.catalogFormats.peek();
+	}
+
+	set catalog(value: CatalogAttr | CatalogFormat[]) {
+		if (typeof value === "string") {
+			this.broadcast.catalogFormats.set(parseCatalogAttr(value));
+		} else {
+			this.broadcast.catalogFormats.set(value);
+		}
 	}
 }
 

--- a/js/watch/src/msf.ts
+++ b/js/watch/src/msf.ts
@@ -61,6 +61,7 @@ function toVideoConfig(track: Msf.Track): Catalog.VideoConfig | undefined {
 		codedHeight: track.height != null ? u53(track.height) : undefined,
 		framerate: track.framerate,
 		bitrate: track.bitrate != null ? u53(track.bitrate) : undefined,
+		jitter: track.jitter != null ? u53(track.jitter) : undefined,
 	};
 }
 
@@ -81,6 +82,7 @@ function toAudioConfig(track: Msf.Track): Catalog.AudioConfig | undefined {
 		sampleRate: u53(track.samplerate ?? DEFAULT_SAMPLE_RATE),
 		numberOfChannels: u53(channels),
 		bitrate: track.bitrate != null ? u53(track.bitrate) : undefined,
+		jitter: track.jitter != null ? u53(track.jitter) : undefined,
 	};
 }
 

--- a/js/watch/src/msf.ts
+++ b/js/watch/src/msf.ts
@@ -1,0 +1,113 @@
+import type * as Catalog from "@moq/hang/catalog";
+import { u53 } from "@moq/hang/catalog";
+import { Cmaf } from "@moq/hang/container";
+import type * as Msf from "@moq/msf";
+
+const DEFAULT_SAMPLE_RATE = 48000;
+const DEFAULT_NUMBER_OF_CHANNELS = 2;
+
+function base64ToBytes(b64: string): Uint8Array | undefined {
+	try {
+		const raw = atob(b64);
+		const bytes = new Uint8Array(raw.length);
+		for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+		return bytes;
+	} catch {
+		return undefined;
+	}
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+	let hex = "";
+	for (let i = 0; i < bytes.length; i++) hex += bytes[i].toString(16).padStart(2, "0");
+	return hex;
+}
+
+interface ContainerInfo {
+	container: Catalog.Container;
+	description?: string;
+}
+
+function toContainer(track: Msf.Track): ContainerInfo {
+	const initBytes = track.initData ? base64ToBytes(track.initData) : undefined;
+
+	if (track.packaging === "cmaf" && initBytes) {
+		try {
+			const init = Cmaf.decodeInitSegment(initBytes);
+			return {
+				container: { kind: "cmaf", timescale: u53(init.timescale), trackId: u53(init.trackId) },
+				description: init.description ? bytesToHex(init.description) : undefined,
+			};
+		} catch (err) {
+			console.warn("failed to parse MSF cmaf initData, falling back to legacy", err);
+		}
+	}
+
+	return {
+		container: { kind: "legacy" },
+		description: initBytes ? bytesToHex(initBytes) : undefined,
+	};
+}
+
+function toVideoConfig(track: Msf.Track): Catalog.VideoConfig | undefined {
+	if (!track.codec) return undefined;
+
+	const { container, description } = toContainer(track);
+	return {
+		codec: track.codec,
+		container,
+		description,
+		codedWidth: track.width != null ? u53(track.width) : undefined,
+		codedHeight: track.height != null ? u53(track.height) : undefined,
+		framerate: track.framerate,
+		bitrate: track.bitrate != null ? u53(track.bitrate) : undefined,
+	};
+}
+
+function toAudioConfig(track: Msf.Track): Catalog.AudioConfig | undefined {
+	if (!track.codec) return undefined;
+
+	const channels = (() => {
+		if (!track.channelConfig) return DEFAULT_NUMBER_OF_CHANNELS;
+		const parsed = Number.parseInt(track.channelConfig, 10);
+		return Number.isFinite(parsed) ? parsed : DEFAULT_NUMBER_OF_CHANNELS;
+	})();
+
+	const { container, description } = toContainer(track);
+	return {
+		codec: track.codec,
+		container,
+		description,
+		sampleRate: u53(track.samplerate ?? DEFAULT_SAMPLE_RATE),
+		numberOfChannels: u53(channels),
+		bitrate: track.bitrate != null ? u53(track.bitrate) : undefined,
+	};
+}
+
+/** Convert an MSF catalog to a hang catalog Root. */
+export function toHang(msf: Msf.Catalog): Catalog.Root {
+	const videoRenditions: Record<string, Catalog.VideoConfig> = {};
+	const audioRenditions: Record<string, Catalog.AudioConfig> = {};
+
+	for (const track of msf.tracks) {
+		if (track.role === "video") {
+			const config = toVideoConfig(track);
+			if (config) videoRenditions[track.name] = config;
+		} else if (track.role === "audio") {
+			const config = toAudioConfig(track);
+			if (config) audioRenditions[track.name] = config;
+		}
+	}
+
+	const root: Catalog.Root = {};
+
+	if (Object.keys(videoRenditions).length > 0) {
+		root.video = { renditions: videoRenditions };
+	}
+
+	if (Object.keys(audioRenditions).length > 0) {
+		root.audio = { renditions: audioRenditions };
+	}
+
+	return root;
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"js/clock",
 		"js/token",
 		"js/hang",
+		"js/msf",
 		"js/ui-core",
 		"js/watch",
 		"js/publish",


### PR DESCRIPTION
## Summary
This PR adds support for the MSF (MOQT Streaming Format) catalog format alongside the existing hang format, with intelligent format negotiation that races both formats and selects the first successful response.

## Key Changes

- **New `@moq/msf` package**: Created a new package with MSF catalog types and utilities
  - `catalog.ts`: Defines MSF catalog schema with Zod validation and encode/decode functions
  - Supports parsing MSF track metadata (codec, dimensions, sample rate, bitrate, etc.)

- **MSF to hang conversion**: Added `js/watch/src/msf.ts` with conversion utilities
  - `toHang()`: Converts MSF catalogs to hang format for unified internal representation
  - `toVideoConfig()` and `toAudioConfig()`: Extract and normalize track configurations
  - `toContainer()`: Parses CMAF init segments with fallback to legacy format

- **Catalog format negotiation in Broadcast**:
  - Added `catalogFormats` signal to allow configurable format preferences
  - Implements race-based format selection: hang format gets a 100ms headstart, then both formats compete via `Promise.any()`
  - Winner continues streaming updates; loser track is closed
  - Supports single or multiple format preferences

- **HTML element API**: Extended `<moq-watch>` element
  - New `catalog` attribute: accepts "hang", "msf", or "auto" (tries both)
  - New `catalog` property: getter/setter for programmatic control
  - Attribute parsing with `parseCatalogAttr()` utility

## Implementation Details

- Format negotiation uses `Promise.race()` for the initial fetch (with MSF delayed by 100ms) and `Promise.any()` to ensure only successful fetches compete
- MSF catalog fetches are wrapped to reject on empty results, ensuring meaningful competition
- The winning format continues to be used for subsequent updates, avoiding format switching
- All MSF numeric values are wrapped with `u53()` for safe integer handling
- Base64 decoding of init data includes error handling with fallback to legacy format

https://claude.ai/code/session_012gjc9wFMcfGj83fazaJ5ij