### PR TITLE
Update fly.toml to use the hosted docker image

### DIFF
--- a/rs/moq-relay/fly.toml
+++ b/rs/moq-relay/fly.toml
@@ -3,7 +3,7 @@ primary_region = 'sjc'
 
 # Built with `nix build .#moq-relay-docker`
 [build]
-image = "moq-relay:latest"
+image = "moqdev/moq-relay:latest"
 
 # Enable multiple regions for global edge deployment
 [[services]]


### PR DESCRIPTION
Tiny little baby change, but when I went to deploy the relay to Fly it failed because it couldn't pull the image from dockerhub. This just updates the fly.toml config to use the full name of the hosted image.