### PR TITLE
moq-native: resolve DNS hostnames in --server-bind

### DIFF
--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> anyhow::Result<()> {
 
 	match cli.command {
 		Command::Serve { config, dir, name, .. } => {
-			let web_bind = config.bind.unwrap_or("[::]:443".parse().unwrap());
+			let web_bind = config.bind.clone().unwrap_or_else(|| "[::]:443".to_string());
 
 			let server = config.init()?;
 			#[cfg(feature = "iroh")]
@@ -120,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
 
 			tokio::select! {
 				res = run_server(server, name, publish.consume()) => res,
-				res = run_web(web_bind, web_tls, dir) => res,
+				res = run_web(&web_bind, web_tls, dir) => res,
 				res = publish.run(stats_interval) => res,
 			}
 		}

--- a/rs/moq-cli/src/web.rs
+++ b/rs/moq-cli/src/web.rs
@@ -14,11 +14,7 @@ pub async fn run_web(
 	tls_info: Arc<RwLock<moq_native::ServerTlsInfo>>,
 	public: Option<PathBuf>,
 ) -> anyhow::Result<()> {
-	let listen = tokio::net::lookup_host(bind)
-		.await
-		.with_context(|| format!("invalid listen address '{bind}'"))?
-		.next()
-		.with_context(|| format!("no addresses resolved for listen '{bind}'"))?;
+	let listen = moq_native::resolve_addr(bind).context("invalid listen address")?;
 
 	async fn handle_404() -> impl IntoResponse {
 		(StatusCode::NOT_FOUND, "Not found")

--- a/rs/moq-cli/src/web.rs
+++ b/rs/moq-cli/src/web.rs
@@ -3,7 +3,6 @@ use axum::handler::HandlerWithoutStateExt;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Router, http::Method, routing::get};
-use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tower_http::cors::{Any, CorsLayer};
@@ -11,15 +10,15 @@ use tower_http::services::ServeDir;
 
 // Initialize the HTTP server (but don't serve yet).
 pub async fn run_web(
-	bind: SocketAddr,
+	bind: &str,
 	tls_info: Arc<RwLock<moq_native::ServerTlsInfo>>,
 	public: Option<PathBuf>,
 ) -> anyhow::Result<()> {
 	let listen = tokio::net::lookup_host(bind)
 		.await
-		.context("invalid listen address")?
+		.with_context(|| format!("invalid listen address '{bind}'"))?
 		.next()
-		.context("invalid listen address")?;
+		.with_context(|| format!("no addresses resolved for listen '{bind}'"))?;
 
 	async fn handle_404() -> impl IntoResponse {
 		(StatusCode::NOT_FOUND, "Not found")

--- a/rs/moq-cli/src/web.rs
+++ b/rs/moq-cli/src/web.rs
@@ -14,7 +14,11 @@ pub async fn run_web(
 	tls_info: Arc<RwLock<moq_native::ServerTlsInfo>>,
 	public: Option<PathBuf>,
 ) -> anyhow::Result<()> {
-	let listen = moq_native::resolve_addr(bind).context("invalid listen address")?;
+	let listen = tokio::net::lookup_host(bind)
+		.await
+		.context("invalid listen address")?
+		.next()
+		.context("invalid listen address")?;
 
 	async fn handle_404() -> impl IntoResponse {
 		(StatusCode::NOT_FOUND, "Not found")

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -11,6 +11,21 @@
 /// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
 pub(crate) const DEFAULT_MAX_STREAMS: u64 = 1024;
 
+/// Resolve a `host:port` string to a single [`std::net::SocketAddr`].
+///
+/// Accepts both literal socket addresses (e.g. `[::]:443`) and DNS hostnames
+/// paired with a port (e.g. `fly-global-services:443`). Only the first
+/// resolved address is returned; Quinn only supports a single IP when
+/// binding/connecting.
+pub fn resolve_addr(addr: &str) -> anyhow::Result<std::net::SocketAddr> {
+	use anyhow::Context;
+	use std::net::ToSocketAddrs;
+	addr.to_socket_addrs()
+		.context("invalid address")?
+		.next()
+		.context("no addresses resolved")
+}
+
 mod client;
 mod crypto;
 mod log;

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -11,21 +11,6 @@
 /// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
 pub(crate) const DEFAULT_MAX_STREAMS: u64 = 1024;
 
-/// Resolve a `host:port` string to a single [`std::net::SocketAddr`].
-///
-/// Accepts both literal socket addresses (e.g. `[::]:443`) and DNS hostnames
-/// paired with a port (e.g. `fly-global-services:443`). Only the first
-/// resolved address is returned; Quinn only supports a single IP when
-/// binding/connecting.
-pub fn resolve_addr(addr: &str) -> anyhow::Result<std::net::SocketAddr> {
-	use anyhow::Context;
-	use std::net::ToSocketAddrs;
-	addr.to_socket_addrs()
-		.context("invalid address")?
-		.next()
-		.context("no addresses resolved")
-}
-
 mod client;
 mod crypto;
 mod log;
@@ -37,6 +22,7 @@ mod reconnect;
 mod server;
 #[cfg(any(feature = "noq", feature = "quinn"))]
 mod tls;
+mod util;
 #[cfg(feature = "websocket")]
 mod websocket;
 

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -189,7 +189,8 @@ impl NoqServer {
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = noq::default_runtime().context("no async runtime")?;
 
-		let listen = config.resolve_bind()?;
+		let listen = crate::resolve_addr(config.bind.as_deref().unwrap_or(crate::server::DEFAULT_BIND))
+			.context("failed to resolve bind address")?;
 
 		// Configure connection ID generator with server ID if provided
 		let mut endpoint_config = noq::EndpointConfig::default();

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -189,7 +189,7 @@ impl NoqServer {
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = noq::default_runtime().context("no async runtime")?;
 
-		let listen = crate::resolve_addr(config.bind.as_deref().unwrap_or(crate::server::DEFAULT_BIND))
+		let listen = crate::util::resolve(config.bind.as_deref(), crate::server::DEFAULT_BIND)
 			.context("failed to resolve bind address")?;
 
 		// Configure connection ID generator with server ID if provided

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -189,6 +189,8 @@ impl NoqServer {
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = noq::default_runtime().context("no async runtime")?;
 
+		let listen = config.resolve_bind()?;
+
 		// Configure connection ID generator with server ID if provided
 		let mut endpoint_config = noq::EndpointConfig::default();
 		if let Some(server_id) = config.quic_lb_id {
@@ -206,7 +208,6 @@ impl NoqServer {
 			endpoint_config.cid_generator(move || Box::new(ServerIdGenerator::new(server_id.clone(), nonce_len)));
 		}
 
-		let listen = config.bind.unwrap_or("[::]:443".parse().unwrap());
 		let socket = std::net::UdpSocket::bind(listen).context("failed to bind UDP socket")?;
 
 		// Create the generic QUIC endpoint.

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -114,7 +114,7 @@ impl QuicheServer {
 			tracing::warn!("QUIC-LB is not supported with the quiche backend; ignoring server ID");
 		}
 
-		let listen = config.bind.unwrap_or("[::]:443".parse().unwrap());
+		let listen = config.resolve_bind()?;
 
 		let (chain, key) = if !config.tls.generate.is_empty() {
 			generate_quiche_cert(&config.tls.generate)?

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -114,7 +114,7 @@ impl QuicheServer {
 			tracing::warn!("QUIC-LB is not supported with the quiche backend; ignoring server ID");
 		}
 
-		let listen = crate::resolve_addr(config.bind.as_deref().unwrap_or(crate::server::DEFAULT_BIND))
+		let listen = crate::util::resolve(config.bind.as_deref(), crate::server::DEFAULT_BIND)
 			.context("failed to resolve bind address")?;
 
 		let (chain, key) = if !config.tls.generate.is_empty() {

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -114,7 +114,8 @@ impl QuicheServer {
 			tracing::warn!("QUIC-LB is not supported with the quiche backend; ignoring server ID");
 		}
 
-		let listen = config.resolve_bind()?;
+		let listen = crate::resolve_addr(config.bind.as_deref().unwrap_or(crate::server::DEFAULT_BIND))
+			.context("failed to resolve bind address")?;
 
 		let (chain, key) = if !config.tls.generate.is_empty() {
 			generate_quiche_cert(&config.tls.generate)?

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -227,7 +227,7 @@ impl QuinnServer {
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = quinn::default_runtime().context("no async runtime")?;
 
-		let listen = crate::resolve_addr(config.bind.as_deref().unwrap_or(crate::server::DEFAULT_BIND))
+		let listen = crate::util::resolve(config.bind.as_deref(), crate::server::DEFAULT_BIND)
 			.context("failed to resolve bind address")?;
 
 		// Configure connection ID generator with server ID if provided

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -227,7 +227,8 @@ impl QuinnServer {
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = quinn::default_runtime().context("no async runtime")?;
 
-		let listen = config.resolve_bind()?;
+		let listen = crate::resolve_addr(config.bind.as_deref().unwrap_or(crate::server::DEFAULT_BIND))
+			.context("failed to resolve bind address")?;
 
 		// Configure connection ID generator with server ID if provided
 		let mut endpoint_config = quinn::EndpointConfig::default();

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -227,6 +227,8 @@ impl QuinnServer {
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = quinn::default_runtime().context("no async runtime")?;
 
+		let listen = config.resolve_bind()?;
+
 		// Configure connection ID generator with server ID if provided
 		let mut endpoint_config = quinn::EndpointConfig::default();
 		if let Some(server_id) = config.quic_lb_id {
@@ -244,7 +246,6 @@ impl QuinnServer {
 			endpoint_config.cid_generator(move || Box::new(ServerIdGenerator::new(server_id.clone(), nonce_len)));
 		}
 
-		let listen = config.bind.unwrap_or("[::]:443".parse().unwrap());
 		let socket = std::net::UdpSocket::bind(listen).context("failed to bind UDP socket")?;
 
 		// Create the generic QUIC endpoint.

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -90,9 +90,14 @@ impl ServerTlsConfig {
 pub struct ServerConfig {
 	/// Listen for UDP packets on the given address.
 	/// Defaults to `[::]:443` if not provided.
+	///
+	/// Accepts standard socket address syntax (e.g. `[::]:443`) or a DNS
+	/// `host:port` pair (e.g. `fly-global-services:443`), which is resolved
+	/// at bind time. Only the first resolved address is used; Quinn does not
+	/// support binding to multiple addresses.
 	#[serde(alias = "listen")]
 	#[arg(id = "server-bind", long = "server-bind", alias = "listen", env = "MOQ_SERVER_BIND")]
-	pub bind: Option<net::SocketAddr>,
+	pub bind: Option<String>,
 
 	/// The QUIC backend to use.
 	/// Auto-detected from compiled features if not specified.
@@ -154,6 +159,31 @@ impl ServerConfig {
 			moq_lite::Versions::from(self.version.clone())
 		}
 	}
+
+	/// Resolve [`Self::bind`] to a single [`net::SocketAddr`], performing DNS
+	/// lookup when the value is a `host:port` pair.
+	///
+	/// Defaults to `[::]:443` if no bind address was configured. Only the first
+	/// resolved address is returned; Quinn does not support binding to multiple
+	/// addresses.
+	pub(crate) fn resolve_bind(&self) -> anyhow::Result<net::SocketAddr> {
+		let bind = self.bind.as_deref().unwrap_or("[::]:443");
+		resolve_host_port(bind).with_context(|| format!("failed to resolve bind address '{bind}'"))
+	}
+}
+
+/// Resolve a `host:port` string to a single [`net::SocketAddr`].
+///
+/// Accepts both literal socket addresses (e.g. `[::]:443`) and DNS hostnames
+/// paired with a port (e.g. `fly-global-services:443`). Only the first
+/// resolved address is returned, matching the client-side resolver, since
+/// Quinn only supports binding/connecting to a single IP.
+pub(crate) fn resolve_host_port(addr: &str) -> anyhow::Result<net::SocketAddr> {
+	use std::net::ToSocketAddrs;
+	addr.to_socket_addrs()
+		.context("DNS lookup failed")?
+		.next()
+		.context("no addresses resolved")
 }
 
 /// Server for accepting MoQ connections over QUIC.

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -159,32 +159,10 @@ impl ServerConfig {
 			moq_lite::Versions::from(self.version.clone())
 		}
 	}
-
-	/// Resolve [`Self::bind`] to a single [`net::SocketAddr`], performing DNS
-	/// lookup when the value is a `host:port` pair.
-	///
-	/// Defaults to `[::]:443` if no bind address was configured. Only the first
-	/// resolved address is returned; Quinn does not support binding to multiple
-	/// addresses.
-	pub(crate) fn resolve_bind(&self) -> anyhow::Result<net::SocketAddr> {
-		let bind = self.bind.as_deref().unwrap_or("[::]:443");
-		resolve_host_port(bind).with_context(|| format!("failed to resolve bind address '{bind}'"))
-	}
 }
 
-/// Resolve a `host:port` string to a single [`net::SocketAddr`].
-///
-/// Accepts both literal socket addresses (e.g. `[::]:443`) and DNS hostnames
-/// paired with a port (e.g. `fly-global-services:443`). Only the first
-/// resolved address is returned, matching the client-side resolver, since
-/// Quinn only supports binding/connecting to a single IP.
-pub(crate) fn resolve_host_port(addr: &str) -> anyhow::Result<net::SocketAddr> {
-	use std::net::ToSocketAddrs;
-	addr.to_socket_addrs()
-		.context("DNS lookup failed")?
-		.next()
-		.context("no addresses resolved")
-}
+/// Default bind address used when [`ServerConfig::bind`] is not set.
+pub(crate) const DEFAULT_BIND: &str = "[::]:443";
 
 /// Server for accepting MoQ connections over QUIC.
 ///

--- a/rs/moq-native/src/util.rs
+++ b/rs/moq-native/src/util.rs
@@ -1,0 +1,17 @@
+use anyhow::Context;
+
+/// Resolve a `host:port` string to a single [`std::net::SocketAddr`],
+/// falling back to `default` when `addr` is `None`.
+///
+/// Accepts both literal socket addresses (e.g. `[::]:443`) and DNS hostnames
+/// paired with a port (e.g. `fly-global-services:443`). Only the first
+/// resolved address is returned; Quinn only supports a single IP when
+/// binding/connecting.
+pub(crate) fn resolve(addr: Option<&str>, default: &str) -> anyhow::Result<std::net::SocketAddr> {
+	use std::net::ToSocketAddrs;
+	addr.unwrap_or(default)
+		.to_socket_addrs()
+		.context("invalid address")?
+		.next()
+		.context("no addresses resolved")
+}

--- a/rs/moq-native/src/util.rs
+++ b/rs/moq-native/src/util.rs
@@ -15,3 +15,29 @@ pub(crate) fn resolve(addr: Option<&str>, default: &str) -> anyhow::Result<std::
 		.next()
 		.context("no addresses resolved")
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn resolves_socket_literal() {
+		let addr = resolve(Some("[::]:0"), "[::]:443").unwrap();
+		assert!(addr.ip().is_unspecified());
+		assert_eq!(addr.port(), 0);
+	}
+
+	#[test]
+	fn resolves_dns_hostname() {
+		let addr = resolve(Some("localhost:0"), "[::]:443").unwrap();
+		assert!(addr.ip().is_loopback());
+		assert_eq!(addr.port(), 0);
+	}
+
+	#[test]
+	fn falls_back_to_default() {
+		let addr = resolve(None, "127.0.0.1:1234").unwrap();
+		assert_eq!(addr.ip().to_string(), "127.0.0.1");
+		assert_eq!(addr.port(), 1234);
+	}
+}

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -15,7 +15,7 @@ async fn connect_with_version(version: &str) {
 
 	// ── server ──────────────────────────────────────────────────────
 	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".parse().unwrap());
+	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 	server_config.version = vec![version];
 
@@ -64,7 +64,7 @@ async fn connect_with_webtransport(version: Option<&str>) {
 
 	// ── server ──────────────────────────────────────────────────────
 	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".parse().unwrap());
+	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 	if let Some(v) = version {
 		server_config.version = vec![v];

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -25,7 +25,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	group.finish().expect("failed to finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".parse().unwrap());
+	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 	server_config.backend = Some(backend.clone());
 
@@ -163,7 +163,7 @@ async fn iroh_connect() {
 
 	// Server still needs a QUIC bind for init, but we'll connect via iroh
 	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".parse().unwrap());
+	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 
 	let mut server = server_config

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -35,7 +35,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	group.finish().expect("failed to finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".parse().unwrap());
+	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 	if let Some(v) = server_version {
 		server_config.version = vec![v];
@@ -373,7 +373,7 @@ async fn broadcast_websocket() {
 
 	// Server with both QUIC (required) and WebSocket listeners.
 	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".parse().unwrap());
+	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 
 	let ws_listener = moq_native::WebSocketListener::bind("[::]:0".parse().unwrap())
@@ -477,7 +477,7 @@ async fn broadcast_websocket_fallback() {
 
 	// QUIC binds on its own port; WebSocket on a different port.
 	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".parse().unwrap());
+	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 
 	let ws_listener = moq_native::WebSocketListener::bind("[::]:0".parse().unwrap())

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -16,8 +16,6 @@ async fn main() -> anyhow::Result<()> {
 
 	let mut config = Config::load()?;
 
-	let addr = config.server.bind.unwrap_or("[::]:443".parse().unwrap());
-
 	config.client.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
 	config.server.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
 
@@ -26,6 +24,8 @@ async fn main() -> anyhow::Result<()> {
 	#[allow(unused_mut)]
 	let mut server = config.server.init()?;
 	let client = config.client.clone().init()?;
+
+	let addr = server.local_addr()?;
 
 	#[cfg(feature = "iroh")]
 	let (server, client) = {


### PR DESCRIPTION
Accept host:port inputs like `fly-global-services:443` (used on Fly.io)
by changing ServerConfig::bind from SocketAddr to String and resolving
at bind time. Only the first resolved address is used since Quinn does
not support binding to multiple addresses.

https://claude.ai/code/session_01BJSqQsZ5iyuCtY9EuYSy5b