### PR TITLE
lite: raise WebSocket race head start to 500ms and skip if WebTransport won

### DIFF
--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -409,10 +409,6 @@ async function connectWebSocket(
 
 	const active = await Promise.race([cancel, timer.then(() => true)]);
 	if (!active) return undefined;
-
-	// Yield a microtask so a concurrently-resolving WebTransport has a chance
-	// to flip the cancelled flag before we open a socket.
-	await Promise.resolve();
 	if (isCancelled()) return undefined;
 
 	const quic = new Session(url);

--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -13,7 +13,7 @@ export interface WebSocketOptions {
 	// By default, `https` => `wss` and `http` => `ws`.
 	url?: URL;
 
-	// The delay in milliseconds before attempting the WebSocket fallback. (default: 200)
+	// The delay in milliseconds before attempting the WebSocket fallback. (default: 500)
 	// If WebSocket won the previous race for a given URL, this will be 0.
 	delay?: DOMHighResTimeStamp;
 }
@@ -50,20 +50,26 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	}
 
 	// Create a cancel promise to kill whichever is still connecting.
+	// `cancelled` lets us synchronously check if the race is already decided,
+	// so the WebSocket fallback can bail before opening a socket.
+	let cancelled = false;
 	let done: (() => void) | undefined;
 	const cancel = new Promise<void>((resolve) => {
-		done = resolve;
+		done = () => {
+			cancelled = true;
+			resolve();
+		};
 	});
 
 	const webtransport =
 		globalThis.WebTransport && !isFirefox ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
 
-	// Give QUIC a 200ms head start to connect before trying WebSocket, unless WebSocket has won in the past.
+	// Give QUIC a 500ms head start to connect before trying WebSocket, unless WebSocket has won in the past.
 	// NOTE that QUIC should be faster because it involves 1/2 fewer RTTs.
-	const headstart = !webtransport || websocketWon.has(url.toString()) ? 0 : (props?.websocket?.delay ?? 200);
+	const headstart = !webtransport || websocketWon.has(url.toString()) ? 0 : (props?.websocket?.delay ?? 500);
 	const websocket =
 		props?.websocket?.enabled !== false
-			? connectWebSocket(props?.websocket?.url ?? url, headstart, cancel)
+			? connectWebSocket(props?.websocket?.url ?? url, headstart, cancel, () => cancelled)
 			: undefined;
 
 	if (!websocket && !webtransport) {
@@ -393,11 +399,21 @@ async function connectWebTransport(
 }
 
 // TODO accept arguments to control the port/path used.
-async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>): Promise<Session | undefined> {
+async function connectWebSocket(
+	url: URL,
+	delay: number,
+	cancel: Promise<void>,
+	isCancelled: () => boolean,
+): Promise<Session | undefined> {
 	const timer = new Promise<void>((resolve) => setTimeout(resolve, delay));
 
 	const active = await Promise.race([cancel, timer.then(() => true)]);
 	if (!active) return undefined;
+
+	// Yield a microtask so a concurrently-resolving WebTransport has a chance
+	// to flip the cancelled flag before we open a socket.
+	await Promise.resolve();
+	if (isCancelled()) return undefined;
 
 	const quic = new Session(url);
 

--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -50,15 +50,9 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	}
 
 	// Create a cancel promise to kill whichever is still connecting.
-	// `cancelled` lets us synchronously check if the race is already decided,
-	// so the WebSocket fallback can bail before opening a socket.
-	let cancelled = false;
 	let done: (() => void) | undefined;
 	const cancel = new Promise<void>((resolve) => {
-		done = () => {
-			cancelled = true;
-			resolve();
-		};
+		done = resolve;
 	});
 
 	const webtransport =
@@ -69,7 +63,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	const headstart = !webtransport || websocketWon.has(url.toString()) ? 0 : (props?.websocket?.delay ?? 500);
 	const websocket =
 		props?.websocket?.enabled !== false
-			? connectWebSocket(props?.websocket?.url ?? url, headstart, cancel, () => cancelled)
+			? connectWebSocket(props?.websocket?.url ?? url, headstart, cancel)
 			: undefined;
 
 	if (!websocket && !webtransport) {
@@ -399,17 +393,11 @@ async function connectWebTransport(
 }
 
 // TODO accept arguments to control the port/path used.
-async function connectWebSocket(
-	url: URL,
-	delay: number,
-	cancel: Promise<void>,
-	isCancelled: () => boolean,
-): Promise<Session | undefined> {
+async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>): Promise<Session | undefined> {
 	const timer = new Promise<void>((resolve) => setTimeout(resolve, delay));
 
 	const active = await Promise.race([cancel, timer.then(() => true)]);
 	if (!active) return undefined;
-	if (isCancelled()) return undefined;
 
 	const quic = new Session(url);
 

--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -5,6 +5,9 @@ import { Reader, Stream, Writer } from "../stream.ts";
 import * as Hex from "../util/hex.ts";
 import type { Established } from "./established.ts";
 
+// Default head start for WebTransport before attempting the WebSocket fallback.
+const DEFAULT_WEBSOCKET_DELAY_MS = 500;
+
 export interface WebSocketOptions {
 	// If true (default), enable the WebSocket fallback.
 	enabled?: boolean;
@@ -13,7 +16,8 @@ export interface WebSocketOptions {
 	// By default, `https` => `wss` and `http` => `ws`.
 	url?: URL;
 
-	// The delay in milliseconds before attempting the WebSocket fallback. (default: 500)
+	// The delay in milliseconds before attempting the WebSocket fallback.
+	// Defaults to DEFAULT_WEBSOCKET_DELAY_MS.
 	// If WebSocket won the previous race for a given URL, this will be 0.
 	delay?: DOMHighResTimeStamp;
 }
@@ -58,9 +62,12 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	const webtransport =
 		globalThis.WebTransport && !isFirefox ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
 
-	// Give QUIC a 500ms head start to connect before trying WebSocket, unless WebSocket has won in the past.
+	// Give QUIC a head start to connect before trying WebSocket, unless WebSocket has won in the past.
 	// NOTE that QUIC should be faster because it involves 1/2 fewer RTTs.
-	const headstart = !webtransport || websocketWon.has(url.toString()) ? 0 : (props?.websocket?.delay ?? 500);
+	const headstart =
+		!webtransport || websocketWon.has(url.toString())
+			? 0
+			: (props?.websocket?.delay ?? DEFAULT_WEBSOCKET_DELAY_MS);
 	const websocket =
 		props?.websocket?.enabled !== false
 			? connectWebSocket(props?.websocket?.url ?? url, headstart, cancel)

--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -54,10 +54,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	}
 
 	// Create a cancel promise to kill whichever is still connecting.
-	let done: (() => void) | undefined;
-	const cancel = new Promise<void>((resolve) => {
-		done = resolve;
-	});
+	const { promise: cancel, resolve: done } = Promise.withResolvers<void>();
 
 	const webtransport =
 		globalThis.WebTransport && !isFirefox ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
@@ -65,9 +62,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	// Give QUIC a head start to connect before trying WebSocket, unless WebSocket has won in the past.
 	// NOTE that QUIC should be faster because it involves 1/2 fewer RTTs.
 	const headstart =
-		!webtransport || websocketWon.has(url.toString())
-			? 0
-			: (props?.websocket?.delay ?? DEFAULT_WEBSOCKET_DELAY_MS);
+		!webtransport || websocketWon.has(url.toString()) ? 0 : (props?.websocket?.delay ?? DEFAULT_WEBSOCKET_DELAY_MS);
 	const websocket =
 		props?.websocket?.enabled !== false
 			? connectWebSocket(props?.websocket?.url ?? url, headstart, cancel)
@@ -81,7 +76,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	const session = await Promise.any(
 		webtransport ? (websocket ? [websocket, webtransport] : [webtransport]) : [websocket],
 	);
-	if (done) done();
+	done();
 
 	if (!session) throw new Error("no transport available");
 

--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -16,8 +16,7 @@ export interface WebSocketOptions {
 	// By default, `https` => `wss` and `http` => `ws`.
 	url?: URL;
 
-	// The delay in milliseconds before attempting the WebSocket fallback.
-	// Defaults to DEFAULT_WEBSOCKET_DELAY_MS.
+	// The delay in milliseconds before attempting the WebSocket fallback. (default: 500)
 	// If WebSocket won the previous race for a given URL, this will be 0.
 	delay?: DOMHighResTimeStamp;
 }


### PR DESCRIPTION
Bumps the default WebSocket fallback delay from 200ms to 500ms to give
QUIC more runway, and adds an explicit synchronous check so the
WebSocket connect attempt bails out when WebTransport has already won
the race (previously the socket could still be opened in a tight
microtask ordering window).