### PR TITLE
nix: use rust-overlay's latest stable toolchain in crane builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,9 +1041,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dab3fe76c1571ecd5cfe878b61bce3fedf4adbde5d8a8653b2a7956ffd14628"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"


### PR DESCRIPTION
The Docker/Cachix workflows run `nix build .#<package>`, which goes
through the crane derivations in `nix/overlay.nix`. `crane.mkLib final`
inherits `final.rustc` from nixpkgs, which currently pins Rust 1.94 even
though rust-overlay already exposes 1.95. The release PR's `cargo
update` bumped `constant_time_eq` to 0.4.3, whose MSRV is 1.95, so the
nix build failed to compile while the devShell (using
`rust-bin.stable.latest.default`) kept working.

Override crane's toolchain with `rust-bin.stable.latest.default` to
match the devShell and track Mozilla's stable channel.