### PR TITLE
nix: align crane toolchain with devShell (rust-overlay's latest stable)

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -2,7 +2,11 @@
 { crane }:
 final: prev:
 let
-  craneLib = crane.mkLib final;
+  # Pin crane to rust-overlay's latest stable so `nix build` uses the same
+  # toolchain as `nix develop`. Without this, crane falls back to
+  # `final.rustc`/`final.cargo`, which nixpkgs resolves to its default Rust
+  # (currently 1.94) while the devShell pulls 1.95 from rust-overlay.
+  craneLib = (crane.mkLib final).overrideToolchain final.rust-bin.stable.latest.default;
 
   # Helper function to get crate info from Cargo.toml
   crateInfo = cargoTomlPath: craneLib.crateNameFromCargoToml { cargoToml = cargoTomlPath; };


### PR DESCRIPTION
## Summary
- `nix/overlay.nix` called `crane.mkLib final` with no toolchain override, so crane picked up `final.rustc`/`final.cargo` — nixpkgs's default Rust (currently 1.94) — while `devShells.default` uses `pkgs.rust-bin.stable.latest.default` from rust-overlay (currently 1.95). rust-overlay only adds `rust-bin.*`; it doesn't replace the top-level `rustc`/`cargo`, so the two code paths silently diverged.
- That split is what broke the `moq-relay-v0.10.24` Docker release: a cargo update bumped `constant_time_eq` to 0.4.3 (MSRV 1.95), devShell-based CI was fine on 1.95, and the crane-based `nix build` failed on 1.94.
- Pin crane's toolchain to `rust-bin.stable.latest.default` so `nix build` and `nix develop` track the same channel and can't drift again.

## Test plan
- [ ] `nix build .#moq-relay` on CI (Docker + Cachix)
- [ ] `nix build .#moq-cli`, `.#moq-token-cli`, `.#moq-clock`, `.#moq-boy`
- [ ] `nix develop --command just ci` still passes

https://claude.ai/code/session_01TWWsyQaG1WWZdNBDNDNg1i