### PR TITLE
chore: bump JS patch versions to publish recvGroup

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/lite/package.json
+++ b/js/lite/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/lite",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": {

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",


### PR DESCRIPTION
@moq/lite@0.2.1 on NPM was published on 2026-04-16, before the
recvGroup API was added on 2026-04-17 (#1324). The subsequent
@moq/watch@0.2.9 was built against the new API but declares
@moq/lite: ^0.2.1, which resolves to the broken 0.2.1 for
consumers, causing runtime errors when recvGroup is called.

Bump lite/hang to republish with recvGroup, and bump watch /
publish / moq-boy so downstream package.json deps lock to
^0.2.2 of lite going forward.