### PR TITLE
moq-lite: add OriginConsumer::wait_for_broadcast; deprecate consume_broadcast

### DIFF
--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -106,7 +106,7 @@ impl Origin {
 
 	pub fn consume<P: moq_lite::AsPath>(&mut self, origin: Id, path: P) -> Result<moq_lite::BroadcastConsumer, Error> {
 		let origin = self.active.get_mut(origin).ok_or(Error::OriginNotFound)?;
-		// TODO: expose an async variant backed by `wait_for_broadcast` so FFI callers can wait
+		// TODO: expose an async variant backed by `announced_broadcast` so FFI callers can wait
 		// for gossip instead of racing it.
 		#[allow(deprecated)]
 		origin.consume().consume_broadcast(path).ok_or(Error::BroadcastNotFound)

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -106,6 +106,9 @@ impl Origin {
 
 	pub fn consume<P: moq_lite::AsPath>(&mut self, origin: Id, path: P) -> Result<moq_lite::BroadcastConsumer, Error> {
 		let origin = self.active.get_mut(origin).ok_or(Error::OriginNotFound)?;
+		// TODO: expose an async variant backed by `wait_for_broadcast` so FFI callers can wait
+		// for gossip instead of racing it.
+		#[allow(deprecated)]
 		origin.consume().consume_broadcast(path).ok_or(Error::BroadcastNotFound)
 	}
 

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -427,7 +427,7 @@ async fn run_session(
 	// announcements that happens after the session is established.
 	tracing::info!(broadcast = %settings.broadcast, "waiting for broadcast to be announced");
 	let broadcast = tokio::select! {
-		broadcast = origin_consumer.wait_for_broadcast(&settings.broadcast) => broadcast
+		broadcast = origin_consumer.announced_broadcast(&settings.broadcast) => broadcast
 			.ok_or_else(|| anyhow::anyhow!("Broadcast '{}' not allowed or origin closed", settings.broadcast))?,
 		_ = shutdown.changed() => return Ok(()),
 	};

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -428,7 +428,7 @@ async fn run_session(
 	tracing::info!(broadcast = %settings.broadcast, "waiting for broadcast to be announced");
 	let broadcast = tokio::select! {
 		broadcast = origin_consumer.announced_broadcast(&settings.broadcast) => broadcast
-			.ok_or_else(|| anyhow::anyhow!("Broadcast '{}' not allowed or origin closed", settings.broadcast))?,
+			.context("broadcast not allowed or origin closed")?,
 		_ = shutdown.changed() => return Ok(()),
 	};
 

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -423,9 +423,14 @@ async fn run_session(
 
 	let _session = client.connect(settings.url.clone()).await?;
 
-	let broadcast = origin_consumer
-		.consume_broadcast(&settings.broadcast)
-		.ok_or_else(|| anyhow::anyhow!("Broadcast '{}' not found", settings.broadcast))?;
+	// Wait for the broadcast to be announced. Synchronous lookup would race the gossip of
+	// announcements that happens after the session is established.
+	tracing::info!(broadcast = %settings.broadcast, "waiting for broadcast to be announced");
+	let broadcast = tokio::select! {
+		broadcast = origin_consumer.wait_for_broadcast(&settings.broadcast) => broadcast
+			.ok_or_else(|| anyhow::anyhow!("Broadcast '{}' not allowed or origin closed", settings.broadcast))?,
+		_ = shutdown.changed() => return Ok(()),
+	};
 
 	let catalog_track = broadcast.subscribe_track(&hang::catalog::Catalog::default_track())?;
 	let mut catalog = hang::catalog::CatalogConsumer::new(catalog_track);

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -105,6 +105,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		tracing::info!(id = %request_id, broadcast = %absolute, track = %track_name, "subscribe started");
 
+		// We just received a subscribe for this exact namespace, so the peer must have already
+		// seen the announcement — synchronous lookup is appropriate here.
+		#[allow(deprecated)]
 		let Some(broadcast) = self.origin.consume_broadcast(&msg.track_namespace) else {
 			self.write_subscribe_error(&mut stream.writer, request_id, 404, "Broadcast not found")
 				.await?;

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -223,6 +223,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		tracing::info!(%id, broadcast = %absolute, %track, "subscribed started");
 
+		// We just received a subscribe for this exact path, so by definition the peer has
+		// already seen an announcement for it — synchronous lookup is appropriate here.
+		#[allow(deprecated)]
 		let broadcast = self.origin.consume_broadcast(&subscribe.broadcast);
 		let priority = self.priority.clone();
 		let version = self.version;

--- a/rs/moq-lite/src/model/origin.rs
+++ b/rs/moq-lite/src/model/origin.rs
@@ -546,6 +546,13 @@ impl OriginConsumer {
 		// Scope a fresh consumer down to this path so we only wake up for relevant announcements.
 		let mut consumer = self.consume_only(std::slice::from_ref(&path))?;
 
+		// consume_only keeps narrower permissions intact: if we ask for `foo` on a consumer limited
+		// to `foo/specific`, consume_only returns a consumer scoped to `foo/specific` — no
+		// announcement at the exact path `foo` can ever arrive. Bail rather than loop forever.
+		if !consumer.allowed().any(|allowed| path.has_prefix(allowed)) {
+			return None;
+		}
+
 		loop {
 			let (announced, broadcast) = consumer.announced().await?;
 			// consume_only narrows by prefix, but we only want an exact-path match.
@@ -1627,5 +1634,22 @@ mod tests {
 
 		// Path is outside allowed prefixes — should return None immediately.
 		assert!(limited.announced_broadcast("notallowed").await.is_none());
+	}
+
+	#[tokio::test]
+	async fn test_announced_broadcast_scope_too_narrow() {
+		// Consumer's scope is narrower than the requested path: asking for `foo` on a consumer
+		// limited to `foo/specific` can never resolve. Must return None, not loop forever.
+		let origin = Origin::produce();
+		let limited = origin
+			.consume_only(&["foo/specific".into()])
+			.expect("should create limited");
+
+		// now_or_never so we fail fast instead of hanging if the guard regresses.
+		let result = limited
+			.announced_broadcast("foo")
+			.now_or_never()
+			.expect("must not block");
+		assert!(result.is_none());
 	}
 }

--- a/rs/moq-lite/src/model/origin.rs
+++ b/rs/moq-lite/src/model/origin.rs
@@ -1062,51 +1062,6 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_duplicate_fifo_order() {
-		tokio::time::pause();
-
-		let origin = Origin::random().produce();
-
-		let broadcast1 = Broadcast::new().produce();
-		let broadcast2 = Broadcast::new().produce();
-		let broadcast3 = Broadcast::new().produce();
-
-		let consumer1 = broadcast1.consume();
-		let consumer2 = broadcast2.consume();
-		let consumer3 = broadcast3.consume();
-
-		let mut consumer = origin.consume();
-
-		origin.publish_broadcast("test", consumer1.clone());
-		origin.publish_broadcast("test", consumer2.clone());
-		origin.publish_broadcast("test", consumer3.clone());
-
-		// The oldest broadcast is active; the rest are queued in publish order.
-		consumer.assert_next("test", &consumer1);
-		consumer.assert_next_wait();
-
-		// Drop the active; the next-oldest (not the newest) should be promoted.
-		drop(broadcast1);
-		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-		consumer.assert_next_none("test");
-		consumer.assert_next("test", &consumer2);
-		consumer.assert_next_wait();
-
-		// Drop the now-active; the remaining backup is promoted.
-		drop(broadcast2);
-		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-		consumer.assert_next_none("test");
-		consumer.assert_next("test", &consumer3);
-		consumer.assert_next_wait();
-
-		// Drop the last broadcast; the entry is fully unannounced.
-		drop(broadcast3);
-		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-		consumer.assert_next_none("test");
-		consumer.assert_next_wait();
-	}
-
-	#[tokio::test]
 	#[allow(deprecated)] // exercises consume_broadcast
 	async fn test_duplicate_reverse() {
 		tokio::time::pause();

--- a/rs/moq-lite/src/model/origin.rs
+++ b/rs/moq-lite/src/model/origin.rs
@@ -424,7 +424,7 @@ impl OriginProducer {
 	#[deprecated(
 		note = "synchronous lookup is a footgun: over-the-wire origins need time to gossip announcements. \
 			Prefer looping over announcements via `consume()` or `consume_only(..).announced()`, or use \
-			`OriginConsumer::wait_for_broadcast` which blocks until a specific path is announced."
+			`OriginConsumer::announced_broadcast` which blocks until a specific path is announced."
 	)]
 	pub fn consume_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();
@@ -524,7 +524,7 @@ impl OriginConsumer {
 	#[deprecated(
 		note = "synchronous lookup is a footgun: freshly-connected origins have not yet received any \
 			announcements, so this will return None even when the broadcast is about to arrive. \
-			Prefer `wait_for_broadcast` (blocks until announced) or loop over `announced()`."
+			Prefer `announced_broadcast` (blocks until announced) or loop over `announced()`."
 	)]
 	pub fn consume_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();
@@ -541,7 +541,7 @@ impl OriginConsumer {
 	///
 	/// Prefer this over the deprecated [`Self::consume_broadcast`] when you know the exact path
 	/// you want but cannot guarantee the announcement has already been received.
-	pub async fn wait_for_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
+	pub async fn announced_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();
 
 		// Scope a fresh consumer down to this path so we only wake up for relevant announcements.
@@ -649,7 +649,6 @@ impl OriginConsumer {
 }
 
 #[cfg(test)]
-#[allow(deprecated)] // Existing tests exercise `consume_broadcast`; keep them running.
 mod tests {
 	use crate::Broadcast;
 
@@ -722,6 +721,7 @@ mod tests {
 	}
 
 	#[tokio::test]
+	#[allow(deprecated)] // exercises consume_broadcast
 	async fn test_duplicate() {
 		tokio::time::pause();
 
@@ -822,6 +822,7 @@ mod tests {
 	}
 
 	#[tokio::test]
+	#[allow(deprecated)] // exercises consume_broadcast
 	async fn test_duplicate_reverse() {
 		tokio::time::pause();
 
@@ -848,6 +849,7 @@ mod tests {
 	}
 
 	#[tokio::test]
+	#[allow(deprecated)] // exercises consume_broadcast
 	async fn test_double_publish() {
 		tokio::time::pause();
 
@@ -1119,6 +1121,7 @@ mod tests {
 	}
 
 	#[tokio::test]
+	#[allow(deprecated)] // exercises consume_broadcast
 	async fn test_consume_broadcast_with_permissions() {
 		let origin = Origin::produce();
 		let broadcast1 = Broadcast::produce();
@@ -1529,19 +1532,19 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_wait_for_broadcast_already_announced() {
+	async fn test_announced_broadcast_already_announced() {
 		let origin = Origin::produce();
 		let broadcast = Broadcast::produce();
 
 		origin.publish_broadcast("test", broadcast.consume());
 
 		let consumer = origin.consume();
-		let result = consumer.wait_for_broadcast("test").await.expect("should find it");
+		let result = consumer.announced_broadcast("test").await.expect("should find it");
 		assert!(result.is_clone(&broadcast.consume()));
 	}
 
 	#[tokio::test]
-	async fn test_wait_for_broadcast_delayed() {
+	async fn test_announced_broadcast_delayed() {
 		tokio::time::pause();
 
 		let origin = Origin::produce();
@@ -1552,7 +1555,7 @@ mod tests {
 		// Start waiting before it's announced.
 		let wait = tokio::spawn({
 			let consumer = consumer.clone();
-			async move { consumer.wait_for_broadcast("test").await }
+			async move { consumer.announced_broadcast("test").await }
 		});
 
 		// Give the spawned task a chance to subscribe.
@@ -1565,7 +1568,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_wait_for_broadcast_ignores_unrelated_paths() {
+	async fn test_announced_broadcast_ignores_unrelated_paths() {
 		tokio::time::pause();
 
 		let origin = Origin::produce();
@@ -1576,12 +1579,12 @@ mod tests {
 
 		let wait = tokio::spawn({
 			let consumer = consumer.clone();
-			async move { consumer.wait_for_broadcast("target").await }
+			async move { consumer.announced_broadcast("target").await }
 		});
 
 		tokio::task::yield_now().await;
 
-		// Publish an unrelated broadcast first — wait_for_broadcast should skip it.
+		// Publish an unrelated broadcast first — announced_broadcast should skip it.
 		origin.publish_broadcast("other", other.consume());
 		tokio::task::yield_now().await;
 		assert!(!wait.is_finished(), "must not resolve on unrelated path");
@@ -1592,7 +1595,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_wait_for_broadcast_skips_nested_paths() {
+	async fn test_announced_broadcast_skips_nested_paths() {
 		tokio::time::pause();
 
 		let origin = Origin::produce();
@@ -1603,7 +1606,7 @@ mod tests {
 
 		let wait = tokio::spawn({
 			let consumer = consumer.clone();
-			async move { consumer.wait_for_broadcast("foo").await }
+			async move { consumer.announced_broadcast("foo").await }
 		});
 
 		tokio::task::yield_now().await;
@@ -1619,11 +1622,11 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_wait_for_broadcast_disallowed() {
+	async fn test_announced_broadcast_disallowed() {
 		let origin = Origin::produce();
 		let limited = origin.consume_only(&["allowed".into()]).expect("should create limited");
 
 		// Path is outside allowed prefixes — should return None immediately.
-		assert!(limited.wait_for_broadcast("notallowed").await.is_none());
+		assert!(limited.announced_broadcast("notallowed").await.is_none());
 	}
 }

--- a/rs/moq-lite/src/model/origin.rs
+++ b/rs/moq-lite/src/model/origin.rs
@@ -423,8 +423,7 @@ impl OriginProducer {
 	/// Returns None if the broadcast is not found.
 	#[deprecated(
 		note = "synchronous lookup is a footgun: over-the-wire origins need time to gossip announcements. \
-			Prefer looping over announcements via `consume()` or `consume_only(..).announced()`, or use \
-			`OriginConsumer::announced_broadcast` which blocks until a specific path is announced."
+			Use [OriginConsumer::announced_broadcast] which blocks until the given path is announced."
 	)]
 	pub fn consume_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();

--- a/rs/moq-lite/src/model/origin.rs
+++ b/rs/moq-lite/src/model/origin.rs
@@ -421,6 +421,11 @@ impl OriginProducer {
 	/// Subscribe to a specific broadcast.
 	///
 	/// Returns None if the broadcast is not found.
+	#[deprecated(
+		note = "synchronous lookup is a footgun: over-the-wire origins need time to gossip announcements. \
+			Prefer looping over announcements via `consume()` or `consume_only(..).announced()`, or use \
+			`OriginConsumer::wait_for_broadcast` which blocks until a specific path is announced."
+	)]
 	pub fn consume_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();
 		let (root, rest) = self.nodes.get(&path)?;
@@ -515,14 +520,42 @@ impl OriginConsumer {
 
 	/// Get a specific broadcast by path.
 	///
-	/// TODO This should include announcement support.
-	///
 	/// Returns None if the path hasn't been announced yet.
+	#[deprecated(
+		note = "synchronous lookup is a footgun: freshly-connected origins have not yet received any \
+			announcements, so this will return None even when the broadcast is about to arrive. \
+			Prefer `wait_for_broadcast` (blocks until announced) or loop over `announced()`."
+	)]
 	pub fn consume_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();
 		let (root, rest) = self.nodes.get(&path)?;
 		let state = root.lock();
 		state.consume_broadcast(&rest)
+	}
+
+	/// Block until a broadcast with the given path is announced and return it.
+	///
+	/// Returns `None` if the path is outside this consumer's allowed prefixes or if the consumer
+	/// is closed before the broadcast is announced. The returned broadcast may itself be closed
+	/// later — subscribers should watch [`BroadcastConsumer::closed`] to react to that.
+	///
+	/// Prefer this over the deprecated [`Self::consume_broadcast`] when you know the exact path
+	/// you want but cannot guarantee the announcement has already been received.
+	pub async fn wait_for_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
+		let path = path.as_path();
+
+		// Scope a fresh consumer down to this path so we only wake up for relevant announcements.
+		let mut consumer = self.consume_only(std::slice::from_ref(&path))?;
+
+		loop {
+			let (announced, broadcast) = consumer.announced().await?;
+			// consume_only narrows by prefix, but we only want an exact-path match.
+			if announced.as_path() == path {
+				if let Some(broadcast) = broadcast {
+					return Some(broadcast);
+				}
+			}
+		}
 	}
 
 	/// Returns a new OriginConsumer that only consumes broadcasts matching one of the prefixes.
@@ -616,6 +649,7 @@ impl OriginConsumer {
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // Existing tests exercise `consume_broadcast`; keep them running.
 mod tests {
 	use crate::Broadcast;
 
@@ -1492,5 +1526,104 @@ mod tests {
 
 		let allowed: Vec<_> = producer.allowed().collect();
 		assert_eq!(allowed.len(), 2, "demo/foo should be subsumed by demo");
+	}
+
+	#[tokio::test]
+	async fn test_wait_for_broadcast_already_announced() {
+		let origin = Origin::produce();
+		let broadcast = Broadcast::produce();
+
+		origin.publish_broadcast("test", broadcast.consume());
+
+		let consumer = origin.consume();
+		let result = consumer.wait_for_broadcast("test").await.expect("should find it");
+		assert!(result.is_clone(&broadcast.consume()));
+	}
+
+	#[tokio::test]
+	async fn test_wait_for_broadcast_delayed() {
+		tokio::time::pause();
+
+		let origin = Origin::produce();
+		let broadcast = Broadcast::produce();
+
+		let consumer = origin.consume();
+
+		// Start waiting before it's announced.
+		let wait = tokio::spawn({
+			let consumer = consumer.clone();
+			async move { consumer.wait_for_broadcast("test").await }
+		});
+
+		// Give the spawned task a chance to subscribe.
+		tokio::task::yield_now().await;
+
+		origin.publish_broadcast("test", broadcast.consume());
+
+		let result = wait.await.unwrap().expect("should find it");
+		assert!(result.is_clone(&broadcast.consume()));
+	}
+
+	#[tokio::test]
+	async fn test_wait_for_broadcast_ignores_unrelated_paths() {
+		tokio::time::pause();
+
+		let origin = Origin::produce();
+		let other = Broadcast::produce();
+		let target = Broadcast::produce();
+
+		let consumer = origin.consume();
+
+		let wait = tokio::spawn({
+			let consumer = consumer.clone();
+			async move { consumer.wait_for_broadcast("target").await }
+		});
+
+		tokio::task::yield_now().await;
+
+		// Publish an unrelated broadcast first — wait_for_broadcast should skip it.
+		origin.publish_broadcast("other", other.consume());
+		tokio::task::yield_now().await;
+		assert!(!wait.is_finished(), "must not resolve on unrelated path");
+
+		origin.publish_broadcast("target", target.consume());
+		let result = wait.await.unwrap().expect("should find target");
+		assert!(result.is_clone(&target.consume()));
+	}
+
+	#[tokio::test]
+	async fn test_wait_for_broadcast_skips_nested_paths() {
+		tokio::time::pause();
+
+		let origin = Origin::produce();
+		let nested = Broadcast::produce();
+		let exact = Broadcast::produce();
+
+		let consumer = origin.consume();
+
+		let wait = tokio::spawn({
+			let consumer = consumer.clone();
+			async move { consumer.wait_for_broadcast("foo").await }
+		});
+
+		tokio::task::yield_now().await;
+
+		// "foo/bar" is under the prefix scope, but it's not the exact path — skip it.
+		origin.publish_broadcast("foo/bar", nested.consume());
+		tokio::task::yield_now().await;
+		assert!(!wait.is_finished(), "must not resolve on a nested path");
+
+		origin.publish_broadcast("foo", exact.consume());
+		let result = wait.await.unwrap().expect("should find foo exactly");
+		assert!(result.is_clone(&exact.consume()));
+	}
+
+	#[tokio::test]
+	async fn test_wait_for_broadcast_disallowed() {
+		let origin = Origin::produce();
+		let limited = origin.consume_only(&["allowed".into()]).expect("should create limited");
+
+		// Path is outside allowed prefixes — should return None immediately.
+		assert!(limited.wait_for_broadcast("notallowed").await.is_none());
 	}
 }

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -131,6 +131,7 @@ impl Cluster {
 	}
 
 	/// Looks up a broadcast by name across primary and secondary origins.
+	#[allow(deprecated)] // Synchronous cluster lookup by design; callers know the broadcast is local.
 	pub fn get(&self, broadcast: &str) -> Option<BroadcastConsumer> {
 		self.primary
 			.consume_broadcast(broadcast)

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -328,6 +328,9 @@ async fn serve_fetch(
 	};
 
 	// NOTE: The auth token is already scoped to the broadcast.
+	// TODO: switch to `wait_for_broadcast` (bounded by the fetch deadline) so freshly-connected
+	// subscribers don't get a spurious 404 before the broadcast has gossiped.
+	#[allow(deprecated)]
 	let broadcast = origin.consume_broadcast("").ok_or(StatusCode::NOT_FOUND)?;
 	let mut track = broadcast.subscribe_track(&track).map_err(|err| match err {
 		moq_lite::Error::NotFound => StatusCode::NOT_FOUND,

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -328,7 +328,7 @@ async fn serve_fetch(
 	};
 
 	// NOTE: The auth token is already scoped to the broadcast.
-	// TODO: switch to `wait_for_broadcast` (bounded by the fetch deadline) so freshly-connected
+	// TODO: switch to `announced_broadcast` (bounded by the fetch deadline) so freshly-connected
 	// subscribers don't get a spurious 404 before the broadcast has gossiped.
 	#[allow(deprecated)]
 	let broadcast = origin.consume_broadcast("").ok_or(StatusCode::NOT_FOUND)?;


### PR DESCRIPTION
Synchronous consume_broadcast is a common footgun: a freshly-connected origin
has not yet received any announcements over the wire, so a sync lookup
returns None even when the broadcast is about to arrive. moq-gst's source
hit this directly by calling consume_broadcast immediately after connect.

Add OriginConsumer::wait_for_broadcast(path), which scopes a fresh consumer
to the path and loops over announcements until an exact-path match arrives.
Deprecate both OriginProducer::consume_broadcast and
OriginConsumer::consume_broadcast to steer callers to the announcement-aware
alternatives. Internal moq-lite callers (lite/ietf publishers) and
deliberately-synchronous app callers (relay cluster lookup, libmoq FFI,
relay web fetch) are annotated with #[allow(deprecated)] with a note.

Fix moq-gst source to wait for the broadcast after connecting, selecting on
the shutdown signal so it stays cancel-safe.