### PR TITLE
relay: add subdomain-based slug routing for customer isolation

### DIFF
--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -34,8 +34,8 @@ impl AuthParams {
 	///
 	/// When the URL host matches one of `domains` as `<labels>.<suffix>`, the
 	/// labels are prepended to the URL path in DNS-reverse order (broadest
-	/// scope first), so `customer.usw.cdn.moq.dev/foo` with suffix
-	/// `cdn.moq.dev` routes to `/usw/customer/foo`. An exact-suffix or
+	/// scope first), so `team.customer.cdn.moq.dev/foo` with suffix
+	/// `cdn.moq.dev` routes to `/customer/team/foo`. An exact-suffix or
 	/// non-matching host is left as-is (plain path-based routing).
 	///
 	/// `domains` must be pre-canonicalized by [`Auth::new`] (lowercased and
@@ -66,8 +66,8 @@ impl AuthParams {
 /// the labels joined with `/` in DNS-reverse order so the broadest scope
 /// becomes the outermost path segment. With suffix `cdn.moq.dev`:
 ///
-/// - `customer.cdn.moq.dev`     → `Some("customer")`
-/// - `customer.usw.cdn.moq.dev` → `Some("usw/customer")`
+/// - `customer.cdn.moq.dev`      → `Some("customer")`
+/// - `team.customer.cdn.moq.dev` → `Some("customer/team")`
 ///
 /// An exact match against a suffix or a host that matches no suffix returns
 /// `None` (plain path-based routing).
@@ -284,19 +284,19 @@ pub struct AuthConfig {
 	/// reversing puts the broadest label first in the path). With suffix
 	/// `cdn.moq.dev`:
 	///
-	/// - `customer.cdn.moq.dev/foo`     → `cdn.moq.dev/customer/foo`
-	/// - `customer.usw.cdn.moq.dev/foo` → `cdn.moq.dev/usw/customer/foo`
+	/// - `customer.cdn.moq.dev/foo`      → `cdn.moq.dev/customer/foo`
+	/// - `team.customer.cdn.moq.dev/foo` → `cdn.moq.dev/customer/team/foo`
 	///
 	/// A host that exactly matches a suffix contributes no slug. Hosts that
 	/// don't match any suffix fall back to plain path-based routing.
 	///
-	/// Overlapping suffixes are resolved longest-first. With
-	/// `["cdn.moq.dev", "usw.cdn.moq.dev"]`, `customer.usw.cdn.moq.dev/foo`
+	/// Pass `--auth-domain` multiple times to configure more than one suffix
+	/// — useful for serving multiple regions or product domains from one
+	/// relay. Overlapping suffixes are resolved longest-first. For example,
+	/// with `["cdn.moq.dev", "usw.cdn.moq.dev"]`, `customer.usw.cdn.moq.dev`
 	/// matches the more specific `usw.cdn.moq.dev` (slug `customer`,
 	/// path `/customer/foo`) rather than `cdn.moq.dev` (slug `usw/customer`,
 	/// path `/usw/customer/foo`).
-	///
-	/// Pass `--auth-domain` multiple times to configure more than one suffix.
 	#[arg(long = "auth-domain", env = "MOQ_AUTH_DOMAIN")]
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub domains: Vec<String>,
@@ -2415,10 +2415,10 @@ api = "https://api.example.com/access"
 	fn test_match_domain_multi_label_to_path() {
 		// Multi-label slugs reverse so the DNS label closest to the suffix
 		// (broadest scope) becomes the outermost path segment. With suffix
-		// `cdn.moq.dev`, `customer.usw.cdn.moq.dev/foo` routes to
-		// `/usw/customer/foo`.
-		let p = parse("https://customer.usw.cdn.moq.dev/foo", &["cdn.moq.dev"]);
-		assert_eq!(p.path, "/usw/customer/foo");
+		// `cdn.moq.dev`, `team.customer.cdn.moq.dev/foo` routes to
+		// `/customer/team/foo` — the customer is the broader scope.
+		let p = parse("https://team.customer.cdn.moq.dev/foo", &["cdn.moq.dev"]);
+		assert_eq!(p.path, "/customer/team/foo");
 	}
 
 	#[test]

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -2422,7 +2422,7 @@ api = "https://api.example.com/access"
 	}
 
 	#[test]
-	fn test_match_domain_multiple_suffixes_first_match() {
+	fn test_match_domain_multiple_non_overlapping_suffixes() {
 		let p = parse(
 			"https://customer.staging.moq.dev/foo",
 			&["cdn.moq.dev", "staging.moq.dev"],

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -32,12 +32,17 @@ impl AuthParams {
 
 	/// Extracts authentication parameters from a URL's path and query string.
 	///
-	/// When the URL host matches one of `domains` as `<slug>.<domain>`, the slug
-	/// is prepended to the URL path. An exact-suffix or non-matching host is
-	/// left as-is (plain path-based routing).
-	pub fn from_url(url: &url::Url, domains: &[String]) -> Result<Self, AuthError> {
+	/// When the URL host matches one of `domains` as `<labels>.<suffix>`, the
+	/// labels are prepended to the URL path in DNS-reverse order (broadest
+	/// scope first), so `customer.usw.cdn.moq.dev/foo` with suffix
+	/// `cdn.moq.dev` routes to `/usw/customer/foo`. An exact-suffix or
+	/// non-matching host is left as-is (plain path-based routing).
+	///
+	/// `domains` must be pre-canonicalized by [`Auth::new`] (lowercased and
+	/// prefixed with `.`).
+	pub(crate) fn from_url(url: &url::Url, domains: &[String]) -> Self {
 		// url.path() always starts with '/' for http/https/wss URLs.
-		let path = match match_domain(url.host_str(), domains)? {
+		let path = match match_domain(url.host_str(), domains) {
 			Some(slug) => format!("/{slug}{}", url.path()),
 			None => url.path().to_string(),
 		};
@@ -53,34 +58,45 @@ impl AuthParams {
 			}
 		}
 
-		Ok(Self { path, jwt })
+		Self { path, jwt }
 	}
 }
 
-/// If `host` is `<slug>.<suffix>` for any configured suffix, returns the slug.
-/// An exact match against a suffix, or a host that matches no suffix, returns
-/// `None` (plain path-based routing). A multi-label slug (e.g. `a.b.<suffix>`)
-/// is rejected to keep customer isolation unambiguous — operators who want
-/// nested customers can add the inner domain to the list.
-fn match_domain(host: Option<&str>, domains: &[String]) -> Result<Option<String>, AuthError> {
-	let Some(host) = host else {
-		return Ok(None);
-	};
-	// URL hosts are case-insensitive; match that way.
-	let host_lc = host.to_ascii_lowercase();
+/// If `host` matches any configured suffix as `<labels>.<suffix>`, returns
+/// the labels joined with `/` in DNS-reverse order so the broadest scope
+/// becomes the outermost path segment. With suffix `cdn.moq.dev`:
+///
+/// - `customer.cdn.moq.dev`     → `Some("customer")`
+/// - `customer.usw.cdn.moq.dev` → `Some("usw/customer")`
+///
+/// An exact match against a suffix or a host that matches no suffix returns
+/// `None` (plain path-based routing).
+///
+/// `domains` must be pre-validated, ASCII-lowercased, and `.`-prefixed (e.g.
+/// `".cdn.moq.dev"`); [`Auth::new`] does this once at startup so a single
+/// `strip_suffix` covers both exact (slug = `""`) and slug match.
+fn match_domain(host: Option<&str>, domains: &[String]) -> Option<String> {
+	let host = host?;
+	// Most relays don't configure --auth-domain; skip the lowercase alloc
+	// when there's nothing to match against.
+	if domains.is_empty() {
+		return None;
+	}
+	// Pre-pend '.' to the host so the dot-prefixed suffixes match exact and
+	// slug hosts identically.
+	let host_lc = format!(".{}", host.to_ascii_lowercase());
 	for suffix in domains {
-		let suffix_lc = suffix.to_ascii_lowercase();
-		if host_lc == suffix_lc {
-			return Ok(None);
-		}
-		if let Some(slug) = host_lc.strip_suffix(&suffix_lc).and_then(|s| s.strip_suffix('.')) {
-			if slug.is_empty() || slug.contains('.') {
-				return Err(AuthError::InvalidHost);
+		if let Some(slug) = host_lc.strip_suffix(suffix) {
+			if slug.is_empty() {
+				return None;
 			}
-			return Ok(Some(slug.to_owned()));
+			// Drop the leading '.' left by strip_suffix, then reverse the
+			// labels and join with '/' — DNS nests broader scopes rightward,
+			// so reversing puts the broadest label first in the path.
+			return Some(slug.trim_start_matches('.').rsplit('.').collect::<Vec<_>>().join("/"));
 		}
 	}
-	Ok(None)
+	None
 }
 
 /// Errors returned when authentication or authorization fails.
@@ -98,9 +114,6 @@ pub enum AuthError {
 
 	#[error("the path does not match the root")]
 	IncorrectRoot,
-
-	#[error("the URL host is not a valid customer under a configured domain")]
-	InvalidHost,
 
 	#[error("key not found")]
 	KeyNotFound,
@@ -134,7 +147,6 @@ impl From<&AuthError> for http::StatusCode {
 			// problem, not a credential problem.
 			AuthError::ApiUnavailable(_) => http::StatusCode::BAD_GATEWAY,
 			AuthError::InvalidUrl(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
-			AuthError::InvalidHost => http::StatusCode::BAD_REQUEST,
 			_ => http::StatusCode::UNAUTHORIZED,
 		}
 	}
@@ -266,16 +278,23 @@ pub struct AuthConfig {
 
 	/// Domain suffixes for subdomain-based (SNI) slug routing.
 	///
-	/// When an incoming connection's URL host is `<slug>.<suffix>` for one of
-	/// these suffixes, `<slug>` is prepended to the URL path before auth runs,
-	/// so `customer.cdn.moq.dev/foo` is equivalent to `cdn.moq.dev/customer/foo`.
+	/// When an incoming connection's URL host is `<labels>.<suffix>` for one
+	/// of these suffixes, the labels are reversed and prepended to the URL
+	/// path before auth runs (DNS nests broader scopes rightward, so
+	/// reversing puts the broadest label first in the path). With suffix
+	/// `cdn.moq.dev`:
+	///
+	/// - `customer.cdn.moq.dev/foo`     → `cdn.moq.dev/customer/foo`
+	/// - `customer.usw.cdn.moq.dev/foo` → `cdn.moq.dev/usw/customer/foo`
+	///
 	/// A host that exactly matches a suffix contributes no slug. Hosts that
 	/// don't match any suffix fall back to plain path-based routing.
 	///
-	/// Overlapping suffixes are resolved longest-first, so
-	/// `["moq.dev", "cdn.moq.dev"]` accepts `customer.cdn.moq.dev` under
-	/// `cdn.moq.dev` rather than rejecting it as a multi-label slug under
-	/// `moq.dev`.
+	/// Overlapping suffixes are resolved longest-first. With
+	/// `["cdn.moq.dev", "usw.cdn.moq.dev"]`, `customer.usw.cdn.moq.dev/foo`
+	/// matches the more specific `usw.cdn.moq.dev` (slug `customer`,
+	/// path `/customer/foo`) rather than `cdn.moq.dev` (slug `usw/customer`,
+	/// path `/usw/customer/foo`).
 	///
 	/// Pass `--auth-domain` multiple times to configure more than one suffix.
 	#[arg(long = "auth-domain", env = "MOQ_AUTH_DOMAIN")]
@@ -636,10 +655,18 @@ impl Auth {
 			anyhow::bail!("no auth-key, auth-key-dir, or public path configured");
 		}
 
-		// Sort domain suffixes longest-first so overlapping configurations
-		// (e.g. ["moq.dev", "cdn.moq.dev"]) match the most specific suffix,
-		// rather than letting the configured order silently decide.
-		let mut domains = config.domains;
+		// Canonicalize domain suffixes once at startup: lowercase and prefix
+		// with '.' so `match_domain` can do plain dot-prefixed strip_suffix
+		// per request without per-call allocations. Sort longest-first so
+		// overlapping configurations (e.g. ["moq.dev", "cdn.moq.dev"]) match
+		// the most specific suffix rather than letting the configured order
+		// silently decide.
+		let mut domains: Vec<String> = Vec::with_capacity(config.domains.len());
+		for d in config.domains {
+			let d = d.trim_start_matches('.').to_ascii_lowercase();
+			anyhow::ensure!(!d.is_empty(), "auth-domain suffix must not be empty");
+			domains.push(format!(".{d}"));
+		}
 		domains.sort_by_key(|d| std::cmp::Reverse(d.len()));
 
 		Ok(Self {
@@ -651,7 +678,7 @@ impl Auth {
 
 	/// Build [`AuthParams`] from an incoming connection URL, applying any
 	/// configured subdomain-based slug routing.
-	pub fn params_from_url(&self, url: &url::Url) -> Result<AuthParams, AuthError> {
+	pub(crate) fn params_from_url(&self, url: &url::Url) -> AuthParams {
 		AuthParams::from_url(url, &self.domains)
 	}
 
@@ -2347,26 +2374,31 @@ api = "https://api.example.com/access"
 		Ok(())
 	}
 
-	fn parse(url: &str, domains: &[&str]) -> Result<AuthParams, AuthError> {
-		let domains: Vec<String> = domains.iter().map(|s| s.to_string()).collect();
+	fn parse(url: &str, domains: &[&str]) -> AuthParams {
+		// Mirror the canonicalization Auth::new does so unit tests of from_url
+		// take suffixes in the same form callers would.
+		let domains: Vec<String> = domains
+			.iter()
+			.map(|s| format!(".{}", s.trim_start_matches('.').to_ascii_lowercase()))
+			.collect();
 		AuthParams::from_url(&url::Url::parse(url).unwrap(), &domains)
 	}
 
 	#[test]
 	fn test_match_domain_slug_prepended() {
-		let p = parse("https://customer.cdn.moq.dev/foo", &["cdn.moq.dev"]).unwrap();
+		let p = parse("https://customer.cdn.moq.dev/foo", &["cdn.moq.dev"]);
 		assert_eq!(p.path, "/customer/foo");
 	}
 
 	#[test]
 	fn test_match_domain_exact_suffix_no_slug() {
-		let p = parse("https://cdn.moq.dev/foo", &["cdn.moq.dev"]).unwrap();
+		let p = parse("https://cdn.moq.dev/foo", &["cdn.moq.dev"]);
 		assert_eq!(p.path, "/foo");
 	}
 
 	#[test]
 	fn test_match_domain_non_matching_host() {
-		let p = parse("https://something.else.com/foo", &["cdn.moq.dev"]).unwrap();
+		let p = parse("https://something.else.com/foo", &["cdn.moq.dev"]);
 		assert_eq!(p.path, "/foo");
 	}
 
@@ -2375,14 +2407,18 @@ api = "https://api.example.com/access"
 		// url::Url canonicalizes an empty path to "/", so the output is
 		// "/customer/" rather than "/customer" — the trailing slash is harmless
 		// since Path strips it.
-		let p = parse("https://customer.cdn.moq.dev/", &["cdn.moq.dev"]).unwrap();
+		let p = parse("https://customer.cdn.moq.dev/", &["cdn.moq.dev"]);
 		assert_eq!(p.path, "/customer/");
 	}
 
 	#[test]
-	fn test_match_domain_multi_label_rejected() {
-		let err = parse("https://a.b.cdn.moq.dev/foo", &["cdn.moq.dev"]).unwrap_err();
-		assert!(matches!(err, AuthError::InvalidHost));
+	fn test_match_domain_multi_label_to_path() {
+		// Multi-label slugs reverse so the DNS label closest to the suffix
+		// (broadest scope) becomes the outermost path segment. With suffix
+		// `cdn.moq.dev`, `customer.usw.cdn.moq.dev/foo` routes to
+		// `/usw/customer/foo`.
+		let p = parse("https://customer.usw.cdn.moq.dev/foo", &["cdn.moq.dev"]);
+		assert_eq!(p.path, "/usw/customer/foo");
 	}
 
 	#[test]
@@ -2390,27 +2426,26 @@ api = "https://api.example.com/access"
 		let p = parse(
 			"https://customer.staging.moq.dev/foo",
 			&["cdn.moq.dev", "staging.moq.dev"],
-		)
-		.unwrap();
+		);
 		assert_eq!(p.path, "/customer/foo");
 	}
 
 	#[test]
 	fn test_match_domain_case_insensitive() {
-		let p = parse("https://CUSTOMER.CDN.moq.dev/Foo", &["cdn.moq.dev"]).unwrap();
+		let p = parse("https://CUSTOMER.CDN.moq.dev/Foo", &["cdn.moq.dev"]);
 		// The URL crate lowercases the host but preserves the path case.
 		assert_eq!(p.path, "/customer/Foo");
 	}
 
 	#[test]
 	fn test_match_domain_no_domains_configured() {
-		let p = parse("https://customer.cdn.moq.dev/foo", &[]).unwrap();
+		let p = parse("https://customer.cdn.moq.dev/foo", &[]);
 		assert_eq!(p.path, "/foo");
 	}
 
 	#[test]
 	fn test_match_domain_preserves_jwt() {
-		let p = parse("https://customer.cdn.moq.dev/foo?jwt=abc", &["cdn.moq.dev"]).unwrap();
+		let p = parse("https://customer.cdn.moq.dev/foo?jwt=abc", &["cdn.moq.dev"]);
 		assert_eq!(p.path, "/customer/foo");
 		assert_eq!(p.jwt.as_deref(), Some("abc"));
 	}
@@ -2418,12 +2453,13 @@ api = "https://api.example.com/access"
 	#[tokio::test]
 	async fn test_match_domain_overlapping_suffixes_longest_first() -> anyhow::Result<()> {
 		// `Auth::new` sorts configured domains longest-first so that a nested
-		// suffix like "cdn.moq.dev" wins over its parent "moq.dev". Without
-		// this, `customer.cdn.moq.dev` would be rejected as a multi-label slug
-		// under "moq.dev" depending on the configured order.
+		// suffix like "usw.cdn.moq.dev" wins over its parent "cdn.moq.dev".
+		// Without this, `customer.usw.cdn.moq.dev` would route under
+		// "cdn.moq.dev" as `/usw/customer/foo` depending on the configured
+		// order, instead of `/customer/foo` under "usw.cdn.moq.dev".
 		for order in [
-			vec!["moq.dev".to_string(), "cdn.moq.dev".to_string()],
-			vec!["cdn.moq.dev".to_string(), "moq.dev".to_string()],
+			vec!["cdn.moq.dev".to_string(), "usw.cdn.moq.dev".to_string()],
+			vec!["usw.cdn.moq.dev".to_string(), "cdn.moq.dev".to_string()],
 		] {
 			let auth = Auth::new(AuthConfig {
 				public: detailed_public(&["customer"], &[]),
@@ -2431,7 +2467,7 @@ api = "https://api.example.com/access"
 				..Default::default()
 			})
 			.await?;
-			let params = auth.params_from_url(&url::Url::parse("https://customer.cdn.moq.dev/foo")?)?;
+			let params = auth.params_from_url(&url::Url::parse("https://customer.usw.cdn.moq.dev/foo")?);
 			assert_eq!(params.path, "/customer/foo");
 		}
 		Ok(())
@@ -2448,7 +2484,7 @@ api = "https://api.example.com/access"
 		})
 		.await?;
 
-		let params = auth.params_from_url(&url::Url::parse("https://customer.cdn.moq.dev/anon/room")?)?;
+		let params = auth.params_from_url(&url::Url::parse("https://customer.cdn.moq.dev/anon/room")?);
 		assert_eq!(params.path, "/customer/anon/room");
 
 		let token = auth.verify(&params).await?;
@@ -2456,7 +2492,7 @@ api = "https://api.example.com/access"
 		assert_eq!(token.subscribe, vec!["".as_path()]);
 
 		// A different customer under the same suffix is rejected by the prefix check.
-		let params = auth.params_from_url(&url::Url::parse("https://other.cdn.moq.dev/anon/room")?)?;
+		let params = auth.params_from_url(&url::Url::parse("https://other.cdn.moq.dev/anon/room")?);
 		assert_eq!(params.path, "/other/anon/room");
 		assert!(auth.verify(&params).await.is_err());
 

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -33,8 +33,17 @@ impl AuthParams {
 	}
 
 	/// Extracts authentication parameters from a URL's path and query string.
-	pub fn from_url(url: &url::Url) -> Self {
-		let path = url.path().to_string();
+	///
+	/// When the URL host matches one of `domains` as `<slug>.<domain>`, the slug
+	/// is prepended to the URL path. An exact-suffix or non-matching host is
+	/// left as-is (plain path-based routing).
+	pub fn from_url(url: &url::Url, domains: &[String]) -> Result<Self, AuthError> {
+		// url.path() always starts with '/' for http/https/wss URLs.
+		let path = match match_domain(url.host_str(), domains)? {
+			Some(slug) => format!("/{slug}{}", url.path()),
+			None => url.path().to_string(),
+		};
+
 		let mut jwt = None;
 		let mut register = None;
 
@@ -49,8 +58,34 @@ impl AuthParams {
 			}
 		}
 
-		Self { path, jwt, register }
+		Ok(Self { path, jwt, register })
 	}
+}
+
+/// If `host` is `<slug>.<suffix>` for any configured suffix, returns the slug.
+/// An exact match against a suffix, or a host that matches no suffix, returns
+/// `None` (plain path-based routing). A multi-label slug (e.g. `a.b.<suffix>`)
+/// is rejected to keep customer isolation unambiguous — operators who want
+/// nested customers can add the inner domain to the list.
+fn match_domain(host: Option<&str>, domains: &[String]) -> Result<Option<String>, AuthError> {
+	let Some(host) = host else {
+		return Ok(None);
+	};
+	// URL hosts are case-insensitive; match that way.
+	let host_lc = host.to_ascii_lowercase();
+	for suffix in domains {
+		let suffix_lc = suffix.to_ascii_lowercase();
+		if host_lc == suffix_lc {
+			return Ok(None);
+		}
+		if let Some(slug) = host_lc.strip_suffix(&suffix_lc).and_then(|s| s.strip_suffix('.')) {
+			if slug.is_empty() || slug.contains('.') {
+				return Err(AuthError::InvalidHost);
+			}
+			return Ok(Some(slug.to_owned()));
+		}
+	}
+	Ok(None)
 }
 
 /// Errors returned when authentication or authorization fails.
@@ -68,6 +103,9 @@ pub enum AuthError {
 
 	#[error("the path does not match the root")]
 	IncorrectRoot,
+
+	#[error("the URL host is not a valid customer under a configured domain")]
+	InvalidHost,
 
 	#[error("a cluster token was expected")]
 	ExpectedCluster,
@@ -104,6 +142,7 @@ impl From<&AuthError> for http::StatusCode {
 			// problem, not a credential problem.
 			AuthError::ApiUnavailable(_) => http::StatusCode::BAD_GATEWAY,
 			AuthError::InvalidUrl(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
+			AuthError::InvalidHost => http::StatusCode::BAD_REQUEST,
 			_ => http::StatusCode::UNAUTHORIZED,
 		}
 	}
@@ -232,6 +271,19 @@ pub struct AuthConfig {
 	#[arg(long = "auth-public-api", env = "MOQ_AUTH_PUBLIC_API")]
 	#[serde(skip)]
 	pub public_api: Option<String>,
+
+	/// Domain suffixes for subdomain-based (SNI) slug routing.
+	///
+	/// When an incoming connection's URL host is `<slug>.<suffix>` for one of
+	/// these suffixes, `<slug>` is prepended to the URL path before auth runs,
+	/// so `customer.cdn.moq.dev/foo` is equivalent to `cdn.moq.dev/customer/foo`.
+	/// A host that exactly matches a suffix contributes no slug. Hosts that
+	/// don't match any suffix fall back to plain path-based routing.
+	///
+	/// Pass `--auth-domain` multiple times to configure more than one suffix.
+	#[arg(long = "auth-domain", env = "MOQ_AUTH_DOMAIN")]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub domains: Vec<String>,
 }
 
 /// Public access configuration.
@@ -498,6 +550,8 @@ pub struct Auth {
 	resolver: Option<Arc<KeyResolver>>,
 	/// Public (unauthenticated) access with static prefixes and/or an API.
 	public: PublicAccess,
+	/// Domain suffixes for subdomain-based slug routing. See [`AuthConfig::domains`].
+	domains: Arc<[String]>,
 }
 
 impl Auth {
@@ -593,7 +647,17 @@ impl Auth {
 			anyhow::bail!("no auth-key, auth-key-dir, or public path configured");
 		}
 
-		Ok(Self { resolver, public })
+		Ok(Self {
+			resolver,
+			public,
+			domains: Arc::from(config.domains.into_boxed_slice()),
+		})
+	}
+
+	/// Build [`AuthParams`] from an incoming connection URL, applying any
+	/// configured subdomain-based slug routing.
+	pub fn params_from_url(&self, url: &url::Url) -> Result<AuthParams, AuthError> {
+		AuthParams::from_url(url, &self.domains)
 	}
 
 	async fn fetch_public_response(client: &ClientWithMiddleware, url: &url::Url) -> Result<PublicResponse, AuthError> {
@@ -2323,6 +2387,105 @@ api = "https://api.example.com/access"
 			matches!(result, Err(AuthError::ApiUnavailable(_))),
 			"expected ApiUnavailable when client cert missing, got {result:?}"
 		);
+
+		Ok(())
+	}
+
+	fn parse(url: &str, domains: &[&str]) -> Result<AuthParams, AuthError> {
+		let domains: Vec<String> = domains.iter().map(|s| s.to_string()).collect();
+		AuthParams::from_url(&url::Url::parse(url).unwrap(), &domains)
+	}
+
+	#[test]
+	fn test_match_domain_slug_prepended() {
+		let p = parse("https://customer.cdn.moq.dev/foo", &["cdn.moq.dev"]).unwrap();
+		assert_eq!(p.path, "/customer/foo");
+	}
+
+	#[test]
+	fn test_match_domain_exact_suffix_no_slug() {
+		let p = parse("https://cdn.moq.dev/foo", &["cdn.moq.dev"]).unwrap();
+		assert_eq!(p.path, "/foo");
+	}
+
+	#[test]
+	fn test_match_domain_non_matching_host() {
+		let p = parse("https://something.else.com/foo", &["cdn.moq.dev"]).unwrap();
+		assert_eq!(p.path, "/foo");
+	}
+
+	#[test]
+	fn test_match_domain_empty_path_with_slug() {
+		// url::Url canonicalizes an empty path to "/", so the output is
+		// "/customer/" rather than "/customer" — the trailing slash is harmless
+		// since Path strips it.
+		let p = parse("https://customer.cdn.moq.dev/", &["cdn.moq.dev"]).unwrap();
+		assert_eq!(p.path, "/customer/");
+	}
+
+	#[test]
+	fn test_match_domain_multi_label_rejected() {
+		let err = parse("https://a.b.cdn.moq.dev/foo", &["cdn.moq.dev"]).unwrap_err();
+		assert!(matches!(err, AuthError::InvalidHost));
+	}
+
+	#[test]
+	fn test_match_domain_multiple_suffixes_first_match() {
+		let p = parse(
+			"https://customer.staging.moq.dev/foo",
+			&["cdn.moq.dev", "staging.moq.dev"],
+		)
+		.unwrap();
+		assert_eq!(p.path, "/customer/foo");
+	}
+
+	#[test]
+	fn test_match_domain_case_insensitive() {
+		let p = parse("https://CUSTOMER.CDN.moq.dev/Foo", &["cdn.moq.dev"]).unwrap();
+		// The URL crate lowercases the host but preserves the path case.
+		assert_eq!(p.path, "/customer/Foo");
+	}
+
+	#[test]
+	fn test_match_domain_no_domains_configured() {
+		let p = parse("https://customer.cdn.moq.dev/foo", &[]).unwrap();
+		assert_eq!(p.path, "/foo");
+	}
+
+	#[test]
+	fn test_match_domain_preserves_jwt_and_register() {
+		let p = parse(
+			"https://customer.cdn.moq.dev/foo?jwt=abc&register=leaf0",
+			&["cdn.moq.dev"],
+		)
+		.unwrap();
+		assert_eq!(p.path, "/customer/foo");
+		assert_eq!(p.jwt.as_deref(), Some("abc"));
+		assert_eq!(p.register.as_deref(), Some("leaf0"));
+	}
+
+	#[tokio::test]
+	async fn test_subdomain_slug_flows_through_public_prefix() -> anyhow::Result<()> {
+		// End-to-end: a subdomain slug, combined with a public prefix scoped to
+		// the customer, authorizes a connection that would otherwise be rejected.
+		let auth = Auth::new(AuthConfig {
+			public: detailed_public(&["customer/anon"], &[]),
+			domains: vec!["cdn.moq.dev".to_string()],
+			..Default::default()
+		})
+		.await?;
+
+		let params = auth.params_from_url(&url::Url::parse("https://customer.cdn.moq.dev/anon/room")?)?;
+		assert_eq!(params.path, "/customer/anon/room");
+
+		let token = auth.verify(&params).await?;
+		assert_eq!(token.root, Path::new("customer/anon/room").to_owned());
+		assert_eq!(token.subscribe, vec!["".as_path()]);
+
+		// A different customer under the same suffix is rejected by the prefix check.
+		let params = auth.params_from_url(&url::Url::parse("https://other.cdn.moq.dev/anon/room")?)?;
+		assert_eq!(params.path, "/other/anon/room");
+		assert!(auth.verify(&params).await.is_err());
 
 		Ok(())
 	}

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -58,7 +58,14 @@ impl Connection {
 	#[tracing::instrument("conn", skip_all, fields(id = self.id))]
 	pub async fn run(self) -> anyhow::Result<()> {
 		let params = match self.request.url() {
-			Some(url) => AuthParams::from_url(url),
+			Some(url) => match self.auth.params_from_url(url) {
+				Ok(params) => params,
+				Err(err) => {
+					let status: http::StatusCode = (&err).into();
+					let _ = self.request.close(status.as_u16()).await;
+					return Err(err.into());
+				}
+			},
 			None => AuthParams::default(),
 		};
 

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -107,7 +107,7 @@ impl Connection {
 		}
 
 		let params = match self.request.url() {
-			Some(url) => self.auth.params_from_url(url)?,
+			Some(url) => self.auth.params_from_url(url),
 			None => AuthParams::default(),
 		};
 		Ok(self.auth.verify(&params).await?)

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -99,7 +99,10 @@ impl Connection {
 			(None, Some(subscribe)) => {
 				tracing::info!(transport, root = %token.root, subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "subscriber accepted")
 			}
-			_ => anyhow::bail!("invalid session; no allowed paths"),
+			_ => {
+				let _ = self.request.close(http::StatusCode::FORBIDDEN.as_u16()).await;
+				anyhow::bail!("invalid session; no allowed paths");
+			}
 		}
 
 		// Accept the connection.

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -1,8 +1,26 @@
-use crate::{Auth, AuthParams, AuthToken, Cluster};
+use crate::{Auth, AuthError, AuthParams, AuthToken, Cluster};
 
 use anyhow::Context;
 use axum::http;
-use moq_native::Request;
+use moq_native::{PeerIdentity, Request};
+
+/// An error carrying the HTTP status to send when closing the request.
+///
+/// Used only on the pre-accept auth path so the caller can close once with
+/// the right code instead of sprinkling close/return at each failure site.
+struct StatusError {
+	status: http::StatusCode,
+	source: anyhow::Error,
+}
+
+impl From<AuthError> for StatusError {
+	fn from(err: AuthError) -> Self {
+		Self {
+			status: (&err).into(),
+			source: err.into(),
+		}
+	}
+}
 
 /// True when `candidate` is `base` followed by `:<digits>` (a non-empty,
 /// all-ASCII-digit port). DNS SANs cannot carry ports, so a node name
@@ -57,43 +75,12 @@ impl Connection {
 	/// Authenticates and serves this connection until it closes.
 	#[tracing::instrument("conn", skip_all, fields(id = self.id))]
 	pub async fn run(self) -> anyhow::Result<()> {
-		let params = match self.request.url() {
-			Some(url) => match self.auth.params_from_url(url) {
-				Ok(params) => params,
-				Err(err) => {
-					let status: http::StatusCode = (&err).into();
-					let _ = self.request.close(status.as_u16()).await;
-					return Err(err.into());
-				}
-			},
-			None => AuthParams::default(),
-		};
-
-		// If the client presented a valid mTLS client certificate, skip JWT
-		// entirely and grant full (cluster) access. The node name comes
-		// from the cert's first DNS SAN. Since DNS SANs cannot carry a
-		// port, a `?register=` query param is accepted only if it extends
-		// the SAN with a `:port` suffix (e.g. SAN `leaf0` + `?register=leaf0:4444`).
-		let token = if let Some(peer) = self.request.peer_identity()? {
-			match validate_peer(peer.dns_name.as_deref(), params.register.as_deref()) {
-				Ok(node) => {
-					tracing::debug!(?node, "mTLS peer authenticated");
-					AuthToken::from_peer(node)
-				}
-				Err(err) => {
-					let _ = self.request.close(http::StatusCode::FORBIDDEN.as_u16()).await;
-					return Err(err);
-				}
-			}
-		} else {
-			// Verify the URL before accepting the connection.
-			match self.auth.verify(&params).await {
-				Ok(token) => token,
-				Err(err) => {
-					let status: http::StatusCode = (&err).into();
-					let _ = self.request.close(status.as_u16()).await;
-					return Err(err.into());
-				}
+		let peer = self.request.peer_identity()?;
+		let token = match self.authenticate(peer).await {
+			Ok(token) => token,
+			Err(err) => {
+				let _ = self.request.close(err.status.as_u16()).await;
+				return Err(err.source);
 			}
 		};
 
@@ -135,5 +122,34 @@ impl Connection {
 		session.closed().await?;
 		drop(registration);
 		Ok(())
+	}
+
+	/// Resolve an [`AuthToken`] from the request's URL and (optional) mTLS peer
+	/// identity. Any failure is returned as a [`StatusError`] so [`run`] can
+	/// close the request with the mapped HTTP status exactly once.
+	///
+	/// If the client presented a valid mTLS client certificate, JWT is skipped
+	/// and full (cluster) access is granted. The node name comes from the
+	/// cert's first DNS SAN; since DNS SANs cannot carry a port, a `?register=`
+	/// query param is accepted only if it extends the SAN with a `:port`
+	/// suffix (e.g. SAN `leaf0` + `?register=leaf0:4444`).
+	async fn authenticate(&self, peer: Option<PeerIdentity>) -> Result<AuthToken, StatusError> {
+		let params = match self.request.url() {
+			Some(url) => self.auth.params_from_url(url)?,
+			None => AuthParams::default(),
+		};
+
+		if let Some(peer) = peer {
+			let node = validate_peer(peer.dns_name.as_deref(), params.register.as_deref()).map_err(|source| {
+				StatusError {
+					status: http::StatusCode::FORBIDDEN,
+					source,
+				}
+			})?;
+			tracing::debug!(?node, "mTLS peer authenticated");
+			Ok(AuthToken::from_peer(node))
+		} else {
+			Ok(self.auth.verify(&params).await?)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `--auth-domain` (env `MOQ_AUTH_DOMAIN`, TOML `domains`) to configure suffix lists for host-based routing.
- When a connection URL host is `<slug>.<suffix>`, the slug is prepended to the path before auth runs, so `customer.cdn.moq.dev/foo` is equivalent to `cdn.moq.dev/customer/foo`.
- Hosts that exactly match a suffix — or match none — fall back to plain path routing. Multi-label slugs (`a.b.<suffix>`) are rejected as `400 InvalidHost` to keep customer isolation unambiguous.
- `AuthError::InvalidHost` maps to `400 Bad Request` (distinct from credential errors, which stay `401`).

## Test plan
- [x] `cargo test -p moq-relay` — 69 passed, including new unit tests for slug prepend, exact-suffix, non-match, empty path, multi-label rejection, multiple suffixes, case-insensitive host match, no-domains-configured, JWT/register passthrough, and an end-to-end flow where a subdomain slug combined with a public prefix authorizes a connection (and a different subdomain is rejected).
- [ ] Manual smoke with a wildcard cert against a real relay deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)