### PR TITLE
Add catalog format configuration to @moq/watch documentation

### DIFF
--- a/doc/js/@moq/watch.md
+++ b/doc/js/@moq/watch.md
@@ -69,6 +69,37 @@ a real bundler (the examples below).
 - `paused` — Pause playback (boolean)
 - `muted` — Mute audio (boolean)
 - `volume` — Audio volume (0–1, default: 1)
+- `catalog-format` — Catalog format: `"hang"` (default) or `"msf"` (see [MSF](/concept/standard/msf))
+
+## Catalog Formats
+
+`@moq/watch` can consume either the default [hang](/concept/layer/hang) catalog
+or [MSF](/concept/standard/msf) (MoQ Streaming Format). Set `catalog-format="msf"`
+on the element, or assign the `catalogFormat` signal on the `Broadcast` to
+switch formats at runtime:
+
+```html
+<moq-watch
+    url="https://relay.example.com/anon"
+    name="room/alice"
+    catalog-format="msf">
+    <canvas></canvas>
+</moq-watch>
+```
+
+```typescript
+import * as Watch from "@moq/watch";
+
+const broadcast = new Watch.Broadcast({
+    connection,
+    enabled: true,
+    name: "alice",
+    catalogFormat: "msf",
+});
+
+// or toggle at runtime
+broadcast.catalogFormat.set("msf");
+```
 
 ## UI Overlay
 


### PR DESCRIPTION
## Summary
Added documentation for the new `catalog-format` configuration option in `@moq/watch`, enabling users to switch between hang (default) and MSF (MoQ Streaming Format) catalog formats.

## Changes
- Added `catalog-format` attribute to the list of supported element properties
- Created new "Catalog Formats" section with:
  - Explanation of supported formats (hang and MSF)
  - HTML example showing `catalog-format="msf"` attribute usage
  - TypeScript example demonstrating programmatic configuration via `catalogFormat` signal
  - Runtime toggle example using the `catalogFormat.set()` method
- Included cross-references to related documentation (hang layer and MSF standard)

## Details
The documentation clarifies that users can configure the catalog format in two ways:
1. Statically via the `catalog-format` HTML attribute
2. Dynamically at runtime by calling `broadcast.catalogFormat.set()` on the Broadcast instance

This enables flexibility for applications that need to support multiple catalog formats or switch formats based on runtime conditions.

https://claude.ai/code/session_01UgGe4T5FBeNLJjGoxPRcYy