### PR TITLE
moq-lite: backport Subscription model API for FETCH readiness

### DIFF
--- a/rs/conducer/src/consumer.rs
+++ b/rs/conducer/src/consumer.rs
@@ -8,6 +8,7 @@ use crate::{
 	lock::*,
 	producer::{Producer, Ref},
 	waiter::*,
+	weak::Weak,
 };
 
 /// The consuming side of a shared state channel.
@@ -109,6 +110,14 @@ impl<T> Consumer<T> {
 	/// Returns `true` if both consumers share the same underlying state.
 	pub fn same_channel(&self, other: &Self) -> bool {
 		self.state.is_clone(&other.state)
+	}
+
+	/// Create a [`Weak`] reference that doesn't affect the producer/consumer ref counts.
+	pub fn weak(&self) -> Weak<T> {
+		Weak {
+			state: self.state.clone(),
+			counts: self.counts.clone(),
+		}
 	}
 }
 

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -50,7 +50,8 @@ async fn run_subscribe(mut consumer: moq_lite::OriginConsumer) -> anyhow::Result
 	tracing::info!(%path, "broadcast announced");
 
 	// Read the catalog to discover available tracks.
-	let catalog_track = broadcast.subscribe_track(&hang::Catalog::default_track())?;
+	let catalog_track =
+		broadcast.subscribe_track(&hang::Catalog::default_track(), moq_lite::Subscription::default())?;
 	let mut catalog = hang::CatalogConsumer::new(catalog_track);
 
 	let info = catalog.next().await?.ok_or_else(|| anyhow::anyhow!("no catalog"))?;
@@ -72,12 +73,9 @@ async fn run_subscribe(mut consumer: moq_lite::OriginConsumer) -> anyhow::Result
 	);
 
 	// Subscribe to the video track.
-	let track = moq_lite::Track {
-		name: name.clone(),
-		priority: 1,
-	};
+	let track = moq_lite::Track::new(name.clone());
 
-	let track_consumer = broadcast.subscribe_track(&track)?;
+	let track_consumer = broadcast.subscribe_track(&track, moq_lite::Subscription::default())?;
 	let mut ordered = hang::container::OrderedConsumer::new(track_consumer, Duration::from_millis(500));
 
 	// Read frames in presentation order.

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -50,8 +50,7 @@ async fn run_subscribe(mut consumer: moq_lite::OriginConsumer) -> anyhow::Result
 	tracing::info!(%path, "broadcast announced");
 
 	// Read the catalog to discover available tracks.
-	let catalog_track =
-		broadcast.subscribe_track(&hang::Catalog::default_track(), hang::Catalog::default_subscription())?;
+	let catalog_track = broadcast.subscribe_track(&hang::Catalog::default_track(), hang::Catalog::SUBSCRIPTION)?;
 	let mut catalog = hang::CatalogConsumer::new(catalog_track);
 
 	let info = catalog.next().await?.ok_or_else(|| anyhow::anyhow!("no catalog"))?;

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -51,7 +51,7 @@ async fn run_subscribe(mut consumer: moq_lite::OriginConsumer) -> anyhow::Result
 
 	// Read the catalog to discover available tracks.
 	let catalog_track =
-		broadcast.subscribe_track(&hang::Catalog::default_track(), moq_lite::Subscription::default())?;
+		broadcast.subscribe_track(&hang::Catalog::default_track(), hang::Catalog::default_subscription())?;
 	let mut catalog = hang::CatalogConsumer::new(catalog_track);
 
 	let info = catalog.next().await?.ok_or_else(|| anyhow::anyhow!("no catalog"))?;

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -74,7 +74,13 @@ async fn run_subscribe(mut consumer: moq_lite::OriginConsumer) -> anyhow::Result
 	// Subscribe to the video track.
 	let track = moq_lite::Track::new(name.clone());
 
-	let track_consumer = broadcast.subscribe_track(&track, moq_lite::Subscription::default())?;
+	let track_consumer = broadcast.subscribe_track(
+		&track,
+		moq_lite::Subscription {
+			priority: 1,
+			..Default::default()
+		},
+	)?;
 	let mut ordered = hang::container::OrderedConsumer::new(track_consumer, Duration::from_millis(500));
 
 	// Read frames in presentation order.

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -41,10 +41,7 @@ async fn run_session(origin: moq_lite::OriginConsumer) -> anyhow::Result<()> {
 // The catalog can contain multiple tracks, used by the viewer to choose the best track.
 fn create_track(broadcast: &mut moq_lite::BroadcastProducer) -> anyhow::Result<moq_lite::TrackProducer> {
 	// Basic information about the video track.
-	let video_track = moq_lite::Track {
-		name: "video".to_string(),
-		priority: 1, // Video typically has lower priority than audio
-	};
+	let video_track = moq_lite::Track::new("video");
 
 	// Example video configuration
 	// In a real application, you would get this from the encoder

--- a/rs/hang/src/catalog/audio/mod.rs
+++ b/rs/hang/src/catalog/audio/mod.rs
@@ -50,8 +50,7 @@ impl Audio {
 
 			if let btree_map::Entry::Vacant(entry) = self.renditions.entry(name.clone()) {
 				entry.insert(config.clone());
-				// TODO: Remove priority
-				return moq_lite::Track { name, priority: 2 };
+				return moq_lite::Track::new(name);
 			}
 		}
 

--- a/rs/hang/src/catalog/consumer.rs
+++ b/rs/hang/src/catalog/consumer.rs
@@ -2,18 +2,17 @@ use crate::{Catalog, Result};
 
 /// A catalog consumer, used to receive catalog updates and discover tracks.
 ///
-/// This wraps a `moq_lite::TrackConsumer` and automatically deserializes JSON
+/// This wraps a `moq_lite::TrackSubscriber` and automatically deserializes JSON
 /// catalog data to discover available audio and video tracks in a broadcast.
-#[derive(Clone)]
 pub struct CatalogConsumer {
-	/// Access to the underlying track consumer.
-	pub track: moq_lite::TrackConsumer,
+	/// Access to the underlying track subscriber.
+	pub track: moq_lite::TrackSubscriber,
 	group: Option<moq_lite::GroupConsumer>,
 }
 
 impl CatalogConsumer {
-	/// Create a new catalog consumer from a MoQ track consumer.
-	pub fn new(track: moq_lite::TrackConsumer) -> Self {
+	/// Create a new catalog consumer from a MoQ track subscriber.
+	pub fn new(track: moq_lite::TrackSubscriber) -> Self {
 		Self { track, group: None }
 	}
 
@@ -49,8 +48,8 @@ impl CatalogConsumer {
 	}
 }
 
-impl From<moq_lite::TrackConsumer> for CatalogConsumer {
-	fn from(inner: moq_lite::TrackConsumer) -> Self {
+impl From<moq_lite::TrackSubscriber> for CatalogConsumer {
+	fn from(inner: moq_lite::TrackSubscriber) -> Self {
 		Self::new(inner)
 	}
 }

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -77,10 +77,7 @@ impl Catalog {
 	}
 
 	pub fn default_track() -> moq_lite::Track {
-		moq_lite::Track {
-			name: Catalog::DEFAULT_NAME.to_string(),
-			priority: 100,
-		}
+		moq_lite::Track::new(Catalog::DEFAULT_NAME)
 	}
 }
 

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -79,6 +79,17 @@ impl Catalog {
 	pub fn default_track() -> moq_lite::Track {
 		moq_lite::Track::new(Catalog::DEFAULT_NAME)
 	}
+
+	/// The default subscription for the catalog track.
+	///
+	/// The catalog should be high priority since downstream players block on
+	/// it before they can subscribe to anything else.
+	pub fn default_subscription() -> moq_lite::Subscription {
+		moq_lite::Subscription {
+			priority: 100,
+			..Default::default()
+		}
+	}
 }
 
 #[cfg(test)]

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -80,16 +80,17 @@ impl Catalog {
 		moq_lite::Track::new(Catalog::DEFAULT_NAME)
 	}
 
-	/// The default subscription for the catalog track.
+	/// The recommended subscription for the catalog track.
 	///
 	/// The catalog should be high priority since downstream players block on
 	/// it before they can subscribe to anything else.
-	pub fn default_subscription() -> moq_lite::Subscription {
-		moq_lite::Subscription {
-			priority: 100,
-			..Default::default()
-		}
-	}
+	pub const SUBSCRIPTION: moq_lite::Subscription = moq_lite::Subscription {
+		priority: 100,
+		ordered: false,
+		max_latency: std::time::Duration::ZERO,
+		start: None,
+		end: None,
+	};
 }
 
 #[cfg(test)]

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -70,8 +70,7 @@ impl Video {
 			};
 			if let btree_map::Entry::Vacant(entry) = self.renditions.entry(name.clone()) {
 				entry.insert(config.clone());
-				// TODO: Remove priority
-				return moq_lite::Track { name, priority: 1 };
+				return moq_lite::Track::new(name);
 			}
 		}
 

--- a/rs/hang/src/container/consumer.rs
+++ b/rs/hang/src/container/consumer.rs
@@ -44,7 +44,7 @@ impl From<OrderedFrame> for Frame {
 
 /// A consumer for hang-formatted media tracks with timestamp reordering.
 ///
-/// This wraps a `moq_lite::TrackConsumer` and adds hang-specific functionality
+/// This wraps a `moq_lite::TrackSubscriber` and adds hang-specific functionality
 /// like timestamp decoding, latency management, and frame buffering.
 ///
 /// ## Latency Management
@@ -52,7 +52,7 @@ impl From<OrderedFrame> for Frame {
 /// The consumer can skip groups that are too far behind to maintain low latency.
 /// Configure the maximum acceptable delay through the consumer's latency settings.
 pub struct OrderedConsumer {
-	pub track: moq_lite::TrackConsumer,
+	pub track: moq_lite::TrackSubscriber,
 
 	// The current group that we want to read from
 	current: u64,
@@ -69,8 +69,8 @@ pub struct OrderedConsumer {
 }
 
 impl OrderedConsumer {
-	/// Create a new OrderedConsumer wrapping the given moq-lite consumer.
-	pub fn new(track: moq_lite::TrackConsumer, max_latency: std::time::Duration) -> Self {
+	/// Create a new OrderedConsumer wrapping the given moq-lite subscriber.
+	pub fn new(track: moq_lite::TrackSubscriber, max_latency: std::time::Duration) -> Self {
 		Self {
 			track,
 			current: 0,
@@ -227,14 +227,14 @@ impl OrderedConsumer {
 	}
 }
 
-impl From<OrderedConsumer> for moq_lite::TrackConsumer {
+impl From<OrderedConsumer> for moq_lite::TrackSubscriber {
 	fn from(inner: OrderedConsumer) -> Self {
 		inner.track
 	}
 }
 
 impl std::ops::Deref for OrderedConsumer {
-	type Target = moq_lite::TrackConsumer;
+	type Target = moq_lite::TrackSubscriber;
 
 	fn deref(&self) -> &Self::Target {
 		&self.track
@@ -416,7 +416,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -434,7 +434,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_frames_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_000), ts(66_000)]);
@@ -454,7 +454,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_groups_within_latency() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// 5 groups, 20ms spacing. Total span = 80ms, well within 500ms latency.
@@ -477,7 +477,7 @@ mod tests {
 	async fn latency_skip_delivers_recent_groups() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
@@ -514,7 +514,7 @@ mod tests {
 	async fn zero_latency_skips_aggressively() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::ZERO);
 
 		// Group 0: 1 frame at a HIGH timestamp, NOT finished.
@@ -555,7 +555,7 @@ mod tests {
 	async fn latency_skip_correctness() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Group 0: 1 frame, NOT finished
@@ -601,7 +601,7 @@ mod tests {
 	async fn groups_delivered_in_sequence_order() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 0: 1 frame, NOT finished (blocks consumer, lets groups 2 and 1 accumulate in pending)
@@ -637,7 +637,7 @@ mod tests {
 	#[tokio::test]
 	async fn adjacent_group_flushed_immediately() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -655,7 +655,7 @@ mod tests {
 	#[tokio::test]
 	async fn bframes_within_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// B-frame decode order: timestamps [0, 66ms, 33ms]
@@ -676,7 +676,7 @@ mod tests {
 	async fn empty_track_returns_none() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		track.finish().unwrap();
@@ -694,7 +694,7 @@ mod tests {
 	async fn track_closed_with_error() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -717,7 +717,7 @@ mod tests {
 	async fn closed_resolves_when_track_ends() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// closed() should not resolve yet
@@ -743,7 +743,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_in_group_sequence_recovery() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Groups 0, 1 then skip 2, write 3-6
@@ -764,7 +764,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_at_start_of_sequence() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(80));
 
 		// First group at sequence 5 (simulating joining mid-stream), gap at 6
@@ -783,7 +783,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_timestamp_and_index_decoding() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_333), ts(66_666)]);
@@ -805,7 +805,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_payload_preserved() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
@@ -843,7 +843,7 @@ mod tests {
 	async fn no_infinite_loop_with_buffered_frames() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_secs(10));
 
 		// Group 0: 1 frame, NOT finished
@@ -889,7 +889,7 @@ mod tests {
 	#[tokio::test]
 	async fn large_timestamps() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_secs(3700));
 
 		// 1 hour = 3,600,000,000 microseconds
@@ -906,7 +906,7 @@ mod tests {
 	#[tokio::test]
 	async fn set_max_latency_changes_behavior() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_secs(10));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -936,7 +936,7 @@ mod tests {
 	async fn max_timestamp_tracks_through_bframes() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(40));
 
 		// Group 0: B-frame decode order [0, 66ms, 33ms], NOT finished (blocks consumer)
@@ -984,7 +984,7 @@ mod tests {
 	async fn startup_selects_earliest_group() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		// max_latency = 100ms.
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
@@ -1041,7 +1041,7 @@ mod tests {
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 5: no frames written yet (pending)
@@ -1068,7 +1068,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_single_group_mid_stream() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Only group 100 exists.
@@ -1084,7 +1084,7 @@ mod tests {
 	async fn multiple_sequential_latency_skips() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(50));
 
 		// Group 0: blocks
@@ -1116,7 +1116,7 @@ mod tests {
 	async fn latency_skip_boundary_exact() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Group 0: blocks
@@ -1145,7 +1145,7 @@ mod tests {
 	#[tokio::test]
 	async fn group_error_skips_to_next() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 0: aborted
@@ -1165,7 +1165,7 @@ mod tests {
 	async fn track_finishes_while_reading() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1195,7 +1195,7 @@ mod tests {
 	#[tokio::test]
 	async fn empty_group_advances() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 0: empty (no frames, just finished)

--- a/rs/hang/src/container/consumer.rs
+++ b/rs/hang/src/container/consumer.rs
@@ -416,7 +416,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -434,7 +434,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_frames_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_000), ts(66_000)]);
@@ -454,7 +454,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_groups_within_latency() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// 5 groups, 20ms spacing. Total span = 80ms, well within 500ms latency.
@@ -477,7 +477,7 @@ mod tests {
 	async fn latency_skip_delivers_recent_groups() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
@@ -514,7 +514,7 @@ mod tests {
 	async fn zero_latency_skips_aggressively() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::ZERO);
 
 		// Group 0: 1 frame at a HIGH timestamp, NOT finished.
@@ -555,7 +555,7 @@ mod tests {
 	async fn latency_skip_correctness() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Group 0: 1 frame, NOT finished
@@ -601,7 +601,7 @@ mod tests {
 	async fn groups_delivered_in_sequence_order() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 0: 1 frame, NOT finished (blocks consumer, lets groups 2 and 1 accumulate in pending)
@@ -637,7 +637,7 @@ mod tests {
 	#[tokio::test]
 	async fn adjacent_group_flushed_immediately() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -655,7 +655,7 @@ mod tests {
 	#[tokio::test]
 	async fn bframes_within_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// B-frame decode order: timestamps [0, 66ms, 33ms]
@@ -676,7 +676,7 @@ mod tests {
 	async fn empty_track_returns_none() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		track.finish().unwrap();
@@ -694,7 +694,7 @@ mod tests {
 	async fn track_closed_with_error() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -717,7 +717,7 @@ mod tests {
 	async fn closed_resolves_when_track_ends() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// closed() should not resolve yet
@@ -743,7 +743,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_in_group_sequence_recovery() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Groups 0, 1 then skip 2, write 3-6
@@ -764,7 +764,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_at_start_of_sequence() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(80));
 
 		// First group at sequence 5 (simulating joining mid-stream), gap at 6
@@ -783,7 +783,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_timestamp_and_index_decoding() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_333), ts(66_666)]);
@@ -805,7 +805,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_payload_preserved() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
@@ -843,7 +843,7 @@ mod tests {
 	async fn no_infinite_loop_with_buffered_frames() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_secs(10));
 
 		// Group 0: 1 frame, NOT finished
@@ -889,7 +889,7 @@ mod tests {
 	#[tokio::test]
 	async fn large_timestamps() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_secs(3700));
 
 		// 1 hour = 3,600,000,000 microseconds
@@ -906,7 +906,7 @@ mod tests {
 	#[tokio::test]
 	async fn set_max_latency_changes_behavior() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_secs(10));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -936,7 +936,7 @@ mod tests {
 	async fn max_timestamp_tracks_through_bframes() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(40));
 
 		// Group 0: B-frame decode order [0, 66ms, 33ms], NOT finished (blocks consumer)
@@ -984,7 +984,7 @@ mod tests {
 	async fn startup_selects_earliest_group() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		// max_latency = 100ms.
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
@@ -1041,7 +1041,7 @@ mod tests {
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 5: no frames written yet (pending)
@@ -1068,7 +1068,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_single_group_mid_stream() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Only group 100 exists.
@@ -1084,7 +1084,7 @@ mod tests {
 	async fn multiple_sequential_latency_skips() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(50));
 
 		// Group 0: blocks
@@ -1116,7 +1116,7 @@ mod tests {
 	async fn latency_skip_boundary_exact() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Group 0: blocks
@@ -1145,7 +1145,7 @@ mod tests {
 	#[tokio::test]
 	async fn group_error_skips_to_next() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 0: aborted
@@ -1165,7 +1165,7 @@ mod tests {
 	async fn track_finishes_while_reading() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1195,7 +1195,7 @@ mod tests {
 	#[tokio::test]
 	async fn empty_group_advances() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = track.consume().subscribe_default().unwrap();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 0: empty (no frames, just finished)

--- a/rs/hang/src/container/producer.rs
+++ b/rs/hang/src/container/producer.rs
@@ -134,11 +134,7 @@ impl OrderedProducer {
 	/// Multiple consumers can be created from the same producer, each receiving
 	/// a copy of all data written to the track.
 	pub fn consume(&self, max_latency: std::time::Duration) -> OrderedConsumer {
-		let subscriber = self
-			.track
-			.consume()
-			.subscribe(moq_lite::Subscription::default())
-			.expect("producer alive");
+		let subscriber = self.track.consume().subscribe_default().expect("producer alive");
 		OrderedConsumer::new(subscriber, max_latency)
 	}
 }

--- a/rs/hang/src/container/producer.rs
+++ b/rs/hang/src/container/producer.rs
@@ -134,7 +134,12 @@ impl OrderedProducer {
 	/// Multiple consumers can be created from the same producer, each receiving
 	/// a copy of all data written to the track.
 	pub fn consume(&self, max_latency: std::time::Duration) -> OrderedConsumer {
-		OrderedConsumer::new(self.track.consume(), max_latency)
+		let subscriber = self
+			.track
+			.consume()
+			.subscribe(moq_lite::Subscription::default())
+			.expect("track was just produced");
+		OrderedConsumer::new(subscriber, max_latency)
 	}
 }
 

--- a/rs/hang/src/container/producer.rs
+++ b/rs/hang/src/container/producer.rs
@@ -138,7 +138,7 @@ impl OrderedProducer {
 			.track
 			.consume()
 			.subscribe(moq_lite::Subscription::default())
-			.expect("track was just produced");
+			.expect("producer alive");
 		OrderedConsumer::new(subscriber, max_latency)
 	}
 }

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -50,7 +50,7 @@ impl Consume {
 		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
 		let catalog = broadcast.subscribe_track(
 			&hang::catalog::Catalog::default_track(),
-			hang::catalog::Catalog::default_subscription(),
+			hang::catalog::Catalog::SUBSCRIPTION,
 		)?;
 
 		let channel = oneshot::channel();

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -48,7 +48,10 @@ impl Consume {
 
 	pub fn catalog(&mut self, broadcast: Id, on_catalog: OnStatus) -> Result<Id, Error> {
 		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
-		let catalog = broadcast.subscribe_track(&hang::catalog::Catalog::default_track())?;
+		let catalog = broadcast.subscribe_track(
+			&hang::catalog::Catalog::default_track(),
+			moq_lite::Subscription::default(),
+		)?;
 
 		let channel = oneshot::channel();
 		let entry = TaskEntry {
@@ -217,10 +220,13 @@ impl Consume {
 			.nth(index)
 			.ok_or(Error::NoIndex)?;
 
-		let track = consume.broadcast.subscribe_track(&moq_lite::Track {
-			name: rendition.clone(),
-			priority: 1, // TODO: Remove priority
-		})?;
+		let track = consume.broadcast.subscribe_track(
+			&moq_lite::Track::new(rendition.clone()),
+			moq_lite::Subscription {
+				priority: 1,
+				..Default::default()
+			},
+		)?;
 		let track = hang::container::OrderedConsumer::new(track, latency);
 
 		let channel = oneshot::channel();
@@ -261,10 +267,13 @@ impl Consume {
 			.nth(index)
 			.ok_or(Error::NoIndex)?;
 
-		let track = consume.broadcast.subscribe_track(&moq_lite::Track {
-			name: rendition.clone(),
-			priority: 2, // TODO: Remove priority
-		})?;
+		let track = consume.broadcast.subscribe_track(
+			&moq_lite::Track::new(rendition.clone()),
+			moq_lite::Subscription {
+				priority: 2,
+				..Default::default()
+			},
+		)?;
 		let track = hang::container::OrderedConsumer::new(track, latency);
 
 		let channel = oneshot::channel();

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -50,7 +50,7 @@ impl Consume {
 		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
 		let catalog = broadcast.subscribe_track(
 			&hang::catalog::Catalog::default_track(),
-			moq_lite::Subscription::default(),
+			hang::catalog::Catalog::default_subscription(),
 		)?;
 
 		let channel = oneshot::channel();

--- a/rs/moq-boy/src/input.rs
+++ b/rs/moq-boy/src/input.rs
@@ -99,12 +99,9 @@ async fn handle_viewer_commands(
 	broadcast: moq_lite::BroadcastConsumer,
 	cmd_tx: &tokio::sync::mpsc::Sender<Command>,
 ) -> anyhow::Result<()> {
-	let command_track = moq_lite::Track {
-		name: "command".to_string(),
-		priority: 0,
-	};
+	let command_track = moq_lite::Track::new("command");
 
-	let mut track = broadcast.subscribe_track(&command_track)?;
+	let mut track = broadcast.subscribe_track(&command_track, moq_lite::Subscription::default())?;
 
 	while let Some(mut group) = track.recv_group().await? {
 		while let Some(frame) = group.read_frame().await? {

--- a/rs/moq-boy/src/status.rs
+++ b/rs/moq-boy/src/status.rs
@@ -40,10 +40,7 @@ pub struct StatusPublisher {
 
 impl StatusPublisher {
 	pub fn new(broadcast: &mut moq_lite::BroadcastProducer) -> anyhow::Result<Self> {
-		let track = moq_lite::Track {
-			name: "status".to_string(),
-			priority: 10,
-		};
+		let track = moq_lite::Track::new("status");
 		let producer = broadcast.create_track(track)?;
 
 		Ok(Self {

--- a/rs/moq-clock/src/clock.rs
+++ b/rs/moq-clock/src/clock.rs
@@ -71,11 +71,11 @@ impl Publisher {
 	}
 }
 pub struct Subscriber {
-	track: TrackConsumer,
+	track: TrackSubscriber,
 }
 
 impl Subscriber {
-	pub fn new(track: TrackConsumer) -> Self {
+	pub fn new(track: TrackSubscriber) -> Self {
 		Self { track }
 	}
 

--- a/rs/moq-clock/src/main.rs
+++ b/rs/moq-clock/src/main.rs
@@ -54,10 +54,7 @@ async fn main() -> anyhow::Result<()> {
 
 	tracing::info!(url = ?config.url, "connecting to server");
 
-	let track = Track {
-		name: config.track,
-		priority: 0,
-	};
+	let track = Track::new(config.track);
 
 	let origin = moq_lite::Origin::random().produce();
 
@@ -98,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
 					Some(announce) = origin.announced() => match announce {
 						(path, Some(broadcast)) => {
 							tracing::info!(broadcast = %path, "broadcast is online, subscribing to track");
-							let track = broadcast.subscribe_track(&track)?;
+							let track = broadcast.subscribe_track(&track, moq_lite::Subscription::default())?;
 							clock = Some(clock::Subscriber::new(track));
 						}
 						(path, None) => {

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -79,7 +79,7 @@ impl MoqBroadcastConsumer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let track = self.inner.subscribe_track(
 			&hang::catalog::Catalog::default_track(),
-			hang::catalog::Catalog::default_subscription(),
+			hang::catalog::Catalog::SUBSCRIPTION,
 		)?;
 		let consumer = hang::CatalogConsumer::from(track);
 		Ok(Arc::new(MoqCatalogConsumer {

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -77,7 +77,10 @@ impl MoqBroadcastConsumer {
 	/// Subscribe to the catalog for this broadcast.
 	pub fn subscribe_catalog(&self) -> Result<Arc<MoqCatalogConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let track = self.inner.subscribe_track(&hang::catalog::Catalog::default_track())?;
+		let track = self.inner.subscribe_track(
+			&hang::catalog::Catalog::default_track(),
+			moq_lite::Subscription::default(),
+		)?;
 		let consumer = hang::CatalogConsumer::from(track);
 		Ok(Arc::new(MoqCatalogConsumer {
 			task: Task::new(Catalog { inner: consumer }),
@@ -89,7 +92,9 @@ impl MoqBroadcastConsumer {
 	/// Frames are returned as plain byte payloads with no codec or container parsing.
 	pub fn subscribe_track(&self, name: String) -> Result<Arc<MoqTrackConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let track = self.inner.subscribe_track(&moq_lite::Track { name, priority: 0 })?;
+		let track = self
+			.inner
+			.subscribe_track(&moq_lite::Track::new(name), moq_lite::Subscription::default())?;
 		Ok(Arc::new(MoqTrackConsumer::new(track)))
 	}
 
@@ -104,7 +109,9 @@ impl MoqBroadcastConsumer {
 		max_latency_ms: u64,
 	) -> Result<Arc<MoqMediaConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let track = self.inner.subscribe_track(&moq_lite::Track { name, priority: 0 })?;
+		let track = self
+			.inner
+			.subscribe_track(&moq_lite::Track::new(name), moq_lite::Subscription::default())?;
 		let container: hang::catalog::Container = container.into();
 		let latency = std::time::Duration::from_millis(max_latency_ms);
 		let consumer = moq_mux::ordered::Consumer::new(track, container).with_latency(latency);
@@ -117,7 +124,7 @@ impl MoqBroadcastConsumer {
 // ---- Track Consumer ----
 
 struct TrackInner {
-	track: moq_lite::TrackConsumer,
+	track: moq_lite::TrackSubscriber,
 }
 
 impl TrackInner {
@@ -126,7 +133,7 @@ impl TrackInner {
 	}
 
 	async fn next_group(&mut self) -> Result<Option<moq_lite::GroupConsumer>, MoqError> {
-		Ok(self.track.next_group_ordered().await?)
+		Ok(self.track.next_group().await?)
 	}
 
 	async fn read_frame(&mut self) -> Result<Option<Vec<u8>>, MoqError> {
@@ -140,7 +147,7 @@ pub struct MoqTrackConsumer {
 }
 
 impl MoqTrackConsumer {
-	pub(crate) fn new(track: moq_lite::TrackConsumer) -> Self {
+	pub(crate) fn new(track: moq_lite::TrackSubscriber) -> Self {
 		Self {
 			task: Task::new(TrackInner { track }),
 		}

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -79,7 +79,7 @@ impl MoqBroadcastConsumer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let track = self.inner.subscribe_track(
 			&hang::catalog::Catalog::default_track(),
-			moq_lite::Subscription::default(),
+			hang::catalog::Catalog::default_subscription(),
 		)?;
 		let consumer = hang::CatalogConsumer::from(track);
 		Ok(Arc::new(MoqCatalogConsumer {

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -83,7 +83,7 @@ impl MoqBroadcastProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		let track = moq_lite::Track { name, priority: 0 };
+		let track = moq_lite::Track::new(name);
 		// Clone the broadcast handle (shared Arc internally) to get &mut access.
 		let mut broadcast = state.broadcast.clone();
 		let producer = broadcast.create_track(track)?;
@@ -118,7 +118,9 @@ impl MoqTrackProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.inner.lock().unwrap();
 		let track = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		Ok(Arc::new(MoqTrackConsumer::new(track.consume())))
+		Ok(Arc::new(MoqTrackConsumer::new(
+			track.consume().subscribe(moq_lite::Subscription::default())?,
+		)))
 	}
 
 	/// Append a new group to the track, returning a producer for writing frames into it.

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -118,9 +118,7 @@ impl MoqTrackProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.inner.lock().unwrap();
 		let track = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		Ok(Arc::new(MoqTrackConsumer::new(
-			track.consume().subscribe(moq_lite::Subscription::default())?,
-		)))
+		Ok(Arc::new(MoqTrackConsumer::new(track.consume().subscribe_default()?)))
 	}
 
 	/// Append a new group to the track, returning a producer for writing frames into it.

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -427,7 +427,10 @@ async fn run_session(
 		.consume_broadcast(&settings.broadcast)
 		.ok_or_else(|| anyhow::anyhow!("Broadcast '{}' not found", settings.broadcast))?;
 
-	let catalog_track = broadcast.subscribe_track(&hang::catalog::Catalog::default_track())?;
+	let catalog_track = broadcast.subscribe_track(
+		&hang::catalog::Catalog::default_track(),
+		moq_lite::Subscription::default(),
+	)?;
 	let mut catalog = hang::catalog::CatalogConsumer::new(catalog_track);
 	let catalog = catalog.next().await?.context("catalog missing")?.clone();
 
@@ -441,7 +444,7 @@ async fn run_session(
 		let caps = video_caps(&config)?;
 		let endpoint = request_pad(&control_tx, descriptor.clone(), caps).await?;
 		let track_ref = moq_lite::Track::new(&track_name);
-		let track_consumer = broadcast.subscribe_track(&track_ref)?;
+		let track_consumer = broadcast.subscribe_track(&track_ref, moq_lite::Subscription::default())?;
 		let track = hang::container::OrderedConsumer::new(track_consumer, Duration::from_secs(1));
 		tasks.push(spawn_track_pump(track, descriptor, endpoint, shutdown.clone()));
 	}
@@ -454,7 +457,7 @@ async fn run_session(
 		let caps = audio_caps(&config)?;
 		let endpoint = request_pad(&control_tx, descriptor.clone(), caps).await?;
 		let track_ref = moq_lite::Track::new(&track_name);
-		let track_consumer = broadcast.subscribe_track(&track_ref)?;
+		let track_consumer = broadcast.subscribe_track(&track_ref, moq_lite::Subscription::default())?;
 		let track = hang::container::OrderedConsumer::new(track_consumer, Duration::from_secs(1));
 		tasks.push(spawn_track_pump(track, descriptor, endpoint, shutdown.clone()));
 	}

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -429,7 +429,7 @@ async fn run_session(
 
 	let catalog_track = broadcast.subscribe_track(
 		&hang::catalog::Catalog::default_track(),
-		hang::catalog::Catalog::default_subscription(),
+		hang::catalog::Catalog::SUBSCRIPTION,
 	)?;
 	let mut catalog = hang::catalog::CatalogConsumer::new(catalog_track);
 	let catalog = catalog.next().await?.context("catalog missing")?.clone();

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -429,7 +429,7 @@ async fn run_session(
 
 	let catalog_track = broadcast.subscribe_track(
 		&hang::catalog::Catalog::default_track(),
-		moq_lite::Subscription::default(),
+		hang::catalog::Catalog::default_subscription(),
 	)?;
 	let mut catalog = hang::catalog::CatalogConsumer::new(catalog_track);
 	let catalog = catalog.next().await?.context("catalog missing")?.clone();

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -113,13 +113,30 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		let track = Track::new(msg.track_name.to_string());
 
-		let subscriber = match broadcast.subscribe_track(
-			&track,
-			Subscription {
-				priority: msg.subscriber_priority,
-				..Default::default()
-			},
-		) {
+		let consumer = match broadcast.consume_track(&track) {
+			Ok(consumer) => consumer,
+			Err(err) => {
+				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())
+					.await?;
+				return Ok(());
+			}
+		};
+
+		// LargestObject means "start from the latest cached group". Other filter
+		// types are still ignored (see the warn above) — TODO: full FilterType
+		// support along with FETCH wiring.
+		let start = matches!(msg.filter_type, FilterType::LargestObject)
+			.then(|| consumer.latest())
+			.flatten();
+
+		let subscription = Subscription {
+			priority: msg.subscriber_priority,
+			ordered: matches!(msg.group_order, GroupOrder::Ascending),
+			start,
+			..Default::default()
+		};
+
+		let subscriber = match consumer.subscribe(subscription) {
 			Ok(subscriber) => subscriber,
 			Err(err) => {
 				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -5,7 +5,7 @@ use web_async::FuturesExt;
 use web_transport_trait::SendStream;
 
 use crate::{
-	AsPath, Error, Origin, OriginConsumer, Track, TrackConsumer,
+	AsPath, Error, Origin, OriginConsumer, Subscription, Track, TrackSubscriber,
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
 	model::GroupConsumer,
@@ -111,13 +111,16 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			return Ok(());
 		};
 
-		let track = Track {
-			name: msg.track_name.to_string(),
-			priority: msg.subscriber_priority,
-		};
+		let track = Track::new(msg.track_name.to_string());
 
-		let track = match broadcast.subscribe_track(&track) {
-			Ok(track) => track,
+		let subscriber = match broadcast.subscribe_track(
+			&track,
+			Subscription {
+				priority: msg.subscriber_priority,
+				..Default::default()
+			},
+		) {
+			Ok(subscriber) => subscriber,
 			Err(err) => {
 				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())
 					.await?;
@@ -139,8 +142,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			.await?;
 
 		// Run the track, cancelling on reader close (Unsubscribe or stream close)
+		let priority = msg.subscriber_priority;
 		let res = tokio::select! {
-			res = self.run_track(track, request_id) => res,
+			res = self.run_track(subscriber, request_id, priority) => res,
 			_ = stream.reader.closed() => Ok(()),
 			_ = self.session.closed() => Ok(()),
 		};
@@ -215,7 +219,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// Serve a track using FuturesUnordered for unlimited concurrent groups.
-	async fn run_track(&self, mut track: TrackConsumer, request_id: RequestId) -> Result<(), Error> {
+	async fn run_track(
+		&self,
+		mut subscriber: TrackSubscriber,
+		request_id: RequestId,
+		priority: u8,
+	) -> Result<(), Error> {
 		let mut tasks = FuturesUnordered::new();
 
 		loop {
@@ -225,12 +234,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					while tasks.next().await.is_some() {}
 					false
 				} => unreachable!(),
-				Some(group) = track.recv_group().transpose() => group,
+				Some(group) = subscriber.recv_group().transpose() => group,
 				else => return Ok(()),
 			}?;
 
 			let sequence = group.sequence;
-			tracing::debug!(subscribe = %request_id, track = %track.name, sequence, "serving group");
+			tracing::debug!(subscribe = %request_id, track = %subscriber.name, sequence, "serving group");
 
 			let msg = ietf::GroupHeader {
 				track_alias: request_id.0,
@@ -240,7 +249,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				flags: Default::default(),
 			};
 
-			tasks.push(Self::run_group(self.session.clone(), msg, track.priority, group, self.version).map(|_| ()));
+			tasks.push(Self::run_group(self.session.clone(), msg, priority, group, self.version).map(|_| ()));
 		}
 	}
 

--- a/rs/moq-lite/src/ietf/subscriber.rs
+++ b/rs/moq-lite/src/ietf/subscriber.rs
@@ -550,7 +550,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 
 		// Write Subscribe message
-		if let Err(err) = self.write_subscribe(&mut stream, request_id, &broadcast, &track).await {
+		if let Err(err) = self
+			.write_subscribe(&mut stream, request_id, &broadcast, &mut track)
+			.await
+		{
 			tracing::debug!(%err, "failed to write subscribe");
 			self.state.lock().subscribes.remove(&request_id);
 			let _ = track.abort(err);
@@ -613,8 +616,17 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		stream: &mut Stream<S, Version>,
 		request_id: RequestId,
 		broadcast: &Path<'_>,
-		track: &TrackProducer,
+		track: &mut TrackProducer,
 	) -> Result<(), Error> {
+		// Wait for the first interested subscriber so the relayed SUBSCRIBE
+		// reflects the union of downstream subscribers' preferences.
+		// TODO follow `track.subscription()` and emit SUBSCRIBE_UPDATE upstream
+		// as the aggregate changes.
+		let initial = match track.subscription().await {
+			Some(sub) => sub,
+			None => return Err(Error::Cancel),
+		};
+
 		stream.writer.encode(&ietf::Subscribe::ID).await?;
 		stream
 			.writer
@@ -622,8 +634,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				request_id,
 				track_namespace: broadcast.to_owned(),
 				track_name: (&track.name).into(),
-				// TODO surface the producer's aggregate subscription priority instead.
-				subscriber_priority: 0,
+				subscriber_priority: initial.priority,
 				group_order: GroupOrder::Descending,
 				filter_type: FilterType::LargestObject,
 			})

--- a/rs/moq-lite/src/ietf/subscriber.rs
+++ b/rs/moq-lite/src/ietf/subscriber.rs
@@ -462,11 +462,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	fn start_publish(&mut self, msg: &ietf::Publish<'_>) -> Result<(), Error> {
 		let request_id = msg.request_id;
 
-		let track = Track {
-			name: msg.track_name.to_string(),
-			priority: 0,
-		}
-		.produce();
+		let track = Track::new(msg.track_name.to_string()).produce();
 
 		let mut state = self.state.lock();
 		match state.subscribes.entry(request_id) {
@@ -626,7 +622,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				request_id,
 				track_namespace: broadcast.to_owned(),
 				track_name: (&track.name).into(),
-				subscriber_priority: track.priority,
+				// TODO surface the producer's aggregate subscription priority instead.
+				subscriber_priority: 0,
 				group_order: GroupOrder::Descending,
 				filter_type: FilterType::LargestObject,
 			})

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -293,7 +293,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			end: subscribe.end_group,
 		})?;
 
-		// TODO surface the producer's aggregate subscription back to the wire.
 		let info = lite::SubscribeOk {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,
@@ -304,10 +303,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		stream.writer.encode(&lite::SubscribeResponse::Ok(info)).await?;
 
-		tokio::select! {
-			res = Self::run_track(session, subscriber, subscribe, priority, version) => res?,
-			res = stream.reader.closed() => res?,
-		}
+		Self::run_track(session, subscriber, stream, subscribe.id, priority, version).await?;
 
 		stream.writer.finish()?;
 		stream.writer.closed().await
@@ -316,33 +312,49 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	async fn run_track(
 		session: S,
 		mut subscriber: TrackSubscriber,
-		subscribe: &lite::Subscribe<'_>,
+		stream: &mut Stream<S, Version>,
+		subscribe_id: u64,
 		priority: PriorityQueue,
 		version: Version,
 	) -> Result<(), Error> {
 		let mut tasks = FuturesUnordered::new();
 
 		loop {
-			let group = tokio::select! {
+			tokio::select! {
 				// Poll all active group futures; never matches but keeps them running.
 				true = async {
 					while tasks.next().await.is_some() {}
 					false
 				} => unreachable!(),
-				Some(group) = subscriber.recv_group().transpose() => group,
-				else => return Ok(()),
-			}?;
+				group = subscriber.recv_group().transpose() => match group {
+					Some(group) => {
+						let group = group?;
+						let sequence = group.sequence;
+						tracing::debug!(subscribe = %subscribe_id, track = %subscriber.name, sequence, "serving group");
 
-			let sequence = group.sequence;
-			tracing::debug!(subscribe = %subscribe.id, track = %subscriber.name, sequence, "serving group");
+						let msg = lite::Group {
+							subscribe: subscribe_id,
+							sequence,
+						};
 
-			let msg = lite::Group {
-				subscribe: subscribe.id,
-				sequence,
-			};
-
-			let priority = priority.insert(subscribe.priority, sequence);
-			tasks.push(Self::serve_group(session.clone(), msg, priority, group, version).map(|_| ()));
+						let p = priority.insert(subscriber.subscription().priority, sequence);
+						tasks.push(Self::serve_group(session.clone(), msg, p, group, version).map(|_| ()));
+					}
+					None => return Ok(()),
+				},
+				upd = stream.reader.decode_maybe::<lite::SubscribeUpdate>() => match upd? {
+					Some(upd) => {
+						subscriber.update(Subscription {
+							priority: upd.priority,
+							ordered: upd.ordered,
+							max_latency: upd.max_latency,
+							start: upd.start_group,
+							end: upd.end_group,
+						});
+					}
+					None => return Ok(()),
+				},
+			}
 		}
 	}
 

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -340,7 +340,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						let p = priority.insert(subscriber.subscription().priority, sequence);
 						tasks.push(Self::serve_group(session.clone(), msg, p, group, version).map(|_| ()));
 					}
-					None => return Ok(()),
+					None => break,
 				},
 				upd = stream.reader.decode_maybe::<lite::SubscribeUpdate>() => match upd? {
 					Some(upd) => {
@@ -352,10 +352,15 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							end: upd.end_group,
 						});
 					}
-					None => return Ok(()),
+					None => break,
 				},
 			}
 		}
+
+		// Drain in-flight group futures so they finish writing before we close the stream.
+		while tasks.next().await.is_some() {}
+
+		Ok(())
 	}
 
 	async fn serve_group(

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -5,7 +5,7 @@ use web_async::FuturesExt;
 use web_transport_trait::Stats;
 
 use crate::{
-	AsPath, BroadcastConsumer, Error, Origin, OriginConsumer, OriginList, Track, TrackConsumer,
+	AsPath, BroadcastConsumer, Error, Origin, OriginConsumer, OriginList, Subscription, Track, TrackSubscriber,
 	coding::{Stream, Writer},
 	lite::{
 		self,
@@ -278,28 +278,34 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		priority: PriorityQueue,
 		version: Version,
 	) -> Result<(), Error> {
-		let track = Track {
-			name: subscribe.track.to_string(),
-			priority: subscribe.priority,
-		};
+		let track = Track::new(subscribe.track.to_string());
 
 		let broadcast = consumer.ok_or(Error::NotFound)?;
-		let track = broadcast.subscribe_track(&track)?;
+		let consumer = broadcast.consume_track(&track)?;
 
-		// TODO wait until track.info() to get the *real* priority
+		// Pick the start group: explicit, else the latest cached group.
+		let start = subscribe.start_group.or_else(|| consumer.latest());
+		let subscriber = consumer.subscribe(Subscription {
+			priority: subscribe.priority,
+			ordered: subscribe.ordered,
+			max_latency: subscribe.max_latency,
+			start,
+			end: subscribe.end_group,
+		})?;
 
+		// TODO surface the producer's aggregate subscription back to the wire.
 		let info = lite::SubscribeOk {
-			priority: track.priority,
-			ordered: false,
-			max_latency: std::time::Duration::ZERO,
-			start_group: None,
-			end_group: None,
+			priority: subscribe.priority,
+			ordered: subscribe.ordered,
+			max_latency: subscribe.max_latency,
+			start_group: start,
+			end_group: subscribe.end_group,
 		};
 
 		stream.writer.encode(&lite::SubscribeResponse::Ok(info)).await?;
 
 		tokio::select! {
-			res = Self::run_track(session, track, subscribe, priority, version) => res?,
+			res = Self::run_track(session, subscriber, subscribe, priority, version) => res?,
 			res = stream.reader.closed() => res?,
 		}
 
@@ -309,17 +315,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	async fn run_track(
 		session: S,
-		mut track: TrackConsumer,
+		mut subscriber: TrackSubscriber,
 		subscribe: &lite::Subscribe<'_>,
 		priority: PriorityQueue,
 		version: Version,
 	) -> Result<(), Error> {
 		let mut tasks = FuturesUnordered::new();
-
-		// Start the consumer at the specified sequence, otherwise start at the latest group.
-		if let Some(start_group) = subscribe.start_group.or_else(|| track.latest()) {
-			track.start_at(start_group);
-		}
 
 		loop {
 			let group = tokio::select! {
@@ -328,19 +329,19 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					while tasks.next().await.is_some() {}
 					false
 				} => unreachable!(),
-				Some(group) = track.recv_group().transpose() => group,
+				Some(group) = subscriber.recv_group().transpose() => group,
 				else => return Ok(()),
 			}?;
 
 			let sequence = group.sequence;
-			tracing::debug!(subscribe = %subscribe.id, track = %track.name, sequence, "serving group");
+			tracing::debug!(subscribe = %subscribe.id, track = %subscriber.name, sequence, "serving group");
 
 			let msg = lite::Group {
 				subscribe: subscribe.id,
 				sequence,
 			};
 
-			let priority = priority.insert(track.priority, sequence);
+			let priority = priority.insert(subscribe.priority, sequence);
 			tasks.push(Self::serve_group(session.clone(), msg, priority, group, version).map(|_| ()));
 		}
 	}

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -271,7 +271,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			id,
 			broadcast: broadcast.to_owned(),
 			track: (&track.name).into(),
-			priority: track.priority,
+			// TODO surface the producer's aggregate subscription preferences instead.
+			priority: 0,
 			ordered: true,
 			max_latency: std::time::Duration::ZERO,
 			start_group: None,

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -267,23 +267,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	async fn run_subscribe(&mut self, id: u64, broadcast: Path<'_>, mut track: TrackProducer) {
 		self.subscribes.lock().insert(id, track.clone());
 
-		let msg = lite::Subscribe {
-			id,
-			broadcast: broadcast.to_owned(),
-			track: (&track.name).into(),
-			// TODO surface the producer's aggregate subscription preferences instead.
-			priority: 0,
-			ordered: true,
-			max_latency: std::time::Duration::ZERO,
-			start_group: None,
-			end_group: None,
-		};
-
 		tracing::info!(id, broadcast = %self.log_path(&broadcast), track = %track.name, "subscribe started");
 
+		// Cancel as soon as the track has no consumers. Cloned so it doesn't conflict
+		// with `track.subscription()`'s `&mut self` borrow inside `run_track`.
+		let unused = track.clone();
 		let res = tokio::select! {
-			_ = track.unused() => Err(Error::Cancel),
-			res = self.run_track(msg) => res,
+			_ = unused.unused() => Err(Error::Cancel),
+			res = self.run_track(id, &broadcast, &mut track) => res,
 		};
 
 		match res {
@@ -302,11 +293,28 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 	}
 
-	async fn run_track(&mut self, msg: lite::Subscribe<'_>) -> Result<(), Error> {
+	async fn run_track(&mut self, id: u64, broadcast: &Path<'_>, track: &mut TrackProducer) -> Result<(), Error> {
+		// Wait for the first interested subscriber before opening an upstream
+		// SUBSCRIBE stream — relays only relay when somebody's listening.
+		let Some(initial) = track.subscription().await else {
+			return Ok(());
+		};
+
 		let mut stream = Stream::open(&self.session, self.version).await?;
 		stream.writer.encode(&lite::ControlType::Subscribe).await?;
 
-		if let Err(err) = self.run_track_stream(&mut stream, msg).await {
+		let msg = lite::Subscribe {
+			id,
+			broadcast: broadcast.to_owned(),
+			track: track.name.clone().into(),
+			priority: initial.priority,
+			ordered: initial.ordered,
+			max_latency: initial.max_latency,
+			start_group: initial.start,
+			end_group: initial.end,
+		};
+
+		if let Err(err) = self.run_track_stream(&mut stream, msg, track).await {
 			stream.writer.abort(&err);
 			return Err(err);
 		}
@@ -319,6 +327,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		stream: &mut Stream<S, Version>,
 		msg: lite::Subscribe<'_>,
+		track: &mut TrackProducer,
 	) -> Result<(), Error> {
 		stream.writer.encode(&msg).await?;
 
@@ -328,10 +337,27 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Err(Error::ProtocolViolation);
 		};
 
+		// Forward subsequent aggregate-subscription changes upstream as
+		// SUBSCRIBE_UPDATE. Exit cleanly when the upstream stream closes
+		// (PublishDone) or when no live subscribers remain.
 		// TODO handle additional SUBSCRIBE_OK and SUBSCRIBE_DROP messages.
-		stream.reader.closed().await?;
-
-		Ok(())
+		loop {
+			tokio::select! {
+				sub = track.subscription() => match sub {
+					Some(sub) => {
+						stream.writer.encode(&lite::SubscribeUpdate {
+							priority: sub.priority,
+							ordered: sub.ordered,
+							max_latency: sub.max_latency,
+							start_group: sub.start,
+							end_group: sub.end,
+						}).await?;
+					}
+					None => return Ok(()),
+				},
+				res = stream.reader.closed() => return res,
+			}
+		}
 	}
 
 	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {

--- a/rs/moq-lite/src/model/broadcast.rs
+++ b/rs/moq-lite/src/model/broadcast.rs
@@ -375,6 +375,11 @@ impl BroadcastConsumer {
 		self.consume_track(track)?.subscribe(sub)
 	}
 
+	/// Convenience: [`Self::subscribe_track`] with [`Subscription::default`].
+	pub fn subscribe_track_default(&self, track: &Track) -> Result<TrackSubscriber, Error> {
+		self.consume_track(track)?.subscribe_default()
+	}
+
 	pub async fn closed(&self) -> Error {
 		self.state.closed().await;
 		self.state.read().abort.clone().unwrap_or(Error::Dropped)

--- a/rs/moq-lite/src/model/broadcast.rs
+++ b/rs/moq-lite/src/model/broadcast.rs
@@ -4,7 +4,7 @@ use std::{
 	task::{Poll, ready},
 };
 
-use crate::{Error, TrackConsumer, TrackProducer, model::track::TrackWeak};
+use crate::{Error, Subscription, TrackConsumer, TrackProducer, TrackSubscriber, model::track::TrackWeak};
 
 use super::{OriginList, Track};
 
@@ -124,7 +124,7 @@ impl BroadcastProducer {
 		}
 		drop(state);
 
-		self.create_track(Track { name, priority: 0 })
+		self.create_track(Track::new(name))
 	}
 
 	/// Create a dynamic producer that handles on-demand track requests from consumers.
@@ -311,7 +311,12 @@ impl Deref for BroadcastConsumer {
 }
 
 impl BroadcastConsumer {
-	pub fn subscribe_track(&self, track: &Track) -> Result<TrackConsumer, Error> {
+	/// Returns a fanout consumer for the given track.
+	///
+	/// Returns the cached track if it exists, otherwise routes a new request via
+	/// [`BroadcastDynamic`]. Errors with [`Error::NotFound`] when no dynamic
+	/// producer is attached.
+	pub fn consume_track(&self, track: &Track) -> Result<TrackConsumer, Error> {
 		// Upgrade to a temporary producer so we can modify the state.
 		let producer = self
 			.state
@@ -363,6 +368,13 @@ impl BroadcastConsumer {
 		Ok(consumer)
 	}
 
+	/// Subscribe to a track with the given preferences.
+	///
+	/// Convenience: calls [`Self::consume_track`] then [`TrackConsumer::subscribe`].
+	pub fn subscribe_track(&self, track: &Track, sub: Subscription) -> Result<TrackSubscriber, Error> {
+		self.consume_track(track)?.subscribe(sub)
+	}
+
 	pub async fn closed(&self) -> Error {
 		self.state.closed().await;
 		self.state.read().abort.clone().unwrap_or(Error::Dropped)
@@ -376,8 +388,13 @@ impl BroadcastConsumer {
 
 #[cfg(test)]
 impl BroadcastConsumer {
-	pub fn assert_subscribe_track(&self, track: &Track) -> TrackConsumer {
-		self.subscribe_track(track).expect("should not have errored")
+	pub fn assert_consume_track(&self, track: &Track) -> TrackConsumer {
+		self.consume_track(track).expect("should not have errored")
+	}
+
+	pub fn assert_subscribe_track(&self, track: &Track) -> TrackSubscriber {
+		self.subscribe_track(track, Subscription::default())
+			.expect("should not have errored")
 	}
 
 	pub fn assert_not_closed(&self) {
@@ -464,9 +481,6 @@ mod test {
 		let mut track3 = producer.assert_request();
 		producer.assert_no_request();
 
-		// Make sure the consumer is the same.
-		track3.consume().assert_is_clone(&track1);
-
 		// Append a group and make sure they all get it.
 		track3.append_group().unwrap();
 		track1.assert_group();
@@ -479,7 +493,7 @@ mod test {
 		// Make sure the track is errored, not closed.
 		track4.assert_error();
 
-		let track5 = consumer2.subscribe_track(&Track::new("track3"));
+		let track5 = consumer2.subscribe_track(&Track::new("track3"), Subscription::default());
 		assert!(track5.is_err(), "should have errored");
 	}
 
@@ -557,7 +571,9 @@ mod test {
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
 		// Now the cleanup task should have run and we can subscribe again to the unknown track.
-		let consumer3 = broadcast.consume().subscribe_track(&Track::new("unknown_track"));
+		let consumer3 = broadcast
+			.consume()
+			.subscribe_track(&Track::new("unknown_track"), Subscription::default());
 		let producer2 = broadcast.assert_request();
 
 		// Drop the consumer, now the producer should be unused

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -237,7 +237,12 @@ impl State {
 	/// - `priority`: max across all subscribers (highest-priority wins).
 	/// - `ordered`: AND of all subscribers (true only if every subscriber requests ordered).
 	/// - `max_latency`: max across subscribers, with `Duration::ZERO` meaning unlimited (ZERO wins).
-	/// - `start`/`end`: min/max of concrete values; `None` means no preference.
+	/// - `start`: `None` is the maximally-permissive bound (deliver from the
+	///   beginning); any subscriber with `None` yields `None`. Otherwise pick
+	///   the minimum numeric start.
+	/// - `end`: `None` is the maximally-permissive bound (no end); any
+	///   subscriber with `None` yields `None`. Otherwise pick the maximum
+	///   numeric end.
 	///
 	/// Returns `None` if there are no active subscriptions.
 	fn subscription(&self) -> Option<Subscription> {
@@ -278,8 +283,7 @@ impl State {
 			.map(|s| s.start)
 			.reduce(|a, b| match (a, b) {
 				(Some(a), Some(b)) => Some(a.min(b)),
-				(Some(a), None) | (None, Some(a)) => Some(a),
-				(None, None) => None,
+				_ => None,
 			})
 			.unwrap();
 
@@ -288,8 +292,7 @@ impl State {
 			.map(|s| s.end)
 			.reduce(|a, b| match (a, b) {
 				(Some(a), Some(b)) => Some(a.max(b)),
-				(Some(a), None) | (None, Some(a)) => Some(a),
-				(None, None) => None,
+				_ => None,
 			})
 			.unwrap();
 
@@ -649,6 +652,11 @@ impl TrackConsumer {
 		})
 	}
 
+	/// Convenience: [`Self::subscribe`] with [`Subscription::default`].
+	pub fn subscribe_default(&self) -> Result<TrackSubscriber> {
+		self.subscribe(Subscription::default())
+	}
+
 	/// Poll for the group with the given sequence, without blocking.
 	pub fn poll_get_group(&self, waiter: &conducer::Waiter, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
 		self.poll(waiter, |state| state.poll_get_group(sequence))
@@ -726,7 +734,7 @@ impl TrackConsumer {
 /// producer's aggregate reflects this subscriber's preferences as long as the
 /// subscriber is alive.
 pub struct TrackSubscriber {
-	pub info: Track,
+	info: Track,
 	state: conducer::Consumer<State>,
 	sub: conducer::Producer<Subscription>,
 	/// Arrival-order cursor used by [`Self::recv_group`] / [`Self::next_group`].
@@ -772,6 +780,10 @@ impl TrackSubscriber {
 	/// Respects this subscriber's [`Subscription::start`] / `end` bounds.
 	/// Groups may arrive out of order or with gaps. Use [`Self::next_group`]
 	/// if you need monotonic delivery (skipping late arrivals).
+	///
+	/// Returns `Ok(None)` once the track is finished or the first group past
+	/// `end` is observed; the subscription is considered complete and further
+	/// polls will keep returning `Ok(None)`.
 	pub fn poll_recv_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
 		let sub = self.sub.read();
 		let min_sequence = sub.start.unwrap_or(0);
@@ -984,8 +996,7 @@ impl TrackSubscriber {
 #[cfg(test)]
 impl TrackConsumer {
 	pub fn assert_subscribe(&self) -> TrackSubscriber {
-		self.subscribe(Subscription::default())
-			.expect("subscribe should not have errored")
+		self.subscribe_default().expect("subscribe should not have errored")
 	}
 
 	pub fn assert_is_clone(&self, other: &Self) {
@@ -1641,6 +1652,31 @@ mod test {
 			.expect("aggregate should exist");
 		assert_eq!(agg.start, Some(3));
 		assert_eq!(agg.end, Some(20));
+	}
+
+	#[tokio::test]
+	async fn aggregate_subscription_none_wins_over_some() {
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+
+		// One concrete bound, one unbounded — the unbounded subscriber wants the full range,
+		// so the aggregate must be unbounded too.
+		let _a = consumer
+			.subscribe(Subscription {
+				start: Some(5),
+				end: Some(20),
+				..Default::default()
+			})
+			.unwrap();
+		let _b = consumer.subscribe(Subscription::default()).unwrap();
+
+		let agg = producer
+			.subscription()
+			.now_or_never()
+			.expect("should not block")
+			.expect("aggregate should exist");
+		assert_eq!(agg.start, None, "None subscriber wants from the beginning");
+		assert_eq!(agg.end, None, "None subscriber wants no end");
 	}
 
 	#[tokio::test]

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -1,14 +1,16 @@
 //! A track is a collection of semi-reliable and semi-ordered streams, split into a [TrackProducer] and [TrackConsumer] handle.
 //!
 //! A [TrackProducer] creates streams with a sequence number and priority.
-//! The sequest number is used to determine the order of streams, while the priority is used to determine which stream to transmit first.
+//! The sequence number is used to determine the order of streams, while the priority is used to determine which stream to transmit first.
 //! This may seem counter-intuitive, but is designed for live streaming where the newest streams may be higher priority.
 //! A cloned [TrackProducer] can be used to create streams in parallel, but will error if a duplicate sequence number is used.
 //!
-//! A [TrackConsumer] may not receive all streams in order or at all.
-//! These streams are meant to be transmitted over congested networks and the key to MoQ Tranport is to not block on them.
-//! streams will be cached for a potentially limited duration added to the unreliable nature.
-//! A cloned [TrackConsumer] will receive a copy of all new stream going forward (fanout).
+//! A [TrackConsumer] is a fanout handle: it doesn't iterate groups itself but
+//! can be cloned, queried for cached groups by sequence, and produce a
+//! [TrackSubscriber] via [`TrackConsumer::subscribe`]. The subscriber is what
+//! delivers groups, respects the per-subscriber [`Subscription`] preferences,
+//! and feeds those preferences into the producer's aggregate so the publisher
+//! can react to subscription state (priority, latency, group range).
 //!
 //! The track is closed with [Error] when all writers or readers are dropped.
 
@@ -26,25 +28,39 @@ use std::{
 // TODO: Replace with a configurable cache size.
 const MAX_GROUP_AGE: Duration = Duration::from_secs(30);
 
-/// A track is a collection of groups, delivered out-of-order until expired.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// A track is a collection of groups, identified by name.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Track {
 	pub name: String,
-	pub priority: u8,
 }
 
 impl Track {
 	pub fn new<T: Into<String>>(name: T) -> Self {
-		Self {
-			name: name.into(),
-			priority: 0,
-		}
+		Self { name: name.into() }
 	}
 
 	pub fn produce(self) -> TrackProducer {
 		TrackProducer::new(self)
 	}
+}
+
+/// Subscription preferences for a single subscriber.
+///
+/// Describes how groups should be delivered: priority, ordering, latency
+/// bounds, and the range of groups requested. The producer aggregates the
+/// preferences across all live subscribers so the publisher can serve the
+/// union (highest priority, lowest start, etc.).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Subscription {
+	pub priority: u8,
+	pub ordered: bool,
+	/// Maximum cache/latency. `Duration::ZERO` means unlimited.
+	pub max_latency: Duration,
+	/// First group sequence to deliver. `None` means no preference.
+	pub start: Option<u64>,
+	/// Last group sequence to deliver. `None` means no preference (live).
+	pub end: Option<u64>,
 }
 
 #[derive(Default)]
@@ -56,6 +72,9 @@ struct State {
 	max_sequence: Option<u64>,
 	final_sequence: Option<u64>,
 	abort: Option<Error>,
+
+	/// Per-subscriber subscription values, read by the producer for aggregation.
+	subscriptions: Vec<conducer::Consumer<Subscription>>,
 }
 
 impl State {
@@ -196,12 +215,97 @@ impl State {
 			Poll::Pending
 		}
 	}
+
+	/// "Ready" means at least one group exists, the track is finished, or it's aborted.
+	fn poll_ready(&self) -> Poll<Result<()>> {
+		if self.max_sequence.is_some() || self.final_sequence.is_some() {
+			Poll::Ready(Ok(()))
+		} else if let Some(err) = &self.abort {
+			Poll::Ready(Err(err.clone()))
+		} else {
+			Poll::Pending
+		}
+	}
+
+	/// Aggregate the active (non-closed) subscriber preferences into a single
+	/// [`Subscription`].
+	///
+	/// Aggregation rules:
+	/// - `priority`: max across all subscribers (highest-priority wins).
+	/// - `ordered`: AND of all subscribers (true only if every subscriber requests ordered).
+	/// - `max_latency`: max across subscribers, with `Duration::ZERO` meaning unlimited (ZERO wins).
+	/// - `start`/`end`: min/max of concrete values; `None` means no preference.
+	///
+	/// Returns `None` if there are no active subscriptions.
+	fn subscription(&self) -> Option<Subscription> {
+		if self.subscriptions.is_empty() {
+			return None;
+		}
+
+		let subs: Vec<Subscription> = self
+			.subscriptions
+			.iter()
+			.filter_map(|c| {
+				let r = c.read();
+				if r.is_closed() { None } else { Some(r.clone()) }
+			})
+			.collect();
+
+		if subs.is_empty() {
+			return None;
+		}
+
+		let priority = subs.iter().map(|s| s.priority).max().unwrap();
+		let ordered = subs.iter().all(|s| s.ordered);
+
+		let max_latency = subs
+			.iter()
+			.map(|s| s.max_latency)
+			.reduce(|a, b| {
+				if a.is_zero() || b.is_zero() {
+					Duration::ZERO
+				} else {
+					a.max(b)
+				}
+			})
+			.unwrap();
+
+		let start = subs
+			.iter()
+			.map(|s| s.start)
+			.reduce(|a, b| match (a, b) {
+				(Some(a), Some(b)) => Some(a.min(b)),
+				(Some(a), None) | (None, Some(a)) => Some(a),
+				(None, None) => None,
+			})
+			.unwrap();
+
+		let end = subs
+			.iter()
+			.map(|s| s.end)
+			.reduce(|a, b| match (a, b) {
+				(Some(a), Some(b)) => Some(a.max(b)),
+				(Some(a), None) | (None, Some(a)) => Some(a),
+				(None, None) => None,
+			})
+			.unwrap();
+
+		Some(Subscription {
+			priority,
+			ordered,
+			max_latency,
+			start,
+			end,
+		})
+	}
 }
 
 /// A producer for a track, used to create new groups.
 pub struct TrackProducer {
 	info: Track,
 	state: conducer::Producer<State>,
+	/// The last aggregate subscription returned by [`Self::poll_subscription`].
+	prev_subscription: Option<Subscription>,
 }
 
 impl std::ops::Deref for TrackProducer {
@@ -217,6 +321,7 @@ impl TrackProducer {
 		Self {
 			info,
 			state: conducer::Producer::default(),
+			prev_subscription: None,
 		}
 	}
 
@@ -332,14 +437,11 @@ impl TrackProducer {
 		Ok(())
 	}
 
-	/// Create a new consumer for the track, starting at the beginning.
+	/// Create a new consumer for the track.
 	pub fn consume(&self) -> TrackConsumer {
 		TrackConsumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
-			index: 0,
-			min_sequence: 0,
-			next_sequence: 0,
 		}
 	}
 
@@ -377,6 +479,49 @@ impl TrackProducer {
 		}
 	}
 
+	/// Poll for changes to the aggregate subscription.
+	///
+	/// Returns `Ready(Some(sub))` when the aggregate differs from the last value
+	/// returned. Returns `Ready(None)` when no subscriptions are active (or the
+	/// track is closed).
+	pub fn poll_subscription(&mut self, waiter: &conducer::Waiter) -> Poll<Option<Subscription>> {
+		let prev = self.prev_subscription.clone();
+		match self.state.poll(waiter, |state| {
+			// Drop closed subscription consumers.
+			state.subscriptions.retain(|c| !c.read().is_closed());
+
+			// Register the waiter on each per-subscriber channel so we wake when any
+			// individual subscription changes (e.g. update()).
+			for sub in &state.subscriptions {
+				let _ = sub.poll(waiter, |_| Poll::<()>::Pending);
+			}
+
+			let current = state.subscription();
+			if current != prev {
+				Poll::Ready(current)
+			} else {
+				Poll::Pending
+			}
+		}) {
+			Poll::Ready(Ok(sub)) => {
+				self.prev_subscription = sub.clone();
+				Poll::Ready(sub)
+			}
+			Poll::Ready(Err(_)) => {
+				self.prev_subscription = None;
+				Poll::Ready(None)
+			}
+			Poll::Pending => Poll::Pending,
+		}
+	}
+
+	/// Block until the aggregate subscription changes.
+	///
+	/// Returns `None` when all subscriptions are dropped or the track is closed.
+	pub async fn subscription(&mut self) -> Option<Subscription> {
+		conducer::wait(|waiter| self.poll_subscription(waiter)).await
+	}
+
 	fn modify(&self) -> Result<conducer::Mut<'_, State>> {
 		self.state
 			.write()
@@ -389,6 +534,7 @@ impl Clone for TrackProducer {
 		Self {
 			info: self.info.clone(),
 			state: self.state.clone(),
+			prev_subscription: self.prev_subscription.clone(),
 		}
 	}
 }
@@ -427,9 +573,6 @@ impl TrackWeak {
 		TrackConsumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
-			index: 0,
-			min_sequence: 0,
-			next_sequence: 0,
 		}
 	}
 
@@ -445,18 +588,16 @@ impl TrackWeak {
 	}
 }
 
-/// A consumer for a track, used to read groups.
+/// A consumer for a track.
+///
+/// `TrackConsumer` is a fanout handle: clone it freely, query for cached
+/// groups via [`Self::get_group`], or call [`Self::subscribe`] to get a
+/// [`TrackSubscriber`] that delivers groups respecting [`Subscription`]
+/// preferences.
 #[derive(Clone)]
 pub struct TrackConsumer {
 	info: Track,
 	state: conducer::Consumer<State>,
-	/// Arrival-order cursor used by [`Self::recv_group`].
-	index: usize,
-	/// Minimum sequence to return from any `recv` method. Set by [`Self::start_at`].
-	min_sequence: u64,
-	/// One past the highest sequence returned by [`Self::next_group_ordered`].
-	/// Used only by that method to skip late arrivals; does not affect [`Self::recv_group`].
-	next_sequence: u64,
 }
 
 impl std::ops::Deref for TrackConsumer {
@@ -475,101 +616,34 @@ impl TrackConsumer {
 	{
 		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
 			Ok(res) => res,
-			// We try to clone abort just in case the function forgot to check for terminal state.
 			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
 		})
 	}
 
-	/// Poll for the next group received over the network, in arrival order, without blocking.
+	/// Register a subscription and return a [`TrackSubscriber`].
 	///
-	/// Groups may arrive out of order or with gaps due to network conditions.
-	/// Use [`Self::next_group_ordered`] if you need groups in sequence order,
-	/// skipping those that arrive too late.
-	///
-	/// Returns `Poll::Ready(Ok(Some(group)))` when a group is available,
-	/// `Poll::Ready(Ok(None))` when the track is finished,
-	/// `Poll::Ready(Err(e))` when the track has been aborted, or
-	/// `Poll::Pending` when no group is available yet.
-	pub fn poll_recv_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
-		let Some((consumer, found_index)) =
-			ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, self.min_sequence))?)
-		else {
-			return Poll::Ready(Ok(None));
-		};
+	/// The subscriber can be used right away; callers may want to call
+	/// [`TrackSubscriber::ready`] to wait until the first group exists (or
+	/// finish/abort). Dropping the subscriber removes it from the producer's
+	/// aggregate.
+	pub fn subscribe(&self, sub: Subscription) -> Result<TrackSubscriber> {
+		let sub_producer = conducer::Producer::new(sub);
+		let sub_consumer = sub_producer.consume();
 
-		self.index = found_index + 1;
-		Poll::Ready(Ok(Some(consumer)))
-	}
-
-	/// Receive the next group available on this track, in arrival order.
-	///
-	/// Groups may arrive out of order or with gaps due to network conditions.
-	/// Use [`Self::next_group_ordered`] if you need groups in sequence order,
-	/// skipping those that arrive too late.
-	pub async fn recv_group(&mut self) -> Result<Option<GroupConsumer>> {
-		conducer::wait(|waiter| self.poll_recv_group(waiter)).await
-	}
-
-	/// Deprecated alias for [`Self::poll_recv_group`].
-	#[deprecated(note = "use poll_recv_group for arrival order, or poll_next_group_ordered for sequence order")]
-	pub fn poll_next_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
-		self.poll_recv_group(waiter)
-	}
-
-	/// Deprecated alias for [`Self::recv_group`].
-	#[deprecated(note = "use recv_group for arrival order, or next_group_ordered for sequence order")]
-	pub async fn next_group(&mut self) -> Result<Option<GroupConsumer>> {
-		self.recv_group().await
-	}
-
-	/// A helper that calls [`Self::poll_recv_group`] but only returns groups with a sequence number higher than any previously returned.
-	///
-	/// NOTE: This will be renamed to `poll_next_group` in the next major version.
-	pub fn poll_next_group_ordered(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
-		loop {
-			let Some(group) = ready!(self.poll_recv_group(waiter)?) else {
-				return Poll::Ready(Ok(None));
-			};
-			if group.sequence < self.next_sequence {
-				// Late arrival; discard and keep looking.
-				continue;
-			}
-			self.next_sequence = group.sequence.saturating_add(1);
-			return Poll::Ready(Ok(Some(group)));
+		// Insert via a weak handle so we don't bump the producer ref count and prevent auto-close.
+		// If the channel is already closed, skip — the subscriber can still drain cached groups.
+		let weak = self.state.weak();
+		if let Ok(mut state) = weak.write() {
+			state.subscriptions.push(sub_consumer);
 		}
-	}
 
-	/// Return the next group with a strictly-greater sequence number than the last returned.
-	///
-	/// Groups that arrive late (with a sequence number at or below the last one returned)
-	/// are silently skipped.
-	///
-	/// NOTE: This will be renamed to `next_group` in the next major version.
-	pub async fn next_group_ordered(&mut self) -> Result<Option<GroupConsumer>> {
-		conducer::wait(|waiter| self.poll_next_group_ordered(waiter)).await
-	}
-
-	/// A helper that calls [`Self::poll_next_group_ordered`] and returns its first frame,
-	/// skipping the rest of the group. Intended for single-frame groups (see
-	/// [`TrackProducer::write_frame`]).
-	pub fn poll_read_frame(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<bytes::Bytes>>> {
-		let lower = self.min_sequence.max(self.next_sequence);
-		let Some((frame, found_index, sequence)) =
-			ready!(self.poll(waiter, |state| { state.poll_read_frame(self.index, lower, waiter) })?)
-		else {
-			return Poll::Ready(Ok(None));
-		};
-
-		self.index = found_index + 1;
-		self.next_sequence = sequence.saturating_add(1);
-		Poll::Ready(Ok(Some(frame)))
-	}
-
-	/// Read a single full frame from the next group in sequence order.
-	///
-	/// See [`Self::poll_read_frame`] for semantics.
-	pub async fn read_frame(&mut self) -> Result<Option<bytes::Bytes>> {
-		conducer::wait(|waiter| self.poll_read_frame(waiter)).await
+		Ok(TrackSubscriber {
+			info: self.info.clone(),
+			state: self.state.clone(),
+			sub: sub_producer,
+			index: 0,
+			next: 0,
+		})
 	}
 
 	/// Poll for the group with the given sequence, without blocking.
@@ -601,18 +675,13 @@ impl TrackConsumer {
 	}
 
 	/// Poll for the total number of groups in the track.
-	pub fn poll_finished(&mut self, waiter: &conducer::Waiter) -> Poll<Result<u64>> {
+	pub fn poll_finished(&self, waiter: &conducer::Waiter) -> Poll<Result<u64>> {
 		self.poll(waiter, |state| state.poll_finished())
 	}
 
 	/// Block until the track is finished, returning the total number of groups.
-	pub async fn finished(&mut self) -> Result<u64> {
+	pub async fn finished(&self) -> Result<u64> {
 		conducer::wait(|waiter| self.poll_finished(waiter)).await
-	}
-
-	/// Start the consumer at the specified sequence.
-	pub fn start_at(&mut self, sequence: u64) {
-		self.min_sequence = sequence;
 	}
 
 	/// Return the latest sequence number in the track.
@@ -642,7 +711,226 @@ impl TrackConsumer {
 		Ok(TrackProducer {
 			info: self.info.clone(),
 			state,
+			prev_subscription: None,
 		})
+	}
+}
+
+/// Iterates groups from a track while managing this subscriber's lifecycle.
+///
+/// Created via [`TrackConsumer::subscribe`]. Registers a [`Subscription`] in
+/// the shared state on creation; automatically removes it on drop. The
+/// producer's aggregate reflects this subscriber's preferences as long as the
+/// subscriber is alive.
+pub struct TrackSubscriber {
+	pub info: Track,
+	state: conducer::Consumer<State>,
+	sub: conducer::Producer<Subscription>,
+	/// Arrival-order cursor used by [`Self::recv_group`] / [`Self::next_group`].
+	index: usize,
+	/// One past the highest sequence returned by [`Self::next_group`] /
+	/// [`Self::read_frame`]. Late arrivals below this are silently skipped by
+	/// those methods (but [`Self::recv_group`] still returns them).
+	next: u64,
+}
+
+impl std::ops::Deref for TrackSubscriber {
+	type Target = Track;
+
+	fn deref(&self) -> &Self::Target {
+		&self.info
+	}
+}
+
+impl TrackSubscriber {
+	// A helper to automatically apply Dropped if the state is closed without an error.
+	fn poll<F, R>(&self, waiter: &conducer::Waiter, f: F) -> Poll<Result<R>>
+	where
+		F: Fn(&conducer::Ref<'_, State>) -> Poll<Result<R>>,
+	{
+		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
+			Ok(res) => res,
+			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
+		})
+	}
+
+	/// Poll whether the track is "ready": has at least one group, is finished, or aborted.
+	pub fn poll_ready(&self, waiter: &conducer::Waiter) -> Poll<Result<()>> {
+		self.poll(waiter, |state| state.poll_ready())
+	}
+
+	/// Wait until the track is ready (has at least one group, is finished, or aborted).
+	pub async fn ready(&self) -> Result<()> {
+		conducer::wait(|waiter| self.poll_ready(waiter)).await
+	}
+
+	/// Poll for the next group received over the network, in arrival order.
+	///
+	/// Respects this subscriber's [`Subscription::start`] / `end` bounds.
+	/// Groups may arrive out of order or with gaps. Use [`Self::next_group`]
+	/// if you need monotonic delivery (skipping late arrivals).
+	pub fn poll_recv_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+		let sub = self.sub.read();
+		let min_sequence = sub.start.unwrap_or(0);
+		let end = sub.end;
+		drop(sub);
+
+		let Some((consumer, found_index)) =
+			ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, min_sequence))?)
+		else {
+			return Poll::Ready(Ok(None));
+		};
+
+		if let Some(end) = end
+			&& consumer.sequence > end
+		{
+			return Poll::Ready(Ok(None));
+		}
+
+		self.index = found_index + 1;
+		Poll::Ready(Ok(Some(consumer)))
+	}
+
+	/// Receive the next group available on this track, in arrival order.
+	pub async fn recv_group(&mut self) -> Result<Option<GroupConsumer>> {
+		conducer::wait(|waiter| self.poll_recv_group(waiter)).await
+	}
+
+	/// Return the next group with a strictly-greater sequence number than the last returned.
+	///
+	/// Groups that arrive late (sequence at or below the last one returned) are
+	/// silently skipped. Respects [`Subscription::start`] / `end`.
+	pub fn poll_next_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+		let sub = self.sub.read();
+		let min_sequence = self.next.max(sub.start.unwrap_or(0));
+		let end = sub.end;
+		drop(sub);
+
+		let Some((consumer, found_index)) =
+			ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, min_sequence))?)
+		else {
+			return Poll::Ready(Ok(None));
+		};
+
+		if let Some(end) = end
+			&& consumer.sequence > end
+		{
+			return Poll::Ready(Ok(None));
+		}
+
+		self.index = found_index + 1;
+		self.next = consumer.sequence.saturating_add(1);
+		Poll::Ready(Ok(Some(consumer)))
+	}
+
+	/// Block until the next strictly-greater-sequence group is available.
+	pub async fn next_group(&mut self) -> Result<Option<GroupConsumer>> {
+		conducer::wait(|waiter| self.poll_next_group(waiter)).await
+	}
+
+	/// Deprecated alias for [`Self::poll_next_group`].
+	#[deprecated(note = "use poll_next_group")]
+	pub fn poll_next_group_ordered(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+		self.poll_next_group(waiter)
+	}
+
+	/// Deprecated alias for [`Self::next_group`].
+	#[deprecated(note = "use next_group")]
+	pub async fn next_group_ordered(&mut self) -> Result<Option<GroupConsumer>> {
+		self.next_group().await
+	}
+
+	/// Return the first frame of the next strictly-greater-sequence group,
+	/// skipping the rest of the group. Intended for single-frame groups (see
+	/// [`TrackProducer::write_frame`]).
+	///
+	/// Respects [`Subscription::start`] / `end`.
+	pub fn poll_read_frame(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<bytes::Bytes>>> {
+		let sub = self.sub.read();
+		let lower = self.next.max(sub.start.unwrap_or(0));
+		let end = sub.end;
+		drop(sub);
+
+		let Some((frame, found_index, sequence)) =
+			ready!(self.poll(waiter, |state| { state.poll_read_frame(self.index, lower, waiter) })?)
+		else {
+			return Poll::Ready(Ok(None));
+		};
+
+		if let Some(end) = end
+			&& sequence > end
+		{
+			return Poll::Ready(Ok(None));
+		}
+
+		self.index = found_index + 1;
+		self.next = sequence.saturating_add(1);
+		Poll::Ready(Ok(Some(frame)))
+	}
+
+	/// Block until a frame is available from the next group in sequence order.
+	pub async fn read_frame(&mut self) -> Result<Option<bytes::Bytes>> {
+		conducer::wait(|waiter| self.poll_read_frame(waiter)).await
+	}
+
+	/// Update this subscription's preferences. Wakes the producer's
+	/// [`TrackProducer::poll_subscription`] if the aggregate changed.
+	pub fn update(&mut self, sub: Subscription) {
+		if let Ok(mut guard) = self.sub.write() {
+			*guard = sub;
+		}
+	}
+
+	/// Read this subscriber's current preferences.
+	pub fn subscription(&self) -> Subscription {
+		self.sub.read().clone()
+	}
+
+	/// Return the latest sequence number in the track.
+	pub fn latest(&self) -> Option<u64> {
+		self.state.read().max_sequence
+	}
+
+	/// Poll for the group with the given sequence, without blocking.
+	pub fn poll_get_group(&self, waiter: &conducer::Waiter, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
+		self.poll(waiter, |state| state.poll_get_group(sequence))
+	}
+
+	/// Block until the group with the given sequence is available.
+	pub async fn get_group(&self, sequence: u64) -> Result<Option<GroupConsumer>> {
+		conducer::wait(|waiter| self.poll_get_group(waiter, sequence)).await
+	}
+
+	/// Poll for track closure, without blocking.
+	pub fn poll_closed(&self, waiter: &conducer::Waiter) -> Poll<Result<()>> {
+		self.poll(waiter, |state| state.poll_closed())
+	}
+
+	/// Block until the track is closed.
+	pub async fn closed(&self) -> Result<()> {
+		conducer::wait(|waiter| self.poll_closed(waiter)).await
+	}
+
+	/// Poll for the total number of groups in the track.
+	pub fn poll_finished(&self, waiter: &conducer::Waiter) -> Poll<Result<u64>> {
+		self.poll(waiter, |state| state.poll_finished())
+	}
+
+	/// Block until the track is finished.
+	pub async fn finished(&self) -> Result<u64> {
+		conducer::wait(|waiter| self.poll_finished(waiter)).await
+	}
+
+	pub fn is_clone(&self, other: &Self) -> bool {
+		self.state.same_channel(&other.state)
+	}
+}
+
+impl Drop for TrackSubscriber {
+	fn drop(&mut self) {
+		// Closing the per-subscriber channel marks it as closed so the producer's
+		// aggregator drops it on the next poll.
+		let _ = self.sub.close();
 	}
 }
 
@@ -650,7 +938,7 @@ impl TrackConsumer {
 use futures::FutureExt;
 
 #[cfg(test)]
-impl TrackConsumer {
+impl TrackSubscriber {
 	pub fn assert_group(&mut self) -> GroupConsumer {
 		self.recv_group()
 			.now_or_never()
@@ -674,12 +962,27 @@ impl TrackConsumer {
 		assert!(self.closed().now_or_never().is_some(), "should be closed");
 	}
 
-	// TODO assert specific errors after implementing PartialEq
 	pub fn assert_error(&self) {
 		assert!(
 			self.closed().now_or_never().expect("should not block").is_err(),
 			"should be error"
 		);
+	}
+
+	pub fn assert_is_clone(&self, other: &Self) {
+		assert!(self.is_clone(other), "should be clone");
+	}
+
+	pub fn assert_not_clone(&self, other: &Self) {
+		assert!(!self.is_clone(other), "should not be clone");
+	}
+}
+
+#[cfg(test)]
+impl TrackConsumer {
+	pub fn assert_subscribe(&self) -> TrackSubscriber {
+		self.subscribe(Subscription::default())
+			.expect("subscribe should not have errored")
 	}
 
 	pub fn assert_is_clone(&self, other: &Self) {
@@ -711,7 +1014,6 @@ mod test {
 
 		let mut producer = Track::new("test").produce();
 
-		// Create 3 groups at time 0.
 		producer.append_group().unwrap(); // seq 0
 		producer.append_group().unwrap(); // seq 1
 		producer.append_group().unwrap(); // seq 2
@@ -722,14 +1024,10 @@ mod test {
 			assert_eq!(state.offset, 0);
 		}
 
-		// Advance time past the eviction threshold.
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
-		// Append a new group to trigger eviction.
 		producer.append_group().unwrap(); // seq 3
 
-		// Groups 0, 1, 2 are expired but seq 3 (max_sequence) is kept.
-		// Leading tombstones are trimmed, so only seq 3 remains.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 1);
@@ -747,13 +1045,11 @@ mod test {
 		tokio::time::pause();
 
 		let mut producer = Track::new("test").produce();
-		producer.append_group().unwrap(); // seq 0
+		producer.append_group().unwrap();
 
-		// Advance time past threshold.
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
-		// Append another group; seq 0 is expired and evicted.
-		producer.append_group().unwrap(); // seq 1
+		producer.append_group().unwrap();
 
 		{
 			let state = producer.state.read();
@@ -768,9 +1064,9 @@ mod test {
 		tokio::time::pause();
 
 		let mut producer = Track::new("test").produce();
-		producer.append_group().unwrap(); // seq 0
-		producer.append_group().unwrap(); // seq 1
-		producer.append_group().unwrap(); // seq 2
+		producer.append_group().unwrap();
+		producer.append_group().unwrap();
+		producer.append_group().unwrap();
 
 		{
 			let state = producer.state.read();
@@ -780,19 +1076,20 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn consumer_skips_evicted_groups() {
+	async fn subscriber_skips_evicted_groups() {
 		tokio::time::pause();
 
 		let mut producer = Track::new("test").produce();
 		producer.append_group().unwrap(); // seq 0
 
-		let mut consumer = producer.consume();
+		let consumer = producer.consume();
+		let mut subscriber = consumer.assert_subscribe();
 
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 		producer.append_group().unwrap(); // seq 1
 
-		// Group 0 was evicted. Consumer should get group 1.
-		let group = consumer.assert_group();
+		// Group 0 was evicted. Subscriber should get group 1.
+		let group = subscriber.assert_group();
 		assert_eq!(group.sequence, 1);
 	}
 
@@ -802,25 +1099,19 @@ mod test {
 
 		let mut producer = Track::new("test").produce();
 
-		// Arrive out of order: seq 5 first, then 3, then 4.
 		producer.create_group(Group { sequence: 5 }).unwrap();
 		producer.create_group(Group { sequence: 3 }).unwrap();
 		producer.create_group(Group { sequence: 4 }).unwrap();
 
-		// max_sequence = 5, which is at the front of the VecDeque.
 		{
 			let state = producer.state.read();
 			assert_eq!(state.max_sequence, Some(5));
 		}
 
-		// Expire all three groups.
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
-		// Append seq 6 (becomes new max_sequence).
 		producer.append_group().unwrap(); // seq 6
 
-		// Seq 3, 4, 5 are all expired. Seq 5 was the old max_sequence but now 6 is.
-		// All old groups are evicted.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 1);
@@ -838,32 +1129,22 @@ mod test {
 
 		let mut producer = Track::new("test").produce();
 
-		// Arrive: seq 5, then seq 3.
 		producer.create_group(Group { sequence: 5 }).unwrap();
 
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
-		// Seq 3 arrives late; max_sequence is still 5 (at front).
 		producer.create_group(Group { sequence: 3 }).unwrap();
 
-		// Seq 5 is max_sequence (protected). Seq 3 is not expired (just created).
-		// Nothing should be evicted.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 2);
 			assert_eq!(state.offset, 0);
 		}
 
-		// Expire seq 3 as well.
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
-		// Seq 2 arrives late, triggering eviction.
 		producer.create_group(Group { sequence: 2 }).unwrap();
 
-		// Seq 5 is still max_sequence (protected, at front, blocks trim).
-		// Seq 3 is expired → tombstoned.
-		// Seq 2 is fresh → kept.
-		// VecDeque: [Some(5), None, Some(2)]. Leading entry is Some, so offset stays.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 2);
@@ -873,10 +1154,9 @@ mod test {
 			assert!(state.duplicates.contains(&2));
 		}
 
-		// Consumer should still be able to read through the hole.
-		let mut consumer = producer.consume();
-		let group = consumer.assert_group();
-		// consume() starts at index 0, first non-tombstoned group is seq 5.
+		let mut subscriber = producer.consume().assert_subscribe();
+		let group = subscriber.assert_group();
+		// First non-tombstoned group is seq 5.
 		assert_eq!(group.sequence, 5);
 	}
 
@@ -884,7 +1164,6 @@ mod test {
 	fn append_finish_cannot_be_rewritten() {
 		let mut producer = Track::new("test").produce();
 
-		// Finishing an empty track is valid (fin = 0, total groups = 0).
 		assert!(producer.finish().is_ok());
 		assert!(producer.finish().is_err());
 		assert!(producer.append_group().is_err());
@@ -925,10 +1204,10 @@ mod test {
 		producer.create_group(Group { sequence: 1 }).unwrap();
 		producer.finish_at(1).unwrap();
 
-		let mut consumer = producer.consume();
-		assert_eq!(consumer.assert_group().sequence, 1);
+		let mut subscriber = producer.consume().assert_subscribe();
+		assert_eq!(subscriber.assert_group().sequence, 1);
 
-		let done = consumer
+		let done = subscriber
 			.recv_group()
 			.now_or_never()
 			.expect("should not block")
@@ -937,61 +1216,56 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn next_group_ordered_skips_late_arrivals() {
+	async fn next_group_skips_late_arrivals() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.consume();
+		let mut subscriber = producer.consume().assert_subscribe();
 
-		// Seq 5 arrives first.
 		producer.create_group(Group { sequence: 5 }).unwrap();
-		let group = consumer
-			.next_group_ordered()
+		let group = subscriber
+			.next_group()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
 			.expect("track should not be closed");
 		assert_eq!(group.sequence, 5);
 
-		// Seq 3 arrives late — skipped because 3 <= 5.
+		// Late arrivals are skipped.
 		producer.create_group(Group { sequence: 3 }).unwrap();
-		// Seq 4 arrives late — also skipped.
 		producer.create_group(Group { sequence: 4 }).unwrap();
-		// Seq 7 arrives — returned.
 		producer.create_group(Group { sequence: 7 }).unwrap();
 
-		let group = consumer
-			.next_group_ordered()
+		let group = subscriber
+			.next_group()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
 			.expect("track should not be closed");
 		assert_eq!(group.sequence, 7);
 
-		// No more groups — would block.
 		assert!(
-			consumer.next_group_ordered().now_or_never().is_none(),
+			subscriber.next_group().now_or_never().is_none(),
 			"should block waiting for a higher sequence"
 		);
 	}
 
 	#[tokio::test]
-	async fn next_group_ordered_returns_arrivals_in_order() {
+	async fn next_group_returns_arrivals_in_order() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.consume();
+		let mut subscriber = producer.consume().assert_subscribe();
 
-		// Seq 3 arrives first, then seq 5 — both should be returned in arrival order.
 		producer.create_group(Group { sequence: 3 }).unwrap();
 		producer.create_group(Group { sequence: 5 }).unwrap();
 
-		let group = consumer
-			.next_group_ordered()
+		let group = subscriber
+			.next_group()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
 			.expect("track should not be closed");
 		assert_eq!(group.sequence, 3);
 
-		let group = consumer
-			.next_group_ordered()
+		let group = subscriber
+			.next_group()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
@@ -1000,36 +1274,42 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn recv_group_after_next_group_ordered_sees_late_arrivals() {
+	async fn recv_group_after_next_group_sees_late_arrivals() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.consume();
+		let consumer = producer.consume();
+		let mut ordered = consumer.assert_subscribe();
+		let mut arrival = consumer.assert_subscribe();
 
 		producer.create_group(Group { sequence: 5 }).unwrap();
 		producer.create_group(Group { sequence: 3 }).unwrap();
 
-		// Ordered returns seq 5 and advances its internal cursor past it.
-		let group = consumer
-			.next_group_ordered()
+		// Ordered subscriber sees seq 5 and skips the late seq 3.
+		let group = ordered
+			.next_group()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
 			.expect("track should not be closed");
 		assert_eq!(group.sequence, 5);
+		assert!(
+			ordered.next_group().now_or_never().is_none(),
+			"ordered should block waiting for >5"
+		);
 
-		// Intermixing: recv_group on the same consumer still returns the late seq 3.
-		// The ordered cursor is separate from the recv_group filter.
-		assert_eq!(consumer.assert_group().sequence, 3);
+		// Arrival-order subscriber sees both, in arrival order.
+		assert_eq!(arrival.assert_group().sequence, 5);
+		assert_eq!(arrival.assert_group().sequence, 3);
 	}
 
 	#[tokio::test]
 	async fn read_frame_returns_single_frame_per_group() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.consume();
+		let mut subscriber = producer.consume().assert_subscribe();
 
 		producer.write_frame(b"hello".as_slice()).unwrap();
 		producer.write_frame(b"world".as_slice()).unwrap();
 
-		let frame = consumer
+		let frame = subscriber
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1037,7 +1317,7 @@ mod test {
 			.expect("track should not be closed");
 		assert_eq!(&frame[..], b"hello");
 
-		let frame = consumer
+		let frame = subscriber
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1049,17 +1329,14 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_skips_stalled_group_for_newer_ready_frame() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.consume();
+		let mut subscriber = producer.consume().assert_subscribe();
 
-		// Seq 3: group open, no frame yet (stalled).
 		let _stalled = producer.create_group(Group { sequence: 3 }).unwrap();
-		// Seq 5: fully-written group with a frame.
 		let mut g5 = producer.create_group(Group { sequence: 5 }).unwrap();
 		g5.write_frame(bytes::Bytes::from_static(b"later")).unwrap();
 		g5.finish().unwrap();
 
-		// read_frame should not block on the stalled seq 3 — it returns seq 5's frame.
-		let frame = consumer
+		let frame = subscriber
 			.read_frame()
 			.now_or_never()
 			.expect("should not block on stalled earlier group")
@@ -1071,18 +1348,16 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_discards_rest_of_multi_frame_group() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.consume();
+		let mut subscriber = producer.consume().assert_subscribe();
 
-		// Group 0 has two frames; only the first is returned.
 		let mut g0 = producer.create_group(Group { sequence: 0 }).unwrap();
 		g0.write_frame(bytes::Bytes::from_static(b"one")).unwrap();
 		g0.write_frame(bytes::Bytes::from_static(b"two")).unwrap();
 		g0.finish().unwrap();
 
-		// Group 1 is a normal single-frame group.
 		producer.write_frame(b"next".as_slice()).unwrap();
 
-		let frame = consumer
+		let frame = subscriber
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1090,8 +1365,7 @@ mod test {
 			.expect("track should not be closed");
 		assert_eq!(&frame[..], b"one");
 
-		// The second frame of group 0 is discarded; the next read jumps to group 1.
-		let frame = consumer
+		let frame = subscriber
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1102,23 +1376,19 @@ mod test {
 
 	#[tokio::test]
 	async fn read_frame_waits_for_pending_group_after_finish() {
-		// finish() sets final_sequence, but groups already created with lower sequences
-		// can still produce frames. read_frame must not return None prematurely.
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.consume();
+		let mut subscriber = producer.consume().assert_subscribe();
 
 		let mut g0 = producer.create_group(Group { sequence: 0 }).unwrap();
 		producer.finish().unwrap();
 
-		// Track is finished but group 0 has no frame yet — must block, not return None.
 		assert!(
-			consumer.read_frame().now_or_never().is_none(),
+			subscriber.read_frame().now_or_never().is_none(),
 			"read_frame must block on a pending group even after finish()"
 		);
 
-		// A late frame on the pending group is still delivered.
 		g0.write_frame(bytes::Bytes::from_static(b"late")).unwrap();
-		let frame = consumer
+		let frame = subscriber
 			.read_frame()
 			.now_or_never()
 			.expect("should not block once a frame is written")
@@ -1128,14 +1398,16 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn read_frame_respects_start_at() {
-		// start_at sets min_sequence; read_frame must skip groups below it even though
-		// next_sequence is still 0.
+	async fn read_frame_respects_subscription_start() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.consume();
-		consumer.start_at(5);
+		let consumer = producer.consume();
+		let mut subscriber = consumer
+			.subscribe(Subscription {
+				start: Some(5),
+				..Default::default()
+			})
+			.unwrap();
 
-		// Seq 3 has a frame but is below min_sequence — must be skipped.
 		let mut g3 = producer.create_group(Group { sequence: 3 }).unwrap();
 		g3.write_frame(bytes::Bytes::from_static(b"skip-me")).unwrap();
 		g3.finish().unwrap();
@@ -1144,7 +1416,7 @@ mod test {
 		g5.write_frame(bytes::Bytes::from_static(b"keep")).unwrap();
 		g5.finish().unwrap();
 
-		let frame = consumer
+		let frame = subscriber
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1156,12 +1428,12 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_returns_none_when_finished() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.consume();
+		let mut subscriber = producer.consume().assert_subscribe();
 
 		producer.write_frame(b"only".as_slice()).unwrap();
 		producer.finish().unwrap();
 
-		let frame = consumer
+		let frame = subscriber
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1169,7 +1441,7 @@ mod test {
 			.expect("track should not be closed");
 		assert_eq!(&frame[..], b"only");
 
-		let done = consumer
+		let done = subscriber
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1184,7 +1456,6 @@ mod test {
 		producer.finish_at(1).unwrap();
 
 		let consumer = producer.consume();
-		// get_group(0) blocks because group 0 is below final_sequence and could still arrive.
 		assert!(
 			consumer.get_group(0).now_or_never().is_none(),
 			"sequence below fin should block (group could still arrive)"
@@ -1218,15 +1489,13 @@ mod test {
 
 		let consumer = producer.consume();
 
-		// Upgrade consumer back to producer — shared state.
 		let got = consumer.produce().expect("should produce");
 		assert!(got.is_clone(&producer), "should be the same track");
 
-		// Writing through the upgraded producer is visible to new consumers.
 		got.clone().append_group().unwrap();
-		let mut sub = producer.consume();
-		sub.assert_group(); // group 0
-		sub.assert_group(); // group 1, written via upgraded producer
+		let mut subscriber = producer.consume().assert_subscribe();
+		subscriber.assert_group(); // group 0
+		subscriber.assert_group(); // group 1
 	}
 
 	#[tokio::test]
@@ -1235,8 +1504,6 @@ mod test {
 		let consumer = producer.consume();
 		drop(producer);
 
-		// Original producer dropped. Consumer's produce() should fail
-		// because there are no remaining producers.
 		let err = consumer.produce();
 		assert!(matches!(err, Err(Error::Dropped)), "expected Dropped");
 	}
@@ -1248,7 +1515,6 @@ mod test {
 		producer.abort(Error::Cancel).unwrap();
 		drop(producer);
 
-		// Track was aborted — produce() should return the abort error, not Dropped.
 		let err = consumer.produce();
 		assert!(matches!(err, Err(Error::Cancel)), "expected Cancel");
 	}
@@ -1260,11 +1526,202 @@ mod test {
 		let upgraded = consumer.produce().expect("should produce");
 		drop(producer);
 
-		// Channel still open because upgraded producer exists.
 		assert!(consumer.closed().now_or_never().is_none(), "should not be closed");
 		drop(upgraded);
 
-		// Now it should close.
 		assert!(consumer.closed().now_or_never().is_some(), "should be closed");
+	}
+
+	#[tokio::test]
+	async fn aggregate_subscription_priority_max() {
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+
+		let _a = consumer
+			.subscribe(Subscription {
+				priority: 1,
+				..Default::default()
+			})
+			.unwrap();
+		let _b = consumer
+			.subscribe(Subscription {
+				priority: 5,
+				..Default::default()
+			})
+			.unwrap();
+
+		let agg = producer
+			.subscription()
+			.now_or_never()
+			.expect("should not block")
+			.expect("aggregate should exist");
+		assert_eq!(agg.priority, 5);
+		assert!(!agg.ordered);
+	}
+
+	#[tokio::test]
+	async fn aggregate_subscription_ordered_and() {
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+
+		let _a = consumer
+			.subscribe(Subscription {
+				ordered: true,
+				..Default::default()
+			})
+			.unwrap();
+		let _b = consumer
+			.subscribe(Subscription {
+				ordered: false,
+				..Default::default()
+			})
+			.unwrap();
+
+		let agg = producer
+			.subscription()
+			.now_or_never()
+			.expect("should not block")
+			.expect("aggregate should exist");
+		assert!(!agg.ordered, "ordered should be AND of all");
+	}
+
+	#[tokio::test]
+	async fn aggregate_subscription_max_latency_zero_wins() {
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+
+		let _a = consumer
+			.subscribe(Subscription {
+				max_latency: Duration::from_secs(1),
+				..Default::default()
+			})
+			.unwrap();
+		let _b = consumer
+			.subscribe(Subscription {
+				max_latency: Duration::ZERO,
+				..Default::default()
+			})
+			.unwrap();
+
+		let agg = producer
+			.subscription()
+			.now_or_never()
+			.expect("should not block")
+			.expect("aggregate should exist");
+		assert_eq!(agg.max_latency, Duration::ZERO, "ZERO (unlimited) should win");
+	}
+
+	#[tokio::test]
+	async fn aggregate_subscription_start_min_end_max() {
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+
+		let _a = consumer
+			.subscribe(Subscription {
+				start: Some(5),
+				end: Some(20),
+				..Default::default()
+			})
+			.unwrap();
+		let _b = consumer
+			.subscribe(Subscription {
+				start: Some(3),
+				end: Some(10),
+				..Default::default()
+			})
+			.unwrap();
+
+		let agg = producer
+			.subscription()
+			.now_or_never()
+			.expect("should not block")
+			.expect("aggregate should exist");
+		assert_eq!(agg.start, Some(3));
+		assert_eq!(agg.end, Some(20));
+	}
+
+	#[tokio::test]
+	async fn aggregate_subscription_drops_on_subscriber_drop() {
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+
+		let a = consumer
+			.subscribe(Subscription {
+				priority: 1,
+				..Default::default()
+			})
+			.unwrap();
+
+		// First poll establishes the baseline.
+		let agg = producer
+			.subscription()
+			.now_or_never()
+			.expect("should not block")
+			.expect("aggregate should exist");
+		assert_eq!(agg.priority, 1);
+
+		drop(a);
+
+		// After the only subscriber drops, the aggregate becomes None on next change.
+		let agg = producer.subscription().now_or_never().expect("should not block");
+		assert!(agg.is_none(), "no live subscribers should yield None");
+	}
+
+	#[tokio::test]
+	async fn aggregate_subscription_reflects_update() {
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+
+		let mut sub = consumer
+			.subscribe(Subscription {
+				priority: 1,
+				..Default::default()
+			})
+			.unwrap();
+
+		let agg = producer
+			.subscription()
+			.now_or_never()
+			.expect("should not block")
+			.expect("aggregate should exist");
+		assert_eq!(agg.priority, 1);
+
+		sub.update(Subscription {
+			priority: 7,
+			..Default::default()
+		});
+
+		let agg = producer
+			.subscription()
+			.now_or_never()
+			.expect("should not block")
+			.expect("aggregate should exist");
+		assert_eq!(agg.priority, 7);
+	}
+
+	#[tokio::test]
+	async fn recv_group_respects_end_bound() {
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		let mut subscriber = consumer
+			.subscribe(Subscription {
+				end: Some(2),
+				..Default::default()
+			})
+			.unwrap();
+
+		producer.create_group(Group { sequence: 1 }).unwrap();
+		producer.create_group(Group { sequence: 2 }).unwrap();
+		producer.create_group(Group { sequence: 3 }).unwrap();
+
+		assert_eq!(subscriber.assert_group().sequence, 1);
+		assert_eq!(subscriber.assert_group().sequence, 2);
+		// Group 3 is past `end`; subscriber should treat the stream as done.
+		let done = subscriber
+			.recv_group()
+			.now_or_never()
+			.expect("should not block")
+			.expect("would have errored");
+		assert!(done.is_none(), "groups past end should yield None");
 	}
 }

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -57,9 +57,12 @@ pub struct Subscription {
 	pub ordered: bool,
 	/// Maximum cache/latency. `Duration::ZERO` means unlimited.
 	pub max_latency: Duration,
-	/// First group sequence to deliver. `None` means no preference.
+	/// First group sequence to deliver. `None` is treated as 0 — i.e. deliver
+	/// all cached history plus future groups. For "live from now" semantics,
+	/// pass `Some(latest + 1)` (or `Some(latest)` to include the in-flight
+	/// group). `Subscription::default()` therefore yields full history.
 	pub start: Option<u64>,
-	/// Last group sequence to deliver. `None` means no preference (live).
+	/// Last group sequence to deliver. `None` means no end (live).
 	pub end: Option<u64>,
 }
 

--- a/rs/moq-mux/src/catalog.rs
+++ b/rs/moq-mux/src/catalog.rs
@@ -29,10 +29,7 @@ impl CatalogProducer {
 		catalog: hang::Catalog,
 	) -> Result<Self, moq_lite::Error> {
 		let hang_track = broadcast.create_track(hang::Catalog::default_track())?;
-		let msf_track = broadcast.create_track(moq_lite::Track {
-			name: moq_msf::DEFAULT_NAME.to_string(),
-			priority: 100,
-		})?;
+		let msf_track = broadcast.create_track(moq_lite::Track::new(moq_msf::DEFAULT_NAME))?;
 
 		Ok(Self {
 			hang_track,
@@ -53,7 +50,12 @@ impl CatalogProducer {
 
 	/// Create a consumer for this catalog, receiving updates as they're published.
 	pub fn consume(&self) -> hang::CatalogConsumer {
-		hang::CatalogConsumer::new(self.hang_track.consume())
+		let subscriber = self
+			.hang_track
+			.consume()
+			.subscribe(moq_lite::Subscription::default())
+			.expect("track was just produced");
+		hang::CatalogConsumer::new(subscriber)
 	}
 
 	/// Finish publishing to this catalog.

--- a/rs/moq-mux/src/catalog.rs
+++ b/rs/moq-mux/src/catalog.rs
@@ -53,7 +53,7 @@ impl CatalogProducer {
 		let subscriber = self
 			.hang_track
 			.consume()
-			.subscribe(hang::Catalog::default_subscription())
+			.subscribe(hang::Catalog::SUBSCRIPTION)
 			.expect("hang_track producer is alive");
 		hang::CatalogConsumer::new(subscriber)
 	}

--- a/rs/moq-mux/src/catalog.rs
+++ b/rs/moq-mux/src/catalog.rs
@@ -53,8 +53,8 @@ impl CatalogProducer {
 		let subscriber = self
 			.hang_track
 			.consume()
-			.subscribe(moq_lite::Subscription::default())
-			.expect("track was just produced");
+			.subscribe(hang::Catalog::default_subscription())
+			.expect("hang_track producer is alive");
 		hang::CatalogConsumer::new(subscriber)
 	}
 

--- a/rs/moq-mux/src/ordered/consumer.rs
+++ b/rs/moq-mux/src/ordered/consumer.rs
@@ -382,6 +382,14 @@ mod tests {
 		Timestamp::from_micros(micros).unwrap()
 	}
 
+	/// Subscribe to a track with default preferences (test helper).
+	fn subscribe_default(track: &moq_lite::TrackProducer) -> moq_lite::TrackSubscriber {
+		track
+			.consume()
+			.subscribe(moq_lite::Subscription::default())
+			.expect("producer alive")
+	}
+
 	/// Write a finished group with explicit sequence and timestamps (Legacy format).
 	fn write_group(track: &mut moq_lite::TrackProducer, sequence: u64, timestamps: &[Timestamp]) {
 		let mut group = track.create_group(moq_lite::Group { sequence }).unwrap();
@@ -418,7 +426,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -436,7 +444,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_frames_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_000), ts(66_000)]);
@@ -454,7 +462,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_groups_within_latency() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		// 5 groups, 20ms spacing. Total span = 80ms, well within 500ms latency.
@@ -473,7 +481,7 @@ mod tests {
 	async fn latency_skip_delivers_recent_groups() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
@@ -514,7 +522,7 @@ mod tests {
 	async fn zero_latency_skips_aggressively() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::ZERO);
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -550,7 +558,7 @@ mod tests {
 	async fn latency_skip_correctness() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -592,7 +600,7 @@ mod tests {
 	async fn groups_delivered_in_sequence_order() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -627,7 +635,7 @@ mod tests {
 	#[tokio::test]
 	async fn adjacent_group_flushed_immediately() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -645,7 +653,7 @@ mod tests {
 	#[tokio::test]
 	async fn bframes_within_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(66_000), ts(33_000)]);
@@ -664,7 +672,7 @@ mod tests {
 	async fn empty_track_returns_none() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		track.finish().unwrap();
@@ -682,7 +690,7 @@ mod tests {
 	async fn track_closed_with_error() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -704,7 +712,7 @@ mod tests {
 	async fn closed_resolves_when_track_ends() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		assert!(
@@ -727,7 +735,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_in_group_sequence_recovery() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		write_group(&mut track, 0, &[ts(0), ts(20_000)]);
@@ -745,7 +753,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_at_start_of_sequence() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(80));
 
 		write_group(&mut track, 5, &[ts(0), ts(20_000)]);
@@ -763,7 +771,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_timestamp_and_index_decoding() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_333), ts(66_666)]);
@@ -783,7 +791,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_payload_preserved() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
@@ -820,7 +828,7 @@ mod tests {
 	async fn no_infinite_loop_with_buffered_frames() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_secs(10));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -865,7 +873,7 @@ mod tests {
 	#[tokio::test]
 	async fn large_timestamps() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_secs(3700));
 
 		let one_hour = 3_600_000_000u64;
@@ -881,7 +889,7 @@ mod tests {
 	#[tokio::test]
 	async fn set_latency_changes_behavior() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_secs(10));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -899,7 +907,7 @@ mod tests {
 	async fn max_timestamp_tracks_through_bframes() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		// latency must exceed (group1_max - group0_min) = 100ms - 0ms = 100ms
 		// to avoid the latency skip and test B-frame timestamp tracking.
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(110));
@@ -950,7 +958,7 @@ mod tests {
 	async fn startup_selects_earliest_group() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		write_group(&mut track, 3, &[ts(0)]);
@@ -1001,7 +1009,7 @@ mod tests {
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let _group5 = track.create_group(moq_lite::Group { sequence: 5 }).unwrap();
@@ -1024,7 +1032,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_single_group_mid_stream() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 100, &[ts(3_000_000)]);
@@ -1038,7 +1046,7 @@ mod tests {
 	async fn multiple_sequential_latency_skips() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(50));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1073,7 +1081,7 @@ mod tests {
 	async fn latency_skip_boundary_exact() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1110,7 +1118,7 @@ mod tests {
 	async fn single_newer_group_triggers_skip() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: stalled at ts=0, NOT finished
@@ -1147,7 +1155,7 @@ mod tests {
 	async fn single_missing_sequence_near_eof_skips() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: finished normally
@@ -1163,7 +1171,7 @@ mod tests {
 	#[tokio::test]
 	async fn group_error_skips_to_next() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1180,7 +1188,7 @@ mod tests {
 	async fn track_finishes_while_reading() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1209,7 +1217,7 @@ mod tests {
 	#[tokio::test]
 	async fn empty_group_advances() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1230,7 +1238,7 @@ mod tests {
 		tokio::time::pause();
 
 		let mut track = moq_lite::Track::new("video").produce();
-		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
+		let consumer_track = subscribe_default(&track);
 		let mut consumer =
 			Consumer::new(consumer_track, hang::catalog::Container::Legacy).with_latency(Duration::from_millis(500));
 

--- a/rs/moq-mux/src/ordered/consumer.rs
+++ b/rs/moq-mux/src/ordered/consumer.rs
@@ -384,10 +384,7 @@ mod tests {
 
 	/// Subscribe to a track with default preferences (test helper).
 	fn subscribe_default(track: &moq_lite::TrackProducer) -> moq_lite::TrackSubscriber {
-		track
-			.consume()
-			.subscribe(moq_lite::Subscription::default())
-			.expect("producer alive")
+		track.consume().subscribe_default().expect("producer alive")
 	}
 
 	/// Write a finished group with explicit sequence and timestamps (Legacy format).

--- a/rs/moq-mux/src/ordered/consumer.rs
+++ b/rs/moq-mux/src/ordered/consumer.rs
@@ -5,7 +5,7 @@ use crate::container::{Container, Frame, Timestamp};
 
 /// A consumer for media tracks with timestamp reordering.
 ///
-/// This wraps a `moq_lite::TrackConsumer` and adds functionality
+/// This wraps a `moq_lite::TrackSubscriber` and adds functionality
 /// like timestamp decoding, latency management, and frame buffering.
 ///
 /// Generic over `F: Container` to support different container encodings.
@@ -15,7 +15,7 @@ use crate::container::{Container, Frame, Timestamp};
 /// The consumer can skip groups that are too far behind to maintain low latency.
 /// Configure the maximum acceptable delay through the consumer's latency settings.
 pub struct Consumer<F: Container> {
-	track: moq_lite::TrackConsumer,
+	track: moq_lite::TrackSubscriber,
 
 	format: F,
 
@@ -34,8 +34,8 @@ pub struct Consumer<F: Container> {
 }
 
 impl<F: Container> Consumer<F> {
-	/// Create a new Consumer wrapping the given moq-lite consumer.
-	pub fn new(track: moq_lite::TrackConsumer, format: F) -> Self {
+	/// Create a new Consumer wrapping the given moq-lite subscriber.
+	pub fn new(track: moq_lite::TrackSubscriber, format: F) -> Self {
 		Self {
 			track,
 			format,
@@ -221,8 +221,8 @@ impl<F: Container> Consumer<F> {
 		Ok(self.track.closed().await?)
 	}
 
-	/// Unwrap into the inner TrackConsumer.
-	pub fn into_inner(self) -> moq_lite::TrackConsumer {
+	/// Unwrap into the inner TrackSubscriber.
+	pub fn into_inner(self) -> moq_lite::TrackSubscriber {
 		self.track
 	}
 }
@@ -418,7 +418,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -436,7 +436,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_frames_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_000), ts(66_000)]);
@@ -454,7 +454,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_groups_within_latency() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		// 5 groups, 20ms spacing. Total span = 80ms, well within 500ms latency.
@@ -473,7 +473,7 @@ mod tests {
 	async fn latency_skip_delivers_recent_groups() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
@@ -514,7 +514,7 @@ mod tests {
 	async fn zero_latency_skips_aggressively() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::ZERO);
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -550,7 +550,7 @@ mod tests {
 	async fn latency_skip_correctness() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -592,7 +592,7 @@ mod tests {
 	async fn groups_delivered_in_sequence_order() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -627,7 +627,7 @@ mod tests {
 	#[tokio::test]
 	async fn adjacent_group_flushed_immediately() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -645,7 +645,7 @@ mod tests {
 	#[tokio::test]
 	async fn bframes_within_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(66_000), ts(33_000)]);
@@ -664,7 +664,7 @@ mod tests {
 	async fn empty_track_returns_none() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		track.finish().unwrap();
@@ -682,7 +682,7 @@ mod tests {
 	async fn track_closed_with_error() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -704,7 +704,7 @@ mod tests {
 	async fn closed_resolves_when_track_ends() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		assert!(
@@ -727,7 +727,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_in_group_sequence_recovery() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		write_group(&mut track, 0, &[ts(0), ts(20_000)]);
@@ -745,7 +745,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_at_start_of_sequence() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(80));
 
 		write_group(&mut track, 5, &[ts(0), ts(20_000)]);
@@ -763,7 +763,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_timestamp_and_index_decoding() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_333), ts(66_666)]);
@@ -783,7 +783,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_payload_preserved() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
@@ -820,7 +820,7 @@ mod tests {
 	async fn no_infinite_loop_with_buffered_frames() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_secs(10));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -865,7 +865,7 @@ mod tests {
 	#[tokio::test]
 	async fn large_timestamps() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_secs(3700));
 
 		let one_hour = 3_600_000_000u64;
@@ -881,7 +881,7 @@ mod tests {
 	#[tokio::test]
 	async fn set_latency_changes_behavior() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_secs(10));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -899,7 +899,7 @@ mod tests {
 	async fn max_timestamp_tracks_through_bframes() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		// latency must exceed (group1_max - group0_min) = 100ms - 0ms = 100ms
 		// to avoid the latency skip and test B-frame timestamp tracking.
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(110));
@@ -950,7 +950,7 @@ mod tests {
 	async fn startup_selects_earliest_group() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		write_group(&mut track, 3, &[ts(0)]);
@@ -1001,7 +1001,7 @@ mod tests {
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let _group5 = track.create_group(moq_lite::Group { sequence: 5 }).unwrap();
@@ -1024,7 +1024,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_single_group_mid_stream() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 100, &[ts(3_000_000)]);
@@ -1038,7 +1038,7 @@ mod tests {
 	async fn multiple_sequential_latency_skips() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(50));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1073,7 +1073,7 @@ mod tests {
 	async fn latency_skip_boundary_exact() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1110,7 +1110,7 @@ mod tests {
 	async fn single_newer_group_triggers_skip() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: stalled at ts=0, NOT finished
@@ -1147,7 +1147,7 @@ mod tests {
 	async fn single_missing_sequence_near_eof_skips() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: finished normally
@@ -1163,7 +1163,7 @@ mod tests {
 	#[tokio::test]
 	async fn group_error_skips_to_next() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1180,7 +1180,7 @@ mod tests {
 	async fn track_finishes_while_reading() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1209,7 +1209,7 @@ mod tests {
 	#[tokio::test]
 	async fn empty_group_advances() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1230,7 +1230,7 @@ mod tests {
 		tokio::time::pause();
 
 		let mut track = moq_lite::Track::new("video").produce();
-		let consumer_track = track.consume();
+		let consumer_track = track.consume().subscribe(moq_lite::Subscription::default()).unwrap();
 		let mut consumer =
 			Consumer::new(consumer_track, hang::catalog::Container::Legacy).with_latency(Duration::from_millis(500));
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -41,10 +41,7 @@ async fn run_broadcast(origin: moq_lite::OriginProducer) -> anyhow::Result<()> {
 
 	// Create a track that we'll insert into the broadcast.
 	// A track is a series of groups representing a live stream.
-	let mut track = broadcast.create_track(moq_lite::Track {
-		name: "chat".to_string(),
-		priority: 0,
-	})?;
+	let mut track = broadcast.create_track(moq_lite::Track::new("chat"))?;
 
 	// NOTE: The path is empty because we're using the URL to scope the broadcast.
 	// If you put "alice" here, it would be published as "anon/chat-example/alice".

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -4,7 +4,7 @@
 //! Each test is gated with `#[cfg(feature = "...")]` so it only compiles when the
 //! corresponding backend is enabled. Running `cargo test --all-features` exercises all.
 
-use moq_native::moq_lite::{Origin, Track};
+use moq_native::moq_lite::{Origin, Subscription, Track};
 use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -70,7 +70,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"))
+		.subscribe_track(&Track::new("video"), Subscription::default())
 		.expect("subscribe_track failed");
 
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
@@ -222,7 +222,7 @@ async fn iroh_connect() {
 	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"))
+		.subscribe_track(&Track::new("video"), Subscription::default())
 		.expect("subscribe_track failed");
 
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -358,8 +358,6 @@ async fn broadcast_webtransport_negotiate_client_all_server_transport_16() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket() {
-	use moq_native::moq_lite::{Origin, Subscription, Track};
-
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
@@ -462,8 +460,6 @@ async fn broadcast_websocket() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket_fallback() {
-	use moq_native::moq_lite::{Origin, Subscription, Track};
-
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -8,7 +8,7 @@
 //! This covers raw QUIC (moqt://) and WebTransport (https://) transports,
 //! exercising every protocol version the library supports.
 
-use moq_native::moq_lite::{self, Origin, Track};
+use moq_native::moq_lite::{self, Origin, Subscription, Track};
 use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -88,7 +88,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 
 	// Subscribe to the track.
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"))
+		.subscribe_track(&Track::new("video"), Subscription::default())
 		.expect("subscribe_track failed");
 
 	// Read one group.
@@ -358,7 +358,7 @@ async fn broadcast_webtransport_negotiate_client_all_server_transport_16() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket() {
-	use moq_native::moq_lite::{Origin, Track};
+	use moq_native::moq_lite::{Origin, Subscription, Track};
 
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
@@ -428,7 +428,7 @@ async fn broadcast_websocket() {
 
 	// Subscribe to the track.
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"))
+		.subscribe_track(&Track::new("video"), Subscription::default())
 		.expect("subscribe_track failed");
 
 	// Read one group.
@@ -462,7 +462,7 @@ async fn broadcast_websocket() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket_fallback() {
-	use moq_native::moq_lite::{Origin, Track};
+	use moq_native::moq_lite::{Origin, Subscription, Track};
 
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
@@ -535,7 +535,7 @@ async fn broadcast_websocket_fallback() {
 
 	// Subscribe to the track.
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"))
+		.subscribe_track(&Track::new("video"), Subscription::default())
 		.expect("subscribe_track failed");
 
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -319,17 +319,16 @@ async fn serve_fetch(
 
 	tracing::info!(%broadcast, %track, "fetching track");
 
-	let track = moq_lite::Track {
-		name: track,
-		priority: 0,
-	};
+	let track = moq_lite::Track::new(track);
 
 	// NOTE: The auth token is already scoped to the broadcast.
 	let broadcast = origin.consume_broadcast("").ok_or(StatusCode::NOT_FOUND)?;
-	let mut track = broadcast.subscribe_track(&track).map_err(|err| match err {
-		moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
-		_ => StatusCode::INTERNAL_SERVER_ERROR,
-	})?;
+	let mut track = broadcast
+		.subscribe_track(&track, moq_lite::Subscription::default())
+		.map_err(|err| match err {
+			moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
+			_ => StatusCode::INTERNAL_SERVER_ERROR,
+		})?;
 
 	let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
 


### PR DESCRIPTION
## Summary

Backports the Subscription / `TrackSubscriber` model-layer API from `dev`'s PR #1134 onto `moq-lite-fetch`. The goal is to land the API surface FETCH needs without implementing FETCH wire/stream handling — fetch can plug into `TrackSubscriber::update` once the wire path is added.

- `Track` loses `priority`; it moves into a new `Subscription { priority, ordered, max_latency, start, end }`.
- New `TrackSubscriber` owns group iteration (`recv_group`, `next_group`, `next_group_ordered`, `read_frame`) and per-subscriber `Subscription` state, with `update()` to mutate it. `TrackConsumer` becomes a fanout handle (`subscribe`, `get_group`, `latest`, `produce`, `closed`, `finished`).
- `TrackProducer` aggregates live subscribers' preferences (priority=max, ordered=AND, max_latency=ZERO-wins, start=min, end=max), exposed via `poll_subscription` / `async subscription()` — the hook FETCH will drive.
- `BroadcastConsumer` splits into `consume_track(&Track) -> TrackConsumer` and `subscribe_track(&Track, Subscription) -> TrackSubscriber`.
- Wire layer (lite + ietf publishers) builds `Subscription` from incoming SUBSCRIBE fields and iterates via `TrackSubscriber`. Upstream subscribers hard-code priority 0 with TODOs to surface the producer aggregate later.
- `conducer::Consumer::weak()` added so `subscribe()` can register without bumping ref counts.
- Mechanical caller updates across hang, moq-mux, moq-clock, moq-boy, moq-ffi, libmoq, moq-relay, moq-gst, moq-native.

`lite/fetch.rs` and `ietf/fetch.rs` remain untouched dead-code stubs.

## Test plan
- [x] `cargo test --workspace` — all tests pass (incl. new aggregation/start-end tests in `model/track.rs`)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace`
- [x] `cargo shear`, `cargo sort --workspace --check`
- [ ] Smoke-test `cargo run -p moq-clock -- subscribe` against a local relay (subscribe → groups still flow through the new `TrackSubscriber` path)
- [ ] Smoke-test `cargo run -p hang --example subscribe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)