### PR TITLE
moq-lite: add fetch_group API + TrackDynamic

### DIFF
--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -88,8 +88,8 @@ impl Catalog {
 		priority: 100,
 		ordered: false,
 		max_latency: std::time::Duration::ZERO,
-		start: None,
-		end: None,
+		start_group: None,
+		end_group: None,
 	};
 }
 

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -129,7 +129,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// types are still ignored (see the warn above) — TODO: full FilterType
 		// support along with FETCH wiring.
 		let start = matches!(msg.filter_type, FilterType::LargestObject)
-			.then(|| consumer.latest())
+			.then(|| consumer.latest_group().map(|g| g.sequence))
 			.flatten();
 
 		let subscription = Subscription {

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -128,14 +128,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// LargestObject means "start from the latest cached group". Other filter
 		// types are still ignored (see the warn above) — TODO: full FilterType
 		// support along with FETCH wiring.
-		let start = matches!(msg.filter_type, FilterType::LargestObject)
+		let start_group = matches!(msg.filter_type, FilterType::LargestObject)
 			.then(|| consumer.latest_group().map(|g| g.sequence))
 			.flatten();
 
 		let subscription = Subscription {
 			priority: msg.subscriber_priority,
 			ordered: matches!(msg.group_order, GroupOrder::Ascending),
-			start,
+			start_group,
 			..Default::default()
 		};
 

--- a/rs/moq-lite/src/lib.rs
+++ b/rs/moq-lite/src/lib.rs
@@ -4,7 +4,7 @@
 //! This is a simplified subset of the *official* Media over QUIC (MoQ) transport, focusing on the practical features.
 //!
 //! **NOTE**: While compatible with a subset of the IETF MoQ specification, many features are not supported on purpose.
-//! I highly highly highly recommend using `moq-lite` instead of the IETF standard until at least draft-30.
+//! I highly highly highly recommend using `moq-lite` instead of the IETF standard.
 //!
 //! ## API
 //!

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -287,7 +287,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let consumer = broadcast.consume_track(&track)?;
 
 		// Pick the start group: explicit, else the latest cached group.
-		let start = subscribe.start_group.or_else(|| consumer.latest());
+		let start = subscribe
+			.start_group
+			.or_else(|| consumer.latest_group().map(|g| g.sequence));
 		let subscriber = consumer.subscribe(Subscription {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -287,22 +287,22 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let consumer = broadcast.consume_track(&track)?;
 
 		// Pick the start group: explicit, else the latest cached group.
-		let start = subscribe
+		let start_group = subscribe
 			.start_group
 			.or_else(|| consumer.latest_group().map(|g| g.sequence));
 		let subscriber = consumer.subscribe(Subscription {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,
 			max_latency: subscribe.max_latency,
-			start,
-			end: subscribe.end_group,
+			start_group,
+			end_group: subscribe.end_group,
 		})?;
 
 		let info = lite::SubscribeOk {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,
 			max_latency: subscribe.max_latency,
-			start_group: start,
+			start_group,
 			end_group: subscribe.end_group,
 		};
 
@@ -353,8 +353,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							priority: upd.priority,
 							ordered: upd.ordered,
 							max_latency: upd.max_latency,
-							start: upd.start_group,
-							end: upd.end_group,
+							start_group: upd.start_group,
+							end_group: upd.end_group,
 						});
 					}
 					None => break,

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -310,8 +310,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			priority: initial.priority,
 			ordered: initial.ordered,
 			max_latency: initial.max_latency,
-			start_group: initial.start,
-			end_group: initial.end,
+			start_group: initial.start_group,
+			end_group: initial.end_group,
 		};
 
 		if let Err(err) = self.run_track_stream(&mut stream, msg, track).await {
@@ -349,8 +349,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 							priority: sub.priority,
 							ordered: sub.ordered,
 							max_latency: sub.max_latency,
-							start_group: sub.start,
-							end_group: sub.end,
+							start_group: sub.start_group,
+							end_group: sub.end_group,
 						}).await?;
 					}
 					None => return Ok(()),

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -78,6 +78,15 @@ struct State {
 
 	/// Per-subscriber subscription values, read by the producer for aggregation.
 	subscriptions: Vec<conducer::Consumer<Subscription>>,
+
+	/// Pending fetch requests waiting for a [`TrackDynamic`] to fulfill them.
+	/// Each entry is a freshly-minted [`GroupProducer`] for the requested
+	/// sequence; the dynamic handler pops it and fills frames.
+	fetch_requests: VecDeque<GroupProducer>,
+
+	/// Number of live [`TrackDynamic`] instances. When 0, fetch requests for
+	/// uncached groups fail with [`Error::NotFound`].
+	dynamic_groups: usize,
 }
 
 impl State {
@@ -451,6 +460,16 @@ impl TrackProducer {
 		}
 	}
 
+	/// Opt in to handling FETCH requests for groups not in the cache.
+	///
+	/// While at least one [`TrackDynamic`] is held, [`TrackConsumer::fetch_group`]
+	/// can route uncached requests to the publisher. When all dynamics are
+	/// dropped, pending requests are aborted and future uncached fetches return
+	/// [`Error::NotFound`].
+	pub fn dynamic(&self) -> TrackDynamic {
+		TrackDynamic::new(self.info.clone(), self.state.clone())
+	}
+
 	/// Block until there are no active consumers.
 	pub async fn unused(&self) -> Result<()> {
 		self.state
@@ -548,6 +567,98 @@ impl Clone for TrackProducer {
 impl From<Track> for TrackProducer {
 	fn from(info: Track) -> Self {
 		TrackProducer::new(info)
+	}
+}
+
+/// Handles on-demand group fetches for a track.
+///
+/// Created via [`TrackProducer::dynamic`]. While alive, [`TrackConsumer::fetch_group`]
+/// requests for uncached groups are queued for the dynamic handler to fulfill
+/// via [`Self::requested_group`]. Dropping the last dynamic aborts any pending
+/// requests with [`Error::Cancel`].
+#[derive(Clone)]
+pub struct TrackDynamic {
+	info: Track,
+	state: conducer::Producer<State>,
+}
+
+impl std::ops::Deref for TrackDynamic {
+	type Target = Track;
+
+	fn deref(&self) -> &Self::Target {
+		&self.info
+	}
+}
+
+impl TrackDynamic {
+	fn new(info: Track, state: conducer::Producer<State>) -> Self {
+		if let Ok(mut state) = state.write() {
+			state.dynamic_groups += 1;
+		}
+		Self { info, state }
+	}
+
+	fn poll<F, R>(&self, waiter: &conducer::Waiter, f: F) -> Poll<Result<R>>
+	where
+		F: FnMut(&mut conducer::Mut<'_, State>) -> Poll<R>,
+	{
+		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
+			Ok(r) => Ok(r),
+			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
+		})
+	}
+
+	/// Poll for the next pending fetch request.
+	///
+	/// Yields a [`GroupProducer`] the publisher fills in. The producer's
+	/// `sequence` is the requested group number.
+	pub fn poll_requested_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<GroupProducer>> {
+		self.poll(waiter, |state| match state.fetch_requests.pop_front() {
+			Some(producer) => Poll::Ready(producer),
+			None => Poll::Pending,
+		})
+	}
+
+	/// Block until a consumer requests a group, returning its producer.
+	pub async fn requested_group(&mut self) -> Result<GroupProducer> {
+		conducer::wait(|waiter| self.poll_requested_group(waiter)).await
+	}
+
+	/// Return true if this is the same dynamic instance.
+	pub fn is_clone(&self, other: &Self) -> bool {
+		self.state.same_channel(&other.state)
+	}
+}
+
+impl Drop for TrackDynamic {
+	fn drop(&mut self) {
+		if let Ok(mut state) = self.state.write() {
+			state.dynamic_groups = state.dynamic_groups.saturating_sub(1);
+			if state.dynamic_groups != 0 {
+				return;
+			}
+
+			// No remaining handler; cancel any pending requests.
+			for mut request in state.fetch_requests.drain(..) {
+				request.abort(Error::Cancel).ok();
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+impl TrackDynamic {
+	pub fn assert_request(&mut self) -> GroupProducer {
+		use futures::FutureExt;
+		self.requested_group()
+			.now_or_never()
+			.expect("should not have blocked")
+			.expect("should not have errored")
+	}
+
+	pub fn assert_no_request(&mut self) {
+		use futures::FutureExt;
+		assert!(self.requested_group().now_or_never().is_none(), "should have blocked");
 	}
 }
 
@@ -695,9 +806,57 @@ impl TrackConsumer {
 		conducer::wait(|waiter| self.poll_finished(waiter)).await
 	}
 
-	/// Return the latest sequence number in the track.
-	pub fn latest(&self) -> Option<u64> {
-		self.state.read().max_sequence
+	/// Return the latest cached group, if any.
+	pub fn latest_group(&self) -> Option<GroupConsumer> {
+		let state = self.state.read();
+		let max = state.max_sequence?;
+		state
+			.groups
+			.iter()
+			.flatten()
+			.find_map(|(g, _)| (g.sequence == max).then(|| g.consume()))
+	}
+
+	/// Fetch a specific group by sequence.
+	///
+	/// - Cache hit → returns the cached consumer (a fetch handler is not required).
+	/// - Cache miss + no [`TrackDynamic`] handler → returns [`Error::NotFound`].
+	/// - Cache miss + handler present → routes a request to the producer; returns
+	///   a [`GroupConsumer`] that fills in as the publisher writes frames. Errors
+	///   later if the publisher aborts/declines (e.g. group is past final).
+	pub fn fetch_group(&self, sequence: u64) -> Result<GroupConsumer> {
+		// Upgrade to a temporary producer so we can mutate the state.
+		let producer = self
+			.state
+			.produce()
+			.ok_or_else(|| self.state.read().abort.clone().unwrap_or(Error::Dropped))?;
+
+		let mut state = producer
+			.write()
+			.map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))?;
+
+		// Cache hit: always return, regardless of dynamic handler state.
+		for (group, _) in state.groups.iter().flatten() {
+			if group.sequence == sequence {
+				return Ok(group.consume());
+			}
+		}
+
+		if state.dynamic_groups == 0 {
+			return Err(Error::NotFound);
+		}
+
+		// Queue a request for the dynamic handler; cache the producer so
+		// concurrent fetches for the same sequence share frames.
+		let group = Group { sequence }.produce();
+		let consumer = group.consume();
+		let now = tokio::time::Instant::now();
+		state.duplicates.insert(sequence);
+		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(sequence));
+		state.groups.push_back(Some((group.clone(), now)));
+		state.fetch_requests.push_back(group);
+
+		Ok(consumer)
 	}
 
 	/// Upgrade this consumer back to a [TrackProducer] sharing the same state.
@@ -901,9 +1060,15 @@ impl TrackSubscriber {
 		self.sub.read().clone()
 	}
 
-	/// Return the latest sequence number in the track.
-	pub fn latest(&self) -> Option<u64> {
-		self.state.read().max_sequence
+	/// Return the latest cached group, if any.
+	pub fn latest_group(&self) -> Option<GroupConsumer> {
+		let state = self.state.read();
+		let max = state.max_sequence?;
+		state
+			.groups
+			.iter()
+			.flatten()
+			.find_map(|(g, _)| (g.sequence == max).then(|| g.consume()))
 	}
 
 	/// Poll for the group with the given sequence, without blocking.
@@ -1762,5 +1927,128 @@ mod test {
 			.expect("should not block")
 			.expect("would have errored");
 		assert!(done.is_none(), "groups past end should yield None");
+	}
+
+	#[tokio::test]
+	async fn fetch_group_cache_hit() {
+		let mut producer = Track::new("test").produce();
+		producer.create_group(Group { sequence: 5 }).unwrap();
+		let consumer = producer.consume();
+
+		// No TrackDynamic registered, but cache hits still succeed.
+		let group = consumer.fetch_group(5).expect("cache hit");
+		assert_eq!(group.sequence, 5);
+	}
+
+	#[tokio::test]
+	async fn fetch_group_no_handler_returns_not_found() {
+		let producer = Track::new("test").produce();
+		let consumer = producer.consume();
+
+		match consumer.fetch_group(0) {
+			Err(Error::NotFound) => {}
+			Err(err) => panic!("expected NotFound, got {err:?}"),
+			Ok(_) => panic!("expected NotFound, got Ok"),
+		}
+	}
+
+	#[tokio::test]
+	async fn fetch_group_via_dynamic_handler() {
+		let producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		let mut dynamic = producer.dynamic();
+
+		// Issue a fetch; the handler should pop a producer for the same sequence.
+		let mut group_consumer = consumer.fetch_group(7).expect("queued");
+		assert_eq!(group_consumer.sequence, 7);
+
+		let mut group_producer = dynamic.assert_request();
+		assert_eq!(group_producer.sequence, 7);
+
+		// Publisher fills frames; consumer reads them.
+		group_producer.write_frame(bytes::Bytes::from_static(b"hello")).unwrap();
+		group_producer.finish().unwrap();
+
+		let frame = group_consumer.read_frame().await.unwrap();
+		assert_eq!(frame.as_deref(), Some(&b"hello"[..]));
+		assert!(group_consumer.read_frame().await.unwrap().is_none());
+	}
+
+	#[tokio::test]
+	async fn fetch_group_shares_in_flight() {
+		let producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		let mut dynamic = producer.dynamic();
+
+		let mut a = consumer.fetch_group(3).expect("queued");
+		let mut b = consumer.fetch_group(3).expect("cache hit second time");
+
+		// Only one request should be queued; both consumers share the same group.
+		let mut group_producer = dynamic.assert_request();
+		dynamic.assert_no_request();
+
+		group_producer
+			.write_frame(bytes::Bytes::from_static(b"shared"))
+			.unwrap();
+		group_producer.finish().unwrap();
+
+		assert_eq!(a.read_frame().await.unwrap().as_deref(), Some(&b"shared"[..]));
+		assert_eq!(b.read_frame().await.unwrap().as_deref(), Some(&b"shared"[..]));
+	}
+
+	#[tokio::test]
+	async fn fetch_group_aborted_by_publisher() {
+		let producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		let mut dynamic = producer.dynamic();
+
+		let mut group_consumer = consumer.fetch_group(2).expect("queued");
+		let mut group_producer = dynamic.assert_request();
+
+		// Publisher decides the group can't be served.
+		group_producer.abort(Error::NotFound).unwrap();
+
+		match group_consumer.read_frame().await {
+			Err(Error::NotFound) => {}
+			other => panic!("expected NotFound, got {other:?}"),
+		}
+	}
+
+	#[tokio::test]
+	async fn fetch_pending_aborted_when_dynamic_dropped() {
+		let producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		let dynamic = producer.dynamic();
+
+		let mut group_consumer = consumer.fetch_group(9).expect("queued");
+
+		// Dropping the only TrackDynamic aborts the pending request.
+		drop(dynamic);
+
+		match group_consumer.read_frame().await {
+			Err(Error::Cancel) => {}
+			other => panic!("expected Cancel, got {other:?}"),
+		}
+
+		// And subsequent fetches for uncached sequences fail with NotFound.
+		assert!(matches!(consumer.fetch_group(10), Err(Error::NotFound)));
+	}
+
+	#[tokio::test]
+	async fn latest_group_returns_max_sequence_consumer() {
+		let mut producer = Track::new("test").produce();
+		producer.create_group(Group { sequence: 1 }).unwrap();
+		producer.create_group(Group { sequence: 5 }).unwrap();
+		producer.create_group(Group { sequence: 3 }).unwrap();
+
+		let consumer = producer.consume();
+		let latest = consumer.latest_group().expect("has groups");
+		assert_eq!(latest.sequence, 5);
+	}
+
+	#[tokio::test]
+	async fn latest_group_none_on_empty_track() {
+		let producer = Track::new("test").produce();
+		assert!(producer.consume().latest_group().is_none());
 	}
 }

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -576,10 +576,15 @@ impl From<Track> for TrackProducer {
 /// requests for uncached groups are queued for the dynamic handler to fulfill
 /// via [`Self::requested_group`]. Dropping the last dynamic aborts any pending
 /// requests with [`Error::Cancel`].
-#[derive(Clone)]
 pub struct TrackDynamic {
 	info: Track,
 	state: conducer::Producer<State>,
+}
+
+impl Clone for TrackDynamic {
+	fn clone(&self) -> Self {
+		Self::new(self.info.clone(), self.state.clone())
+	}
 }
 
 impl std::ops::Deref for TrackDynamic {
@@ -2032,6 +2037,28 @@ mod test {
 
 		// And subsequent fetches for uncached sequences fail with NotFound.
 		assert!(matches!(consumer.fetch_group(10), Err(Error::NotFound)));
+	}
+
+	#[tokio::test]
+	async fn fetch_dynamic_clone_keeps_handler_alive() {
+		let producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		let dynamic = producer.dynamic();
+		let mut dynamic_clone = dynamic.clone();
+
+		let mut group_consumer = consumer.fetch_group(9).expect("queued");
+
+		// Dropping one handle must NOT abort the pending request: the clone
+		// still represents a live handler, so the counter must stay positive.
+		drop(dynamic);
+
+		let mut group_producer = dynamic_clone.assert_request();
+		assert_eq!(group_producer.sequence, 9);
+
+		group_producer.write_frame(bytes::Bytes::from_static(b"clone")).unwrap();
+		group_producer.finish().unwrap();
+
+		assert_eq!(group_consumer.read_frame().await.unwrap().as_deref(), Some(&b"clone"[..]));
 	}
 
 	#[tokio::test]

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -836,6 +836,7 @@ impl TrackConsumer {
 		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(sequence));
 		state.groups.push_back(Some((group.clone(), now)));
 		state.fetch_requests.push_back(group);
+		state.evict_expired(now);
 
 		Ok(consumer)
 	}

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -847,6 +847,14 @@ impl TrackConsumer {
 			}
 		}
 
+		// Track is finalized: groups at/after the final boundary can never exist,
+		// so fail fast instead of queueing an impossible request.
+		if let Some(fin) = state.final_sequence
+			&& sequence >= fin
+		{
+			return Err(Error::NotFound);
+		}
+
 		if state.dynamic_groups == 0 {
 			return Err(Error::NotFound);
 		}
@@ -1958,6 +1966,25 @@ mod test {
 	}
 
 	#[tokio::test]
+	async fn fetch_group_past_final_returns_not_found() {
+		let mut producer = Track::new("test").produce();
+		producer.create_group(Group { sequence: 3 }).unwrap();
+		producer.finish().unwrap();
+		let consumer = producer.consume();
+		let _dynamic = producer.dynamic();
+
+		// Cached group below the final boundary still works.
+		assert_eq!(consumer.fetch_group(3).unwrap().sequence, 3);
+
+		// Sequences at/past the final boundary fail fast even with a handler attached.
+		match consumer.fetch_group(4) {
+			Err(Error::NotFound) => {}
+			Err(err) => panic!("expected NotFound, got {err:?}"),
+			Ok(_) => panic!("expected NotFound, got Ok"),
+		}
+	}
+
+	#[tokio::test]
 	async fn fetch_group_via_dynamic_handler() {
 		let producer = Track::new("test").produce();
 		let consumer = producer.consume();
@@ -2058,7 +2085,10 @@ mod test {
 		group_producer.write_frame(bytes::Bytes::from_static(b"clone")).unwrap();
 		group_producer.finish().unwrap();
 
-		assert_eq!(group_consumer.read_frame().await.unwrap().as_deref(), Some(&b"clone"[..]));
+		assert_eq!(
+			group_consumer.read_frame().await.unwrap().as_deref(),
+			Some(&b"clone"[..])
+		);
 	}
 
 	#[tokio::test]

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -61,9 +61,9 @@ pub struct Subscription {
 	/// all cached history plus future groups. For "live from now" semantics,
 	/// pass `Some(latest + 1)` (or `Some(latest)` to include the in-flight
 	/// group). `Subscription::default()` therefore yields full history.
-	pub start: Option<u64>,
+	pub start_group: Option<u64>,
 	/// Last group sequence to deliver. `None` means no end (live).
-	pub end: Option<u64>,
+	pub end_group: Option<u64>,
 }
 
 #[derive(Default)]
@@ -155,28 +155,6 @@ impl State {
 		} else {
 			Poll::Pending
 		}
-	}
-
-	fn poll_get_group(&self, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
-		// Search for the group with the matching sequence, skipping tombstones.
-		for (group, _) in self.groups.iter().flatten() {
-			if group.sequence == sequence {
-				return Poll::Ready(Ok(Some(group.consume())));
-			}
-		}
-
-		// Once final_sequence is set, groups at or past it can never exist.
-		if let Some(fin) = self.final_sequence
-			&& sequence >= fin
-		{
-			return Poll::Ready(Ok(None));
-		}
-
-		if let Some(err) = &self.abort {
-			return Poll::Ready(Err(err.clone()));
-		}
-
-		Poll::Pending
 	}
 
 	fn poll_closed(&self) -> Poll<Result<()>> {
@@ -287,18 +265,18 @@ impl State {
 			})
 			.unwrap();
 
-		let start = subs
+		let start_group = subs
 			.iter()
-			.map(|s| s.start)
+			.map(|s| s.start_group)
 			.reduce(|a, b| match (a, b) {
 				(Some(a), Some(b)) => Some(a.min(b)),
 				_ => None,
 			})
 			.unwrap();
 
-		let end = subs
+		let end_group = subs
 			.iter()
-			.map(|s| s.end)
+			.map(|s| s.end_group)
 			.reduce(|a, b| match (a, b) {
 				(Some(a), Some(b)) => Some(a.max(b)),
 				_ => None,
@@ -309,8 +287,8 @@ impl State {
 			priority,
 			ordered,
 			max_latency,
-			start,
-			end,
+			start_group,
+			end_group,
 		})
 	}
 }
@@ -462,7 +440,7 @@ impl TrackProducer {
 
 	/// Opt in to handling FETCH requests for groups not in the cache.
 	///
-	/// While at least one [`TrackDynamic`] is held, [`TrackConsumer::fetch_group`]
+	/// While at least one [`TrackDynamic`] is held, [`TrackConsumer::get_group`]
 	/// can route uncached requests to the publisher. When all dynamics are
 	/// dropped, pending requests are aborted and future uncached fetches return
 	/// [`Error::NotFound`].
@@ -572,7 +550,7 @@ impl From<Track> for TrackProducer {
 
 /// Handles on-demand group fetches for a track.
 ///
-/// Created via [`TrackProducer::dynamic`]. While alive, [`TrackConsumer::fetch_group`]
+/// Created via [`TrackProducer::dynamic`]. While alive, [`TrackConsumer::get_group`]
 /// requests for uncached groups are queued for the dynamic handler to fulfill
 /// via [`Self::requested_group`]. Dropping the last dynamic aborts any pending
 /// requests with [`Error::Cancel`].
@@ -773,18 +751,6 @@ impl TrackConsumer {
 		self.subscribe(Subscription::default())
 	}
 
-	/// Poll for the group with the given sequence, without blocking.
-	pub fn poll_get_group(&self, waiter: &conducer::Waiter, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
-		self.poll(waiter, |state| state.poll_get_group(sequence))
-	}
-
-	/// Block until the group with the given sequence is available.
-	///
-	/// Returns None if the group is not in the cache and a newer group exists.
-	pub async fn get_group(&self, sequence: u64) -> Result<Option<GroupConsumer>> {
-		conducer::wait(|waiter| self.poll_get_group(waiter, sequence)).await
-	}
-
 	/// Poll for track closure, without blocking.
 	pub fn poll_closed(&self, waiter: &conducer::Waiter) -> Poll<Result<()>> {
 		self.poll(waiter, |state| state.poll_closed())
@@ -822,14 +788,16 @@ impl TrackConsumer {
 			.find_map(|(g, _)| (g.sequence == max).then(|| g.consume()))
 	}
 
-	/// Fetch a specific group by sequence.
+	/// Get a specific group.
 	///
-	/// - Cache hit → returns the cached consumer (a fetch handler is not required).
+	/// - Cache hit → returns the cached consumer (a [`TrackDynamic`] handler is not required).
 	/// - Cache miss + no [`TrackDynamic`] handler → returns [`Error::NotFound`].
 	/// - Cache miss + handler present → routes a request to the producer; returns
 	///   a [`GroupConsumer`] that fills in as the publisher writes frames. Errors
 	///   later if the publisher aborts/declines (e.g. group is past final).
-	pub fn fetch_group(&self, sequence: u64) -> Result<GroupConsumer> {
+	pub fn get_group(&self, info: Group) -> Result<GroupConsumer> {
+		let sequence = info.sequence;
+
 		// Upgrade to a temporary producer so we can mutate the state.
 		let producer = self
 			.state
@@ -861,7 +829,7 @@ impl TrackConsumer {
 
 		// Queue a request for the dynamic handler; cache the producer so
 		// concurrent fetches for the same sequence share frames.
-		let group = Group { sequence }.produce();
+		let group = info.produce();
 		let consumer = group.consume();
 		let now = tokio::time::Instant::now();
 		state.duplicates.insert(sequence);
@@ -949,7 +917,7 @@ impl TrackSubscriber {
 
 	/// Poll for the next group received over the network, in arrival order.
 	///
-	/// Respects this subscriber's [`Subscription::start`] / `end` bounds.
+	/// Respects this subscriber's [`Subscription::start_group`] / `end_group` bounds.
 	/// Groups may arrive out of order or with gaps. Use [`Self::next_group`]
 	/// if you need monotonic delivery (skipping late arrivals).
 	///
@@ -958,8 +926,8 @@ impl TrackSubscriber {
 	/// polls will keep returning `Ok(None)`.
 	pub fn poll_recv_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
 		let sub = self.sub.read();
-		let min_sequence = sub.start.unwrap_or(0);
-		let end = sub.end;
+		let min_sequence = sub.start_group.unwrap_or(0);
+		let end = sub.end_group;
 		drop(sub);
 
 		let Some((consumer, found_index)) =
@@ -986,11 +954,11 @@ impl TrackSubscriber {
 	/// Return the next group with a strictly-greater sequence number than the last returned.
 	///
 	/// Groups that arrive late (sequence at or below the last one returned) are
-	/// silently skipped. Respects [`Subscription::start`] / `end`.
+	/// silently skipped. Respects [`Subscription::start_group`] / `end_group`.
 	pub fn poll_next_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
 		let sub = self.sub.read();
-		let min_sequence = self.next.max(sub.start.unwrap_or(0));
-		let end = sub.end;
+		let min_sequence = self.next.max(sub.start_group.unwrap_or(0));
+		let end = sub.end_group;
 		drop(sub);
 
 		let Some((consumer, found_index)) =
@@ -1031,11 +999,11 @@ impl TrackSubscriber {
 	/// skipping the rest of the group. Intended for single-frame groups (see
 	/// [`TrackProducer::write_frame`]).
 	///
-	/// Respects [`Subscription::start`] / `end`.
+	/// Respects [`Subscription::start_group`] / `end_group`.
 	pub fn poll_read_frame(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<bytes::Bytes>>> {
 		let sub = self.sub.read();
-		let lower = self.next.max(sub.start.unwrap_or(0));
-		let end = sub.end;
+		let lower = self.next.max(sub.start_group.unwrap_or(0));
+		let end = sub.end_group;
 		drop(sub);
 
 		let Some((frame, found_index, sequence)) =
@@ -1082,16 +1050,6 @@ impl TrackSubscriber {
 			.iter()
 			.flatten()
 			.find_map(|(g, _)| (g.sequence == max).then(|| g.consume()))
-	}
-
-	/// Poll for the group with the given sequence, without blocking.
-	pub fn poll_get_group(&self, waiter: &conducer::Waiter, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
-		self.poll(waiter, |state| state.poll_get_group(sequence))
-	}
-
-	/// Block until the group with the given sequence is available.
-	pub async fn get_group(&self, sequence: u64) -> Result<Option<GroupConsumer>> {
-		conducer::wait(|waiter| self.poll_get_group(waiter, sequence)).await
 	}
 
 	/// Poll for track closure, without blocking.
@@ -1595,7 +1553,7 @@ mod test {
 		let consumer = producer.consume();
 		let mut subscriber = consumer
 			.subscribe(Subscription {
-				start: Some(5),
+				start_group: Some(5),
 				..Default::default()
 			})
 			.unwrap();
@@ -1639,28 +1597,6 @@ mod test {
 			.expect("should not block")
 			.expect("would have errored");
 		assert!(done.is_none());
-	}
-
-	#[tokio::test]
-	async fn get_group_finishes_without_waiting_for_gaps() {
-		let mut producer = Track::new("test").produce();
-		producer.create_group(Group { sequence: 1 }).unwrap();
-		producer.finish_at(1).unwrap();
-
-		let consumer = producer.consume();
-		assert!(
-			consumer.get_group(0).now_or_never().is_none(),
-			"sequence below fin should block (group could still arrive)"
-		);
-		assert!(
-			consumer
-				.get_group(2)
-				.now_or_never()
-				.expect("sequence at-or-after fin should resolve")
-				.expect("should not error")
-				.is_none(),
-			"sequence at-or-after fin should not exist"
-		);
 	}
 
 	#[test]
@@ -1810,15 +1746,15 @@ mod test {
 
 		let _a = consumer
 			.subscribe(Subscription {
-				start: Some(5),
-				end: Some(20),
+				start_group: Some(5),
+				end_group: Some(20),
 				..Default::default()
 			})
 			.unwrap();
 		let _b = consumer
 			.subscribe(Subscription {
-				start: Some(3),
-				end: Some(10),
+				start_group: Some(3),
+				end_group: Some(10),
 				..Default::default()
 			})
 			.unwrap();
@@ -1828,8 +1764,8 @@ mod test {
 			.now_or_never()
 			.expect("should not block")
 			.expect("aggregate should exist");
-		assert_eq!(agg.start, Some(3));
-		assert_eq!(agg.end, Some(20));
+		assert_eq!(agg.start_group, Some(3));
+		assert_eq!(agg.end_group, Some(20));
 	}
 
 	#[tokio::test]
@@ -1841,8 +1777,8 @@ mod test {
 		// so the aggregate must be unbounded too.
 		let _a = consumer
 			.subscribe(Subscription {
-				start: Some(5),
-				end: Some(20),
+				start_group: Some(5),
+				end_group: Some(20),
 				..Default::default()
 			})
 			.unwrap();
@@ -1853,8 +1789,8 @@ mod test {
 			.now_or_never()
 			.expect("should not block")
 			.expect("aggregate should exist");
-		assert_eq!(agg.start, None, "None subscriber wants from the beginning");
-		assert_eq!(agg.end, None, "None subscriber wants no end");
+		assert_eq!(agg.start_group, None, "None subscriber wants from the beginning");
+		assert_eq!(agg.end_group, None, "None subscriber wants no end");
 	}
 
 	#[tokio::test]
@@ -1922,7 +1858,7 @@ mod test {
 		let consumer = producer.consume();
 		let mut subscriber = consumer
 			.subscribe(Subscription {
-				end: Some(2),
+				end_group: Some(2),
 				..Default::default()
 			})
 			.unwrap();
@@ -1943,22 +1879,22 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn fetch_group_cache_hit() {
+	async fn get_group_cache_hit() {
 		let mut producer = Track::new("test").produce();
 		producer.create_group(Group { sequence: 5 }).unwrap();
 		let consumer = producer.consume();
 
 		// No TrackDynamic registered, but cache hits still succeed.
-		let group = consumer.fetch_group(5).expect("cache hit");
+		let group = consumer.get_group(Group { sequence: 5 }).expect("cache hit");
 		assert_eq!(group.sequence, 5);
 	}
 
 	#[tokio::test]
-	async fn fetch_group_no_handler_returns_not_found() {
+	async fn get_group_no_handler_returns_not_found() {
 		let producer = Track::new("test").produce();
 		let consumer = producer.consume();
 
-		match consumer.fetch_group(0) {
+		match consumer.get_group(Group { sequence: 0 }) {
 			Err(Error::NotFound) => {}
 			Err(err) => panic!("expected NotFound, got {err:?}"),
 			Ok(_) => panic!("expected NotFound, got Ok"),
@@ -1966,7 +1902,7 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn fetch_group_past_final_returns_not_found() {
+	async fn get_group_past_final_returns_not_found() {
 		let mut producer = Track::new("test").produce();
 		producer.create_group(Group { sequence: 3 }).unwrap();
 		producer.finish().unwrap();
@@ -1974,10 +1910,10 @@ mod test {
 		let _dynamic = producer.dynamic();
 
 		// Cached group below the final boundary still works.
-		assert_eq!(consumer.fetch_group(3).unwrap().sequence, 3);
+		assert_eq!(consumer.get_group(Group { sequence: 3 }).unwrap().sequence, 3);
 
 		// Sequences at/past the final boundary fail fast even with a handler attached.
-		match consumer.fetch_group(4) {
+		match consumer.get_group(Group { sequence: 4 }) {
 			Err(Error::NotFound) => {}
 			Err(err) => panic!("expected NotFound, got {err:?}"),
 			Ok(_) => panic!("expected NotFound, got Ok"),
@@ -1985,13 +1921,13 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn fetch_group_via_dynamic_handler() {
+	async fn get_group_via_dynamic_handler() {
 		let producer = Track::new("test").produce();
 		let consumer = producer.consume();
 		let mut dynamic = producer.dynamic();
 
 		// Issue a fetch; the handler should pop a producer for the same sequence.
-		let mut group_consumer = consumer.fetch_group(7).expect("queued");
+		let mut group_consumer = consumer.get_group(Group { sequence: 7 }).expect("queued");
 		assert_eq!(group_consumer.sequence, 7);
 
 		let mut group_producer = dynamic.assert_request();
@@ -2007,13 +1943,15 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn fetch_group_shares_in_flight() {
+	async fn get_group_shares_in_flight() {
 		let producer = Track::new("test").produce();
 		let consumer = producer.consume();
 		let mut dynamic = producer.dynamic();
 
-		let mut a = consumer.fetch_group(3).expect("queued");
-		let mut b = consumer.fetch_group(3).expect("cache hit second time");
+		let mut a = consumer.get_group(Group { sequence: 3 }).expect("queued");
+		let mut b = consumer
+			.get_group(Group { sequence: 3 })
+			.expect("cache hit second time");
 
 		// Only one request should be queued; both consumers share the same group.
 		let mut group_producer = dynamic.assert_request();
@@ -2029,12 +1967,12 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn fetch_group_aborted_by_publisher() {
+	async fn get_group_aborted_by_publisher() {
 		let producer = Track::new("test").produce();
 		let consumer = producer.consume();
 		let mut dynamic = producer.dynamic();
 
-		let mut group_consumer = consumer.fetch_group(2).expect("queued");
+		let mut group_consumer = consumer.get_group(Group { sequence: 2 }).expect("queued");
 		let mut group_producer = dynamic.assert_request();
 
 		// Publisher decides the group can't be served.
@@ -2047,12 +1985,12 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn fetch_pending_aborted_when_dynamic_dropped() {
+	async fn get_group_pending_aborted_when_dynamic_dropped() {
 		let producer = Track::new("test").produce();
 		let consumer = producer.consume();
 		let dynamic = producer.dynamic();
 
-		let mut group_consumer = consumer.fetch_group(9).expect("queued");
+		let mut group_consumer = consumer.get_group(Group { sequence: 9 }).expect("queued");
 
 		// Dropping the only TrackDynamic aborts the pending request.
 		drop(dynamic);
@@ -2063,17 +2001,20 @@ mod test {
 		}
 
 		// And subsequent fetches for uncached sequences fail with NotFound.
-		assert!(matches!(consumer.fetch_group(10), Err(Error::NotFound)));
+		assert!(matches!(
+			consumer.get_group(Group { sequence: 10 }),
+			Err(Error::NotFound)
+		));
 	}
 
 	#[tokio::test]
-	async fn fetch_dynamic_clone_keeps_handler_alive() {
+	async fn get_group_dynamic_clone_keeps_handler_alive() {
 		let producer = Track::new("test").produce();
 		let consumer = producer.consume();
 		let dynamic = producer.dynamic();
 		let mut dynamic_clone = dynamic.clone();
 
-		let mut group_consumer = consumer.fetch_group(9).expect("queued");
+		let mut group_consumer = consumer.get_group(Group { sequence: 9 }).expect("queued");
 
 		// Dropping one handle must NOT abort the pending request: the clone
 		// still represents a live handler, so the counter must stay positive.

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -335,7 +335,7 @@ async fn serve_fetch(
 
 	let result = tokio::time::timeout_at(deadline, async {
 		let group = match params.group {
-			FetchGroup::Num(sequence) => track.fetch_group(sequence).map_err(|err| match err {
+			FetchGroup::Num(sequence) => track.get_group(sequence.into()).map_err(|err| match err {
 				moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
 				_ => StatusCode::INTERNAL_SERVER_ERROR,
 			})?,

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -326,28 +326,33 @@ async fn serve_fetch(
 	// subscribers don't get a spurious 404 before the broadcast has gossiped.
 	#[allow(deprecated)]
 	let broadcast = origin.consume_broadcast("").ok_or(StatusCode::NOT_FOUND)?;
-	let mut track = broadcast
-		.subscribe_track(&track, moq_lite::Subscription::default())
-		.map_err(|err| match err {
-			moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
-			_ => StatusCode::INTERNAL_SERVER_ERROR,
-		})?;
+	let track = broadcast.consume_track(&track).map_err(|err| match err {
+		moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
+		_ => StatusCode::INTERNAL_SERVER_ERROR,
+	})?;
 
 	let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
 
 	let result = tokio::time::timeout_at(deadline, async {
 		let group = match params.group {
-			FetchGroup::Latest => match track.latest() {
-				Some(sequence) => track.get_group(sequence).await,
-				None => track.recv_group().await,
+			FetchGroup::Num(sequence) => track.fetch_group(sequence).map_err(|err| match err {
+				moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
+				_ => StatusCode::INTERNAL_SERVER_ERROR,
+			})?,
+			FetchGroup::Latest => match track.latest_group() {
+				Some(group) => group,
+				None => {
+					// No cached group yet — wait for the first one via subscribe.
+					let mut sub = track
+						.subscribe_default()
+						.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+					match sub.next_group().await {
+						Ok(Some(group)) => group,
+						Ok(None) => return Err(StatusCode::NOT_FOUND),
+						Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+					}
+				}
 			},
-			FetchGroup::Num(sequence) => track.get_group(sequence).await,
-		};
-
-		let group = match group {
-			Ok(Some(group)) => group,
-			Ok(None) => return Err(StatusCode::NOT_FOUND),
-			Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
 		};
 
 		tracing::info!(track = %track.name, group = %group.sequence, "serving group");


### PR DESCRIPTION
## Summary

A first-class FETCH path at the track level. The breaking API change is captured here so the wire-side hookup (lite `ControlType::Fetch`, `ietf::run_fetch_stream`) can land as a clean follow-up.

### New API

- `TrackConsumer::fetch_group(seq) -> Result<GroupConsumer>`
  - Cache hit → returns the cached consumer (no `TrackDynamic` needed).
  - Cache miss + no fetch handler → `Err(NotFound)`.
  - Cache miss + handler present → queues a request; returns a consumer that fills as the publisher writes frames. Concurrent fetches for the same sequence share the in-flight group.
- `TrackConsumer::latest_group() -> Option<GroupConsumer>` (replaces `latest()` returning `Option<u64>`; consistent with `get_group` / `recv_group` / `next_group`).
- `TrackSubscriber::latest_group()` — same rename.
- `TrackProducer::dynamic() -> TrackDynamic` — mirrors `BroadcastProducer::dynamic()`. Drop the last dynamic and pending requests are aborted with `Error::Cancel`.
- `TrackDynamic::poll_requested_group` / `requested_group` — yields `GroupProducer` for the publisher to fill.

### Caller migrations

- `moq-relay/src/web.rs` fetch handler: drops the upfront `subscribe_track` round-trip; uses `consume_track` + `fetch_group` / `latest_group` directly.
- `lite/publisher.rs` and `ietf/publisher.rs`: `consumer.latest()` → `consumer.latest_group().map(|g| g.sequence)` for the LargestObject / fallback `start_group` case.

### What's not here

Wire-side hookup. Specifically:

- `lite::ControlType::Fetch` still returns `Error::UnexpectedStream` (the breaking change captures the in-process API; the wire format choice for response framing — inline-on-bidi vs. uni stream with fetch IDs — is its own conversation).
- `ietf::run_fetch_stream` Standalone variant still returns "not supported".

When those land they slot into the existing `fetch_group` API without further breaks.

## Test plan

- [x] 8 new unit tests in `rs/moq-lite/src/model/track.rs`:
  - `fetch_group_cache_hit` (no dynamic needed)
  - `fetch_group_no_handler_returns_not_found`
  - `fetch_group_via_dynamic_handler` (round-trip with frame data)
  - `fetch_group_shares_in_flight` (single queued request, both consumers see frames)
  - `fetch_group_aborted_by_publisher` (publisher abort surfaces to consumer)
  - `fetch_pending_aborted_when_dynamic_dropped`
  - `latest_group_returns_max_sequence_consumer`
  - `latest_group_none_on_empty_track`
- [x] `cargo test --workspace` — 290 moq-lite tests pass (up from 282), all other crates green.
- [x] `cargo build --workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)