### PR TITLE
@moq/watch: expose AudioContext on the audio backend

### DIFF
--- a/js/watch/src/audio/backend.ts
+++ b/js/watch/src/audio/backend.ts
@@ -18,6 +18,9 @@ export interface Backend {
 
 	// Buffered time ranges (for MSE backend).
 	buffered: Getter<BufferedRanges>;
+
+	// The AudioContext used for playback (WebCodecs backend only).
+	context: Getter<AudioContext | undefined>;
 }
 
 export interface Stats {

--- a/js/watch/src/audio/mse.ts
+++ b/js/watch/src/audio/mse.ts
@@ -25,6 +25,9 @@ export class Mse implements Backend {
 	#buffered = new Signal<BufferedRanges>([]);
 	readonly buffered: Getter<BufferedRanges> = this.#buffered;
 
+	// MSE plays through the <video> element, not WebAudio.
+	readonly context: Getter<AudioContext | undefined> = new Signal<AudioContext | undefined>(undefined);
+
 	#signals = new Effect();
 
 	constructor(muxer: Muxer, source: Source, props?: MseProps) {

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -212,6 +212,7 @@ export class MultiBackend implements Backend {
 
 		effect.proxy(this.audio.stats, audio.stats);
 		effect.proxy(this.audio.buffered, audio.buffered);
+		effect.proxy(this.audio.context, audio.context);
 	}
 
 	close(): void {

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -94,6 +94,9 @@ class AudioBackend implements Audio.Backend {
 	// Buffered time ranges
 	buffered = new Signal<BufferedRanges>([]);
 
+	// The AudioContext used for playback (set by the WebCodecs backend; undefined under MSE).
+	context = new Signal<AudioContext | undefined>(undefined);
+
 	constructor(source: Audio.Source) {
 		this.source = source;
 	}
@@ -180,6 +183,7 @@ export class MultiBackend implements Backend {
 
 		effect.proxy(this.audio.stats, audioSource.stats);
 		effect.proxy(this.audio.buffered, audioSource.buffered);
+		effect.proxy(this.audio.context, audioSource.context);
 	}
 
 	#runMse(effect: Effect, element: HTMLVideoElement): void {


### PR DESCRIPTION
The WebCodecs decoder owns its own AudioContext but doesn't surface it past the Decoder class. Browsers create the context in `suspended` state when there's no user gesture, and applications need a handle on it to prompt the user (e.g. a "click to enable audio" button) and call `resume()` from within a real gesture handler.

Add `context: Getter<AudioContext | undefined>` to `Audio.Backend` and proxy it from the WebCodecs path in `MultiBackend`. The MSE backend plays through the `<video>` element rather than WebAudio, so its `context` signal stays undefined.