### PR TITLE
@moq/watch: add pull mode to video renderer

### DIFF
--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -166,7 +166,7 @@ export class MultiBackend implements Backend {
 			paused: this.paused,
 		});
 
-		const videoRenderer = new Video.Renderer(videoSource, { canvas: element, paused: this.paused });
+		const videoRenderer = new Video.Renderer(videoSource, { canvas: element, paused: this.paused, mode: "pull" });
 
 		effect.cleanup(() => {
 			videoSource.close();

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -2,12 +2,15 @@ import { Time } from "@moq/lite";
 import { Effect, Signal } from "@moq/signals";
 import type { Decoder } from "./decoder";
 
+export type RendererMode = "push" | "pull";
+
 export type RendererProps = {
 	canvas?: HTMLCanvasElement | Signal<HTMLCanvasElement | undefined>;
 	paused?: boolean | Signal<boolean>;
+	mode?: RendererMode | Signal<RendererMode>;
 };
 
-// An component to render a video to a canvas.
+// A component to render a video to a canvas.
 export class Renderer {
 	decoder: Decoder;
 
@@ -16,6 +19,10 @@ export class Renderer {
 
 	// Whether the video is paused.
 	paused: Signal<boolean>;
+
+	// "push" re-renders each time the decoder publishes a new frame; "pull" drives a
+	// continuous rAF loop and redraws only when the decoder's current frame differs.
+	mode: Signal<RendererMode>;
 
 	// The most recently rendered frame, updated after each rAF paint.
 	readonly frame = new Signal<VideoFrame | undefined>(undefined);
@@ -31,6 +38,7 @@ export class Renderer {
 		this.decoder = decoder;
 		this.canvas = Signal.from(props?.canvas);
 		this.paused = Signal.from(props?.paused ?? false);
+		this.mode = Signal.from(props?.mode ?? "push");
 
 		this.#signals.run((effect) => {
 			const canvas = effect.get(this.canvas);
@@ -108,6 +116,15 @@ export class Renderer {
 		const ctx = effect.get(this.#ctx);
 		if (!ctx) return;
 
+		const mode = effect.get(this.mode);
+		if (mode === "push") {
+			this.#runPush(effect, ctx);
+		} else {
+			this.#runPull(effect, ctx);
+		}
+	}
+
+	#runPush(effect: Effect, ctx: CanvasRenderingContext2D) {
 		const paused = effect.get(this.paused);
 
 		// Read new frames from the decoder when not paused.
@@ -120,7 +137,7 @@ export class Renderer {
 		// Always render, even when paused (to show last frame)
 		let animate: number | undefined = requestAnimationFrame(() => {
 			const frame = decoded ?? this.frame.peek();
-			this.#render(ctx, frame);
+			this.#draw(ctx, frame);
 
 			// Update signals to reflect what's actually on screen.
 			if (decoded) {
@@ -141,7 +158,32 @@ export class Renderer {
 		});
 	}
 
-	#render(ctx: CanvasRenderingContext2D, frame?: VideoFrame) {
+	#runPull(effect: Effect, ctx: CanvasRenderingContext2D) {
+		let lastDrawn: VideoFrame | undefined;
+		let rafId: number | undefined;
+
+		const tick = () => {
+			const current = this.decoder.frame.peek();
+			if (current && current !== lastDrawn) {
+				this.#draw(ctx, current);
+				this.frame.update((old) => {
+					old?.close();
+					return current.clone();
+				});
+				this.timestamp.set(Time.Milli.fromMicro(current.timestamp as Time.Micro));
+				lastDrawn = current;
+			}
+			rafId = requestAnimationFrame(tick);
+		};
+
+		rafId = requestAnimationFrame(tick);
+
+		effect.cleanup(() => {
+			if (rafId !== undefined) cancelAnimationFrame(rafId);
+		});
+	}
+
+	#draw(ctx: CanvasRenderingContext2D, frame?: VideoFrame) {
 		if (!frame) {
 			// Clear canvas when no frame
 			ctx.fillStyle = "#000";


### PR DESCRIPTION
For me (on Chrome with 144hz+ monitors) the existing renderer for some reason causes chrome to render the page at 120fps. I checked and the logic is not drawing at that rate so nothing wrong with it.

Instead, if the requestAnimationFrame is done inside another one it apparently does different schedule logic and actually syncs correctly. So the new pull mode causes it to render at the actually video refresh rate...

| push | pull |
| --- | --- |
| <img width="198" height="181" alt="image" src="https://github.com/user-attachments/assets/12a7188c-ea9a-4196-8ccd-6a78e3364b1d" /> | <img width="198" height="181" alt="image" src="https://github.com/user-attachments/assets/7c29a1ed-ad53-4f2c-91cc-11801ff6b739" /> |

Let me know what you think and if you are seeing something similar.
Visually they both should be the same so if everything checks out we can also drop the push mode if you want.


Adds a `mode: "push" | "pull"` prop on Renderer:

- "push" (default, existing behavior): the render effect subscribes to decoder.frame and schedules a single rAF paint per decoded frame.
- "pull": runs a self-recursive rAF loop and redraws only when the decoder's current frame differs from what was last drawn.

MultiBackend's WebCodecs path now constructs the renderer with `mode: "pull"` so playback runs off the display's vsync rather than the decoder's frame cadence.