### PR TITLE
Update Cloudflare limitation note for latency=real-time

### DIFF
--- a/demo/web/src/index.html
+++ b/demo/web/src/index.html
@@ -28,7 +28,7 @@
 				- `latency`: The target jitter buffer size in milliseconds, or "real-time" to use the RTT.
 				- `reload`: Whether to automatically reconnect when the broadcast goes offline/online.
 
-				NOTE: Cloudflare doesn't support reload yet.
+				NOTE: Cloudflare doesn't support reload yet or latency=real-time.
 			-->
 			<moq-watch id="watch" url="%VITE_RELAY_URL%" name="bbb" muted latency="real-time" reload>
 				<!-- Provide a canvas element to render the video via WebCodecs. -->


### PR DESCRIPTION
## Summary
Updated the documentation note in the demo HTML file to clarify Cloudflare's limitations regarding the `latency=real-time` parameter.

## Changes
- Updated the NOTE comment to indicate that Cloudflare doesn't support both the `reload` feature AND the `latency=real-time` option, not just `reload` alone

## Details
The change clarifies an existing limitation by expanding the note from only mentioning the `reload` parameter to also explicitly calling out that `latency=real-time` is not supported on Cloudflare. This helps users understand the full scope of constraints when using Cloudflare as a relay.

https://claude.ai/code/session_01MLSBQpPUDAuP5jCaxia9Cp