### PR TITLE
Revert moq-lite FETCH/Subscription API changes

### DIFF
--- a/rs/conducer/src/consumer.rs
+++ b/rs/conducer/src/consumer.rs
@@ -8,7 +8,6 @@ use crate::{
 	lock::*,
 	producer::{Producer, Ref},
 	waiter::*,
-	weak::Weak,
 };
 
 /// The consuming side of a shared state channel.
@@ -110,14 +109,6 @@ impl<T> Consumer<T> {
 	/// Returns `true` if both consumers share the same underlying state.
 	pub fn same_channel(&self, other: &Self) -> bool {
 		self.state.is_clone(&other.state)
-	}
-
-	/// Create a [`Weak`] reference that doesn't affect the producer/consumer ref counts.
-	pub fn weak(&self) -> Weak<T> {
-		Weak {
-			state: self.state.clone(),
-			counts: self.counts.clone(),
-		}
 	}
 }
 

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -50,7 +50,7 @@ async fn run_subscribe(mut consumer: moq_lite::OriginConsumer) -> anyhow::Result
 	tracing::info!(%path, "broadcast announced");
 
 	// Read the catalog to discover available tracks.
-	let catalog_track = broadcast.subscribe_track(&hang::Catalog::default_track(), hang::Catalog::SUBSCRIPTION)?;
+	let catalog_track = broadcast.subscribe_track(&hang::Catalog::default_track())?;
 	let mut catalog = hang::CatalogConsumer::new(catalog_track);
 
 	let info = catalog.next().await?.ok_or_else(|| anyhow::anyhow!("no catalog"))?;
@@ -72,15 +72,12 @@ async fn run_subscribe(mut consumer: moq_lite::OriginConsumer) -> anyhow::Result
 	);
 
 	// Subscribe to the video track.
-	let track = moq_lite::Track::new(name.clone());
+	let track = moq_lite::Track {
+		name: name.clone(),
+		priority: 1,
+	};
 
-	let track_consumer = broadcast.subscribe_track(
-		&track,
-		moq_lite::Subscription {
-			priority: 1,
-			..Default::default()
-		},
-	)?;
+	let track_consumer = broadcast.subscribe_track(&track)?;
 	let mut ordered = hang::container::OrderedConsumer::new(track_consumer, Duration::from_millis(500));
 
 	// Read frames in presentation order.

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -41,7 +41,10 @@ async fn run_session(origin: moq_lite::OriginConsumer) -> anyhow::Result<()> {
 // The catalog can contain multiple tracks, used by the viewer to choose the best track.
 fn create_track(broadcast: &mut moq_lite::BroadcastProducer) -> anyhow::Result<moq_lite::TrackProducer> {
 	// Basic information about the video track.
-	let video_track = moq_lite::Track::new("video");
+	let video_track = moq_lite::Track {
+		name: "video".to_string(),
+		priority: 1, // Video typically has lower priority than audio
+	};
 
 	// Example video configuration
 	// In a real application, you would get this from the encoder

--- a/rs/hang/src/catalog/audio/mod.rs
+++ b/rs/hang/src/catalog/audio/mod.rs
@@ -50,7 +50,8 @@ impl Audio {
 
 			if let btree_map::Entry::Vacant(entry) = self.renditions.entry(name.clone()) {
 				entry.insert(config.clone());
-				return moq_lite::Track::new(name);
+				// TODO: Remove priority
+				return moq_lite::Track { name, priority: 2 };
 			}
 		}
 

--- a/rs/hang/src/catalog/consumer.rs
+++ b/rs/hang/src/catalog/consumer.rs
@@ -2,17 +2,18 @@ use crate::{Catalog, Result};
 
 /// A catalog consumer, used to receive catalog updates and discover tracks.
 ///
-/// This wraps a `moq_lite::TrackSubscriber` and automatically deserializes JSON
+/// This wraps a `moq_lite::TrackConsumer` and automatically deserializes JSON
 /// catalog data to discover available audio and video tracks in a broadcast.
+#[derive(Clone)]
 pub struct CatalogConsumer {
-	/// Access to the underlying track subscriber.
-	pub track: moq_lite::TrackSubscriber,
+	/// Access to the underlying track consumer.
+	pub track: moq_lite::TrackConsumer,
 	group: Option<moq_lite::GroupConsumer>,
 }
 
 impl CatalogConsumer {
-	/// Create a new catalog consumer from a MoQ track subscriber.
-	pub fn new(track: moq_lite::TrackSubscriber) -> Self {
+	/// Create a new catalog consumer from a MoQ track consumer.
+	pub fn new(track: moq_lite::TrackConsumer) -> Self {
 		Self { track, group: None }
 	}
 
@@ -48,8 +49,8 @@ impl CatalogConsumer {
 	}
 }
 
-impl From<moq_lite::TrackSubscriber> for CatalogConsumer {
-	fn from(inner: moq_lite::TrackSubscriber) -> Self {
+impl From<moq_lite::TrackConsumer> for CatalogConsumer {
+	fn from(inner: moq_lite::TrackConsumer) -> Self {
 		Self::new(inner)
 	}
 }

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -88,8 +88,8 @@ impl Catalog {
 		priority: 100,
 		ordered: false,
 		max_latency: std::time::Duration::ZERO,
-		start_group: None,
-		end_group: None,
+		start: None,
+		end: None,
 	};
 }
 

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -77,20 +77,11 @@ impl Catalog {
 	}
 
 	pub fn default_track() -> moq_lite::Track {
-		moq_lite::Track::new(Catalog::DEFAULT_NAME)
+		moq_lite::Track {
+			name: Catalog::DEFAULT_NAME.to_string(),
+			priority: 100,
+		}
 	}
-
-	/// The recommended subscription for the catalog track.
-	///
-	/// The catalog should be high priority since downstream players block on
-	/// it before they can subscribe to anything else.
-	pub const SUBSCRIPTION: moq_lite::Subscription = moq_lite::Subscription {
-		priority: 100,
-		ordered: false,
-		max_latency: std::time::Duration::ZERO,
-		start: None,
-		end: None,
-	};
 }
 
 #[cfg(test)]

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -70,7 +70,8 @@ impl Video {
 			};
 			if let btree_map::Entry::Vacant(entry) = self.renditions.entry(name.clone()) {
 				entry.insert(config.clone());
-				return moq_lite::Track::new(name);
+				// TODO: Remove priority
+				return moq_lite::Track { name, priority: 1 };
 			}
 		}
 

--- a/rs/hang/src/container/consumer.rs
+++ b/rs/hang/src/container/consumer.rs
@@ -44,7 +44,7 @@ impl From<OrderedFrame> for Frame {
 
 /// A consumer for hang-formatted media tracks with timestamp reordering.
 ///
-/// This wraps a `moq_lite::TrackSubscriber` and adds hang-specific functionality
+/// This wraps a `moq_lite::TrackConsumer` and adds hang-specific functionality
 /// like timestamp decoding, latency management, and frame buffering.
 ///
 /// ## Latency Management
@@ -52,7 +52,7 @@ impl From<OrderedFrame> for Frame {
 /// The consumer can skip groups that are too far behind to maintain low latency.
 /// Configure the maximum acceptable delay through the consumer's latency settings.
 pub struct OrderedConsumer {
-	pub track: moq_lite::TrackSubscriber,
+	pub track: moq_lite::TrackConsumer,
 
 	// The current group that we want to read from
 	current: u64,
@@ -69,8 +69,8 @@ pub struct OrderedConsumer {
 }
 
 impl OrderedConsumer {
-	/// Create a new OrderedConsumer wrapping the given moq-lite subscriber.
-	pub fn new(track: moq_lite::TrackSubscriber, max_latency: std::time::Duration) -> Self {
+	/// Create a new OrderedConsumer wrapping the given moq-lite consumer.
+	pub fn new(track: moq_lite::TrackConsumer, max_latency: std::time::Duration) -> Self {
 		Self {
 			track,
 			current: 0,
@@ -227,14 +227,14 @@ impl OrderedConsumer {
 	}
 }
 
-impl From<OrderedConsumer> for moq_lite::TrackSubscriber {
+impl From<OrderedConsumer> for moq_lite::TrackConsumer {
 	fn from(inner: OrderedConsumer) -> Self {
 		inner.track
 	}
 }
 
 impl std::ops::Deref for OrderedConsumer {
-	type Target = moq_lite::TrackSubscriber;
+	type Target = moq_lite::TrackConsumer;
 
 	fn deref(&self) -> &Self::Target {
 		&self.track
@@ -416,7 +416,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -434,7 +434,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_frames_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_000), ts(66_000)]);
@@ -454,7 +454,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_groups_within_latency() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// 5 groups, 20ms spacing. Total span = 80ms, well within 500ms latency.
@@ -477,7 +477,7 @@ mod tests {
 	async fn latency_skip_delivers_recent_groups() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
@@ -514,7 +514,7 @@ mod tests {
 	async fn zero_latency_skips_aggressively() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::ZERO);
 
 		// Group 0: 1 frame at a HIGH timestamp, NOT finished.
@@ -555,7 +555,7 @@ mod tests {
 	async fn latency_skip_correctness() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Group 0: 1 frame, NOT finished
@@ -601,7 +601,7 @@ mod tests {
 	async fn groups_delivered_in_sequence_order() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 0: 1 frame, NOT finished (blocks consumer, lets groups 2 and 1 accumulate in pending)
@@ -637,7 +637,7 @@ mod tests {
 	#[tokio::test]
 	async fn adjacent_group_flushed_immediately() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -655,7 +655,7 @@ mod tests {
 	#[tokio::test]
 	async fn bframes_within_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// B-frame decode order: timestamps [0, 66ms, 33ms]
@@ -676,7 +676,7 @@ mod tests {
 	async fn empty_track_returns_none() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		track.finish().unwrap();
@@ -694,7 +694,7 @@ mod tests {
 	async fn track_closed_with_error() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -717,7 +717,7 @@ mod tests {
 	async fn closed_resolves_when_track_ends() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// closed() should not resolve yet
@@ -743,7 +743,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_in_group_sequence_recovery() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Groups 0, 1 then skip 2, write 3-6
@@ -764,7 +764,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_at_start_of_sequence() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(80));
 
 		// First group at sequence 5 (simulating joining mid-stream), gap at 6
@@ -783,7 +783,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_timestamp_and_index_decoding() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_333), ts(66_666)]);
@@ -805,7 +805,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_payload_preserved() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
@@ -843,7 +843,7 @@ mod tests {
 	async fn no_infinite_loop_with_buffered_frames() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_secs(10));
 
 		// Group 0: 1 frame, NOT finished
@@ -889,7 +889,7 @@ mod tests {
 	#[tokio::test]
 	async fn large_timestamps() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_secs(3700));
 
 		// 1 hour = 3,600,000,000 microseconds
@@ -906,7 +906,7 @@ mod tests {
 	#[tokio::test]
 	async fn set_max_latency_changes_behavior() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_secs(10));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -936,7 +936,7 @@ mod tests {
 	async fn max_timestamp_tracks_through_bframes() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(40));
 
 		// Group 0: B-frame decode order [0, 66ms, 33ms], NOT finished (blocks consumer)
@@ -984,7 +984,7 @@ mod tests {
 	async fn startup_selects_earliest_group() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		// max_latency = 100ms.
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
@@ -1041,7 +1041,7 @@ mod tests {
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 5: no frames written yet (pending)
@@ -1068,7 +1068,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_single_group_mid_stream() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Only group 100 exists.
@@ -1084,7 +1084,7 @@ mod tests {
 	async fn multiple_sequential_latency_skips() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(50));
 
 		// Group 0: blocks
@@ -1116,7 +1116,7 @@ mod tests {
 	async fn latency_skip_boundary_exact() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(100));
 
 		// Group 0: blocks
@@ -1145,7 +1145,7 @@ mod tests {
 	#[tokio::test]
 	async fn group_error_skips_to_next() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 0: aborted
@@ -1165,7 +1165,7 @@ mod tests {
 	async fn track_finishes_while_reading() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1195,7 +1195,7 @@ mod tests {
 	#[tokio::test]
 	async fn empty_group_advances() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = track.consume().subscribe_default().unwrap();
+		let consumer_track = track.consume();
 		let mut consumer = OrderedConsumer::new(consumer_track, Duration::from_millis(500));
 
 		// Group 0: empty (no frames, just finished)

--- a/rs/hang/src/container/producer.rs
+++ b/rs/hang/src/container/producer.rs
@@ -134,8 +134,7 @@ impl OrderedProducer {
 	/// Multiple consumers can be created from the same producer, each receiving
 	/// a copy of all data written to the track.
 	pub fn consume(&self, max_latency: std::time::Duration) -> OrderedConsumer {
-		let subscriber = self.track.consume().subscribe_default().expect("producer alive");
-		OrderedConsumer::new(subscriber, max_latency)
+		OrderedConsumer::new(self.track.consume(), max_latency)
 	}
 }
 

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -48,10 +48,7 @@ impl Consume {
 
 	pub fn catalog(&mut self, broadcast: Id, on_catalog: OnStatus) -> Result<Id, Error> {
 		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
-		let catalog = broadcast.subscribe_track(
-			&hang::catalog::Catalog::default_track(),
-			hang::catalog::Catalog::SUBSCRIPTION,
-		)?;
+		let catalog = broadcast.subscribe_track(&hang::catalog::Catalog::default_track())?;
 
 		let channel = oneshot::channel();
 		let entry = TaskEntry {
@@ -220,13 +217,10 @@ impl Consume {
 			.nth(index)
 			.ok_or(Error::NoIndex)?;
 
-		let track = consume.broadcast.subscribe_track(
-			&moq_lite::Track::new(rendition.clone()),
-			moq_lite::Subscription {
-				priority: 1,
-				..Default::default()
-			},
-		)?;
+		let track = consume.broadcast.subscribe_track(&moq_lite::Track {
+			name: rendition.clone(),
+			priority: 1, // TODO: Remove priority
+		})?;
 		let track = hang::container::OrderedConsumer::new(track, latency);
 
 		let channel = oneshot::channel();
@@ -267,13 +261,10 @@ impl Consume {
 			.nth(index)
 			.ok_or(Error::NoIndex)?;
 
-		let track = consume.broadcast.subscribe_track(
-			&moq_lite::Track::new(rendition.clone()),
-			moq_lite::Subscription {
-				priority: 2,
-				..Default::default()
-			},
-		)?;
+		let track = consume.broadcast.subscribe_track(&moq_lite::Track {
+			name: rendition.clone(),
+			priority: 2, // TODO: Remove priority
+		})?;
 		let track = hang::container::OrderedConsumer::new(track, latency);
 
 		let channel = oneshot::channel();

--- a/rs/moq-boy/src/input.rs
+++ b/rs/moq-boy/src/input.rs
@@ -99,9 +99,12 @@ async fn handle_viewer_commands(
 	broadcast: moq_lite::BroadcastConsumer,
 	cmd_tx: &tokio::sync::mpsc::Sender<Command>,
 ) -> anyhow::Result<()> {
-	let command_track = moq_lite::Track::new("command");
+	let command_track = moq_lite::Track {
+		name: "command".to_string(),
+		priority: 0,
+	};
 
-	let mut track = broadcast.subscribe_track(&command_track, moq_lite::Subscription::default())?;
+	let mut track = broadcast.subscribe_track(&command_track)?;
 
 	while let Some(mut group) = track.recv_group().await? {
 		while let Some(frame) = group.read_frame().await? {

--- a/rs/moq-boy/src/status.rs
+++ b/rs/moq-boy/src/status.rs
@@ -40,7 +40,10 @@ pub struct StatusPublisher {
 
 impl StatusPublisher {
 	pub fn new(broadcast: &mut moq_lite::BroadcastProducer) -> anyhow::Result<Self> {
-		let track = moq_lite::Track::new("status");
+		let track = moq_lite::Track {
+			name: "status".to_string(),
+			priority: 10,
+		};
 		let producer = broadcast.create_track(track)?;
 
 		Ok(Self {

--- a/rs/moq-clock/src/clock.rs
+++ b/rs/moq-clock/src/clock.rs
@@ -71,11 +71,11 @@ impl Publisher {
 	}
 }
 pub struct Subscriber {
-	track: TrackSubscriber,
+	track: TrackConsumer,
 }
 
 impl Subscriber {
-	pub fn new(track: TrackSubscriber) -> Self {
+	pub fn new(track: TrackConsumer) -> Self {
 		Self { track }
 	}
 

--- a/rs/moq-clock/src/main.rs
+++ b/rs/moq-clock/src/main.rs
@@ -54,7 +54,10 @@ async fn main() -> anyhow::Result<()> {
 
 	tracing::info!(url = ?config.url, "connecting to server");
 
-	let track = Track::new(config.track);
+	let track = Track {
+		name: config.track,
+		priority: 0,
+	};
 
 	let origin = moq_lite::Origin::random().produce();
 
@@ -95,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
 					Some(announce) = origin.announced() => match announce {
 						(path, Some(broadcast)) => {
 							tracing::info!(broadcast = %path, "broadcast is online, subscribing to track");
-							let track = broadcast.subscribe_track(&track, moq_lite::Subscription::default())?;
+							let track = broadcast.subscribe_track(&track)?;
 							clock = Some(clock::Subscriber::new(track));
 						}
 						(path, None) => {

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -77,10 +77,7 @@ impl MoqBroadcastConsumer {
 	/// Subscribe to the catalog for this broadcast.
 	pub fn subscribe_catalog(&self) -> Result<Arc<MoqCatalogConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let track = self.inner.subscribe_track(
-			&hang::catalog::Catalog::default_track(),
-			hang::catalog::Catalog::SUBSCRIPTION,
-		)?;
+		let track = self.inner.subscribe_track(&hang::catalog::Catalog::default_track())?;
 		let consumer = hang::CatalogConsumer::from(track);
 		Ok(Arc::new(MoqCatalogConsumer {
 			task: Task::new(Catalog { inner: consumer }),
@@ -92,9 +89,7 @@ impl MoqBroadcastConsumer {
 	/// Frames are returned as plain byte payloads with no codec or container parsing.
 	pub fn subscribe_track(&self, name: String) -> Result<Arc<MoqTrackConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let track = self
-			.inner
-			.subscribe_track(&moq_lite::Track::new(name), moq_lite::Subscription::default())?;
+		let track = self.inner.subscribe_track(&moq_lite::Track { name, priority: 0 })?;
 		Ok(Arc::new(MoqTrackConsumer::new(track)))
 	}
 
@@ -109,9 +104,7 @@ impl MoqBroadcastConsumer {
 		max_latency_ms: u64,
 	) -> Result<Arc<MoqMediaConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let track = self
-			.inner
-			.subscribe_track(&moq_lite::Track::new(name), moq_lite::Subscription::default())?;
+		let track = self.inner.subscribe_track(&moq_lite::Track { name, priority: 0 })?;
 		let container: hang::catalog::Container = container.into();
 		let latency = std::time::Duration::from_millis(max_latency_ms);
 		let consumer = moq_mux::ordered::Consumer::new(track, container).with_latency(latency);
@@ -124,7 +117,7 @@ impl MoqBroadcastConsumer {
 // ---- Track Consumer ----
 
 struct TrackInner {
-	track: moq_lite::TrackSubscriber,
+	track: moq_lite::TrackConsumer,
 }
 
 impl TrackInner {
@@ -133,7 +126,7 @@ impl TrackInner {
 	}
 
 	async fn next_group(&mut self) -> Result<Option<moq_lite::GroupConsumer>, MoqError> {
-		Ok(self.track.next_group().await?)
+		Ok(self.track.next_group_ordered().await?)
 	}
 
 	async fn read_frame(&mut self) -> Result<Option<Vec<u8>>, MoqError> {
@@ -147,7 +140,7 @@ pub struct MoqTrackConsumer {
 }
 
 impl MoqTrackConsumer {
-	pub(crate) fn new(track: moq_lite::TrackSubscriber) -> Self {
+	pub(crate) fn new(track: moq_lite::TrackConsumer) -> Self {
 		Self {
 			task: Task::new(TrackInner { track }),
 		}

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -83,7 +83,7 @@ impl MoqBroadcastProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		let track = moq_lite::Track::new(name);
+		let track = moq_lite::Track { name, priority: 0 };
 		// Clone the broadcast handle (shared Arc internally) to get &mut access.
 		let mut broadcast = state.broadcast.clone();
 		let producer = broadcast.create_track(track)?;
@@ -118,7 +118,7 @@ impl MoqTrackProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.inner.lock().unwrap();
 		let track = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		Ok(Arc::new(MoqTrackConsumer::new(track.consume().subscribe_default()?)))
+		Ok(Arc::new(MoqTrackConsumer::new(track.consume())))
 	}
 
 	/// Append a new group to the track, returning a producer for writing frames into it.

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -432,10 +432,7 @@ async fn run_session(
 		_ = shutdown.changed() => return Ok(()),
 	};
 
-	let catalog_track = broadcast.subscribe_track(
-		&hang::catalog::Catalog::default_track(),
-		hang::catalog::Catalog::SUBSCRIPTION,
-	)?;
+	let catalog_track = broadcast.subscribe_track(&hang::catalog::Catalog::default_track())?;
 	let mut catalog = hang::catalog::CatalogConsumer::new(catalog_track);
 	let catalog = catalog.next().await?.context("catalog missing")?.clone();
 
@@ -449,7 +446,7 @@ async fn run_session(
 		let caps = video_caps(&config)?;
 		let endpoint = request_pad(&control_tx, descriptor.clone(), caps).await?;
 		let track_ref = moq_lite::Track::new(&track_name);
-		let track_consumer = broadcast.subscribe_track(&track_ref, moq_lite::Subscription::default())?;
+		let track_consumer = broadcast.subscribe_track(&track_ref)?;
 		let track = hang::container::OrderedConsumer::new(track_consumer, Duration::from_secs(1));
 		tasks.push(spawn_track_pump(track, descriptor, endpoint, shutdown.clone()));
 	}
@@ -462,7 +459,7 @@ async fn run_session(
 		let caps = audio_caps(&config)?;
 		let endpoint = request_pad(&control_tx, descriptor.clone(), caps).await?;
 		let track_ref = moq_lite::Track::new(&track_name);
-		let track_consumer = broadcast.subscribe_track(&track_ref, moq_lite::Subscription::default())?;
+		let track_consumer = broadcast.subscribe_track(&track_ref)?;
 		let track = hang::container::OrderedConsumer::new(track_consumer, Duration::from_secs(1));
 		tasks.push(spawn_track_pump(track, descriptor, endpoint, shutdown.clone()));
 	}

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -5,7 +5,7 @@ use web_async::FuturesExt;
 use web_transport_trait::SendStream;
 
 use crate::{
-	AsPath, Error, Origin, OriginConsumer, Subscription, Track, TrackSubscriber,
+	AsPath, Error, Origin, OriginConsumer, Track, TrackConsumer,
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
 	model::GroupConsumer,
@@ -114,33 +114,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			return Ok(());
 		};
 
-		let track = Track::new(msg.track_name.to_string());
-
-		let consumer = match broadcast.consume_track(&track) {
-			Ok(consumer) => consumer,
-			Err(err) => {
-				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())
-					.await?;
-				return Ok(());
-			}
-		};
-
-		// LargestObject means "start from the latest cached group". Other filter
-		// types are still ignored (see the warn above) — TODO: full FilterType
-		// support along with FETCH wiring.
-		let start = matches!(msg.filter_type, FilterType::LargestObject)
-			.then(|| consumer.latest())
-			.flatten();
-
-		let subscription = Subscription {
+		let track = Track {
+			name: msg.track_name.to_string(),
 			priority: msg.subscriber_priority,
-			ordered: matches!(msg.group_order, GroupOrder::Ascending),
-			start,
-			..Default::default()
 		};
 
-		let subscriber = match consumer.subscribe(subscription) {
-			Ok(subscriber) => subscriber,
+		let track = match broadcast.subscribe_track(&track) {
+			Ok(track) => track,
 			Err(err) => {
 				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())
 					.await?;
@@ -162,9 +142,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			.await?;
 
 		// Run the track, cancelling on reader close (Unsubscribe or stream close)
-		let priority = msg.subscriber_priority;
 		let res = tokio::select! {
-			res = self.run_track(subscriber, request_id, priority) => res,
+			res = self.run_track(track, request_id) => res,
 			_ = stream.reader.closed() => Ok(()),
 			_ = self.session.closed() => Ok(()),
 		};
@@ -239,12 +218,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// Serve a track using FuturesUnordered for unlimited concurrent groups.
-	async fn run_track(
-		&self,
-		mut subscriber: TrackSubscriber,
-		request_id: RequestId,
-		priority: u8,
-	) -> Result<(), Error> {
+	async fn run_track(&self, mut track: TrackConsumer, request_id: RequestId) -> Result<(), Error> {
 		let mut tasks = FuturesUnordered::new();
 
 		loop {
@@ -254,12 +228,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					while tasks.next().await.is_some() {}
 					false
 				} => unreachable!(),
-				Some(group) = subscriber.recv_group().transpose() => group,
+				Some(group) = track.recv_group().transpose() => group,
 				else => return Ok(()),
 			}?;
 
 			let sequence = group.sequence;
-			tracing::debug!(subscribe = %request_id, track = %subscriber.name, sequence, "serving group");
+			tracing::debug!(subscribe = %request_id, track = %track.name, sequence, "serving group");
 
 			let msg = ietf::GroupHeader {
 				track_alias: request_id.0,
@@ -269,7 +243,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				flags: Default::default(),
 			};
 
-			tasks.push(Self::run_group(self.session.clone(), msg, priority, group, self.version).map(|_| ()));
+			tasks.push(Self::run_group(self.session.clone(), msg, track.priority, group, self.version).map(|_| ()));
 		}
 	}
 

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -128,14 +128,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// LargestObject means "start from the latest cached group". Other filter
 		// types are still ignored (see the warn above) — TODO: full FilterType
 		// support along with FETCH wiring.
-		let start_group = matches!(msg.filter_type, FilterType::LargestObject)
-			.then(|| consumer.latest_group().map(|g| g.sequence))
+		let start = matches!(msg.filter_type, FilterType::LargestObject)
+			.then(|| consumer.latest())
 			.flatten();
 
 		let subscription = Subscription {
 			priority: msg.subscriber_priority,
 			ordered: matches!(msg.group_order, GroupOrder::Ascending),
-			start_group,
+			start,
 			..Default::default()
 		};
 

--- a/rs/moq-lite/src/ietf/subscriber.rs
+++ b/rs/moq-lite/src/ietf/subscriber.rs
@@ -462,7 +462,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	fn start_publish(&mut self, msg: &ietf::Publish<'_>) -> Result<(), Error> {
 		let request_id = msg.request_id;
 
-		let track = Track::new(msg.track_name.to_string()).produce();
+		let track = Track {
+			name: msg.track_name.to_string(),
+			priority: 0,
+		}
+		.produce();
 
 		let mut state = self.state.lock();
 		match state.subscribes.entry(request_id) {
@@ -550,10 +554,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 
 		// Write Subscribe message
-		if let Err(err) = self
-			.write_subscribe(&mut stream, request_id, &broadcast, &mut track)
-			.await
-		{
+		if let Err(err) = self.write_subscribe(&mut stream, request_id, &broadcast, &track).await {
 			tracing::debug!(%err, "failed to write subscribe");
 			self.state.lock().subscribes.remove(&request_id);
 			let _ = track.abort(err);
@@ -616,17 +617,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		stream: &mut Stream<S, Version>,
 		request_id: RequestId,
 		broadcast: &Path<'_>,
-		track: &mut TrackProducer,
+		track: &TrackProducer,
 	) -> Result<(), Error> {
-		// Wait for the first interested subscriber so the relayed SUBSCRIBE
-		// reflects the union of downstream subscribers' preferences.
-		// TODO follow `track.subscription()` and emit SUBSCRIBE_UPDATE upstream
-		// as the aggregate changes.
-		let initial = match track.subscription().await {
-			Some(sub) => sub,
-			None => return Err(Error::Cancel),
-		};
-
 		stream.writer.encode(&ietf::Subscribe::ID).await?;
 		stream
 			.writer
@@ -634,7 +626,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				request_id,
 				track_namespace: broadcast.to_owned(),
 				track_name: (&track.name).into(),
-				subscriber_priority: initial.priority,
+				subscriber_priority: track.priority,
 				group_order: GroupOrder::Descending,
 				filter_type: FilterType::LargestObject,
 			})

--- a/rs/moq-lite/src/lib.rs
+++ b/rs/moq-lite/src/lib.rs
@@ -4,7 +4,7 @@
 //! This is a simplified subset of the *official* Media over QUIC (MoQ) transport, focusing on the practical features.
 //!
 //! **NOTE**: While compatible with a subset of the IETF MoQ specification, many features are not supported on purpose.
-//! I highly highly highly recommend using `moq-lite` instead of the IETF standard.
+//! I highly highly highly recommend using `moq-lite` instead of the IETF standard until at least draft-30.
 //!
 //! ## API
 //!

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -287,22 +287,20 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let consumer = broadcast.consume_track(&track)?;
 
 		// Pick the start group: explicit, else the latest cached group.
-		let start_group = subscribe
-			.start_group
-			.or_else(|| consumer.latest_group().map(|g| g.sequence));
+		let start = subscribe.start_group.or_else(|| consumer.latest());
 		let subscriber = consumer.subscribe(Subscription {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,
 			max_latency: subscribe.max_latency,
-			start_group,
-			end_group: subscribe.end_group,
+			start,
+			end: subscribe.end_group,
 		})?;
 
 		let info = lite::SubscribeOk {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,
 			max_latency: subscribe.max_latency,
-			start_group,
+			start_group: start,
 			end_group: subscribe.end_group,
 		};
 
@@ -353,8 +351,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							priority: upd.priority,
 							ordered: upd.ordered,
 							max_latency: upd.max_latency,
-							start_group: upd.start_group,
-							end_group: upd.end_group,
+							start: upd.start_group,
+							end: upd.end_group,
 						});
 					}
 					None => break,

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -5,7 +5,7 @@ use web_async::FuturesExt;
 use web_transport_trait::Stats;
 
 use crate::{
-	AsPath, BroadcastConsumer, Error, Origin, OriginConsumer, OriginList, Subscription, Track, TrackSubscriber,
+	AsPath, BroadcastConsumer, Error, Origin, OriginConsumer, OriginList, Track, TrackConsumer,
 	coding::{Stream, Writer},
 	lite::{
 		self,
@@ -281,32 +281,30 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		priority: PriorityQueue,
 		version: Version,
 	) -> Result<(), Error> {
-		let track = Track::new(subscribe.track.to_string());
+		let track = Track {
+			name: subscribe.track.to_string(),
+			priority: subscribe.priority,
+		};
 
 		let broadcast = consumer.ok_or(Error::NotFound)?;
-		let consumer = broadcast.consume_track(&track)?;
+		let track = broadcast.subscribe_track(&track)?;
 
-		// Pick the start group: explicit, else the latest cached group.
-		let start = subscribe.start_group.or_else(|| consumer.latest());
-		let subscriber = consumer.subscribe(Subscription {
-			priority: subscribe.priority,
-			ordered: subscribe.ordered,
-			max_latency: subscribe.max_latency,
-			start,
-			end: subscribe.end_group,
-		})?;
+		// TODO wait until track.info() to get the *real* priority
 
 		let info = lite::SubscribeOk {
-			priority: subscribe.priority,
-			ordered: subscribe.ordered,
-			max_latency: subscribe.max_latency,
-			start_group: start,
-			end_group: subscribe.end_group,
+			priority: track.priority,
+			ordered: false,
+			max_latency: std::time::Duration::ZERO,
+			start_group: None,
+			end_group: None,
 		};
 
 		stream.writer.encode(&lite::SubscribeResponse::Ok(info)).await?;
 
-		Self::run_track(session, subscriber, stream, subscribe.id, priority, version).await?;
+		tokio::select! {
+			res = Self::run_track(session, track, subscribe, priority, version) => res?,
+			res = stream.reader.closed() => res?,
+		}
 
 		stream.writer.finish()?;
 		stream.writer.closed().await
@@ -314,56 +312,40 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	async fn run_track(
 		session: S,
-		mut subscriber: TrackSubscriber,
-		stream: &mut Stream<S, Version>,
-		subscribe_id: u64,
+		mut track: TrackConsumer,
+		subscribe: &lite::Subscribe<'_>,
 		priority: PriorityQueue,
 		version: Version,
 	) -> Result<(), Error> {
 		let mut tasks = FuturesUnordered::new();
 
+		// Start the consumer at the specified sequence, otherwise start at the latest group.
+		if let Some(start_group) = subscribe.start_group.or_else(|| track.latest()) {
+			track.start_at(start_group);
+		}
+
 		loop {
-			tokio::select! {
+			let group = tokio::select! {
 				// Poll all active group futures; never matches but keeps them running.
 				true = async {
 					while tasks.next().await.is_some() {}
 					false
 				} => unreachable!(),
-				group = subscriber.recv_group().transpose() => match group {
-					Some(group) => {
-						let group = group?;
-						let sequence = group.sequence;
-						tracing::debug!(subscribe = %subscribe_id, track = %subscriber.name, sequence, "serving group");
+				Some(group) = track.recv_group().transpose() => group,
+				else => return Ok(()),
+			}?;
 
-						let msg = lite::Group {
-							subscribe: subscribe_id,
-							sequence,
-						};
+			let sequence = group.sequence;
+			tracing::debug!(subscribe = %subscribe.id, track = %track.name, sequence, "serving group");
 
-						let p = priority.insert(subscriber.subscription().priority, sequence);
-						tasks.push(Self::serve_group(session.clone(), msg, p, group, version).map(|_| ()));
-					}
-					None => break,
-				},
-				upd = stream.reader.decode_maybe::<lite::SubscribeUpdate>() => match upd? {
-					Some(upd) => {
-						subscriber.update(Subscription {
-							priority: upd.priority,
-							ordered: upd.ordered,
-							max_latency: upd.max_latency,
-							start: upd.start_group,
-							end: upd.end_group,
-						});
-					}
-					None => break,
-				},
-			}
+			let msg = lite::Group {
+				subscribe: subscribe.id,
+				sequence,
+			};
+
+			let priority = priority.insert(track.priority, sequence);
+			tasks.push(Self::serve_group(session.clone(), msg, priority, group, version).map(|_| ()));
 		}
-
-		// Drain in-flight group futures so they finish writing before we close the stream.
-		while tasks.next().await.is_some() {}
-
-		Ok(())
 	}
 
 	async fn serve_group(

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -310,8 +310,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			priority: initial.priority,
 			ordered: initial.ordered,
 			max_latency: initial.max_latency,
-			start_group: initial.start_group,
-			end_group: initial.end_group,
+			start_group: initial.start,
+			end_group: initial.end,
 		};
 
 		if let Err(err) = self.run_track_stream(&mut stream, msg, track).await {
@@ -349,8 +349,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 							priority: sub.priority,
 							ordered: sub.ordered,
 							max_latency: sub.max_latency,
-							start_group: sub.start_group,
-							end_group: sub.end_group,
+							start_group: sub.start,
+							end_group: sub.end,
 						}).await?;
 					}
 					None => return Ok(()),

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -267,14 +267,22 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	async fn run_subscribe(&mut self, id: u64, broadcast: Path<'_>, mut track: TrackProducer) {
 		self.subscribes.lock().insert(id, track.clone());
 
+		let msg = lite::Subscribe {
+			id,
+			broadcast: broadcast.to_owned(),
+			track: (&track.name).into(),
+			priority: track.priority,
+			ordered: true,
+			max_latency: std::time::Duration::ZERO,
+			start_group: None,
+			end_group: None,
+		};
+
 		tracing::info!(id, broadcast = %self.log_path(&broadcast), track = %track.name, "subscribe started");
 
-		// Cancel as soon as the track has no consumers. Cloned so it doesn't conflict
-		// with `track.subscription()`'s `&mut self` borrow inside `run_track`.
-		let unused = track.clone();
 		let res = tokio::select! {
-			_ = unused.unused() => Err(Error::Cancel),
-			res = self.run_track(id, &broadcast, &mut track) => res,
+			_ = track.unused() => Err(Error::Cancel),
+			res = self.run_track(msg) => res,
 		};
 
 		match res {
@@ -293,28 +301,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 	}
 
-	async fn run_track(&mut self, id: u64, broadcast: &Path<'_>, track: &mut TrackProducer) -> Result<(), Error> {
-		// Wait for the first interested subscriber before opening an upstream
-		// SUBSCRIBE stream — relays only relay when somebody's listening.
-		let Some(initial) = track.subscription().await else {
-			return Ok(());
-		};
-
+	async fn run_track(&mut self, msg: lite::Subscribe<'_>) -> Result<(), Error> {
 		let mut stream = Stream::open(&self.session, self.version).await?;
 		stream.writer.encode(&lite::ControlType::Subscribe).await?;
 
-		let msg = lite::Subscribe {
-			id,
-			broadcast: broadcast.to_owned(),
-			track: track.name.clone().into(),
-			priority: initial.priority,
-			ordered: initial.ordered,
-			max_latency: initial.max_latency,
-			start_group: initial.start,
-			end_group: initial.end,
-		};
-
-		if let Err(err) = self.run_track_stream(&mut stream, msg, track).await {
+		if let Err(err) = self.run_track_stream(&mut stream, msg).await {
 			stream.writer.abort(&err);
 			return Err(err);
 		}
@@ -327,7 +318,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		stream: &mut Stream<S, Version>,
 		msg: lite::Subscribe<'_>,
-		track: &mut TrackProducer,
 	) -> Result<(), Error> {
 		stream.writer.encode(&msg).await?;
 
@@ -337,27 +327,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Err(Error::ProtocolViolation);
 		};
 
-		// Forward subsequent aggregate-subscription changes upstream as
-		// SUBSCRIBE_UPDATE. Exit cleanly when the upstream stream closes
-		// (PublishDone) or when no live subscribers remain.
 		// TODO handle additional SUBSCRIBE_OK and SUBSCRIBE_DROP messages.
-		loop {
-			tokio::select! {
-				sub = track.subscription() => match sub {
-					Some(sub) => {
-						stream.writer.encode(&lite::SubscribeUpdate {
-							priority: sub.priority,
-							ordered: sub.ordered,
-							max_latency: sub.max_latency,
-							start_group: sub.start,
-							end_group: sub.end,
-						}).await?;
-					}
-					None => return Ok(()),
-				},
-				res = stream.reader.closed() => return res,
-			}
-		}
+		stream.reader.closed().await?;
+
+		Ok(())
 	}
 
 	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {

--- a/rs/moq-lite/src/model/broadcast.rs
+++ b/rs/moq-lite/src/model/broadcast.rs
@@ -4,7 +4,7 @@ use std::{
 	task::{Poll, ready},
 };
 
-use crate::{Error, Subscription, TrackConsumer, TrackProducer, TrackSubscriber, model::track::TrackWeak};
+use crate::{Error, TrackConsumer, TrackProducer, model::track::TrackWeak};
 
 use super::{OriginList, Track};
 
@@ -124,7 +124,7 @@ impl BroadcastProducer {
 		}
 		drop(state);
 
-		self.create_track(Track::new(name))
+		self.create_track(Track { name, priority: 0 })
 	}
 
 	/// Create a dynamic producer that handles on-demand track requests from consumers.
@@ -311,12 +311,7 @@ impl Deref for BroadcastConsumer {
 }
 
 impl BroadcastConsumer {
-	/// Returns a fanout consumer for the given track.
-	///
-	/// Returns the cached track if it exists, otherwise routes a new request via
-	/// [`BroadcastDynamic`]. Errors with [`Error::NotFound`] when no dynamic
-	/// producer is attached.
-	pub fn consume_track(&self, track: &Track) -> Result<TrackConsumer, Error> {
+	pub fn subscribe_track(&self, track: &Track) -> Result<TrackConsumer, Error> {
 		// Upgrade to a temporary producer so we can modify the state.
 		let producer = self
 			.state
@@ -368,18 +363,6 @@ impl BroadcastConsumer {
 		Ok(consumer)
 	}
 
-	/// Subscribe to a track with the given preferences.
-	///
-	/// Convenience: calls [`Self::consume_track`] then [`TrackConsumer::subscribe`].
-	pub fn subscribe_track(&self, track: &Track, sub: Subscription) -> Result<TrackSubscriber, Error> {
-		self.consume_track(track)?.subscribe(sub)
-	}
-
-	/// Convenience: [`Self::subscribe_track`] with [`Subscription::default`].
-	pub fn subscribe_track_default(&self, track: &Track) -> Result<TrackSubscriber, Error> {
-		self.consume_track(track)?.subscribe_default()
-	}
-
 	pub async fn closed(&self) -> Error {
 		self.state.closed().await;
 		self.state.read().abort.clone().unwrap_or(Error::Dropped)
@@ -393,13 +376,8 @@ impl BroadcastConsumer {
 
 #[cfg(test)]
 impl BroadcastConsumer {
-	pub fn assert_consume_track(&self, track: &Track) -> TrackConsumer {
-		self.consume_track(track).expect("should not have errored")
-	}
-
-	pub fn assert_subscribe_track(&self, track: &Track) -> TrackSubscriber {
-		self.subscribe_track(track, Subscription::default())
-			.expect("should not have errored")
+	pub fn assert_subscribe_track(&self, track: &Track) -> TrackConsumer {
+		self.subscribe_track(track).expect("should not have errored")
 	}
 
 	pub fn assert_not_closed(&self) {
@@ -486,6 +464,9 @@ mod test {
 		let mut track3 = producer.assert_request();
 		producer.assert_no_request();
 
+		// Make sure the consumer is the same.
+		track3.consume().assert_is_clone(&track1);
+
 		// Append a group and make sure they all get it.
 		track3.append_group().unwrap();
 		track1.assert_group();
@@ -498,7 +479,7 @@ mod test {
 		// Make sure the track is errored, not closed.
 		track4.assert_error();
 
-		let track5 = consumer2.subscribe_track(&Track::new("track3"), Subscription::default());
+		let track5 = consumer2.subscribe_track(&Track::new("track3"));
 		assert!(track5.is_err(), "should have errored");
 	}
 
@@ -576,9 +557,7 @@ mod test {
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
 		// Now the cleanup task should have run and we can subscribe again to the unknown track.
-		let consumer3 = broadcast
-			.consume()
-			.subscribe_track(&Track::new("unknown_track"), Subscription::default());
+		let consumer3 = broadcast.consume().subscribe_track(&Track::new("unknown_track"));
 		let producer2 = broadcast.assert_request();
 
 		// Drop the consumer, now the producer should be unused

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -1,16 +1,14 @@
 //! A track is a collection of semi-reliable and semi-ordered streams, split into a [TrackProducer] and [TrackConsumer] handle.
 //!
 //! A [TrackProducer] creates streams with a sequence number and priority.
-//! The sequence number is used to determine the order of streams, while the priority is used to determine which stream to transmit first.
+//! The sequest number is used to determine the order of streams, while the priority is used to determine which stream to transmit first.
 //! This may seem counter-intuitive, but is designed for live streaming where the newest streams may be higher priority.
 //! A cloned [TrackProducer] can be used to create streams in parallel, but will error if a duplicate sequence number is used.
 //!
-//! A [TrackConsumer] is a fanout handle: it doesn't iterate groups itself but
-//! can be cloned, queried for cached groups by sequence, and produce a
-//! [TrackSubscriber] via [`TrackConsumer::subscribe`]. The subscriber is what
-//! delivers groups, respects the per-subscriber [`Subscription`] preferences,
-//! and feeds those preferences into the producer's aggregate so the publisher
-//! can react to subscription state (priority, latency, group range).
+//! A [TrackConsumer] may not receive all streams in order or at all.
+//! These streams are meant to be transmitted over congested networks and the key to MoQ Tranport is to not block on them.
+//! streams will be cached for a potentially limited duration added to the unreliable nature.
+//! A cloned [TrackConsumer] will receive a copy of all new stream going forward (fanout).
 //!
 //! The track is closed with [Error] when all writers or readers are dropped.
 
@@ -28,42 +26,25 @@ use std::{
 // TODO: Replace with a configurable cache size.
 const MAX_GROUP_AGE: Duration = Duration::from_secs(30);
 
-/// A track is a collection of groups, identified by name.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// A track is a collection of groups, delivered out-of-order until expired.
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Track {
 	pub name: String,
+	pub priority: u8,
 }
 
 impl Track {
 	pub fn new<T: Into<String>>(name: T) -> Self {
-		Self { name: name.into() }
+		Self {
+			name: name.into(),
+			priority: 0,
+		}
 	}
 
 	pub fn produce(self) -> TrackProducer {
 		TrackProducer::new(self)
 	}
-}
-
-/// Subscription preferences for a single subscriber.
-///
-/// Describes how groups should be delivered: priority, ordering, latency
-/// bounds, and the range of groups requested. The producer aggregates the
-/// preferences across all live subscribers so the publisher can serve the
-/// union (highest priority, lowest start, etc.).
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct Subscription {
-	pub priority: u8,
-	pub ordered: bool,
-	/// Maximum cache/latency. `Duration::ZERO` means unlimited.
-	pub max_latency: Duration,
-	/// First group sequence to deliver. `None` is treated as 0 — i.e. deliver
-	/// all cached history plus future groups. For "live from now" semantics,
-	/// pass `Some(latest + 1)` (or `Some(latest)` to include the in-flight
-	/// group). `Subscription::default()` therefore yields full history.
-	pub start: Option<u64>,
-	/// Last group sequence to deliver. `None` means no end (live).
-	pub end: Option<u64>,
 }
 
 #[derive(Default)]
@@ -75,9 +56,6 @@ struct State {
 	max_sequence: Option<u64>,
 	final_sequence: Option<u64>,
 	abort: Option<Error>,
-
-	/// Per-subscriber subscription values, read by the producer for aggregation.
-	subscriptions: Vec<conducer::Consumer<Subscription>>,
 }
 
 impl State {
@@ -218,100 +196,12 @@ impl State {
 			Poll::Pending
 		}
 	}
-
-	/// "Ready" means at least one group exists, the track is finished, or it's aborted.
-	fn poll_ready(&self) -> Poll<Result<()>> {
-		if self.max_sequence.is_some() || self.final_sequence.is_some() {
-			Poll::Ready(Ok(()))
-		} else if let Some(err) = &self.abort {
-			Poll::Ready(Err(err.clone()))
-		} else {
-			Poll::Pending
-		}
-	}
-
-	/// Aggregate the active (non-closed) subscriber preferences into a single
-	/// [`Subscription`].
-	///
-	/// Aggregation rules:
-	/// - `priority`: max across all subscribers (highest-priority wins).
-	/// - `ordered`: AND of all subscribers (true only if every subscriber requests ordered).
-	/// - `max_latency`: max across subscribers, with `Duration::ZERO` meaning unlimited (ZERO wins).
-	/// - `start`: `None` is the maximally-permissive bound (deliver from the
-	///   beginning); any subscriber with `None` yields `None`. Otherwise pick
-	///   the minimum numeric start.
-	/// - `end`: `None` is the maximally-permissive bound (no end); any
-	///   subscriber with `None` yields `None`. Otherwise pick the maximum
-	///   numeric end.
-	///
-	/// Returns `None` if there are no active subscriptions.
-	fn subscription(&self) -> Option<Subscription> {
-		if self.subscriptions.is_empty() {
-			return None;
-		}
-
-		let subs: Vec<Subscription> = self
-			.subscriptions
-			.iter()
-			.filter_map(|c| {
-				let r = c.read();
-				if r.is_closed() { None } else { Some(r.clone()) }
-			})
-			.collect();
-
-		if subs.is_empty() {
-			return None;
-		}
-
-		let priority = subs.iter().map(|s| s.priority).max().unwrap();
-		let ordered = subs.iter().all(|s| s.ordered);
-
-		let max_latency = subs
-			.iter()
-			.map(|s| s.max_latency)
-			.reduce(|a, b| {
-				if a.is_zero() || b.is_zero() {
-					Duration::ZERO
-				} else {
-					a.max(b)
-				}
-			})
-			.unwrap();
-
-		let start = subs
-			.iter()
-			.map(|s| s.start)
-			.reduce(|a, b| match (a, b) {
-				(Some(a), Some(b)) => Some(a.min(b)),
-				_ => None,
-			})
-			.unwrap();
-
-		let end = subs
-			.iter()
-			.map(|s| s.end)
-			.reduce(|a, b| match (a, b) {
-				(Some(a), Some(b)) => Some(a.max(b)),
-				_ => None,
-			})
-			.unwrap();
-
-		Some(Subscription {
-			priority,
-			ordered,
-			max_latency,
-			start,
-			end,
-		})
-	}
 }
 
 /// A producer for a track, used to create new groups.
 pub struct TrackProducer {
 	info: Track,
 	state: conducer::Producer<State>,
-	/// The last aggregate subscription returned by [`Self::poll_subscription`].
-	prev_subscription: Option<Subscription>,
 }
 
 impl std::ops::Deref for TrackProducer {
@@ -327,7 +217,6 @@ impl TrackProducer {
 		Self {
 			info,
 			state: conducer::Producer::default(),
-			prev_subscription: None,
 		}
 	}
 
@@ -443,11 +332,14 @@ impl TrackProducer {
 		Ok(())
 	}
 
-	/// Create a new consumer for the track.
+	/// Create a new consumer for the track, starting at the beginning.
 	pub fn consume(&self) -> TrackConsumer {
 		TrackConsumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
+			index: 0,
+			min_sequence: 0,
+			next_sequence: 0,
 		}
 	}
 
@@ -485,49 +377,6 @@ impl TrackProducer {
 		}
 	}
 
-	/// Poll for changes to the aggregate subscription.
-	///
-	/// Returns `Ready(Some(sub))` when the aggregate differs from the last value
-	/// returned. Returns `Ready(None)` when no subscriptions are active (or the
-	/// track is closed).
-	pub fn poll_subscription(&mut self, waiter: &conducer::Waiter) -> Poll<Option<Subscription>> {
-		let prev = self.prev_subscription.clone();
-		match self.state.poll(waiter, |state| {
-			// Drop closed subscription consumers.
-			state.subscriptions.retain(|c| !c.read().is_closed());
-
-			// Register the waiter on each per-subscriber channel so we wake when any
-			// individual subscription changes (e.g. update()).
-			for sub in &state.subscriptions {
-				let _ = sub.poll(waiter, |_| Poll::<()>::Pending);
-			}
-
-			let current = state.subscription();
-			if current != prev {
-				Poll::Ready(current)
-			} else {
-				Poll::Pending
-			}
-		}) {
-			Poll::Ready(Ok(sub)) => {
-				self.prev_subscription = sub.clone();
-				Poll::Ready(sub)
-			}
-			Poll::Ready(Err(_)) => {
-				self.prev_subscription = None;
-				Poll::Ready(None)
-			}
-			Poll::Pending => Poll::Pending,
-		}
-	}
-
-	/// Block until the aggregate subscription changes.
-	///
-	/// Returns `None` when all subscriptions are dropped or the track is closed.
-	pub async fn subscription(&mut self) -> Option<Subscription> {
-		conducer::wait(|waiter| self.poll_subscription(waiter)).await
-	}
-
 	fn modify(&self) -> Result<conducer::Mut<'_, State>> {
 		self.state
 			.write()
@@ -540,7 +389,6 @@ impl Clone for TrackProducer {
 		Self {
 			info: self.info.clone(),
 			state: self.state.clone(),
-			prev_subscription: self.prev_subscription.clone(),
 		}
 	}
 }
@@ -579,6 +427,9 @@ impl TrackWeak {
 		TrackConsumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
+			index: 0,
+			min_sequence: 0,
+			next_sequence: 0,
 		}
 	}
 
@@ -594,16 +445,18 @@ impl TrackWeak {
 	}
 }
 
-/// A consumer for a track.
-///
-/// `TrackConsumer` is a fanout handle: clone it freely, query for cached
-/// groups via [`Self::get_group`], or call [`Self::subscribe`] to get a
-/// [`TrackSubscriber`] that delivers groups respecting [`Subscription`]
-/// preferences.
+/// A consumer for a track, used to read groups.
 #[derive(Clone)]
 pub struct TrackConsumer {
 	info: Track,
 	state: conducer::Consumer<State>,
+	/// Arrival-order cursor used by [`Self::recv_group`].
+	index: usize,
+	/// Minimum sequence to return from any `recv` method. Set by [`Self::start_at`].
+	min_sequence: u64,
+	/// One past the highest sequence returned by [`Self::next_group_ordered`].
+	/// Used only by that method to skip late arrivals; does not affect [`Self::recv_group`].
+	next_sequence: u64,
 }
 
 impl std::ops::Deref for TrackConsumer {
@@ -622,39 +475,101 @@ impl TrackConsumer {
 	{
 		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
 			Ok(res) => res,
+			// We try to clone abort just in case the function forgot to check for terminal state.
 			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
 		})
 	}
 
-	/// Register a subscription and return a [`TrackSubscriber`].
+	/// Poll for the next group received over the network, in arrival order, without blocking.
 	///
-	/// The subscriber can be used right away; callers may want to call
-	/// [`TrackSubscriber::ready`] to wait until the first group exists (or
-	/// finish/abort). Dropping the subscriber removes it from the producer's
-	/// aggregate.
-	pub fn subscribe(&self, sub: Subscription) -> Result<TrackSubscriber> {
-		let sub_producer = conducer::Producer::new(sub);
-		let sub_consumer = sub_producer.consume();
+	/// Groups may arrive out of order or with gaps due to network conditions.
+	/// Use [`Self::next_group_ordered`] if you need groups in sequence order,
+	/// skipping those that arrive too late.
+	///
+	/// Returns `Poll::Ready(Ok(Some(group)))` when a group is available,
+	/// `Poll::Ready(Ok(None))` when the track is finished,
+	/// `Poll::Ready(Err(e))` when the track has been aborted, or
+	/// `Poll::Pending` when no group is available yet.
+	pub fn poll_recv_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+		let Some((consumer, found_index)) =
+			ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, self.min_sequence))?)
+		else {
+			return Poll::Ready(Ok(None));
+		};
 
-		// Insert via a weak handle so we don't bump the producer ref count and prevent auto-close.
-		// If the channel is already closed, skip — the subscriber can still drain cached groups.
-		let weak = self.state.weak();
-		if let Ok(mut state) = weak.write() {
-			state.subscriptions.push(sub_consumer);
-		}
-
-		Ok(TrackSubscriber {
-			info: self.info.clone(),
-			state: self.state.clone(),
-			sub: sub_producer,
-			index: 0,
-			next: 0,
-		})
+		self.index = found_index + 1;
+		Poll::Ready(Ok(Some(consumer)))
 	}
 
-	/// Convenience: [`Self::subscribe`] with [`Subscription::default`].
-	pub fn subscribe_default(&self) -> Result<TrackSubscriber> {
-		self.subscribe(Subscription::default())
+	/// Receive the next group available on this track, in arrival order.
+	///
+	/// Groups may arrive out of order or with gaps due to network conditions.
+	/// Use [`Self::next_group_ordered`] if you need groups in sequence order,
+	/// skipping those that arrive too late.
+	pub async fn recv_group(&mut self) -> Result<Option<GroupConsumer>> {
+		conducer::wait(|waiter| self.poll_recv_group(waiter)).await
+	}
+
+	/// Deprecated alias for [`Self::poll_recv_group`].
+	#[deprecated(note = "use poll_recv_group for arrival order, or poll_next_group_ordered for sequence order")]
+	pub fn poll_next_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+		self.poll_recv_group(waiter)
+	}
+
+	/// Deprecated alias for [`Self::recv_group`].
+	#[deprecated(note = "use recv_group for arrival order, or next_group_ordered for sequence order")]
+	pub async fn next_group(&mut self) -> Result<Option<GroupConsumer>> {
+		self.recv_group().await
+	}
+
+	/// A helper that calls [`Self::poll_recv_group`] but only returns groups with a sequence number higher than any previously returned.
+	///
+	/// NOTE: This will be renamed to `poll_next_group` in the next major version.
+	pub fn poll_next_group_ordered(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+		loop {
+			let Some(group) = ready!(self.poll_recv_group(waiter)?) else {
+				return Poll::Ready(Ok(None));
+			};
+			if group.sequence < self.next_sequence {
+				// Late arrival; discard and keep looking.
+				continue;
+			}
+			self.next_sequence = group.sequence.saturating_add(1);
+			return Poll::Ready(Ok(Some(group)));
+		}
+	}
+
+	/// Return the next group with a strictly-greater sequence number than the last returned.
+	///
+	/// Groups that arrive late (with a sequence number at or below the last one returned)
+	/// are silently skipped.
+	///
+	/// NOTE: This will be renamed to `next_group` in the next major version.
+	pub async fn next_group_ordered(&mut self) -> Result<Option<GroupConsumer>> {
+		conducer::wait(|waiter| self.poll_next_group_ordered(waiter)).await
+	}
+
+	/// A helper that calls [`Self::poll_next_group_ordered`] and returns its first frame,
+	/// skipping the rest of the group. Intended for single-frame groups (see
+	/// [`TrackProducer::write_frame`]).
+	pub fn poll_read_frame(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<bytes::Bytes>>> {
+		let lower = self.min_sequence.max(self.next_sequence);
+		let Some((frame, found_index, sequence)) =
+			ready!(self.poll(waiter, |state| { state.poll_read_frame(self.index, lower, waiter) })?)
+		else {
+			return Poll::Ready(Ok(None));
+		};
+
+		self.index = found_index + 1;
+		self.next_sequence = sequence.saturating_add(1);
+		Poll::Ready(Ok(Some(frame)))
+	}
+
+	/// Read a single full frame from the next group in sequence order.
+	///
+	/// See [`Self::poll_read_frame`] for semantics.
+	pub async fn read_frame(&mut self) -> Result<Option<bytes::Bytes>> {
+		conducer::wait(|waiter| self.poll_read_frame(waiter)).await
 	}
 
 	/// Poll for the group with the given sequence, without blocking.
@@ -686,13 +601,18 @@ impl TrackConsumer {
 	}
 
 	/// Poll for the total number of groups in the track.
-	pub fn poll_finished(&self, waiter: &conducer::Waiter) -> Poll<Result<u64>> {
+	pub fn poll_finished(&mut self, waiter: &conducer::Waiter) -> Poll<Result<u64>> {
 		self.poll(waiter, |state| state.poll_finished())
 	}
 
 	/// Block until the track is finished, returning the total number of groups.
-	pub async fn finished(&self) -> Result<u64> {
+	pub async fn finished(&mut self) -> Result<u64> {
 		conducer::wait(|waiter| self.poll_finished(waiter)).await
+	}
+
+	/// Start the consumer at the specified sequence.
+	pub fn start_at(&mut self, sequence: u64) {
+		self.min_sequence = sequence;
 	}
 
 	/// Return the latest sequence number in the track.
@@ -722,230 +642,7 @@ impl TrackConsumer {
 		Ok(TrackProducer {
 			info: self.info.clone(),
 			state,
-			prev_subscription: None,
 		})
-	}
-}
-
-/// Iterates groups from a track while managing this subscriber's lifecycle.
-///
-/// Created via [`TrackConsumer::subscribe`]. Registers a [`Subscription`] in
-/// the shared state on creation; automatically removes it on drop. The
-/// producer's aggregate reflects this subscriber's preferences as long as the
-/// subscriber is alive.
-pub struct TrackSubscriber {
-	info: Track,
-	state: conducer::Consumer<State>,
-	sub: conducer::Producer<Subscription>,
-	/// Arrival-order cursor used by [`Self::recv_group`] / [`Self::next_group`].
-	index: usize,
-	/// One past the highest sequence returned by [`Self::next_group`] /
-	/// [`Self::read_frame`]. Late arrivals below this are silently skipped by
-	/// those methods (but [`Self::recv_group`] still returns them).
-	next: u64,
-}
-
-impl std::ops::Deref for TrackSubscriber {
-	type Target = Track;
-
-	fn deref(&self) -> &Self::Target {
-		&self.info
-	}
-}
-
-impl TrackSubscriber {
-	// A helper to automatically apply Dropped if the state is closed without an error.
-	fn poll<F, R>(&self, waiter: &conducer::Waiter, f: F) -> Poll<Result<R>>
-	where
-		F: Fn(&conducer::Ref<'_, State>) -> Poll<Result<R>>,
-	{
-		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
-			Ok(res) => res,
-			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
-		})
-	}
-
-	/// Poll whether the track is "ready": has at least one group, is finished, or aborted.
-	pub fn poll_ready(&self, waiter: &conducer::Waiter) -> Poll<Result<()>> {
-		self.poll(waiter, |state| state.poll_ready())
-	}
-
-	/// Wait until the track is ready (has at least one group, is finished, or aborted).
-	pub async fn ready(&self) -> Result<()> {
-		conducer::wait(|waiter| self.poll_ready(waiter)).await
-	}
-
-	/// Poll for the next group received over the network, in arrival order.
-	///
-	/// Respects this subscriber's [`Subscription::start`] / `end` bounds.
-	/// Groups may arrive out of order or with gaps. Use [`Self::next_group`]
-	/// if you need monotonic delivery (skipping late arrivals).
-	///
-	/// Returns `Ok(None)` once the track is finished or the first group past
-	/// `end` is observed; the subscription is considered complete and further
-	/// polls will keep returning `Ok(None)`.
-	pub fn poll_recv_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
-		let sub = self.sub.read();
-		let min_sequence = sub.start.unwrap_or(0);
-		let end = sub.end;
-		drop(sub);
-
-		let Some((consumer, found_index)) =
-			ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, min_sequence))?)
-		else {
-			return Poll::Ready(Ok(None));
-		};
-
-		if let Some(end) = end
-			&& consumer.sequence > end
-		{
-			return Poll::Ready(Ok(None));
-		}
-
-		self.index = found_index + 1;
-		Poll::Ready(Ok(Some(consumer)))
-	}
-
-	/// Receive the next group available on this track, in arrival order.
-	pub async fn recv_group(&mut self) -> Result<Option<GroupConsumer>> {
-		conducer::wait(|waiter| self.poll_recv_group(waiter)).await
-	}
-
-	/// Return the next group with a strictly-greater sequence number than the last returned.
-	///
-	/// Groups that arrive late (sequence at or below the last one returned) are
-	/// silently skipped. Respects [`Subscription::start`] / `end`.
-	pub fn poll_next_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
-		let sub = self.sub.read();
-		let min_sequence = self.next.max(sub.start.unwrap_or(0));
-		let end = sub.end;
-		drop(sub);
-
-		let Some((consumer, found_index)) =
-			ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, min_sequence))?)
-		else {
-			return Poll::Ready(Ok(None));
-		};
-
-		if let Some(end) = end
-			&& consumer.sequence > end
-		{
-			return Poll::Ready(Ok(None));
-		}
-
-		self.index = found_index + 1;
-		self.next = consumer.sequence.saturating_add(1);
-		Poll::Ready(Ok(Some(consumer)))
-	}
-
-	/// Block until the next strictly-greater-sequence group is available.
-	pub async fn next_group(&mut self) -> Result<Option<GroupConsumer>> {
-		conducer::wait(|waiter| self.poll_next_group(waiter)).await
-	}
-
-	/// Deprecated alias for [`Self::poll_next_group`].
-	#[deprecated(note = "use poll_next_group")]
-	pub fn poll_next_group_ordered(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
-		self.poll_next_group(waiter)
-	}
-
-	/// Deprecated alias for [`Self::next_group`].
-	#[deprecated(note = "use next_group")]
-	pub async fn next_group_ordered(&mut self) -> Result<Option<GroupConsumer>> {
-		self.next_group().await
-	}
-
-	/// Return the first frame of the next strictly-greater-sequence group,
-	/// skipping the rest of the group. Intended for single-frame groups (see
-	/// [`TrackProducer::write_frame`]).
-	///
-	/// Respects [`Subscription::start`] / `end`.
-	pub fn poll_read_frame(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<bytes::Bytes>>> {
-		let sub = self.sub.read();
-		let lower = self.next.max(sub.start.unwrap_or(0));
-		let end = sub.end;
-		drop(sub);
-
-		let Some((frame, found_index, sequence)) =
-			ready!(self.poll(waiter, |state| { state.poll_read_frame(self.index, lower, waiter) })?)
-		else {
-			return Poll::Ready(Ok(None));
-		};
-
-		if let Some(end) = end
-			&& sequence > end
-		{
-			return Poll::Ready(Ok(None));
-		}
-
-		self.index = found_index + 1;
-		self.next = sequence.saturating_add(1);
-		Poll::Ready(Ok(Some(frame)))
-	}
-
-	/// Block until a frame is available from the next group in sequence order.
-	pub async fn read_frame(&mut self) -> Result<Option<bytes::Bytes>> {
-		conducer::wait(|waiter| self.poll_read_frame(waiter)).await
-	}
-
-	/// Update this subscription's preferences. Wakes the producer's
-	/// [`TrackProducer::poll_subscription`] if the aggregate changed.
-	pub fn update(&mut self, sub: Subscription) {
-		if let Ok(mut guard) = self.sub.write() {
-			*guard = sub;
-		}
-	}
-
-	/// Read this subscriber's current preferences.
-	pub fn subscription(&self) -> Subscription {
-		self.sub.read().clone()
-	}
-
-	/// Return the latest sequence number in the track.
-	pub fn latest(&self) -> Option<u64> {
-		self.state.read().max_sequence
-	}
-
-	/// Poll for the group with the given sequence, without blocking.
-	pub fn poll_get_group(&self, waiter: &conducer::Waiter, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
-		self.poll(waiter, |state| state.poll_get_group(sequence))
-	}
-
-	/// Block until the group with the given sequence is available.
-	pub async fn get_group(&self, sequence: u64) -> Result<Option<GroupConsumer>> {
-		conducer::wait(|waiter| self.poll_get_group(waiter, sequence)).await
-	}
-
-	/// Poll for track closure, without blocking.
-	pub fn poll_closed(&self, waiter: &conducer::Waiter) -> Poll<Result<()>> {
-		self.poll(waiter, |state| state.poll_closed())
-	}
-
-	/// Block until the track is closed.
-	pub async fn closed(&self) -> Result<()> {
-		conducer::wait(|waiter| self.poll_closed(waiter)).await
-	}
-
-	/// Poll for the total number of groups in the track.
-	pub fn poll_finished(&self, waiter: &conducer::Waiter) -> Poll<Result<u64>> {
-		self.poll(waiter, |state| state.poll_finished())
-	}
-
-	/// Block until the track is finished.
-	pub async fn finished(&self) -> Result<u64> {
-		conducer::wait(|waiter| self.poll_finished(waiter)).await
-	}
-
-	pub fn is_clone(&self, other: &Self) -> bool {
-		self.state.same_channel(&other.state)
-	}
-}
-
-impl Drop for TrackSubscriber {
-	fn drop(&mut self) {
-		// Closing the per-subscriber channel marks it as closed so the producer's
-		// aggregator drops it on the next poll.
-		let _ = self.sub.close();
 	}
 }
 
@@ -953,7 +650,7 @@ impl Drop for TrackSubscriber {
 use futures::FutureExt;
 
 #[cfg(test)]
-impl TrackSubscriber {
+impl TrackConsumer {
 	pub fn assert_group(&mut self) -> GroupConsumer {
 		self.recv_group()
 			.now_or_never()
@@ -977,26 +674,12 @@ impl TrackSubscriber {
 		assert!(self.closed().now_or_never().is_some(), "should be closed");
 	}
 
+	// TODO assert specific errors after implementing PartialEq
 	pub fn assert_error(&self) {
 		assert!(
 			self.closed().now_or_never().expect("should not block").is_err(),
 			"should be error"
 		);
-	}
-
-	pub fn assert_is_clone(&self, other: &Self) {
-		assert!(self.is_clone(other), "should be clone");
-	}
-
-	pub fn assert_not_clone(&self, other: &Self) {
-		assert!(!self.is_clone(other), "should not be clone");
-	}
-}
-
-#[cfg(test)]
-impl TrackConsumer {
-	pub fn assert_subscribe(&self) -> TrackSubscriber {
-		self.subscribe_default().expect("subscribe should not have errored")
 	}
 
 	pub fn assert_is_clone(&self, other: &Self) {
@@ -1028,6 +711,7 @@ mod test {
 
 		let mut producer = Track::new("test").produce();
 
+		// Create 3 groups at time 0.
 		producer.append_group().unwrap(); // seq 0
 		producer.append_group().unwrap(); // seq 1
 		producer.append_group().unwrap(); // seq 2
@@ -1038,10 +722,14 @@ mod test {
 			assert_eq!(state.offset, 0);
 		}
 
+		// Advance time past the eviction threshold.
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
+		// Append a new group to trigger eviction.
 		producer.append_group().unwrap(); // seq 3
 
+		// Groups 0, 1, 2 are expired but seq 3 (max_sequence) is kept.
+		// Leading tombstones are trimmed, so only seq 3 remains.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 1);
@@ -1059,11 +747,13 @@ mod test {
 		tokio::time::pause();
 
 		let mut producer = Track::new("test").produce();
-		producer.append_group().unwrap();
+		producer.append_group().unwrap(); // seq 0
 
+		// Advance time past threshold.
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
-		producer.append_group().unwrap();
+		// Append another group; seq 0 is expired and evicted.
+		producer.append_group().unwrap(); // seq 1
 
 		{
 			let state = producer.state.read();
@@ -1078,9 +768,9 @@ mod test {
 		tokio::time::pause();
 
 		let mut producer = Track::new("test").produce();
-		producer.append_group().unwrap();
-		producer.append_group().unwrap();
-		producer.append_group().unwrap();
+		producer.append_group().unwrap(); // seq 0
+		producer.append_group().unwrap(); // seq 1
+		producer.append_group().unwrap(); // seq 2
 
 		{
 			let state = producer.state.read();
@@ -1090,20 +780,19 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn subscriber_skips_evicted_groups() {
+	async fn consumer_skips_evicted_groups() {
 		tokio::time::pause();
 
 		let mut producer = Track::new("test").produce();
 		producer.append_group().unwrap(); // seq 0
 
-		let consumer = producer.consume();
-		let mut subscriber = consumer.assert_subscribe();
+		let mut consumer = producer.consume();
 
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 		producer.append_group().unwrap(); // seq 1
 
-		// Group 0 was evicted. Subscriber should get group 1.
-		let group = subscriber.assert_group();
+		// Group 0 was evicted. Consumer should get group 1.
+		let group = consumer.assert_group();
 		assert_eq!(group.sequence, 1);
 	}
 
@@ -1113,19 +802,25 @@ mod test {
 
 		let mut producer = Track::new("test").produce();
 
+		// Arrive out of order: seq 5 first, then 3, then 4.
 		producer.create_group(Group { sequence: 5 }).unwrap();
 		producer.create_group(Group { sequence: 3 }).unwrap();
 		producer.create_group(Group { sequence: 4 }).unwrap();
 
+		// max_sequence = 5, which is at the front of the VecDeque.
 		{
 			let state = producer.state.read();
 			assert_eq!(state.max_sequence, Some(5));
 		}
 
+		// Expire all three groups.
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
+		// Append seq 6 (becomes new max_sequence).
 		producer.append_group().unwrap(); // seq 6
 
+		// Seq 3, 4, 5 are all expired. Seq 5 was the old max_sequence but now 6 is.
+		// All old groups are evicted.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 1);
@@ -1143,22 +838,32 @@ mod test {
 
 		let mut producer = Track::new("test").produce();
 
+		// Arrive: seq 5, then seq 3.
 		producer.create_group(Group { sequence: 5 }).unwrap();
 
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
+		// Seq 3 arrives late; max_sequence is still 5 (at front).
 		producer.create_group(Group { sequence: 3 }).unwrap();
 
+		// Seq 5 is max_sequence (protected). Seq 3 is not expired (just created).
+		// Nothing should be evicted.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 2);
 			assert_eq!(state.offset, 0);
 		}
 
+		// Expire seq 3 as well.
 		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
 
+		// Seq 2 arrives late, triggering eviction.
 		producer.create_group(Group { sequence: 2 }).unwrap();
 
+		// Seq 5 is still max_sequence (protected, at front, blocks trim).
+		// Seq 3 is expired → tombstoned.
+		// Seq 2 is fresh → kept.
+		// VecDeque: [Some(5), None, Some(2)]. Leading entry is Some, so offset stays.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 2);
@@ -1168,9 +873,10 @@ mod test {
 			assert!(state.duplicates.contains(&2));
 		}
 
-		let mut subscriber = producer.consume().assert_subscribe();
-		let group = subscriber.assert_group();
-		// First non-tombstoned group is seq 5.
+		// Consumer should still be able to read through the hole.
+		let mut consumer = producer.consume();
+		let group = consumer.assert_group();
+		// consume() starts at index 0, first non-tombstoned group is seq 5.
 		assert_eq!(group.sequence, 5);
 	}
 
@@ -1178,6 +884,7 @@ mod test {
 	fn append_finish_cannot_be_rewritten() {
 		let mut producer = Track::new("test").produce();
 
+		// Finishing an empty track is valid (fin = 0, total groups = 0).
 		assert!(producer.finish().is_ok());
 		assert!(producer.finish().is_err());
 		assert!(producer.append_group().is_err());
@@ -1218,10 +925,10 @@ mod test {
 		producer.create_group(Group { sequence: 1 }).unwrap();
 		producer.finish_at(1).unwrap();
 
-		let mut subscriber = producer.consume().assert_subscribe();
-		assert_eq!(subscriber.assert_group().sequence, 1);
+		let mut consumer = producer.consume();
+		assert_eq!(consumer.assert_group().sequence, 1);
 
-		let done = subscriber
+		let done = consumer
 			.recv_group()
 			.now_or_never()
 			.expect("should not block")
@@ -1230,56 +937,61 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn next_group_skips_late_arrivals() {
+	async fn next_group_ordered_skips_late_arrivals() {
 		let mut producer = Track::new("test").produce();
-		let mut subscriber = producer.consume().assert_subscribe();
+		let mut consumer = producer.consume();
 
+		// Seq 5 arrives first.
 		producer.create_group(Group { sequence: 5 }).unwrap();
-		let group = subscriber
-			.next_group()
+		let group = consumer
+			.next_group_ordered()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
 			.expect("track should not be closed");
 		assert_eq!(group.sequence, 5);
 
-		// Late arrivals are skipped.
+		// Seq 3 arrives late — skipped because 3 <= 5.
 		producer.create_group(Group { sequence: 3 }).unwrap();
+		// Seq 4 arrives late — also skipped.
 		producer.create_group(Group { sequence: 4 }).unwrap();
+		// Seq 7 arrives — returned.
 		producer.create_group(Group { sequence: 7 }).unwrap();
 
-		let group = subscriber
-			.next_group()
+		let group = consumer
+			.next_group_ordered()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
 			.expect("track should not be closed");
 		assert_eq!(group.sequence, 7);
 
+		// No more groups — would block.
 		assert!(
-			subscriber.next_group().now_or_never().is_none(),
+			consumer.next_group_ordered().now_or_never().is_none(),
 			"should block waiting for a higher sequence"
 		);
 	}
 
 	#[tokio::test]
-	async fn next_group_returns_arrivals_in_order() {
+	async fn next_group_ordered_returns_arrivals_in_order() {
 		let mut producer = Track::new("test").produce();
-		let mut subscriber = producer.consume().assert_subscribe();
+		let mut consumer = producer.consume();
 
+		// Seq 3 arrives first, then seq 5 — both should be returned in arrival order.
 		producer.create_group(Group { sequence: 3 }).unwrap();
 		producer.create_group(Group { sequence: 5 }).unwrap();
 
-		let group = subscriber
-			.next_group()
+		let group = consumer
+			.next_group_ordered()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
 			.expect("track should not be closed");
 		assert_eq!(group.sequence, 3);
 
-		let group = subscriber
-			.next_group()
+		let group = consumer
+			.next_group_ordered()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
@@ -1288,42 +1000,36 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn recv_group_after_next_group_sees_late_arrivals() {
+	async fn recv_group_after_next_group_ordered_sees_late_arrivals() {
 		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-		let mut ordered = consumer.assert_subscribe();
-		let mut arrival = consumer.assert_subscribe();
+		let mut consumer = producer.consume();
 
 		producer.create_group(Group { sequence: 5 }).unwrap();
 		producer.create_group(Group { sequence: 3 }).unwrap();
 
-		// Ordered subscriber sees seq 5 and skips the late seq 3.
-		let group = ordered
-			.next_group()
+		// Ordered returns seq 5 and advances its internal cursor past it.
+		let group = consumer
+			.next_group_ordered()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
 			.expect("track should not be closed");
 		assert_eq!(group.sequence, 5);
-		assert!(
-			ordered.next_group().now_or_never().is_none(),
-			"ordered should block waiting for >5"
-		);
 
-		// Arrival-order subscriber sees both, in arrival order.
-		assert_eq!(arrival.assert_group().sequence, 5);
-		assert_eq!(arrival.assert_group().sequence, 3);
+		// Intermixing: recv_group on the same consumer still returns the late seq 3.
+		// The ordered cursor is separate from the recv_group filter.
+		assert_eq!(consumer.assert_group().sequence, 3);
 	}
 
 	#[tokio::test]
 	async fn read_frame_returns_single_frame_per_group() {
 		let mut producer = Track::new("test").produce();
-		let mut subscriber = producer.consume().assert_subscribe();
+		let mut consumer = producer.consume();
 
 		producer.write_frame(b"hello".as_slice()).unwrap();
 		producer.write_frame(b"world".as_slice()).unwrap();
 
-		let frame = subscriber
+		let frame = consumer
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1331,7 +1037,7 @@ mod test {
 			.expect("track should not be closed");
 		assert_eq!(&frame[..], b"hello");
 
-		let frame = subscriber
+		let frame = consumer
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1343,14 +1049,17 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_skips_stalled_group_for_newer_ready_frame() {
 		let mut producer = Track::new("test").produce();
-		let mut subscriber = producer.consume().assert_subscribe();
+		let mut consumer = producer.consume();
 
+		// Seq 3: group open, no frame yet (stalled).
 		let _stalled = producer.create_group(Group { sequence: 3 }).unwrap();
+		// Seq 5: fully-written group with a frame.
 		let mut g5 = producer.create_group(Group { sequence: 5 }).unwrap();
 		g5.write_frame(bytes::Bytes::from_static(b"later")).unwrap();
 		g5.finish().unwrap();
 
-		let frame = subscriber
+		// read_frame should not block on the stalled seq 3 — it returns seq 5's frame.
+		let frame = consumer
 			.read_frame()
 			.now_or_never()
 			.expect("should not block on stalled earlier group")
@@ -1362,16 +1071,18 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_discards_rest_of_multi_frame_group() {
 		let mut producer = Track::new("test").produce();
-		let mut subscriber = producer.consume().assert_subscribe();
+		let mut consumer = producer.consume();
 
+		// Group 0 has two frames; only the first is returned.
 		let mut g0 = producer.create_group(Group { sequence: 0 }).unwrap();
 		g0.write_frame(bytes::Bytes::from_static(b"one")).unwrap();
 		g0.write_frame(bytes::Bytes::from_static(b"two")).unwrap();
 		g0.finish().unwrap();
 
+		// Group 1 is a normal single-frame group.
 		producer.write_frame(b"next".as_slice()).unwrap();
 
-		let frame = subscriber
+		let frame = consumer
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1379,7 +1090,8 @@ mod test {
 			.expect("track should not be closed");
 		assert_eq!(&frame[..], b"one");
 
-		let frame = subscriber
+		// The second frame of group 0 is discarded; the next read jumps to group 1.
+		let frame = consumer
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1390,19 +1102,23 @@ mod test {
 
 	#[tokio::test]
 	async fn read_frame_waits_for_pending_group_after_finish() {
+		// finish() sets final_sequence, but groups already created with lower sequences
+		// can still produce frames. read_frame must not return None prematurely.
 		let mut producer = Track::new("test").produce();
-		let mut subscriber = producer.consume().assert_subscribe();
+		let mut consumer = producer.consume();
 
 		let mut g0 = producer.create_group(Group { sequence: 0 }).unwrap();
 		producer.finish().unwrap();
 
+		// Track is finished but group 0 has no frame yet — must block, not return None.
 		assert!(
-			subscriber.read_frame().now_or_never().is_none(),
+			consumer.read_frame().now_or_never().is_none(),
 			"read_frame must block on a pending group even after finish()"
 		);
 
+		// A late frame on the pending group is still delivered.
 		g0.write_frame(bytes::Bytes::from_static(b"late")).unwrap();
-		let frame = subscriber
+		let frame = consumer
 			.read_frame()
 			.now_or_never()
 			.expect("should not block once a frame is written")
@@ -1412,16 +1128,14 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn read_frame_respects_subscription_start() {
+	async fn read_frame_respects_start_at() {
+		// start_at sets min_sequence; read_frame must skip groups below it even though
+		// next_sequence is still 0.
 		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-		let mut subscriber = consumer
-			.subscribe(Subscription {
-				start: Some(5),
-				..Default::default()
-			})
-			.unwrap();
+		let mut consumer = producer.consume();
+		consumer.start_at(5);
 
+		// Seq 3 has a frame but is below min_sequence — must be skipped.
 		let mut g3 = producer.create_group(Group { sequence: 3 }).unwrap();
 		g3.write_frame(bytes::Bytes::from_static(b"skip-me")).unwrap();
 		g3.finish().unwrap();
@@ -1430,7 +1144,7 @@ mod test {
 		g5.write_frame(bytes::Bytes::from_static(b"keep")).unwrap();
 		g5.finish().unwrap();
 
-		let frame = subscriber
+		let frame = consumer
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1442,12 +1156,12 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_returns_none_when_finished() {
 		let mut producer = Track::new("test").produce();
-		let mut subscriber = producer.consume().assert_subscribe();
+		let mut consumer = producer.consume();
 
 		producer.write_frame(b"only".as_slice()).unwrap();
 		producer.finish().unwrap();
 
-		let frame = subscriber
+		let frame = consumer
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1455,7 +1169,7 @@ mod test {
 			.expect("track should not be closed");
 		assert_eq!(&frame[..], b"only");
 
-		let done = subscriber
+		let done = consumer
 			.read_frame()
 			.now_or_never()
 			.expect("should not block")
@@ -1470,6 +1184,7 @@ mod test {
 		producer.finish_at(1).unwrap();
 
 		let consumer = producer.consume();
+		// get_group(0) blocks because group 0 is below final_sequence and could still arrive.
 		assert!(
 			consumer.get_group(0).now_or_never().is_none(),
 			"sequence below fin should block (group could still arrive)"
@@ -1503,13 +1218,15 @@ mod test {
 
 		let consumer = producer.consume();
 
+		// Upgrade consumer back to producer — shared state.
 		let got = consumer.produce().expect("should produce");
 		assert!(got.is_clone(&producer), "should be the same track");
 
+		// Writing through the upgraded producer is visible to new consumers.
 		got.clone().append_group().unwrap();
-		let mut subscriber = producer.consume().assert_subscribe();
-		subscriber.assert_group(); // group 0
-		subscriber.assert_group(); // group 1
+		let mut sub = producer.consume();
+		sub.assert_group(); // group 0
+		sub.assert_group(); // group 1, written via upgraded producer
 	}
 
 	#[tokio::test]
@@ -1518,6 +1235,8 @@ mod test {
 		let consumer = producer.consume();
 		drop(producer);
 
+		// Original producer dropped. Consumer's produce() should fail
+		// because there are no remaining producers.
 		let err = consumer.produce();
 		assert!(matches!(err, Err(Error::Dropped)), "expected Dropped");
 	}
@@ -1529,6 +1248,7 @@ mod test {
 		producer.abort(Error::Cancel).unwrap();
 		drop(producer);
 
+		// Track was aborted — produce() should return the abort error, not Dropped.
 		let err = consumer.produce();
 		assert!(matches!(err, Err(Error::Cancel)), "expected Cancel");
 	}
@@ -1540,227 +1260,11 @@ mod test {
 		let upgraded = consumer.produce().expect("should produce");
 		drop(producer);
 
+		// Channel still open because upgraded producer exists.
 		assert!(consumer.closed().now_or_never().is_none(), "should not be closed");
 		drop(upgraded);
 
+		// Now it should close.
 		assert!(consumer.closed().now_or_never().is_some(), "should be closed");
-	}
-
-	#[tokio::test]
-	async fn aggregate_subscription_priority_max() {
-		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-
-		let _a = consumer
-			.subscribe(Subscription {
-				priority: 1,
-				..Default::default()
-			})
-			.unwrap();
-		let _b = consumer
-			.subscribe(Subscription {
-				priority: 5,
-				..Default::default()
-			})
-			.unwrap();
-
-		let agg = producer
-			.subscription()
-			.now_or_never()
-			.expect("should not block")
-			.expect("aggregate should exist");
-		assert_eq!(agg.priority, 5);
-		assert!(!agg.ordered);
-	}
-
-	#[tokio::test]
-	async fn aggregate_subscription_ordered_and() {
-		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-
-		let _a = consumer
-			.subscribe(Subscription {
-				ordered: true,
-				..Default::default()
-			})
-			.unwrap();
-		let _b = consumer
-			.subscribe(Subscription {
-				ordered: false,
-				..Default::default()
-			})
-			.unwrap();
-
-		let agg = producer
-			.subscription()
-			.now_or_never()
-			.expect("should not block")
-			.expect("aggregate should exist");
-		assert!(!agg.ordered, "ordered should be AND of all");
-	}
-
-	#[tokio::test]
-	async fn aggregate_subscription_max_latency_zero_wins() {
-		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-
-		let _a = consumer
-			.subscribe(Subscription {
-				max_latency: Duration::from_secs(1),
-				..Default::default()
-			})
-			.unwrap();
-		let _b = consumer
-			.subscribe(Subscription {
-				max_latency: Duration::ZERO,
-				..Default::default()
-			})
-			.unwrap();
-
-		let agg = producer
-			.subscription()
-			.now_or_never()
-			.expect("should not block")
-			.expect("aggregate should exist");
-		assert_eq!(agg.max_latency, Duration::ZERO, "ZERO (unlimited) should win");
-	}
-
-	#[tokio::test]
-	async fn aggregate_subscription_start_min_end_max() {
-		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-
-		let _a = consumer
-			.subscribe(Subscription {
-				start: Some(5),
-				end: Some(20),
-				..Default::default()
-			})
-			.unwrap();
-		let _b = consumer
-			.subscribe(Subscription {
-				start: Some(3),
-				end: Some(10),
-				..Default::default()
-			})
-			.unwrap();
-
-		let agg = producer
-			.subscription()
-			.now_or_never()
-			.expect("should not block")
-			.expect("aggregate should exist");
-		assert_eq!(agg.start, Some(3));
-		assert_eq!(agg.end, Some(20));
-	}
-
-	#[tokio::test]
-	async fn aggregate_subscription_none_wins_over_some() {
-		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-
-		// One concrete bound, one unbounded — the unbounded subscriber wants the full range,
-		// so the aggregate must be unbounded too.
-		let _a = consumer
-			.subscribe(Subscription {
-				start: Some(5),
-				end: Some(20),
-				..Default::default()
-			})
-			.unwrap();
-		let _b = consumer.subscribe(Subscription::default()).unwrap();
-
-		let agg = producer
-			.subscription()
-			.now_or_never()
-			.expect("should not block")
-			.expect("aggregate should exist");
-		assert_eq!(agg.start, None, "None subscriber wants from the beginning");
-		assert_eq!(agg.end, None, "None subscriber wants no end");
-	}
-
-	#[tokio::test]
-	async fn aggregate_subscription_drops_on_subscriber_drop() {
-		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-
-		let a = consumer
-			.subscribe(Subscription {
-				priority: 1,
-				..Default::default()
-			})
-			.unwrap();
-
-		// First poll establishes the baseline.
-		let agg = producer
-			.subscription()
-			.now_or_never()
-			.expect("should not block")
-			.expect("aggregate should exist");
-		assert_eq!(agg.priority, 1);
-
-		drop(a);
-
-		// After the only subscriber drops, the aggregate becomes None on next change.
-		let agg = producer.subscription().now_or_never().expect("should not block");
-		assert!(agg.is_none(), "no live subscribers should yield None");
-	}
-
-	#[tokio::test]
-	async fn aggregate_subscription_reflects_update() {
-		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-
-		let mut sub = consumer
-			.subscribe(Subscription {
-				priority: 1,
-				..Default::default()
-			})
-			.unwrap();
-
-		let agg = producer
-			.subscription()
-			.now_or_never()
-			.expect("should not block")
-			.expect("aggregate should exist");
-		assert_eq!(agg.priority, 1);
-
-		sub.update(Subscription {
-			priority: 7,
-			..Default::default()
-		});
-
-		let agg = producer
-			.subscription()
-			.now_or_never()
-			.expect("should not block")
-			.expect("aggregate should exist");
-		assert_eq!(agg.priority, 7);
-	}
-
-	#[tokio::test]
-	async fn recv_group_respects_end_bound() {
-		let mut producer = Track::new("test").produce();
-		let consumer = producer.consume();
-		let mut subscriber = consumer
-			.subscribe(Subscription {
-				end: Some(2),
-				..Default::default()
-			})
-			.unwrap();
-
-		producer.create_group(Group { sequence: 1 }).unwrap();
-		producer.create_group(Group { sequence: 2 }).unwrap();
-		producer.create_group(Group { sequence: 3 }).unwrap();
-
-		assert_eq!(subscriber.assert_group().sequence, 1);
-		assert_eq!(subscriber.assert_group().sequence, 2);
-		// Group 3 is past `end`; subscriber should treat the stream as done.
-		let done = subscriber
-			.recv_group()
-			.now_or_never()
-			.expect("should not block")
-			.expect("would have errored");
-		assert!(done.is_none(), "groups past end should yield None");
 	}
 }

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -61,9 +61,9 @@ pub struct Subscription {
 	/// all cached history plus future groups. For "live from now" semantics,
 	/// pass `Some(latest + 1)` (or `Some(latest)` to include the in-flight
 	/// group). `Subscription::default()` therefore yields full history.
-	pub start_group: Option<u64>,
+	pub start: Option<u64>,
 	/// Last group sequence to deliver. `None` means no end (live).
-	pub end_group: Option<u64>,
+	pub end: Option<u64>,
 }
 
 #[derive(Default)]
@@ -78,15 +78,6 @@ struct State {
 
 	/// Per-subscriber subscription values, read by the producer for aggregation.
 	subscriptions: Vec<conducer::Consumer<Subscription>>,
-
-	/// Pending fetch requests waiting for a [`TrackDynamic`] to fulfill them.
-	/// Each entry is a freshly-minted [`GroupProducer`] for the requested
-	/// sequence; the dynamic handler pops it and fills frames.
-	fetch_requests: VecDeque<GroupProducer>,
-
-	/// Number of live [`TrackDynamic`] instances. When 0, fetch requests for
-	/// uncached groups fail with [`Error::NotFound`].
-	dynamic_groups: usize,
 }
 
 impl State {
@@ -155,6 +146,28 @@ impl State {
 		} else {
 			Poll::Pending
 		}
+	}
+
+	fn poll_get_group(&self, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
+		// Search for the group with the matching sequence, skipping tombstones.
+		for (group, _) in self.groups.iter().flatten() {
+			if group.sequence == sequence {
+				return Poll::Ready(Ok(Some(group.consume())));
+			}
+		}
+
+		// Once final_sequence is set, groups at or past it can never exist.
+		if let Some(fin) = self.final_sequence
+			&& sequence >= fin
+		{
+			return Poll::Ready(Ok(None));
+		}
+
+		if let Some(err) = &self.abort {
+			return Poll::Ready(Err(err.clone()));
+		}
+
+		Poll::Pending
 	}
 
 	fn poll_closed(&self) -> Poll<Result<()>> {
@@ -265,18 +278,18 @@ impl State {
 			})
 			.unwrap();
 
-		let start_group = subs
+		let start = subs
 			.iter()
-			.map(|s| s.start_group)
+			.map(|s| s.start)
 			.reduce(|a, b| match (a, b) {
 				(Some(a), Some(b)) => Some(a.min(b)),
 				_ => None,
 			})
 			.unwrap();
 
-		let end_group = subs
+		let end = subs
 			.iter()
-			.map(|s| s.end_group)
+			.map(|s| s.end)
 			.reduce(|a, b| match (a, b) {
 				(Some(a), Some(b)) => Some(a.max(b)),
 				_ => None,
@@ -287,8 +300,8 @@ impl State {
 			priority,
 			ordered,
 			max_latency,
-			start_group,
-			end_group,
+			start,
+			end,
 		})
 	}
 }
@@ -438,16 +451,6 @@ impl TrackProducer {
 		}
 	}
 
-	/// Opt in to handling FETCH requests for groups not in the cache.
-	///
-	/// While at least one [`TrackDynamic`] is held, [`TrackConsumer::get_group`]
-	/// can route uncached requests to the publisher. When all dynamics are
-	/// dropped, pending requests are aborted and future uncached fetches return
-	/// [`Error::NotFound`].
-	pub fn dynamic(&self) -> TrackDynamic {
-		TrackDynamic::new(self.info.clone(), self.state.clone())
-	}
-
 	/// Block until there are no active consumers.
 	pub async fn unused(&self) -> Result<()> {
 		self.state
@@ -545,103 +548,6 @@ impl Clone for TrackProducer {
 impl From<Track> for TrackProducer {
 	fn from(info: Track) -> Self {
 		TrackProducer::new(info)
-	}
-}
-
-/// Handles on-demand group fetches for a track.
-///
-/// Created via [`TrackProducer::dynamic`]. While alive, [`TrackConsumer::get_group`]
-/// requests for uncached groups are queued for the dynamic handler to fulfill
-/// via [`Self::requested_group`]. Dropping the last dynamic aborts any pending
-/// requests with [`Error::Cancel`].
-pub struct TrackDynamic {
-	info: Track,
-	state: conducer::Producer<State>,
-}
-
-impl Clone for TrackDynamic {
-	fn clone(&self) -> Self {
-		Self::new(self.info.clone(), self.state.clone())
-	}
-}
-
-impl std::ops::Deref for TrackDynamic {
-	type Target = Track;
-
-	fn deref(&self) -> &Self::Target {
-		&self.info
-	}
-}
-
-impl TrackDynamic {
-	fn new(info: Track, state: conducer::Producer<State>) -> Self {
-		if let Ok(mut state) = state.write() {
-			state.dynamic_groups += 1;
-		}
-		Self { info, state }
-	}
-
-	fn poll<F, R>(&self, waiter: &conducer::Waiter, f: F) -> Poll<Result<R>>
-	where
-		F: FnMut(&mut conducer::Mut<'_, State>) -> Poll<R>,
-	{
-		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
-			Ok(r) => Ok(r),
-			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
-		})
-	}
-
-	/// Poll for the next pending fetch request.
-	///
-	/// Yields a [`GroupProducer`] the publisher fills in. The producer's
-	/// `sequence` is the requested group number.
-	pub fn poll_requested_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<GroupProducer>> {
-		self.poll(waiter, |state| match state.fetch_requests.pop_front() {
-			Some(producer) => Poll::Ready(producer),
-			None => Poll::Pending,
-		})
-	}
-
-	/// Block until a consumer requests a group, returning its producer.
-	pub async fn requested_group(&mut self) -> Result<GroupProducer> {
-		conducer::wait(|waiter| self.poll_requested_group(waiter)).await
-	}
-
-	/// Return true if this is the same dynamic instance.
-	pub fn is_clone(&self, other: &Self) -> bool {
-		self.state.same_channel(&other.state)
-	}
-}
-
-impl Drop for TrackDynamic {
-	fn drop(&mut self) {
-		if let Ok(mut state) = self.state.write() {
-			state.dynamic_groups = state.dynamic_groups.saturating_sub(1);
-			if state.dynamic_groups != 0 {
-				return;
-			}
-
-			// No remaining handler; cancel any pending requests.
-			for mut request in state.fetch_requests.drain(..) {
-				request.abort(Error::Cancel).ok();
-			}
-		}
-	}
-}
-
-#[cfg(test)]
-impl TrackDynamic {
-	pub fn assert_request(&mut self) -> GroupProducer {
-		use futures::FutureExt;
-		self.requested_group()
-			.now_or_never()
-			.expect("should not have blocked")
-			.expect("should not have errored")
-	}
-
-	pub fn assert_no_request(&mut self) {
-		use futures::FutureExt;
-		assert!(self.requested_group().now_or_never().is_none(), "should have blocked");
 	}
 }
 
@@ -751,6 +657,18 @@ impl TrackConsumer {
 		self.subscribe(Subscription::default())
 	}
 
+	/// Poll for the group with the given sequence, without blocking.
+	pub fn poll_get_group(&self, waiter: &conducer::Waiter, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
+		self.poll(waiter, |state| state.poll_get_group(sequence))
+	}
+
+	/// Block until the group with the given sequence is available.
+	///
+	/// Returns None if the group is not in the cache and a newer group exists.
+	pub async fn get_group(&self, sequence: u64) -> Result<Option<GroupConsumer>> {
+		conducer::wait(|waiter| self.poll_get_group(waiter, sequence)).await
+	}
+
 	/// Poll for track closure, without blocking.
 	pub fn poll_closed(&self, waiter: &conducer::Waiter) -> Poll<Result<()>> {
 		self.poll(waiter, |state| state.poll_closed())
@@ -777,68 +695,9 @@ impl TrackConsumer {
 		conducer::wait(|waiter| self.poll_finished(waiter)).await
 	}
 
-	/// Return the latest cached group, if any.
-	pub fn latest_group(&self) -> Option<GroupConsumer> {
-		let state = self.state.read();
-		let max = state.max_sequence?;
-		state
-			.groups
-			.iter()
-			.flatten()
-			.find_map(|(g, _)| (g.sequence == max).then(|| g.consume()))
-	}
-
-	/// Get a specific group.
-	///
-	/// - Cache hit → returns the cached consumer (a [`TrackDynamic`] handler is not required).
-	/// - Cache miss + no [`TrackDynamic`] handler → returns [`Error::NotFound`].
-	/// - Cache miss + handler present → routes a request to the producer; returns
-	///   a [`GroupConsumer`] that fills in as the publisher writes frames. Errors
-	///   later if the publisher aborts/declines (e.g. group is past final).
-	pub fn get_group(&self, info: Group) -> Result<GroupConsumer> {
-		let sequence = info.sequence;
-
-		// Upgrade to a temporary producer so we can mutate the state.
-		let producer = self
-			.state
-			.produce()
-			.ok_or_else(|| self.state.read().abort.clone().unwrap_or(Error::Dropped))?;
-
-		let mut state = producer
-			.write()
-			.map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))?;
-
-		// Cache hit: always return, regardless of dynamic handler state.
-		for (group, _) in state.groups.iter().flatten() {
-			if group.sequence == sequence {
-				return Ok(group.consume());
-			}
-		}
-
-		// Track is finalized: groups at/after the final boundary can never exist,
-		// so fail fast instead of queueing an impossible request.
-		if let Some(fin) = state.final_sequence
-			&& sequence >= fin
-		{
-			return Err(Error::NotFound);
-		}
-
-		if state.dynamic_groups == 0 {
-			return Err(Error::NotFound);
-		}
-
-		// Queue a request for the dynamic handler; cache the producer so
-		// concurrent fetches for the same sequence share frames.
-		let group = info.produce();
-		let consumer = group.consume();
-		let now = tokio::time::Instant::now();
-		state.duplicates.insert(sequence);
-		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(sequence));
-		state.groups.push_back(Some((group.clone(), now)));
-		state.fetch_requests.push_back(group);
-		state.evict_expired(now);
-
-		Ok(consumer)
+	/// Return the latest sequence number in the track.
+	pub fn latest(&self) -> Option<u64> {
+		self.state.read().max_sequence
 	}
 
 	/// Upgrade this consumer back to a [TrackProducer] sharing the same state.
@@ -918,7 +777,7 @@ impl TrackSubscriber {
 
 	/// Poll for the next group received over the network, in arrival order.
 	///
-	/// Respects this subscriber's [`Subscription::start_group`] / `end_group` bounds.
+	/// Respects this subscriber's [`Subscription::start`] / `end` bounds.
 	/// Groups may arrive out of order or with gaps. Use [`Self::next_group`]
 	/// if you need monotonic delivery (skipping late arrivals).
 	///
@@ -927,8 +786,8 @@ impl TrackSubscriber {
 	/// polls will keep returning `Ok(None)`.
 	pub fn poll_recv_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
 		let sub = self.sub.read();
-		let min_sequence = sub.start_group.unwrap_or(0);
-		let end = sub.end_group;
+		let min_sequence = sub.start.unwrap_or(0);
+		let end = sub.end;
 		drop(sub);
 
 		let Some((consumer, found_index)) =
@@ -955,11 +814,11 @@ impl TrackSubscriber {
 	/// Return the next group with a strictly-greater sequence number than the last returned.
 	///
 	/// Groups that arrive late (sequence at or below the last one returned) are
-	/// silently skipped. Respects [`Subscription::start_group`] / `end_group`.
+	/// silently skipped. Respects [`Subscription::start`] / `end`.
 	pub fn poll_next_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
 		let sub = self.sub.read();
-		let min_sequence = self.next.max(sub.start_group.unwrap_or(0));
-		let end = sub.end_group;
+		let min_sequence = self.next.max(sub.start.unwrap_or(0));
+		let end = sub.end;
 		drop(sub);
 
 		let Some((consumer, found_index)) =
@@ -1000,11 +859,11 @@ impl TrackSubscriber {
 	/// skipping the rest of the group. Intended for single-frame groups (see
 	/// [`TrackProducer::write_frame`]).
 	///
-	/// Respects [`Subscription::start_group`] / `end_group`.
+	/// Respects [`Subscription::start`] / `end`.
 	pub fn poll_read_frame(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<bytes::Bytes>>> {
 		let sub = self.sub.read();
-		let lower = self.next.max(sub.start_group.unwrap_or(0));
-		let end = sub.end_group;
+		let lower = self.next.max(sub.start.unwrap_or(0));
+		let end = sub.end;
 		drop(sub);
 
 		let Some((frame, found_index, sequence)) =
@@ -1042,15 +901,19 @@ impl TrackSubscriber {
 		self.sub.read().clone()
 	}
 
-	/// Return the latest cached group, if any.
-	pub fn latest_group(&self) -> Option<GroupConsumer> {
-		let state = self.state.read();
-		let max = state.max_sequence?;
-		state
-			.groups
-			.iter()
-			.flatten()
-			.find_map(|(g, _)| (g.sequence == max).then(|| g.consume()))
+	/// Return the latest sequence number in the track.
+	pub fn latest(&self) -> Option<u64> {
+		self.state.read().max_sequence
+	}
+
+	/// Poll for the group with the given sequence, without blocking.
+	pub fn poll_get_group(&self, waiter: &conducer::Waiter, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
+		self.poll(waiter, |state| state.poll_get_group(sequence))
+	}
+
+	/// Block until the group with the given sequence is available.
+	pub async fn get_group(&self, sequence: u64) -> Result<Option<GroupConsumer>> {
+		conducer::wait(|waiter| self.poll_get_group(waiter, sequence)).await
 	}
 
 	/// Poll for track closure, without blocking.
@@ -1554,7 +1417,7 @@ mod test {
 		let consumer = producer.consume();
 		let mut subscriber = consumer
 			.subscribe(Subscription {
-				start_group: Some(5),
+				start: Some(5),
 				..Default::default()
 			})
 			.unwrap();
@@ -1598,6 +1461,28 @@ mod test {
 			.expect("should not block")
 			.expect("would have errored");
 		assert!(done.is_none());
+	}
+
+	#[tokio::test]
+	async fn get_group_finishes_without_waiting_for_gaps() {
+		let mut producer = Track::new("test").produce();
+		producer.create_group(Group { sequence: 1 }).unwrap();
+		producer.finish_at(1).unwrap();
+
+		let consumer = producer.consume();
+		assert!(
+			consumer.get_group(0).now_or_never().is_none(),
+			"sequence below fin should block (group could still arrive)"
+		);
+		assert!(
+			consumer
+				.get_group(2)
+				.now_or_never()
+				.expect("sequence at-or-after fin should resolve")
+				.expect("should not error")
+				.is_none(),
+			"sequence at-or-after fin should not exist"
+		);
 	}
 
 	#[test]
@@ -1747,15 +1632,15 @@ mod test {
 
 		let _a = consumer
 			.subscribe(Subscription {
-				start_group: Some(5),
-				end_group: Some(20),
+				start: Some(5),
+				end: Some(20),
 				..Default::default()
 			})
 			.unwrap();
 		let _b = consumer
 			.subscribe(Subscription {
-				start_group: Some(3),
-				end_group: Some(10),
+				start: Some(3),
+				end: Some(10),
 				..Default::default()
 			})
 			.unwrap();
@@ -1765,8 +1650,8 @@ mod test {
 			.now_or_never()
 			.expect("should not block")
 			.expect("aggregate should exist");
-		assert_eq!(agg.start_group, Some(3));
-		assert_eq!(agg.end_group, Some(20));
+		assert_eq!(agg.start, Some(3));
+		assert_eq!(agg.end, Some(20));
 	}
 
 	#[tokio::test]
@@ -1778,8 +1663,8 @@ mod test {
 		// so the aggregate must be unbounded too.
 		let _a = consumer
 			.subscribe(Subscription {
-				start_group: Some(5),
-				end_group: Some(20),
+				start: Some(5),
+				end: Some(20),
 				..Default::default()
 			})
 			.unwrap();
@@ -1790,8 +1675,8 @@ mod test {
 			.now_or_never()
 			.expect("should not block")
 			.expect("aggregate should exist");
-		assert_eq!(agg.start_group, None, "None subscriber wants from the beginning");
-		assert_eq!(agg.end_group, None, "None subscriber wants no end");
+		assert_eq!(agg.start, None, "None subscriber wants from the beginning");
+		assert_eq!(agg.end, None, "None subscriber wants no end");
 	}
 
 	#[tokio::test]
@@ -1859,7 +1744,7 @@ mod test {
 		let consumer = producer.consume();
 		let mut subscriber = consumer
 			.subscribe(Subscription {
-				end_group: Some(2),
+				end: Some(2),
 				..Default::default()
 			})
 			.unwrap();
@@ -1877,177 +1762,5 @@ mod test {
 			.expect("should not block")
 			.expect("would have errored");
 		assert!(done.is_none(), "groups past end should yield None");
-	}
-
-	#[tokio::test]
-	async fn get_group_cache_hit() {
-		let mut producer = Track::new("test").produce();
-		producer.create_group(Group { sequence: 5 }).unwrap();
-		let consumer = producer.consume();
-
-		// No TrackDynamic registered, but cache hits still succeed.
-		let group = consumer.get_group(Group { sequence: 5 }).expect("cache hit");
-		assert_eq!(group.sequence, 5);
-	}
-
-	#[tokio::test]
-	async fn get_group_no_handler_returns_not_found() {
-		let producer = Track::new("test").produce();
-		let consumer = producer.consume();
-
-		match consumer.get_group(Group { sequence: 0 }) {
-			Err(Error::NotFound) => {}
-			Err(err) => panic!("expected NotFound, got {err:?}"),
-			Ok(_) => panic!("expected NotFound, got Ok"),
-		}
-	}
-
-	#[tokio::test]
-	async fn get_group_past_final_returns_not_found() {
-		let mut producer = Track::new("test").produce();
-		producer.create_group(Group { sequence: 3 }).unwrap();
-		producer.finish().unwrap();
-		let consumer = producer.consume();
-		let _dynamic = producer.dynamic();
-
-		// Cached group below the final boundary still works.
-		assert_eq!(consumer.get_group(Group { sequence: 3 }).unwrap().sequence, 3);
-
-		// Sequences at/past the final boundary fail fast even with a handler attached.
-		match consumer.get_group(Group { sequence: 4 }) {
-			Err(Error::NotFound) => {}
-			Err(err) => panic!("expected NotFound, got {err:?}"),
-			Ok(_) => panic!("expected NotFound, got Ok"),
-		}
-	}
-
-	#[tokio::test]
-	async fn get_group_via_dynamic_handler() {
-		let producer = Track::new("test").produce();
-		let consumer = producer.consume();
-		let mut dynamic = producer.dynamic();
-
-		// Issue a fetch; the handler should pop a producer for the same sequence.
-		let mut group_consumer = consumer.get_group(Group { sequence: 7 }).expect("queued");
-		assert_eq!(group_consumer.sequence, 7);
-
-		let mut group_producer = dynamic.assert_request();
-		assert_eq!(group_producer.sequence, 7);
-
-		// Publisher fills frames; consumer reads them.
-		group_producer.write_frame(bytes::Bytes::from_static(b"hello")).unwrap();
-		group_producer.finish().unwrap();
-
-		let frame = group_consumer.read_frame().await.unwrap();
-		assert_eq!(frame.as_deref(), Some(&b"hello"[..]));
-		assert!(group_consumer.read_frame().await.unwrap().is_none());
-	}
-
-	#[tokio::test]
-	async fn get_group_shares_in_flight() {
-		let producer = Track::new("test").produce();
-		let consumer = producer.consume();
-		let mut dynamic = producer.dynamic();
-
-		let mut a = consumer.get_group(Group { sequence: 3 }).expect("queued");
-		let mut b = consumer
-			.get_group(Group { sequence: 3 })
-			.expect("cache hit second time");
-
-		// Only one request should be queued; both consumers share the same group.
-		let mut group_producer = dynamic.assert_request();
-		dynamic.assert_no_request();
-
-		group_producer
-			.write_frame(bytes::Bytes::from_static(b"shared"))
-			.unwrap();
-		group_producer.finish().unwrap();
-
-		assert_eq!(a.read_frame().await.unwrap().as_deref(), Some(&b"shared"[..]));
-		assert_eq!(b.read_frame().await.unwrap().as_deref(), Some(&b"shared"[..]));
-	}
-
-	#[tokio::test]
-	async fn get_group_aborted_by_publisher() {
-		let producer = Track::new("test").produce();
-		let consumer = producer.consume();
-		let mut dynamic = producer.dynamic();
-
-		let mut group_consumer = consumer.get_group(Group { sequence: 2 }).expect("queued");
-		let mut group_producer = dynamic.assert_request();
-
-		// Publisher decides the group can't be served.
-		group_producer.abort(Error::NotFound).unwrap();
-
-		match group_consumer.read_frame().await {
-			Err(Error::NotFound) => {}
-			other => panic!("expected NotFound, got {other:?}"),
-		}
-	}
-
-	#[tokio::test]
-	async fn get_group_pending_aborted_when_dynamic_dropped() {
-		let producer = Track::new("test").produce();
-		let consumer = producer.consume();
-		let dynamic = producer.dynamic();
-
-		let mut group_consumer = consumer.get_group(Group { sequence: 9 }).expect("queued");
-
-		// Dropping the only TrackDynamic aborts the pending request.
-		drop(dynamic);
-
-		match group_consumer.read_frame().await {
-			Err(Error::Cancel) => {}
-			other => panic!("expected Cancel, got {other:?}"),
-		}
-
-		// And subsequent fetches for uncached sequences fail with NotFound.
-		assert!(matches!(
-			consumer.get_group(Group { sequence: 10 }),
-			Err(Error::NotFound)
-		));
-	}
-
-	#[tokio::test]
-	async fn get_group_dynamic_clone_keeps_handler_alive() {
-		let producer = Track::new("test").produce();
-		let consumer = producer.consume();
-		let dynamic = producer.dynamic();
-		let mut dynamic_clone = dynamic.clone();
-
-		let mut group_consumer = consumer.get_group(Group { sequence: 9 }).expect("queued");
-
-		// Dropping one handle must NOT abort the pending request: the clone
-		// still represents a live handler, so the counter must stay positive.
-		drop(dynamic);
-
-		let mut group_producer = dynamic_clone.assert_request();
-		assert_eq!(group_producer.sequence, 9);
-
-		group_producer.write_frame(bytes::Bytes::from_static(b"clone")).unwrap();
-		group_producer.finish().unwrap();
-
-		assert_eq!(
-			group_consumer.read_frame().await.unwrap().as_deref(),
-			Some(&b"clone"[..])
-		);
-	}
-
-	#[tokio::test]
-	async fn latest_group_returns_max_sequence_consumer() {
-		let mut producer = Track::new("test").produce();
-		producer.create_group(Group { sequence: 1 }).unwrap();
-		producer.create_group(Group { sequence: 5 }).unwrap();
-		producer.create_group(Group { sequence: 3 }).unwrap();
-
-		let consumer = producer.consume();
-		let latest = consumer.latest_group().expect("has groups");
-		assert_eq!(latest.sequence, 5);
-	}
-
-	#[tokio::test]
-	async fn latest_group_none_on_empty_track() {
-		let producer = Track::new("test").produce();
-		assert!(producer.consume().latest_group().is_none());
 	}
 }

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -1,14 +1,14 @@
 //! A track is a collection of semi-reliable and semi-ordered streams, split into a [TrackProducer] and [TrackConsumer] handle.
 //!
 //! A [TrackProducer] creates streams with a sequence number and priority.
-//! The sequest number is used to determine the order of streams, while the priority is used to determine which stream to transmit first.
+//! The sequence number is used to determine the order of streams, while the priority is used to determine which stream to transmit first.
 //! This may seem counter-intuitive, but is designed for live streaming where the newest streams may be higher priority.
 //! A cloned [TrackProducer] can be used to create streams in parallel, but will error if a duplicate sequence number is used.
 //!
 //! A [TrackConsumer] may not receive all streams in order or at all.
-//! These streams are meant to be transmitted over congested networks and the key to MoQ Tranport is to not block on them.
-//! streams will be cached for a potentially limited duration added to the unreliable nature.
-//! A cloned [TrackConsumer] will receive a copy of all new stream going forward (fanout).
+//! These streams are meant to be transmitted over congested networks and the key to MoQ Transport is to not block on them.
+//! Streams will be cached for a potentially limited duration added to the unreliable nature.
+//! A cloned [TrackConsumer] will receive a copy of all new streams going forward (fanout).
 //!
 //! The track is closed with [Error] when all writers or readers are dropped.
 
@@ -577,9 +577,13 @@ impl TrackConsumer {
 		self.poll(waiter, |state| state.poll_get_group(sequence))
 	}
 
-	/// Block until the group with the given sequence is available.
+	/// Wait until the group with the given sequence becomes available.
 	///
-	/// Returns None if the group is not in the cache and a newer group exists.
+	/// Resolves to `Some(GroupConsumer)` once the group is in the cache.
+	/// Resolves to `None` only when `sequence` is at or past the track's
+	/// `final_sequence` (set by `finish()` / `finish_at()`), since such a
+	/// group can never be produced. Sequences below `final_sequence` still
+	/// wait, since older groups may still arrive out of order.
 	pub async fn get_group(&self, sequence: u64) -> Result<Option<GroupConsumer>> {
 		conducer::wait(|waiter| self.poll_get_group(waiter, sequence)).await
 	}

--- a/rs/moq-mux/src/catalog.rs
+++ b/rs/moq-mux/src/catalog.rs
@@ -29,7 +29,10 @@ impl CatalogProducer {
 		catalog: hang::Catalog,
 	) -> Result<Self, moq_lite::Error> {
 		let hang_track = broadcast.create_track(hang::Catalog::default_track())?;
-		let msf_track = broadcast.create_track(moq_lite::Track::new(moq_msf::DEFAULT_NAME))?;
+		let msf_track = broadcast.create_track(moq_lite::Track {
+			name: moq_msf::DEFAULT_NAME.to_string(),
+			priority: 100,
+		})?;
 
 		Ok(Self {
 			hang_track,
@@ -50,12 +53,7 @@ impl CatalogProducer {
 
 	/// Create a consumer for this catalog, receiving updates as they're published.
 	pub fn consume(&self) -> hang::CatalogConsumer {
-		let subscriber = self
-			.hang_track
-			.consume()
-			.subscribe(hang::Catalog::SUBSCRIPTION)
-			.expect("hang_track producer is alive");
-		hang::CatalogConsumer::new(subscriber)
+		hang::CatalogConsumer::new(self.hang_track.consume())
 	}
 
 	/// Finish publishing to this catalog.

--- a/rs/moq-mux/src/ordered/consumer.rs
+++ b/rs/moq-mux/src/ordered/consumer.rs
@@ -5,7 +5,7 @@ use crate::container::{Container, Frame, Timestamp};
 
 /// A consumer for media tracks with timestamp reordering.
 ///
-/// This wraps a `moq_lite::TrackSubscriber` and adds functionality
+/// This wraps a `moq_lite::TrackConsumer` and adds functionality
 /// like timestamp decoding, latency management, and frame buffering.
 ///
 /// Generic over `F: Container` to support different container encodings.
@@ -15,7 +15,7 @@ use crate::container::{Container, Frame, Timestamp};
 /// The consumer can skip groups that are too far behind to maintain low latency.
 /// Configure the maximum acceptable delay through the consumer's latency settings.
 pub struct Consumer<F: Container> {
-	track: moq_lite::TrackSubscriber,
+	track: moq_lite::TrackConsumer,
 
 	format: F,
 
@@ -34,8 +34,8 @@ pub struct Consumer<F: Container> {
 }
 
 impl<F: Container> Consumer<F> {
-	/// Create a new Consumer wrapping the given moq-lite subscriber.
-	pub fn new(track: moq_lite::TrackSubscriber, format: F) -> Self {
+	/// Create a new Consumer wrapping the given moq-lite consumer.
+	pub fn new(track: moq_lite::TrackConsumer, format: F) -> Self {
 		Self {
 			track,
 			format,
@@ -221,8 +221,8 @@ impl<F: Container> Consumer<F> {
 		Ok(self.track.closed().await?)
 	}
 
-	/// Unwrap into the inner TrackSubscriber.
-	pub fn into_inner(self) -> moq_lite::TrackSubscriber {
+	/// Unwrap into the inner TrackConsumer.
+	pub fn into_inner(self) -> moq_lite::TrackConsumer {
 		self.track
 	}
 }
@@ -382,11 +382,6 @@ mod tests {
 		Timestamp::from_micros(micros).unwrap()
 	}
 
-	/// Subscribe to a track with default preferences (test helper).
-	fn subscribe_default(track: &moq_lite::TrackProducer) -> moq_lite::TrackSubscriber {
-		track.consume().subscribe_default().expect("producer alive")
-	}
-
 	/// Write a finished group with explicit sequence and timestamps (Legacy format).
 	fn write_group(track: &mut moq_lite::TrackProducer, sequence: u64, timestamps: &[Timestamp]) {
 		let mut group = track.create_group(moq_lite::Group { sequence }).unwrap();
@@ -423,7 +418,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -441,7 +436,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_frames_single_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_000), ts(66_000)]);
@@ -459,7 +454,7 @@ mod tests {
 	#[tokio::test]
 	async fn read_multiple_groups_within_latency() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		// 5 groups, 20ms spacing. Total span = 80ms, well within 500ms latency.
@@ -478,7 +473,7 @@ mod tests {
 	async fn latency_skip_delivers_recent_groups() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
@@ -519,7 +514,7 @@ mod tests {
 	async fn zero_latency_skips_aggressively() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::ZERO);
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -555,7 +550,7 @@ mod tests {
 	async fn latency_skip_correctness() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -597,7 +592,7 @@ mod tests {
 	async fn groups_delivered_in_sequence_order() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -632,7 +627,7 @@ mod tests {
 	#[tokio::test]
 	async fn adjacent_group_flushed_immediately() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -650,7 +645,7 @@ mod tests {
 	#[tokio::test]
 	async fn bframes_within_group() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(66_000), ts(33_000)]);
@@ -669,7 +664,7 @@ mod tests {
 	async fn empty_track_returns_none() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		track.finish().unwrap();
@@ -687,7 +682,7 @@ mod tests {
 	async fn track_closed_with_error() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -709,7 +704,7 @@ mod tests {
 	async fn closed_resolves_when_track_ends() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		assert!(
@@ -732,7 +727,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_in_group_sequence_recovery() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		write_group(&mut track, 0, &[ts(0), ts(20_000)]);
@@ -750,7 +745,7 @@ mod tests {
 	#[tokio::test]
 	async fn gap_at_start_of_sequence() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(80));
 
 		write_group(&mut track, 5, &[ts(0), ts(20_000)]);
@@ -768,7 +763,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_timestamp_and_index_decoding() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_333), ts(66_666)]);
@@ -788,7 +783,7 @@ mod tests {
 	#[tokio::test]
 	async fn frame_payload_preserved() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
@@ -825,7 +820,7 @@ mod tests {
 	async fn no_infinite_loop_with_buffered_frames() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_secs(10));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -870,7 +865,7 @@ mod tests {
 	#[tokio::test]
 	async fn large_timestamps() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_secs(3700));
 
 		let one_hour = 3_600_000_000u64;
@@ -886,7 +881,7 @@ mod tests {
 	#[tokio::test]
 	async fn set_latency_changes_behavior() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_secs(10));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -904,7 +899,7 @@ mod tests {
 	async fn max_timestamp_tracks_through_bframes() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		// latency must exceed (group1_max - group0_min) = 100ms - 0ms = 100ms
 		// to avoid the latency skip and test B-frame timestamp tracking.
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(110));
@@ -955,7 +950,7 @@ mod tests {
 	async fn startup_selects_earliest_group() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		write_group(&mut track, 3, &[ts(0)]);
@@ -1006,7 +1001,7 @@ mod tests {
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let _group5 = track.create_group(moq_lite::Group { sequence: 5 }).unwrap();
@@ -1029,7 +1024,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_single_group_mid_stream() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 100, &[ts(3_000_000)]);
@@ -1043,7 +1038,7 @@ mod tests {
 	async fn multiple_sequential_latency_skips() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(50));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1078,7 +1073,7 @@ mod tests {
 	async fn latency_skip_boundary_exact() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1115,7 +1110,7 @@ mod tests {
 	async fn single_newer_group_triggers_skip() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: stalled at ts=0, NOT finished
@@ -1152,7 +1147,7 @@ mod tests {
 	async fn single_missing_sequence_near_eof_skips() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: finished normally
@@ -1168,7 +1163,7 @@ mod tests {
 	#[tokio::test]
 	async fn group_error_skips_to_next() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1185,7 +1180,7 @@ mod tests {
 	async fn track_finishes_while_reading() {
 		tokio::time::pause();
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1214,7 +1209,7 @@ mod tests {
 	#[tokio::test]
 	async fn empty_group_advances() {
 		let mut track = moq_lite::Track::new("test").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer = Consumer::new(consumer_track, Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_lite::Group { sequence: 0 }).unwrap();
@@ -1235,7 +1230,7 @@ mod tests {
 		tokio::time::pause();
 
 		let mut track = moq_lite::Track::new("video").produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.consume();
 		let mut consumer =
 			Consumer::new(consumer_track, hang::catalog::Container::Legacy).with_latency(Duration::from_millis(500));
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -41,7 +41,10 @@ async fn run_broadcast(origin: moq_lite::OriginProducer) -> anyhow::Result<()> {
 
 	// Create a track that we'll insert into the broadcast.
 	// A track is a series of groups representing a live stream.
-	let mut track = broadcast.create_track(moq_lite::Track::new("chat"))?;
+	let mut track = broadcast.create_track(moq_lite::Track {
+		name: "chat".to_string(),
+		priority: 0,
+	})?;
 
 	// NOTE: The path is empty because we're using the URL to scope the broadcast.
 	// If you put "alice" here, it would be published as "anon/chat-example/alice".

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -4,7 +4,7 @@
 //! Each test is gated with `#[cfg(feature = "...")]` so it only compiles when the
 //! corresponding backend is enabled. Running `cargo test --all-features` exercises all.
 
-use moq_native::moq_lite::{Origin, Subscription, Track};
+use moq_native::moq_lite::{Origin, Track};
 use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -70,7 +70,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"), Subscription::default())
+		.subscribe_track(&Track::new("video"))
 		.expect("subscribe_track failed");
 
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
@@ -222,7 +222,7 @@ async fn iroh_connect() {
 	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"), Subscription::default())
+		.subscribe_track(&Track::new("video"))
 		.expect("subscribe_track failed");
 
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -8,7 +8,7 @@
 //! This covers raw QUIC (moqt://) and WebTransport (https://) transports,
 //! exercising every protocol version the library supports.
 
-use moq_native::moq_lite::{self, Origin, Subscription, Track};
+use moq_native::moq_lite::{self, Origin, Track};
 use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -88,7 +88,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 
 	// Subscribe to the track.
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"), Subscription::default())
+		.subscribe_track(&Track::new("video"))
 		.expect("subscribe_track failed");
 
 	// Read one group.
@@ -358,6 +358,8 @@ async fn broadcast_webtransport_negotiate_client_all_server_transport_16() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket() {
+	use moq_native::moq_lite::{Origin, Track};
+
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
@@ -426,7 +428,7 @@ async fn broadcast_websocket() {
 
 	// Subscribe to the track.
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"), Subscription::default())
+		.subscribe_track(&Track::new("video"))
 		.expect("subscribe_track failed");
 
 	// Read one group.
@@ -460,6 +462,8 @@ async fn broadcast_websocket() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket_fallback() {
+	use moq_native::moq_lite::{Origin, Track};
+
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
@@ -531,7 +535,7 @@ async fn broadcast_websocket_fallback() {
 
 	// Subscribe to the track.
 	let mut track_sub = bc
-		.subscribe_track(&Track::new("video"), Subscription::default())
+		.subscribe_track(&Track::new("video"))
 		.expect("subscribe_track failed");
 
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -502,19 +502,20 @@ async fn serve_fetch(
 
 	tracing::info!(%broadcast, %track, "fetching track");
 
-	let track = moq_lite::Track::new(track);
+	let track = moq_lite::Track {
+		name: track,
+		priority: 0,
+	};
 
 	// NOTE: The auth token is already scoped to the broadcast.
 	// TODO: switch to `announced_broadcast` (bounded by the fetch deadline) so freshly-connected
 	// subscribers don't get a spurious 404 before the broadcast has gossiped.
 	#[allow(deprecated)]
 	let broadcast = origin.consume_broadcast("").ok_or(StatusCode::NOT_FOUND)?;
-	let mut track = broadcast
-		.subscribe_track(&track, moq_lite::Subscription::default())
-		.map_err(|err| match err {
-			moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
-			_ => StatusCode::INTERNAL_SERVER_ERROR,
-		})?;
+	let mut track = broadcast.subscribe_track(&track).map_err(|err| match err {
+		moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
+		_ => StatusCode::INTERNAL_SERVER_ERROR,
+	})?;
 
 	let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
 

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -509,33 +509,28 @@ async fn serve_fetch(
 	// subscribers don't get a spurious 404 before the broadcast has gossiped.
 	#[allow(deprecated)]
 	let broadcast = origin.consume_broadcast("").ok_or(StatusCode::NOT_FOUND)?;
-	let track = broadcast.consume_track(&track).map_err(|err| match err {
-		moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
-		_ => StatusCode::INTERNAL_SERVER_ERROR,
-	})?;
+	let mut track = broadcast
+		.subscribe_track(&track, moq_lite::Subscription::default())
+		.map_err(|err| match err {
+			moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
+			_ => StatusCode::INTERNAL_SERVER_ERROR,
+		})?;
 
 	let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
 
 	let result = tokio::time::timeout_at(deadline, async {
 		let group = match params.group {
-			FetchGroup::Num(sequence) => track.get_group(sequence.into()).map_err(|err| match err {
-				moq_lite::Error::NotFound => StatusCode::NOT_FOUND,
-				_ => StatusCode::INTERNAL_SERVER_ERROR,
-			})?,
-			FetchGroup::Latest => match track.latest_group() {
-				Some(group) => group,
-				None => {
-					// No cached group yet — wait for the first one via subscribe.
-					let mut sub = track
-						.subscribe_default()
-						.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-					match sub.next_group().await {
-						Ok(Some(group)) => group,
-						Ok(None) => return Err(StatusCode::NOT_FOUND),
-						Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
-					}
-				}
+			FetchGroup::Latest => match track.latest() {
+				Some(sequence) => track.get_group(sequence).await,
+				None => track.recv_group().await,
 			},
+			FetchGroup::Num(sequence) => track.get_group(sequence).await,
+		};
+
+		let group = match group {
+			Ok(Some(group)) => group,
+			Ok(None) => return Err(StatusCode::NOT_FOUND),
+			Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
 		};
 
 		tracing::info!(track = %track.name, group = %group.sequence, "serving group");


### PR DESCRIPTION
## Summary
- Reverts #1357 (fetch_group API + TrackDynamic) and #1348 (Subscription model API for FETCH readiness)
- FETCH isn't hooked up yet, so the breaking API change isn't worth it; the API also wasn't quite right
- Hop-based clustering (#1322) and the per-frame buffer changes (#1353) are preserved

## Test plan
- [x] `just check` passes