### PR TITLE
Fix DNS resolution to prefer matching address family

### DIFF
--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -57,12 +57,15 @@ impl NoqClient {
 		let port = url.port().unwrap_or(443);
 
 		// Look up the DNS entry.
-		// Noq doesn't support happy eyeballs, so we use the first address.
-		let ip = tokio::net::lookup_host((host.clone(), port))
+		// Noq doesn't support happy eyeballs, so we pick a single address,
+		// preferring one whose family matches the local socket so the OS
+		// doesn't reject it (notably on Windows, where IPv6 sockets aren't
+		// dual-stack by default).
+		let local = self.quic.local_addr().context("failed to get local address")?;
+		let addrs = tokio::net::lookup_host((host.clone(), port))
 			.await
-			.context("failed DNS lookup")?
-			.next()
-			.context("no DNS entries")?;
+			.context("failed DNS lookup")?;
+		let ip = crate::util::pick_addr(addrs, local).context("no DNS entries")?;
 
 		if url.scheme() == "http" {
 			// Perform a HTTP request to fetch the certificate fingerprint.

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -57,12 +57,15 @@ impl QuinnClient {
 		let port = url.port().unwrap_or(443);
 
 		// Look up the DNS entry.
-		// Quinn doesn't support happy eyeballs, so we use the first address.
-		let ip = tokio::net::lookup_host((host.clone(), port))
+		// Quinn doesn't support happy eyeballs, so we pick a single address,
+		// preferring one whose family matches the local socket so the OS
+		// doesn't reject it (notably on Windows, where IPv6 sockets aren't
+		// dual-stack by default).
+		let local = self.quic.local_addr().context("failed to get local address")?;
+		let addrs = tokio::net::lookup_host((host.clone(), port))
 			.await
-			.context("failed DNS lookup")?
-			.next()
-			.context("no DNS entries")?;
+			.context("failed DNS lookup")?;
+		let ip = crate::util::pick_addr(addrs, local).context("no DNS entries")?;
 
 		if url.scheme() == "http" {
 			// Perform a HTTP request to fetch the certificate fingerprint.

--- a/rs/moq-native/src/util.rs
+++ b/rs/moq-native/src/util.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use std::net::SocketAddr;
 
 /// Resolve a `host:port` string to a single [`std::net::SocketAddr`],
 /// falling back to `default` when `addr` is `None`.
@@ -7,13 +8,35 @@ use anyhow::Context;
 /// paired with a port (e.g. `fly-global-services:443`). Only the first
 /// resolved address is returned; Quinn only supports a single IP when
 /// binding/connecting.
-pub(crate) fn resolve(addr: Option<&str>, default: &str) -> anyhow::Result<std::net::SocketAddr> {
+pub(crate) fn resolve(addr: Option<&str>, default: &str) -> anyhow::Result<SocketAddr> {
 	use std::net::ToSocketAddrs;
 	addr.unwrap_or(default)
 		.to_socket_addrs()
 		.context("invalid address")?
 		.next()
 		.context("no addresses resolved")
+}
+
+/// Pick a single DNS entry from `addrs`, preferring one whose address family
+/// matches `local`. Falls back to the first entry when no family match exists.
+///
+/// Quinn doesn't support happy eyeballs and the local socket may be bound to a
+/// single family (especially on Windows, where IPv6 sockets are not dual-stack
+/// by default), so a mismatched DNS entry causes `sendmsg` to fail with
+/// `AddrNotAvailable`. See <https://github.com/moq-dev/moq/issues/1375>.
+pub(crate) fn pick_addr(addrs: impl IntoIterator<Item = SocketAddr>, local: SocketAddr) -> Option<SocketAddr> {
+	let mut first = None;
+	let mut matching = None;
+	for addr in addrs {
+		if first.is_none() {
+			first = Some(addr);
+		}
+		if addr.is_ipv4() == local.is_ipv4() {
+			matching = Some(addr);
+			break;
+		}
+	}
+	matching.or(first)
 }
 
 #[cfg(test)]
@@ -39,5 +62,33 @@ mod tests {
 		let addr = resolve(None, "127.0.0.1:1234").unwrap();
 		assert_eq!(addr.ip().to_string(), "127.0.0.1");
 		assert_eq!(addr.port(), 1234);
+	}
+
+	#[test]
+	fn pick_addr_prefers_matching_family() {
+		let v4: SocketAddr = "127.0.0.1:443".parse().unwrap();
+		let v6: SocketAddr = "[::1]:443".parse().unwrap();
+		let local_v4: SocketAddr = "0.0.0.0:0".parse().unwrap();
+		let local_v6: SocketAddr = "[::]:0".parse().unwrap();
+
+		// IPv6 listed first, but local socket is IPv4: pick IPv4.
+		assert_eq!(pick_addr([v6, v4], local_v4), Some(v4));
+		// IPv4 listed first, but local socket is IPv6: pick IPv6.
+		assert_eq!(pick_addr([v4, v6], local_v6), Some(v6));
+	}
+
+	#[test]
+	fn pick_addr_falls_back_to_first() {
+		let v4: SocketAddr = "127.0.0.1:443".parse().unwrap();
+		let local_v6: SocketAddr = "[::]:0".parse().unwrap();
+
+		// No IPv6 entry available, fall back to the IPv4 entry.
+		assert_eq!(pick_addr([v4], local_v6), Some(v4));
+	}
+
+	#[test]
+	fn pick_addr_empty() {
+		let local: SocketAddr = "0.0.0.0:0".parse().unwrap();
+		assert_eq!(pick_addr(std::iter::empty(), local), None);
 	}
 }

--- a/rs/moq-native/src/util.rs
+++ b/rs/moq-native/src/util.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 /// Resolve a `host:port` string to a single [`std::net::SocketAddr`],
 /// falling back to `default` when `addr` is `None`.
@@ -20,23 +20,44 @@ pub(crate) fn resolve(addr: Option<&str>, default: &str) -> anyhow::Result<Socke
 /// Pick a single DNS entry from `addrs`, preferring one whose address family
 /// matches `local`. Falls back to the first entry when no family match exists.
 ///
-/// Quinn doesn't support happy eyeballs and the local socket may be bound to a
-/// single family (especially on Windows, where IPv6 sockets are not dual-stack
-/// by default), so a mismatched DNS entry causes `sendmsg` to fail with
+/// Each entry is normalized to the local socket's family when possible: an
+/// IPv4-mapped IPv6 address is unwrapped for an IPv4 socket, and a plain IPv4
+/// address is wrapped for an IPv6 socket. Quinn doesn't support happy eyeballs
+/// and the local socket may be bound to a single family (especially on
+/// Windows, where IPv6 sockets are not dual-stack by default), so a
+/// family-mismatched destination causes `sendmsg` to fail with
 /// `AddrNotAvailable`. See <https://github.com/moq-dev/moq/issues/1375>.
 pub(crate) fn pick_addr(addrs: impl IntoIterator<Item = SocketAddr>, local: SocketAddr) -> Option<SocketAddr> {
-	let mut first = None;
-	let mut matching = None;
+	let mut converted = None;
+	let mut other = None;
 	for addr in addrs {
-		if first.is_none() {
-			first = Some(addr);
-		}
+		// A native family match wins outright.
 		if addr.is_ipv4() == local.is_ipv4() {
-			matching = Some(addr);
-			break;
+			return Some(addr);
+		}
+		let normalized = normalize_family(addr, local);
+		if normalized.is_ipv4() == local.is_ipv4() {
+			if converted.is_none() {
+				converted = Some(normalized);
+			}
+		} else if other.is_none() {
+			other = Some(addr);
 		}
 	}
-	matching.or(first)
+	converted.or(other)
+}
+
+/// Convert `addr` to match the family of `local` when the conversion is
+/// lossless: unwrap IPv4-mapped IPv6 to IPv4, or wrap IPv4 as IPv4-mapped IPv6.
+fn normalize_family(addr: SocketAddr, local: SocketAddr) -> SocketAddr {
+	match (addr, local.is_ipv4()) {
+		(SocketAddr::V6(v6), true) => match v6.ip().to_ipv4_mapped() {
+			Some(v4) => SocketAddr::new(IpAddr::V4(v4), v6.port()),
+			None => addr,
+		},
+		(SocketAddr::V4(v4), false) => SocketAddr::new(IpAddr::V6(v4.ip().to_ipv6_mapped()), v4.port()),
+		_ => addr,
+	}
 }
 
 #[cfg(test)]
@@ -78,12 +99,33 @@ mod tests {
 	}
 
 	#[test]
-	fn pick_addr_falls_back_to_first() {
+	fn pick_addr_wraps_v4_for_v6_socket() {
 		let v4: SocketAddr = "127.0.0.1:443".parse().unwrap();
+		let mapped: SocketAddr = "[::ffff:127.0.0.1]:443".parse().unwrap();
 		let local_v6: SocketAddr = "[::]:0".parse().unwrap();
 
-		// No IPv6 entry available, fall back to the IPv4 entry.
-		assert_eq!(pick_addr([v4], local_v6), Some(v4));
+		// IPv6 socket with only an IPv4 DNS entry: wrap as IPv4-mapped IPv6.
+		assert_eq!(pick_addr([v4], local_v6), Some(mapped));
+	}
+
+	#[test]
+	fn pick_addr_unwraps_v4_mapped_for_v4_socket() {
+		let mapped: SocketAddr = "[::ffff:127.0.0.1]:443".parse().unwrap();
+		let v4: SocketAddr = "127.0.0.1:443".parse().unwrap();
+		let local_v4: SocketAddr = "0.0.0.0:0".parse().unwrap();
+
+		// IPv4 socket given an IPv4-mapped IPv6 entry: unwrap to plain IPv4.
+		assert_eq!(pick_addr([mapped], local_v4), Some(v4));
+	}
+
+	#[test]
+	fn pick_addr_falls_back_for_unmappable_v6() {
+		let v6: SocketAddr = "[2001:db8::1]:443".parse().unwrap();
+		let local_v4: SocketAddr = "0.0.0.0:0".parse().unwrap();
+
+		// IPv4 socket with only a true IPv6 entry: no conversion possible,
+		// fall back to the entry as-is so the OS surfaces a clear error.
+		assert_eq!(pick_addr([v6], local_v4), Some(v6));
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary
This PR fixes DNS resolution issues on Windows and other platforms where sockets may be bound to a single address family (IPv4 or IPv6). When DNS returns multiple addresses, the code now intelligently selects one that matches the local socket's address family, preventing `AddrNotAvailable` errors.

## Key Changes
- **New utility function `pick_addr()`**: Added to `util.rs` to select a single DNS entry from multiple results, preferring one whose address family (IPv4/IPv6) matches the local socket. Falls back to the first entry if no family match exists.
- **Updated DNS lookup in `quinn.rs`**: Modified to get the local socket address and use `pick_addr()` to select a compatible remote address instead of blindly using the first DNS result.
- **Updated DNS lookup in `noq.rs`**: Applied the same fix to maintain consistency across both client implementations.
- **Added comprehensive tests**: Included three test cases covering preference matching, fallback behavior, and empty address lists.

## Implementation Details
- The `pick_addr()` function iterates through resolved addresses, tracking the first entry and any entry matching the local socket's address family.
- Uses `SocketAddr::is_ipv4()` for efficient family comparison.
- Addresses the root cause documented in issue #1375 where Quinn's lack of happy eyeballs support combined with non-dual-stack IPv6 sockets (especially on Windows) causes connection failures.
- Updated comments in both client files to explain the rationale for this approach.

https://claude.ai/code/session_01RdRzsR3mmy2cDgTo5GxSbB