### PR TITLE
Unignore moq-mux test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ node_modules
 *.m3u8
 *.m4s
 
+# Except these test fixtures, which are committed.
+!rs/moq-mux/src/import/test/*.mp4
+
 # Cloudflare Wrangler
 .wrangler/
 


### PR DESCRIPTION
## Summary
- The `*.mp4` rule in `.gitignore` matched the committed test fixtures under `rs/moq-mux/src/import/test/`, leaving them both tracked and ignored.
- `release-plz` refuses to compute next versions in that state, which broke the `Release` job on `main` (run [25411375308](https://github.com/moq-dev/moq/actions/runs/25411375308/job/74533660385)).
- Adds `!rs/moq-mux/src/import/test/*.mp4` to re-include those fixtures.

## Test plan
- [x] `git ls-files -ci --exclude-standard` returns empty
- [x] `git check-ignore` no longer matches the three fixtures
- [ ] Next `Release` run on `main` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)