### PR TITLE
@moq/watch: don't tear down a broadcast when an unrelated path flaps

### DIFF
--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -58,6 +58,11 @@ export class Broadcast {
 	// All actively announced broadcast paths from the connection.
 	#announced: Getter<Set<Moq.Path.Valid>>;
 
+	// Whether `name` is currently in the announced set (or skipping the check).
+	// Derived in its own effect so that flaps for unrelated broadcasts don't
+	// retrigger the broadcast/catalog subscriptions.
+	#announcedNow = new Signal(false);
+
 	signals = new Effect();
 
 	constructor(props?: BroadcastProps) {
@@ -70,13 +75,17 @@ export class Broadcast {
 
 		this.#announced = props?.announced ?? new Signal(new Set());
 
+		this.signals.run(this.#runAnnouncedNow.bind(this));
 		this.signals.run(this.#runBroadcast.bind(this));
 		this.signals.run(this.#runCatalog.bind(this));
 	}
 
-	#isAnnounced(effect: Effect): boolean {
+	#runAnnouncedNow(effect: Effect): void {
 		const reload = effect.get(this.reload);
-		if (!reload) return true;
+		if (!reload) {
+			this.#announcedNow.set(true);
+			return;
+		}
 
 		// Cloudflare's relay does not yet support announcement subscriptions,
 		// so an announcement will never arrive. Fall back to subscribing
@@ -84,19 +93,20 @@ export class Broadcast {
 		const conn = effect.get(this.connection);
 		if (conn?.url.hostname.endsWith("mediaoverquic.com")) {
 			console.warn("Cloudflare relay does not support broadcast discovery yet; ignoring reload signal.");
-			return true;
+			this.#announcedNow.set(true);
+			return;
 		}
 
 		const name = effect.get(this.name);
 		const announced = effect.get(this.#announced);
-		return announced.has(name);
+		this.#announcedNow.set(announced.has(name));
 	}
 
 	#runBroadcast(effect: Effect): void {
 		const enabled = effect.get(this.enabled);
 		if (!enabled) return;
 
-		if (!this.#isAnnounced(effect)) return;
+		if (!effect.get(this.#announcedNow)) return;
 
 		const conn = effect.get(this.connection);
 		if (!conn) return;


### PR DESCRIPTION
## Summary

When `reload=true`, `Broadcast` re-subscribed to its catalog and media tracks every time *any* broadcast on the connection flapped `active=true/false`, not just the one being watched.

The chain:
- `Reload.#runAnnounced` calls `Signal.mutate` on the announced `Set` whenever any path flips state. `mutate` force-notifies subscribers (it can't dedupe an in-place set mutation).
- `Broadcast.#runBroadcast` did `effect.get(this.#announced)` directly, so it re-ran on every flap, ran cleanup (closing `conn.consume(name)`), and rebuilt from scratch.

Fix: derive a `Signal<boolean>` for "is `name` in the announced set right now" in its own inner effect. Booleans dedupe via `isEqual` on `Signal.set`, so `#runBroadcast` only re-runs when membership of `name` actually flips.

Reproducer in the wild: an OBS publisher of `kixel` saw catalog + video subscriptions cycle every couple of seconds because an unrelated `forge-nbc-sports-philly` broadcast was flapping. Publisher logs showed paired `subscribed cancelled` / `subscribed started` events, player logs showed `received catalog` repeatedly with new subscribe IDs.

## Test plan

- [ ] `just check`
- [ ] Watch a broadcast with `reload=true` against a relay that announces multiple broadcasts; flap an unrelated broadcast and confirm the watched broadcast's subscriptions stay open.
- [ ] Confirm the watched broadcast still tears down + reloads when its own announce goes `active=false` then `active=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)