### PR TITLE
Revert "moq-lite: switch insert_track to take TrackConsumer (#1356)"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,10 +107,6 @@ match version {
 - **Error handling**: Use `thiserror` with `#[from]` for library crates, `anyhow` for binaries. Always add `#[non_exhaustive]` to public `thiserror` enums.
 - Use `anyhow::Context` (`.context("msg")`) instead of `.map_err(|_| anyhow::anyhow!("msg"))` for error conversion
 
-## Comment Conventions
-
-- Comments must reflect the **current** state of the code, not its history. Don't write "X no longer does Y" or "this used to cascade" — describe what the code does today, or delete the comment. Migration context belongs in commit messages and PR descriptions, where it ages with the change rather than rotting in the source.
-
 ## Tooling
 
 - **TypeScript**: Always use `bun` for all package management and script execution (not npm, yarn, or pnpm)

--- a/rs/conducer/src/consumer.rs
+++ b/rs/conducer/src/consumer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-	Counts, State, Weak,
+	Counts, State,
 	lock::*,
 	producer::{Producer, Ref},
 	waiter::*,
@@ -109,17 +109,6 @@ impl<T> Consumer<T> {
 	/// Returns `true` if both consumers share the same underlying state.
 	pub fn same_channel(&self, other: &Self) -> bool {
 		self.state.is_clone(&other.state)
-	}
-
-	/// Create a [`Weak`] reference to this state.
-	///
-	/// Does not affect ref counts, so it won't prevent auto-close when all
-	/// producers are dropped.
-	pub fn weak(&self) -> Weak<T> {
-		Weak {
-			state: self.state.clone(),
-			counts: self.counts.clone(),
-		}
 	}
 }
 

--- a/rs/moq-lite/src/ietf/subscriber.rs
+++ b/rs/moq-lite/src/ietf/subscriber.rs
@@ -492,7 +492,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		drop(state);
 
 		let mut broadcast = self.start_announce(msg.track_namespace.to_owned())?;
-		broadcast.insert_track(track.consume())?;
+		broadcast.insert_track(&track)?;
 
 		Ok(())
 	}
@@ -513,16 +513,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let mut this = self.clone();
 
 			let path = path.to_owned();
-			let broadcast = broadcast.clone();
 			web_async::spawn(async move {
-				this.run_subscribe(path, broadcast, track).await;
+				this.run_subscribe(path, track).await;
 			});
 		}
 
 		Ok(())
 	}
 
-	async fn run_subscribe(&mut self, broadcast_path: Path<'_>, broadcast: BroadcastDynamic, mut track: TrackProducer) {
+	async fn run_subscribe(&mut self, broadcast: Path<'_>, mut track: TrackProducer) {
 		let request_id = match self.control.next_request_id().await {
 			Ok(id) => id,
 			Err(err) => {
@@ -555,17 +554,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 
 		// Write Subscribe message
-		if let Err(err) = self
-			.write_subscribe(&mut stream, request_id, &broadcast_path, &track)
-			.await
-		{
+		if let Err(err) = self.write_subscribe(&mut stream, request_id, &broadcast, &track).await {
 			tracing::debug!(%err, "failed to write subscribe");
 			self.state.lock().subscribes.remove(&request_id);
 			let _ = track.abort(err);
 			return;
 		}
 
-		tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast_path), track = %track.name, "subscribe started");
+		tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast), track = %track.name, "subscribe started");
 
 		// Read the response and register the alias mapping
 		let track_alias = match self.read_subscribe_response(&mut stream).await {
@@ -587,19 +583,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		};
 
+		// Wait for track unused or PublishDone (stream reader close)
 		tokio::select! {
 			_ = track.unused() => {
-				tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast_path), track = %track.name, "subscribe cancelled");
+				tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast), track = %track.name, "subscribe cancelled");
 				let _ = track.abort(Error::Cancel);
-			}
-			err = broadcast.closed() => {
-				tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast_path), track = %track.name, "broadcast closed");
-				let _ = track.abort(err);
 			}
 			res = stream.reader.closed() => {
 				match res {
 					Ok(()) => {
-						tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast_path), track = %track.name, "subscribe complete");
+						tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast), track = %track.name, "subscribe complete");
 						let _ = track.finish();
 					}
 					Err(err) => {
@@ -675,7 +668,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Err(Error::Unsupported);
 		}
 
-		let (mut producer, track) = {
+		let mut producer = {
 			let mut state = self.state.lock();
 			let request_id = match state.aliases.get(&group.track_alias) {
 				Some(request_id) => *request_id,
@@ -686,15 +679,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			};
 			let track = state.subscribes.get_mut(&request_id).ok_or(Error::NotFound)?;
 
-			let group_info = Group {
+			let group = Group {
 				sequence: group.group_id,
 			};
-			let producer = track.producer.create_group(group_info)?;
-			(producer, track.producer.clone())
+			track.producer.create_group(group)?
 		};
 
 		let res = tokio::select! {
-			err = track.closed() => Err(err),
 			err = producer.closed() => Err(err),
 			res = self.run_group(group, stream, producer.clone()) => res,
 		};

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -257,20 +257,19 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let mut this = self.clone();
 
 			let path = path.clone();
-			let broadcast = broadcast.clone();
 			web_async::spawn(async move {
-				this.run_subscribe(id, path, broadcast, track).await;
+				this.run_subscribe(id, path, track).await;
 				this.subscribes.lock().remove(&id);
 			});
 		}
 	}
 
-	async fn run_subscribe(&mut self, id: u64, path: PathOwned, broadcast: BroadcastDynamic, mut track: TrackProducer) {
+	async fn run_subscribe(&mut self, id: u64, broadcast: Path<'_>, mut track: TrackProducer) {
 		self.subscribes.lock().insert(id, track.clone());
 
 		let msg = lite::Subscribe {
 			id,
-			broadcast: path.as_path(),
+			broadcast: broadcast.to_owned(),
 			track: (&track.name).into(),
 			priority: track.priority,
 			ordered: true,
@@ -279,25 +278,24 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			end_group: None,
 		};
 
-		tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "subscribe started");
+		tracing::info!(id, broadcast = %self.log_path(&broadcast), track = %track.name, "subscribe started");
 
 		let res = tokio::select! {
 			_ = track.unused() => Err(Error::Cancel),
-			err = broadcast.closed() => Err(err),
 			res = self.run_track(msg) => res,
 		};
 
 		match res {
 			Err(Error::Cancel) => {
-				tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "subscribe cancelled");
+				tracing::info!(id, broadcast = %self.log_path(&broadcast), track = %track.name, "subscribe cancelled");
 				let _ = track.abort(Error::Cancel);
 			}
 			Err(err) => {
-				tracing::warn!(id, broadcast = %self.log_path(&path), track = %track.name, %err, "subscribe error");
+				tracing::warn!(id, broadcast = %self.log_path(&broadcast), track = %track.name, %err, "subscribe error");
 				let _ = track.abort(err);
 			}
 			_ => {
-				tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "subscribe complete");
+				tracing::info!(id, broadcast = %self.log_path(&broadcast), track = %track.name, "subscribe complete");
 				let _ = track.finish();
 			}
 		}
@@ -338,17 +336,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		let hdr: lite::Group = stream.decode().await?;
 
-		let (mut group, track) = {
+		let mut group = {
 			let mut subs = self.subscribes.lock();
 			let track = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
 
-			let group_info = Group { sequence: hdr.sequence };
-			let group = track.create_group(group_info)?;
-			(group, track.clone())
+			let group = Group { sequence: hdr.sequence };
+			track.create_group(group)?
 		};
 
 		let res = tokio::select! {
-			err = track.closed() => Err(err),
 			err = group.closed() => Err(err),
 			res = self.run_group(stream, group.clone()) => res,
 		};

--- a/rs/moq-lite/src/model/broadcast.rs
+++ b/rs/moq-lite/src/model/broadcast.rs
@@ -55,17 +55,6 @@ fn modify(state: &conducer::Producer<State>) -> Result<conducer::Mut<'_, State>,
 	}
 }
 
-impl State {
-	/// Insert a track weak handle into the lookup, returning an error on duplicate.
-	fn insert_track(&mut self, weak: TrackWeak) -> Result<(), Error> {
-		let hash_map::Entry::Vacant(entry) = self.tracks.entry(weak.info.name.clone()) else {
-			return Err(Error::Duplicate);
-		};
-		entry.insert(weak);
-		Ok(())
-	}
-}
-
 /// Manages tracks within a broadcast.
 ///
 /// Insert tracks statically with [Self::insert_track] / [Self::create_track],
@@ -95,13 +84,17 @@ impl BroadcastProducer {
 
 	/// Insert a track into the lookup, returning an error on duplicate.
 	///
-	/// Stores a weak handle to the track. The caller (or the owner of the
-	/// track's [`TrackProducer`]) is responsible for keeping the track alive;
-	/// when all producers are dropped, the entry becomes closed and is
-	/// eventually evicted.
-	pub fn insert_track(&mut self, track: TrackConsumer) -> Result<(), Error> {
+	/// NOTE: You probably want to [TrackProducer::clone] first to keep publishing to the track.
+	pub fn insert_track(&mut self, track: &TrackProducer) -> Result<(), Error> {
 		let mut state = modify(&self.state)?;
-		state.insert_track(track.weak())
+
+		let hash_map::Entry::Vacant(entry) = state.tracks.entry(track.name.clone()) else {
+			return Err(Error::Duplicate);
+		};
+
+		entry.insert(track.weak());
+
+		Ok(())
 	}
 
 	/// Remove a track from the lookup.
@@ -114,9 +107,7 @@ impl BroadcastProducer {
 	/// Produce a new track and insert it into the broadcast.
 	pub fn create_track(&mut self, track: Track) -> Result<TrackProducer, Error> {
 		let track = TrackProducer::new(track);
-		let mut state = modify(&self.state)?;
-		state.insert_track(track.weak())?;
-		drop(state);
+		self.insert_track(&track)?;
 		Ok(track)
 	}
 
@@ -151,18 +142,16 @@ impl BroadcastProducer {
 		}
 	}
 
-	/// Abort the broadcast with the given error.
-	///
-	/// Externally-owned tracks are independent and must be aborted separately;
-	/// inserted tracks are referenced via weak handles so that consumers can
-	/// finish reading them. Pending dynamic track requests, however, are owned
-	/// by the broadcast and have no other producer to fulfill them, so they are
-	/// aborted here.
+	/// Abort the broadcast and all child tracks with the given error.
 	pub fn abort(&mut self, err: Error) -> Result<(), Error> {
 		let mut guard = modify(&self.state)?;
 
-		// Abort any pending dynamic track requests; their producers are owned
-		// by the broadcast and would otherwise leave consumers stuck forever.
+		// Cascade abort to all child tracks.
+		for weak in guard.tracks.values() {
+			weak.abort(err.clone());
+		}
+
+		// Abort any pending dynamic track requests.
 		for mut request in guard.requests.drain(..) {
 			request.abort(err.clone()).ok();
 		}
@@ -185,7 +174,7 @@ impl BroadcastProducer {
 	}
 
 	pub fn assert_insert_track(&mut self, track: &TrackProducer) {
-		self.insert_track(track.consume()).expect("should not have errored")
+		self.insert_track(track).expect("should not have errored")
 	}
 }
 
@@ -251,23 +240,16 @@ impl BroadcastDynamic {
 		}
 	}
 
-	/// Block until the broadcast is closed or aborted, returning the cause.
-	pub async fn closed(&self) -> Error {
-		self.state.closed().await;
-		self.state.read().abort.clone().unwrap_or(Error::Dropped)
-	}
-
 	/// Abort the broadcast with the given error.
-	///
-	/// Externally-owned tracks are independent and must be aborted separately;
-	/// inserted tracks are referenced via weak handles. Pending dynamic track
-	/// requests are owned by the broadcast and aborted here so consumers don't
-	/// stay stuck waiting on producers nobody will fulfill.
 	pub fn abort(&mut self, err: Error) -> Result<(), Error> {
 		let mut guard = modify(&self.state)?;
 
-		// Abort any pending dynamic track requests; their producers are owned
-		// by the broadcast and would otherwise leave consumers stuck forever.
+		// Cascade abort to all child tracks.
+		for weak in guard.tracks.values() {
+			weak.abort(err.clone());
+		}
+
+		// Abort any pending dynamic track requests.
 		for mut request in guard.requests.drain(..) {
 			request.abort(err.clone()).ok();
 		}
@@ -478,16 +460,17 @@ mod test {
 		let track1c = consumer.assert_subscribe_track(&track1);
 		let track2 = consumer.assert_subscribe_track(&Track::new("track2"));
 
-		// Aborting the broadcast must NOT cascade to externally-owned tracks.
+		// Explicitly aborting the broadcast should cascade to child tracks.
 		producer.abort(Error::Cancel).unwrap();
 
-		// track2's producer was owned by the broadcast (a pending dynamic
-		// request), so the consumer surfaces the abort.
+		// The requested TrackProducer should have been aborted.
 		track2.assert_error();
 
-		// track1's producer is held outside the broadcast, so it survives.
-		assert!(!track1.is_closed());
-		track1c.assert_not_closed();
+		// track1 should also be closed because close() cascades.
+		track1c.assert_error();
+
+		// track1's producer should also be closed.
+		assert!(track1.is_closed());
 	}
 
 	#[tokio::test]

--- a/rs/moq-lite/src/model/group.rs
+++ b/rs/moq-lite/src/model/group.rs
@@ -209,11 +209,16 @@ impl GroupProducer {
 
 	/// Abort the group with the given error.
 	///
-	/// No updates can be made after this point. Child frames are independent and
-	/// must be aborted separately if desired; existing frame consumers can still
-	/// finish reading any frames that were already created.
+	/// No updates can be made after this point.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
 		let mut guard = modify(&self.state)?;
+
+		// Abort all frames still in progress.
+		for frame in guard.frames.iter_mut() {
+			// Ignore errors, we don't care if the frame was already closed.
+			frame.abort(err.clone()).ok();
+		}
+
 		guard.abort = Some(err);
 		guard.close();
 		Ok(())

--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -314,12 +314,15 @@ impl TrackProducer {
 	}
 
 	/// Abort the track with the given error.
-	///
-	/// Child groups are independent and must be aborted separately if desired;
-	/// existing group consumers can still finish reading any groups that were
-	/// already created.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
 		let mut guard = self.modify()?;
+
+		// Abort all groups still in progress.
+		for (group, _) in guard.groups.iter_mut().flatten() {
+			// Ignore errors, we don't care if the group was already closed.
+			group.abort(err.clone()).ok();
+		}
+
 		guard.abort = Some(err);
 		guard.close();
 		Ok(())
@@ -350,12 +353,6 @@ impl TrackProducer {
 			.used()
 			.await
 			.map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
-	}
-
-	/// Block until the track is closed or aborted, returning the cause.
-	pub async fn closed(&self) -> Error {
-		self.state.closed().await;
-		self.state.read().abort.clone().unwrap_or(Error::Dropped)
 	}
 
 	/// Return true if the track has been closed.
@@ -406,6 +403,18 @@ pub(crate) struct TrackWeak {
 }
 
 impl TrackWeak {
+	pub fn abort(&self, err: Error) {
+		let Ok(mut guard) = self.state.write() else { return };
+
+		// Cascade abort to all groups.
+		for (group, _) in guard.groups.iter_mut().flatten() {
+			group.abort(err.clone()).ok();
+		}
+
+		guard.abort = Some(err);
+		guard.close();
+	}
+
 	pub fn is_closed(&self) -> bool {
 		self.state.is_closed()
 	}
@@ -601,12 +610,29 @@ impl TrackConsumer {
 		self.state.read().max_sequence
 	}
 
-	/// Create a weak reference that doesn't prevent auto-close.
-	pub(crate) fn weak(&self) -> TrackWeak {
-		TrackWeak {
+	/// Upgrade this consumer back to a [TrackProducer] sharing the same state.
+	///
+	/// This enables zero-copy track sharing between broadcasts: subscribe to a
+	/// track, then [`crate::BroadcastProducer::insert_track`] the producer into another
+	/// broadcast. Both broadcasts serve the same underlying track data with no
+	/// forwarding overhead.
+	///
+	/// # Shared Ownership
+	///
+	/// The returned producer shares state with the original track. Mutations
+	/// (appending groups, finishing, aborting) through either producer affect
+	/// all consumers of the track. The returned producer keeps the track alive
+	/// (prevents auto-close) as long as it exists, even if the original producer
+	/// is dropped.
+	pub fn produce(&self) -> Result<TrackProducer> {
+		let state = self
+			.state
+			.produce()
+			.ok_or_else(|| self.state.read().abort.clone().unwrap_or(Error::Dropped))?;
+		Ok(TrackProducer {
 			info: self.info.clone(),
-			state: self.state.weak(),
-		}
+			state,
+		})
 	}
 }
 
@@ -1173,5 +1199,62 @@ mod test {
 		}
 
 		assert!(matches!(producer.append_group(), Err(Error::BoundsExceeded(_))));
+	}
+
+	#[tokio::test]
+	async fn consumer_produce() {
+		let mut producer = Track::new("test").produce();
+		producer.append_group().unwrap();
+
+		let consumer = producer.consume();
+
+		// Upgrade consumer back to producer — shared state.
+		let got = consumer.produce().expect("should produce");
+		assert!(got.is_clone(&producer), "should be the same track");
+
+		// Writing through the upgraded producer is visible to new consumers.
+		got.clone().append_group().unwrap();
+		let mut sub = producer.consume();
+		sub.assert_group(); // group 0
+		sub.assert_group(); // group 1, written via upgraded producer
+	}
+
+	#[tokio::test]
+	async fn consumer_produce_after_drop() {
+		let producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		drop(producer);
+
+		// Original producer dropped. Consumer's produce() should fail
+		// because there are no remaining producers.
+		let err = consumer.produce();
+		assert!(matches!(err, Err(Error::Dropped)), "expected Dropped");
+	}
+
+	#[tokio::test]
+	async fn consumer_produce_after_abort() {
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		producer.abort(Error::Cancel).unwrap();
+		drop(producer);
+
+		// Track was aborted — produce() should return the abort error, not Dropped.
+		let err = consumer.produce();
+		assert!(matches!(err, Err(Error::Cancel)), "expected Cancel");
+	}
+
+	#[tokio::test]
+	async fn consumer_produce_keeps_alive() {
+		let producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		let upgraded = consumer.produce().expect("should produce");
+		drop(producer);
+
+		// Channel still open because upgraded producer exists.
+		assert!(consumer.closed().now_or_never().is_none(), "should not be closed");
+		drop(upgraded);
+
+		// Now it should close.
+		assert!(consumer.closed().now_or_never().is_some(), "should be closed");
 	}
 }


### PR DESCRIPTION
This reverts commit b611acd1bdeb7890051fee8ebdb99b052eed5564.