### PR TITLE
@moq/watch: source network stats from the connection, not navigator

### DIFF
--- a/js/moq-boy/src/index.ts
+++ b/js/moq-boy/src/index.ts
@@ -110,15 +110,7 @@ export class Game {
 		});
 		this.#signals.cleanup(() => this.broadcast.close());
 
-		// Flatten the RTT signal from the connection for real-time jitter.
-		const rtt = new Moq.Signals.Signal<number | undefined>(undefined);
-		this.#signals.run((effect) => {
-			const conn = effect.get(connection.established);
-			const rttSignal = conn?.rtt;
-			rtt.set(rttSignal ? effect.get(rttSignal) : undefined);
-		});
-
-		this.sync = new Watch.Sync({ latency: this.latency, rtt });
+		this.sync = new Watch.Sync({ latency: this.latency, connection: connection.established });
 		this.#signals.cleanup(() => this.sync.close());
 
 		this.videoSource = new Watch.Video.Source(this.sync, { broadcast: this.broadcast });

--- a/js/ui-core/src/stats/components/StatsItem.tsx
+++ b/js/ui-core/src/stats/components/StatsItem.tsx
@@ -30,6 +30,7 @@ export const StatsItem = (props: StatsItemProps) => {
 		const provider = new StatsInformationProvider({
 			audio: props.audio,
 			video: props.video,
+			network: props.network,
 		});
 
 		provider.setup({ setDisplayData });

--- a/js/ui-core/src/stats/components/StatsItem.tsx
+++ b/js/ui-core/src/stats/components/StatsItem.tsx
@@ -30,7 +30,7 @@ export const StatsItem = (props: StatsItemProps) => {
 		const provider = new StatsInformationProvider({
 			audio: props.audio,
 			video: props.video,
-			network: props.network,
+			connection: props.connection,
 		});
 
 		provider.setup({ setDisplayData });

--- a/js/ui-core/src/stats/components/StatsPanel.tsx
+++ b/js/ui-core/src/stats/components/StatsPanel.tsx
@@ -45,7 +45,7 @@ export const StatsPanel = (props: StatsPanelProps) => {
 						svg={icon()}
 						audio={props.audio}
 						video={props.video}
-						network={props.network}
+						connection={props.connection}
 					/>
 				)}
 			</For>

--- a/js/ui-core/src/stats/components/StatsPanel.tsx
+++ b/js/ui-core/src/stats/components/StatsPanel.tsx
@@ -45,6 +45,7 @@ export const StatsPanel = (props: StatsPanelProps) => {
 						svg={icon()}
 						audio={props.audio}
 						video={props.video}
+						network={props.network}
 					/>
 				)}
 			</For>

--- a/js/ui-core/src/stats/index.tsx
+++ b/js/ui-core/src/stats/index.tsx
@@ -18,7 +18,7 @@ export const Stats = <T = unknown>(props: StatsProps<T>) => {
 		<Show when={props.getElement(contextValue)}>
 			{(_element) => (
 				<div class="stats">
-					<StatsPanel audio={_element().audio} video={_element().video} network={_element().network} />
+					<StatsPanel audio={_element().audio} video={_element().video} connection={_element().connection} />
 				</div>
 			)}
 		</Show>

--- a/js/ui-core/src/stats/index.tsx
+++ b/js/ui-core/src/stats/index.tsx
@@ -18,7 +18,7 @@ export const Stats = <T = unknown>(props: StatsProps<T>) => {
 		<Show when={props.getElement(contextValue)}>
 			{(_element) => (
 				<div class="stats">
-					<StatsPanel audio={_element().audio} video={_element().video} />
+					<StatsPanel audio={_element().audio} video={_element().video} network={_element().network} />
 				</div>
 			)}
 		</Show>

--- a/js/ui-core/src/stats/providers/network.ts
+++ b/js/ui-core/src/stats/providers/network.ts
@@ -12,7 +12,7 @@ export class NetworkProvider extends BaseProvider {
 	setup(context: ProviderContext): void {
 		this.context = context;
 
-		if (!this.props.network) {
+		if (!this.props.connection) {
 			context.setDisplayData("N/A");
 			return;
 		}
@@ -22,15 +22,16 @@ export class NetworkProvider extends BaseProvider {
 	}
 
 	private updateDisplayData(): void {
-		if (!this.context || !this.props.network) {
-			return;
-		}
+		if (!this.context) return;
 
-		const parts = [
-			formatBandwidth(this.props.network.recvBandwidth.peek(), "down"),
-			formatBandwidth(this.props.network.sendBandwidth.peek(), "up"),
-			formatRtt(this.props.network.rtt.peek()),
-		].filter((part): part is string => part !== null);
+		const conn = this.props.connection?.peek();
+		const parts = conn
+			? [
+					formatBandwidth(conn.recvBandwidth?.peek(), "down"),
+					formatBandwidth(conn.sendBandwidth?.peek(), "up"),
+					formatRtt(conn.rtt?.peek()),
+				].filter((part): part is string => part !== null)
+			: [];
 
 		this.context.setDisplayData(parts.length > 0 ? parts.join("\n") : "N/A");
 	}

--- a/js/ui-core/src/stats/providers/network.ts
+++ b/js/ui-core/src/stats/providers/network.ts
@@ -8,7 +8,6 @@ import { BaseProvider } from "./base";
 export class NetworkProvider extends BaseProvider {
 	private static readonly POLLING_INTERVAL_MS = 250;
 	private context: ProviderContext | undefined;
-	private updateInterval?: number;
 
 	setup(context: ProviderContext): void {
 		this.context = context;
@@ -18,18 +17,8 @@ export class NetworkProvider extends BaseProvider {
 			return;
 		}
 
-		this.updateInterval = window.setInterval(
-			this.updateDisplayData.bind(this),
-			NetworkProvider.POLLING_INTERVAL_MS,
-		);
+		this.signals.interval(this.updateDisplayData.bind(this), NetworkProvider.POLLING_INTERVAL_MS);
 		this.updateDisplayData();
-	}
-
-	override cleanup(): void {
-		if (this.updateInterval !== undefined) {
-			clearInterval(this.updateInterval);
-		}
-		super.cleanup();
 	}
 
 	private updateDisplayData(): void {

--- a/js/ui-core/src/stats/providers/network.ts
+++ b/js/ui-core/src/stats/providers/network.ts
@@ -2,166 +2,68 @@ import type { ProviderContext } from "../types";
 import { BaseProvider } from "./base";
 
 /**
- * Extended Navigator interface with connection property
- */
-interface NavigatorWithConnection extends Navigator {
-	/** Standard Network Information API */
-	connection?: NetworkInformation;
-	/** Mozilla variant */
-	mozConnection?: NetworkInformation;
-	/** WebKit variant */
-	webkitConnection?: NetworkInformation;
-}
-
-/**
- * Network information interface from navigator.connection
- */
-interface NetworkInformation {
-	/** Connection type (wifi, cellular, etc) */
-	type?: string;
-	/** Effective connection speed category */
-	effectiveType?: "slow-2g" | "2g" | "3g" | "4g";
-	/** Downlink speed in Mbps */
-	downlink?: number;
-	/** Round-trip time in ms */
-	rtt?: number;
-	/** User has enabled data saver mode */
-	saveData?: boolean;
-	/** Listen for connection changes */
-	addEventListener?(type: string, listener: () => void): void;
-	/** Stop listening for connection changes */
-	removeEventListener?(type: string, listener: () => void): void;
-}
-
-/**
- * Provider for network metrics (connection type, bandwidth, latency)
+ * Provider for network metrics (bandwidth, latency) sourced from the
+ * underlying MoQ connection (PROBE / QUIC stats).
  */
 export class NetworkProvider extends BaseProvider {
-	/** Polling interval in milliseconds */
-	private static readonly POLLING_INTERVAL_MS = 100;
-	/** Display context for updating metrics */
+	private static readonly POLLING_INTERVAL_MS = 250;
 	private context: ProviderContext | undefined;
-	/** Network information from navigator.connection */
-	private networkInfo?: NetworkInformation;
-	/** Polling interval ID */
 	private updateInterval?: number;
-	private readonly boundUpdateDisplayData = this.updateDisplayData.bind(this);
 
-	/**
-	 * Initialize network provider with connection listeners
-	 */
 	setup(context: ProviderContext): void {
 		this.context = context;
 
-		const nav = navigator as NavigatorWithConnection;
-		this.networkInfo = nav.connection ?? nav.mozConnection ?? nav.webkitConnection;
-
-		if (!this.networkInfo) {
+		if (!this.props.network) {
 			context.setDisplayData("N/A");
 			return;
 		}
 
-		this.networkInfo.addEventListener?.("change", this.boundUpdateDisplayData);
-
-		window.addEventListener("online", this.boundUpdateDisplayData);
-		window.addEventListener("offline", this.boundUpdateDisplayData);
-
-		this.updateInterval = window.setInterval(this.boundUpdateDisplayData, NetworkProvider.POLLING_INTERVAL_MS);
+		this.updateInterval = window.setInterval(
+			this.updateDisplayData.bind(this),
+			NetworkProvider.POLLING_INTERVAL_MS,
+		);
 		this.updateDisplayData();
 	}
 
-	/**
-	 * Clean up event listeners and polling interval
-	 */
 	override cleanup(): void {
-		if (this.networkInfo?.removeEventListener) {
-			this.networkInfo.removeEventListener("change", this.boundUpdateDisplayData);
-		}
-		window.removeEventListener("online", this.boundUpdateDisplayData);
-		window.removeEventListener("offline", this.boundUpdateDisplayData);
 		if (this.updateInterval !== undefined) {
 			clearInterval(this.updateInterval);
 		}
 		super.cleanup();
 	}
 
-	/**
-	 * Calculate and display current network metrics
-	 */
 	private updateDisplayData(): void {
-		if (!this.context) {
+		if (!this.context || !this.props.network) {
 			return;
 		}
 
 		const parts = [
-			this.getConnectionType(),
-			this.getEffectiveBandwidth(),
-			this.getLatency(),
-			this.getSaveDataStatus(),
+			formatBandwidth(this.props.network.recvBandwidth.peek(), "down"),
+			formatBandwidth(this.props.network.sendBandwidth.peek(), "up"),
+			formatRtt(this.props.network.rtt.peek()),
 		].filter((part): part is string => part !== null);
 
 		this.context.setDisplayData(parts.length > 0 ? parts.join("\n") : "N/A");
 	}
+}
 
-	/**
-	 * Get formatted connection type
-	 * @returns Connection type or null if unavailable
-	 */
-	private getConnectionType(): string | null {
-		if (!navigator.onLine) {
-			return "offline";
-		}
+function formatBandwidth(bitsPerSecond: number | undefined, direction: "up" | "down"): string | null {
+	if (bitsPerSecond === undefined || bitsPerSecond <= 0) return null;
 
-		if (!this.networkInfo) {
-			return null;
-		}
-
-		const effectiveType = this.networkInfo.effectiveType;
-		if (effectiveType) {
-			const typeMap = {
-				"slow-2g": "Slow-2G",
-				"2g": "2G",
-				"3g": "3G",
-				"4g": "4G",
-			};
-			return typeMap[effectiveType];
-		}
-
-		const type = this.networkInfo.type;
-		return type ? type.charAt(0).toUpperCase() + type.slice(1) : null;
+	const arrow = direction === "down" ? "↓" : "↑";
+	if (bitsPerSecond >= 1_000_000_000) {
+		return `${arrow} ${(bitsPerSecond / 1_000_000_000).toFixed(1)}Gbps`;
 	}
-
-	/**
-	 * Get formatted bandwidth in Mbps or Gbps
-	 * @returns Bandwidth string or null if unavailable
-	 */
-	private getEffectiveBandwidth(): string | null {
-		const downlink = this.networkInfo?.downlink;
-		if (!downlink || downlink <= 0) return null;
-
-		if (downlink >= 1000) {
-			return `${(downlink / 1000).toFixed(1)}Gbps`;
-		}
-		if (downlink >= 1) {
-			return `${downlink.toFixed(1)}Mbps`;
-		}
-		return `${(downlink * 1000).toFixed(0)}Kbps`;
+	if (bitsPerSecond >= 1_000_000) {
+		return `${arrow} ${(bitsPerSecond / 1_000_000).toFixed(1)}Mbps`;
 	}
-
-	/**
-	 * Get formatted round-trip latency
-	 * @returns Latency string or null if unavailable
-	 */
-	private getLatency(): string | null {
-		const rtt = this.networkInfo?.rtt;
-		return rtt && rtt > 0 ? `${rtt}ms` : null;
+	if (bitsPerSecond >= 1_000) {
+		return `${arrow} ${(bitsPerSecond / 1_000).toFixed(0)}kbps`;
 	}
+	return `${arrow} ${bitsPerSecond.toFixed(0)}bps`;
+}
 
-	/**
-	 * Get data saver mode status
-	 * @returns Data saver indicator or null if disabled
-	 */
-	private getSaveDataStatus(): string | null {
-		return this.networkInfo?.saveData ? "Save-Data" : null;
-	}
+function formatRtt(rtt: number | undefined): string | null {
+	if (rtt === undefined || rtt <= 0) return null;
+	return `${rtt.toFixed(0)}ms`;
 }

--- a/js/ui-core/src/stats/types.ts
+++ b/js/ui-core/src/stats/types.ts
@@ -37,18 +37,18 @@ export interface VideoBackend {
 }
 
 /**
- * Structural interface for connection-level network signals.
- * Each value is a Peekable yielding bits-per-second for bandwidth and
- * milliseconds for rtt, or undefined when the metric isn't available.
+ * Structural interface for an established connection. Bandwidth values
+ * are bits per second; rtt is milliseconds. Each is undefined when the
+ * underlying transport doesn't expose it.
  */
-export interface NetworkBackend {
-	rtt: Peekable<number | undefined>;
-	recvBandwidth: Peekable<number | undefined>;
-	sendBandwidth: Peekable<number | undefined>;
+export interface Connection {
+	rtt?: Peekable<number | undefined>;
+	recvBandwidth?: Peekable<number | undefined>;
+	sendBandwidth?: Peekable<number | undefined>;
 }
 
 export type ProviderProps = {
 	audio: AudioBackend;
 	video: VideoBackend;
-	network?: NetworkBackend;
+	connection?: Peekable<Connection | undefined>;
 };

--- a/js/ui-core/src/stats/types.ts
+++ b/js/ui-core/src/stats/types.ts
@@ -36,7 +36,19 @@ export interface VideoBackend {
 	stats: Peekable<{ frameCount: number; bytesReceived: number } | undefined>;
 }
 
+/**
+ * Structural interface for connection-level network signals.
+ * Each value is a Peekable yielding bits-per-second for bandwidth and
+ * milliseconds for rtt, or undefined when the metric isn't available.
+ */
+export interface NetworkBackend {
+	rtt: Peekable<number | undefined>;
+	recvBandwidth: Peekable<number | undefined>;
+	sendBandwidth: Peekable<number | undefined>;
+}
+
 export type ProviderProps = {
 	audio: AudioBackend;
 	video: VideoBackend;
+	network?: NetworkBackend;
 };

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -26,18 +26,6 @@ export function timeRangesToArray(ranges: TimeRanges): BufferedRanges {
 	return result;
 }
 
-// Network signals derived from the underlying connection.
-export interface NetworkBackend {
-	// Round-trip time in milliseconds, from PROBE or QUIC stats.
-	rtt: Signal<number | undefined>;
-
-	// Receive bitrate in bits per second, from PROBE.
-	recvBandwidth: Signal<number | undefined>;
-
-	// Send bitrate in bits per second, from the local congestion controller.
-	sendBandwidth: Signal<number | undefined>;
-}
-
 export interface Backend {
 	// Whether audio/video playback is paused.
 	paused: Signal<boolean>;
@@ -47,9 +35,6 @@ export interface Backend {
 
 	// Audio specific signals.
 	audio?: Audio.Backend;
-
-	// Connection-level network signals.
-	network: NetworkBackend;
 
 	// The latency setting: "real-time" auto-computes jitter, a number sets a fixed jitter.
 	latency: Signal<Latency>;
@@ -65,14 +50,8 @@ export interface MultiBackendProps {
 	// Latency: "real-time" auto-computes jitter from RTT, a number sets a fixed jitter in ms.
 	latency?: Latency | Signal<Latency>;
 
-	// RTT signal from the connection (PROBE), used for dynamic jitter in "real-time" mode.
-	rtt?: Signal<number | undefined>;
-
-	// Receive bitrate signal from the connection (PROBE).
-	recvBandwidth?: Signal<number | undefined>;
-
-	// Send bitrate signal from the connection (QUIC stats).
-	sendBandwidth?: Signal<number | undefined>;
+	// Established connection, used by Sync to read RTT (PROBE) for dynamic jitter in "real-time" mode.
+	connection?: Signal<Moq.Connection.Established | undefined>;
 
 	paused?: boolean | Signal<boolean>;
 }
@@ -139,8 +118,6 @@ export class MultiBackend implements Backend {
 	audio: AudioBackend;
 	#audioSource: Audio.Source;
 
-	network: NetworkBackend;
-
 	// Used to sync audio and video playback at a target delay.
 	sync: Sync;
 
@@ -149,15 +126,9 @@ export class MultiBackend implements Backend {
 	constructor(props?: MultiBackendProps) {
 		this.element = Signal.from(props?.element);
 		this.broadcast = Signal.from(props?.broadcast);
-		this.sync = new Sync({ latency: props?.latency, rtt: props?.rtt });
+		this.sync = new Sync({ latency: props?.latency, connection: props?.connection });
 		this.latency = this.sync.latency;
 		this.jitter = this.sync.jitter;
-
-		this.network = {
-			rtt: props?.rtt ?? new Signal<number | undefined>(undefined),
-			recvBandwidth: props?.recvBandwidth ?? new Signal<number | undefined>(undefined),
-			sendBandwidth: props?.sendBandwidth ?? new Signal<number | undefined>(undefined),
-		};
 
 		this.#videoSource = new Video.Source(this.sync, {
 			broadcast: this.broadcast,

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -26,6 +26,18 @@ export function timeRangesToArray(ranges: TimeRanges): BufferedRanges {
 	return result;
 }
 
+// Network signals derived from the underlying connection.
+export interface NetworkBackend {
+	// Round-trip time in milliseconds, from PROBE or QUIC stats.
+	rtt: Signal<number | undefined>;
+
+	// Receive bitrate in bits per second, from PROBE.
+	recvBandwidth: Signal<number | undefined>;
+
+	// Send bitrate in bits per second, from the local congestion controller.
+	sendBandwidth: Signal<number | undefined>;
+}
+
 export interface Backend {
 	// Whether audio/video playback is paused.
 	paused: Signal<boolean>;
@@ -35,6 +47,9 @@ export interface Backend {
 
 	// Audio specific signals.
 	audio?: Audio.Backend;
+
+	// Connection-level network signals.
+	network: NetworkBackend;
 
 	// The latency setting: "real-time" auto-computes jitter, a number sets a fixed jitter.
 	latency: Signal<Latency>;
@@ -52,6 +67,12 @@ export interface MultiBackendProps {
 
 	// RTT signal from the connection (PROBE), used for dynamic jitter in "real-time" mode.
 	rtt?: Signal<number | undefined>;
+
+	// Receive bitrate signal from the connection (PROBE).
+	recvBandwidth?: Signal<number | undefined>;
+
+	// Send bitrate signal from the connection (QUIC stats).
+	sendBandwidth?: Signal<number | undefined>;
 
 	paused?: boolean | Signal<boolean>;
 }
@@ -118,6 +139,8 @@ export class MultiBackend implements Backend {
 	audio: AudioBackend;
 	#audioSource: Audio.Source;
 
+	network: NetworkBackend;
+
 	// Used to sync audio and video playback at a target delay.
 	sync: Sync;
 
@@ -129,6 +152,12 @@ export class MultiBackend implements Backend {
 		this.sync = new Sync({ latency: props?.latency, rtt: props?.rtt });
 		this.latency = this.sync.latency;
 		this.jitter = this.sync.jitter;
+
+		this.network = {
+			rtt: props?.rtt ?? new Signal<number | undefined>(undefined),
+			recvBandwidth: props?.recvBandwidth ?? new Signal<number | undefined>(undefined),
+			sendBandwidth: props?.sendBandwidth ?? new Signal<number | undefined>(undefined),
+		};
 
 		this.#videoSource = new Video.Source(this.sync, {
 			broadcast: this.broadcast,

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -56,17 +56,24 @@ export default class MoqWatch extends HTMLElement {
 		});
 		this.signals.cleanup(() => this.broadcast.close());
 
-		// Flatten the RTT signal from the connection for the backend.
+		// Flatten the network signals from the connection for the backend.
+		// These follow the underlying signals on the established connection,
+		// resetting to undefined while disconnected or reconnecting.
 		const rtt = new Signal<number | undefined>(undefined);
+		const recvBandwidth = new Signal<number | undefined>(undefined);
+		const sendBandwidth = new Signal<number | undefined>(undefined);
 		this.signals.run((effect) => {
 			const conn = effect.get(this.connection.established);
-			const rttSignal = conn?.rtt;
-			rtt.set(rttSignal ? effect.get(rttSignal) : undefined);
+			rtt.set(conn?.rtt ? effect.get(conn.rtt) : undefined);
+			recvBandwidth.set(conn?.recvBandwidth ? effect.get(conn.recvBandwidth) : undefined);
+			sendBandwidth.set(conn?.sendBandwidth ? effect.get(conn.sendBandwidth) : undefined);
 		});
 
 		this.backend = new MultiBackend({
 			broadcast: this.broadcast,
 			rtt,
+			recvBandwidth,
+			sendBandwidth,
 		});
 		this.signals.cleanup(() => this.backend.close());
 

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -56,24 +56,9 @@ export default class MoqWatch extends HTMLElement {
 		});
 		this.signals.cleanup(() => this.broadcast.close());
 
-		// Flatten the network signals from the connection for the backend.
-		// These follow the underlying signals on the established connection,
-		// resetting to undefined while disconnected or reconnecting.
-		const rtt = new Signal<number | undefined>(undefined);
-		const recvBandwidth = new Signal<number | undefined>(undefined);
-		const sendBandwidth = new Signal<number | undefined>(undefined);
-		this.signals.run((effect) => {
-			const conn = effect.get(this.connection.established);
-			rtt.set(conn?.rtt ? effect.get(conn.rtt) : undefined);
-			recvBandwidth.set(conn?.recvBandwidth ? effect.get(conn.recvBandwidth) : undefined);
-			sendBandwidth.set(conn?.sendBandwidth ? effect.get(conn.sendBandwidth) : undefined);
-		});
-
 		this.backend = new MultiBackend({
 			broadcast: this.broadcast,
-			rtt,
-			recvBandwidth,
-			sendBandwidth,
+			connection: this.connection.established,
 		});
 		this.signals.cleanup(() => this.backend.close());
 

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -1,3 +1,4 @@
+import type * as Moq from "@moq/lite";
 import { Time } from "@moq/lite";
 import { Effect, Signal } from "@moq/signals";
 
@@ -9,7 +10,7 @@ const FALLBACK_JITTER = 100 as Time.Milli;
 
 export interface SyncProps {
 	latency?: Latency | Signal<Latency>;
-	rtt?: Signal<number | undefined>;
+	connection?: Signal<Moq.Connection.Established | undefined>;
 	audio?: Time.Milli | Signal<Time.Milli | undefined>;
 	video?: Time.Milli | Signal<Time.Milli | undefined>;
 }
@@ -46,8 +47,8 @@ export class Sync {
 	// Per-label late-frame tracking: accumulate count and max lateness, flush on recovery.
 	#late = new Map<string, { count: number; maxMs: number }>();
 
-	// RTT signal from the connection (PROBE or getStats).
-	rtt?: Signal<number | undefined>;
+	// The connection used for "real-time" jitter: PROBE supplies RTT.
+	#connection?: Signal<Moq.Connection.Established | undefined>;
 
 	// Minimum RTT seen, used as the baseline for jitter calculation.
 	// Avoids inflating jitter due to bufferbloat.
@@ -58,7 +59,7 @@ export class Sync {
 	constructor(props?: SyncProps) {
 		this.latency = Signal.from(props?.latency ?? ("real-time" as Latency));
 		this.jitter = new Signal<Time.Milli>(FALLBACK_JITTER);
-		this.rtt = props?.rtt;
+		this.#connection = props?.connection;
 		this.audio = Signal.from(props?.audio);
 		this.video = Signal.from(props?.video);
 
@@ -78,19 +79,18 @@ export class Sync {
 			return;
 		}
 
-		// "real-time" mode: compute jitter from RTT.
-		if (this.rtt) {
-			const rtt = effect.get(this.rtt);
-			if (rtt !== undefined) {
-				// Track minimum RTT as baseline, ignoring bufferbloat.
-				this.#minRtt = this.#minRtt !== undefined ? Math.min(this.#minRtt, rtt) : rtt;
+		// "real-time" mode: compute jitter from RTT on the established connection.
+		const conn = this.#connection ? effect.get(this.#connection) : undefined;
+		const rttSignal = conn?.rtt;
+		const rtt = rttSignal ? effect.get(rttSignal) : undefined;
+		if (rtt !== undefined) {
+			// Track minimum RTT as baseline, ignoring bufferbloat.
+			this.#minRtt = this.#minRtt !== undefined ? Math.min(this.#minRtt, rtt) : rtt;
 
-				// Buffer enough for a retransmit (1 RTT for ACK + retransmit).
-				const jitter = Math.max(MIN_JITTER, this.#minRtt * 1.25) as Time.Milli;
-				this.jitter.set(jitter);
-
-				return;
-			}
+			// Buffer enough for a retransmit (1 RTT for ACK + retransmit).
+			const jitter = Math.max(MIN_JITTER, this.#minRtt * 1.25) as Time.Milli;
+			this.jitter.set(jitter);
+			return;
 		}
 
 		// No RTT available: fall back to static default.

--- a/js/watch/src/ui/element.tsx
+++ b/js/watch/src/ui/element.tsx
@@ -23,11 +23,10 @@ export function WatchUI(props: { watch: MoqWatch }) {
 								context={WatchUIContext}
 								getElement={(ctx) => {
 									if (!ctx) return undefined;
-									const backend = ctx.moqWatch.backend;
 									return {
-										audio: backend.audio,
-										video: backend.video,
-										network: backend.network,
+										audio: ctx.moqWatch.backend.audio,
+										video: ctx.moqWatch.backend.video,
+										connection: ctx.moqWatch.connection.established,
 									};
 								}}
 							/>

--- a/js/watch/src/ui/element.tsx
+++ b/js/watch/src/ui/element.tsx
@@ -22,7 +22,13 @@ export function WatchUI(props: { watch: MoqWatch }) {
 							<Stats
 								context={WatchUIContext}
 								getElement={(ctx) => {
-									return ctx?.moqWatch.backend;
+									if (!ctx) return undefined;
+									const backend = ctx.moqWatch.backend;
+									return {
+										audio: backend.audio,
+										video: backend.video,
+										network: backend.network,
+									};
 								}}
 							/>
 						</Show>


### PR DESCRIPTION
The stats panel's network row was driven by navigator.connection, which
on most browsers reports a coarse effectiveType ("4G") and synthetic
downlink/rtt values that have nothing to do with the actual MoQ session.
Replace it with the bandwidth and RTT signals that the connection
already exposes (PROBE for recv bandwidth and RTT, QUIC stats for send
bandwidth), plumbed through MultiBackend.network.