### PR TITLE
moq-ffi: fix uniffi-bindgen invocation, bump to 0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,7 +3568,7 @@ version = "0.0.2"
 
 [[package]]
 name = "moq-ffi"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "bytes",
  "hang",

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>", "Brian Medley <bpm@bmedley.org>"
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]

--- a/rs/moq-ffi/build.sh
+++ b/rs/moq-ffi/build.sh
@@ -130,7 +130,7 @@ generate_bindings() {
 
     for lang in kotlin swift python; do
         echo "  Generating $lang bindings..."
-        cargo run --release --bin uniffi-bindgen --manifest-path "$WORKSPACE_DIR/Cargo.toml" -- \
+        cargo run --release --package moq-ffi --bin uniffi-bindgen --manifest-path "$WORKSPACE_DIR/Cargo.toml" -- \
             generate --library "$lib_path" \
             --language "$lang" --out-dir "$OUTPUT_DIR/bindings/$lang"
     done


### PR DESCRIPTION
## Summary

The `moq-ffi-v0.2.8` release pipeline ([run](https://github.com/moq-dev/moq/actions/runs/25609959647)) failed across `Generate bindings` and the desktop `Build` jobs (x86_64-apple-darwin, aarch64-apple-darwin, universal-apple-darwin, x86_64-pc-windows-msvc, x86_64-unknown-linux-gnu) with:

```
error: no bin target named `uniffi-bindgen` in default-run packages
help: available bin in `moq-ffi` package:
    uniffi-bindgen
```

`moq-ffi` is intentionally excluded from the workspace's `default-members` (it requires Python/maturin), so `cargo run --bin uniffi-bindgen` from `rs/moq-ffi/build.sh` can't pick the bin without an explicit package. Cross-compiled targets (iOS, Android, aarch64-linux-gnu) skipped the bindings step via `can_run_on_host` and weren't affected.

## Changes

- `rs/moq-ffi/build.sh`: pass `--package moq-ffi` to the `cargo run` invocation that drives `uniffi-bindgen`.
- `rs/moq-ffi/Cargo.toml`: bump `0.2.8` → `0.2.9` so release-plz can re-tag with the fix in place.

## Test plan

- [x] Verified locally: `cargo run --release --package moq-ffi --bin uniffi-bindgen --manifest-path Cargo.toml -- --help` builds and prints help.
- [ ] After merge, release-plz issues a new `moq-ffi-v0.2.9` tag and the release workflow completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)