### PR TITLE
Reduce track group cache eviction timeout from 30s to 5s

### DIFF
--- a/rs/moq-lite/src/model/track.rs
+++ b/rs/moq-lite/src/model/track.rs
@@ -24,7 +24,7 @@ use std::{
 
 /// Groups older than this are evicted from the track cache (unless they are the max_sequence group).
 // TODO: Replace with a configurable cache size.
-const MAX_GROUP_AGE: Duration = Duration::from_secs(30);
+const MAX_GROUP_AGE: Duration = Duration::from_secs(5);
 
 /// A track is a collection of groups, delivered out-of-order until expired.
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
Reduced the `MAX_GROUP_AGE` constant that controls track group cache eviction from 30 seconds to 5 seconds.

## Changes
- Decreased `MAX_GROUP_AGE` duration from `Duration::from_secs(30)` to `Duration::from_secs(5)` in the track model
- This affects how aggressively older groups are evicted from the track cache (except for the max_sequence group which is retained)

## Details
This change makes the track cache more aggressive in removing stale group data, reducing memory footprint at the cost of shorter retention time for cached groups. Groups older than 5 seconds will now be evicted instead of 30 seconds.

https://claude.ai/code/session_01BNxmu9Q5bWtEJ59RxBQt8M