### PR TITLE
moq-cli: rename --output to --format, --name to --broadcast, add accept subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "moq-cli"
-version = "0.7.21"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3538,6 +3538,7 @@ dependencies = [
  "bytes",
  "clap",
  "hang",
+ "humantime",
  "moq-mux",
  "moq-native",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "moq-cli"
-version = "0.8.0"
+version = "0.7.22"
 dependencies = [
  "anyhow",
  "axum",

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.8.0"
+version = "0.7.22"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.7.21"
+version = "0.8.0"
 edition = "2024"
 rust-version.workspace = true
 
@@ -26,6 +26,7 @@ axum-server = { version = "0.8", features = ["tls-rustls"] }
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 hang = { workspace = true }
+humantime = "2.3"
 moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
 rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false }

--- a/rs/moq-cli/README.md
+++ b/rs/moq-cli/README.md
@@ -1,7 +1,7 @@
 # moq-cli
 
 A command-line tool for publishing and subscribing to media over MoQ.
-It works with FFmpeg for encoding.
+It works with FFmpeg for encoding and decoding.
 
 ## Install
 
@@ -19,14 +19,41 @@ Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub
 
 ## Usage
 
-### Publish a Video File
+`moq-cli` reads media from stdin (or writes media to stdout) and exchanges it with a MoQ relay. Pick a subcommand based on whether you want to publish or subscribe, and whether your relay is local or remote.
+
+### Publish to a remote relay
 
 ```bash
-moq-cli publish video.mp4 https://relay.example.com/anon/my-stream
+ffmpeg -i input.mp4 -f mp4 -movflags cmaf - | \
+    moq-cli publish --url https://relay.example.com --broadcast my-stream fmp4
 ```
 
-### Publish from FFmpeg
+### Subscribe from a remote relay
 
 ```bash
-ffmpeg -i input.mp4 -f mpegts - | moq-cli publish - https://relay.example.com/anon/my-stream
+moq-cli subscribe --url https://relay.example.com --broadcast my-stream --format fmp4 | \
+    ffplay -
 ```
+
+### Self-host: publish into a local relay (`serve`)
+
+Runs a relay and publishes a single broadcast read from stdin into it. Useful for local testing without a separate relay process.
+
+```bash
+ffmpeg -i input.mp4 -f mp4 -movflags cmaf - | \
+    moq-cli serve --broadcast my-stream fmp4
+```
+
+### Self-host: subscribe to an inbound broadcast (`accept`)
+
+Runs a relay and writes the first incoming broadcast's media to stdout. The inverse of `serve`.
+
+```bash
+moq-cli accept --broadcast my-stream --format fmp4 | ffplay -
+```
+
+### Input formats (`publish` / `serve`)
+
+- `avc3` raw H.264 Annex-B from stdin
+- `fmp4` fragmented MP4 from stdin
+- `hls --playlist <url-or-path>` ingest from an HLS playlist

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -32,13 +32,14 @@ pub struct Cli {
 
 #[derive(Subcommand, Clone)]
 pub enum Command {
+	/// Run a relay and publish a single broadcast read from stdin into it.
 	Serve {
 		#[command(flatten)]
 		config: moq_native::ServerConfig,
 
 		/// The name of the broadcast to serve.
-		#[arg(long)]
-		name: String,
+		#[arg(long, alias = "name")]
+		broadcast: String,
 
 		/// Optionally serve static files from the given directory.
 		#[arg(long)]
@@ -48,6 +49,23 @@ pub enum Command {
 		#[command(subcommand)]
 		format: PublishFormat,
 	},
+	/// Run a relay and write the first incoming broadcast's media to stdout.
+	Accept {
+		#[command(flatten)]
+		config: moq_native::ServerConfig,
+
+		/// The name of the broadcast to accept.
+		#[arg(long, alias = "name")]
+		broadcast: String,
+
+		/// Optionally serve static files from the given directory.
+		#[arg(long)]
+		dir: Option<PathBuf>,
+
+		#[command(flatten)]
+		args: SubscribeArgs,
+	},
+	/// Publish a broadcast read from stdin to a remote relay.
 	Publish {
 		/// The MoQ client configuration.
 		#[command(flatten)]
@@ -67,14 +85,14 @@ pub enum Command {
 		url: Url,
 
 		/// The name of the broadcast to publish.
-		#[arg(long)]
-		name: String,
+		#[arg(long, alias = "name")]
+		broadcast: String,
 
 		/// The format of the input media.
 		#[command(subcommand)]
 		format: PublishFormat,
 	},
-	/// Subscribe to a broadcast and write the media to stdout.
+	/// Subscribe to a broadcast on a remote relay and write the media to stdout.
 	Subscribe {
 		/// The MoQ client configuration.
 		#[command(flatten)]
@@ -85,8 +103,8 @@ pub enum Command {
 		url: Url,
 
 		/// The name of the broadcast to subscribe to.
-		#[arg(long)]
-		name: String,
+		#[arg(long, alias = "name")]
+		broadcast: String,
 
 		#[command(flatten)]
 		args: SubscribeArgs,
@@ -111,7 +129,7 @@ async fn main() -> anyhow::Result<()> {
 		Command::Serve {
 			config,
 			dir,
-			name,
+			broadcast,
 			format,
 		} => {
 			let publish = Publish::new(&format)?;
@@ -124,15 +142,39 @@ async fn main() -> anyhow::Result<()> {
 			let web_tls = server.tls_info();
 
 			tokio::select! {
-				res = run_server(server, name, publish.consume()) => res,
+				res = run_server(server, broadcast, publish.consume()) => res,
 				res = run_web(&web_bind, web_tls, dir) => res,
 				res = publish.run() => res,
+			}
+		}
+		Command::Accept {
+			config,
+			broadcast,
+			dir,
+			args,
+		} => {
+			let web_bind = config.bind.clone().unwrap_or_else(|| "[::]:443".to_string());
+
+			let server = config.init()?;
+			#[cfg(feature = "iroh")]
+			let server = server.with_iroh(iroh);
+
+			let web_tls = server.tls_info();
+
+			let origin = moq_lite::Origin::random().produce();
+			let consumer = origin.consume();
+
+			tokio::select! {
+				res = run_accept(server, origin) => res,
+				res = run_web(&web_bind, web_tls, dir) => res,
+				res = run_announced_subscribe(consumer, broadcast, args) => res,
+				_ = tokio::signal::ctrl_c() => Ok(()),
 			}
 		}
 		Command::Publish {
 			config,
 			url,
-			name,
+			broadcast,
 			format,
 		} => {
 			let publish = Publish::new(&format)?;
@@ -141,12 +183,12 @@ async fn main() -> anyhow::Result<()> {
 			#[cfg(feature = "iroh")]
 			let client = client.with_iroh(iroh);
 
-			run_client(client, url, name, publish).await
+			run_client(client, url, broadcast, publish).await
 		}
 		Command::Subscribe {
 			config,
 			url,
-			name,
+			broadcast,
 			args,
 		} => {
 			let client = config.init()?;
@@ -154,32 +196,43 @@ async fn main() -> anyhow::Result<()> {
 			#[cfg(feature = "iroh")]
 			let client = client.with_iroh(iroh);
 
-			run_subscribe(client, url, name, args).await
+			run_subscribe(client, url, broadcast, args).await
 		}
 	}
 }
 
-async fn run_subscribe(client: moq_native::Client, url: Url, name: String, args: SubscribeArgs) -> anyhow::Result<()> {
+async fn run_subscribe(
+	client: moq_native::Client,
+	url: Url,
+	broadcast: String,
+	args: SubscribeArgs,
+) -> anyhow::Result<()> {
 	let origin = moq_lite::Origin::random().produce();
 	let consumer = origin.consume();
 
-	tracing::info!(%url, %name, "connecting");
+	tracing::info!(%url, %broadcast, "connecting");
 
 	let reconnect = client.with_consume(origin).reconnect(url);
 
 	#[cfg(unix)]
 	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
 
-	let broadcast = consumer
-		.announced_broadcast(&name)
-		.await
-		.ok_or_else(|| anyhow::anyhow!("origin closed before broadcast was announced"))?;
-
-	let subscribe = Subscribe::new(broadcast, args);
-
 	tokio::select! {
-		res = subscribe.run() => res,
+		res = run_announced_subscribe(consumer, broadcast, args) => res,
 		res = reconnect.closed() => res,
 		_ = tokio::signal::ctrl_c() => Ok(()),
 	}
+}
+
+async fn run_announced_subscribe(
+	consumer: moq_lite::OriginConsumer,
+	broadcast: String,
+	args: SubscribeArgs,
+) -> anyhow::Result<()> {
+	let consumer = consumer
+		.announced_broadcast(&broadcast)
+		.await
+		.ok_or_else(|| anyhow::anyhow!("origin closed before broadcast was announced"))?;
+
+	Subscribe::new(consumer, args).run().await
 }

--- a/rs/moq-cli/src/server.rs
+++ b/rs/moq-cli/src/server.rs
@@ -22,7 +22,7 @@ pub async fn run_server(
 		let consumer = consumer.clone();
 		// Handle the connection in a new task.
 		tokio::spawn(async move {
-			if let Err(err) = run_session(id, session, name, consumer).await {
+			if let Err(err) = run_serve_session(id, session, name, consumer).await {
 				tracing::warn!(%err, "failed to accept session");
 			}
 		});
@@ -32,7 +32,7 @@ pub async fn run_server(
 }
 
 #[tracing::instrument("session", skip_all, fields(id))]
-async fn run_session(
+async fn run_serve_session(
 	id: u64,
 	session: moq_native::Request,
 	name: String,
@@ -44,6 +44,43 @@ async fn run_session(
 
 	// Blindly accept the session (WebTransport or QUIC), regardless of the URL.
 	let session = session.with_publish(origin.consume()).ok().await?;
+
+	tracing::info!(id, "accepted session");
+
+	session.closed().await.map_err(Into::into)
+}
+
+pub async fn run_accept(mut server: moq_native::Server, origin: moq_lite::OriginProducer) -> anyhow::Result<()> {
+	#[cfg(unix)]
+	// Notify systemd that we're ready.
+	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
+
+	let mut conn_id = 0;
+
+	tracing::info!(addr = ?server.local_addr(), "listening");
+
+	while let Some(session) = server.accept().await {
+		let id = conn_id;
+		conn_id += 1;
+
+		let origin = origin.clone();
+		tokio::spawn(async move {
+			if let Err(err) = run_accept_session(id, session, origin).await {
+				tracing::warn!(%err, "failed to accept session");
+			}
+		});
+	}
+
+	Ok(())
+}
+
+#[tracing::instrument("session", skip_all, fields(id))]
+async fn run_accept_session(
+	id: u64,
+	session: moq_native::Request,
+	origin: moq_lite::OriginProducer,
+) -> anyhow::Result<()> {
+	let session = session.with_consume(origin).ok().await?;
 
 	tracing::info!(id, "accepted session");
 

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -1,21 +1,23 @@
+use std::time::Duration;
+
 use clap::ValueEnum;
 use hang::moq_lite;
 use tokio::io::AsyncWriteExt;
 
 #[derive(ValueEnum, Clone, Copy)]
-pub enum OutputFormat {
+pub enum SubscribeFormat {
 	Fmp4,
 }
 
 #[derive(clap::Args, Clone)]
 pub struct SubscribeArgs {
-	/// Output format for stdout
+	/// The format to write to stdout.
 	#[arg(long)]
-	pub output: OutputFormat,
+	pub format: SubscribeFormat,
 
-	/// Maximum latency in milliseconds before skipping groups
-	#[arg(long, default_value = "500")]
-	pub max_latency: u64,
+	/// Maximum latency before skipping groups (e.g. `500ms`, `1s`).
+	#[arg(long, default_value = "500ms", value_parser = humantime::parse_duration)]
+	pub max_latency: Duration,
 }
 
 pub struct Subscribe {
@@ -29,19 +31,18 @@ impl Subscribe {
 	}
 
 	pub async fn run(self) -> anyhow::Result<()> {
-		match self.args.output {
-			OutputFormat::Fmp4 => self.run_fmp4().await,
+		match self.args.format {
+			SubscribeFormat::Fmp4 => self.run_fmp4().await,
 		}
 	}
 
 	async fn run_fmp4(self) -> anyhow::Result<()> {
 		let mut stdout = tokio::io::stdout();
-		let max_latency = std::time::Duration::from_millis(self.args.max_latency);
 
 		// Fmp4 subscribes to the catalog internally, builds the merged init segment
 		// from the first catalog snapshot, then yields moof+mdat fragments in
 		// timestamp order across tracks.
-		let mut fmp4 = moq_mux::export::Fmp4::new(self.broadcast)?.with_latency(max_latency);
+		let mut fmp4 = moq_mux::export::Fmp4::new(self.broadcast)?.with_latency(self.args.max_latency);
 
 		while let Some(chunk) = fmp4.next().await? {
 			stdout.write_all(&chunk).await?;


### PR DESCRIPTION
## Summary

- Rename `--output` → `--format` on `subscribe` for symmetry with `publish`. `OutputFormat` enum becomes `SubscribeFormat`.
- Rename `--name` → `--broadcast` on every subcommand; the old `--name` is kept as a hidden alias for backwards compatibility.
- `--max-latency` now accepts humantime durations (`500ms`, `1s`) instead of a bare millisecond integer.
- Add a new `accept` subcommand: the server-side counterpart of `subscribe`. Runs a relay and writes the first incoming broadcast's media to stdout.
- Add doc comments to every `Command` variant so `--help` no longer leaks the flattened struct's about text on `serve` / `publish`.
- Update the README, which was several releases out of date.

CLI surface now:

\`\`\`
moq-cli serve     --broadcast N [--dir D]    <fmp4|avc3|hls --playlist P>
moq-cli accept    --broadcast N [--dir D]    --format fmp4 [--max-latency 500ms]
moq-cli publish   --url U --broadcast N      <fmp4|avc3|hls --playlist P>
moq-cli subscribe --url U --broadcast N      --format fmp4 [--max-latency 500ms]
\`\`\`

Manual patch bump to \`0.7.22\` since release-plz uses cargo-semver-checks, which only inspects library API. Binary CLI surface changes aren't auto-detected, so the bump won't happen on its own.

## Test plan

- [x] \`just check\` passes
- [x] \`--help\` text reads cleanly on all four subcommands (no leaked "Configuration for the MoQ ..." about text)
- [x] \`subscribe --name foo --format fmp4 --url https://...\` parses (\`--name\` alias still works); log shows \`broadcast=foo\`
- [x] \`--max-latency 500ms\` parses
- [ ] Smoke test \`accept\` against a live publisher locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)