### PR TITLE
Expose track name and used/unused activity signals

### DIFF
--- a/py/moq-lite/moq_lite/publish.py
+++ b/py/moq-lite/moq_lite/publish.py
@@ -16,6 +16,19 @@ class MediaProducer:
     def __init__(self, inner: MoqMediaProducer) -> None:
         self._inner = inner
 
+    @property
+    def name(self) -> str:
+        """The generated media track name."""
+        return self._inner.name()
+
+    async def used(self) -> None:
+        """Wait until this media track has at least one active subscriber."""
+        await self._inner.used()
+
+    async def unused(self) -> None:
+        """Wait until this media track has no active subscribers."""
+        await self._inner.unused()
+
     def write_frame(self, payload: bytes, timestamp_us: int) -> None:
         self._inner.write_frame(payload, timestamp_us)
 
@@ -55,6 +68,19 @@ class TrackProducer:
 
     def __init__(self, inner: MoqTrackProducer) -> None:
         self._inner = inner
+
+    @property
+    def name(self) -> str:
+        """The track name."""
+        return self._inner.name()
+
+    async def used(self) -> None:
+        """Wait until this track has at least one active subscriber."""
+        await self._inner.used()
+
+    async def unused(self) -> None:
+        """Wait until this track has no active subscribers."""
+        await self._inner.unused()
 
     def append_group(self) -> GroupProducer:
         """Start a new group; write frames into it, then finish()."""

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -152,23 +152,13 @@ impl MoqTrackProducer {
 
 	/// Wait until this track has at least one active consumer.
 	pub async fn used(&self) -> Result<(), MoqError> {
-		let track = {
-			let _guard = crate::ffi::RUNTIME.enter();
-			let guard = self.inner.lock().unwrap();
-			guard.as_ref().ok_or_else(|| MoqError::Closed)?.clone()
-		};
-
+		let track = self.inner.lock().unwrap().as_ref().ok_or(MoqError::Closed)?.clone();
 		wait_for_track_activity(track, TrackActivity::Used).await
 	}
 
 	/// Wait until this track has no active consumers.
 	pub async fn unused(&self) -> Result<(), MoqError> {
-		let track = {
-			let _guard = crate::ffi::RUNTIME.enter();
-			let guard = self.inner.lock().unwrap();
-			guard.as_ref().ok_or_else(|| MoqError::Closed)?.clone()
-		};
-
+		let track = self.inner.lock().unwrap().as_ref().ok_or(MoqError::Closed)?.clone();
 		wait_for_track_activity(track, TrackActivity::Unused).await
 	}
 
@@ -267,23 +257,27 @@ impl MoqMediaProducer {
 
 	/// Wait until this media track has at least one active consumer.
 	pub async fn used(&self) -> Result<(), MoqError> {
-		let track = {
-			let _guard = crate::ffi::RUNTIME.enter();
-			let guard = self.inner.lock().unwrap();
-			guard.as_ref().ok_or_else(|| MoqError::Closed)?.track.clone()
-		};
-
+		let track = self
+			.inner
+			.lock()
+			.unwrap()
+			.as_ref()
+			.ok_or(MoqError::Closed)?
+			.track
+			.clone();
 		wait_for_track_activity(track, TrackActivity::Used).await
 	}
 
 	/// Wait until this media track has no active consumers.
 	pub async fn unused(&self) -> Result<(), MoqError> {
-		let track = {
-			let _guard = crate::ffi::RUNTIME.enter();
-			let guard = self.inner.lock().unwrap();
-			guard.as_ref().ok_or_else(|| MoqError::Closed)?.track.clone()
-		};
-
+		let track = self
+			.inner
+			.lock()
+			.unwrap()
+			.as_ref()
+			.ok_or(MoqError::Closed)?
+			.track
+			.clone();
 		wait_for_track_activity(track, TrackActivity::Unused).await
 	}
 

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -13,6 +13,11 @@ struct BroadcastProducer {
 	catalog: moq_mux::catalog::Producer,
 }
 
+struct MediaProducer {
+	decoder: moq_mux::import::Framed,
+	track: moq_lite::TrackProducer,
+}
+
 #[derive(uniffi::Object)]
 pub struct MoqBroadcastProducer {
 	state: std::sync::Mutex<Option<BroadcastProducer>>,
@@ -28,7 +33,28 @@ impl MoqBroadcastProducer {
 
 #[derive(uniffi::Object)]
 pub struct MoqMediaProducer {
-	inner: std::sync::Mutex<Option<moq_mux::import::Framed>>,
+	inner: std::sync::Mutex<Option<MediaProducer>>,
+}
+
+enum TrackActivity {
+	Used,
+	Unused,
+}
+
+async fn wait_for_track_activity(track: moq_lite::TrackProducer, activity: TrackActivity) -> Result<(), MoqError> {
+	let handle = crate::ffi::RUNTIME.spawn(async move {
+		match activity {
+			TrackActivity::Used => track.used().await,
+			TrackActivity::Unused => track.unused().await,
+		}
+		.map_err(Into::into)
+	});
+
+	match handle.await {
+		Ok(result) => result,
+		Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
+		Err(e) => Err(MoqError::Task(e)),
+	}
 }
 
 #[uniffi::export]
@@ -70,8 +96,13 @@ impl MoqBroadcastProducer {
 			return Err(MoqError::Codec("init failed: trailing bytes".into()));
 		}
 
+		let track = decoder
+			.track()
+			.map_err(|err| MoqError::Codec(format!("track unavailable: {err}")))?
+			.clone();
+
 		Ok(Arc::new(MoqMediaProducer {
-			inner: std::sync::Mutex::new(Some(decoder)),
+			inner: std::sync::Mutex::new(Some(MediaProducer { decoder, track })),
 		}))
 	}
 
@@ -111,6 +142,36 @@ pub struct MoqTrackProducer {
 
 #[uniffi::export]
 impl MoqTrackProducer {
+	/// Return the name of this track.
+	pub fn name(&self) -> Result<String, MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		let guard = self.inner.lock().unwrap();
+		let track = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
+		Ok(track.name.clone())
+	}
+
+	/// Wait until this track has at least one active consumer.
+	pub async fn used(&self) -> Result<(), MoqError> {
+		let track = {
+			let _guard = crate::ffi::RUNTIME.enter();
+			let guard = self.inner.lock().unwrap();
+			guard.as_ref().ok_or_else(|| MoqError::Closed)?.clone()
+		};
+
+		wait_for_track_activity(track, TrackActivity::Used).await
+	}
+
+	/// Wait until this track has no active consumers.
+	pub async fn unused(&self) -> Result<(), MoqError> {
+		let track = {
+			let _guard = crate::ffi::RUNTIME.enter();
+			let guard = self.inner.lock().unwrap();
+			guard.as_ref().ok_or_else(|| MoqError::Closed)?.clone()
+		};
+
+		wait_for_track_activity(track, TrackActivity::Unused).await
+	}
+
 	/// Create a consumer that reads from this producer's track.
 	///
 	/// Useful for local pub/sub without going through an origin/broadcast.
@@ -196,17 +257,48 @@ impl MoqGroupProducer {
 
 #[uniffi::export]
 impl MoqMediaProducer {
+	/// Return the name of the media track.
+	pub fn name(&self) -> Result<String, MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		let guard = self.inner.lock().unwrap();
+		let media = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
+		Ok(media.track.name.clone())
+	}
+
+	/// Wait until this media track has at least one active consumer.
+	pub async fn used(&self) -> Result<(), MoqError> {
+		let track = {
+			let _guard = crate::ffi::RUNTIME.enter();
+			let guard = self.inner.lock().unwrap();
+			guard.as_ref().ok_or_else(|| MoqError::Closed)?.track.clone()
+		};
+
+		wait_for_track_activity(track, TrackActivity::Used).await
+	}
+
+	/// Wait until this media track has no active consumers.
+	pub async fn unused(&self) -> Result<(), MoqError> {
+		let track = {
+			let _guard = crate::ffi::RUNTIME.enter();
+			let guard = self.inner.lock().unwrap();
+			guard.as_ref().ok_or_else(|| MoqError::Closed)?.track.clone()
+		};
+
+		wait_for_track_activity(track, TrackActivity::Unused).await
+	}
+
 	/// Write a frame to this media track.
 	///
 	/// `timestamp_us` is the presentation timestamp in microseconds.
 	pub fn write_frame(&self, payload: Vec<u8>, timestamp_us: u64) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.inner.lock().unwrap();
-		let decoder = guard.as_mut().ok_or_else(|| MoqError::Closed)?;
+		let media = guard.as_mut().ok_or_else(|| MoqError::Closed)?;
 
 		let timestamp = hang::container::Timestamp::from_micros(timestamp_us)?;
 		let mut data = payload.as_slice();
-		decoder
+		media
+			.decoder
 			.decode_frame(&mut data, Some(timestamp))
 			.map_err(|err| MoqError::Codec(format!("decode failed: {err}")))?;
 
@@ -221,8 +313,9 @@ impl MoqMediaProducer {
 	pub fn finish(&self) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.inner.lock().unwrap();
-		let mut decoder = guard.take().ok_or_else(|| MoqError::Closed)?;
-		decoder
+		let mut media = guard.take().ok_or_else(|| MoqError::Closed)?;
+		media
+			.decoder
 			.finish()
 			.map_err(|err| MoqError::Codec(format!("finish failed: {err}")))?;
 		Ok(())

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -36,27 +36,6 @@ pub struct MoqMediaProducer {
 	inner: std::sync::Mutex<Option<MediaProducer>>,
 }
 
-enum TrackActivity {
-	Used,
-	Unused,
-}
-
-async fn wait_for_track_activity(track: moq_lite::TrackProducer, activity: TrackActivity) -> Result<(), MoqError> {
-	let handle = crate::ffi::RUNTIME.spawn(async move {
-		match activity {
-			TrackActivity::Used => track.used().await,
-			TrackActivity::Unused => track.unused().await,
-		}
-		.map_err(Into::into)
-	});
-
-	match handle.await {
-		Ok(result) => result,
-		Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
-		Err(e) => Err(MoqError::Task(e)),
-	}
-}
-
 #[uniffi::export]
 impl MoqBroadcastProducer {
 	/// Create a consumer that reads from this broadcast's tracks.
@@ -153,13 +132,21 @@ impl MoqTrackProducer {
 	/// Wait until this track has at least one active consumer.
 	pub async fn used(&self) -> Result<(), MoqError> {
 		let track = self.inner.lock().unwrap().as_ref().ok_or(MoqError::Closed)?.clone();
-		wait_for_track_activity(track, TrackActivity::Used).await
+		match crate::ffi::RUNTIME.spawn(async move { track.used().await }).await {
+			Ok(result) => result.map_err(Into::into),
+			Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
+			Err(e) => Err(MoqError::Task(e)),
+		}
 	}
 
 	/// Wait until this track has no active consumers.
 	pub async fn unused(&self) -> Result<(), MoqError> {
 		let track = self.inner.lock().unwrap().as_ref().ok_or(MoqError::Closed)?.clone();
-		wait_for_track_activity(track, TrackActivity::Unused).await
+		match crate::ffi::RUNTIME.spawn(async move { track.unused().await }).await {
+			Ok(result) => result.map_err(Into::into),
+			Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
+			Err(e) => Err(MoqError::Task(e)),
+		}
 	}
 
 	/// Create a consumer that reads from this producer's track.
@@ -265,7 +252,11 @@ impl MoqMediaProducer {
 			.ok_or(MoqError::Closed)?
 			.track
 			.clone();
-		wait_for_track_activity(track, TrackActivity::Used).await
+		match crate::ffi::RUNTIME.spawn(async move { track.used().await }).await {
+			Ok(result) => result.map_err(Into::into),
+			Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
+			Err(e) => Err(MoqError::Task(e)),
+		}
 	}
 
 	/// Wait until this media track has no active consumers.
@@ -278,7 +269,11 @@ impl MoqMediaProducer {
 			.ok_or(MoqError::Closed)?
 			.track
 			.clone();
-		wait_for_track_activity(track, TrackActivity::Unused).await
+		match crate::ffi::RUNTIME.spawn(async move { track.unused().await }).await {
+			Ok(result) => result.map_err(Into::into),
+			Err(e) if e.is_cancelled() => Err(MoqError::Cancelled),
+			Err(e) => Err(MoqError::Task(e)),
+		}
 	}
 
 	/// Write a frame to this media track.

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -50,6 +50,55 @@ fn publish_media_lifecycle() {
 	broadcast.finish().unwrap();
 }
 
+#[tokio::test]
+async fn raw_track_activity() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let track = broadcast.publish_track("status".into()).unwrap();
+	assert_eq!(track.name().unwrap(), "status");
+
+	let consumer = track.consume().unwrap();
+	tokio::time::timeout(TIMEOUT, track.used())
+		.await
+		.expect("timed out waiting for raw track to become used")
+		.unwrap();
+
+	drop(consumer);
+	tokio::time::timeout(TIMEOUT, track.unused())
+		.await
+		.expect("timed out waiting for raw track to become unused")
+		.unwrap();
+}
+
+#[tokio::test]
+async fn media_track_activity_and_name() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let init = opus_head();
+	let media = broadcast.publish_media("opus".into(), init).unwrap();
+	let track_name = media.name().unwrap();
+	assert_eq!(track_name, "0.opus");
+
+	let broadcast_consumer = broadcast.consume().unwrap();
+	let catalog_consumer = broadcast_consumer.subscribe_catalog().unwrap();
+	let catalog = tokio::time::timeout(TIMEOUT, catalog_consumer.next())
+		.await
+		.expect("timed out waiting for catalog")
+		.unwrap()
+		.expect("expected a catalog");
+	assert!(catalog.audio.contains_key(&track_name));
+
+	let track_consumer = broadcast_consumer.subscribe_track(track_name).unwrap();
+	tokio::time::timeout(TIMEOUT, media.used())
+		.await
+		.expect("timed out waiting for media track to become used")
+		.unwrap();
+
+	drop(track_consumer);
+	tokio::time::timeout(TIMEOUT, media.unused())
+		.await
+		.expect("timed out waiting for media track to become unused")
+		.unwrap();
+}
+
 #[test]
 fn unknown_format() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();

--- a/rs/moq-mux/src/import/aac.rs
+++ b/rs/moq-mux/src/import/aac.rs
@@ -142,6 +142,11 @@ impl Aac {
 		})
 	}
 
+	/// Returns a reference to the underlying track producer.
+	pub fn track(&self) -> &moq_lite::TrackProducer {
+		&self.track.track
+	}
+
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> anyhow::Result<()> {
 		self.track.finish()?;

--- a/rs/moq-mux/src/import/av01.rs
+++ b/rs/moq-mux/src/import/av01.rs
@@ -249,6 +249,11 @@ impl Av01 {
 		Ok(())
 	}
 
+	/// Returns a reference to the underlying track producer.
+	pub fn track(&self) -> anyhow::Result<&moq_lite::TrackProducer> {
+		Ok(&self.track.as_ref().context("not initialized")?.track)
+	}
+
 	/// Decode as much data as possible from the given buffer.
 	pub fn decode_stream<T: Buf + AsRef<[u8]>>(
 		&mut self,

--- a/rs/moq-mux/src/import/avc1.rs
+++ b/rs/moq-mux/src/import/avc1.rs
@@ -115,6 +115,11 @@ impl Avc1 {
 		Ok(())
 	}
 
+	/// Returns a reference to the underlying track producer.
+	pub fn track(&self) -> anyhow::Result<&moq_lite::TrackProducer> {
+		Ok(&self.track.as_ref().context("not initialized")?.track)
+	}
+
 	/// Decode an AVCC-formatted H.264 packet (length-prefixed NALUs).
 	///
 	/// If `pts` is `None`, the wall clock time is used.

--- a/rs/moq-mux/src/import/framed.rs
+++ b/rs/moq-mux/src/import/framed.rs
@@ -160,6 +160,22 @@ impl Framed {
 		}
 	}
 
+	/// Return the single track produced by this importer.
+	///
+	/// Container formats like fMP4 can produce multiple tracks, so callers that
+	/// need one concrete track must use a single-track format.
+	pub fn track(&self) -> anyhow::Result<&moq_lite::TrackProducer> {
+		match self.decoder {
+			FramedKind::Avc1(ref decoder) => decoder.track(),
+			FramedKind::Avc3(ref decoder) => Ok(decoder.track()),
+			FramedKind::Fmp4(_) => anyhow::bail!("fmp4 can contain multiple tracks"),
+			FramedKind::Hev1(ref decoder) => decoder.track(),
+			FramedKind::Av01(ref decoder) => decoder.track(),
+			FramedKind::Aac(ref decoder) => Ok(decoder.track()),
+			FramedKind::Opus(ref decoder) => Ok(decoder.track()),
+		}
+	}
+
 	/// Decode a frame from the given buffer.
 	///
 	/// This method should be used when the caller knows the buffer consists of an entire frame.

--- a/rs/moq-mux/src/import/hev1.rs
+++ b/rs/moq-mux/src/import/hev1.rs
@@ -117,6 +117,11 @@ impl Hev1 {
 		Ok(())
 	}
 
+	/// Returns a reference to the underlying track producer.
+	pub fn track(&self) -> anyhow::Result<&moq_lite::TrackProducer> {
+		Ok(&self.track.as_ref().context("not initialized")?.track)
+	}
+
 	/// Decode as much data as possible from the given buffer.
 	///
 	/// Unlike [Self::decode_frame], this method needs the start code for the next frame.


### PR DESCRIPTION
Add `name()`, `used()`, and `unused()` to MoqTrackProducer and MoqMediaProducer so FFI consumers can observe subscriber activity. Plumb a single track accessor through moq-mux's import decoder and mirror the new API in the Python moq-lite bindings.