### PR TITLE
fix(watch): close MultiBackend's sync and sources

### DIFF
--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -217,5 +217,8 @@ export class MultiBackend implements Backend {
 
 	close(): void {
 		this.signals.close();
+		this.#videoSource.close();
+		this.#audioSource.close();
+		this.sync.close();
 	}
 }


### PR DESCRIPTION
MultiBackend.close() only closed its own #runElement signal, leaving the Sync and the two Source instances (constructed as fields, not inside an Effect) alive. Each owns its own Effect with several .run() handlers that never get cleaned up, surfacing as "Signals was garbage collected without being closed" warnings whenever a watch component unmounts.

Close them explicitly, ordered so inner Decoder/Renderer/Emitter (spawned via the #runElement effect) finish before the sources/sync they reference are torn down.