### PR TITLE
fix: stop leaking PromiseReactions in consumer loops

### DIFF
--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -230,15 +230,20 @@ export class Consumer {
 				throw new Error("multiple calls to next not supported");
 			}
 
-			const wait = new Promise<void>((resolve) => {
-				this.#notify = resolve;
-			}).then(() => true);
+			const abort = this.#signals.abort;
+			if (abort.aborted) return undefined;
 
-			if (!(await Promise.race([wait, this.#signals.closed]))) {
-				this.#notify = undefined;
-				// Consumer was closed while waiting for a new frame.
-				return undefined;
-			}
+			const aborted = await new Promise<boolean>((resolve) => {
+				const onAbort = () => resolve(true);
+				abort.addEventListener("abort", onAbort, { once: true });
+				this.#notify = () => {
+					abort.removeEventListener("abort", onAbort);
+					resolve(false);
+				};
+			});
+
+			this.#notify = undefined;
+			if (aborted) return undefined;
 		}
 	}
 

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -308,7 +308,7 @@ export class Decoder {
 			});
 
 			for (;;) {
-				const next = await Promise.race([consumer.next(), effect.cancel]);
+				const next = await consumer.next();
 				if (!next) break;
 
 				const { frame } = next;

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -310,7 +310,7 @@ class DecoderTrack {
 
 		effect.spawn(async () => {
 			for (;;) {
-				const next = await Promise.race([consumer.next(), effect.cancel]);
+				const next = await consumer.next();
 				if (!next) break;
 
 				const { frame, group } = next;
@@ -390,7 +390,7 @@ class DecoderTrack {
 
 		effect.spawn(async () => {
 			for (;;) {
-				const next = await Promise.race([consumer.next(), effect.cancel]);
+				const next = await consumer.next();
 				if (!next) break;
 
 				const { frame, group } = next;


### PR DESCRIPTION
Promise.race against a never-settling Promise (Effect#closed, Effect#cancel) attaches a .then reaction to that long-lived promise on every call. Because the promise never settles, those reactions never run and never get GC'd. Each leaked reaction's closure retains the awaiter state, which keeps the resolved {frame, group} alive.

Over a multi-minute playback session this accumulates one retained Frame per consumed video frame (~400MB after 9 minutes at 60fps) and grows the PromiseReaction chain to tens of thousands of nodes, which inflates major GC pauses to 100-200ms. That's the cause of the periodic ~700ms stalls.

Two changes, no API impact:

* @moq/hang Consumer.next() waits via an AbortSignal listener registered with { once: true } and explicitly removed when notify wins, instead of Promise.race([wait, signals.closed]).

* @moq/watch video and audio decoder loops drop the outer Promise.race([consumer.next(), effect.cancel]). When the effect closes, effect.cleanup runs consumer.close(), which makes next() return undefined naturally and the loop exits.