### PR TITLE
Refactor/video pacing rAF

### DIFF
--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -260,6 +260,7 @@ export class Decoder {
 					timestamp: frame.timestamp,
 				});
 
+				if (decoder.state === "closed") break;
 				decoder.decode(chunk);
 			}
 		});

--- a/js/watch/src/sync.test.ts
+++ b/js/watch/src/sync.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import type { Time } from "@moq/net";
+import { Sync } from "./sync.ts";
+
+const ms = (n: number) => n as Time.Milli;
+
+let clock = 0;
+const realNow = performance.now;
+const opened: Sync[] = [];
+
+beforeEach(() => {
+	clock = 0;
+	performance.now = () => clock;
+});
+
+afterEach(() => {
+	performance.now = realNow;
+	for (const s of opened.splice(0)) s.close();
+});
+
+// Fixed latency keeps the jitter buffer deterministic (buffer === latency).
+function sync(latency = 0): Sync {
+	const s = new Sync({ latency: ms(latency) });
+	opened.push(s);
+	return s;
+}
+
+test("now() tracks the live edge on a single stream", () => {
+	const s = sync();
+
+	clock = 1000;
+	s.received(ms(0), "video");
+	expect(s.now()).toBe(ms(0));
+
+	clock = 2000;
+	s.received(ms(1000), "video");
+	expect(s.now()).toBe(ms(1000));
+});
+
+test("re-baselines the reference when the stream restarts with a fresh PTS epoch", () => {
+	const s = sync();
+
+	// First stream: a few seconds of playback establishes the reference.
+	clock = 1000;
+	s.received(ms(0), "video");
+	clock = 6000;
+	s.received(ms(5000), "video");
+	expect(s.now()).toBe(ms(5000));
+
+	// Publisher restarts much later: PTS resets toward zero. Without a
+	// re-baseline now() would stay pinned to the old epoch (~54000).
+	clock = 60000;
+	s.received(ms(0), "video");
+	expect(s.now()).toBe(ms(0));
+
+	clock = 61000;
+	s.received(ms(1000), "video");
+	expect(s.now()).toBe(ms(1000));
+});
+
+test("does not re-baseline on small backward reordering", () => {
+	const s = sync();
+
+	clock = 1000;
+	s.received(ms(0), "video");
+	clock = 1100;
+	s.received(ms(100), "video");
+
+	// A frame a little out of order (within the discontinuity threshold) must
+	// not reset the reference.
+	clock = 1120;
+	s.received(ms(80), "video");
+	expect(s.now()).toBe(ms(120));
+});

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -8,6 +8,10 @@ export type Latency = "real-time" | Time.Milli;
 const MIN_JITTER = 20 as Time.Milli;
 const FALLBACK_JITTER = 100 as Time.Milli;
 
+// A backward media-time jump larger than this is treated as a stream restart
+// (new PTS epoch) rather than reordering, and re-baselines the reference clock.
+const DISCONTINUITY = 1000 as Time.Milli;
+
 export interface SyncProps {
 	latency?: Latency | Signal<Latency>;
 	connection?: Signal<Moq.Connection.Established | undefined>;
@@ -103,7 +107,20 @@ export class Sync {
 
 	// Update the reference if this is the earliest frame we've seen, relative to its timestamp.
 	received(timestamp: Time.Milli, label = ""): void {
-		this.timestamp.update((current) => (current === undefined || timestamp > current ? timestamp : current));
+		const lastMax = this.timestamp.peek();
+
+		// A large backward jump in media time means the publisher restarted with a
+		// fresh PTS epoch. #reference is still pinned to the previous stream, and
+		// since we only ever keep the minimum it would never recover, leaving now()
+		// far ahead of the new frames. Re-baseline so pacing works on the new stream.
+		if (lastMax !== undefined && timestamp < lastMax - DISCONTINUITY) {
+			this.#reference.set(undefined);
+			this.timestamp.set(timestamp);
+			this.#late.clear();
+		} else {
+			this.timestamp.update((current) => (current === undefined || timestamp > current ? timestamp : current));
+		}
+
 		const now = Time.Milli.now();
 		const ref = Time.Milli.sub(now, timestamp);
 		const currentRef = this.#reference.peek();

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -37,10 +37,6 @@ export class Sync {
 	#buffer = new Signal<Time.Milli>(Time.Milli.zero);
 	readonly buffer: Signal<Time.Milli> = this.#buffer;
 
-	// A ghetto way to learn when the reference/buffer changes.
-	// There's probably a way to use Effect, but lets keep it simple for now.
-	#update: PromiseWithResolvers<void>;
-
 	// The media timestamp of the most recently received frame.
 	readonly timestamp = new Signal<Time.Milli | undefined>(undefined);
 
@@ -62,8 +58,6 @@ export class Sync {
 		this.#connection = props?.connection;
 		this.audio = Signal.from(props?.audio);
 		this.video = Signal.from(props?.video);
-
-		this.#update = Promise.withResolvers();
 
 		this.signals.run(this.#runJitter.bind(this));
 		this.signals.run(this.#runBuffer.bind(this));
@@ -105,9 +99,6 @@ export class Sync {
 
 		const buffer = Time.Milli.add(Time.Milli.max(video, audio), jitter);
 		this.#buffer.set(buffer);
-
-		this.#update.resolve();
-		this.#update = Promise.withResolvers();
 	}
 
 	// Update the reference if this is the earliest frame we've seen, relative to its timestamp.
@@ -118,9 +109,9 @@ export class Sync {
 		const currentRef = this.#reference.peek();
 
 		if (currentRef !== undefined) {
-			// Check if `wait()` would not sleep at all.
-			// NOTE: We check here instead of in `wait()` so we can identify when frames are received late.
-			// Otherwise, chained `wait()` calls would cause a false-positive during CPU starvation.
+			// Detect frames received later than their scheduled play time, so we can
+			// distinguish "the network is dropping us behind" from CPU starvation in
+			// downstream pacing.
 			const sleep = Time.Milli.add(Time.Milli.sub(currentRef, ref), this.#buffer.peek());
 			if (sleep < 0) {
 				const entry = this.#late.get(label);
@@ -147,8 +138,6 @@ export class Sync {
 		}
 
 		this.#reference.set(ref);
-		this.#update.resolve();
-		this.#update = Promise.withResolvers();
 	}
 
 	// The PTS that should be rendering right now, derived from the reference + buffer.
@@ -157,35 +146,6 @@ export class Sync {
 		const reference = this.#reference.peek();
 		if (reference === undefined) return undefined;
 		return Time.Milli.sub(Time.Milli.sub(Time.Milli.now(), reference), this.#buffer.peek());
-	}
-
-	// Sleep until it's time to render this frame.
-	async wait(timestamp: Time.Milli): Promise<void> {
-		const reference = this.#reference.peek();
-		if (reference === undefined) {
-			throw new Error("reference not set; call update() first");
-		}
-
-		for (;;) {
-			// Sleep until it's time to decode the next frame.
-			// NOTE: This function runs in parallel for each frame.
-			const now = Time.Milli.now();
-			const ref = Time.Milli.sub(now, timestamp);
-
-			const currentRef = this.#reference.peek();
-			if (currentRef === undefined) return;
-
-			const sleep = Time.Milli.add(Time.Milli.sub(currentRef, ref), this.#buffer.peek());
-			if (sleep <= 0) return;
-
-			// Skip setTimeout for small sleeps; the timer resolution (~4ms) would overshoot.
-			if (sleep < 5) return;
-
-			const wait = new Promise((resolve) => setTimeout(resolve, sleep)).then(() => true);
-
-			const ok = await Promise.race([this.#update.promise, wait]);
-			if (ok) return;
-		}
 	}
 
 	static #formatDuration(ms: number): string {

--- a/js/watch/src/video/decoder.test.ts
+++ b/js/watch/src/video/decoder.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "bun:test";
+import type { Time } from "@moq/net";
+import { consumeFrame } from "./decoder.ts";
+
+class StubFrame {
+	readonly timestamp: number;
+	closed = false;
+	constructor(timestamp: number) {
+		this.timestamp = timestamp;
+	}
+	close(): void {
+		this.closed = true;
+	}
+}
+
+const us = (ms: number) => (ms * 1_000) as Time.Micro;
+const ms = (n: number) => n as Time.Milli;
+
+test("returns undefined when the queue is empty", () => {
+	const queue: StubFrame[] = [];
+	expect(consumeFrame(queue, ms(100))).toBeUndefined();
+	expect(queue.length).toBe(0);
+});
+
+test("returns undefined when every frame is still in the future", () => {
+	const a = new StubFrame(us(50));
+	const b = new StubFrame(us(100));
+	const queue = [a, b];
+	expect(consumeFrame(queue, ms(10))).toBeUndefined();
+	expect(queue).toEqual([a, b]);
+	expect(a.closed).toBe(false);
+	expect(b.closed).toBe(false);
+});
+
+test("returns the frame when its PTS equals now", () => {
+	const a = new StubFrame(us(33));
+	const queue = [a];
+	expect(consumeFrame(queue, ms(33))).toBe(a);
+	expect(queue.length).toBe(0);
+	expect(a.closed).toBe(false);
+});
+
+test("returns the only frame when it is ready", () => {
+	const a = new StubFrame(us(0));
+	const queue = [a];
+	expect(consumeFrame(queue, ms(16))).toBe(a);
+	expect(queue.length).toBe(0);
+	expect(a.closed).toBe(false);
+});
+
+test("returns the newest ready frame and closes older ones", () => {
+	const a = new StubFrame(us(0));
+	const b = new StubFrame(us(33));
+	const c = new StubFrame(us(66));
+	const queue = [a, b, c];
+
+	expect(consumeFrame(queue, ms(50))).toBe(b);
+	expect(queue).toEqual([c]);
+	expect(a.closed).toBe(true);
+	expect(b.closed).toBe(false);
+	expect(c.closed).toBe(false);
+});
+
+test("preserves future frames when there are no ready ones", () => {
+	const a = new StubFrame(us(100));
+	const b = new StubFrame(us(200));
+	const queue = [a, b];
+
+	expect(consumeFrame(queue, ms(50))).toBeUndefined();
+	expect(queue).toEqual([a, b]);
+	expect(a.closed).toBe(false);
+	expect(b.closed).toBe(false);
+});
+
+test("60Hz vsync with 120fps content drops the older frame each tick", () => {
+	const older = new StubFrame(us(8));
+	const newer = new StubFrame(us(16));
+	const queue = [older, newer];
+
+	expect(consumeFrame(queue, ms(16))).toBe(newer);
+	expect(queue.length).toBe(0);
+	expect(older.closed).toBe(true);
+	expect(newer.closed).toBe(false);
+});
+
+test("120Hz vsync with 30fps content returns undefined between frames", () => {
+	const frame = new StubFrame(us(0));
+	const queue = [frame];
+
+	expect(consumeFrame(queue, ms(0))).toBe(frame);
+	expect(queue.length).toBe(0);
+
+	expect(consumeFrame(queue, ms(8))).toBeUndefined();
+	expect(consumeFrame(queue, ms(16))).toBeUndefined();
+	expect(consumeFrame(queue, ms(24))).toBeUndefined();
+});
+
+test("returns a late frame when nothing newer is queued", () => {
+	const late = new StubFrame(us(10));
+	const queue = [late];
+
+	expect(consumeFrame(queue, ms(500))).toBe(late);
+	expect(queue.length).toBe(0);
+	expect(late.closed).toBe(false);
+});
+
+test("closes every older frame, not just the immediately preceding one", () => {
+	const frames = [0, 8, 16, 24, 32, 40].map((t) => new StubFrame(us(t)));
+	const queue = [...frames];
+
+	expect(consumeFrame(queue, ms(40))).toBe(frames[5]);
+	expect(queue.length).toBe(0);
+	for (let i = 0; i < 5; i++) {
+		expect(frames[i].closed).toBe(true);
+	}
+	expect(frames[5].closed).toBe(false);
+});
+
+test("60fps content on 60Hz vsync paints one frame per tick with no growth", () => {
+	const queue: StubFrame[] = [];
+	const created: StubFrame[] = [];
+	const painted: number[] = [];
+
+	const VSYNC_MS = 1000 / 60;
+	const FRAME_MS = 1000 / 60;
+
+	for (let i = 0; i < 30; i++) {
+		const frame = new StubFrame(us(i * FRAME_MS));
+		queue.push(frame);
+		created.push(frame);
+
+		const picked = consumeFrame(queue, (i * VSYNC_MS) as Time.Milli);
+		if (picked) painted.push(picked.timestamp);
+	}
+
+	expect(painted.length).toBe(30);
+	expect(created.filter((f) => f.closed).length).toBe(0);
+	expect(queue.length).toBe(0);
+});

--- a/js/watch/src/video/decoder.test.ts
+++ b/js/watch/src/video/decoder.test.ts
@@ -137,3 +137,76 @@ test("60fps content on 60Hz vsync paints one frame per tick with no growth", () 
 	expect(created.filter((f) => f.closed).length).toBe(0);
 	expect(queue.length).toBe(0);
 });
+
+// Steady-state simulation: producer at content fps, consumer each vsync
+// with now = wall - latency. Written by Claude.
+function simulate({
+	fps,
+	vsyncHz,
+	latencyMs,
+	durationMs,
+}: {
+	fps: number;
+	vsyncHz: number;
+	latencyMs: number;
+	durationMs: number;
+}) {
+	const FRAME_MS = 1000 / fps;
+	const VSYNC_MS = 1000 / vsyncHz;
+
+	const queue: StubFrame[] = [];
+	const created: StubFrame[] = [];
+	const painted: StubFrame[] = [];
+	let peakDepth = 0;
+
+	let nextProducePts = 0;
+	let nextProduceAt = 0;
+	let nextVsyncAt = 0;
+
+	while (nextProduceAt < durationMs || nextVsyncAt < durationMs) {
+		if (nextProduceAt <= nextVsyncAt) {
+			const f = new StubFrame(us(nextProducePts));
+			queue.push(f);
+			created.push(f);
+			peakDepth = Math.max(peakDepth, queue.length);
+			nextProducePts += FRAME_MS;
+			nextProduceAt += FRAME_MS;
+		} else {
+			const now = (nextVsyncAt - latencyMs) as Time.Milli;
+			if (now >= 0) {
+				const picked = consumeFrame(queue, now);
+				if (picked) painted.push(picked);
+			}
+			nextVsyncAt += VSYNC_MS;
+		}
+	}
+
+	return { queue, created, painted, peakDepth };
+}
+
+test("queue depth scales linearly with configured latency", () => {
+	const fps = 30;
+	const vsyncHz = 60;
+
+	for (const latencyMs of [20, 100, 500, 1000, 5000]) {
+		const { peakDepth } = simulate({ fps, vsyncHz, latencyMs, durationMs: latencyMs + 2000 });
+
+		const expected = Math.ceil((latencyMs * fps) / 1000);
+		expect(peakDepth).toBeGreaterThanOrEqual(expected);
+		expect(peakDepth).toBeLessThanOrEqual(expected + 2);
+	}
+});
+
+test("no produced frames are leaked at 5s latency", () => {
+	const { queue, created, painted } = simulate({
+		fps: 30,
+		vsyncHz: 60,
+		latencyMs: 5000,
+		durationMs: 10000,
+	});
+
+	const closed = created.filter((f) => f.closed).length;
+	expect(painted.length + closed + queue.length).toBe(created.length);
+	expect(painted.length).toBe(created.length - queue.length);
+	expect(closed).toBe(0);
+});

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -129,6 +129,7 @@ export class Decoder implements Backend {
 
 			// Upgrade the pending track to active.
 			// #runActive will be in charge of it now.
+			pending.promote();
 			this.#active.set(pending);
 			pending = undefined;
 
@@ -235,6 +236,12 @@ class DecoderTrack {
 
 	#queueDrain = Promise.withResolvers<void>();
 
+	// Whether this track has been promoted to active. A pending track is never
+	// consumed, so while false the output callback drops all but the newest
+	// frame to keep decoding (and `decoded`) racing toward the live edge instead
+	// of stalling at QUEUE_CAP.
+	#promoted = false;
+
 	signals = new Effect();
 
 	constructor(props: DecoderTrackProps) {
@@ -274,6 +281,15 @@ class DecoderTrack {
 				// Queue for the renderer to pick up on its next vsync.
 				this.#queue.push(frame);
 				this.decoded.set(timestamp);
+
+				// While pending, nothing consumes the queue, so drop everything but
+				// the newest frame and release backpressure. This lets the track
+				// catch up to live before it takes over (e.g. on a rendition switch).
+				if (!this.#promoted) {
+					while (this.#queue.length > 1) this.#queue.shift()?.close();
+					this.#queueDrain.resolve();
+					this.#queueDrain = Promise.withResolvers<void>();
+				}
 			},
 			// TODO bubble up error
 			error: (error) => {
@@ -487,6 +503,12 @@ class DecoderTrack {
 				current.shift();
 			}
 		});
+	}
+
+	// Mark this track as active. After this the output callback stops trimming
+	// the queue so the render buffer can build up normally.
+	promote(): void {
+		this.#promoted = true;
 	}
 
 	// Pop the newest queued frame whose PTS is <= now, closing any older ones.

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -116,12 +116,15 @@ export class Decoder implements Backend {
 
 			const active = effect.get(this.#active);
 			if (active) {
-				const pendingTimestamp = effect.get(pending.timestamp);
+				// Compare the pending track's decode frontier against the active
+				// playhead: a pending track is never consumed, so its `timestamp`
+				// stays undefined. `decoded` tracks how far it has buffered.
+				const pendingDecoded = effect.get(pending.decoded);
 				const activeTimestamp = effect.get(active.timestamp);
 
 				// Switch to the new track if it's ready and we've caught up enough.
-				if (!pendingTimestamp) return;
-				if (activeTimestamp && activeTimestamp > pendingTimestamp + SWITCH) return;
+				if (!pendingDecoded) return;
+				if (activeTimestamp && activeTimestamp > pendingDecoded + SWITCH) return;
 			}
 
 			// Upgrade the pending track to active.
@@ -208,7 +211,13 @@ class DecoderTrack {
 	config: RequiredDecoderConfig;
 	stats: Signal<Stats | undefined>;
 
+	// The PTS of the most recently consumed (painted) frame.
 	timestamp = new Signal<Time.Milli | undefined>(undefined);
+
+	// The PTS of the newest decoded frame, set at queue time. Reflects how far a
+	// track has buffered even before it becomes active, so #runPending can decide
+	// when a pending track is ready to take over.
+	decoded = new Signal<Time.Milli | undefined>(undefined);
 
 	// Display dimensions taken from the first decoded frame, used as a fallback
 	// when the catalog doesn't carry display metadata.
@@ -264,6 +273,7 @@ class DecoderTrack {
 
 				// Queue for the renderer to pick up on its next vsync.
 				this.#queue.push(frame);
+				this.decoded.set(timestamp);
 			},
 			// TODO bubble up error
 			error: (error) => {

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -13,6 +13,12 @@ import type { Source } from "./source";
 const BUFFERING = 500 as Time.Milli;
 const SWITCH = 100 as Time.Milli;
 
+// Cap on decoded frames + decoder input queue. Each decoded VideoFrame
+// pins a GPU surface, so without a cap this would grow to latency * fps.
+// Backpressuring decoder.decode() pushes the wait upstream into
+// Container.Consumer, where it costs encoded bytes instead. Written by Claude.
+const QUEUE_CAP = 8;
+
 export type DecoderProps = {
 	enabled?: boolean | Signal<boolean>;
 };
@@ -218,6 +224,8 @@ class DecoderTrack {
 	// emits in display order, so push order is already monotonic.
 	#queue: VideoFrame[] = [];
 
+	#queueDrain = Promise.withResolvers<void>();
+
 	signals = new Effect();
 
 	constructor(props: DecoderTrackProps) {
@@ -350,6 +358,8 @@ class DecoderTrack {
 					final: false,
 				};
 
+				if (!(await this.#awaitQueueSpace(effect, decoder))) return;
+				if (decoder.state === "closed") break;
 				decoder.decode(chunk);
 			}
 		});
@@ -424,6 +434,7 @@ class DecoderTrack {
 					final: false,
 				};
 
+				if (!(await this.#awaitQueueSpace(effect, decoder))) return;
 				if (decoder.state === "closed") break;
 				decoder.decode(
 					new EncodedVideoChunk({
@@ -474,11 +485,34 @@ class DecoderTrack {
 		const frame = consumeFrame(this.#queue, now);
 		if (!frame) return undefined;
 
+		this.#queueDrain.resolve();
+		this.#queueDrain = Promise.withResolvers<void>();
+
 		const timestamp = Time.Milli.fromMicro(frame.timestamp as Time.Micro);
 		this.timestamp.set(timestamp);
 		this.#trimBuffered(timestamp);
 
 		return frame;
+	}
+
+	// AbortSignal with explicit removal, not Promise.race against
+	// effect.cancel, to avoid leaking a PromiseReaction per iteration onto
+	// the long-lived cancel promise (see #1400). Written by Claude.
+	async #awaitQueueSpace(effect: Effect, decoder: VideoDecoder): Promise<boolean> {
+		const abort = effect.abort;
+		while (this.#queue.length + decoder.decodeQueueSize >= QUEUE_CAP) {
+			if (abort.aborted) return false;
+			const aborted = await new Promise<boolean>((resolve) => {
+				const onAbort = () => resolve(true);
+				abort.addEventListener("abort", onAbort, { once: true });
+				this.#queueDrain.promise.then(() => {
+					abort.removeEventListener("abort", onAbort);
+					resolve(false);
+				});
+			});
+			if (aborted) return false;
+		}
+		return true;
 	}
 
 	close(): void {

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -29,11 +29,7 @@ export class Decoder implements Backend {
 	// The current track running, held so we can cancel it when the new track is ready.
 	#active = new Signal<DecoderTrack | undefined>(undefined);
 
-	// Expose the current frame to render as a signal
-	#frame = new Signal<VideoFrame | undefined>(undefined);
-	readonly frame: Getter<VideoFrame | undefined> = this.#frame;
-
-	// The timestamp of the current frame.
+	// The timestamp of the most recently consumed frame.
 	#timestamp = new Signal<Time.Milli | undefined>(undefined);
 	readonly timestamp: Getter<Time.Milli | undefined> = this.#timestamp;
 
@@ -53,12 +49,17 @@ export class Decoder implements Backend {
 
 	#signals = new Effect();
 
-	#clearCurrentFrame(): void {
-		this.#frame.update((prev) => {
-			prev?.close();
-			return undefined;
-		});
-		this.#timestamp.set(undefined);
+	// Pop the newest decoded frame whose PTS is at or before sync.now(), closing
+	// any older queued frames. The caller takes ownership of the returned frame
+	// and is responsible for closing it. Returns undefined if no frame is ready.
+	consume(): VideoFrame | undefined {
+		const active = this.#active.peek();
+		if (!active) return undefined;
+
+		const now = this.source.sync.now();
+		if (now === undefined) return undefined;
+
+		return active.consume(now);
 	}
 
 	constructor(source: Source, props?: DecoderProps) {
@@ -85,9 +86,10 @@ export class Decoder implements Backend {
 
 		const broadcast: Moq.Broadcast | undefined = effect.get(source.active);
 		if (!broadcast) {
-			// Going offline should clear the last rendered frame.
+			// Going offline should clear the last rendered timestamp so the
+			// buffering overlay logic in #runBuffering treats us as stalled.
 			this.#active.set(undefined);
-			this.#clearCurrentFrame();
+			this.#timestamp.set(undefined);
 			this.#buffered.set([]);
 			return;
 		}
@@ -136,15 +138,6 @@ export class Decoder implements Backend {
 
 		effect.cleanup(() => active.close());
 
-		// Clone the frame so we own it independently of the DecoderTrack.
-		// proxy() would share the same reference, allowing the source to close our frame.
-		effect.run((inner) => {
-			const frame = inner.get(active.frame);
-			this.#frame.update((prev) => {
-				prev?.close();
-				return frame?.clone();
-			});
-		});
 		effect.proxy(this.#timestamp, active.timestamp);
 		effect.proxy(this.#buffered, active.buffered);
 	}
@@ -162,21 +155,21 @@ export class Decoder implements Backend {
 			return;
 		}
 
-		const frame = effect.get(this.frame);
-		if (!frame) return;
+		const active = effect.get(this.#active);
+		if (!active) return;
 
-		effect.set(this.#display, {
-			width: frame.displayWidth,
-			height: frame.displayHeight,
-		});
+		const dims = effect.get(active.display);
+		if (!dims) return;
+
+		effect.set(this.#display, dims);
 	}
 
 	#runBuffering(effect: Effect): void {
 		const enabled = effect.get(this.enabled);
 		if (!enabled) return;
 
-		const frame = effect.get(this.frame);
-		if (!frame) {
+		const timestamp = effect.get(this.#timestamp);
+		if (timestamp === undefined) {
 			this.#stalled.set(true);
 			return;
 		}
@@ -189,8 +182,6 @@ export class Decoder implements Backend {
 	}
 
 	close() {
-		this.#clearCurrentFrame();
-
 		this.#signals.close();
 	}
 }
@@ -212,13 +203,20 @@ class DecoderTrack {
 	stats: Signal<Stats | undefined>;
 
 	timestamp = new Signal<Time.Milli | undefined>(undefined);
-	frame = new Signal<VideoFrame | undefined>(undefined);
+
+	// Display dimensions taken from the first decoded frame, used as a fallback
+	// when the catalog doesn't carry display metadata.
+	display = new Signal<{ width: number; height: number } | undefined>(undefined);
 
 	// Network jitter + decode buffer.
 	buffered = new Signal<BufferedRanges>([]);
 
 	// Decoded frames waiting to be rendered.
 	#buffered = new Signal<BufferedRanges>([]);
+
+	// Decoded frames awaiting paint, in PTS-ascending order. VideoDecoder
+	// emits in display order, so push order is already monotonic.
+	#queue: VideoFrame[] = [];
 
 	signals = new Effect();
 
@@ -240,41 +238,24 @@ class DecoderTrack {
 		effect.cleanup(() => sub.close());
 
 		const decoder = new VideoDecoder({
-			output: async (frame: VideoFrame) => {
-				try {
-					const timestamp = Time.Milli.fromMicro(frame.timestamp as Time.Micro);
-					if (timestamp < (this.timestamp.peek() ?? 0)) {
-						// Late frame, don't render it.
-						return;
-					}
+			output: (frame: VideoFrame) => {
+				const timestamp = Time.Milli.fromMicro(frame.timestamp as Time.Micro);
 
-					if (this.frame.peek() === undefined) {
-						// Render something while we wait for the sync to catch up.
-						this.frame.set(frame.clone());
-					}
-
-					const wait = this.source.sync.wait(timestamp).then(() => true);
-					const ok = await Promise.race([wait, effect.cancel]);
-					if (!ok) return;
-
-					if (timestamp < (this.timestamp.peek() ?? 0)) {
-						// Late frame, don't render it.
-						// NOTE: This can happen when the ref is updated, such as on playback start.
-						return;
-					}
-
-					this.timestamp.set(timestamp);
-
-					// Trim the decode buffer as frames are rendered
-					this.#trimBuffered(timestamp);
-
-					this.frame.update((prev) => {
-						prev?.close();
-						return frame.clone(); // avoid closing the frame here
-					});
-				} finally {
+				// Drop frames that have already been displayed (can happen if the
+				// reference resets, e.g. on playback start).
+				if (timestamp < (this.timestamp.peek() ?? 0)) {
 					frame.close();
+					return;
 				}
+
+				// Capture display dimensions from the first frame so #runDisplay
+				// can fall back to them when the catalog has no display metadata.
+				if (this.display.peek() === undefined) {
+					this.display.set({ width: frame.displayWidth, height: frame.displayHeight });
+				}
+
+				// Queue for the renderer to pick up on its next vsync.
+				this.#queue.push(frame);
 			},
 			// TODO bubble up error
 			error: (error) => {
@@ -284,6 +265,9 @@ class DecoderTrack {
 		});
 		effect.cleanup(() => {
 			if (decoder.state !== "closed") decoder.close();
+			// Drain any frames the renderer never got to.
+			for (const frame of this.#queue) frame.close();
+			this.#queue.length = 0;
 		});
 
 		// Input processing - depends on container type
@@ -484,13 +468,36 @@ class DecoderTrack {
 		});
 	}
 
+	// Pop the newest queued frame whose PTS is <= now, closing any older ones.
+	// Caller takes ownership of the returned frame and must close it.
+	consume(now: Time.Milli): VideoFrame | undefined {
+		let pickIdx = -1;
+		for (let i = this.#queue.length - 1; i >= 0; i--) {
+			const ts = Time.Milli.fromMicro(this.#queue[i].timestamp as Time.Micro);
+			if (ts <= now) {
+				pickIdx = i;
+				break;
+			}
+		}
+		if (pickIdx < 0) return undefined;
+
+		// Close older frames — they would render in the past.
+		for (let i = 0; i < pickIdx; i++) {
+			this.#queue[i].close();
+		}
+
+		const frame = this.#queue[pickIdx];
+		this.#queue.splice(0, pickIdx + 1);
+
+		const timestamp = Time.Milli.fromMicro(frame.timestamp as Time.Micro);
+		this.timestamp.set(timestamp);
+		this.#trimBuffered(timestamp);
+
+		return frame;
+	}
+
 	close(): void {
 		this.signals.close();
-
-		this.frame.update((prev) => {
-			prev?.close();
-			return undefined;
-		});
 	}
 }
 

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -471,23 +471,8 @@ class DecoderTrack {
 	// Pop the newest queued frame whose PTS is <= now, closing any older ones.
 	// Caller takes ownership of the returned frame and must close it.
 	consume(now: Time.Milli): VideoFrame | undefined {
-		let pickIdx = -1;
-		for (let i = this.#queue.length - 1; i >= 0; i--) {
-			const ts = Time.Milli.fromMicro(this.#queue[i].timestamp as Time.Micro);
-			if (ts <= now) {
-				pickIdx = i;
-				break;
-			}
-		}
-		if (pickIdx < 0) return undefined;
-
-		// Close older frames — they would render in the past.
-		for (let i = 0; i < pickIdx; i++) {
-			this.#queue[i].close();
-		}
-
-		const frame = this.#queue[pickIdx];
-		this.#queue.splice(0, pickIdx + 1);
+		const frame = consumeFrame(this.#queue, now);
+		if (!frame) return undefined;
 
 		const timestamp = Time.Milli.fromMicro(frame.timestamp as Time.Micro);
 		this.timestamp.set(timestamp);
@@ -499,6 +484,33 @@ class DecoderTrack {
 	close(): void {
 		this.signals.close();
 	}
+}
+
+export interface ConsumableFrame {
+	readonly timestamp: number; // microseconds
+	close(): void;
+}
+
+// Pop the newest frame in `queue` whose PTS is <= now, closing any older
+// entries. Mutates the queue.
+export function consumeFrame<F extends ConsumableFrame>(queue: F[], now: Time.Milli): F | undefined {
+	let pickIdx = -1;
+	for (let i = queue.length - 1; i >= 0; i--) {
+		const ts = Time.Milli.fromMicro(queue[i].timestamp as Time.Micro);
+		if (ts <= now) {
+			pickIdx = i;
+			break;
+		}
+	}
+	if (pickIdx < 0) return undefined;
+
+	for (let i = 0; i < pickIdx; i++) {
+		queue[i].close();
+	}
+
+	const frame = queue[pickIdx];
+	queue.splice(0, pickIdx + 1);
+	return frame;
 }
 
 async function supported(config: Catalog.VideoConfig): Promise<boolean> {

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -7,7 +7,7 @@ export type RendererProps = {
 	paused?: boolean | Signal<boolean>;
 };
 
-// An component to render a video to a canvas.
+// A component to render a video to a canvas.
 export class Renderer {
 	decoder: Decoder;
 
@@ -53,6 +53,13 @@ export class Renderer {
 		if (canvas.width !== display.width || canvas.height !== display.height) {
 			canvas.width = display.width;
 			canvas.height = display.height;
+
+			// Setting width/height blanks the canvas. Repaint the cached frame so a
+			// resize while paused (decoder off, no new frames coming) doesn't leave
+			// the canvas black.
+			const ctx = this.#ctx.peek();
+			const frame = this.frame.peek();
+			if (ctx && frame) this.#draw(ctx, frame);
 		}
 	}
 
@@ -100,7 +107,7 @@ export class Renderer {
 		}
 
 		// When paused, fetch a single preview frame then disable.
-		const frame = effect.get(this.decoder.frame);
+		const frame = effect.get(this.frame);
 		this.decoder.enabled.set(!frame);
 	}
 
@@ -108,45 +115,36 @@ export class Renderer {
 		const ctx = effect.get(this.#ctx);
 		if (!ctx) return;
 
-		const frame = effect.get(this.decoder.frame);
+		// When the canvas (and therefore ctx) is replaced, the new canvas starts
+		// blank. Paint the cached frame once so a swap while paused isn't black
+		// until playback resumes.
+		const cached = this.frame.peek();
+		if (cached) this.#draw(ctx, cached);
 
-		// Request a callback to render the frame based on the monitor's refresh rate.
-		// Always render, even when paused (to show last frame).
-		let animate: number | undefined = requestAnimationFrame(() => {
-			this.#render(ctx, frame);
+		let rafId: number | undefined;
 
+		const tick = () => {
+			const frame = this.decoder.consume();
 			if (frame) {
-				this.frame.update((current) => {
-					current?.close();
-					return frame.clone();
+				this.#draw(ctx, frame);
+				this.frame.update((old) => {
+					old?.close();
+					return frame; // transfer ownership from consume()
 				});
 				this.timestamp.set(Time.Milli.fromMicro(frame.timestamp as Time.Micro));
-			} else {
-				this.frame.update((current) => {
-					current?.close();
-					return undefined;
-				});
-				this.timestamp.set(undefined);
 			}
 
-			animate = undefined;
-		});
+			rafId = requestAnimationFrame(tick);
+		};
 
-		// Clean up any pending animation request.
+		rafId = requestAnimationFrame(tick);
+
 		effect.cleanup(() => {
-			if (animate) cancelAnimationFrame(animate);
+			if (rafId !== undefined) cancelAnimationFrame(rafId);
 		});
 	}
 
-	#render(ctx: CanvasRenderingContext2D, frame?: VideoFrame) {
-		if (!frame) {
-			// Clear canvas when no frame
-			ctx.fillStyle = "#000";
-			ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-			return;
-		}
-
-		// Prepare background and transformations for this draw
+	#draw(ctx: CanvasRenderingContext2D, frame: VideoFrame) {
 		ctx.save();
 		ctx.fillStyle = "#000";
 		ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);


### PR DESCRIPTION
## Summary

Consolidate video frame pacing into the renderer's `requestAnimationFrame` loop. Previously pacing happened twice: in the decoder via `Sync.wait()` (a setTimeout/`#update` race per in-flight frame, trying to wake near vsync) and again in the renderer via a single-shot rAF triggered by a frame signal. Two layers, two places to stall, and systematic beating when the display refresh and content fps lined up (the wait would resolve a fraction of a ms past vsync, the signal-driven rAF would schedule against the *next* vsync, so every other frame got dropped).

This PR moves all pacing to paint time:

- `DecoderTrack` enqueues decoded frames into `#queue: VideoFrame[]` immediately; the output callback no longer awaits anything.
- `Decoder.consume()` returns the newest queued frame whose PTS is `<= sync.now()`, closing older entries and transferring ownership to the caller. Late-frame drop and decode-buffer trim move here.
- The renderer's rAF calls `decoder.consume()` each vsync.
- `Sync.wait()` and the `#update` notification machinery are removed. Buffer changes take effect on the next vsync (~<=16ms), which is fine for live media.

The "first-paint preview" path and the `Decoder.frame` mirror that fed it are dropped. The preview saved 20-100ms of black canvas at first paint, but it added a special case to the render loop and held a cloned `VideoFrame` resident at all times for every active track. It's replaced with two narrower signals: `DecoderTrack.display` (set once from the first decoded frame's display dimensions, as a catalog-display fallback) and `#runBuffering` now reacting to consume-time `timestamp` instead of decode-time frame presence.

Net: one rAF loop in the system. Stalls now show up as held frames instead of dropped frames.

## Test plan

- [x] `just check` (biome + tsc + clippy + cargo check, etc.)
- [x] New `js/watch/src/video/decoder.test.ts` covers `consumeFrame()`:
  - empty queue, all-future frames, boundary (`pts === now`)
  - newest-ready selection with older frames closed
  - 60Hz vsync + 120fps content (older frame closed, newer painted)
  - 120Hz vsync + 30fps content (no frame returned between content ticks)
  - late frame still selectable when nothing newer is queued
  - 60fps x 60Hz steady state: one paint per vsync, no queue growth, no spurious closes
- [x] Manual: watch a live stream and confirm no per-frame beating on a 60Hz display
