### PR TITLE
Declare solid-js as a peerDependency

### DIFF
--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -28,6 +28,10 @@
 		"@moq/signals": "workspace:^",
 		"@moq/ui-core": "workspace:^"
 	},
+	"peerDependencies": {
+		"solid-element": "^1.9.1",
+		"solid-js": "^1.9.10"
+	},
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.77",
 		"@typescript/lib-dom": "npm:@types/web@^0.0.241",

--- a/js/ui-core/package.json
+++ b/js/ui-core/package.json
@@ -20,7 +20,8 @@
 		"release": "bun ../common/release.ts"
 	},
 	"peerDependencies": {
-		"@moq/signals": "workspace:^0.1.0"
+		"@moq/signals": "workspace:^0.1.0",
+		"solid-js": "^1.9.10"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.3",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -30,6 +30,10 @@
 		"@moq/signals": "workspace:^",
 		"@moq/ui-core": "workspace:^"
 	},
+	"peerDependencies": {
+		"solid-element": "^1.9.1",
+		"solid-js": "^1.9.10"
+	},
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.77",
 		"@types/bun": "^1.3.11",


### PR DESCRIPTION
@moq/publish, @moq/watch, and @moq/ui-core import from solid-js and solid-js/web, but solid-js was only listed in devDependencies. Since common/package.ts strips devDependencies at release time, the published package.json files declared no solid-js at all, while their JS still contains bare import "solid-js" statements.

Consumers ended up with either an unresolved import or two Solid runtime instances loaded side-by-side. Because Solid's delegateEvents is a per-runtime singleton, UI components rendered by these packages registered click handlers on a different runtime than the one wired up to the host app, so buttons appeared inert.