### PR TITLE
Bump package versions across JS packages

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/lite/package.json
+++ b/js/lite/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/lite",
 	"type": "module",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": {

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.6",
+	"version": "0.2.7",
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/token",
 	"type": "module",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "Media over QUIC - Token Generation and Validation",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/ui-core/package.json
+++ b/js/ui-core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/ui-core",
 	"type": "module",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Shared UI components for Media over QUIC",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",


### PR DESCRIPTION
Increment patch versions for all JavaScript packages in the monorepo to reflect recent changes and maintain version consistency.

**Packages updated:**
- `@moq/hang`: 0.2.4 → 0.2.5
- `@moq/lite`: 0.2.2 → 0.2.3
- `@moq/boy`: 0.2.8 → 0.2.9
- `@moq/publish`: 0.2.6 → 0.2.7
- `@moq/token`: 0.2.2 → 0.2.3
- `@moq/ui-core`: 0.1.0 → 0.1.1
- `@moq/watch`: 0.2.10 → 0.2.11

All packages follow semantic versioning with patch-level increments applied consistently across the workspace.

https://claude.ai/code/session_011ArhKLEtRkZBuWPmggaqNv