### PR TITLE
Vite: Add alias resolver to Vite worker plugin esbuild

### DIFF
--- a/js/common/vite-plugin-worklet.ts
+++ b/js/common/vite-plugin-worklet.ts
@@ -12,7 +12,7 @@ const SUFFIX = "?worklet";
  * then inlined as a string. At runtime, a blob URL is created and exported.
  * Pass the URL to audioWorklet.addModule().
  */
-export function workletInline(alias: Record<string, string>): Plugin {
+export function workletInline(alias?: Record<string, string>): Plugin {
 	return {
 		name: "worklet-inline",
 		enforce: "pre",

--- a/js/common/vite-plugin-worklet.ts
+++ b/js/common/vite-plugin-worklet.ts
@@ -12,7 +12,7 @@ const SUFFIX = "?worklet";
  * then inlined as a string. At runtime, a blob URL is created and exported.
  * Pass the URL to audioWorklet.addModule().
  */
-export function workletInline(alias: Object): Plugin {
+export function workletInline(alias: Record<string, string>): Plugin {
 	return {
 		name: "worklet-inline",
 		enforce: "pre",

--- a/js/common/vite-plugin-worklet.ts
+++ b/js/common/vite-plugin-worklet.ts
@@ -12,7 +12,7 @@ const SUFFIX = "?worklet";
  * then inlined as a string. At runtime, a blob URL is created and exported.
  * Pass the URL to audioWorklet.addModule().
  */
-export function workletInline(): Plugin {
+export function workletInline(alias: Object): Plugin {
 	return {
 		name: "worklet-inline",
 		enforce: "pre",
@@ -42,6 +42,7 @@ export function workletInline(): Plugin {
 				write: false,
 				format: "esm",
 				target: "esnext",
+				alias: alias,
 			});
 
 			const compiled = result.outputFiles[0].text;


### PR DESCRIPTION
Related: #1390 

I'm having to use the github sources as a package requiring aliases to the packages. The worker plugin also requires an alias config to resolve the sources correctly. The project is alpha so best to update from sources anyway.

This adds an optional argument to configure aliases. 

Example usage in my config. note the exclusion required in optimizeDeps to partially compile in dev server mode. However TSX is not transforming still in that. So I can't use dev with the sources properly, it has to do a build and load a local server. Unless built modules are added into github. Dev seems to work only when referencing workspaces in the repo itself not externally. 

```
import tailwindcss from "@tailwindcss/vite";
import { resolve } from "path";
import { defineConfig } from "vite";
import solidPlugin from "vite-plugin-solid";
import { workletInline } from "./node_modules/moq/js/common/vite-plugin-worklet";

const aliases = {
	"@moq/lite": resolve(__dirname, 'node_modules/moq/js/lite/src'),
	'@moq/watch': resolve(__dirname, 'node_modules/moq/js/watch/src'),
	'@moq/publish': resolve(__dirname, 'node_modules/moq/js/publish/src'),
	"@moq/signals": resolve(__dirname, 'node_modules/moq/js/signals/src/'),
	"@moq/hang": resolve(__dirname, 'node_modules/moq/js/hang/src/'),
	"@moq/msf": resolve(__dirname, 'node_modules/moq/js/msf/src'),
	"@moq/ui-core": resolve(__dirname, 'node_modules/moq/js/ui-core/src/')
};


export default defineConfig({
	root: "src/demo",
	envDir: resolve(__dirname),
	plugins: [tailwindcss(), solidPlugin(), workletInline(aliases)],
	resolve: {
			alias: aliases
			
	},
	build: {
		minify: false,
		outDir: '../../demo',
		emptyOutDir: true,
		sourcemap: process.env.NODE_ENV === "production" ? false : "inline",
		rolldownOptions: {
			input: {
				watch: resolve(__dirname, "src/demo/index.html"),
				mse: resolve(__dirname, "src/demo/mse.html"),
				cloudflare: resolve(__dirname, "src/demo/cloudflare.html"),
				subscriber: resolve(__dirname, "src/demo/subscriber.html"),
			},
		},
	},
	server: {
		// TODO: properly support HMR
		hmr: false,
	},
	optimizeDeps: {
		include: ['@moq/ui-core'],
		// No idea why this needs to be done, but I don't want to figure it out.
		//exclude: ["@libav.js/variant-opus-af", "@moq/publish"],
		exclude: ["@libav.js/variant-opus-af", "@moq/watch", "@moq/publish"],
	},
});
```