### PR TITLE
Add pixel budget controls for video rendition selection

### DIFF
--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -12,33 +12,8 @@ function parseCatalogFormat(value: string | null): CatalogFormat {
 	return CATALOG_FORMATS.find((f) => f === value) ?? DEFAULT_CATALOG_FORMAT;
 }
 
-function parsePixelsMode(value: string | null): PixelsMode {
-	if (value === null || value === "" || value === "auto") return "auto";
-	const parsed = Number.parseInt(value, 10);
-	if (Number.isFinite(parsed) && parsed >= 0) return parsed;
-	return "auto";
-}
-
-const OBSERVED = [
-	"url",
-	"name",
-	"paused",
-	"volume",
-	"muted",
-	"reload",
-	"latency",
-	"jitter",
-	"catalog-format",
-	"pixels",
-] as const;
+const OBSERVED = ["url", "name", "paused", "volume", "muted", "reload", "latency", "jitter", "catalog-format"] as const;
 type Observed = (typeof OBSERVED)[number];
-
-/**
- * Pixel budget for video rendition selection.
- * - `"auto"` tracks the rendered size of the element (default).
- * - A non-negative number caps selection at that pixel count.
- */
-export type PixelsMode = number | "auto";
 
 // Close everything when this element is garbage collected.
 // This is primarily to avoid a console.warn that we didn't close() before GC.
@@ -60,11 +35,6 @@ export default class MoqWatch extends HTMLElement {
 
 	// Set when the element is connected to the DOM.
 	#enabled = new Signal(false);
-
-	// Controls the video selection cap. "auto" derives maxWidth/maxHeight from
-	// the element's rendered size so we don't download a 1080p stream for a
-	// 360p slot. A number pins a total-pixel-area budget instead.
-	#pixelsMode = new Signal<PixelsMode>("auto");
 
 	// Expose the Effect class, so users can easily create effects scoped to this element.
 	signals = new Effect();
@@ -158,45 +128,30 @@ export default class MoqWatch extends HTMLElement {
 			}
 		});
 
-		this.signals.run(this.#runPixelBudget.bind(this));
-	}
-
-	#runPixelBudget(effect: Effect): void {
-		const target = this.backend.video.source.target;
-		const mode = effect.get(this.#pixelsMode);
-
-		if (typeof mode === "number") {
-			// Numeric override: pin a total pixel-area budget and let the dimensions
-			// filter sit out so the two don't fight each other.
-			target.update((prev) => ({ ...prev, pixels: mode, maxWidth: undefined, maxHeight: undefined }));
-			return;
-		}
-
-		// Auto mode: track the element's rendered size, scaled by devicePixelRatio
-		// so high-DPI screens still get appropriately sharp renditions. We set
-		// maxWidth/maxHeight (rather than pixels) so aspect-ratio mismatches don't
-		// pick a square rendition for a widescreen slot.
-		const update = (width: number, height: number) => {
+		// Track the element's rendered size and feed it into the rendition picker,
+		// scaled by devicePixelRatio so high-DPI screens still get sharp renditions.
+		const updateDimensions = (width: number, height: number) => {
 			if (width <= 0 || height <= 0) return;
 			const dpr = window.devicePixelRatio || 1;
-			const maxWidth = Math.round(width * dpr);
-			const maxHeight = Math.round(height * dpr);
-			target.update((prev) => ({ ...prev, pixels: undefined, maxWidth, maxHeight }));
+			this.backend.video.source.target.update((prev) => ({
+				...prev,
+				width: Math.round(width * dpr),
+				height: Math.round(height * dpr),
+			}));
 		};
 
-		const observer = new ResizeObserver((entries) => {
+		const resizeObserver = new ResizeObserver((entries) => {
 			const entry = entries[0];
 			if (!entry) return;
-			update(entry.contentRect.width, entry.contentRect.height);
+			updateDimensions(entry.contentRect.width, entry.contentRect.height);
 		});
-
-		observer.observe(this);
-		effect.cleanup(() => observer.disconnect());
+		resizeObserver.observe(this);
+		this.signals.cleanup(() => resizeObserver.disconnect());
 
 		// Seed with the current size in case the observer doesn't fire immediately
 		// (e.g. the element is still 0x0 when we attach).
 		const rect = this.getBoundingClientRect();
-		update(rect.width, rect.height);
+		updateDimensions(rect.width, rect.height);
 	}
 
 	// Annoyingly, we have to use these callbacks to figure out when the element is connected to the DOM.
@@ -246,8 +201,6 @@ export default class MoqWatch extends HTMLElement {
 			this.#setLatencyNumber(newValue);
 		} else if (name === "catalog-format") {
 			this.broadcast.catalogFormat.set(parseCatalogFormat(newValue));
-		} else if (name === "pixels") {
-			this.#pixelsMode.set(parsePixelsMode(newValue));
 		} else {
 			const exhaustive: never = name;
 			throw new Error(`Invalid attribute: ${exhaustive}`);
@@ -326,21 +279,6 @@ export default class MoqWatch extends HTMLElement {
 
 	set catalogFormat(value: CatalogFormat) {
 		this.broadcast.catalogFormat.set(value);
-	}
-
-	/**
-	 * Caps rendition selection.
-	 * - `"auto"` (the default) tracks the element's rendered size and feeds
-	 *   `maxWidth`/`maxHeight` into the target, scaled by `devicePixelRatio`.
-	 * - A non-negative number pins `target.pixels` (total area) instead, useful
-	 *   when you want a bandwidth-style budget regardless of aspect ratio.
-	 */
-	get pixels(): PixelsMode {
-		return this.#pixelsMode.peek();
-	}
-
-	set pixels(value: PixelsMode | null | undefined) {
-		this.#pixelsMode.set(value == null ? "auto" : value);
 	}
 
 	/**

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -12,8 +12,33 @@ function parseCatalogFormat(value: string | null): CatalogFormat {
 	return CATALOG_FORMATS.find((f) => f === value) ?? DEFAULT_CATALOG_FORMAT;
 }
 
-const OBSERVED = ["url", "name", "paused", "volume", "muted", "reload", "latency", "jitter", "catalog-format"] as const;
+function parsePixelsMode(value: string | null): PixelsMode {
+	if (value === null || value === "" || value === "auto") return "auto";
+	const parsed = Number.parseInt(value, 10);
+	if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+	return "auto";
+}
+
+const OBSERVED = [
+	"url",
+	"name",
+	"paused",
+	"volume",
+	"muted",
+	"reload",
+	"latency",
+	"jitter",
+	"catalog-format",
+	"pixels",
+] as const;
 type Observed = (typeof OBSERVED)[number];
+
+/**
+ * Pixel budget for video rendition selection.
+ * - `"auto"` tracks the rendered size of the element (default).
+ * - A non-negative number caps selection at that pixel count.
+ */
+export type PixelsMode = number | "auto";
 
 // Close everything when this element is garbage collected.
 // This is primarily to avoid a console.warn that we didn't close() before GC.
@@ -35,6 +60,10 @@ export default class MoqWatch extends HTMLElement {
 
 	// Set when the element is connected to the DOM.
 	#enabled = new Signal(false);
+
+	// Controls the video pixel budget. "auto" derives it from the element's
+	// rendered size so we don't download a 1080p stream for a 360p slot.
+	#pixelsMode = new Signal<PixelsMode>("auto");
 
 	// Expose the Effect class, so users can easily create effects scoped to this element.
 	signals = new Effect();
@@ -127,6 +156,43 @@ export default class MoqWatch extends HTMLElement {
 				this.setAttribute("latency", jitter.toString());
 			}
 		});
+
+		this.signals.run(this.#runPixelBudget.bind(this));
+	}
+
+	#setPixels(pixels: number | undefined): void {
+		this.backend.video.source.target.update((prev) => ({ ...prev, pixels }));
+	}
+
+	#runPixelBudget(effect: Effect): void {
+		const mode = effect.get(this.#pixelsMode);
+
+		if (typeof mode === "number") {
+			this.#setPixels(mode);
+			return;
+		}
+
+		// Auto mode: track the element's rendered size, scaled by devicePixelRatio
+		// so high-DPI screens still get appropriately sharp renditions.
+		const update = (width: number, height: number) => {
+			if (width <= 0 || height <= 0) return;
+			const dpr = window.devicePixelRatio || 1;
+			this.#setPixels(Math.round(width * dpr * height * dpr));
+		};
+
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			update(entry.contentRect.width, entry.contentRect.height);
+		});
+
+		observer.observe(this);
+		effect.cleanup(() => observer.disconnect());
+
+		// Seed with the current size in case the observer doesn't fire immediately
+		// (e.g. the element is still 0x0 when we attach).
+		const rect = this.getBoundingClientRect();
+		update(rect.width, rect.height);
 	}
 
 	// Annoyingly, we have to use these callbacks to figure out when the element is connected to the DOM.
@@ -176,6 +242,8 @@ export default class MoqWatch extends HTMLElement {
 			this.#setLatencyNumber(newValue);
 		} else if (name === "catalog-format") {
 			this.broadcast.catalogFormat.set(parseCatalogFormat(newValue));
+		} else if (name === "pixels") {
+			this.#pixelsMode.set(parsePixelsMode(newValue));
 		} else {
 			const exhaustive: never = name;
 			throw new Error(`Invalid attribute: ${exhaustive}`);
@@ -254,6 +322,19 @@ export default class MoqWatch extends HTMLElement {
 
 	set catalogFormat(value: CatalogFormat) {
 		this.broadcast.catalogFormat.set(value);
+	}
+
+	/**
+	 * Maximum pixel count (width * height) used to cap rendition selection.
+	 * `"auto"` (the default) tracks the element's rendered size scaled by
+	 * `devicePixelRatio`, so a 360px slot won't pull a 1080p stream.
+	 */
+	get pixels(): PixelsMode {
+		return this.#pixelsMode.peek();
+	}
+
+	set pixels(value: PixelsMode | null | undefined) {
+		this.#pixelsMode.set(value == null ? "auto" : value);
 	}
 
 	/**

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -61,8 +61,9 @@ export default class MoqWatch extends HTMLElement {
 	// Set when the element is connected to the DOM.
 	#enabled = new Signal(false);
 
-	// Controls the video pixel budget. "auto" derives it from the element's
-	// rendered size so we don't download a 1080p stream for a 360p slot.
+	// Controls the video selection cap. "auto" derives maxWidth/maxHeight from
+	// the element's rendered size so we don't download a 1080p stream for a
+	// 360p slot. A number pins a total-pixel-area budget instead.
 	#pixelsMode = new Signal<PixelsMode>("auto");
 
 	// Expose the Effect class, so users can easily create effects scoped to this element.
@@ -160,24 +161,27 @@ export default class MoqWatch extends HTMLElement {
 		this.signals.run(this.#runPixelBudget.bind(this));
 	}
 
-	#setPixels(pixels: number | undefined): void {
-		this.backend.video.source.target.update((prev) => ({ ...prev, pixels }));
-	}
-
 	#runPixelBudget(effect: Effect): void {
+		const target = this.backend.video.source.target;
 		const mode = effect.get(this.#pixelsMode);
 
 		if (typeof mode === "number") {
-			this.#setPixels(mode);
+			// Numeric override: pin a total pixel-area budget and let the dimensions
+			// filter sit out so the two don't fight each other.
+			target.update((prev) => ({ ...prev, pixels: mode, maxWidth: undefined, maxHeight: undefined }));
 			return;
 		}
 
 		// Auto mode: track the element's rendered size, scaled by devicePixelRatio
-		// so high-DPI screens still get appropriately sharp renditions.
+		// so high-DPI screens still get appropriately sharp renditions. We set
+		// maxWidth/maxHeight (rather than pixels) so aspect-ratio mismatches don't
+		// pick a square rendition for a widescreen slot.
 		const update = (width: number, height: number) => {
 			if (width <= 0 || height <= 0) return;
 			const dpr = window.devicePixelRatio || 1;
-			this.#setPixels(Math.round(width * dpr * height * dpr));
+			const maxWidth = Math.round(width * dpr);
+			const maxHeight = Math.round(height * dpr);
+			target.update((prev) => ({ ...prev, pixels: undefined, maxWidth, maxHeight }));
 		};
 
 		const observer = new ResizeObserver((entries) => {
@@ -325,9 +329,11 @@ export default class MoqWatch extends HTMLElement {
 	}
 
 	/**
-	 * Maximum pixel count (width * height) used to cap rendition selection.
-	 * `"auto"` (the default) tracks the element's rendered size scaled by
-	 * `devicePixelRatio`, so a 360px slot won't pull a 1080p stream.
+	 * Caps rendition selection.
+	 * - `"auto"` (the default) tracks the element's rendered size and feeds
+	 *   `maxWidth`/`maxHeight` into the target, scaled by `devicePixelRatio`.
+	 * - A non-negative number pins `target.pixels` (total area) instead, useful
+	 *   when you want a bandwidth-style budget regardless of aspect ratio.
 	 */
 	get pixels(): PixelsMode {
 		return this.#pixelsMode.peek();

--- a/js/watch/src/video/source.ts
+++ b/js/watch/src/video/source.ts
@@ -23,10 +23,10 @@ export type Target = {
 	pixels?: number;
 
 	// Maximum desired coded width in pixels.
-	maxWidth?: number;
+	width?: number;
 
 	// Maximum desired coded height in pixels.
-	maxHeight?: number;
+	height?: number;
 
 	// Maximum desired bitrate in bits per second.
 	bitrate?: number;
@@ -80,11 +80,11 @@ function byPixels(target: number): RenditionFilter {
 
 /**
  * Filter and rank renditions by maximum coded dimensions.
- * Returns renditions where codedWidth <= maxWidth AND codedHeight <= maxHeight
+ * Returns renditions where codedWidth <= width AND codedHeight <= height
  * (each cap is optional). Within-budget renditions rank by area (largest first).
  * If nothing fits, falls back to the single smallest over-budget rendition.
  */
-function byDimensions(maxWidth?: number, maxHeight?: number): RenditionFilter {
+function byDimensions(width?: number, height?: number): RenditionFilter {
 	return (entries) => {
 		const within: { name: string; size: number }[] = [];
 		const rest: { name: string; size: number }[] = [];
@@ -92,8 +92,8 @@ function byDimensions(maxWidth?: number, maxHeight?: number): RenditionFilter {
 		for (const [name, config] of entries) {
 			if (!config.codedWidth || !config.codedHeight) continue;
 			const size = config.codedWidth * config.codedHeight;
-			const fitsWidth = maxWidth == null || config.codedWidth <= maxWidth;
-			const fitsHeight = maxHeight == null || config.codedHeight <= maxHeight;
+			const fitsWidth = width == null || config.codedWidth <= width;
+			const fitsHeight = height == null || config.codedHeight <= height;
 			if (fitsWidth && fitsHeight) {
 				within.push({ name, size });
 			} else {
@@ -315,8 +315,8 @@ export class Source {
 		if (target?.pixels != null) {
 			filters.push(byPixels(target.pixels));
 		}
-		if (target?.maxWidth != null || target?.maxHeight != null) {
-			filters.push(byDimensions(target.maxWidth, target.maxHeight));
+		if (target?.width != null || target?.height != null) {
+			filters.push(byDimensions(target.width, target.height));
 		}
 		if (target?.bitrate != null) {
 			filters.push(byBitrate(target.bitrate));

--- a/js/watch/src/video/source.ts
+++ b/js/watch/src/video/source.ts
@@ -19,8 +19,14 @@ export type Target = {
 	// Optional manual override for the selected rendition name.
 	name?: string;
 
-	// The desired size of the video in pixels.
+	// Maximum desired pixel area (codedWidth * codedHeight).
 	pixels?: number;
+
+	// Maximum desired coded width in pixels.
+	maxWidth?: number;
+
+	// Maximum desired coded height in pixels.
+	maxHeight?: number;
 
 	// Maximum desired bitrate in bits per second.
 	bitrate?: number;
@@ -62,6 +68,47 @@ function byPixels(target: number): RenditionFilter {
 		}
 
 		// Degrade to smallest over-budget resolution.
+		if (rest.length > 0) {
+			rest.sort((a, b) => a.size - b.size);
+			return [rest[0].name];
+		}
+
+		// No entries had resolution metadata — return all names unranked.
+		return entries.map(([name]) => name);
+	};
+}
+
+/**
+ * Filter and rank renditions by maximum coded dimensions.
+ * Returns renditions where codedWidth <= maxWidth AND codedHeight <= maxHeight
+ * (each cap is optional). Within-budget renditions rank by area (largest first).
+ * If nothing fits, falls back to the single smallest over-budget rendition.
+ */
+function byDimensions(maxWidth?: number, maxHeight?: number): RenditionFilter {
+	return (entries) => {
+		const within: { name: string; size: number }[] = [];
+		const rest: { name: string; size: number }[] = [];
+
+		for (const [name, config] of entries) {
+			if (!config.codedWidth || !config.codedHeight) continue;
+			const size = config.codedWidth * config.codedHeight;
+			const fitsWidth = maxWidth == null || config.codedWidth <= maxWidth;
+			const fitsHeight = maxHeight == null || config.codedHeight <= maxHeight;
+			if (fitsWidth && fitsHeight) {
+				within.push({ name, size });
+			} else {
+				rest.push({ name, size });
+			}
+		}
+
+		// Best quality within budget
+		within.sort((a, b) => b.size - a.size);
+
+		if (within.length > 0) {
+			return within.map((e) => e.name);
+		}
+
+		// Degrade to smallest over-budget rendition.
 		if (rest.length > 0) {
 			rest.sort((a, b) => a.size - b.size);
 			return [rest[0].name];
@@ -267,6 +314,9 @@ export class Source {
 
 		if (target?.pixels != null) {
 			filters.push(byPixels(target.pixels));
+		}
+		if (target?.maxWidth != null || target?.maxHeight != null) {
+			filters.push(byDimensions(target.maxWidth, target.maxHeight));
 		}
 		if (target?.bitrate != null) {
 			filters.push(byBitrate(target.bitrate));


### PR DESCRIPTION
## Summary

Adds a new `pixels` attribute and property to the `<moq-watch>` element that controls how video renditions are selected based on pixel constraints. This enables two modes of operation: automatic sizing based on the element's rendered dimensions, or a fixed pixel-area budget for bandwidth control.

## Changes

- **New `PixelsMode` type**: Union of `"auto"` (default) or a non-negative number representing total pixel area budget.

- **Element attribute and property**: Added `pixels` to the observed attributes list and implemented getter/setter that parse and manage the pixel mode via a Signal.

- **Auto mode with ResizeObserver**: When `pixels` is `"auto"`, the element tracks its rendered size using ResizeObserver and feeds `maxWidth`/`maxHeight` constraints to the video source, scaled by `devicePixelRatio` for high-DPI displays. This prevents downloading unnecessarily high-resolution streams for small viewport slots.

- **Numeric mode**: When `pixels` is set to a number, it pins a total pixel-area budget (`pixels` field on the target) and clears dimension constraints so the two don't conflict.

- **New `byDimensions` filter**: Added rendition filtering function that respects `maxWidth` and `maxHeight` constraints independently. Selects the largest rendition within budget, or falls back to the smallest over-budget option if nothing fits.

- **Target type expansion**: Extended the `Target` type with optional `maxWidth` and `maxHeight` fields to support dimension-based filtering alongside the existing `pixels` field.

## Implementation Details

- The pixel budget logic runs as a separate Effect scoped to the element, allowing cleanup when the element is destroyed.
- ResizeObserver is seeded with the element's current bounding rect to handle cases where the element is still 0x0 when the observer attaches.
- The `parsePixelsMode` function handles null/empty/invalid inputs by defaulting to `"auto"`.
- Dimension filtering ranks within-budget renditions by area (largest first) for best quality, matching the behavior of the existing `byPixels` filter.

https://claude.ai/code/session_013QzaZSQikeDkEmuV8ZdTJE