### PR TITLE
audio: send each frame as its own group

### DIFF
--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -38,6 +38,12 @@ export class Producer {
 		this.#group?.writeFrame(Producer.#encode(data, timestamp));
 	}
 
+	// Close the current group so the relay can forward it without waiting for the next keyframe.
+	finishGroup() {
+		this.#group?.close();
+		this.#group = undefined;
+	}
+
 	static #encode(source: Uint8Array | Source, timestamp: Time.Micro): Uint8Array {
 		const timestampBytes = Moq.Varint.encode(timestamp);
 

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -18,6 +18,21 @@ export interface Source {
 	copyTo(buffer: Uint8Array): void;
 }
 
+// Encode a frame as a timestamp varint followed by the payload bytes.
+export function encodeFrame(source: Uint8Array | Source, timestamp: Time.Micro): Uint8Array {
+	const timestampBytes = Moq.Varint.encode(timestamp);
+	const data = new Uint8Array(timestampBytes.byteLength + source.byteLength);
+	data.set(timestampBytes, 0);
+
+	if (source instanceof Uint8Array) {
+		data.set(source, timestampBytes.byteLength);
+	} else {
+		source.copyTo(data.subarray(timestampBytes.byteLength));
+	}
+
+	return data;
+}
+
 // A Helper class to encode frames into a track.
 export class Producer {
 	#track: Moq.Track;
@@ -35,33 +50,7 @@ export class Producer {
 			throw new Error("must start with a keyframe");
 		}
 
-		this.#group?.writeFrame(Producer.#encode(data, timestamp));
-	}
-
-	// Close the current group so the relay can forward it without waiting for the next keyframe.
-	finishGroup() {
-		this.#group?.close();
-		this.#group = undefined;
-	}
-
-	static #encode(source: Uint8Array | Source, timestamp: Time.Micro): Uint8Array {
-		const timestampBytes = Moq.Varint.encode(timestamp);
-
-		// Allocate buffer for timestamp + payload
-		const payloadSize = source instanceof Uint8Array ? source.byteLength : source.byteLength;
-		const data = new Uint8Array(timestampBytes.byteLength + payloadSize);
-
-		// Write timestamp header
-		data.set(timestampBytes, 0);
-
-		// Write payload
-		if (source instanceof Uint8Array) {
-			data.set(source, timestampBytes.byteLength);
-		} else {
-			source.copyTo(data.subarray(timestampBytes.byteLength));
-		}
-
-		return data;
+		this.#group?.writeFrame(encodeFrame(data, timestamp));
 	}
 
 	close(err?: Error) {

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -2,7 +2,7 @@ import * as Catalog from "@moq/hang/catalog";
 import * as Container from "@moq/hang/container";
 import * as Util from "@moq/hang/util";
 import type * as Moq from "@moq/lite";
-import { Time } from "@moq/lite";
+import type { Time } from "@moq/lite";
 import { Effect, type Getter, Signal } from "@moq/signals";
 import type * as Capture from "./capture";
 import type { Source } from "./types";
@@ -22,10 +22,6 @@ export type EncoderProps = {
 	volume?: number | Signal<number>;
 	sampleRate?: number | Signal<number | undefined>;
 
-	// The maximum duration of each group. Larger groups mean fewer drops but the viewer can fall further behind.
-	// NOTE: Each frame is always flushed to the network immediately.
-	groupDuration?: Time.Milli;
-
 	container?: Catalog.Container;
 };
 
@@ -38,7 +34,6 @@ export class Encoder {
 	muted: Signal<boolean>;
 	volume: Signal<number>;
 	sampleRate: Signal<number | undefined>;
-	groupDuration: Time.Milli;
 
 	source: Signal<Source | undefined>;
 
@@ -63,7 +58,6 @@ export class Encoder {
 		this.muted = Signal.from(props?.muted ?? false);
 		this.volume = Signal.from(props?.volume ?? 1);
 		this.sampleRate = Signal.from<number | undefined>(props?.sampleRate);
-		this.groupDuration = props?.groupDuration ?? (100 as Time.Milli); // Default is a group every 100ms
 
 		this.#signals.run(this.#runSource.bind(this));
 		this.#signals.run(this.#runConfig.bind(this));
@@ -162,8 +156,6 @@ export class Encoder {
 		const producer = new Container.Legacy.Producer(track);
 		effect.cleanup(() => producer.close());
 
-		let lastKeyframe: Time.Micro | undefined;
-
 		effect.spawn(async () => {
 			// We're using an async polyfill temporarily for Safari support.
 			await Util.Libav.polyfill();
@@ -174,13 +166,9 @@ export class Encoder {
 						throw new Error("only key frames are supported");
 					}
 
-					let keyframe = false;
-					if (!lastKeyframe || lastKeyframe + Time.Micro.fromMilli(this.groupDuration) <= frame.timestamp) {
-						lastKeyframe = frame.timestamp as Time.Micro;
-						keyframe = true;
-					}
-
-					producer.encode(frame, frame.timestamp as Time.Micro, keyframe);
+					// Each audio frame is its own group so the relay can forward it without
+					// waiting for a group boundary. Loss is handled by the codec's PLC.
+					producer.encode(frame, frame.timestamp as Time.Micro, true);
 				},
 				error: (err) => {
 					console.error("encoder error", err);

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -169,6 +169,7 @@ export class Encoder {
 					// Each audio frame is its own group so the relay can forward it without
 					// waiting for a group boundary. Loss is handled by the codec's PLC.
 					producer.encode(frame, frame.timestamp as Time.Micro, true);
+					producer.finishGroup();
 				},
 				error: (err) => {
 					console.error("encoder error", err);

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -153,8 +153,7 @@ export class Encoder {
 
 		effect.set(this.active, true, false);
 
-		const producer = new Container.Legacy.Producer(track);
-		effect.cleanup(() => producer.close());
+		effect.cleanup(() => track.close());
 
 		effect.spawn(async () => {
 			// We're using an async polyfill temporarily for Safari support.
@@ -168,12 +167,11 @@ export class Encoder {
 
 					// Each audio frame is its own group so the relay can forward it without
 					// waiting for a group boundary. Loss is handled by the codec's PLC.
-					producer.encode(frame, frame.timestamp as Time.Micro, true);
-					producer.finishGroup();
+					track.writeFrame(Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro));
 				},
 				error: (err) => {
 					console.error("encoder error", err);
-					producer.close(err);
+					track.close(err);
 					worklet.port.onmessage = null;
 				},
 			});

--- a/rs/moq-mux/src/import/aac.rs
+++ b/rs/moq-mux/src/import/aac.rs
@@ -1,10 +1,6 @@
 use anyhow::Context;
 use bytes::{Buf, BytesMut};
 
-// Pack ~100ms of audio per group. AAC frames are typically ~21ms (1024 samples at 48kHz),
-// so 5 frames is a good fit. Any value works — this is just a knob for relay efficiency.
-const GROUP_FRAMES: usize = 5;
-
 /// Typed AAC configuration for initialization without binary blobs.
 pub struct AacConfig {
 	pub profile: u8,
@@ -102,12 +98,12 @@ impl AacConfig {
 ///
 /// Initialized from an AudioSpecificConfig blob (variable-length, typically extracted from
 /// an MP4 ESDS atom). Each input buffer passed to [`decode`](Self::decode) is published as
-/// one hang frame; group boundaries are managed automatically every ~100 ms.
+/// one hang frame in its own group, so the relay can forward each frame without waiting for
+/// a group boundary. The codec's packet loss concealment handles drops.
 pub struct Aac {
 	catalog: crate::catalog::Producer,
 	track: crate::container::Producer<crate::container::Hang>,
 	zero: Option<tokio::time::Instant>,
-	frames: usize,
 }
 
 impl Aac {
@@ -138,7 +134,6 @@ impl Aac {
 			catalog,
 			track: crate::container::Producer::new(track, crate::container::Hang::Legacy),
 			zero: None,
-			frames: 0,
 		})
 	}
 
@@ -165,21 +160,16 @@ impl Aac {
 			buf.advance(len);
 		}
 
-		// Start a new group every GROUP_FRAMES frames.
+		// Each frame is its own group so the relay can forward it immediately.
+		// The codec's packet loss concealment handles drops.
 		let frame = crate::container::Frame {
 			timestamp: pts,
 			payload: payload.freeze(),
-			keyframe: self.frames % GROUP_FRAMES == 0,
+			keyframe: true,
 		};
-		self.frames += 1;
 
 		self.track.write(frame)?;
-
-		// Close the group immediately after the Nth frame so the relay can forward it
-		// without waiting for the next keyframe to arrive.
-		if self.frames % GROUP_FRAMES == 0 {
-			self.track.finish_group()?;
-		}
+		self.track.finish_group()?;
 
 		Ok(())
 	}

--- a/rs/moq-mux/src/import/opus.rs
+++ b/rs/moq-mux/src/import/opus.rs
@@ -1,10 +1,5 @@
 use bytes::{Buf, BytesMut};
 
-// Make a new audio group every 100ms.
-// NOTE: We could do this per-frame, but there's not much benefit to it.
-// Pack ~100ms of audio per group. Opus frames are typically 20ms, so 5 is a good fit.
-const GROUP_FRAMES: usize = 5;
-
 /// Typed Opus configuration for initialization without binary blobs.
 pub struct OpusConfig {
 	pub sample_rate: u32,
@@ -45,13 +40,13 @@ impl OpusConfig {
 /// Opus importer.
 ///
 /// Initialized from an OpusHead packet. Each input buffer passed to [`decode`](Self::decode)
-/// is published as one hang frame. Group boundaries are managed automatically every ~100 ms.
-/// Ogg framing is not supported — feed raw Opus packets.
+/// is published as one hang frame in its own group, so the relay can forward each frame
+/// without waiting for a group boundary. Opus' packet loss concealment handles drops.
+/// Ogg framing is not supported, feed raw Opus packets.
 pub struct Opus {
 	catalog: crate::catalog::Producer,
 	track: crate::container::Producer<crate::container::Hang>,
 	zero: Option<tokio::time::Instant>,
-	frames: usize,
 }
 
 impl Opus {
@@ -79,7 +74,6 @@ impl Opus {
 			catalog,
 			track: crate::container::Producer::new(track, crate::container::Hang::Legacy),
 			zero: None,
-			frames: 0,
 		})
 	}
 
@@ -107,21 +101,16 @@ impl Opus {
 			buf.advance(len);
 		}
 
-		// Start a new group every GROUP_FRAMES frames.
+		// Each frame is its own group so the relay can forward it immediately.
+		// Opus' packet loss concealment handles drops.
 		let frame = crate::container::Frame {
 			timestamp: pts,
 			payload: payload.freeze(),
-			keyframe: self.frames % GROUP_FRAMES == 0,
+			keyframe: true,
 		};
-		self.frames += 1;
 
 		self.track.write(frame)?;
-
-		// Close the group immediately after the Nth frame so the relay can forward it
-		// without waiting for the next keyframe to arrive.
-		if self.frames % GROUP_FRAMES == 0 {
-			self.track.finish_group()?;
-		}
+		self.track.finish_group()?;
 
 		Ok(())
 	}


### PR DESCRIPTION
Audio frames were being packed into ~100ms groups for relay efficiency.
For real-time use cases, that bounds end-to-end latency at the group
boundary since the relay cannot forward a group until it is closed.

Go back to one-frame-per-group: each frame is flushed to the relay
immediately, and the codec's packet loss concealment (Opus PLC, AAC PLC)
handles individual frame drops.

Applies to the browser publish encoder and the Rust opus/aac mux
importers, which all had the same 100ms grouping pattern.