### PR TITLE
Add draft-ietf-moq-transport-18 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,3 @@ pnpm-lock.yaml
 __pycache__/
 *.pyc
 .venv/
-
-# IETF spec drafts (downloaded for reference, not part of the repo)
-/spec/

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ pnpm-lock.yaml
 __pycache__/
 *.pyc
 .venv/
+
+# IETF spec drafts (downloaded for reference, not part of the repo)
+/spec/

--- a/js/lite/src/connection/accept.ts
+++ b/js/lite/src/connection/accept.ts
@@ -20,8 +20,10 @@ export async function accept(transport: WebTransport, url: URL, props?: AcceptPr
 	// @ts-expect-error - TODO: add protocol to WebTransport
 	const protocol: string | undefined = transport.protocol;
 
-	if (protocol === Ietf.ALPN.DRAFT_17) {
-		return acceptDraft17(transport, url);
+	if (protocol === Ietf.ALPN.DRAFT_18) {
+		return acceptModern(transport, url, Ietf.Version.DRAFT_18);
+	} else if (protocol === Ietf.ALPN.DRAFT_17) {
+		return acceptModern(transport, url, Ietf.Version.DRAFT_17);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
 		return acceptAlpnVersion(transport, url, Ietf.Version.DRAFT_16);
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
@@ -37,7 +39,11 @@ export async function accept(transport: WebTransport, url: URL, props?: AcceptPr
 	}
 }
 
-async function acceptDraft17(transport: WebTransport, url: URL): Promise<Established> {
+/**
+ * Draft-17+ accept: SETUP is exchanged over a pair of uni streams using
+ * stream type 0x2F00. The same wire format applies for draft-17 and draft-18.
+ */
+async function acceptModern(transport: WebTransport, url: URL, version: Ietf.IetfVersion): Promise<Established> {
 	const encoder = new TextEncoder();
 	const params = new Ietf.SetupOptions();
 	params.setBytes(Ietf.SetupOption.Implementation, encoder.encode("moq-lite-js"));
@@ -60,8 +66,8 @@ async function acceptDraft17(transport: WebTransport, url: URL): Promise<Establi
 
 	// Create control stream from the uni pair (this locks readable/writable once)
 	const controlStream = new Stream({ writable: sendWritable, readable: recvReadable });
-	controlStream.writer.version = Ietf.Version.DRAFT_17;
-	controlStream.reader.version = Ietf.Version.DRAFT_17;
+	controlStream.writer.version = version;
+	controlStream.reader.version = version;
 
 	// Send and receive SETUP concurrently using the control stream's reader/writer
 	await Promise.all([
@@ -70,11 +76,11 @@ async function acceptDraft17(transport: WebTransport, url: URL): Promise<Establi
 			if (streamType !== Ietf.Setup.id) {
 				throw new Error(`unexpected stream type on setup uni: 0x${streamType.toString(16)}`);
 			}
-			await Ietf.Setup.decode(controlStream.reader, Ietf.Version.DRAFT_17);
+			await Ietf.Setup.decode(controlStream.reader, version);
 		})(),
 		(async () => {
 			await controlStream.writer.u53(Ietf.Setup.id);
-			await setupMsg.encode(controlStream.writer, Ietf.Version.DRAFT_17);
+			await setupMsg.encode(controlStream.writer, version);
 		})(),
 	]);
 
@@ -82,9 +88,9 @@ async function acceptDraft17(transport: WebTransport, url: URL): Promise<Establi
 		url,
 		quic: transport,
 		control: controlStream,
-		// v17 uses NativeSession which manages its own request IDs; maxRequestId is unused.
+		// v17+ uses NativeSession which manages its own request IDs; maxRequestId is unused.
 		maxRequestId: 0n,
-		version: Ietf.Version.DRAFT_17,
+		version,
 	});
 }
 

--- a/js/lite/src/connection/accept.ts
+++ b/js/lite/src/connection/accept.ts
@@ -2,6 +2,7 @@ import * as Ietf from "../ietf/index.ts";
 import * as Lite from "../lite/index.ts";
 import { Stream } from "../stream.ts";
 import type { Established } from "./established.ts";
+import { exchangeSetup } from "./handshake.ts";
 
 export interface AcceptProps {
 	// Version to select during SETUP negotiation (for non-ALPN paths).
@@ -21,13 +22,13 @@ export async function accept(transport: WebTransport, url: URL, props?: AcceptPr
 	const protocol: string | undefined = transport.protocol;
 
 	if (protocol === Ietf.ALPN.DRAFT_18) {
-		return acceptModern(transport, url, Ietf.Version.DRAFT_18);
+		return acceptAlpn(transport, url, Ietf.Version.DRAFT_18);
 	} else if (protocol === Ietf.ALPN.DRAFT_17) {
-		return acceptModern(transport, url, Ietf.Version.DRAFT_17);
+		return acceptAlpn(transport, url, Ietf.Version.DRAFT_17);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
-		return acceptAlpnVersion(transport, url, Ietf.Version.DRAFT_16);
+		return acceptSetup(transport, url, Ietf.Version.DRAFT_16);
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
-		return acceptAlpnVersion(transport, url, Ietf.Version.DRAFT_15);
+		return acceptSetup(transport, url, Ietf.Version.DRAFT_15);
 	} else if (protocol === Lite.ALPN_04) {
 		return new Lite.Connection(url, transport, Lite.Version.DRAFT_04, undefined);
 	} else if (protocol === Lite.ALPN_03) {
@@ -40,49 +41,11 @@ export async function accept(transport: WebTransport, url: URL, props?: AcceptPr
 }
 
 /**
- * Draft-17+ accept: SETUP is exchanged over a pair of uni streams using
- * stream type 0x2F00. The same wire format applies for draft-17 and draft-18.
+ * Draft-17+ accept: ALPN already pinned the version. SETUP is exchanged over
+ * a pair of uni streams using stream type 0x2F00.
  */
-async function acceptModern(transport: WebTransport, url: URL, version: Ietf.IetfVersion): Promise<Established> {
-	const encoder = new TextEncoder();
-	const params = new Ietf.SetupOptions();
-	params.setBytes(Ietf.SetupOption.Implementation, encoder.encode("moq-lite-js"));
-
-	const setupMsg = new Ietf.Setup({ parameters: params });
-
-	// Accept recv uni and open send uni concurrently
-	const [recvReadable, sendWritable] = await Promise.all([
-		(async () => {
-			const uniReader = transport.incomingUnidirectionalStreams.getReader() as ReadableStreamDefaultReader<
-				ReadableStream<Uint8Array>
-			>;
-			const next = await uniReader.read();
-			uniReader.releaseLock();
-			if (next.done) throw new Error("no incoming uni stream for SETUP");
-			return next.value;
-		})(),
-		transport.createUnidirectionalStream() as Promise<WritableStream<Uint8Array>>,
-	]);
-
-	// Create control stream from the uni pair (this locks readable/writable once)
-	const controlStream = new Stream({ writable: sendWritable, readable: recvReadable });
-	controlStream.writer.version = version;
-	controlStream.reader.version = version;
-
-	// Send and receive SETUP concurrently using the control stream's reader/writer
-	await Promise.all([
-		(async () => {
-			const streamType = await controlStream.reader.u53();
-			if (streamType !== Ietf.Setup.id) {
-				throw new Error(`unexpected stream type on setup uni: 0x${streamType.toString(16)}`);
-			}
-			await Ietf.Setup.decode(controlStream.reader, version);
-		})(),
-		(async () => {
-			await controlStream.writer.u53(Ietf.Setup.id);
-			await setupMsg.encode(controlStream.writer, version);
-		})(),
-	]);
+async function acceptAlpn(transport: WebTransport, url: URL, version: Ietf.IetfVersion): Promise<Established> {
+	const controlStream = await exchangeSetup(transport, version, "moq-lite-js");
 
 	return new Ietf.Connection({
 		url,
@@ -94,7 +57,11 @@ async function acceptModern(transport: WebTransport, url: URL, version: Ietf.Iet
 	});
 }
 
-async function acceptAlpnVersion(transport: WebTransport, url: URL, version: Ietf.IetfVersion): Promise<Established> {
+/**
+ * Legacy accept (draft-15/16): ALPN pinned the version, but the SETUP message
+ * is still exchanged over a bidi stream wrapped in the moq-lite compat envelope.
+ */
+async function acceptSetup(transport: WebTransport, url: URL, version: Ietf.IetfVersion): Promise<Established> {
 	// Accept bidi, read ClientSetup, write ServerSetup
 	const stream = await Stream.accept(transport);
 	if (!stream) throw new Error("no incoming bidi stream for SETUP");

--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -98,63 +98,14 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 
 	// Choose setup encoding based on negotiated WebTransport protocol (if any).
 	let setupVersion: Ietf.Version;
-	if (protocol === Ietf.ALPN.DRAFT_17) {
-		// Draft-17: SETUP uses uni streams with 0x2F00 stream type
-		const encoder = new TextEncoder();
-		const params = new Ietf.SetupOptions();
-		params.setBytes(Ietf.SetupOption.Implementation, encoder.encode("moq-lite-js"));
-
-		const setupMsg = new Ietf.Setup({ parameters: params });
-
-		// Send and receive SETUP concurrently on uni streams
-		const [sendWriter, recvReader] = await Promise.all([
-			// Send: open uni stream, write 0x2F00 stream type + Setup message
-			(async () => {
-				const writable = (await (
-					session as WebTransport
-				).createUnidirectionalStream()) as WritableStream<Uint8Array>;
-				const writer = new Writer(writable, Ietf.Version.DRAFT_17);
-				await writer.u53(Ietf.Setup.id); // 0x2F00 stream type
-				await setupMsg.encode(writer, Ietf.Version.DRAFT_17);
-				return { writable, writer };
-			})(),
-			// Recv: accept uni stream, read 0x2F00 stream type + Setup message
-			(async () => {
-				const uniReader = (
-					session as WebTransport
-				).incomingUnidirectionalStreams.getReader() as ReadableStreamDefaultReader<ReadableStream<Uint8Array>>;
-				const next = await uniReader.read();
-				uniReader.releaseLock();
-				if (next.done) throw new Error("no incoming uni stream for SETUP");
-				const readable = next.value;
-				const reader = new Reader(readable, undefined, Ietf.Version.DRAFT_17);
-				const streamType = await reader.u53();
-				if (streamType !== Ietf.Setup.id) {
-					throw new Error(`unexpected stream type on setup uni: 0x${streamType.toString(16)}`);
-				}
-				const serverSetup = await Ietf.Setup.decode(reader, Ietf.Version.DRAFT_17);
-				console.debug(url.toString(), "received server setup (d17)", serverSetup);
-				return { readable, reader };
-			})(),
-		]);
-
-		// Construct a synthetic bidi Stream from the two uni streams for GoAway.
-		// Pass existing Writer/Reader to avoid double-locking the streams.
-		const controlStream = new Stream({
-			writable: sendWriter.writable,
-			readable: recvReader.readable,
-			writer: sendWriter.writer,
-			reader: recvReader.reader,
-		});
-
-		return new Ietf.Connection({
-			url,
-			quic: session as WebTransport,
-			control: controlStream,
-			// v17 uses NativeSession which manages its own request IDs; maxRequestId is unused.
-			maxRequestId: 0n,
-			version: Ietf.Version.DRAFT_17,
-		});
+	const modernVersion =
+		protocol === Ietf.ALPN.DRAFT_18
+			? Ietf.Version.DRAFT_18
+			: protocol === Ietf.ALPN.DRAFT_17
+				? Ietf.Version.DRAFT_17
+				: undefined;
+	if (modernVersion !== undefined) {
+		return await modernHandshake(url, session as WebTransport, modernVersion);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
@@ -229,56 +180,14 @@ async function connectTransport(url: URL, session: WebTransport): Promise<Establ
 
 	// Choose setup encoding based on negotiated WebTransport protocol (if any).
 	let setupVersion: Ietf.Version;
-	if (protocol === Ietf.ALPN.DRAFT_17) {
-		// Draft-17: SETUP uses uni streams with 0x2F00 stream type
-		const encoder = new TextEncoder();
-		const params = new Ietf.SetupOptions();
-		params.setBytes(Ietf.SetupOption.Implementation, encoder.encode("moq-lite-js"));
-
-		const setupMsg = new Ietf.Setup({ parameters: params });
-
-		// Open send uni and accept recv uni concurrently
-		const [sendWritable, recvReadable] = await Promise.all([
-			session.createUnidirectionalStream() as Promise<WritableStream<Uint8Array>>,
-			(async () => {
-				const uniReader = session.incomingUnidirectionalStreams.getReader() as ReadableStreamDefaultReader<
-					ReadableStream<Uint8Array>
-				>;
-				const next = await uniReader.read();
-				uniReader.releaseLock();
-				if (next.done) throw new Error("no incoming uni stream for SETUP");
-				return next.value;
-			})(),
-		]);
-
-		// Create control stream from the uni pair (this locks readable/writable once)
-		const controlStream = new Stream({ writable: sendWritable, readable: recvReadable });
-		controlStream.writer.version = Ietf.Version.DRAFT_17;
-		controlStream.reader.version = Ietf.Version.DRAFT_17;
-
-		// Send and receive SETUP concurrently using the control stream's reader/writer
-		await Promise.all([
-			(async () => {
-				await controlStream.writer.u53(Ietf.Setup.id);
-				await setupMsg.encode(controlStream.writer, Ietf.Version.DRAFT_17);
-			})(),
-			(async () => {
-				const streamType = await controlStream.reader.u53();
-				if (streamType !== Ietf.Setup.id) {
-					throw new Error(`unexpected stream type on setup uni: 0x${streamType.toString(16)}`);
-				}
-				await Ietf.Setup.decode(controlStream.reader, Ietf.Version.DRAFT_17);
-			})(),
-		]);
-
-		return new Ietf.Connection({
-			url,
-			quic: session,
-			control: controlStream,
-			// v17 uses NativeSession which manages its own request IDs; maxRequestId is unused.
-			maxRequestId: 0n,
-			version: Ietf.Version.DRAFT_17,
-		});
+	const modernVersion =
+		protocol === Ietf.ALPN.DRAFT_18
+			? Ietf.Version.DRAFT_18
+			: protocol === Ietf.ALPN.DRAFT_17
+				? Ietf.Version.DRAFT_17
+				: undefined;
+	if (modernVersion !== undefined) {
+		return await modernHandshake(url, session, modernVersion);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
@@ -336,6 +245,61 @@ async function connectTransport(url: URL, session: WebTransport): Promise<Establ
 	}
 }
 
+/**
+ * Draft-17+ handshake: SETUP is exchanged over a pair of uni streams using
+ * stream type 0x2F00. The same wire format applies for draft-17 and draft-18.
+ */
+async function modernHandshake(url: URL, session: WebTransport, version: Ietf.IetfVersion): Promise<Established> {
+	const encoder = new TextEncoder();
+	const params = new Ietf.SetupOptions();
+	params.setBytes(Ietf.SetupOption.Implementation, encoder.encode("moq-lite-js"));
+
+	const setupMsg = new Ietf.Setup({ parameters: params });
+
+	const [sendWriter, recvReader] = await Promise.all([
+		(async () => {
+			const writable = (await session.createUnidirectionalStream()) as WritableStream<Uint8Array>;
+			const writer = new Writer(writable, version);
+			await writer.u53(Ietf.Setup.id); // 0x2F00 stream type
+			await setupMsg.encode(writer, version);
+			return { writable, writer };
+		})(),
+		(async () => {
+			const uniReader = session.incomingUnidirectionalStreams.getReader() as ReadableStreamDefaultReader<
+				ReadableStream<Uint8Array>
+			>;
+			const next = await uniReader.read();
+			uniReader.releaseLock();
+			if (next.done) throw new Error("no incoming uni stream for SETUP");
+			const readable = next.value;
+			const reader = new Reader(readable, undefined, version);
+			const streamType = await reader.u53();
+			if (streamType !== Ietf.Setup.id) {
+				throw new Error(`unexpected stream type on setup uni: 0x${streamType.toString(16)}`);
+			}
+			const serverSetup = await Ietf.Setup.decode(reader, version);
+			console.debug(url.toString(), "received server setup", { version, serverSetup });
+			return { readable, reader };
+		})(),
+	]);
+
+	const controlStream = new Stream({
+		writable: sendWriter.writable,
+		readable: recvReader.readable,
+		writer: sendWriter.writer,
+		reader: recvReader.reader,
+	});
+
+	return new Ietf.Connection({
+		url,
+		quic: session,
+		control: controlStream,
+		// v17+ uses NativeSession which manages its own request IDs; maxRequestId is unused.
+		maxRequestId: 0n,
+		version,
+	});
+}
+
 async function connectWebTransport(
 	url: URL,
 	cancel: Promise<void>,
@@ -346,7 +310,15 @@ async function connectWebTransport(
 	const finalOptions: WebTransportOptions = {
 		allowPooling: false,
 		congestionControl: "low-latency",
-		protocols: [Lite.ALPN_04, Lite.ALPN_03, Lite.ALPN, Ietf.ALPN.DRAFT_17, Ietf.ALPN.DRAFT_16, Ietf.ALPN.DRAFT_15],
+		protocols: [
+			Lite.ALPN_04,
+			Lite.ALPN_03,
+			Lite.ALPN,
+			Ietf.ALPN.DRAFT_18,
+			Ietf.ALPN.DRAFT_17,
+			Ietf.ALPN.DRAFT_16,
+			Ietf.ALPN.DRAFT_15,
+		],
 		...options,
 	};
 

--- a/js/lite/src/connection/connect.ts
+++ b/js/lite/src/connection/connect.ts
@@ -1,9 +1,10 @@
 import Session from "@moq/qmux";
 import * as Ietf from "../ietf/index.ts";
 import * as Lite from "../lite/index.ts";
-import { Reader, Stream, Writer } from "../stream.ts";
+import { Stream } from "../stream.ts";
 import * as Hex from "../util/hex.ts";
 import type { Established } from "./established.ts";
+import { exchangeSetup } from "./handshake.ts";
 
 // Default head start for WebTransport before attempting the WebSocket fallback.
 const DEFAULT_WEBSOCKET_DELAY_MS = 500;
@@ -105,7 +106,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 				? Ietf.Version.DRAFT_17
 				: undefined;
 	if (modernVersion !== undefined) {
-		return await modernHandshake(url, session as WebTransport, modernVersion);
+		return await handshakeAlpn(url, session as WebTransport, modernVersion);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
@@ -187,7 +188,7 @@ async function connectTransport(url: URL, session: WebTransport): Promise<Establ
 				? Ietf.Version.DRAFT_17
 				: undefined;
 	if (modernVersion !== undefined) {
-		return await modernHandshake(url, session, modernVersion);
+		return await handshakeAlpn(url, session, modernVersion);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
@@ -246,49 +247,11 @@ async function connectTransport(url: URL, session: WebTransport): Promise<Establ
 }
 
 /**
- * Draft-17+ handshake: SETUP is exchanged over a pair of uni streams using
- * stream type 0x2F00. The same wire format applies for draft-17 and draft-18.
+ * Draft-17+ client handshake. ALPN already pinned the version; SETUP is
+ * exchanged over a pair of uni streams using stream type 0x2F00.
  */
-async function modernHandshake(url: URL, session: WebTransport, version: Ietf.IetfVersion): Promise<Established> {
-	const encoder = new TextEncoder();
-	const params = new Ietf.SetupOptions();
-	params.setBytes(Ietf.SetupOption.Implementation, encoder.encode("moq-lite-js"));
-
-	const setupMsg = new Ietf.Setup({ parameters: params });
-
-	const [sendWriter, recvReader] = await Promise.all([
-		(async () => {
-			const writable = (await session.createUnidirectionalStream()) as WritableStream<Uint8Array>;
-			const writer = new Writer(writable, version);
-			await writer.u53(Ietf.Setup.id); // 0x2F00 stream type
-			await setupMsg.encode(writer, version);
-			return { writable, writer };
-		})(),
-		(async () => {
-			const uniReader = session.incomingUnidirectionalStreams.getReader() as ReadableStreamDefaultReader<
-				ReadableStream<Uint8Array>
-			>;
-			const next = await uniReader.read();
-			uniReader.releaseLock();
-			if (next.done) throw new Error("no incoming uni stream for SETUP");
-			const readable = next.value;
-			const reader = new Reader(readable, undefined, version);
-			const streamType = await reader.u53();
-			if (streamType !== Ietf.Setup.id) {
-				throw new Error(`unexpected stream type on setup uni: 0x${streamType.toString(16)}`);
-			}
-			const serverSetup = await Ietf.Setup.decode(reader, version);
-			console.debug(url.toString(), "received server setup", { version, serverSetup });
-			return { readable, reader };
-		})(),
-	]);
-
-	const controlStream = new Stream({
-		writable: sendWriter.writable,
-		readable: recvReader.readable,
-		writer: sendWriter.writer,
-		reader: recvReader.reader,
-	});
+async function handshakeAlpn(url: URL, session: WebTransport, version: Ietf.IetfVersion): Promise<Established> {
+	const controlStream = await exchangeSetup(session, version, "moq-lite-js");
 
 	return new Ietf.Connection({
 		url,

--- a/js/lite/src/connection/handshake.ts
+++ b/js/lite/src/connection/handshake.ts
@@ -1,0 +1,66 @@
+import * as Ietf from "../ietf/index.ts";
+import { Reader, Stream, Writer } from "../stream.ts";
+
+/**
+ * Draft-17+ SETUP exchange. Each side opens a uni stream, writes its Setup
+ * message, and reads the peer's Setup off an incoming uni stream. The two
+ * halves run in parallel and the protocol is symmetric, so both `connect`
+ * (client) and `accept` (server) use this same function.
+ */
+export async function exchangeSetup(
+	transport: WebTransport,
+	version: Ietf.IetfVersion,
+	implementation: string,
+): Promise<Stream> {
+	const encoder = new TextEncoder();
+	const params = new Ietf.SetupOptions();
+	params.setBytes(Ietf.SetupOption.Implementation, encoder.encode(implementation));
+	const setupMsg = new Ietf.Setup({ parameters: params });
+
+	const [sent, received] = await Promise.all([
+		sendSetup(transport, version, setupMsg),
+		receiveSetup(transport, version),
+	]);
+
+	return new Stream({
+		writable: sent.writable,
+		readable: received.readable,
+		writer: sent.writer,
+		reader: received.reader,
+	});
+}
+
+async function sendSetup(
+	transport: WebTransport,
+	version: Ietf.IetfVersion,
+	setupMsg: Ietf.Setup,
+): Promise<{ writable: WritableStream<Uint8Array>; writer: Writer }> {
+	const writable = (await transport.createUnidirectionalStream()) as WritableStream<Uint8Array>;
+	const writer = new Writer(writable, version);
+	await writer.u53(Ietf.Setup.id); // 0x2F00 stream type
+	await setupMsg.encode(writer, version);
+	return { writable, writer };
+}
+
+async function receiveSetup(
+	transport: WebTransport,
+	version: Ietf.IetfVersion,
+): Promise<{ readable: ReadableStream<Uint8Array>; reader: Reader }> {
+	const uniReader = transport.incomingUnidirectionalStreams.getReader() as ReadableStreamDefaultReader<
+		ReadableStream<Uint8Array>
+	>;
+	const next = await uniReader.read();
+	uniReader.releaseLock();
+	if (next.done) throw new Error("no incoming uni stream for SETUP");
+
+	const readable = next.value;
+	const reader = new Reader(readable, undefined, version);
+
+	const streamType = await reader.u53();
+	if (streamType !== Ietf.Setup.id) {
+		throw new Error(`unexpected stream type on setup uni: 0x${streamType.toString(16)}`);
+	}
+	await Ietf.Setup.decode(reader, version);
+
+	return { readable, reader };
+}

--- a/js/lite/src/ietf/connection.ts
+++ b/js/lite/src/ietf/connection.ts
@@ -69,11 +69,11 @@ export class Connection implements Established {
 		this.version = versionName(version);
 		this.#quic = quic;
 
-		// Two-path dispatch: v14-v16 uses adapter, v17 uses native bidi streams
-		if (version === Version.DRAFT_17) {
+		// Two-path dispatch: v14-v16 uses adapter, v17+ uses native bidi streams
+		if (version === Version.DRAFT_17 || version === Version.DRAFT_18) {
 			this.#session = new NativeSession(quic, version);
-			// v17: control/setup stream only carries GoAway
-			void this.#runGoAway(control);
+			// v17+: control/setup stream only carries GoAway
+			void this.#runGoAway(control, version);
 		} else {
 			const adapter = new ControlStreamAdapter(quic, control, version, maxRequestId);
 			this.#session = adapter;
@@ -240,16 +240,16 @@ export class Connection implements Established {
 	}
 
 	/**
-	 * v17 only: reads GoAway from the setup/control stream.
+	 * v17+ only: reads GoAway from the setup/control stream.
 	 */
-	async #runGoAway(controlStream: Stream) {
+	async #runGoAway(controlStream: Stream, version: IetfVersion) {
 		try {
 			const done = await controlStream.reader.done();
 			if (done) return;
 
 			const typeId = await controlStream.reader.u53();
 			if (typeId === GoAway.id) {
-				const msg = await GoAway.decode(controlStream.reader, Version.DRAFT_17);
+				const msg = await GoAway.decode(controlStream.reader, version);
 				console.warn(`received GOAWAY with redirect URI: ${msg.newSessionUri}`);
 			} else {
 				console.warn(`unexpected message on setup stream: 0x${typeId.toString(16)}`);

--- a/js/lite/src/ietf/control.ts
+++ b/js/lite/src/ietf/control.ts
@@ -216,16 +216,16 @@ export class Stream {
 			}
 
 			let messages: Record<number, MessageType>;
-			if (this.version === Version.DRAFT_18) {
-				messages = MessagesV18 as unknown as Record<number, MessageType>;
-			} else if (this.version === Version.DRAFT_17) {
-				messages = MessagesV17 as unknown as Record<number, MessageType>;
-			} else if (this.version === Version.DRAFT_16) {
-				messages = MessagesV16 as unknown as Record<number, MessageType>;
+			if (this.version === Version.DRAFT_14) {
+				messages = MessagesV14 as unknown as Record<number, MessageType>;
 			} else if (this.version === Version.DRAFT_15) {
 				messages = MessagesV15 as unknown as Record<number, MessageType>;
+			} else if (this.version === Version.DRAFT_16) {
+				messages = MessagesV16 as unknown as Record<number, MessageType>;
+			} else if (this.version === Version.DRAFT_17) {
+				messages = MessagesV17 as unknown as Record<number, MessageType>;
 			} else {
-				messages = MessagesV14 as unknown as Record<number, MessageType>;
+				messages = MessagesV18 as unknown as Record<number, MessageType>;
 			}
 
 			if (!(messageType in messages)) {
@@ -259,13 +259,17 @@ export class Stream {
 		while (true) {
 			const id = this.#requestId;
 
-			// d17+: no flow control, always allowed
-			if (this.version === Version.DRAFT_17 || this.version === Version.DRAFT_18) {
-				this.#requestId += 2n;
-				return id;
-			}
-
-			if (id < this.#maxRequestId) {
+			// d14-d16 use MAX_REQUEST_ID flow control; d17+ removed it.
+			if (
+				this.version === Version.DRAFT_14 ||
+				this.version === Version.DRAFT_15 ||
+				this.version === Version.DRAFT_16
+			) {
+				if (id < this.#maxRequestId) {
+					this.#requestId += 2n;
+					return id;
+				}
+			} else {
 				this.#requestId += 2n;
 				return id;
 			}

--- a/js/lite/src/ietf/control.ts
+++ b/js/lite/src/ietf/control.ts
@@ -14,6 +14,7 @@ import { MaxRequestId, RequestError, RequestOk, RequestsBlocked } from "./reques
 import * as Setup from "./setup.ts";
 import { Subscribe, SubscribeError, SubscribeOk, SubscribeUpdate, Unsubscribe } from "./subscribe.ts";
 import {
+	SUBSCRIBE_TRACKS_ID,
 	SubscribeNamespace,
 	SubscribeNamespaceError,
 	SubscribeNamespaceOk,
@@ -135,6 +136,13 @@ const MessagesV17 = {
 	// RequestsBlocked (0x1a) removed in d17
 } as const;
 
+// v18 message map — same as v17 with these spec changes:
+// * #1615 removes Required Request ID (transparent on the wire for messages here)
+// * #1542 splits SUBSCRIBE_NAMESPACE into SUBSCRIBE_NAMESPACE + SUBSCRIBE_TRACKS (0x51).
+//   moq-lite does not implement track subscription via PUBLISH replication, so 0x51
+//   is rejected as an explicit error rather than silently ignored.
+const MessagesV18 = MessagesV17;
+
 type V14MessageType = (typeof MessagesV14)[keyof typeof MessagesV14];
 type V15MessageType = (typeof MessagesV15)[keyof typeof MessagesV15];
 type V16MessageType = (typeof MessagesV16)[keyof typeof MessagesV16];
@@ -200,8 +208,17 @@ export class Stream {
 		return await this.#readLock.runExclusive(async () => {
 			const messageType = await this.stream.reader.u53();
 
+			// Draft-18 (#1542) splits SUBSCRIBE_NAMESPACE into SUBSCRIBE_NAMESPACE +
+			// SUBSCRIBE_TRACKS (0x51). moq-lite does not support track subscription
+			// via PUBLISH replication, so reject loudly rather than wait forever.
+			if (this.version === Version.DRAFT_18 && messageType === SUBSCRIBE_TRACKS_ID) {
+				throw new Error("SUBSCRIBE_TRACKS (0x51) is not supported in moq-lite (no PUBLISH replication)");
+			}
+
 			let messages: Record<number, MessageType>;
-			if (this.version === Version.DRAFT_17) {
+			if (this.version === Version.DRAFT_18) {
+				messages = MessagesV18 as unknown as Record<number, MessageType>;
+			} else if (this.version === Version.DRAFT_17) {
 				messages = MessagesV17 as unknown as Record<number, MessageType>;
 			} else if (this.version === Version.DRAFT_16) {
 				messages = MessagesV16 as unknown as Record<number, MessageType>;
@@ -242,8 +259,8 @@ export class Stream {
 		while (true) {
 			const id = this.#requestId;
 
-			// d17: no flow control, always allowed
-			if (this.version === Version.DRAFT_17) {
+			// d17+: no flow control, always allowed
+			if (this.version === Version.DRAFT_17 || this.version === Version.DRAFT_18) {
 				this.#requestId += 2n;
 				return id;
 			}

--- a/js/lite/src/ietf/goaway.ts
+++ b/js/lite/src/ietf/goaway.ts
@@ -15,8 +15,9 @@ export class GoAway {
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
 		await w.string(this.newSessionUri);
-		if (version === Version.DRAFT_17) {
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15 && version !== Version.DRAFT_16) {
 			await w.u62(this.timeout);
+			// Draft-18 adds an optional trailing Request ID (#1559). We never emit it.
 		}
 	}
 
@@ -30,7 +31,11 @@ export class GoAway {
 
 	static async #decode(r: Reader, version: IetfVersion): Promise<GoAway> {
 		const newSessionUri = await r.string();
-		const timeout = version === Version.DRAFT_17 ? await r.u62() : 0n;
+		const timeout =
+			version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16
+				? 0n
+				: await r.u62();
+		// Draft-18 optional trailing Request ID (#1559) — read and discard if present.
 		return new GoAway({ newSessionUri, timeout });
 	}
 }

--- a/js/lite/src/ietf/ietf.test.ts
+++ b/js/lite/src/ietf/ietf.test.ts
@@ -532,10 +532,28 @@ test("Leading-ones varint: boundary round-trips", () => {
 	}
 });
 
-test("Leading-ones varint: invalid 0xFC prefix rejected", () => {
+test("Leading-ones varint: 0xFC is a 7-byte form on draft-18+ (per #1595)", () => {
+	// Standalone decoder is permissive; draft-17 enforcement is in Reader#readLeadingOnes.
+	// Only check that it doesn't reject the prefix as "reserved" — it now needs more bytes.
 	expect(() => {
 		Varint.decodeLeadingOnes(new Uint8Array([0xfc]));
-	}).toThrow(/reserved/);
+	}).toThrow(/buffer too short/);
+});
+
+test("Leading-ones varint: 7-byte form round-trips on draft-18", () => {
+	// Encode 7 bytes manually: 1111110_0 (prefix bit 48 = 0) + 6 bytes payload
+	const value = 0x12_3456_789a_bcn;
+	const bytes = new Uint8Array(7);
+	bytes[0] = 0xfc; // 1111110_0
+	bytes[1] = 0x12;
+	bytes[2] = 0x34;
+	bytes[3] = 0x56;
+	bytes[4] = 0x78;
+	bytes[5] = 0x9a;
+	bytes[6] = 0xbc;
+	const [decoded, remain] = Varint.decodeLeadingOnes(bytes);
+	expect(decoded).toBe(value);
+	expect(remain.length).toBe(0);
 });
 
 // --- Draft-17 message tests ---
@@ -833,4 +851,48 @@ test("Namespace: PublishNamespace with empty namespace round trip", async () => 
 	const decoded = await decodeVersioned(encoded, Announce.PublishNamespace.decode, Version.DRAFT_17);
 
 	expect(decoded.trackNamespace).toBe("" as Path.Valid);
+});
+
+// --- Draft-18 message tests ---
+
+test("Subscribe v18: round trip (same wire as v17 minus required_request_id_delta)", async () => {
+	const msg = new Subscribe.Subscribe({
+		requestId: 1n,
+		trackNamespace: Path.from("test"),
+		trackName: "video",
+		subscriberPriority: 128,
+	});
+
+	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
+	const decoded = await decodeVersioned(encoded, Subscribe.Subscribe.decode, Version.DRAFT_18);
+
+	expect(decoded.requestId).toBe(1n);
+	expect(decoded.trackNamespace).toBe("test" as Path.Valid);
+	expect(decoded.trackName).toBe("video");
+	expect(decoded.subscriberPriority).toBe(128);
+});
+
+test("SubscribeOk v18: no requestId", async () => {
+	const msg = new Subscribe.SubscribeOk({ trackAlias: 42n });
+
+	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
+	const decoded = await decodeVersioned(encoded, Subscribe.SubscribeOk.decode, Version.DRAFT_18);
+
+	expect(decoded.requestId).toBe(undefined);
+	expect(decoded.trackAlias).toBe(42n);
+});
+
+test("SubscribeUpdate v18: 1 byte shorter than v17 (no required_request_id_delta)", async () => {
+	const msg = new Subscribe.SubscribeUpdate({ requestId: 10n });
+	const v17 = await encodeVersioned(msg, Version.DRAFT_17);
+	const v18 = await encodeVersioned(msg, Version.DRAFT_18);
+	expect(v17.length).toBe(v18.length + 1);
+});
+
+test("PublishNamespace v18: round trip without required_request_id_delta", async () => {
+	const msg = new Announce.PublishNamespace({ requestId: 5n, trackNamespace: Path.from("v18/broadcast") });
+	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
+	const decoded = await decodeVersioned(encoded, Announce.PublishNamespace.decode, Version.DRAFT_18);
+	expect(decoded.requestId).toBe(5n);
+	expect(decoded.trackNamespace).toBe("v18/broadcast" as Path.Valid);
 });

--- a/js/lite/src/ietf/ietf.test.ts
+++ b/js/lite/src/ietf/ietf.test.ts
@@ -896,3 +896,112 @@ test("PublishNamespace v18: round trip without required_request_id_delta", async
 	expect(decoded.requestId).toBe(5n);
 	expect(decoded.trackNamespace).toBe("v18/broadcast" as Path.Valid);
 });
+
+test("Publish v18: round trip", async () => {
+	const msg = new Publish({
+		requestId: 7n,
+		trackNamespace: Path.from("v18/ns"),
+		trackName: "video",
+		trackAlias: 1n,
+		groupOrder: 2,
+		contentExists: false,
+		largest: undefined,
+		forward: true,
+	});
+
+	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
+	const decoded = await decodeVersioned(encoded, Publish.decode, Version.DRAFT_18);
+
+	expect(decoded.requestId).toBe(7n);
+	expect(decoded.trackNamespace).toBe("v18/ns" as Path.Valid);
+	expect(decoded.trackName).toBe("video");
+	expect(decoded.trackAlias).toBe(1n);
+	expect(decoded.forward).toBe(true);
+});
+
+test("PublishDone v18: no requestId", async () => {
+	const msg = new PublishDone({ statusCode: 200, reasonPhrase: "OK" });
+
+	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
+	const decoded = await decodeVersioned(encoded, PublishDone.decode, Version.DRAFT_18);
+
+	expect(decoded.requestId).toBe(undefined);
+	expect(decoded.statusCode).toBe(200);
+	expect(decoded.reasonPhrase).toBe("OK");
+});
+
+test("RequestOk v18: no requestId (regression: don't treat Draft18 as legacy)", async () => {
+	const msg = new RequestOk({});
+
+	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
+	const decoded = await decodeVersioned(encoded, RequestOk.decode, Version.DRAFT_18);
+
+	expect(decoded.requestId).toBe(undefined);
+});
+
+test("RequestError v18: no requestId, retry_interval still present", async () => {
+	const msg = new RequestError({
+		errorCode: 500,
+		reasonPhrase: "boom",
+		retryInterval: 1234n,
+	});
+
+	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
+	const decoded = await decodeVersioned(encoded, RequestError.decode, Version.DRAFT_18);
+
+	expect(decoded.requestId).toBe(undefined);
+	expect(decoded.errorCode).toBe(500);
+	expect(decoded.reasonPhrase).toBe("boom");
+	expect(decoded.retryInterval).toBe(1234n);
+});
+
+test("Subscribe v18 wire bytes match v17 (FIRST_OBJECT bit doesn't affect control messages)", async () => {
+	const msg = new Subscribe.Subscribe({
+		requestId: 1n,
+		trackNamespace: Path.from("test"),
+		trackName: "video",
+		subscriberPriority: 128,
+	});
+
+	const v17 = await encodeVersioned(msg, Version.DRAFT_17);
+	const v18 = await encodeVersioned(msg, Version.DRAFT_18);
+
+	// Draft18 drops the required_request_id_delta (1 byte) from v17.
+	expect(v18.length).toBe(v17.length - 1);
+});
+
+test("PublishNamespaceDone v18: rejected (removed in draft-17+)", async () => {
+	const msg = new Announce.PublishNamespaceDone({ requestId: 1n });
+	const { stream } = createTestWritableStream();
+	const writer = new Writer(stream, Version.DRAFT_18);
+	await expect(msg.encode(writer, Version.DRAFT_18)).rejects.toThrow(/removed in draft-17/);
+});
+
+test("GoAway v18: round trip (timeout field still present)", async () => {
+	const msg = new GoAway.GoAway({ newSessionUri: "moqt://relay.example/", timeout: 5000n });
+
+	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
+	const decoded = await decodeVersioned(encoded, GoAway.GoAway.decode, Version.DRAFT_18);
+
+	expect(decoded.newSessionUri).toBe("moqt://relay.example/");
+	expect(decoded.timeout).toBe(5000n);
+});
+
+test("Parameters v18 wire is identical to v17 (no count prefix, delta encoded keys)", async () => {
+	const params = new SetupOptions();
+	params.setVarint(0x2n, 42n);
+	params.setVarint(0x4n, 100n);
+
+	const v17 = (() => {
+		const { stream, written } = createTestWritableStream();
+		const w = new Writer(stream, Version.DRAFT_17);
+		return params.encode(w, Version.DRAFT_17).then(() => concatChunks(written));
+	})();
+	const v18 = (() => {
+		const { stream, written } = createTestWritableStream();
+		const w = new Writer(stream, Version.DRAFT_18);
+		return params.encode(w, Version.DRAFT_18).then(() => concatChunks(written));
+	})();
+
+	expect(Array.from(await v18)).toEqual(Array.from(await v17));
+});

--- a/js/lite/src/ietf/ietf.test.ts
+++ b/js/lite/src/ietf/ietf.test.ts
@@ -540,6 +540,20 @@ test("Leading-ones varint: 0xFC is a 7-byte form on draft-18+ (per #1595)", () =
 	}).toThrow(/buffer too short/);
 });
 
+test("Reader#u62: rejects 0xFC 7-byte form on draft-17", async () => {
+	const bytes = new Uint8Array([0xfc, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
+	const reader = new Reader(undefined, bytes, Version.DRAFT_17);
+	await expect(reader.u62()).rejects.toThrow(/reserved on draft-17/);
+});
+
+test("Reader#u62: accepts 0xFC 7-byte form on draft-18", async () => {
+	const value = 0x12_3456_789a_bcn;
+	const bytes = new Uint8Array([0xfc, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
+	const reader = new Reader(undefined, bytes, Version.DRAFT_18);
+	expect(await reader.u62()).toBe(value);
+	expect(await reader.done()).toBe(true);
+});
+
 test("Leading-ones varint: 7-byte form round-trips on draft-18", () => {
 	// Encode 7 bytes manually: 1111110_0 (prefix bit 48 = 0) + 6 bytes payload
 	const value = 0x12_3456_789a_bcn;
@@ -887,6 +901,11 @@ test("SubscribeUpdate v18: 1 byte shorter than v17 (no required_request_id_delta
 	const v17 = await encodeVersioned(msg, Version.DRAFT_17);
 	const v18 = await encodeVersioned(msg, Version.DRAFT_18);
 	expect(v17.length).toBe(v18.length + 1);
+
+	// Round-trip the v18 bytes too. A different shape that happens to be one byte
+	// shorter would silently pass the length check otherwise.
+	const decoded = await decodeVersioned(v18, Subscribe.SubscribeUpdate.decode, Version.DRAFT_18);
+	expect(decoded.requestId).toBe(10n);
 });
 
 test("PublishNamespace v18: round trip without required_request_id_delta", async () => {

--- a/js/lite/src/ietf/parameters.ts
+++ b/js/lite/src/ietf/parameters.ts
@@ -72,9 +72,9 @@ export class SetupOptions {
 	}
 
 	async encode(w: Writer, version: IetfVersion) {
-		if (version === Version.DRAFT_16 || version === Version.DRAFT_17) {
-			// d17: no count prefix; d16: count prefix
-			if (version !== Version.DRAFT_17) {
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15) {
+			// d17+: no count prefix; d16: count prefix
+			if (version === Version.DRAFT_16) {
 				await w.u53(this.vars.size + this.bytes.size);
 			}
 
@@ -120,8 +120,8 @@ export class SetupOptions {
 	static async decode(r: Reader, version: IetfVersion): Promise<SetupOptions> {
 		const params = new SetupOptions();
 
-		if (version === Version.DRAFT_17) {
-			// d17: no count prefix, read until reader is done
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15 && version !== Version.DRAFT_16) {
+			// d17+: no count prefix, read until reader is done
 			let prevType = 0n;
 			let i = 0;
 			while (!(await r.done())) {

--- a/js/lite/src/ietf/publish.ts
+++ b/js/lite/src/ietf/publish.ts
@@ -52,7 +52,7 @@ export class Publish {
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
 		await w.u62(this.requestId);
 		if (version === Version.DRAFT_17) {
-			await w.u62(0n); // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
+			await w.u62(0n); // required_request_id_delta = 0 (Draft17 only)
 		}
 		await Namespace.encode(w, this.trackNamespace);
 		await w.string(this.trackName);
@@ -96,7 +96,7 @@ export class Publish {
 	static async #decode(r: Reader, version: IetfVersion): Promise<Publish> {
 		const requestId = await r.u62();
 		if (version === Version.DRAFT_17) {
-			await r.u62(); // required_request_id_delta (draft-17 only, removed in draft-18 per #1615)
+			await r.u62(); // required_request_id_delta (Draft17 only)
 		}
 		const trackNamespace = await Namespace.decode(r);
 		const trackName = await r.string();

--- a/js/lite/src/ietf/publish.ts
+++ b/js/lite/src/ietf/publish.ts
@@ -52,7 +52,7 @@ export class Publish {
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
 		await w.u62(this.requestId);
 		if (version === Version.DRAFT_17) {
-			await w.u62(0n); // required_request_id_delta = 0
+			await w.u62(0n); // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		await Namespace.encode(w, this.trackNamespace);
 		await w.string(this.trackName);
@@ -96,7 +96,7 @@ export class Publish {
 	static async #decode(r: Reader, version: IetfVersion): Promise<Publish> {
 		const requestId = await r.u62();
 		if (version === Version.DRAFT_17) {
-			await r.u62(); // required_request_id_delta
+			await r.u62(); // required_request_id_delta (draft-17 only, removed in draft-18 per #1615)
 		}
 		const trackNamespace = await Namespace.decode(r);
 		const trackName = await r.string();
@@ -216,7 +216,7 @@ export class PublishDone {
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
-		if (version !== Version.DRAFT_17) {
+		if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
 			if (this.requestId === undefined) throw new Error("requestId required for draft14-16");
 			await w.u62(this.requestId);
 		}
@@ -234,7 +234,10 @@ export class PublishDone {
 	}
 
 	static async #decode(r: Reader, version: IetfVersion): Promise<PublishDone> {
-		const requestId = version === Version.DRAFT_17 ? undefined : await r.u62();
+		const requestId =
+			version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16
+				? await r.u62()
+				: undefined;
 		const statusCode = Number(await r.u62());
 		await r.u62(); // ignore stream_count
 		const reasonPhrase = await r.string();

--- a/js/lite/src/ietf/publish_namespace.ts
+++ b/js/lite/src/ietf/publish_namespace.ts
@@ -138,8 +138,8 @@ export class PublishNamespaceCancel {
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
-		if (version === Version.DRAFT_17) {
-			throw new Error("PublishNamespaceCancel removed in draft-17");
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15 && version !== Version.DRAFT_16) {
+			throw new Error("PublishNamespaceCancel removed in draft-17+");
 		}
 		if (version === Version.DRAFT_16) {
 			await w.u62(this.requestId);
@@ -159,8 +159,8 @@ export class PublishNamespaceCancel {
 	}
 
 	static async #decode(r: Reader, version: IetfVersion): Promise<PublishNamespaceCancel> {
-		if (version === Version.DRAFT_17) {
-			throw new Error("PublishNamespaceCancel removed in draft-17");
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15 && version !== Version.DRAFT_16) {
+			throw new Error("PublishNamespaceCancel removed in draft-17+");
 		}
 		let trackNamespace = "" as Path.Valid;
 		let requestId = 0n;
@@ -196,8 +196,8 @@ export class PublishNamespaceDone {
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
-		if (version === Version.DRAFT_17) {
-			throw new Error("PublishNamespaceDone removed in draft-17");
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15 && version !== Version.DRAFT_16) {
+			throw new Error("PublishNamespaceDone removed in draft-17+");
 		}
 		if (version === Version.DRAFT_16) {
 			await w.u62(this.requestId);
@@ -215,8 +215,8 @@ export class PublishNamespaceDone {
 	}
 
 	static async #decode(r: Reader, version: IetfVersion): Promise<PublishNamespaceDone> {
-		if (version === Version.DRAFT_17) {
-			throw new Error("PublishNamespaceDone removed in draft-17");
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15 && version !== Version.DRAFT_16) {
+			throw new Error("PublishNamespaceDone removed in draft-17+");
 		}
 		if (version === Version.DRAFT_16) {
 			const requestId = await r.u62();

--- a/js/lite/src/ietf/publisher.ts
+++ b/js/lite/src/ietf/publisher.ts
@@ -86,8 +86,12 @@ export class Publisher {
 				// Wait for broadcast to close or stream to close (peer cancelled)
 				await Promise.race([broadcast.closed, stream.reader.closed]);
 
-				// For v14-v16: send explicit PublishNamespaceDone
-				if (this.#session.version !== Version.DRAFT_17) {
+				// For v14-v16: send explicit PublishNamespaceDone (removed in v17+)
+				if (
+					this.#session.version === Version.DRAFT_14 ||
+					this.#session.version === Version.DRAFT_15 ||
+					this.#session.version === Version.DRAFT_16
+				) {
 					try {
 						await stream.writer.u53(PublishNamespaceDone.id);
 						const done = new PublishNamespaceDone({ trackNamespace: path, requestId });
@@ -136,7 +140,7 @@ export class Publisher {
 			} else {
 				await stream.writer.u53(RequestError.id);
 				const err = new RequestError({
-					requestId: version === Version.DRAFT_17 ? undefined : msg.requestId,
+					requestId: version === Version.DRAFT_15 || version === Version.DRAFT_16 ? msg.requestId : undefined,
 					errorCode: 404,
 					reasonPhrase: "Broadcast not found",
 				});
@@ -152,7 +156,10 @@ export class Publisher {
 			// Send SUBSCRIBE_OK
 			await stream.writer.u53(SubscribeOk.id);
 			const ok = new SubscribeOk({
-				requestId: version === Version.DRAFT_17 ? undefined : msg.requestId,
+				requestId:
+					version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16
+						? msg.requestId
+						: undefined,
 				trackAlias: msg.requestId,
 			});
 			await ok.encode(stream.writer, version);
@@ -172,7 +179,7 @@ export class Publisher {
 			console.debug(`publish done: broadcast=${name} track=${track.name}`);
 
 			// v14-v16: send PublishDone before closing
-			if (version !== Version.DRAFT_17) {
+			if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
 				try {
 					await stream.writer.u53(PublishDone.id);
 					const done = new PublishDone({
@@ -255,7 +262,9 @@ export class Publisher {
 				await ok.encode(stream.writer, version);
 			} else {
 				await stream.writer.u53(RequestOk.id);
-				const ok = new RequestOk({ requestId: version === Version.DRAFT_17 ? undefined : msg.requestId });
+				const ok = new RequestOk({
+					requestId: version === Version.DRAFT_15 || version === Version.DRAFT_16 ? msg.requestId : undefined,
+				});
 				await ok.encode(stream.writer, version);
 			}
 
@@ -324,7 +333,9 @@ export class Publisher {
 		} else {
 			// v15+: respond with RequestOk (0x07)
 			await stream.writer.u53(RequestOk.id);
-			const ok = new RequestOk({ requestId: version === Version.DRAFT_17 ? undefined : msg.requestId });
+			const ok = new RequestOk({
+				requestId: version === Version.DRAFT_15 || version === Version.DRAFT_16 ? msg.requestId : undefined,
+			});
 			await ok.encode(stream.writer, version);
 		}
 		stream.close();

--- a/js/lite/src/ietf/request.ts
+++ b/js/lite/src/ietf/request.ts
@@ -70,7 +70,7 @@ export class RequestOk {
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
-		if (version !== Version.DRAFT_17) {
+		if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
 			if (this.requestId === undefined) throw new Error("requestId required for draft14-16");
 			await w.u62(this.requestId);
 		}
@@ -82,7 +82,10 @@ export class RequestOk {
 	}
 
 	static async #decode(r: Reader, version: IetfVersion): Promise<RequestOk> {
-		const requestId = version === Version.DRAFT_17 ? undefined : await r.u62();
+		const requestId =
+			version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16
+				? await r.u62()
+				: undefined;
 		const parameters = await Parameters.decode(r, version);
 		await Properties.skip(r, version);
 		return new RequestOk({ requestId, parameters });
@@ -121,12 +124,12 @@ export class RequestError {
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
-		if (version !== Version.DRAFT_17) {
+		if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
 			if (this.requestId === undefined) throw new Error("requestId required for draft14-16");
 			await w.u62(this.requestId);
 		}
 		await w.u62(BigInt(this.errorCode));
-		if (version === Version.DRAFT_16 || version === Version.DRAFT_17) {
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15) {
 			await w.u62(this.retryInterval);
 		}
 		await w.string(this.reasonPhrase);
@@ -137,9 +140,12 @@ export class RequestError {
 	}
 
 	static async #decode(r: Reader, version: IetfVersion): Promise<RequestError> {
-		const requestId = version === Version.DRAFT_17 ? undefined : await r.u62();
+		const requestId =
+			version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16
+				? await r.u62()
+				: undefined;
 		const errorCode = Number(await r.u62());
-		const retryInterval = version === Version.DRAFT_16 || version === Version.DRAFT_17 ? await r.u62() : 0n;
+		const retryInterval = version === Version.DRAFT_14 || version === Version.DRAFT_15 ? 0n : await r.u62();
 		const reasonPhrase = await r.string();
 		return new RequestError({ requestId, errorCode, reasonPhrase, retryInterval });
 	}

--- a/js/lite/src/ietf/subscribe.ts
+++ b/js/lite/src/ietf/subscribe.ts
@@ -37,7 +37,7 @@ export class Subscribe {
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
 		await w.u62(this.requestId);
 		if (version === Version.DRAFT_17) {
-			await w.u62(0n); // required_request_id_delta = 0
+			await w.u62(0n); // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		await Namespace.encode(w, this.trackNamespace);
 		await w.string(this.trackName);
@@ -137,7 +137,7 @@ export class SubscribeOk {
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
-		if (version !== Version.DRAFT_17) {
+		if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
 			if (this.requestId === undefined) throw new Error("requestId required for draft14-16");
 			await w.u62(this.requestId);
 		}
@@ -165,7 +165,10 @@ export class SubscribeOk {
 	}
 
 	static async #decode(r: Reader, version: IetfVersion): Promise<SubscribeOk> {
-		const requestId = version === Version.DRAFT_17 ? undefined : await r.u62();
+		const requestId =
+			version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16
+				? await r.u62()
+				: undefined;
 		const trackAlias = await r.u62();
 
 		if (version === Version.DRAFT_14) {
@@ -259,9 +262,11 @@ export class SubscribeUpdate {
 			const params = new Parameters();
 			await params.encode(w, version);
 		} else {
-			// v17: request_id, required_request_id_delta, params
+			// v17+: REQUEST_UPDATE
 			await w.u62(this.requestId);
-			await w.u62(0n); // required_request_id_delta
+			if (version === Version.DRAFT_17) {
+				await w.u62(0n); // required_request_id_delta (draft-17 only, removed in draft-18 per #1615)
+			}
 			const params = new Parameters();
 			await params.encode(w, version);
 		}
@@ -292,9 +297,11 @@ export class SubscribeUpdate {
 			await Parameters.decode(r, version);
 			return new SubscribeUpdate({ requestId });
 		} else {
-			// v17
+			// v17+: REQUEST_UPDATE
 			const requestId = await r.u62();
-			await r.u62(); // required_request_id_delta
+			if (version === Version.DRAFT_17) {
+				await r.u62(); // required_request_id_delta (draft-17 only, removed in draft-18 per #1615)
+			}
 			await Parameters.decode(r, version);
 			return new SubscribeUpdate({ requestId });
 		}

--- a/js/lite/src/ietf/subscribe_namespace.ts
+++ b/js/lite/src/ietf/subscribe_namespace.ts
@@ -31,10 +31,10 @@ export class SubscribeNamespace {
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
 		await w.u62(this.requestId);
 		if (version === Version.DRAFT_17) {
-			await w.u62(0n); // required_request_id_delta = 0
+			await w.u62(0n); // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		await Namespace.encode(w, this.namespace);
-		if (version === Version.DRAFT_16 || version === Version.DRAFT_17) {
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15) {
 			await w.u53(this.subscribeOptions);
 		}
 		await new Parameters().encode(w, version);
@@ -51,11 +51,11 @@ export class SubscribeNamespace {
 	static async #decode(r: Reader, version: IetfVersion): Promise<SubscribeNamespace> {
 		const requestId = await r.u62();
 		if (version === Version.DRAFT_17) {
-			await r.u62(); // required_request_id_delta
+			await r.u62(); // required_request_id_delta (draft-17 only, removed in draft-18 per #1615)
 		}
 		const namespace = await Namespace.decode(r);
 		let subscribeOptions = 1;
-		if (version === Version.DRAFT_16 || version === Version.DRAFT_17) {
+		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15) {
 			subscribeOptions = await r.u53();
 		}
 		await Parameters.decode(r, version);
@@ -63,6 +63,14 @@ export class SubscribeNamespace {
 		return new SubscribeNamespace({ namespace, requestId, subscribeOptions });
 	}
 }
+
+/// SUBSCRIBE_TRACKS message ID (0x51) introduced in draft-18 (#1542).
+///
+/// moq-lite does not implement PUBLISH replication through a CDN, which is the
+/// only thing SUBSCRIBE_TRACKS enables. We never send it and reject it loudly
+/// on receipt rather than silently ignoring, since the peer would otherwise
+/// wait forever for a REQUEST_OK.
+export const SUBSCRIBE_TRACKS_ID = 0x51;
 
 export class SubscribeNamespaceOk {
 	static id = 0x12;

--- a/js/lite/src/ietf/subscriber.ts
+++ b/js/lite/src/ietf/subscriber.ts
@@ -227,8 +227,12 @@ export class Subscriber {
 						// Wait for stream close (= PublishDone) or track close (= local unsubscribe)
 						await Promise.race([stream.reader.closed, request.track.closed]);
 
-						// For v14-v16: send Unsubscribe before closing
-						if (version !== Version.DRAFT_17) {
+						// For v14-v16: send Unsubscribe before closing (removed in v17+)
+						if (
+							version === Version.DRAFT_14 ||
+							version === Version.DRAFT_15 ||
+							version === Version.DRAFT_16
+						) {
 							try {
 								await stream.writer.u53(Unsubscribe.id);
 								const unsub = new Unsubscribe({ requestId });
@@ -307,7 +311,7 @@ export class Subscriber {
 			} else {
 				await stream.writer.u53(RequestError.id);
 				const err = new RequestError({
-					requestId: version === Version.DRAFT_17 ? undefined : msg.requestId,
+					requestId: version === Version.DRAFT_15 || version === Version.DRAFT_16 ? msg.requestId : undefined,
 					errorCode: 409,
 					reasonPhrase: "duplicate namespace",
 				});
@@ -330,7 +334,9 @@ export class Subscriber {
 				await ok.encode(stream.writer, version);
 			} else {
 				await stream.writer.u53(RequestOk.id);
-				const ok = new RequestOk({ requestId: version === Version.DRAFT_17 ? undefined : msg.requestId });
+				const ok = new RequestOk({
+					requestId: version === Version.DRAFT_15 || version === Version.DRAFT_16 ? msg.requestId : undefined,
+				});
 				await ok.encode(stream.writer, version);
 			}
 
@@ -383,7 +389,7 @@ export class Subscriber {
 		} else {
 			await stream.writer.u53(RequestError.id);
 			const err = new RequestError({
-				requestId: version === Version.DRAFT_17 ? undefined : msg.requestId,
+				requestId: version === Version.DRAFT_15 || version === Version.DRAFT_16 ? msg.requestId : undefined,
 				errorCode: 500,
 				reasonPhrase: "publish not supported",
 			});

--- a/js/lite/src/ietf/version.ts
+++ b/js/lite/src/ietf/version.ts
@@ -31,6 +31,12 @@ export const Version = {
 	 * https://www.ietf.org/archive/id/draft-ietf-moq-transport-17.txt
 	 */
 	DRAFT_17: 0xff000011,
+
+	/**
+	 * draft-ietf-moq-transport-18
+	 * https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.txt
+	 */
+	DRAFT_18: 0xff000012,
 } as const;
 
 export type Version = (typeof Version)[keyof typeof Version];
@@ -41,6 +47,7 @@ export const ALPN = {
 	DRAFT_15: "moqt-15",
 	DRAFT_16: "moqt-16",
 	DRAFT_17: "moqt-17",
+	DRAFT_18: "moqt-18",
 } as const;
 
 /**
@@ -51,7 +58,8 @@ export type IetfVersion =
 	| typeof Version.DRAFT_14
 	| typeof Version.DRAFT_15
 	| typeof Version.DRAFT_16
-	| typeof Version.DRAFT_17;
+	| typeof Version.DRAFT_17
+	| typeof Version.DRAFT_18;
 
 const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_07]: "moq-transport-07",
@@ -59,6 +67,7 @@ const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_15]: "moq-transport-15",
 	[Version.DRAFT_16]: "moq-transport-16",
 	[Version.DRAFT_17]: "moq-transport-17",
+	[Version.DRAFT_18]: "moq-transport-18",
 };
 
 export function versionName(v: Version): string {

--- a/js/lite/src/stream.ts
+++ b/js/lite/src/stream.ts
@@ -228,8 +228,8 @@ export class Reader {
 			else break;
 		}
 
-		// 1111110x is a 7-byte form: invalid on draft-17, allowed on draft-18+ per #1595.
-		if (ones === 6 && this.version !== Version.DRAFT_18) {
+		// 1111110x is a 7-byte form. Draft-17 rejects it; draft-18+ allows it per #1595.
+		if (ones === 6 && this.version === Version.DRAFT_17) {
 			throw new Error("invalid leading-ones varint: 1111110x prefix is reserved on draft-17");
 		}
 

--- a/js/lite/src/stream.ts
+++ b/js/lite/src/stream.ts
@@ -228,10 +228,14 @@ export class Reader {
 			else break;
 		}
 
-		if (ones === 6) throw new Error("invalid leading-ones varint: 1111110x prefix is reserved");
+		// 1111110x is a 7-byte form: invalid on draft-17, allowed on draft-18+ per #1595.
+		if (ones === 6 && this.version !== Version.DRAFT_18) {
+			throw new Error("invalid leading-ones varint: 1111110x prefix is reserved on draft-17");
+		}
 
 		let totalSize: number;
 		if (ones <= 5) totalSize = ones + 1;
+		else if (ones === 6) totalSize = 7;
 		else if (ones === 7) totalSize = 8;
 		else totalSize = 9; // ones === 8
 

--- a/js/lite/src/varint.ts
+++ b/js/lite/src/varint.ts
@@ -14,7 +14,7 @@ export const MAX_U53 = Number.MAX_SAFE_INTEGER;
 // 1110xxxx + 3B   → 4 bytes (28 bits)
 // 11110xxx + 4B   → 5 bytes (35 bits)
 // 111110xx + 5B   → 6 bytes (42 bits)
-// 1111110x        → INVALID
+// 1111110x + 6B   → 7 bytes (49 bits) — draft-18+ only (invalid in draft-17 per #1595)
 // 11111110 + 7B   → 8 bytes (56 bits)
 // 11111111 + 8B   → 9 bytes (64 bits)
 
@@ -101,10 +101,12 @@ export function decodeLeadingOnes(buf: Uint8Array): [bigint, Uint8Array] {
 		else break;
 	}
 
-	if (ones === 6) throw new Error("invalid leading-ones varint: 1111110x prefix is reserved");
+	// 1111110x is a 7-byte form: invalid on draft-17, allowed on draft-18+ per #1595.
+	// This standalone decoder is permissive (Postel-style) since we lack version context here.
 
 	let totalSize: number;
 	if (ones <= 5) totalSize = ones + 1;
+	else if (ones === 6) totalSize = 7;
 	else if (ones === 7) totalSize = 8;
 	else totalSize = 9; // ones === 8
 
@@ -141,6 +143,18 @@ export function decodeLeadingOnes(buf: Uint8Array): [bigint, Uint8Array] {
 				(BigInt(buf[4]) << 8n) |
 				BigInt(buf[5]);
 			break;
+		case 6: {
+			// 1111110x + 6 bytes = 49 bits (draft-18+)
+			value =
+				(BigInt(b & 0x01) << 48n) |
+				(BigInt(buf[1]) << 40n) |
+				(BigInt(buf[2]) << 32n) |
+				(BigInt(buf[3]) << 24n) |
+				(BigInt(buf[4]) << 16n) |
+				(BigInt(buf[5]) << 8n) |
+				BigInt(buf[6]);
+			break;
+		}
 		case 7: {
 			// 11111110 + 7 bytes = 56 usable bits
 			const hi = new Uint8Array(8);

--- a/js/lite/src/varint.ts
+++ b/js/lite/src/varint.ts
@@ -14,7 +14,7 @@ export const MAX_U53 = Number.MAX_SAFE_INTEGER;
 // 1110xxxx + 3B   → 4 bytes (28 bits)
 // 11110xxx + 4B   → 5 bytes (35 bits)
 // 111110xx + 5B   → 6 bytes (42 bits)
-// 1111110x + 6B   → 7 bytes (49 bits) — draft-18+ only (invalid in draft-17 per #1595)
+// 1111110x + 6B   → 7 bytes (49 bits), draft-18+ only (invalid in draft-17 per #1595)
 // 11111110 + 7B   → 8 bytes (56 bits)
 // 11111111 + 8B   → 9 bytes (64 bits)
 

--- a/rs/moq-lite/src/client.rs
+++ b/rs/moq-lite/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, Error, NEGOTIATED, OriginConsumer,
-	OriginProducer, Session, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, Error, NEGOTIATED,
+	OriginConsumer, OriginProducer, Session, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -50,13 +50,33 @@ impl Client {
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
 		// Default to IETF 14 if no ALPN was used and we'll negotiate the version later.
 		let (encoding, supported) = match session.protocol() {
+			Some(ALPN_18) => {
+				let v = self
+					.versions
+					.select(Version::Ietf(ietf::Version::Draft18))
+					.ok_or(Error::Version)?;
+
+				// Draft-17+: SETUP is exchanged in the background by the session.
+				ietf::start(
+					session.clone(),
+					None,
+					None,
+					true,
+					self.publish.clone(),
+					self.consume.clone(),
+					ietf::Version::Draft18,
+				)?;
+
+				tracing::debug!(version = ?v, "connected");
+				return Ok(Session::new(session, v, None));
+			}
 			Some(ALPN_17) => {
 				let v = self
 					.versions
 					.select(Version::Ietf(ietf::Version::Draft17))
 					.ok_or(Error::Version)?;
 
-				// Draft-17: SETUP is exchanged in the background by the session.
+				// Draft-17+: SETUP is exchanged in the background by the session.
 				ietf::start(
 					session.clone(),
 					None,

--- a/rs/moq-lite/src/coding/varint.rs
+++ b/rs/moq-lite/src/coding/varint.rs
@@ -238,7 +238,7 @@ impl VarInt {
 		Ok(())
 	}
 
-	/// Decode a leading-1-bits varint (draft-17 Section 1.4.1).
+	/// Decode a leading-1-bits varint (draft-17+ Section 1.4.1).
 	///
 	/// The number of leading 1-bits determines the byte length:
 	/// - `0xxxxxxx` → 1 byte, 7 usable bits
@@ -247,9 +247,10 @@ impl VarInt {
 	/// - `1110xxxx` → 4 bytes, 28 usable bits
 	/// - `11110xxx` → 5 bytes, 35 usable bits
 	/// - `111110xx` → 6 bytes, 42 usable bits
-	/// - `11111110` → 8 bytes, 56 usable bits (skips 7)
+	/// - `1111110x` → 7 bytes, 49 usable bits (draft-18+, INVALID in draft-17 per #1595)
+	/// - `11111110` → 8 bytes, 56 usable bits
 	/// - `11111111` → 9 bytes, 64 usable bits
-	fn decode_leading_ones<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+	fn decode_leading_ones<R: bytes::Buf>(r: &mut R, version: ietf::Version) -> Result<Self, DecodeError> {
 		if !r.has_remaining() {
 			return Err(DecodeError::Short);
 		}
@@ -319,8 +320,17 @@ impl VarInt {
 				Ok(Self((hi << 40) | lo))
 			}
 			6 => {
-				// 1111110x — INVALID per draft-17
-				Err(DecodeError::InvalidValue)?
+				// 1111110x + 6 bytes — 49 bits (draft-18+, INVALID in draft-17 per #1595)
+				if matches!(version, ietf::Version::Draft17) {
+					return Err(DecodeError::InvalidValue);
+				}
+				if r.remaining() < 6 {
+					return Err(DecodeError::Short);
+				}
+				let hi = u64::from(b & 0x01);
+				let mut buf = [0u8; 8];
+				r.copy_to_slice(&mut buf[2..]);
+				Ok(Self((hi << 48) | u64::from_be_bytes(buf)))
 			}
 			7 => {
 				// 11111110 + 7 bytes — 56 bits
@@ -345,8 +355,12 @@ impl VarInt {
 		}
 	}
 
-	/// Encode a leading-1-bits varint (draft-17 Section 1.4.1).
-	fn encode_leading_ones<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+	/// Encode a leading-1-bits varint (draft-17+ Section 1.4.1).
+	///
+	/// Always emits the minimal canonical form. Draft-18 also accepts 7-byte form
+	/// (`1111110x`) on decode but we never emit it because the 8-byte form is one byte
+	/// larger but simpler and is universally valid.
+	fn encode_leading_ones<W: bytes::BufMut>(&self, w: &mut W, _version: ietf::Version) -> Result<(), EncodeError> {
 		let x = self.0;
 		let remaining = w.remaining_mut();
 
@@ -431,12 +445,12 @@ impl Decode<lite::Version> for VarInt {
 	}
 }
 
-// IETF versions use QUIC-style except Draft17 which uses leading-ones.
+// Draft14-16 use QUIC-style varints; draft-17+ uses leading-ones.
 impl Encode<ietf::Version> for VarInt {
 	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: ietf::Version) -> Result<(), EncodeError> {
 		match version {
 			ietf::Version::Draft14 | ietf::Version::Draft15 | ietf::Version::Draft16 => self.encode_quic(w),
-			ietf::Version::Draft17 => self.encode_leading_ones(w),
+			_ => self.encode_leading_ones(w, version),
 		}
 	}
 }
@@ -445,7 +459,7 @@ impl Decode<ietf::Version> for VarInt {
 	fn decode<R: bytes::Buf>(r: &mut R, version: ietf::Version) -> Result<Self, DecodeError> {
 		match version {
 			ietf::Version::Draft14 | ietf::Version::Draft15 | ietf::Version::Draft16 => Self::decode_quic(r),
-			ietf::Version::Draft17 => Self::decode_leading_ones(r),
+			_ => Self::decode_leading_ones(r, version),
 		}
 	}
 }
@@ -529,6 +543,7 @@ where
 #[cfg(test)]
 mod tests {
 	use super::{DecodeError, VarInt};
+	use crate::ietf;
 	use bytes::Bytes;
 
 	/// Test vectors from the draft-17 spec (Table 2: Example Integer Encodings),
@@ -555,7 +570,7 @@ mod tests {
 		for (bytes, expected) in cases {
 			// Test decoding
 			let mut buf = Bytes::from(bytes.to_vec());
-			let decoded = VarInt::decode_leading_ones(&mut buf).expect("decode should succeed");
+			let decoded = VarInt::decode_leading_ones(&mut buf, ietf::Version::Draft17).expect("decode should succeed");
 			assert_eq!(
 				decoded.into_inner(),
 				*expected,
@@ -570,19 +585,24 @@ mod tests {
 				&& (bytes.len() == 1 || *expected != 37)
 			{
 				let mut encoded = Vec::new();
-				varint.encode_leading_ones(&mut encoded).expect("encode should succeed");
+				varint
+					.encode_leading_ones(&mut encoded, ietf::Version::Draft17)
+					.expect("encode should succeed");
 				assert_eq!(&encoded, bytes, "encode mismatch for value {expected}");
 			}
 		}
 	}
 
-	/// 11111100 (0xFC) is an invalid code point per the spec.
+	/// 11111100 (0xFC) is an invalid code point on draft-17 (allowed as 7-byte form on draft-18+).
 	#[test]
 	fn leading_ones_invalid_0xfc() {
 		let mut buf = Bytes::from_static(&[0xFC]);
 		assert!(
-			matches!(VarInt::decode_leading_ones(&mut buf), Err(DecodeError::InvalidValue)),
-			"0xFC should be rejected as invalid"
+			matches!(
+				VarInt::decode_leading_ones(&mut buf, ietf::Version::Draft17),
+				Err(DecodeError::InvalidValue)
+			),
+			"0xFC should be rejected as invalid on draft-17"
 		);
 	}
 
@@ -601,7 +621,7 @@ mod tests {
 			let varint = VarInt::from_u64(value).expect("value should be representable as VarInt");
 			let mut encoded = Vec::new();
 			varint
-				.encode_leading_ones(&mut encoded)
+				.encode_leading_ones(&mut encoded, ietf::Version::Draft17)
 				.expect("leading-ones encode should succeed");
 			assert_eq!(
 				encoded.len(),
@@ -610,8 +630,35 @@ mod tests {
 			);
 
 			let mut bytes = Bytes::from(encoded);
-			let decoded = VarInt::decode_leading_ones(&mut bytes).expect("leading-ones decode should succeed");
+			let decoded = VarInt::decode_leading_ones(&mut bytes, ietf::Version::Draft17)
+				.expect("leading-ones decode should succeed");
 			assert_eq!(decoded.into_inner(), value, "round-trip mismatch for value {value}");
 		}
+	}
+
+	#[test]
+	fn draft17_rejects_7_byte_varint() {
+		// 1111110x prefix: invalid on draft-17.
+		let bytes = Bytes::from(vec![0xFC, 0, 0, 0, 0, 0, 0]);
+		let mut buf = bytes.clone();
+		let err = VarInt::decode_leading_ones(&mut buf, ietf::Version::Draft17).unwrap_err();
+		matches!(err, DecodeError::InvalidValue);
+	}
+
+	#[test]
+	fn draft18_accepts_7_byte_varint() {
+		// Value 0x1234_5678_9ABC encoded as 7-byte leading-ones (1111110x | hi, +6 bytes).
+		let value: u64 = 0x1234_5678_9ABC;
+		let mut bytes = Vec::new();
+		// Prefix byte: 1111110_0 + (value >> 48) bit. Top 1 bit of 49 = bit 48.
+		// value fits in 49 bits, so the 0x01 LSB of prefix encodes bit 48 of value.
+		let hi_bit = ((value >> 48) & 0x01) as u8;
+		bytes.push(0xFC | hi_bit);
+		for shift in (0..48).step_by(8).rev() {
+			bytes.push(((value >> shift) & 0xFF) as u8);
+		}
+		let mut buf = Bytes::from(bytes);
+		let decoded = VarInt::decode_leading_ones(&mut buf, ietf::Version::Draft18).unwrap();
+		assert_eq!(decoded.into_inner(), value);
 	}
 }

--- a/rs/moq-lite/src/coding/varint.rs
+++ b/rs/moq-lite/src/coding/varint.rs
@@ -320,7 +320,7 @@ impl VarInt {
 				Ok(Self((hi << 40) | lo))
 			}
 			6 => {
-				// 1111110x + 6 bytes — 49 bits (draft-18+, INVALID in draft-17 per #1595)
+				// 1111110x + 6 bytes, 49 bits (draft-18+, INVALID in draft-17 per #1595)
 				if matches!(version, ietf::Version::Draft17) {
 					return Err(DecodeError::InvalidValue);
 				}
@@ -642,7 +642,7 @@ mod tests {
 		let bytes = Bytes::from(vec![0xFC, 0, 0, 0, 0, 0, 0]);
 		let mut buf = bytes.clone();
 		let err = VarInt::decode_leading_ones(&mut buf, ietf::Version::Draft17).unwrap_err();
-		matches!(err, DecodeError::InvalidValue);
+		assert!(matches!(err, DecodeError::InvalidValue));
 	}
 
 	#[test]

--- a/rs/moq-lite/src/ietf/adapter.rs
+++ b/rs/moq-lite/src/ietf/adapter.rs
@@ -489,6 +489,17 @@ impl<S: web_transport_trait::Session> ControlStreamAdapter<S> {
 				_ => Err(Error::UnexpectedMessage),
 			},
 
+			// SUBSCRIBE_TRACKS (draft-18+, #1542): the half of the SUBSCRIBE_NAMESPACE split
+			// that subscribes to all tracks under a prefix. We don't implement PUBLISH
+			// replication, so this is impossible to honor. Reject loudly.
+			ietf::SUBSCRIBE_TRACKS_ID => {
+				tracing::error!(
+					version = ?self.version,
+					"received SUBSCRIBE_TRACKS (0x51); not supported in moq-lite (no PUBLISH replication)"
+				);
+				Err(Error::Unsupported)
+			}
+
 			// Responses: route to the virtual stream waiting for a reply
 			ietf::SubscribeOk::ID => {
 				let id = decode_response_request_id(body, self.version)?;
@@ -841,6 +852,10 @@ mod tests {
 				}
 				_ => Err(Error::UnexpectedMessage),
 			},
+			ietf::SUBSCRIBE_TRACKS_ID => {
+				tracing::error!(?version, "received SUBSCRIBE_TRACKS (0x51); not supported in moq-lite");
+				Err(Error::Unsupported)
+			}
 			ietf::SubscribeOk::ID => {
 				let id = decode_response_request_id(body, version)?;
 				Ok(Route::Response(id))

--- a/rs/moq-lite/src/ietf/fetch.rs
+++ b/rs/moq-lite/src/ietf/fetch.rs
@@ -119,7 +119,7 @@ impl Message for Fetch<'_> {
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
 		self.request_id.encode(w, version)?;
 		if version == Version::Draft17 {
-			0u64.encode(w, version)?; // required_request_id_delta = 0
+			0u64.encode(w, version)?; // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 
 		match version {
@@ -129,7 +129,7 @@ impl Message for Fetch<'_> {
 				self.fetch_type.encode(w, version)?;
 				0u8.encode(w, version)?; // no parameters
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				self.fetch_type.encode(w, version)?;
 				encode_params!(w, version,
 					0x20 => self.subscriber_priority,
@@ -159,7 +159,7 @@ impl Message for Fetch<'_> {
 					fetch_type,
 				})
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				let fetch_type = FetchType::decode(buf, version)?;
 				decode_params!(buf, version,
 					0x20 => subscriber_priority: Option<u8>,
@@ -191,12 +191,12 @@ impl Message for FetchOk {
 	const ID: u64 = 0x18;
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if version != Version::Draft17 {
+		if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			self.request_id
 				.expect("request_id required for draft14-16")
 				.encode(w, version)?;
 		} else {
-			assert!(self.request_id.is_none(), "request_id must be None for draft17");
+			assert!(self.request_id.is_none(), "request_id must be None for draft17+");
 		}
 
 		match version {
@@ -206,7 +206,7 @@ impl Message for FetchOk {
 				self.end_location.encode(w, version)?;
 				0u8.encode(w, version)?; // no parameters
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				self.end_of_track.encode(w, version)?;
 				self.end_location.encode(w, version)?;
 				encode_params!(w, version,
@@ -218,10 +218,10 @@ impl Message for FetchOk {
 	}
 
 	fn decode_msg<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
-		let request_id = if version == Version::Draft17 {
-			None
-		} else {
+		let request_id = if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			Some(RequestId::decode(buf, version)?)
+		} else {
+			None
 		};
 
 		match version {
@@ -237,7 +237,7 @@ impl Message for FetchOk {
 					end_location,
 				})
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				let end_of_track = bool::decode(buf, version)?;
 				let end_location = Location::decode(buf, version)?;
 				decode_params!(buf, version,

--- a/rs/moq-lite/src/ietf/fetch.rs
+++ b/rs/moq-lite/src/ietf/fetch.rs
@@ -495,4 +495,42 @@ mod tests {
 		assert!(!decoded.end_of_track);
 		assert_eq!(decoded.end_location, Location { group: 5, object: 3 });
 	}
+
+	#[test]
+	fn test_fetch_v18_round_trip() {
+		let msg = Fetch {
+			request_id: RequestId(1),
+			subscriber_priority: 128,
+			group_order: GroupOrder::Descending,
+			fetch_type: FetchType::Standalone {
+				namespace: Path::new("test"),
+				track: "video".into(),
+				start: Location { group: 0, object: 0 },
+				end: Location { group: 10, object: 5 },
+			},
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: Fetch = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, RequestId(1));
+		assert_eq!(decoded.subscriber_priority, 128);
+	}
+
+	#[test]
+	fn test_fetch_ok_v18_round_trip() {
+		let msg = FetchOk {
+			request_id: None,
+			group_order: GroupOrder::Descending,
+			end_of_track: false,
+			end_location: Location { group: 5, object: 3 },
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: FetchOk = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, None);
+		assert!(!decoded.end_of_track);
+		assert_eq!(decoded.end_location, Location { group: 5, object: 3 });
+	}
 }

--- a/rs/moq-lite/src/ietf/goaway.rs
+++ b/rs/moq-lite/src/ietf/goaway.rs
@@ -33,7 +33,16 @@ impl Message for GoAway<'_> {
 		let new_session_uri = Cow::<str>::decode(r, version)?;
 		let timeout = match version {
 			Version::Draft14 | Version::Draft15 | Version::Draft16 => 0,
-			_ => u64::decode(r, version)?,
+			Version::Draft17 => u64::decode(r, version)?,
+			_ => {
+				let timeout = u64::decode(r, version)?;
+				// Draft-18+: optional trailing Request ID (#1559). Drain if present;
+				// moq-lite doesn't act on per-request GOAWAY so the value is discarded.
+				if r.has_remaining() {
+					let _ = u64::decode(r, version)?;
+				}
+				timeout
+			}
 		};
 		Ok(Self {
 			new_session_uri,
@@ -116,5 +125,26 @@ mod tests {
 
 		assert_eq!(decoded.new_session_uri, "moqt://relay.example/");
 		assert_eq!(decoded.timeout, 5000);
+	}
+
+	/// Draft-18 added an optional trailing Request ID (#1559). A peer that emits
+	/// one must not break our decoder; we drain and discard it.
+	#[test]
+	fn test_goaway_v18_drains_optional_request_id() {
+		use bytes::Buf;
+
+		// Hand-construct a draft-18 GOAWAY body that includes the optional Request ID.
+		let mut buf = BytesMut::new();
+		"moqt://relay.example/".encode(&mut buf, Version::Draft18).unwrap();
+		5000u64.encode(&mut buf, Version::Draft18).unwrap();
+		// Optional trailing Request ID:
+		42u64.encode(&mut buf, Version::Draft18).unwrap();
+
+		let mut bytes = bytes::Bytes::from(buf.to_vec());
+		let decoded: GoAway = GoAway::decode_msg(&mut bytes, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.new_session_uri, "moqt://relay.example/");
+		assert_eq!(decoded.timeout, 5000);
+		assert!(!bytes.has_remaining(), "trailing Request ID should be consumed");
 	}
 }

--- a/rs/moq-lite/src/ietf/goaway.rs
+++ b/rs/moq-lite/src/ietf/goaway.rs
@@ -21,7 +21,9 @@ impl Message for GoAway<'_> {
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
 		self.new_session_uri.encode(w, version)?;
-		if version == Version::Draft17 {
+		// Draft-17+ adds a timeout field; draft-18 also adds an optional trailing Request ID
+		// (#1559) which we never emit.
+		if !matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			self.timeout.encode(w, version)?;
 		}
 		Ok(())
@@ -29,10 +31,9 @@ impl Message for GoAway<'_> {
 
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let new_session_uri = Cow::<str>::decode(r, version)?;
-		let timeout = if version == Version::Draft17 {
-			u64::decode(r, version)?
-		} else {
-			0
+		let timeout = match version {
+			Version::Draft14 | Version::Draft15 | Version::Draft16 => 0,
+			_ => u64::decode(r, version)?,
 		};
 		Ok(Self {
 			new_session_uri,
@@ -97,6 +98,23 @@ mod tests {
 		let decoded: GoAway = GoAway::decode_msg(&mut bytes, Version::Draft17).unwrap();
 
 		assert_eq!(decoded.new_session_uri, "https://example.com/new");
+		assert_eq!(decoded.timeout, 5000);
+	}
+
+	#[test]
+	fn test_goaway_v18_timeout() {
+		let msg = GoAway {
+			new_session_uri: "moqt://relay.example/".into(),
+			timeout: 5000,
+		};
+
+		let mut buf = BytesMut::new();
+		msg.encode_msg(&mut buf, Version::Draft18).unwrap();
+
+		let mut bytes = bytes::Bytes::from(buf.to_vec());
+		let decoded: GoAway = GoAway::decode_msg(&mut bytes, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.new_session_uri, "moqt://relay.example/");
 		assert_eq!(decoded.timeout, 5000);
 	}
 }

--- a/rs/moq-lite/src/ietf/group.rs
+++ b/rs/moq-lite/src/ietf/group.rs
@@ -79,7 +79,11 @@ impl GroupFlags {
 	pub const START_NO_PRIORITY: u64 = 0x30;
 	pub const END_NO_PRIORITY: u64 = 0x3d;
 
-	pub fn encode(&self) -> Result<u64, EncodeError> {
+	// draft-18 adds bit 0x40 (FIRST_OBJECT) per spec §11.4.2.
+	// moq-lite always sets this bit on emit because every subgroup starts at object 0.
+	pub const FIRST_OBJECT_BIT: u64 = 0x40;
+
+	pub fn encode(&self, version: Version) -> Result<u64, EncodeError> {
 		if self.has_subgroup && self.has_subgroup_object {
 			return Err(EncodeError::InvalidState);
 		}
@@ -102,10 +106,30 @@ impl GroupFlags {
 		if self.has_end {
 			id |= 0x08;
 		}
+		// Draft-18+: set FIRST_OBJECT. moq-lite always starts subgroups at object 0
+		// and never has gaps, so this is unconditionally true on the publisher side.
+		if !matches!(
+			version,
+			Version::Draft14 | Version::Draft15 | Version::Draft16 | Version::Draft17
+		) {
+			id |= Self::FIRST_OBJECT_BIT;
+		}
 		Ok(id)
 	}
 
-	pub fn decode(id: u64) -> Result<Self, DecodeError> {
+	pub fn decode(id: u64, version: Version) -> Result<Self, DecodeError> {
+		// Draft-18+ allows bit 0x40 (FIRST_OBJECT). Strip it before range check;
+		// moq-lite already assumes every subgroup starts at object 0, so the bit
+		// value carries no extra information for us.
+		let id = if matches!(
+			version,
+			Version::Draft14 | Version::Draft15 | Version::Draft16 | Version::Draft17
+		) {
+			id
+		} else {
+			id & !Self::FIRST_OBJECT_BIT
+		};
+
 		let (has_priority, base_id) = if (Self::START..=Self::END).contains(&id) {
 			(true, id)
 		} else if (Self::START_NO_PRIORITY..=Self::END_NO_PRIORITY).contains(&id) {
@@ -157,7 +181,7 @@ pub struct GroupHeader {
 impl Encode<Version> for GroupHeader {
 	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
 		tracing::trace!(?self, "encoding group header");
-		self.flags.encode()?.encode(w, version)?;
+		self.flags.encode(version)?.encode(w, version)?;
 		self.track_alias.encode(w, version)?;
 		self.group_id.encode(w, version)?;
 
@@ -179,7 +203,7 @@ impl Encode<Version> for GroupHeader {
 
 impl Decode<Version> for GroupHeader {
 	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		let flags = GroupFlags::decode(u64::decode(r, version)?)?;
+		let flags = GroupFlags::decode(u64::decode(r, version)?, version)?;
 		let track_alias = u64::decode(r, version)?;
 		let group_id = u64::decode(r, version)?;
 
@@ -215,129 +239,168 @@ mod tests {
 	#[test]
 	fn test_group_flags_spec_table() {
 		// Type 0x10: No subgroup field, Subgroup ID = 0, No extensions, No end
-		let flags = GroupFlags::decode(0x10).unwrap();
+		let flags = GroupFlags::decode(0x10, Version::Draft14).unwrap();
 		assert!(!flags.has_subgroup);
 		assert!(!flags.has_subgroup_object);
 		assert!(!flags.has_extensions);
 		assert!(!flags.has_end);
 		assert!(flags.has_priority);
-		assert_eq!(flags.encode().unwrap(), 0x10);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x10);
 
 		// Type 0x11: No subgroup field, Subgroup ID = 0, Extensions, No end
-		let flags = GroupFlags::decode(0x11).unwrap();
+		let flags = GroupFlags::decode(0x11, Version::Draft14).unwrap();
 		assert!(!flags.has_subgroup);
 		assert!(!flags.has_subgroup_object);
 		assert!(flags.has_extensions);
 		assert!(!flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x11);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x11);
 
 		// Type 0x12: No subgroup field, Subgroup ID = First Object ID, No extensions, No end
-		let flags = GroupFlags::decode(0x12).unwrap();
+		let flags = GroupFlags::decode(0x12, Version::Draft14).unwrap();
 		assert!(!flags.has_subgroup);
 		assert!(flags.has_subgroup_object);
 		assert!(!flags.has_extensions);
 		assert!(!flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x12);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x12);
 
 		// Type 0x13: No subgroup field, Subgroup ID = First Object ID, Extensions, No end
-		let flags = GroupFlags::decode(0x13).unwrap();
+		let flags = GroupFlags::decode(0x13, Version::Draft14).unwrap();
 		assert!(!flags.has_subgroup);
 		assert!(flags.has_subgroup_object);
 		assert!(flags.has_extensions);
 		assert!(!flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x13);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x13);
 
 		// Type 0x14: Subgroup field present, No extensions, No end
-		let flags = GroupFlags::decode(0x14).unwrap();
+		let flags = GroupFlags::decode(0x14, Version::Draft14).unwrap();
 		assert!(flags.has_subgroup);
 		assert!(!flags.has_subgroup_object);
 		assert!(!flags.has_extensions);
 		assert!(!flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x14);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x14);
 
 		// Type 0x15: Subgroup field present, Extensions, No end
-		let flags = GroupFlags::decode(0x15).unwrap();
+		let flags = GroupFlags::decode(0x15, Version::Draft14).unwrap();
 		assert!(flags.has_subgroup);
 		assert!(!flags.has_subgroup_object);
 		assert!(flags.has_extensions);
 		assert!(!flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x15);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x15);
 
 		// Type 0x18: No subgroup field, Subgroup ID = 0, No extensions, End of group
-		let flags = GroupFlags::decode(0x18).unwrap();
+		let flags = GroupFlags::decode(0x18, Version::Draft14).unwrap();
 		assert!(!flags.has_subgroup);
 		assert!(!flags.has_subgroup_object);
 		assert!(!flags.has_extensions);
 		assert!(flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x18);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x18);
 
 		// Type 0x19: No subgroup field, Subgroup ID = 0, Extensions, End of group
-		let flags = GroupFlags::decode(0x19).unwrap();
+		let flags = GroupFlags::decode(0x19, Version::Draft14).unwrap();
 		assert!(!flags.has_subgroup);
 		assert!(!flags.has_subgroup_object);
 		assert!(flags.has_extensions);
 		assert!(flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x19);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x19);
 
 		// Type 0x1A: No subgroup field, Subgroup ID = First Object ID, No extensions, End of group
-		let flags = GroupFlags::decode(0x1A).unwrap();
+		let flags = GroupFlags::decode(0x1A, Version::Draft14).unwrap();
 		assert!(!flags.has_subgroup);
 		assert!(flags.has_subgroup_object);
 		assert!(!flags.has_extensions);
 		assert!(flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x1A);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x1A);
 
 		// Type 0x1B: No subgroup field, Subgroup ID = First Object ID, Extensions, End of group
-		let flags = GroupFlags::decode(0x1B).unwrap();
+		let flags = GroupFlags::decode(0x1B, Version::Draft14).unwrap();
 		assert!(!flags.has_subgroup);
 		assert!(flags.has_subgroup_object);
 		assert!(flags.has_extensions);
 		assert!(flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x1B);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x1B);
 
 		// Type 0x1C: Subgroup field present, No extensions, End of group
-		let flags = GroupFlags::decode(0x1C).unwrap();
+		let flags = GroupFlags::decode(0x1C, Version::Draft14).unwrap();
 		assert!(flags.has_subgroup);
 		assert!(!flags.has_subgroup_object);
 		assert!(!flags.has_extensions);
 		assert!(flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x1C);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x1C);
 
 		// Type 0x1D: Subgroup field present, Extensions, End of group
-		let flags = GroupFlags::decode(0x1D).unwrap();
+		let flags = GroupFlags::decode(0x1D, Version::Draft14).unwrap();
 		assert!(flags.has_subgroup);
 		assert!(!flags.has_subgroup_object);
 		assert!(flags.has_extensions);
 		assert!(flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x1D);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x1D);
 
 		// Invalid: Both has_subgroup and has_subgroup_object (would be 0x16)
-		assert!(GroupFlags::decode(0x16).is_err());
+		assert!(GroupFlags::decode(0x16, Version::Draft14).is_err());
 	}
 
 	#[test]
 	fn test_group_flags_no_priority_range() {
 		// v15: 0x30 range = same flags as 0x10 range but no priority
-		let flags = GroupFlags::decode(0x30).unwrap();
+		let flags = GroupFlags::decode(0x30, Version::Draft14).unwrap();
 		assert!(!flags.has_priority);
 		assert!(!flags.has_subgroup);
 		assert!(!flags.has_extensions);
 		assert!(!flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x30);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x30);
 
-		let flags = GroupFlags::decode(0x38).unwrap();
+		let flags = GroupFlags::decode(0x38, Version::Draft14).unwrap();
 		assert!(!flags.has_priority);
 		assert!(flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x38);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x38);
 
-		let flags = GroupFlags::decode(0x3D).unwrap();
+		let flags = GroupFlags::decode(0x3D, Version::Draft14).unwrap();
 		assert!(!flags.has_priority);
 		assert!(flags.has_subgroup);
 		assert!(flags.has_extensions);
 		assert!(flags.has_end);
-		assert_eq!(flags.encode().unwrap(), 0x3D);
+		assert_eq!(flags.encode(Version::Draft14).unwrap(), 0x3D);
 
 		// Invalid: Both has_subgroup and has_subgroup_object in no-priority range
-		assert!(GroupFlags::decode(0x36).is_err());
+		assert!(GroupFlags::decode(0x36, Version::Draft14).is_err());
+	}
+
+	/// Draft-18 introduces the FIRST_OBJECT bit (0x40) per spec §11.4.2.
+	/// moq-lite always sets it on emit and ignores it on decode (we already
+	/// require what the bit asserts).
+	#[test]
+	fn test_first_object_bit_draft18() {
+		// Encoding sets bit 0x40 for default flags.
+		let flags = GroupFlags::default();
+		let encoded = flags.encode(Version::Draft18).unwrap();
+		assert_eq!(encoded & GroupFlags::FIRST_OBJECT_BIT, GroupFlags::FIRST_OBJECT_BIT);
+		// The base value is what draft-17 would have produced.
+		let v17 = flags.encode(Version::Draft17).unwrap();
+		assert_eq!(encoded, v17 | GroupFlags::FIRST_OBJECT_BIT);
+
+		// Decoding accepts and discards the bit.
+		let decoded = GroupFlags::decode(v17 | GroupFlags::FIRST_OBJECT_BIT, Version::Draft18).unwrap();
+		assert_eq!(decoded, flags);
+
+		// Draft-17 rejects the FIRST_OBJECT bit (it's outside the 0x10-0x1d / 0x30-0x3d ranges).
+		assert!(GroupFlags::decode(v17 | GroupFlags::FIRST_OBJECT_BIT, Version::Draft17).is_err());
+	}
+
+	/// Draft-18 byte 0x70..=0x7D should decode to the same flags as 0x30..=0x3D.
+	#[test]
+	fn test_draft18_extended_range() {
+		// 0x70 = 0x30 (no-priority, no flags) + 0x40 (FIRST_OBJECT)
+		let flags = GroupFlags::decode(0x70, Version::Draft18).unwrap();
+		assert!(!flags.has_priority);
+		assert!(!flags.has_subgroup);
+		assert!(!flags.has_extensions);
+		assert!(!flags.has_end);
+
+		// 0x7D = 0x3D + 0x40
+		let flags = GroupFlags::decode(0x7D, Version::Draft18).unwrap();
+		assert!(!flags.has_priority);
+		assert!(flags.has_subgroup);
+		assert!(flags.has_extensions);
+		assert!(flags.has_end);
 	}
 }

--- a/rs/moq-lite/src/ietf/group.rs
+++ b/rs/moq-lite/src/ietf/group.rs
@@ -403,4 +403,29 @@ mod tests {
 		assert!(flags.has_extensions);
 		assert!(flags.has_end);
 	}
+
+	/// Regression: a publisher-emitted Draft18 GroupHeader byte must satisfy the
+	/// subscriber's uni-stream classifier mask `(byte & 0x90) == 0x10`. Otherwise
+	/// the uni stream is dropped as UnexpectedStream and the data plane stalls.
+	#[test]
+	fn test_draft18_group_header_passes_stream_classifier() {
+		let header = GroupHeader {
+			track_alias: 1,
+			group_id: 0,
+			sub_group_id: 0,
+			publisher_priority: 0,
+			flags: GroupFlags::default(),
+		};
+
+		let mut buf = bytes::BytesMut::new();
+		header.encode(&mut buf, Version::Draft18).unwrap();
+		let type_byte = buf[0] as u64;
+
+		// The check in session.rs::run_uni_group.
+		assert_eq!(
+			type_byte & 0x90,
+			0x10,
+			"draft-18 SUBGROUP_HEADER type 0x{type_byte:02x} not recognized by uni-stream classifier",
+		);
+	}
 }

--- a/rs/moq-lite/src/ietf/parameters.rs
+++ b/rs/moq-lite/src/ietf/parameters.rs
@@ -47,44 +47,7 @@ impl Decode<Version> for Parameters {
 		let mut bytes = HashMap::new();
 
 		match version {
-			Version::Draft17 | Version::Draft18 => {
-				// Draft17+: no count prefix, read Key-Value-Pairs until buffer empty.
-				// Delta-encoded types, even = varint value, odd = length-prefixed bytes.
-				let mut prev_type: u64 = 0;
-				let mut i = 0u64;
-				while r.has_remaining() {
-					if i >= MAX_PARAMS {
-						return Err(DecodeError::TooMany);
-					}
-					let delta = u64::decode(&mut r, version)?;
-					let abs = if i == 0 {
-						delta
-					} else {
-						prev_type.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?
-					};
-					prev_type = abs;
-					i += 1;
-
-					if abs % 2 == 0 {
-						let kind = ParameterVarInt::from(abs);
-						match vars.entry(kind) {
-							hash_map::Entry::Occupied(_) => return Err(DecodeError::Duplicate),
-							hash_map::Entry::Vacant(entry) => entry.insert(u64::decode(&mut r, version)?),
-						};
-					} else {
-						let kind = ParameterBytes::from(abs);
-						let val = Vec::<u8>::decode(&mut r, version)?;
-						if val.len() > MAX_KVP_VALUE_LEN {
-							return Err(DecodeError::BoundsExceeded);
-						}
-						match bytes.entry(kind) {
-							hash_map::Entry::Occupied(_) => return Err(DecodeError::Duplicate),
-							hash_map::Entry::Vacant(entry) => entry.insert(val),
-						};
-					}
-				}
-			}
-			_ => {
+			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
 				let count = u64::decode(r, version)?;
 
 				if count > MAX_PARAMS {
@@ -117,6 +80,43 @@ impl Decode<Version> for Parameters {
 						};
 					} else {
 						let kind = ParameterBytes::from(kind);
+						let val = Vec::<u8>::decode(&mut r, version)?;
+						if val.len() > MAX_KVP_VALUE_LEN {
+							return Err(DecodeError::BoundsExceeded);
+						}
+						match bytes.entry(kind) {
+							hash_map::Entry::Occupied(_) => return Err(DecodeError::Duplicate),
+							hash_map::Entry::Vacant(entry) => entry.insert(val),
+						};
+					}
+				}
+			}
+			_ => {
+				// Draft17+: no count prefix, read Key-Value-Pairs until buffer empty.
+				// Delta-encoded types, even = varint value, odd = length-prefixed bytes.
+				let mut prev_type: u64 = 0;
+				let mut i = 0u64;
+				while r.has_remaining() {
+					if i >= MAX_PARAMS {
+						return Err(DecodeError::TooMany);
+					}
+					let delta = u64::decode(&mut r, version)?;
+					let abs = if i == 0 {
+						delta
+					} else {
+						prev_type.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?
+					};
+					prev_type = abs;
+					i += 1;
+
+					if abs % 2 == 0 {
+						let kind = ParameterVarInt::from(abs);
+						match vars.entry(kind) {
+							hash_map::Entry::Occupied(_) => return Err(DecodeError::Duplicate),
+							hash_map::Entry::Vacant(entry) => entry.insert(u64::decode(&mut r, version)?),
+						};
+					} else {
+						let kind = ParameterBytes::from(abs);
 						let val = Vec::<u8>::decode(&mut r, version)?;
 						if val.len() > MAX_KVP_VALUE_LEN {
 							return Err(DecodeError::BoundsExceeded);

--- a/rs/moq-lite/src/ietf/parameters.rs
+++ b/rs/moq-lite/src/ietf/parameters.rs
@@ -47,8 +47,8 @@ impl Decode<Version> for Parameters {
 		let mut bytes = HashMap::new();
 
 		match version {
-			Version::Draft17 => {
-				// Draft17: no count prefix, read Key-Value-Pairs until buffer empty.
+			Version::Draft17 | Version::Draft18 => {
+				// Draft17+: no count prefix, read Key-Value-Pairs until buffer empty.
 				// Delta-encoded types, even = varint value, odd = length-prefixed bytes.
 				let mut prev_type: u64 = 0;
 				let mut i = 0u64;
@@ -106,7 +106,7 @@ impl Decode<Version> for Parameters {
 							abs
 						}
 						Version::Draft14 | Version::Draft15 => u64::decode(r, version)?,
-						Version::Draft17 => unreachable!("handled above"),
+						_ => unreachable!("handled above"),
 					};
 
 					if kind % 2 == 0 {
@@ -142,10 +142,26 @@ impl Encode<Version> for Parameters {
 		}
 
 		match version {
-			Version::Draft16 | Version::Draft17 => {
+			Version::Draft14 | Version::Draft15 => {
+				count.encode(w, version)?;
+
+				for (kind, value) in self.vars.iter() {
+					u64::from(*kind).encode(w, version)?;
+					value.encode(w, version)?;
+				}
+
+				for (kind, value) in self.bytes.iter() {
+					if value.len() > MAX_KVP_VALUE_LEN {
+						return Err(EncodeError::BoundsExceeded);
+					}
+					u64::from(*kind).encode(w, version)?;
+					value.encode(w, version)?;
+				}
+			}
+			_ => {
 				// Draft16: count prefix + delta encoding
-				// Draft17: NO count prefix + delta encoding
-				if version != Version::Draft17 {
+				// Draft17+: NO count prefix + delta encoding
+				if matches!(version, Version::Draft16) {
 					count.encode(w, version)?;
 				}
 
@@ -178,22 +194,6 @@ impl Encode<Version> for Parameters {
 							v.encode(w, version)?;
 						}
 					}
-				}
-			}
-			Version::Draft14 | Version::Draft15 => {
-				count.encode(w, version)?;
-
-				for (kind, value) in self.vars.iter() {
-					u64::from(*kind).encode(w, version)?;
-					value.encode(w, version)?;
-				}
-
-				for (kind, value) in self.bytes.iter() {
-					if value.len() > MAX_KVP_VALUE_LEN {
-						return Err(EncodeError::BoundsExceeded);
-					}
-					u64::from(*kind).encode(w, version)?;
-					value.encode(w, version)?;
 				}
 			}
 		}

--- a/rs/moq-lite/src/ietf/parameters.rs
+++ b/rs/moq-lite/src/ietf/parameters.rs
@@ -612,7 +612,13 @@ mod tests {
 
 	#[test]
 	fn test_param_u8_all_versions() {
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			round_trip_params(
 				version,
 				|w, v| {
@@ -630,7 +636,13 @@ mod tests {
 
 	#[test]
 	fn test_param_bool_all_versions() {
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			round_trip_params(
 				version,
 				|w, v| {
@@ -649,7 +661,13 @@ mod tests {
 	#[test]
 	fn test_param_location_all_versions() {
 		let loc = Location { group: 5, object: 3 };
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			round_trip_params(
 				version,
 				|w, v| {
@@ -667,7 +685,13 @@ mod tests {
 
 	#[test]
 	fn test_param_filter_type_all_versions() {
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			round_trip_params(
 				version,
 				|w, v| {
@@ -685,7 +709,13 @@ mod tests {
 
 	#[test]
 	fn test_param_multiple_delta_encoding() {
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			round_trip_params(
 				version,
 				|w, v| {
@@ -716,7 +746,13 @@ mod tests {
 
 	#[test]
 	fn test_param_empty_set() {
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			round_trip_params(
 				version,
 				|w, v| {
@@ -733,7 +769,13 @@ mod tests {
 
 	#[test]
 	fn test_param_option_skip_none() {
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			round_trip_params(
 				version,
 				|w, v| {
@@ -759,7 +801,13 @@ mod tests {
 
 	#[test]
 	fn test_param_option_encode_some() {
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			round_trip_params(
 				version,
 				|w, v| {
@@ -786,7 +834,13 @@ mod tests {
 	#[test]
 	fn test_param_bare_type_defaults() {
 		// Bare types use T::default() when the parameter is absent
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			round_trip_params(
 				version,
 				|w, v| {
@@ -810,7 +864,13 @@ mod tests {
 	#[test]
 	fn test_param_unknown_rejected() {
 		// Manually encode one param at key 0x10, try to decode expecting key 0x20
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			let mut buf = BytesMut::new();
 			1usize.encode(&mut buf, version).unwrap();
 			0x10u64.encode(&mut buf, version).unwrap();
@@ -832,25 +892,29 @@ mod tests {
 	#[test]
 	fn test_param_duplicate_rejected() {
 		// Manually construct a buffer with duplicate key 0x20
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+		for version in [
+			Version::Draft14,
+			Version::Draft15,
+			Version::Draft16,
+			Version::Draft17,
+			Version::Draft18,
+		] {
 			let mut buf = BytesMut::new();
 			// Encode count = 2
 			2usize.encode(&mut buf, version).unwrap();
 			match version {
-				Version::Draft16 | Version::Draft17 => {
-					// First: key delta=0x20, value=100
+				Version::Draft14 | Version::Draft15 => {
+					// Plain (non-delta) keys: first key=0x20, second key=0x20
 					0x20u64.encode(&mut buf, version).unwrap();
 					100u8.param_encode(&mut buf, version).unwrap();
-					// Second: key delta=0 (same key 0x20), value=200
-					0u64.encode(&mut buf, version).unwrap();
+					0x20u64.encode(&mut buf, version).unwrap();
 					200u8.param_encode(&mut buf, version).unwrap();
 				}
 				_ => {
-					// First: key=0x20, value=100
+					// Delta-encoded: first delta=0x20 (abs=0x20), second delta=0 (abs=0x20)
 					0x20u64.encode(&mut buf, version).unwrap();
 					100u8.param_encode(&mut buf, version).unwrap();
-					// Second: key=0x20, value=200
-					0x20u64.encode(&mut buf, version).unwrap();
+					0u64.encode(&mut buf, version).unwrap();
 					200u8.param_encode(&mut buf, version).unwrap();
 				}
 			}

--- a/rs/moq-lite/src/ietf/publish.rs
+++ b/rs/moq-lite/src/ietf/publish.rs
@@ -132,12 +132,12 @@ impl Message for PublishDone<'_> {
 	const ID: u64 = 0x0b;
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if version != Version::Draft17 {
+		if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			self.request_id
 				.expect("request_id required for draft14-16")
 				.encode(w, version)?;
 		} else {
-			assert!(self.request_id.is_none(), "request_id must be None for draft17");
+			assert!(self.request_id.is_none(), "request_id must be None for draft17+");
 		}
 		self.status_code.encode(w, version)?;
 		self.stream_count.encode(w, version)?;
@@ -146,10 +146,10 @@ impl Message for PublishDone<'_> {
 	}
 
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		let request_id = if version == Version::Draft17 {
-			None
-		} else {
+		let request_id = if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			Some(RequestId::decode(r, version)?)
+		} else {
+			None
 		};
 		let status_code = u64::decode(r, version)?;
 		let stream_count = u64::decode(r, version)?;
@@ -202,7 +202,7 @@ impl Message for Publish<'_> {
 				// parameters
 				0u8.encode(w, version)?;
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				encode_params!(w, version,
 					0x09 => self.largest_location,
 					0x10 => self.forward,
@@ -245,7 +245,7 @@ impl Message for Publish<'_> {
 					forward,
 				})
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				decode_params!(r, version,
 					0x09 => largest_location: Option<Location>,
 					0x10 => forward: Option<bool>,
@@ -284,12 +284,12 @@ impl Message for PublishOk {
 	const ID: u64 = 0x1E;
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if version != Version::Draft17 {
+		if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			self.request_id
 				.expect("request_id required for draft14-16")
 				.encode(w, version)?;
 		} else {
-			assert!(self.request_id.is_none(), "request_id must be None for draft17");
+			assert!(self.request_id.is_none(), "request_id must be None for draft17+");
 		}
 
 		match version {
@@ -305,7 +305,7 @@ impl Message for PublishOk {
 				// no parameters
 				0u8.encode(w, version)?;
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				encode_params!(w, version,
 					0x10 => self.forward,
 					0x20 => self.subscriber_priority,
@@ -319,10 +319,10 @@ impl Message for PublishOk {
 	}
 
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		let request_id = if version == Version::Draft17 {
-			None
-		} else {
+		let request_id = if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			Some(RequestId::decode(r, version)?)
+		} else {
+			None
 		};
 
 		match version {
@@ -353,7 +353,7 @@ impl Message for PublishOk {
 					filter_type,
 				})
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				decode_params!(r, version,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,

--- a/rs/moq-lite/src/ietf/publish.rs
+++ b/rs/moq-lite/src/ietf/publish.rs
@@ -562,4 +562,82 @@ mod tests {
 		assert_eq!(decoded.stream_count, 5);
 		assert_eq!(decoded.reason_phrase, "OK");
 	}
+
+	#[test]
+	fn test_publish_v18_round_trip() {
+		let msg = Publish {
+			request_id: RequestId(1),
+			track_namespace: Path::new("test/ns"),
+			track_name: "video".into(),
+			track_alias: 42,
+			group_order: GroupOrder::Descending,
+			largest_location: Some(Location { group: 10, object: 5 }),
+			forward: true,
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: Publish = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, RequestId(1));
+		assert_eq!(decoded.track_namespace.as_str(), "test/ns");
+		assert_eq!(decoded.track_name, "video");
+		assert_eq!(decoded.track_alias, 42);
+		assert_eq!(decoded.largest_location, Some(Location { group: 10, object: 5 }));
+		assert!(decoded.forward);
+	}
+
+	/// Draft-18 drops the required_request_id_delta varint (#1615).
+	/// For Publish (#1D) the field is a single zero varint = 1 byte.
+	#[test]
+	fn test_publish_v18_is_one_byte_shorter_than_v17() {
+		let msg = Publish {
+			request_id: RequestId(1),
+			track_namespace: Path::new("test/ns"),
+			track_name: "video".into(),
+			track_alias: 42,
+			group_order: GroupOrder::Descending,
+			largest_location: None,
+			forward: true,
+		};
+
+		let v17 = encode_message(&msg, Version::Draft17);
+		let v18 = encode_message(&msg, Version::Draft18);
+		assert_eq!(v17.len(), v18.len() + 1);
+	}
+
+	#[test]
+	fn test_publish_ok_v18_round_trip() {
+		let msg = PublishOk {
+			request_id: None,
+			forward: true,
+			subscriber_priority: 128,
+			group_order: GroupOrder::Descending,
+			filter_type: FilterType::LargestObject,
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: PublishOk = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, None);
+		assert!(decoded.forward);
+		assert_eq!(decoded.subscriber_priority, 128);
+	}
+
+	#[test]
+	fn test_publish_done_v18_round_trip() {
+		let msg = PublishDone {
+			request_id: None,
+			status_code: 200,
+			stream_count: 5,
+			reason_phrase: "OK".into(),
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: PublishDone = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, None);
+		assert_eq!(decoded.status_code, 200);
+		assert_eq!(decoded.stream_count, 5);
+		assert_eq!(decoded.reason_phrase, "OK");
+	}
 }

--- a/rs/moq-lite/src/ietf/publish_namespace.rs
+++ b/rs/moq-lite/src/ietf/publish_namespace.rs
@@ -23,7 +23,7 @@ impl Message for PublishNamespace<'_> {
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
 		self.request_id.encode(w, version)?;
 		if version == Version::Draft17 {
-			0u64.encode(w, version)?; // required_request_id_delta = 0
+			0u64.encode(w, version)?; // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		encode_namespace(w, &self.track_namespace, version)?;
 		encode_params!(w, version,);
@@ -119,7 +119,7 @@ impl Message for PublishNamespaceDone<'_> {
 			Version::Draft16 => {
 				self.request_id.encode(w, version)?;
 			}
-			Version::Draft17 => return Err(EncodeError::Version),
+			_ => return Err(EncodeError::Version),
 		}
 		Ok(())
 	}
@@ -140,7 +140,7 @@ impl Message for PublishNamespaceDone<'_> {
 					request_id,
 				})
 			}
-			Version::Draft17 => Err(DecodeError::Version),
+			_ => Err(DecodeError::Version),
 		}
 	}
 }
@@ -168,7 +168,7 @@ impl Message for PublishNamespaceCancel<'_> {
 			Version::Draft16 => {
 				self.request_id.encode(w, version)?;
 			}
-			Version::Draft17 => {
+			_ => {
 				return Err(EncodeError::Version);
 			}
 		}
@@ -187,7 +187,7 @@ impl Message for PublishNamespaceCancel<'_> {
 				let request_id = RequestId::decode(r, version)?;
 				(Path::default(), request_id)
 			}
-			Version::Draft17 => {
+			_ => {
 				return Err(DecodeError::Version);
 			}
 		};

--- a/rs/moq-lite/src/ietf/publish_namespace.rs
+++ b/rs/moq-lite/src/ietf/publish_namespace.rs
@@ -321,6 +321,31 @@ mod tests {
 	}
 
 	#[test]
+	fn test_publish_namespace_v18_round_trip() {
+		let msg = PublishNamespace {
+			request_id: RequestId(5),
+			track_namespace: Path::new("v18/broadcast"),
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: PublishNamespace = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, RequestId(5));
+		assert_eq!(decoded.track_namespace.as_str(), "v18/broadcast");
+	}
+
+	#[test]
+	fn test_publish_namespace_done_v18_rejected() {
+		let msg = PublishNamespaceDone {
+			track_namespace: Path::default(),
+			request_id: RequestId(42),
+		};
+
+		let mut buf = BytesMut::new();
+		assert!(msg.encode_msg(&mut buf, Version::Draft18).is_err());
+	}
+
+	#[test]
 	fn test_publish_namespace_done_v17_rejected() {
 		let msg = PublishNamespaceDone {
 			track_namespace: Path::default(),

--- a/rs/moq-lite/src/ietf/publisher.rs
+++ b/rs/moq-lite/src/ietf/publisher.rs
@@ -133,8 +133,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			.writer
 			.encode(&ietf::SubscribeOk {
 				request_id: match self.version {
-					Version::Draft17 => None,
-					_ => Some(request_id),
+					Version::Draft14 | Version::Draft15 | Version::Draft16 => Some(request_id),
+					_ => None,
 				},
 				track_alias: request_id.0,
 			})
@@ -157,8 +157,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			.writer
 			.encode(&ietf::PublishDone {
 				request_id: match self.version {
-					Version::Draft17 => None,
-					_ => Some(request_id),
+					Version::Draft14 | Version::Draft15 | Version::Draft16 => Some(request_id),
+					_ => None,
 				},
 				status_code,
 				stream_count: 0,
@@ -201,7 +201,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					})
 					.await?;
 			}
-			Version::Draft17 => {
+			_ => {
 				writer.encode(&ietf::RequestError::ID).await?;
 				writer
 					.encode(&ietf::RequestError {
@@ -384,7 +384,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					})
 					.await?;
 			}
-			Version::Draft17 => {
+			_ => {
 				writer.encode(&ietf::RequestOk::ID).await?;
 				writer.encode(&ietf::RequestOk { request_id: None }).await?;
 			}
@@ -421,7 +421,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					})
 					.await?;
 			}
-			Version::Draft17 => {
+			_ => {
 				writer.encode(&ietf::RequestError::ID).await?;
 				writer
 					.encode(&ietf::RequestError {
@@ -500,7 +500,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			} else {
 				tracing::debug!(broadcast = %self.origin.absolute(&path), "unannounce");
 				if let Some((request_id, mut stream)) = namespace_streams.remove(&suffix) {
-					// For v14-16, send PublishNamespaceDone. For v17, just close the stream.
+					// v14-16 sends PublishNamespaceDone; v17+ just closes the stream.
 					match self.version {
 						Version::Draft14 | Version::Draft15 | Version::Draft16 => {
 							let _ = stream
@@ -511,7 +511,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								})
 								.await;
 						}
-						Version::Draft17 => {}
+						_ => {}
 					}
 					stream.writer.finish().ok();
 				}
@@ -530,7 +530,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						})
 						.await;
 				}
-				Version::Draft17 => {}
+				_ => {}
 			}
 			stream.writer.finish().ok();
 		}
@@ -570,7 +570,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					})
 					.await?;
 			}
-			Version::Draft17 => {
+			_ => {
 				stream.writer.encode(&ietf::RequestOk::ID).await?;
 				stream.writer.encode(&ietf::RequestOk { request_id: None }).await?;
 			}

--- a/rs/moq-lite/src/ietf/request.rs
+++ b/rs/moq-lite/src/ietf/request.rs
@@ -91,22 +91,22 @@ impl Message for RequestOk {
 	const ID: u64 = 0x07;
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if version != Version::Draft17 {
+		if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			self.request_id
 				.expect("request_id required for draft14-16")
 				.encode(w, version)?;
 		} else {
-			assert!(self.request_id.is_none(), "request_id must be None for draft17");
+			assert!(self.request_id.is_none(), "request_id must be None for draft17+");
 		}
 		encode_params!(w, version,);
 		Ok(())
 	}
 
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		let request_id = if version == Version::Draft17 {
-			None
-		} else {
+		let request_id = if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			Some(RequestId::decode(r, version)?)
+		} else {
+			None
 		};
 		decode_params!(r, version,);
 		Ok(Self { request_id })

--- a/rs/moq-lite/src/ietf/request.rs
+++ b/rs/moq-lite/src/ietf/request.rs
@@ -129,15 +129,15 @@ impl Message for RequestError<'_> {
 	const ID: u64 = 0x05;
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if version != Version::Draft17 {
+		if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			self.request_id
 				.expect("request_id required for draft14-16")
 				.encode(w, version)?;
 		} else {
-			assert!(self.request_id.is_none(), "request_id must be None for draft17");
+			assert!(self.request_id.is_none(), "request_id must be None for draft17+");
 		}
 		self.error_code.encode(w, version)?;
-		if version == Version::Draft16 || version == Version::Draft17 {
+		if !matches!(version, Version::Draft14 | Version::Draft15) {
 			self.retry_interval.encode(w, version)?;
 		}
 		self.reason_phrase.encode(w, version)?;
@@ -145,15 +145,15 @@ impl Message for RequestError<'_> {
 	}
 
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		let request_id = if version == Version::Draft17 {
-			None
-		} else {
+		let request_id = if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			Some(RequestId::decode(r, version)?)
+		} else {
+			None
 		};
 		let error_code = u64::decode(r, version)?;
 		let retry_interval = match version {
-			Version::Draft16 | Version::Draft17 => u64::decode(r, version)?,
 			Version::Draft14 | Version::Draft15 => 0,
+			_ => u64::decode(r, version)?,
 		};
 		let reason_phrase = Cow::<str>::decode(r, version)?;
 		Ok(Self {

--- a/rs/moq-lite/src/ietf/request.rs
+++ b/rs/moq-lite/src/ietf/request.rs
@@ -256,4 +256,42 @@ mod tests {
 		assert_eq!(decoded.reason_phrase, "Internal error");
 		assert_eq!(decoded.retry_interval, 3000);
 	}
+
+	#[test]
+	fn test_request_ok_v18_round_trip() {
+		let msg = RequestOk { request_id: None };
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: RequestOk = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, None);
+	}
+
+	/// Regression: pre-fix, the `version != Draft17` check caused Draft18 to be
+	/// treated as Draft14-16 and panic in the encoder.
+	#[test]
+	fn test_request_ok_v18_wire_matches_v17() {
+		let msg = RequestOk { request_id: None };
+		let v17 = encode_message(&msg, Version::Draft17);
+		let v18 = encode_message(&msg, Version::Draft18);
+		assert_eq!(v17, v18);
+	}
+
+	#[test]
+	fn test_request_error_v18_round_trip() {
+		let msg = RequestError {
+			request_id: None,
+			error_code: 500,
+			reason_phrase: "Internal error".into(),
+			retry_interval: 3000,
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: RequestError = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, None);
+		assert_eq!(decoded.error_code, 500);
+		assert_eq!(decoded.reason_phrase, "Internal error");
+		assert_eq!(decoded.retry_interval, 3000);
+	}
 }

--- a/rs/moq-lite/src/ietf/session.rs
+++ b/rs/moq-lite/src/ietf/session.rs
@@ -64,7 +64,7 @@ pub fn start<S: web_transport_trait::Session>(
 				web_async::spawn({
 					let session = session.clone();
 					async move {
-						if let Err(err) = run_setup(session).await {
+						if let Err(err) = run_setup(session, version).await {
 							tracing::warn!(%err, "setup send error");
 						}
 					}
@@ -115,8 +115,7 @@ pub fn start<S: web_transport_trait::Session>(
 }
 
 /// Send our SETUP on a uni stream and keep it alive for potential GOAWAY.
-async fn run_setup<S: web_transport_trait::Session>(session: S) -> Result<(), Error> {
-	let version = Version::Draft17;
+async fn run_setup<S: web_transport_trait::Session>(session: S, version: Version) -> Result<(), Error> {
 	let outer_version = crate::Version::Ietf(version);
 
 	let send = session.open_uni().await.map_err(Error::from_transport)?;
@@ -163,7 +162,7 @@ async fn run_unis<S: web_transport_trait::Session>(
 				}
 
 				// Monitor for GOAWAY after setup completes.
-				if let Err(err) = run_goaway(reader.with_version(version)).await {
+				if let Err(err) = run_goaway(reader.with_version(version), version).await {
 					tracing::warn!(%err, "goaway error");
 				}
 			});
@@ -230,7 +229,10 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 }
 
 /// Block until GOAWAY or stream close.
-async fn run_goaway<R: web_transport_trait::RecvStream>(mut reader: Reader<R, Version>) -> Result<(), Error> {
+async fn run_goaway<R: web_transport_trait::RecvStream>(
+	mut reader: Reader<R, Version>,
+	version: Version,
+) -> Result<(), Error> {
 	let id: u64 = match reader.decode_maybe().await? {
 		Some(id) => id,
 		None => return Ok(()),
@@ -240,7 +242,7 @@ async fn run_goaway<R: web_transport_trait::RecvStream>(mut reader: Reader<R, Ve
 	let mut data = reader.read_exact(size as usize).await?;
 
 	if id == ietf::GoAway::ID {
-		let msg = ietf::GoAway::decode_msg(&mut data, Version::Draft17)?;
+		let msg = ietf::GoAway::decode_msg(&mut data, version)?;
 		tracing::debug!(message = ?msg, "received GOAWAY");
 		Err(Error::Unsupported)
 	} else {

--- a/rs/moq-lite/src/ietf/session.rs
+++ b/rs/moq-lite/src/ietf/session.rs
@@ -1,7 +1,7 @@
 use crate::{
 	Error, OriginConsumer, OriginProducer,
 	coding::{Encode, Reader, Stream, Writer},
-	ietf::{self, FetchHeader, GroupFlags, RequestId},
+	ietf::{self, FetchHeader, RequestId},
 	setup,
 };
 
@@ -188,10 +188,16 @@ async fn run_uni_group<S: web_transport_trait::Session>(
 ) -> Result<(), Error> {
 	let kind: u64 = stream.decode_peek().await?;
 
+	// SUBGROUP_HEADER type bytes match the form 0b0XX1XXXX (spec §11.4.2):
+	// draft-14-17 use 0x10-0x1D and 0x30-0x3D, draft-18 adds 0x40 (FIRST_OBJECT)
+	// extending the form to also cover 0x50-0x5D and 0x70-0x7D. Per-version and
+	// per-bit validation (e.g., FIRST_OBJECT must be 0 on draft-17) is done in
+	// `GroupFlags::decode`.
+	if kind <= 0xff && (kind & 0x90) == 0x10 {
+		return subscriber.recv_group(stream).await;
+	}
+
 	match kind {
-		GroupFlags::START..=GroupFlags::END | GroupFlags::START_NO_PRIORITY..=GroupFlags::END_NO_PRIORITY => {
-			subscriber.recv_group(stream).await
-		}
 		FetchHeader::TYPE => Err(Error::Unsupported),
 		_ => Err(Error::UnexpectedStream),
 	}

--- a/rs/moq-lite/src/ietf/subscribe.rs
+++ b/rs/moq-lite/src/ietf/subscribe.rs
@@ -94,7 +94,7 @@ impl Message for Subscribe<'_> {
 					filter_type,
 				})
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				decode_params!(r, version,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
@@ -125,7 +125,7 @@ impl Message for Subscribe<'_> {
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
 		self.request_id.encode(w, version)?;
 		if version == Version::Draft17 {
-			0u64.encode(w, version)?; // required_request_id_delta = 0
+			0u64.encode(w, version)?; // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		encode_namespace(w, &self.track_namespace, version)?;
 		self.track_name.encode(w, version)?;
@@ -144,7 +144,7 @@ impl Message for Subscribe<'_> {
 				self.filter_type.encode(w, version)?;
 				0u8.encode(w, version)?; // no parameters
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				encode_params!(w, version,
 					0x10 => true,
 					0x20 => self.subscriber_priority,
@@ -169,12 +169,12 @@ impl Message for SubscribeOk {
 	const ID: u64 = 0x04;
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if version != Version::Draft17 {
+		if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			self.request_id
 				.expect("request_id required for draft14-16")
 				.encode(w, version)?;
 		} else {
-			assert!(self.request_id.is_none(), "request_id must be None for draft17");
+			assert!(self.request_id.is_none(), "request_id must be None for draft17+");
 		}
 		self.track_alias.encode(w, version)?;
 
@@ -185,7 +185,7 @@ impl Message for SubscribeOk {
 				false.encode(w, version)?; // no content
 				0u8.encode(w, version)?; // no parameters
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				encode_params!(w, version,
 					0x22 => GroupOrder::Descending,
 				);
@@ -196,10 +196,10 @@ impl Message for SubscribeOk {
 	}
 
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		let request_id = if version == Version::Draft17 {
-			None
-		} else {
+		let request_id = if matches!(version, Version::Draft14 | Version::Draft15 | Version::Draft16) {
 			Some(RequestId::decode(r, version)?)
+		} else {
+			None
 		};
 		let track_alias = u64::decode(r, version)?;
 
@@ -219,7 +219,7 @@ impl Message for SubscribeOk {
 
 				let _params = Parameters::decode(r, version)?;
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				decode_params!(r, version,
 					0x22 => _group_order: Option<GroupOrder>,
 				);
@@ -286,7 +286,7 @@ impl Message for Unsubscribe {
 }
 
 /// SubscribeUpdate message (0x02)
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SubscribeUpdate {
 	pub request_id: RequestId,
 	pub subscription_request_id: Option<RequestId>,
@@ -323,14 +323,16 @@ impl Message for SubscribeUpdate {
 					0x21 => FilterType::LargestObject,
 				);
 			}
-			Version::Draft17 => {
+			_ => {
 				assert!(
 					self.subscription_request_id.is_none(),
-					"subscription_request_id must be None for draft17"
+					"subscription_request_id must be None for draft17+"
 				);
-				// REQUEST_UPDATE: request_id, required_request_id_delta, params
+				// REQUEST_UPDATE
 				self.request_id.encode(w, version)?;
-				0u64.encode(w, version)?; // required_request_id_delta = 0
+				if matches!(version, Version::Draft17) {
+					0u64.encode(w, version)?; // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
+				}
 				encode_params!(w, version,
 					0x10 => self.forward,
 					0x20 => self.subscriber_priority,
@@ -383,10 +385,12 @@ impl Message for SubscribeUpdate {
 					forward,
 				})
 			}
-			Version::Draft17 => {
-				// REQUEST_UPDATE: request_id, required_request_id_delta, params
+			_ => {
+				// REQUEST_UPDATE
 				let request_id = RequestId::decode(r, version)?;
-				let _required_request_id_delta = u64::decode(r, version)?;
+				if matches!(version, Version::Draft17) {
+					let _required_request_id_delta = u64::decode(r, version)?;
+				}
 				decode_params!(r, version,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
@@ -665,5 +669,81 @@ mod tests {
 		assert_eq!(decoded.subscription_request_id, None);
 		assert_eq!(decoded.subscriber_priority, 200);
 		assert!(decoded.forward);
+	}
+
+	#[test]
+	fn test_subscribe_v18_round_trip() {
+		let msg = Subscribe {
+			request_id: RequestId(1),
+			track_namespace: Path::new("test"),
+			track_name: "video".into(),
+			subscriber_priority: 128,
+			group_order: GroupOrder::Descending,
+			filter_type: FilterType::LargestObject,
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: Subscribe = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, RequestId(1));
+		assert_eq!(decoded.track_namespace.as_str(), "test");
+		assert_eq!(decoded.track_name, "video");
+		assert_eq!(decoded.subscriber_priority, 128);
+	}
+
+	#[test]
+	fn test_subscribe_ok_v18_round_trip() {
+		let msg = SubscribeOk {
+			request_id: None,
+			track_alias: 42,
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: SubscribeOk = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, None);
+		assert_eq!(decoded.track_alias, 42);
+	}
+
+	/// Draft-18 removes the `required_request_id_delta` field (#1615), so the
+	/// REQUEST_UPDATE wire format is 1 varint shorter than draft-17.
+	#[test]
+	fn test_subscribe_update_v18_round_trip() {
+		let msg = SubscribeUpdate {
+			request_id: RequestId(10),
+			subscription_request_id: None,
+			start_location: Location { group: 0, object: 0 },
+			end_group: 0,
+			subscriber_priority: 200,
+			forward: true,
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: SubscribeUpdate = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, RequestId(10));
+		assert_eq!(decoded.subscription_request_id, None);
+		assert_eq!(decoded.subscriber_priority, 200);
+		assert!(decoded.forward);
+	}
+
+	/// Cross-check: draft-17 emits an extra 0-byte (required_request_id_delta) that
+	/// draft-18 does not. So a draft-18 encoding should be exactly 1 byte shorter
+	/// than draft-17 for SUBSCRIBE_UPDATE.
+	#[test]
+	fn test_subscribe_update_v17_v18_size_differs() {
+		let v17_msg = SubscribeUpdate {
+			request_id: RequestId(10),
+			subscription_request_id: None,
+			start_location: Location { group: 0, object: 0 },
+			end_group: 0,
+			subscriber_priority: 200,
+			forward: true,
+		};
+		let v18_msg = SubscribeUpdate { ..v17_msg.clone() };
+
+		let v17 = encode_message(&v17_msg, Version::Draft17);
+		let v18 = encode_message(&v18_msg, Version::Draft18);
+		assert_eq!(v17.len(), v18.len() + 1);
 	}
 }

--- a/rs/moq-lite/src/ietf/subscribe_namespace.rs
+++ b/rs/moq-lite/src/ietf/subscribe_namespace.rs
@@ -9,6 +9,15 @@ use super::namespace::{decode_namespace, encode_namespace};
 
 use super::Version;
 
+/// SUBSCRIBE_TRACKS message ID (0x51) introduced in draft-18 (#1542).
+///
+/// moq-lite does not implement PUBLISH replication through a CDN, which is the
+/// only thing that SUBSCRIBE_TRACKS enables (subscribing to all tracks under a
+/// prefix). If a peer sends this we fail the session loudly rather than
+/// silently ignoring it, since ignoring would leave the peer waiting forever
+/// for a REQUEST_OK.
+pub const SUBSCRIBE_TRACKS_ID: u64 = 0x51;
+
 /// SubscribeNamespace message (0x11)
 /// In v16, this moves from the control stream to its own bidirectional stream.
 #[derive(Clone, Debug)]
@@ -25,10 +34,10 @@ impl Message for SubscribeNamespace<'_> {
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
 		self.request_id.encode(w, version)?;
 		if version == Version::Draft17 {
-			0u64.encode(w, version)?; // required_request_id_delta = 0
+			0u64.encode(w, version)?; // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		encode_namespace(w, &self.namespace, version)?;
-		if version == Version::Draft16 || version == Version::Draft17 {
+		if !matches!(version, Version::Draft14 | Version::Draft15) {
 			self.subscribe_options.encode(w, version)?;
 		}
 		encode_params!(w, version,);
@@ -42,8 +51,8 @@ impl Message for SubscribeNamespace<'_> {
 		}
 		let namespace = decode_namespace(r, version)?;
 		let subscribe_options = match version {
-			Version::Draft16 | Version::Draft17 => u64::decode(r, version)?,
 			Version::Draft14 | Version::Draft15 => 0x01,
+			_ => u64::decode(r, version)?,
 		};
 
 		// Ignore parameters

--- a/rs/moq-lite/src/ietf/subscriber.rs
+++ b/rs/moq-lite/src/ietf/subscriber.rs
@@ -266,7 +266,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					})
 					.await?;
 			}
-			Version::Draft17 => {
+			_ => {
 				stream.writer.encode(&ietf::RequestOk::ID).await?;
 				stream.writer.encode(&ietf::RequestOk { request_id: None }).await?;
 			}
@@ -306,7 +306,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					})
 					.await?;
 			}
-			Version::Draft17 => {
+			_ => {
 				stream.writer.encode(&ietf::RequestError::ID).await?;
 				stream
 					.writer
@@ -346,7 +346,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					})
 					.await?;
 			}
-			Version::Draft17 => {
+			_ => {
 				stream.writer.encode(&ietf::RequestOk::ID).await?;
 				stream.writer.encode(&ietf::RequestOk { request_id: None }).await?;
 			}
@@ -385,7 +385,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					})
 					.await?;
 			}
-			Version::Draft17 => {
+			_ => {
 				stream.writer.encode(&ietf::RequestError::ID).await?;
 				stream
 					.writer

--- a/rs/moq-lite/src/ietf/track.rs
+++ b/rs/moq-lite/src/ietf/track.rs
@@ -181,4 +181,20 @@ mod tests {
 		assert_eq!(decoded.track_namespace.as_str(), "test/ns");
 		assert_eq!(decoded.track_name, "video");
 	}
+
+	#[test]
+	fn test_track_status_v18_round_trip() {
+		let msg = TrackStatus {
+			request_id: RequestId(1),
+			track_namespace: Path::new("test/ns"),
+			track_name: "video".into(),
+		};
+
+		let encoded = encode_message(&msg, Version::Draft18);
+		let decoded: TrackStatus = decode_message(&encoded, Version::Draft18).unwrap();
+
+		assert_eq!(decoded.request_id, RequestId(1));
+		assert_eq!(decoded.track_namespace.as_str(), "test/ns");
+		assert_eq!(decoded.track_name, "video");
+	}
 }

--- a/rs/moq-lite/src/ietf/track.rs
+++ b/rs/moq-lite/src/ietf/track.rs
@@ -44,7 +44,7 @@ impl Message for TrackStatus<'_> {
 				FilterType::LargestObject.encode(w, version)?; // filter type
 				0u8.encode(w, version)?; // no parameters
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				encode_params!(w, version,);
 			}
 		}
@@ -67,7 +67,7 @@ impl Message for TrackStatus<'_> {
 				let _filter_type = u64::decode(r, version)?;
 				let _params = Parameters::decode(r, version)?;
 			}
-			Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+			_ => {
 				decode_params!(r, version,);
 			}
 		}

--- a/rs/moq-lite/src/ietf/version.rs
+++ b/rs/moq-lite/src/ietf/version.rs
@@ -7,6 +7,7 @@ pub enum Version {
 	Draft15,
 	Draft16,
 	Draft17,
+	Draft18,
 }
 
 impl fmt::Display for Version {
@@ -16,18 +17,14 @@ impl fmt::Display for Version {
 			Self::Draft15 => write!(f, "moq-transport-15"),
 			Self::Draft16 => write!(f, "moq-transport-16"),
 			Self::Draft17 => write!(f, "moq-transport-17"),
+			Self::Draft18 => write!(f, "moq-transport-18"),
 		}
 	}
 }
 
 impl From<Version> for crate::Version {
 	fn from(v: Version) -> Self {
-		match v {
-			Version::Draft14 => crate::Version::Ietf(Version::Draft14),
-			Version::Draft15 => crate::Version::Ietf(Version::Draft15),
-			Version::Draft16 => crate::Version::Ietf(Version::Draft16),
-			Version::Draft17 => crate::Version::Ietf(Version::Draft17),
-		}
+		crate::Version::Ietf(v)
 	}
 }
 

--- a/rs/moq-lite/src/server.rs
+++ b/rs/moq-lite/src/server.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, Error, NEGOTIATED, OriginConsumer,
-	OriginProducer, Session, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, Error, NEGOTIATED,
+	OriginConsumer, OriginProducer, Session, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -48,13 +48,33 @@ impl Server {
 		}
 
 		let (encoding, supported) = match session.protocol() {
+			Some(ALPN_18) => {
+				let v = self
+					.versions
+					.select(Version::Ietf(ietf::Version::Draft18))
+					.ok_or(Error::Version)?;
+
+				// Draft-17+: SETUP is exchanged in the background by the session.
+				ietf::start(
+					session.clone(),
+					None,
+					None,
+					false,
+					self.publish.clone(),
+					self.consume.clone(),
+					ietf::Version::Draft18,
+				)?;
+
+				tracing::debug!(version = ?v, "connected");
+				return Ok(Session::new(session, v, None));
+			}
 			Some(ALPN_17) => {
 				let v = self
 					.versions
 					.select(Version::Ietf(ietf::Version::Draft17))
 					.ok_or(Error::Version)?;
 
-				// Draft-17: SETUP is exchanged in the background by the session.
+				// Draft-17+: SETUP is exchanged in the background by the session.
 				ietf::start(
 					session.clone(),
 					None,

--- a/rs/moq-lite/src/setup.rs
+++ b/rs/moq-lite/src/setup.rs
@@ -63,7 +63,8 @@ impl Decode<Version> for Setup {
 enum SetupVersion {
 	Draft14,
 	Draft15Plus,
-	Draft17,
+	/// Draft17+ uses ALPN-only negotiation with no legacy SETUP message.
+	Modern,
 	LiteLegacy,
 	Unsupported,
 }
@@ -73,7 +74,7 @@ impl SetupVersion {
 		match v {
 			Version::Ietf(ietf::Version::Draft14) => Self::Draft14,
 			Version::Ietf(ietf::Version::Draft15) | Version::Ietf(ietf::Version::Draft16) => Self::Draft15Plus,
-			Version::Ietf(ietf::Version::Draft17) => Self::Draft17,
+			Version::Ietf(ietf::Version::Draft17) | Version::Ietf(ietf::Version::Draft18) => Self::Modern,
 			Version::Lite(lite::Version::Lite01) | Version::Lite(lite::Version::Lite02) => Self::LiteLegacy,
 			Version::Lite(lite::Version::Lite03 | lite::Version::Lite04) => Self::Unsupported,
 		}
@@ -97,7 +98,7 @@ impl Client {
 				// Draft15+: no versions list, parameters only.
 			}
 			SetupVersion::Draft14 | SetupVersion::LiteLegacy => self.versions.encode(w, v)?,
-			SetupVersion::Draft17 | SetupVersion::Unsupported => return Err(EncodeError::Version),
+			SetupVersion::Modern | SetupVersion::Unsupported => return Err(EncodeError::Version),
 		};
 		if w.remaining_mut() < self.parameters.len() {
 			return Err(EncodeError::Short);
@@ -118,7 +119,7 @@ impl Decode<Version> for Client {
 		let size = match SetupVersion::from_version(v) {
 			SetupVersion::Draft14 | SetupVersion::Draft15Plus => u16::decode(r, v)? as usize,
 			SetupVersion::LiteLegacy => u64::decode(r, v)? as usize,
-			SetupVersion::Draft17 | SetupVersion::Unsupported => return Err(DecodeError::Version),
+			SetupVersion::Modern | SetupVersion::Unsupported => return Err(DecodeError::Version),
 		};
 
 		if r.remaining() < size {
@@ -133,7 +134,7 @@ impl Decode<Version> for Client {
 				coding::Versions::from([v.into()])
 			}
 			SetupVersion::Draft14 | SetupVersion::LiteLegacy => coding::Versions::decode(&mut msg, v)?,
-			SetupVersion::Draft17 | SetupVersion::Unsupported => return Err(DecodeError::Version),
+			SetupVersion::Modern | SetupVersion::Unsupported => return Err(DecodeError::Version),
 		};
 
 		Ok(Self {
@@ -157,7 +158,7 @@ impl Encode<Version> for Client {
 				u16::try_from(size).map_err(|_| EncodeError::TooLarge)?.encode(w, v)?;
 			}
 			SetupVersion::LiteLegacy => (size as u64).encode(w, v)?,
-			SetupVersion::Draft17 | SetupVersion::Unsupported => return Err(EncodeError::Version),
+			SetupVersion::Modern | SetupVersion::Unsupported => return Err(EncodeError::Version),
 		}
 		self.encode_inner(w, v)
 	}
@@ -180,7 +181,7 @@ impl Server {
 				// Draft15+: No version field, parameters only.
 			}
 			SetupVersion::Draft14 | SetupVersion::LiteLegacy => self.version.encode(w, v)?,
-			SetupVersion::Draft17 | SetupVersion::Unsupported => return Err(EncodeError::Version),
+			SetupVersion::Modern | SetupVersion::Unsupported => return Err(EncodeError::Version),
 		};
 		if w.remaining_mut() < self.parameters.len() {
 			return Err(EncodeError::Short);
@@ -204,7 +205,7 @@ impl Encode<Version> for Server {
 				u16::try_from(size).map_err(|_| EncodeError::TooLarge)?.encode(w, v)?;
 			}
 			SetupVersion::LiteLegacy => (size as u64).encode(w, v)?,
-			SetupVersion::Draft17 | SetupVersion::Unsupported => return Err(EncodeError::Version),
+			SetupVersion::Modern | SetupVersion::Unsupported => return Err(EncodeError::Version),
 		}
 
 		self.encode_inner(w, v)
@@ -222,7 +223,7 @@ impl Decode<Version> for Server {
 		let size = match SetupVersion::from_version(v) {
 			SetupVersion::Draft14 | SetupVersion::Draft15Plus => u16::decode(r, v)? as usize,
 			SetupVersion::LiteLegacy => u64::decode(r, v)? as usize,
-			SetupVersion::Draft17 | SetupVersion::Unsupported => return Err(DecodeError::Version),
+			SetupVersion::Modern | SetupVersion::Unsupported => return Err(DecodeError::Version),
 		};
 
 		if r.remaining() < size {
@@ -233,7 +234,7 @@ impl Decode<Version> for Server {
 		let version = match SetupVersion::from_version(v) {
 			SetupVersion::Draft15Plus => v.into(),
 			SetupVersion::Draft14 | SetupVersion::LiteLegacy => coding::Version::decode(&mut msg, v)?,
-			SetupVersion::Draft17 | SetupVersion::Unsupported => return Err(DecodeError::Version),
+			SetupVersion::Modern | SetupVersion::Unsupported => return Err(DecodeError::Version),
 		};
 
 		Ok(Self {

--- a/rs/moq-lite/src/version.rs
+++ b/rs/moq-lite/src/version.rs
@@ -19,6 +19,7 @@ pub const ALPNS: &[&str] = &[
 	ALPN_LITE_04,
 	ALPN_LITE_03,
 	ALPN_LITE,
+	ALPN_18,
 	ALPN_17,
 	ALPN_16,
 	ALPN_15,
@@ -33,6 +34,7 @@ pub(crate) const ALPN_14: &str = "moq-00";
 pub(crate) const ALPN_15: &str = "moqt-15";
 pub(crate) const ALPN_16: &str = "moqt-16";
 pub(crate) const ALPN_17: &str = "moqt-17";
+pub(crate) const ALPN_18: &str = "moqt-18";
 
 /// A MoQ protocol version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -54,6 +56,7 @@ impl Version {
 			0xff00000f => Some(Self::Ietf(ietf::Version::Draft15)),
 			0xff000010 => Some(Self::Ietf(ietf::Version::Draft16)),
 			0xff000011 => Some(Self::Ietf(ietf::Version::Draft17)),
+			0xff000012 => Some(Self::Ietf(ietf::Version::Draft18)),
 			_ => None,
 		}
 	}
@@ -69,6 +72,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft15) => 0xff00000f,
 			Self::Ietf(ietf::Version::Draft16) => 0xff000010,
 			Self::Ietf(ietf::Version::Draft17) => 0xff000011,
+			Self::Ietf(ietf::Version::Draft18) => 0xff000012,
 		}
 	}
 
@@ -85,6 +89,7 @@ impl Version {
 			ALPN_15 => Some(Self::Ietf(ietf::Version::Draft15)),
 			ALPN_16 => Some(Self::Ietf(ietf::Version::Draft16)),
 			ALPN_17 => Some(Self::Ietf(ietf::Version::Draft17)),
+			ALPN_18 => Some(Self::Ietf(ietf::Version::Draft18)),
 			_ => None,
 		}
 	}
@@ -99,6 +104,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft15) => ALPN_15,
 			Self::Ietf(ietf::Version::Draft16) => ALPN_16,
 			Self::Ietf(ietf::Version::Draft17) => ALPN_17,
+			Self::Ietf(ietf::Version::Draft18) => ALPN_18,
 		}
 	}
 
@@ -150,6 +156,7 @@ impl FromStr for Version {
 			"moq-transport-15" => Ok(Self::Ietf(ietf::Version::Draft15)),
 			"moq-transport-16" => Ok(Self::Ietf(ietf::Version::Draft16)),
 			"moq-transport-17" => Ok(Self::Ietf(ietf::Version::Draft17)),
+			"moq-transport-18" => Ok(Self::Ietf(ietf::Version::Draft18)),
 			_ => Err(format!("unknown version: {s}")),
 		}
 	}
@@ -215,6 +222,7 @@ impl Versions {
 			Version::Lite(lite::Version::Lite03),
 			Version::Lite(lite::Version::Lite02),
 			Version::Lite(lite::Version::Lite01),
+			Version::Ietf(ietf::Version::Draft18),
 			Version::Ietf(ietf::Version::Draft17),
 			Version::Ietf(ietf::Version::Draft16),
 			Version::Ietf(ietf::Version::Draft15),

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -1,9 +1,9 @@
 //! Integration test: verify that forcing each supported version results in a
 //! successful MoQ handshake between a Quinn server and client.
 //!
-//! This covers both ALPN-based version negotiation (moq-lite-03, moqt-15,
-//! moqt-16) and SETUP-based version negotiation (moql, moq-00) used by
-//! older protocol versions like moq-transport-14 and moq-lite-01/02.
+//! This covers both ALPN-based version negotiation (moq-lite-03/04,
+//! moqt-15/16/17/18) and SETUP-based version negotiation (moql, moq-00) used
+//! by older protocol versions like moq-transport-14 and moq-lite-01/02.
 //!
 //! It also tests WebTransport, which uses sub-protocols in the HTTP CONNECT
 //! request instead of TLS ALPN, but serves the same purpose.
@@ -151,6 +151,18 @@ async fn version_moq_transport_16() {
 	connect_with_version("moq-transport-16").await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn version_moq_transport_17() {
+	connect_with_version("moq-transport-17").await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn version_moq_transport_18() {
+	connect_with_version("moq-transport-18").await;
+}
+
 // ── WebTransport: sub-protocol negotiation ──────────────────────────
 // Browser clients use WebTransport (h3 ALPN) and negotiate the MoQ
 // protocol version via sub-protocols in the HTTP CONNECT request.
@@ -195,4 +207,16 @@ async fn webtransport_moq_transport_15() {
 #[tokio::test]
 async fn webtransport_moq_transport_16() {
 	connect_with_webtransport(Some("moq-transport-16")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn webtransport_moq_transport_17() {
+	connect_with_webtransport(Some("moq-transport-17")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn webtransport_moq_transport_18() {
+	connect_with_webtransport(Some("moq-transport-18")).await;
 }

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -153,6 +153,18 @@ async fn broadcast_moq_transport_16() {
 	broadcast_test("moqt", Some("moq-transport-16"), Some("moq-transport-16")).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_moq_transport_17() {
+	broadcast_test("moqt", Some("moq-transport-17"), Some("moq-transport-17")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_moq_transport_18() {
+	broadcast_test("moqt", Some("moq-transport-18"), Some("moq-transport-18")).await;
+}
+
 // ── Raw QUIC – server supports all versions, client pins one ─────────
 
 #[tracing_test::traced_test]
@@ -191,6 +203,18 @@ async fn broadcast_negotiate_server_all_client_transport_16() {
 	broadcast_test("moqt", Some("moq-transport-16"), None).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_negotiate_server_all_client_transport_17() {
+	broadcast_test("moqt", Some("moq-transport-17"), None).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_negotiate_server_all_client_transport_18() {
+	broadcast_test("moqt", Some("moq-transport-18"), None).await;
+}
+
 // ── Raw QUIC – client supports all versions, server pins one ─────────
 
 #[tracing_test::traced_test]
@@ -227,6 +251,18 @@ async fn broadcast_negotiate_client_all_server_transport_15() {
 #[tokio::test]
 async fn broadcast_negotiate_client_all_server_transport_16() {
 	broadcast_test("moqt", None, Some("moq-transport-16")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_negotiate_client_all_server_transport_17() {
+	broadcast_test("moqt", None, Some("moq-transport-17")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_negotiate_client_all_server_transport_18() {
+	broadcast_test("moqt", None, Some("moq-transport-18")).await;
 }
 
 // ── WebTransport (https://) – same version on both sides ────────────
@@ -273,6 +309,18 @@ async fn broadcast_webtransport_moq_transport_16() {
 	broadcast_test("https", Some("moq-transport-16"), Some("moq-transport-16")).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_moq_transport_17() {
+	broadcast_test("https", Some("moq-transport-17"), Some("moq-transport-17")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_moq_transport_18() {
+	broadcast_test("https", Some("moq-transport-18"), Some("moq-transport-18")).await;
+}
+
 // ── WebTransport – server supports all, client pins one ─────────────
 
 #[tracing_test::traced_test]
@@ -311,6 +359,18 @@ async fn broadcast_webtransport_negotiate_server_all_client_transport_16() {
 	broadcast_test("https", Some("moq-transport-16"), None).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_negotiate_server_all_client_transport_17() {
+	broadcast_test("https", Some("moq-transport-17"), None).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_negotiate_server_all_client_transport_18() {
+	broadcast_test("https", Some("moq-transport-18"), None).await;
+}
+
 // ── WebTransport – client supports all, server pins one ─────────────
 
 #[tracing_test::traced_test]
@@ -347,6 +407,18 @@ async fn broadcast_webtransport_negotiate_client_all_server_transport_15() {
 #[tokio::test]
 async fn broadcast_webtransport_negotiate_client_all_server_transport_16() {
 	broadcast_test("https", None, Some("moq-transport-16")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_negotiate_client_all_server_transport_17() {
+	broadcast_test("https", None, Some("moq-transport-17")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_negotiate_client_all_server_transport_18() {
+	broadcast_test("https", None, Some("moq-transport-18")).await;
 }
 
 // ── WebSocket (ws://) ───────────────────────────────────────────────


### PR DESCRIPTION
Adds Draft18 as a negotiated version alongside Draft14-17 in both moq-lite
Rust and JS implementations. Draft18 reuses the Draft17 unified SETUP path
and applies the wire-format changes from the draft-17 to draft-18 changelog.

Spec-driven changes:
* Wire version 0xff000012 / ALPN "moqt-18", prepended to negotiation lists
* Varint 7-byte form (1111110x prefix) accepted on draft-18 (#1595)
* SUBGROUP_HEADER FIRST_OBJECT bit (0x40) set on emit and ignored on decode
  in draft-18 per §11.4.2 (#1618). moq-lite always starts subgroups at
  object 0, so the bit is constant-true on the publisher side.
* Required Request ID removed from PUBLISH_NAMESPACE/SUBSCRIBE/etc on
  draft-18 (#1615) - the field is draft-17-only
* SUBSCRIBE_TRACKS (0x51, #1542): explicitly rejected with a clear error
  rather than silently ignored, since moq-lite does not implement PUBLISH
  replication and the peer would otherwise wait forever for REQUEST_OK
* Optional trailing Request ID in GOAWAY (#1559): never emitted, read-and-
  discarded if present

Refactor: switch version matches from "explicit newest" to
"newest defaults forward" per CLAUDE.md. Each match now lists Draft14-16
(legacy) explicitly and falls through to `_` for newer drafts, so Draft19
will inherit Draft18 behavior unless explicitly opted out. The
`SetupVersion::Draft17` internal enum variant is renamed to `Modern` to
reflect "uses ALPN-only negotiation".

Intentionally NOT changed:
* LARGEST_OBJECT (#1621): we lie on purpose - honoring the new MUST is
  strictly worse for live latency
* Track Properties on REQUEST_OK (#1576) and mandatory-to-understand
  track extensions (#1509) are read-and-dropped, never emitted - moq-lite
  does not use track properties