### PR TITLE
Drop BEM prefixes from watch and publish UI CSS

### DIFF
--- a/js/publish/src/ui/components/camera-source-button.ts
+++ b/js/publish/src/ui/components/camera-source-button.ts
@@ -5,7 +5,7 @@ import { camera, icon } from "../icons";
 import { mediaSourceSelector } from "./media-source-selector";
 
 export function cameraSourceButton(parent: Effect, publish: MoqPublish): HTMLElement {
-	const wrapper = DOM.create("div", { className: "publish-ui__source-button-wrapper flex--center" });
+	const wrapper = DOM.create("div", { className: "source-button-wrapper flex-center" });
 
 	const button = DOM.create("button", {
 		type: "button",
@@ -28,7 +28,7 @@ export function cameraSourceButton(parent: Effect, publish: MoqPublish): HTMLEle
 		const source = effect.get(publish.state.source);
 		const invisible = effect.get(publish.state.invisible);
 		const active = source === "camera" && !invisible;
-		button.className = `button publish-ui__source-button flex--center${active ? " publish-ui__source-button--active" : ""}`;
+		button.className = `button source-button flex-center${active ? " source-button--active" : ""}`;
 
 		if (!active) return;
 

--- a/js/publish/src/ui/components/file-source-button.ts
+++ b/js/publish/src/ui/components/file-source-button.ts
@@ -20,7 +20,7 @@ export function fileSourceButton(parent: Effect, publish: MoqPublish): HTMLEleme
 	parent.run((effect) => {
 		const source = effect.get(publish.state.source);
 		const active = source instanceof File;
-		button.className = `button publish-ui__source-button flex--center${active ? " publish-ui__source-button--active" : ""}`;
+		button.className = `button source-button flex-center${active ? " source-button--active" : ""}`;
 	});
 
 	parent.event(button, "click", () => input.click());

--- a/js/publish/src/ui/components/media-source-selector.ts
+++ b/js/publish/src/ui/components/media-source-selector.ts
@@ -9,16 +9,16 @@ export type SelectorOptions = {
 
 export function mediaSourceSelector(parent: Effect, opts: SelectorOptions): HTMLElement {
 	const wrapper = document.createElement("div");
-	wrapper.className = "publish-ui__media-selector-wrapper flex--center";
+	wrapper.className = "media-selector-wrapper flex-center";
 
 	const toggle = document.createElement("button");
 	toggle.type = "button";
-	toggle.className = "button publish-ui__media-selector-toggle";
+	toggle.className = "button media-selector-toggle";
 	toggle.title = "Show Sources";
 	toggle.appendChild(icon(arrowDown));
 
 	const select = document.createElement("select");
-	select.className = "publish-ui__media-selector-dropdown";
+	select.className = "media-selector-dropdown";
 	select.style.display = "none";
 
 	wrapper.append(toggle, select);

--- a/js/publish/src/ui/components/microphone-source-button.ts
+++ b/js/publish/src/ui/components/microphone-source-button.ts
@@ -5,7 +5,7 @@ import { icon, microphone } from "../icons";
 import { mediaSourceSelector } from "./media-source-selector";
 
 export function microphoneSourceButton(parent: Effect, publish: MoqPublish): HTMLElement {
-	const wrapper = DOM.create("div", { className: "publish-ui__source-button-wrapper flex--center" });
+	const wrapper = DOM.create("div", { className: "source-button-wrapper flex-center" });
 
 	const button = DOM.create("button", {
 		type: "button",
@@ -27,7 +27,7 @@ export function microphoneSourceButton(parent: Effect, publish: MoqPublish): HTM
 	parent.run((effect) => {
 		const muted = effect.get(publish.state.muted);
 		const active = !muted;
-		button.className = `button publish-ui__source-button flex--center${active ? " publish-ui__source-button--active" : ""}`;
+		button.className = `button source-button flex-center${active ? " source-button--active" : ""}`;
 
 		if (!active) return;
 

--- a/js/publish/src/ui/components/nothing-source-button.ts
+++ b/js/publish/src/ui/components/nothing-source-button.ts
@@ -14,7 +14,7 @@ export function nothingSourceButton(parent: Effect, publish: MoqPublish): HTMLEl
 		const muted = effect.get(publish.state.muted);
 		const invisible = effect.get(publish.state.invisible);
 		const active = source === undefined && muted && invisible;
-		button.className = `button publish-ui__source-button flex--center publish-ui__source-button--no-source${active ? " publish-ui__source-button--no-source-active" : ""}`;
+		button.className = `button source-button flex-center source-button--no-source${active ? " source-button--no-source-active" : ""}`;
 	});
 
 	parent.event(button, "click", () => {

--- a/js/publish/src/ui/components/publish-status-indicator.ts
+++ b/js/publish/src/ui/components/publish-status-indicator.ts
@@ -20,7 +20,7 @@ function deriveStatus(
 
 export function publishStatusIndicator(parent: Effect, publish: MoqPublish): HTMLElement {
 	const wrapper = document.createElement("div");
-	wrapper.className = "publish-ui__status-indicator flex--center";
+	wrapper.className = "status-indicator flex-center";
 
 	const dot = document.createElement("span");
 	const text = document.createElement("span");
@@ -40,8 +40,8 @@ export function publishStatusIndicator(parent: Effect, publish: MoqPublish): HTM
 			!!audioSource && !muted,
 			!!videoSource && !invisible,
 		);
-		dot.className = `publish-ui__status-indicator-dot publish-ui__status-indicator-dot--${variant}`;
-		text.className = `publish-ui__status-indicator-text publish-ui__status-indicator-text--${variant}`;
+		dot.className = `status-indicator-dot status-indicator-dot--${variant}`;
+		text.className = `status-indicator-text status-indicator-text--${variant}`;
 		text.textContent = label;
 	});
 

--- a/js/publish/src/ui/components/screen-source-button.ts
+++ b/js/publish/src/ui/components/screen-source-button.ts
@@ -13,7 +13,7 @@ export function screenSourceButton(parent: Effect, publish: MoqPublish): HTMLEle
 		const source = effect.get(publish.state.source);
 		const invisible = effect.get(publish.state.invisible);
 		const active = source === "screen" && !invisible;
-		button.className = `button publish-ui__source-button flex--center${active ? " publish-ui__source-button--active" : ""}`;
+		button.className = `button source-button flex-center${active ? " source-button--active" : ""}`;
 	});
 
 	parent.event(button, "click", () => {

--- a/js/publish/src/ui/element.ts
+++ b/js/publish/src/ui/element.ts
@@ -67,11 +67,11 @@ export default class MoqPublishUi extends HTMLElement {
 			}
 		}
 
-		const controls = DOM.create("div", { className: "publish-ui__controls flex--center flex--space-between" });
+		const controls = DOM.create("div", { className: "controls flex-center flex-space-between" });
 
-		const selector = DOM.create("div", { className: "publish-ui__source-selector flex--center" });
+		const selector = DOM.create("div", { className: "source-selector flex-center" });
 		selector.append(
-			DOM.create("span", { className: "publish-ui__source-label" }, "Source:"),
+			DOM.create("span", { className: "source-label" }, "Source:"),
 			microphoneSourceButton(effect, publish),
 			cameraSourceButton(effect, publish),
 			screenSourceButton(effect, publish),

--- a/js/publish/src/ui/icons.ts
+++ b/js/publish/src/ui/icons.ts
@@ -10,7 +10,7 @@ export { arrowDown, arrowUp, ban, camera, file, microphone, screen };
 
 export function icon(svg: string): HTMLElement {
 	const span = document.createElement("span");
-	span.className = "flex--center";
+	span.className = "flex-center";
 	span.setAttribute("role", "img");
 	span.setAttribute("aria-hidden", "true");
 	span.innerHTML = svg;

--- a/js/publish/src/ui/styles/base.css
+++ b/js/publish/src/ui/styles/base.css
@@ -46,13 +46,13 @@
 	--border-radius-lg: 1rem;
 }
 
-.flex--center {
+.flex-center {
 	display: flex;
 	justify-content: center;
 	align-items: center;
 }
 
-.flex--space-between {
+.flex-space-between {
 	justify-content: space-between;
 }
 

--- a/js/publish/src/ui/styles/controls.css
+++ b/js/publish/src/ui/styles/controls.css
@@ -1,4 +1,4 @@
-.publish-ui__controls {
+.controls {
 	gap: var(--spacing-16);
 	margin: var(--spacing-8) 0;
 	border-radius: var(--border-radius-lg);
@@ -6,13 +6,13 @@
 	padding: var(--spacing-16);
 }
 
-.publish-ui__source-label {
+.source-label {
 	font-size: 1rem;
 	font-weight: 600;
 	letter-spacing: 0.1rem;
 	color: var(--color-white-alpha-90);
 }
 
-.publish-ui__source-selector {
+.source-selector {
 	gap: var(--spacing-16);
 }

--- a/js/publish/src/ui/styles/media-selector.css
+++ b/js/publish/src/ui/styles/media-selector.css
@@ -1,21 +1,21 @@
-.publish-ui__media-selector-wrapper {
+.media-selector-wrapper {
 	position: relative;
 	gap: var(--spacing-8);
 }
 
-.publish-ui__media-selector-toggle {
+.media-selector-toggle {
 	font-size: 0.75rem;
 	cursor: pointer;
 }
 
-.publish-ui__media-selector-toggle.button,
-.publish-ui__media-selector-toggle.button:hover:not(:disabled) {
+.media-selector-toggle.button,
+.media-selector-toggle.button:hover:not(:disabled) {
 	background-color: unset;
 	box-shadow: none;
 	border: unset;
 }
 
-.publish-ui__media-selector-dropdown {
+.media-selector-dropdown {
 	position: absolute;
 	top: var(--spacing-48);
 	right: var(--spacing-8);

--- a/js/publish/src/ui/styles/source-button.css
+++ b/js/publish/src/ui/styles/source-button.css
@@ -1,8 +1,8 @@
-.publish-ui__source-button-wrapper {
+.source-button-wrapper {
 	position: relative;
 }
 
-.publish-ui__source-button {
+.source-button {
 	width: 44px;
 	height: 44px;
 	border-radius: var(--border-radius-md);
@@ -16,28 +16,28 @@
 		transform 0.15s ease;
 }
 
-.publish-ui__source-button:hover {
+.source-button:hover {
 	border-color: var(--color-white-alpha-20);
 }
 
-.publish-ui__source-button svg {
+.source-button svg {
 	color: var(--color-white-alpha-70);
 	transition: color 0.2s ease;
 	position: relative;
 	z-index: 1;
 }
 
-.publish-ui__source-button--active {
+.source-button--active {
 	background: linear-gradient(135deg, var(--color-orange-500-alpha-30), var(--color-amber-600-alpha-30));
 	border: var(--spacing-1) solid var(--color-orange-500-alpha-50);
 	box-shadow: 0 0 24px var(--color-orange-500-alpha-40);
 }
 
-.publish-ui__source-button--active svg {
+.source-button--active svg {
 	color: var(--color-orange-300);
 }
 
-.publish-ui__source-button--active::before {
+.source-button--active::before {
 	content: "";
 	position: absolute;
 	inset: 0;
@@ -47,26 +47,26 @@
 	z-index: 0;
 }
 
-.publish-ui__source-button--no-source {
+.source-button--no-source {
 	background: var(--color-white-alpha-05);
 	border: var(--spacing-1) solid var(--color-white-alpha-10);
 }
 
-.publish-ui__source-button--no-source svg {
+.source-button--no-source svg {
 	color: var(--color-white-alpha-50);
 }
 
-.publish-ui__source-button--no-source-active {
+.source-button--no-source-active {
 	background: linear-gradient(135deg, var(--color-red-500-alpha-25), var(--color-red-900-alpha-35));
 	border: var(--spacing-1) solid var(--color-red-500-alpha-60);
 	box-shadow: 0 0 18px var(--color-red-500-alpha-45);
 }
 
-.publish-ui__source-button--no-source-active svg {
+.source-button--no-source-active svg {
 	color: var(--color-red-300);
 }
 
-.publish-ui__source-button--no-source-active::before {
+.source-button--no-source-active::before {
 	content: "";
 	position: absolute;
 	inset: 0;

--- a/js/publish/src/ui/styles/status-indicator.css
+++ b/js/publish/src/ui/styles/status-indicator.css
@@ -1,4 +1,4 @@
-.publish-ui__status-indicator {
+.status-indicator {
 	gap: var(--spacing-12);
 	padding: var(--spacing-12) var(--spacing-24);
 	border-radius: 12px;
@@ -7,7 +7,7 @@
 	border: var(--spacing-1) solid var(--color-white-alpha-10);
 }
 
-.publish-ui__status-indicator-dot {
+.status-indicator-dot {
 	position: relative;
 	width: 12px;
 	height: 12px;
@@ -16,7 +16,7 @@
 	z-index: 1;
 }
 
-.publish-ui__status-indicator-dot::after {
+.status-indicator-dot::after {
 	content: "";
 	position: absolute;
 	inset: 0;
@@ -28,73 +28,73 @@
 	z-index: -1;
 }
 
-.publish-ui__status-indicator-dot::after {
+.status-indicator-dot::after {
 	display: none;
 }
 
-.publish-ui__status-indicator-dot--live::after,
-.publish-ui__status-indicator-dot--warning::after,
-.publish-ui__status-indicator-dot--connecting::after,
-.publish-ui__status-indicator-dot--audio-only::after,
-.publish-ui__status-indicator-dot--video-only::after {
+.status-indicator-dot--live::after,
+.status-indicator-dot--warning::after,
+.status-indicator-dot--connecting::after,
+.status-indicator-dot--audio-only::after,
+.status-indicator-dot--video-only::after {
 	display: block;
 }
 
-.publish-ui__status-indicator-dot--error {
+.status-indicator-dot--error {
 	background: var(--color-gray-100);
 	color: var(--color-gray-100);
 }
 
-.publish-ui__status-indicator-text--error {
+.status-indicator-text--error {
 	color: var(--color-gray-100);
 }
 
-.publish-ui__status-indicator-dot--warning {
+.status-indicator-dot--warning {
 	background: var(--color-yellow-400);
 	color: var(--color-yellow-400);
 }
 
-.publish-ui__status-indicator-text--warning {
+.status-indicator-text--warning {
 	color: var(--color-yellow-400);
 }
 
-.publish-ui__status-indicator-dot--live {
+.status-indicator-dot--live {
 	background: var(--color-green-400);
 	color: var(--color-green-400);
 }
 
-.publish-ui__status-indicator-text--live {
+.status-indicator-text--live {
 	color: var(--color-green-400);
 }
 
-.publish-ui__status-indicator-dot--audio-only {
+.status-indicator-dot--audio-only {
 	background: var(--color-blue-500);
 	color: var(--color-blue-500);
 }
 
-.publish-ui__status-indicator-text--audio-only {
+.status-indicator-text--audio-only {
 	color: var(--color-blue-500);
 }
 
-.publish-ui__status-indicator-dot--video-only {
+.status-indicator-dot--video-only {
 	background: var(--color-purple-500);
 	color: var(--color-purple-500);
 }
 
-.publish-ui__status-indicator-text--video-only {
+.status-indicator-text--video-only {
 	color: var(--color-purple-500);
 }
 
-.publish-ui__status-indicator-dot--connecting {
+.status-indicator-dot--connecting {
 	background: var(--color-gray-100);
 	color: var(--color-gray-100);
 }
 
-.publish-ui__status-indicator-text--connecting {
+.status-indicator-text--connecting {
 	color: var(--color-gray-100);
 }
 
-.publish-ui__status-indicator-text {
+.status-indicator-text {
 	font-size: 1rem;
 	letter-spacing: 0.1rem;
 }

--- a/js/watch/src/ui/components/buffer-control.ts
+++ b/js/watch/src/ui/components/buffer-control.ts
@@ -76,10 +76,10 @@ function drawRanges(
 
 export function bufferControl(parent: Effect, watch: MoqWatch, max: Moq.Time.Milli = DEFAULT_MAX): HTMLElement {
 	const wrapper = document.createElement("div");
-	wrapper.className = "watch-ui__buffer";
+	wrapper.className = "buffer";
 
 	const viz = document.createElement("div");
-	viz.className = "watch-ui__buffer-visualization";
+	viz.className = "buffer-visualization";
 	viz.setAttribute("role", "slider");
 	viz.tabIndex = 0;
 	viz.setAttribute("aria-valuemin", MIN_RANGE.toString());
@@ -87,37 +87,37 @@ export function bufferControl(parent: Effect, watch: MoqWatch, max: Moq.Time.Mil
 	viz.setAttribute("aria-label", "Buffer jitter");
 
 	const playhead = document.createElement("div");
-	playhead.className = "watch-ui__buffer-playhead";
+	playhead.className = "buffer-playhead";
 
 	const videoTrack = document.createElement("div");
-	videoTrack.className = "watch-ui__buffer-track watch-ui__buffer-track--video";
+	videoTrack.className = "buffer-track buffer-track--video";
 	const videoLabel = document.createElement("span");
-	videoLabel.className = "watch-ui__buffer-track-label";
+	videoLabel.className = "buffer-track-label";
 	videoLabel.textContent = "Video";
 	const videoCanvas = document.createElement("canvas");
-	videoCanvas.className = "watch-ui__buffer-canvas";
+	videoCanvas.className = "buffer-canvas";
 	videoTrack.append(videoLabel, videoCanvas);
 
 	const audioTrack = document.createElement("div");
-	audioTrack.className = "watch-ui__buffer-track watch-ui__buffer-track--audio";
+	audioTrack.className = "buffer-track buffer-track--audio";
 	const audioLabel = document.createElement("span");
-	audioLabel.className = "watch-ui__buffer-track-label";
+	audioLabel.className = "buffer-track-label";
 	audioLabel.textContent = "Audio";
 	const audioCanvas = document.createElement("canvas");
-	audioCanvas.className = "watch-ui__buffer-canvas";
+	audioCanvas.className = "buffer-canvas";
 	audioTrack.append(audioLabel, audioCanvas);
 
 	const targetArea = document.createElement("div");
-	targetArea.className = "watch-ui__buffer-target-area";
+	targetArea.className = "buffer-target-area";
 	const targetLine = document.createElement("div");
-	targetLine.className = "watch-ui__buffer-target-line";
+	targetLine.className = "buffer-target-line";
 	const targetLabel = document.createElement("span");
-	targetLabel.className = "watch-ui__buffer-target-label";
+	targetLabel.className = "buffer-target-label";
 	targetLine.appendChild(targetLabel);
 	targetArea.appendChild(targetLine);
 
 	const help = document.createElement("span");
-	help.className = "watch-ui__buffer-help";
+	help.className = "buffer-help";
 	help.textContent = "click to change latency";
 
 	viz.append(playhead, videoTrack, audioTrack, targetArea, help);
@@ -153,7 +153,7 @@ export function bufferControl(parent: Effect, watch: MoqWatch, max: Moq.Time.Mil
 
 	parent.event(viz, "mousedown", (e) => {
 		dragging = true;
-		viz.classList.add("watch-ui__buffer-visualization--dragging");
+		viz.classList.add("buffer-visualization--dragging");
 		interact();
 		updateFromX(e.clientX);
 	});
@@ -165,7 +165,7 @@ export function bufferControl(parent: Effect, watch: MoqWatch, max: Moq.Time.Mil
 	parent.event(document, "mouseup", () => {
 		if (!dragging) return;
 		dragging = false;
-		viz.classList.remove("watch-ui__buffer-visualization--dragging");
+		viz.classList.remove("buffer-visualization--dragging");
 	});
 
 	parent.event(viz, "keydown", (e) => {

--- a/js/watch/src/ui/components/buffering-indicator.ts
+++ b/js/watch/src/ui/components/buffering-indicator.ts
@@ -3,9 +3,9 @@ import type MoqWatch from "../../element";
 
 export function bufferingIndicator(parent: Effect, watch: MoqWatch): HTMLElement {
 	const container = document.createElement("div");
-	container.className = "watch-ui__buffering flex--center";
+	container.className = "buffering flex-center";
 	const spinner = document.createElement("div");
-	spinner.className = "watch-ui__buffering-spinner";
+	spinner.className = "buffering-spinner";
 	container.appendChild(spinner);
 
 	parent.run((effect) => {

--- a/js/watch/src/ui/components/fullscreen-button.ts
+++ b/js/watch/src/ui/components/fullscreen-button.ts
@@ -5,7 +5,7 @@ import { fullscreenEnter, fullscreenExit, icon } from "../icons";
 export function fullscreenButton(parent: Effect, watch: MoqWatch): HTMLElement {
 	const button = document.createElement("button");
 	button.type = "button";
-	button.className = "button flex--center";
+	button.className = "button flex-center";
 	button.title = "Fullscreen";
 	button.setAttribute("aria-label", "Fullscreen");
 	button.replaceChildren(icon(fullscreenEnter));

--- a/js/watch/src/ui/components/play-pause.ts
+++ b/js/watch/src/ui/components/play-pause.ts
@@ -5,7 +5,7 @@ import { icon, pause, play } from "../icons";
 export function playPauseButton(parent: Effect, watch: MoqWatch): HTMLElement {
 	const button = document.createElement("button");
 	button.type = "button";
-	button.className = "button button--playback flex--center";
+	button.className = "button button--playback flex-center";
 
 	parent.run((effect) => {
 		const paused = effect.get(watch.backend.paused);

--- a/js/watch/src/ui/components/quality-selector.ts
+++ b/js/watch/src/ui/components/quality-selector.ts
@@ -9,16 +9,16 @@ function formatBitrate(bps: number): string {
 
 export function qualitySelector(parent: Effect, watch: MoqWatch): HTMLElement {
 	const wrapper = document.createElement("div");
-	wrapper.className = "watch-ui__quality-selector";
+	wrapper.className = "quality-selector";
 
 	const label = document.createElement("label");
 	label.htmlFor = "moq-watch-quality-select";
-	label.className = "watch-ui__quality-label";
+	label.className = "quality-label";
 	label.textContent = "Quality: ";
 
 	const select = document.createElement("select");
 	select.id = "moq-watch-quality-select";
-	select.className = "watch-ui__quality-select";
+	select.className = "quality-select";
 
 	wrapper.append(label, select);
 

--- a/js/watch/src/ui/components/stats-button.ts
+++ b/js/watch/src/ui/components/stats-button.ts
@@ -4,7 +4,7 @@ import { icon, stats } from "../icons";
 export function statsButton(parent: Effect, visible: Signal<boolean>): HTMLElement {
 	const button = document.createElement("button");
 	button.type = "button";
-	button.className = "button flex--center";
+	button.className = "button flex-center";
 	button.replaceChildren(icon(stats));
 
 	parent.run((effect) => {

--- a/js/watch/src/ui/components/volume-slider.ts
+++ b/js/watch/src/ui/components/volume-slider.ts
@@ -11,11 +11,11 @@ function volumeIcon(volumePct: number, muted: boolean): string {
 
 export function volumeSlider(parent: Effect, watch: MoqWatch): HTMLElement {
 	const wrapper = document.createElement("div");
-	wrapper.className = "watch-ui__volume-slider flex--center";
+	wrapper.className = "volume-slider flex-center";
 
 	const button = document.createElement("button");
 	button.type = "button";
-	button.className = "button flex--center";
+	button.className = "button flex-center";
 
 	const slider = document.createElement("input");
 	slider.type = "range";
@@ -23,7 +23,7 @@ export function volumeSlider(parent: Effect, watch: MoqWatch): HTMLElement {
 	slider.max = "100";
 
 	const label = document.createElement("span");
-	label.className = "watch-ui__volume-label";
+	label.className = "volume-label";
 
 	wrapper.append(button, slider, label);
 

--- a/js/watch/src/ui/components/watch-status-indicator.ts
+++ b/js/watch/src/ui/components/watch-status-indicator.ts
@@ -19,7 +19,7 @@ function deriveStatus(
 
 export function watchStatusIndicator(parent: Effect, watch: MoqWatch): HTMLElement {
 	const wrapper = document.createElement("div");
-	wrapper.className = "watch-ui__status-indicator flex--center";
+	wrapper.className = "status-indicator flex-center";
 
 	const dot = document.createElement("span");
 	const text = document.createElement("span");
@@ -31,8 +31,8 @@ export function watchStatusIndicator(parent: Effect, watch: MoqWatch): HTMLEleme
 		const broadcast = effect.get(watch.broadcast.status);
 		const { variant, text: label } = deriveStatus(url, conn, broadcast);
 
-		dot.className = `watch-ui__status-indicator-dot watch-ui__status-indicator-dot--${variant}`;
-		text.className = `watch-ui__status-indicator-text watch-ui__status-indicator-text--${variant}`;
+		dot.className = `status-indicator-dot status-indicator-dot--${variant}`;
+		text.className = `status-indicator-text status-indicator-text--${variant}`;
 		text.textContent = label;
 	});
 

--- a/js/watch/src/ui/element.ts
+++ b/js/watch/src/ui/element.ts
@@ -55,16 +55,16 @@ export default class MoqWatchUi extends HTMLElement {
 
 		const visible = new Signal(false);
 
-		const videoContainer = DOM.create("div", { className: "watch-ui__video-container" });
+		const videoContainer = DOM.create("div", { className: "video-container" });
 		videoContainer.append(
 			DOM.create("slot"),
 			statsPanel(effect, watch, visible),
 			bufferingIndicator(effect, watch),
 		);
 
-		const controls = DOM.create("div", { className: "watch-ui__controls" });
+		const controls = DOM.create("div", { className: "controls" });
 
-		const playback = DOM.create("div", { className: "watch-ui__playback-controls flex--align-center" });
+		const playback = DOM.create("div", { className: "playback-controls flex-align-center" });
 		playback.append(
 			playPauseButton(effect, watch),
 			volumeSlider(effect, watch),
@@ -73,7 +73,7 @@ export default class MoqWatchUi extends HTMLElement {
 			fullscreenButton(effect, watch),
 		);
 
-		const latency = DOM.create("div", { className: "watch-ui__latency-controls" });
+		const latency = DOM.create("div", { className: "latency-controls" });
 		latency.append(bufferControl(effect, watch), qualitySelector(effect, watch));
 
 		controls.append(playback, latency);

--- a/js/watch/src/ui/icons.ts
+++ b/js/watch/src/ui/icons.ts
@@ -30,7 +30,7 @@ export {
 
 export function icon(svg: string): HTMLElement {
 	const span = document.createElement("span");
-	span.className = "flex--center";
+	span.className = "flex-center";
 	span.setAttribute("role", "img");
 	span.setAttribute("aria-hidden", "true");
 	span.innerHTML = svg;

--- a/js/watch/src/ui/stats.ts
+++ b/js/watch/src/ui/stats.ts
@@ -8,15 +8,15 @@ const POLL_MS = 250;
 type Kind = "network" | "video" | "audio" | "buffer";
 
 function row(kind: Kind, label: string, svg: string): { el: HTMLElement; data: HTMLSpanElement } {
-	const el = DOM.create("div", { className: `stats__item stats__item--${kind}` });
+	const el = DOM.create("div", { className: `stats-item stats-item--${kind}` });
 
-	const iconWrap = DOM.create("div", { className: "stats__icon-wrapper" });
+	const iconWrap = DOM.create("div", { className: "stats-icon-wrapper" });
 	iconWrap.appendChild(icon(svg));
 
-	const title = DOM.create("span", { className: "stats__item-title" }, label);
-	const data = DOM.create("span", { className: "stats__item-data" }, "N/A");
+	const title = DOM.create("span", { className: "stats-item-title" }, label);
+	const data = DOM.create("span", { className: "stats-item-data" }, "N/A");
 
-	const detail = DOM.create("div", { className: "stats__item-detail" });
+	const detail = DOM.create("div", { className: "stats-item-detail" });
 	detail.append(title, data);
 
 	el.append(iconWrap, detail);
@@ -150,7 +150,7 @@ function bufferRow(parent: Effect, watch: MoqWatch): HTMLElement {
 
 export function statsPanel(parent: Effect, watch: MoqWatch, visible: Signal<boolean>): HTMLElement {
 	const wrap = DOM.create("div", { className: "stats" });
-	const panel = DOM.create("div", { className: "stats__panel" });
+	const panel = DOM.create("div", { className: "stats-panel" });
 	wrap.appendChild(panel);
 
 	parent.run((effect) => {

--- a/js/watch/src/ui/styles/base.css
+++ b/js/watch/src/ui/styles/base.css
@@ -44,13 +44,13 @@
 	--border-radius-lg: 1rem;
 }
 
-.flex--center {
+.flex-center {
 	display: flex;
 	justify-content: center;
 	align-items: center;
 }
 
-.flex--align-center {
+.flex-align-center {
 	align-items: center;
 }
 

--- a/js/watch/src/ui/styles/buffer-control.css
+++ b/js/watch/src/ui/styles/buffer-control.css
@@ -1,9 +1,9 @@
 /* Buffer Control styles (BEM) */
-.watch-ui__buffer {
+.buffer {
 	width: 100%;
 }
 
-.watch-ui__buffer-visualization {
+.buffer-visualization {
 	position: relative;
 	width: 100%;
 	height: 3.75rem;
@@ -15,7 +15,7 @@
 	box-sizing: border-box;
 }
 
-.watch-ui__buffer-playhead {
+.buffer-playhead {
 	position: absolute;
 	left: var(--spacing-48);
 	top: 0;
@@ -25,7 +25,7 @@
 	z-index: 3;
 }
 
-.watch-ui__buffer-track {
+.buffer-track {
 	display: flex;
 	align-items: center;
 	position: absolute;
@@ -34,15 +34,15 @@
 	height: var(--spacing-24);
 }
 
-.watch-ui__buffer-track--video {
+.buffer-track--video {
 	top: var(--spacing-4);
 }
 
-.watch-ui__buffer-track--audio {
+.buffer-track--audio {
 	top: var(--spacing-32);
 }
 
-.watch-ui__buffer-track-label {
+.buffer-track-label {
 	position: absolute;
 	left: -2.875rem;
 	width: 2.5rem;
@@ -54,7 +54,7 @@
 	box-sizing: border-box;
 }
 
-.watch-ui__buffer-canvas {
+.buffer-canvas {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -62,7 +62,7 @@
 	height: 100%;
 }
 
-.watch-ui__buffer-target-area {
+.buffer-target-area {
 	position: absolute;
 	top: 0;
 	bottom: 0;
@@ -71,7 +71,7 @@
 	pointer-events: none;
 }
 
-.watch-ui__buffer-target-line {
+.buffer-target-line {
 	position: absolute;
 	top: 0;
 	bottom: 0;
@@ -83,7 +83,7 @@
 	pointer-events: auto;
 }
 
-.watch-ui__buffer-target-label {
+.buffer-target-label {
 	position: absolute;
 	bottom: 100%;
 	left: 50%;
@@ -98,12 +98,12 @@
 	pointer-events: none;
 }
 
-.watch-ui__buffer-visualization:hover .watch-ui__buffer-target-label,
-.watch-ui__buffer-visualization--dragging .watch-ui__buffer-target-label {
+.buffer-visualization:hover .buffer-target-label,
+.buffer-visualization--dragging .buffer-target-label {
 	opacity: 1;
 }
 
-.watch-ui__buffer-help {
+.buffer-help {
 	position: absolute;
 	top: 50%;
 	left: 50%;

--- a/js/watch/src/ui/styles/buffering-indicator.css
+++ b/js/watch/src/ui/styles/buffering-indicator.css
@@ -1,4 +1,4 @@
-.watch-ui__buffering {
+.buffering {
 	position: absolute;
 	width: 100%;
 	height: 100%;
@@ -10,7 +10,7 @@
 	pointer-events: auto;
 }
 
-.watch-ui__buffering-spinner {
+.buffering-spinner {
 	width: 2.5rem;
 	height: 2.5rem;
 	border: var(--spacing-4) solid var(--color-white-alpha-20);

--- a/js/watch/src/ui/styles/controls.css
+++ b/js/watch/src/ui/styles/controls.css
@@ -1,4 +1,4 @@
-.watch-ui__video-container {
+.video-container {
 	display: block;
 	position: relative;
 	width: 100%;
@@ -8,7 +8,7 @@
 	pointer-events: none;
 }
 
-.watch-ui__controls {
+.controls {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing-24);
@@ -62,14 +62,14 @@
 	pointer-events: none;
 }
 
-.watch-ui__playback-controls {
+.playback-controls {
 	display: flex;
 	place-content: center space-around;
 	gap: var(--spacing-8);
 	padding: var(--spacing-8) 0;
 }
 
-.watch-ui__latency-controls {
+.latency-controls {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing-16);

--- a/js/watch/src/ui/styles/quality-selector.css
+++ b/js/watch/src/ui/styles/quality-selector.css
@@ -1,4 +1,4 @@
-.watch-ui__quality-selector {
+.quality-selector {
 	display: flex;
 	align-items: center;
 	gap: var(--spacing-8);
@@ -6,14 +6,14 @@
 	border-radius: var(--spacing-8);
 }
 
-.watch-ui__quality-label {
+.quality-label {
 	font-size: 1.25rem;
 	font-weight: 500;
 	color: var(--color-white);
 	white-space: nowrap;
 }
 
-.watch-ui__quality-select {
+.quality-select {
 	flex: 0 1 auto;
 	font-size: 1rem;
 	padding: var(--spacing-8);
@@ -25,16 +25,16 @@
 	transition: background 0.2s ease;
 }
 
-.watch-ui__quality-select:hover {
+.quality-select:hover {
 	background: var(--color-white-alpha-15);
 }
 
-.watch-ui__quality-select:focus {
+.quality-select:focus {
 	outline: var(--spacing-2) solid var(--color-white-alpha-30);
 	outline-offset: var(--spacing-2);
 }
 
-.watch-ui__quality-select option {
+.quality-select option {
 	background: var(--color-gray-950);
 	color: var(--color-white);
 }

--- a/js/watch/src/ui/styles/stats.css
+++ b/js/watch/src/ui/styles/stats.css
@@ -11,7 +11,7 @@
 	container-type: inline-size;
 }
 
-.stats .stats__panel {
+.stats .stats-panel {
 	position: absolute;
 	display: flex;
 	align-items: flex-start;
@@ -30,20 +30,20 @@
 }
 
 @container (width > 480px) and (width <= 768px) {
-	.stats .stats__panel {
+	.stats .stats-panel {
 		max-width: 360px;
 		padding: var(--spacing-24);
 	}
 }
 
 @container (width > 768px) {
-	.stats .stats__panel {
+	.stats .stats-panel {
 		max-width: 600px;
 		padding: var(--spacing-24);
 	}
 }
 
-.stats .stats__panel .stats__item {
+.stats .stats-panel .stats-item {
 	display: flex;
 	align-items: flex-start;
 	justify-content: flex-start;
@@ -56,12 +56,12 @@
 }
 
 @container (width > 480px) {
-	.stats .stats__panel .stats__item {
+	.stats .stats-panel .stats-item {
 		flex-basis: calc(25% - var(--spacing-12));
 	}
 }
 
-.stats .stats__panel .stats__item .stats__icon-wrapper {
+.stats .stats-panel .stats-item .stats-icon-wrapper {
 	display: none;
 	padding: var(--spacing-8);
 	border-radius: 8px;
@@ -71,7 +71,7 @@
 }
 
 @container (width > 480px) {
-	.stats .stats__panel .stats__item .stats__icon-wrapper {
+	.stats .stats-panel .stats-item .stats-icon-wrapper {
 		width: 24px;
 		height: 24px;
 		display: flex;
@@ -81,48 +81,48 @@
 	}
 }
 
-.stats .stats__panel .stats__item .stats__icon-wrapper svg {
+.stats .stats-panel .stats-item .stats-icon-wrapper svg {
 	width: 100%;
 	height: 100%;
 }
 
-.stats .stats__panel .stats__item.stats__item--network .stats__icon-wrapper {
+.stats .stats-panel .stats-item.stats-item--network .stats-icon-wrapper {
 	background-color: var(--color-blue-900);
 }
 
-.stats .stats__panel .stats__item.stats__item--network,
-.stats .stats__panel .stats__item.stats__item--network .stats__item-data {
+.stats .stats-panel .stats-item.stats-item--network,
+.stats .stats-panel .stats-item.stats-item--network .stats-item-data {
 	color: var(--color-blue-400);
 }
 
-.stats .stats__panel .stats__item.stats__item--video .stats__icon-wrapper {
+.stats .stats-panel .stats-item.stats-item--video .stats-icon-wrapper {
 	background-color: var(--color-purple-900);
 }
 
-.stats .stats__panel .stats__item.stats__item--video,
-.stats .stats__panel .stats__item.stats__item--video .stats__item-data {
+.stats .stats-panel .stats-item.stats-item--video,
+.stats .stats-panel .stats-item.stats-item--video .stats-item-data {
 	color: var(--color-purple-400);
 }
 
-.stats .stats__panel .stats__item.stats__item--audio .stats__icon-wrapper {
+.stats .stats-panel .stats-item.stats-item--audio .stats-icon-wrapper {
 	background-color: var(--color-green-900);
 }
 
-.stats .stats__panel .stats__item.stats__item--audio,
-.stats .stats__panel .stats__item.stats__item--audio .stats__item-data {
+.stats .stats-panel .stats-item.stats-item--audio,
+.stats .stats-panel .stats-item.stats-item--audio .stats-item-data {
 	color: var(--color-green-400);
 }
 
-.stats .stats__panel .stats__item.stats__item--buffer .stats__icon-wrapper {
+.stats .stats-panel .stats-item.stats-item--buffer .stats-icon-wrapper {
 	background-color: var(--color-orange-900);
 }
 
-.stats .stats__panel .stats__item.stats__item--buffer,
-.stats .stats__panel .stats__item.stats__item--buffer .stats__item-data {
+.stats .stats-panel .stats-item.stats-item--buffer,
+.stats .stats-panel .stats-item.stats-item--buffer .stats-item-data {
 	color: var(--color-orange-400);
 }
 
-.stats .stats__panel .stats__item .stats__item-detail {
+.stats .stats-panel .stats-item .stats-item-detail {
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-evenly;
@@ -130,7 +130,7 @@
 	gap: var(--spacing-4);
 }
 
-.stats .stats__panel .stats__item .stats__item-detail .stats__item-title {
+.stats .stats-panel .stats-item .stats-item-detail .stats-item-title {
 	font-size: 12px;
 	font-weight: 500;
 	text-transform: capitalize;
@@ -140,7 +140,7 @@
 	line-height: 12px;
 }
 
-.stats .stats__panel .stats__item .stats__item-detail .stats__item-data {
+.stats .stats-panel .stats-item .stats-item-detail .stats-item-data {
 	font-size: 16px;
 	font-weight: bold;
 	font-family: "Segoe UI", Roboto, sans-serif;

--- a/js/watch/src/ui/styles/status-indicator.css
+++ b/js/watch/src/ui/styles/status-indicator.css
@@ -1,9 +1,9 @@
-.watch-ui__status-indicator {
+.status-indicator {
 	gap: var(--spacing-12);
 	backdrop-filter: blur(var(--spacing-16));
 }
 
-.watch-ui__status-indicator-dot {
+.status-indicator-dot {
 	position: relative;
 	width: 0.75rem;
 	height: 0.75rem;
@@ -12,7 +12,7 @@
 	z-index: 1;
 }
 
-.watch-ui__status-indicator-dot::after {
+.status-indicator-dot::after {
 	content: "";
 	position: absolute;
 	inset: 0;
@@ -24,63 +24,63 @@
 	z-index: -1;
 }
 
-.watch-ui__status-indicator-dot::after {
+.status-indicator-dot::after {
 	display: none;
 }
 
-.watch-ui__status-indicator-dot--live::after,
-.watch-ui__status-indicator-dot--connected::after,
-.watch-ui__status-indicator-dot--loading::after,
-.watch-ui__status-indicator-dot--connecting::after {
+.status-indicator-dot--live::after,
+.status-indicator-dot--connected::after,
+.status-indicator-dot--loading::after,
+.status-indicator-dot--connecting::after {
 	display: block;
 }
 
-.watch-ui__status-indicator-dot--error {
+.status-indicator-dot--error {
 	background: var(--color-gray-100);
 	color: var(--color-gray-100);
 }
 
-.watch-ui__status-indicator-text--error {
+.status-indicator-text--error {
 	color: var(--color-gray-100);
 }
 
-.watch-ui__status-indicator-dot--connecting {
+.status-indicator-dot--connecting {
 	background: var(--color-yellow-400);
 	color: var(--color-yellow-400);
 }
 
-.watch-ui__status-indicator-text--connecting {
+.status-indicator-text--connecting {
 	color: var(--color-yellow-400);
 }
 
-.watch-ui__status-indicator-dot--loading {
+.status-indicator-dot--loading {
 	background: var(--color-yellow-400);
 	color: var(--color-yellow-400);
 }
 
-.watch-ui__status-indicator-text--loading {
+.status-indicator-text--loading {
 	color: var(--color-yellow-400);
 }
 
-.watch-ui__status-indicator-dot--live {
+.status-indicator-dot--live {
 	background: var(--color-green-400);
 	color: var(--color-green-400);
 }
 
-.watch-ui__status-indicator-text--live {
+.status-indicator-text--live {
 	color: var(--color-green-400);
 }
 
-.watch-ui__status-indicator-dot--connected {
+.status-indicator-dot--connected {
 	background: var(--color-blue-500);
 	color: var(--color-blue-500);
 }
 
-.watch-ui__status-indicator-text--connected {
+.status-indicator-text--connected {
 	color: var(--color-blue-500);
 }
 
-.watch-ui__status-indicator-text {
+.status-indicator-text {
 	font-size: 1rem;
 	letter-spacing: 0.1rem;
 }

--- a/js/watch/src/ui/styles/volume-slider.css
+++ b/js/watch/src/ui/styles/volume-slider.css
@@ -1,8 +1,8 @@
-.watch-ui__volume-slider {
+.volume-slider {
 	gap: var(--spacing-4);
 }
 
-.watch-ui__volume-label {
+.volume-label {
 	width: var(--spacing-16);
 	text-align: right;
 }


### PR DESCRIPTION
## Summary

Shadow DOM already scopes class names, so the `watch-ui__` / `publish-ui__` / `stats__` prefixes were redundant. Dropping them and collapsing the `flex--*` utilities to single-hyphen names.

- Audited all 73 class selectors against literal strings, template fragments (`${variant}`, `${kind}`), and `classList.add/remove` calls — **zero unused classes**, nothing was deleted.
- Pure mechanical rename, no behavior change.

## Bundle sizes (`ui/element.js`)

| | raw | gz |
|---|---|---|
| watch  | 30,569 → 29,660 (−909 B) | 7,423 → 7,374 (**−49 B**, −0.7%) |
| publish | 17,376 → 16,569 (−807 B) | 4,164 → 4,127 (**−37 B**, −0.9%) |

Gzip already deduplicates repeated prefix strings well, so wire-byte savings are small. The real win is source readability: ~5% smaller CSS source and no noise prefixes in the `className = "..."` strings.

## Test plan

- [x] `just check` passes
- [x] `bun run build` succeeds in both packages
- [ ] Smoke test watch UI in browser: play/pause, volume, fullscreen, stats panel toggle, buffer control, quality selector, status indicator all render correctly
- [ ] Smoke test publish UI in browser: source buttons render with correct colors, "Nothing" ban icon shows red when active, media selector dropdown appears when multiple devices are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)