### PR TITLE
moq-lite: tolerate Ended for unknown paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -154,9 +154,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					let path = prefix.join(&suffix);
 					tracing::debug!(broadcast = %self.log_path(&path), "unannounced");
 
-					// Abort the producer.
-					let mut producer = producers.remove(&path).ok_or(Error::NotFound)?;
-					producer.abort(Error::Cancel).ok();
+					// The matching Active may have been silently dropped by
+					// start_announce as a reflected loop, in which case
+					// `producers` has no entry; that's expected, not an error.
+					if let Some(mut producer) = producers.remove(&path) {
+						producer.abort(Error::Cancel).ok();
+					}
 				}
 			}
 		}

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary

- Fixes a v0.11.1 regression introduced by #1420 that crashed cluster sessions with `NotFound` (code=13) on the first unannounce.
- Cluster loop detection silently drops reflected `Active` announces in `start_announce`, and the publisher side also skips them via `exclude_hop` / `self_origin` checks. Either way, when the upstream broadcast later closes, the peer sends `Ended` for a path the receiver never tracked — and `producers.remove(&path).ok_or(Error::NotFound)?` killed the whole session.
- In a full mesh every broadcast traverses N−1 paths and loop-detect fires on N−2 of them, so the first unannounce tore down every cluster link. Demo viewers then couldn't find any broadcasts and were closed shortly after accept.
- Fix: ignore `Ended` for unknown paths in `Subscriber::run_announce_prefix`. Bumps moq-relay to 0.11.2.

## Test plan

- [x] `just check` passes locally
- [ ] Deploy and confirm cluster mesh holds (peers stop cycling with `code=13 reason=not found`)
- [ ] Demo viewers stay connected past the announce phase