### PR TITLE
chore: build and cache moq-boy on release tags

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -6,6 +6,7 @@ on:
       - 'moq-relay-v*'
       - 'moq-token-cli-v*'
       - 'moq-cli-v*'
+      - 'moq-boy-v*'
 
 jobs:
   cache:
@@ -46,4 +47,9 @@ jobs:
       - name: Build and cache moq-token-cli
         run: |
           nix build .#moq-token-cli --print-build-logs
+          cachix push kixelated ./result
+
+      - name: Build and cache moq-boy
+        run: |
+          nix build .#moq-boy --print-build-logs
           cachix push kixelated ./result


### PR DESCRIPTION
## Summary
- Add `moq-boy-v*` to the Cachix workflow's tag triggers
- Add a build/push step for `moq-boy` alongside the existing relay/cli/token-cli steps

This means when release-plz (or a manual tag) cuts a new `moq-boy-v*`, the binary's closure gets pushed to Cachix on both Ubuntu and macOS. The boy CDN deployment in `cdn/boy` already pins to the latest `moq-boy-v*` tag, so it'll start pulling pre-built binaries instead of compiling on the Linode box.

## Test plan
- [ ] Workflow YAML is syntactically valid (verified by GitHub Actions on push)
- [ ] On next `moq-boy-v*` tag, confirm both ubuntu-latest and macos-latest jobs build and push successfully
- [ ] On next `cdn/boy` deploy, confirm the binary comes from cache rather than a full rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)