### PR TITLE
moq-lite: keep probe stream errors out of the session

### DIFF
--- a/js/lite/src/lite/publisher.ts
+++ b/js/lite/src/lite/publisher.ts
@@ -281,8 +281,10 @@ export class Publisher {
 			getStats?: () => Promise<{ estimatedSendRate: number | null }>;
 		};
 		if (!quic.getStats) {
-			// Close gracefully instead of aborting to avoid killing the session.
-			stream.close();
+			// Best-effort: close the write side with a FIN so the peer's reader sees EOF.
+			// Don't STOP_SENDING the read side, which can surface as a session-level
+			// error in some WebTransport implementations.
+			stream.writer.close();
 			return;
 		}
 
@@ -322,9 +324,8 @@ export class Publisher {
 				}
 			}
 		} catch (err: unknown) {
-			const e = error(err);
-			console.warn(`probe error: ${e.message}`);
-			stream.abort(e);
+			console.warn("probe stream error", err);
+			stream.writer.close();
 		}
 	}
 

--- a/js/lite/src/lite/publisher.ts
+++ b/js/lite/src/lite/publisher.ts
@@ -281,10 +281,9 @@ export class Publisher {
 			getStats?: () => Promise<{ estimatedSendRate: number | null }>;
 		};
 		if (!quic.getStats) {
-			// Best-effort: close the write side with a FIN so the peer's reader sees EOF.
-			// Don't STOP_SENDING the read side, which can surface as a session-level
-			// error in some WebTransport implementations.
-			stream.writer.close();
+			// Best-effort: we can't supply bandwidth estimates, so close the
+			// whole bidi (FIN + STOP_SENDING) to let the peer release its end.
+			stream.close();
 			return;
 		}
 
@@ -325,7 +324,7 @@ export class Publisher {
 			}
 		} catch (err: unknown) {
 			console.warn("probe stream error", err);
-			stream.writer.close();
+			stream.close();
 		}
 	}
 

--- a/js/lite/src/lite/subscriber.ts
+++ b/js/lite/src/lite/subscriber.ts
@@ -258,16 +258,26 @@ export class Subscriber {
 		if (!this.#recvBandwidth) return;
 		if (this.version === Version.DRAFT_01 || this.version === Version.DRAFT_02) return;
 
-		const stream = await Stream.open(this.#quic);
-		await stream.writer.u53(StreamId.Probe);
+		// Probe is best-effort: any failure (stream reset by peer, missing peer support,
+		// transport hiccup) MUST NOT tear down the connection. On error, drop the
+		// bandwidth/RTT estimates so consumers know they're stale.
+		try {
+			const stream = await Stream.open(this.#quic);
+			await stream.writer.u53(StreamId.Probe);
 
-		for (;;) {
-			const probe = await Probe.decodeMaybe(stream.reader, this.version);
-			if (!probe) break;
-			this.#recvBandwidth.set(probe.bitrate || undefined);
-			if (this.#rtt && probe.rtt !== undefined) {
-				this.#rtt.set(probe.rtt as Time.Milli);
+			for (;;) {
+				const probe = await Probe.decodeMaybe(stream.reader, this.version);
+				if (!probe) break;
+				this.#recvBandwidth.set(probe.bitrate || undefined);
+				if (this.#rtt && probe.rtt !== undefined) {
+					this.#rtt.set(probe.rtt as Time.Milli);
+				}
 			}
+		} catch (err: unknown) {
+			console.warn("probe stream error", err);
+		} finally {
+			this.#recvBandwidth.set(undefined);
+			this.#rtt?.set(undefined);
 		}
 	}
 

--- a/js/lite/src/lite/subscriber.ts
+++ b/js/lite/src/lite/subscriber.ts
@@ -275,7 +275,7 @@ export class Subscriber {
 			for (;;) {
 				const probe = await Probe.decodeMaybe(stream.reader, this.version);
 				if (!probe) break;
-				this.#recvBandwidth.set(probe.bitrate || undefined);
+				this.#recvBandwidth.set(probe.bitrate ?? undefined);
 				if (this.#rtt && probe.rtt !== undefined) {
 					this.#rtt.set(probe.rtt as Time.Milli);
 				}

--- a/js/lite/src/lite/subscriber.ts
+++ b/js/lite/src/lite/subscriber.ts
@@ -250,7 +250,11 @@ export class Subscriber {
 	/**
 	 * Opens a PROBE bidi stream to receive bandwidth estimates from the publisher.
 	 * Returns immediately if recv bandwidth is not supported.
-	 * Errors are fatal and propagate to the connection.
+	 *
+	 * Probe is best-effort telemetry: a stream-level failure (peer reset, FIN,
+	 * missing peer support, transport hiccup) is caught and logged, never
+	 * propagated to the connection. On exit the bandwidth/RTT signals are
+	 * cleared so consumers see them as stale.
 	 *
 	 * @internal
 	 */

--- a/rs/moq-lite/src/lite/publisher.rs
+++ b/rs/moq-lite/src/lite/publisher.rs
@@ -74,18 +74,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let version = self.version;
 
 		web_async::spawn(async move {
-			if let Err(err) = Self::run_probe(&session, &mut stream, version).await {
-				match &err {
-					Error::Cancel | Error::Transport(_) => {
-						tracing::debug!("probe stream closed");
-					}
-					err => {
-						tracing::warn!(%err, "probe stream error");
-					}
+			match Self::run_probe(&session, &mut stream, version).await {
+				Ok(()) => {
+					tracing::debug!("probe stream closed");
 				}
-				stream.writer.abort(&err);
-			} else {
-				tracing::debug!("probe stream complete");
+				Err(err) => {
+					tracing::warn!(%err, "probe stream error");
+					stream.writer.abort(&err);
+				}
 			}
 		});
 	}

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -170,23 +170,37 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	/// Opens a PROBE stream when consumers exist, reads bandwidth estimates.
-	/// Returns Ok(()) only when recv_bandwidth is None (disabled).
-	/// Stream-level errors (e.g. peer reset) are non-fatal and logged as debug.
+	///
+	/// PROBE measures the peer's upload bandwidth to us, which is only meaningful
+	/// when the peer is publishing broadcasts. If we have no origin to insert
+	/// remote broadcasts into, skip the probe stream entirely. Otherwise probe
+	/// is best-effort: any failure here MUST NOT tear down the session, so on
+	/// error we abort the BandwidthProducer and return Ok.
 	async fn run_recv_bandwidth(self) -> Result<(), Error> {
+		if self.origin.is_none() {
+			return Ok(());
+		}
+
 		let Some(bandwidth) = &self.recv_bandwidth else {
 			return Ok(());
 		};
 
-		bandwidth.used().await?;
-
-		let res = self.run_probe_stream(bandwidth).await;
-		match res {
-			Ok(()) | Err(Error::Cancel | Error::Transport(_) | Error::Decode(_) | Error::Remote(_)) => {
-				tracing::debug!("probe stream closed");
-				Ok(())
-			}
-			Err(err) => Err(err),
+		if let Err(err) = bandwidth.used().await {
+			tracing::warn!(%err, "probe stream error");
+			return Ok(());
 		}
+
+		match self.run_probe_stream(bandwidth).await {
+			Ok(()) => {
+				tracing::debug!("probe stream closed");
+			}
+			Err(err) => {
+				tracing::warn!(%err, "probe stream error");
+				let _ = bandwidth.close(err);
+			}
+		}
+
+		Ok(())
 	}
 
 	async fn run_probe_stream(&self, bandwidth: &BandwidthProducer) -> Result<(), Error> {

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -169,13 +169,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		stream.writer.closed().await
 	}
 
-	/// Opens a PROBE stream when consumers exist, reads bandwidth estimates.
+	/// Opens a PROBE stream on demand while a consumer is interested.
 	///
 	/// PROBE measures the peer's upload bandwidth to us, which is only meaningful
 	/// when the peer is publishing broadcasts. If we have no origin to insert
-	/// remote broadcasts into, skip the probe stream entirely. Otherwise probe
-	/// is best-effort: any failure here MUST NOT tear down the session, so on
-	/// error we abort the BandwidthProducer and return Ok.
+	/// remote broadcasts into, skip the probe stream entirely.
+	///
+	/// Otherwise loop forever: wait for a consumer, race the probe stream against
+	/// the consumer leaving, then loop back. Probe is best-effort, so stream
+	/// errors are logged but never tear down the session.
 	async fn run_recv_bandwidth(self) -> Result<(), Error> {
 		if self.origin.is_none() {
 			return Ok(());
@@ -185,47 +187,37 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Ok(());
 		};
 
-		if let Err(err) = bandwidth.used().await {
-			tracing::warn!(%err, "probe stream error");
-			return Ok(());
-		}
-
-		match self.run_probe_stream(bandwidth).await {
-			Ok(()) => {
-				tracing::debug!("probe stream closed");
+		loop {
+			// Wait until at least one consumer is interested in the estimate.
+			if bandwidth.used().await.is_err() {
+				return Ok(());
 			}
-			Err(err) => {
-				tracing::warn!(%err, "probe stream error");
-				let _ = bandwidth.close(err);
+
+			tokio::select! {
+				res = bandwidth.unused() => {
+					if res.is_err() {
+						return Ok(());
+					}
+				}
+				res = self.run_probe_stream(bandwidth) => {
+					match res {
+						Ok(()) => tracing::debug!("probe stream closed"),
+						Err(err) => tracing::warn!(%err, "probe stream error"),
+					}
+				}
 			}
 		}
-
-		Ok(())
 	}
 
 	async fn run_probe_stream(&self, bandwidth: &BandwidthProducer) -> Result<(), Error> {
 		let mut stream = Stream::open(&self.session, self.version).await?;
 		stream.writer.encode(&lite::ControlType::Probe).await?;
 
-		loop {
-			tokio::select! {
-				biased;
-				_ = bandwidth.closed() => {
-					stream.writer.finish()?;
-					return stream.writer.closed().await;
-				}
-				res = bandwidth.unused() => {
-					res?;
-					// No more consumers, close the probe stream.
-					stream.writer.finish()?;
-					return stream.writer.closed().await;
-				}
-				probe = stream.reader.decode::<lite::Probe>() => {
-					let probe = probe?;
-					bandwidth.set(Some(probe.bitrate))?;
-				}
-			}
+		while let Some(probe) = stream.reader.decode_maybe::<lite::Probe>().await? {
+			bandwidth.set(Some(probe.bitrate))?;
 		}
+
+		Ok(())
 	}
 
 	fn start_announce(

--- a/rs/moq-lite/src/lite/subscriber.rs
+++ b/rs/moq-lite/src/lite/subscriber.rs
@@ -198,12 +198,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					if res.is_err() {
 						return Ok(());
 					}
+					// Loop back: a new consumer may arrive later.
 				}
 				res = self.run_probe_stream(bandwidth) => {
 					match res {
 						Ok(()) => tracing::debug!("probe stream closed"),
 						Err(err) => tracing::warn!(%err, "probe stream error"),
 					}
+					// Stream ended (peer FIN'd or errored). Don't hammer an
+					// uncooperative peer; give up for the rest of the session.
+					return Ok(());
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

PROBE is best-effort telemetry, but a stream-level failure (peer reset, FIN, missing `getStats`, transport hiccup) was tearing down the entire session on both ends. This change scopes those failures to the probe stream itself.

- **JS \`Subscriber.runProbe\`**: catches all errors, drops the \`recvBandwidth\`/\`rtt\` signals back to \`undefined\`, never throws into \`Connection.#run\`'s \`Promise.all\`.
- **JS \`Publisher.runProbe\`**: declines gracefully via \`stream.close()\` when the browser has no \`getStats\`; same on the error path.
- **Rust \`Subscriber::run_recv_bandwidth\`**: gated on \`self.origin.is_some()\` so viewer-only sessions skip the outbound probe entirely. Wraps an outer loop with \`select!(unused, run_probe_stream)\` so the stream only stays open while a \`BandwidthConsumer\` exists; reopens when a new consumer arrives. If the probe stream ends (peer FIN'd or errored), we don't reopen against an uncooperative peer for the rest of the session.
- **Rust \`Publisher::recv_probe\`**: \`debug!(\"probe stream closed\")\` on \`Ok\`, \`warn!(%err, \"probe stream error\")\` with the actual error otherwise.

## Test plan
- [ ] \`just check\` passes
- [ ] \`just dev\`: web demo connects to local relay, no \`probe stream error\` / \`session is closed\` cascade, bbb stream renders (depends on the separate AnnounceInterest.exclude_hop fix landing first)
- [ ] Local relay + watcher with full publish/subscribe perms still negotiates the outbound probe (verify \`recvBandwidth\` updates as before)

> Note: the actual session-tear-down bug was an unrelated \`u53\` overflow in \`AnnounceInterest.exclude_hop\` — see the follow-up PR. The changes here are independent quality-of-life / resilience tweaks for the probe lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)