### PR TITLE
moq-lite: fix AnnounceInterest.exclude_hop overflow on JS side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "moq-lite"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "bytes",
  "conducer",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/js/lite/package.json
+++ b/js/lite/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/lite",
 	"type": "module",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/lite/src/lite/announce.ts
+++ b/js/lite/src/lite/announce.ts
@@ -92,9 +92,11 @@ export class Announce {
 
 export class AnnounceInterest {
 	prefix: Path.Valid;
-	excludeHop: number;
+	// 62-bit Origin id of the peer asking for announces. Zero means "no exclusion".
+	// Must be a bigint: peer origins are up to 62 bits and overflow u53.
+	excludeHop: bigint;
 
-	constructor(prefix: Path.Valid, excludeHop = 0) {
+	constructor(prefix: Path.Valid, excludeHop: bigint = 0n) {
 		this.prefix = prefix;
 		this.excludeHop = excludeHop;
 	}
@@ -107,22 +109,22 @@ export class AnnounceInterest {
 			case Version.DRAFT_03:
 				break;
 			default:
-				// Lite04+: exclude_hop field
-				await w.u53(this.excludeHop);
+				// Lite04+: exclude_hop field (u62 varint).
+				await w.u62(this.excludeHop);
 				break;
 		}
 	}
 
 	static async #decode(r: Reader, version: Version): Promise<AnnounceInterest> {
 		const prefix = Path.from(await r.string());
-		let excludeHop = 0;
+		let excludeHop = 0n;
 		switch (version) {
 			case Version.DRAFT_01:
 			case Version.DRAFT_02:
 			case Version.DRAFT_03:
 				break;
 			default:
-				excludeHop = await r.u53();
+				excludeHop = await r.u62();
 				break;
 		}
 		return new AnnounceInterest(prefix, excludeHop);

--- a/js/lite/src/lite/subscriber.ts
+++ b/js/lite/src/lite/subscriber.ts
@@ -93,7 +93,10 @@ export class Subscriber {
 
 	async #runAnnounced(announced: Announced, prefix: Path.Valid, options: AnnouncedOptions): Promise<void> {
 		console.debug(`announced: prefix=${prefix}`);
-		const msg = new AnnounceInterest(prefix);
+		// Send our own session-level origin id so the peer can skip announces
+		// whose hop chain already passed through us. Matches the Rust subscriber's
+		// `exclude_hop: self.self_origin.id` in `run_announce_prefix`.
+		const msg = new AnnounceInterest(prefix, this.origin);
 
 		try {
 			// Open a stream and send the announce interest.

--- a/js/lite/src/stream.ts
+++ b/js/lite/src/stream.ts
@@ -170,11 +170,14 @@ export class Reader {
 		return result;
 	}
 
-	// Returns a Number using 53-bits, the max Javascript can use for integer math
+	// Returns a Number using 53-bits, the max Javascript can use for integer math.
+	// Values > 2^53-1 are coerced to a Number (precision is lost) and logged. We
+	// downgrade overflow from throw to warn so a stray u64 field on the wire (e.g.
+	// a peer's session-level Origin id) doesn't tear down the whole stream/session.
 	async u53(): Promise<number> {
 		const v = await this.u62();
 		if (v > Varint.MAX_U53) {
-			throw new Error("value larger than 53-bits; use v62 instead");
+			console.warn(`value larger than 53-bits; use u62 instead (precision lost): ${v.toString()}`);
 		}
 
 		return Number(v);
@@ -303,7 +306,11 @@ export class Writer {
 
 	async u53(v: number) {
 		if (v > Varint.MAX_U53) {
-			throw new Error(`overflow, value larger than 53-bits: ${v.toString()}`);
+			// Number values above 2^53-1 have already lost precision before reaching
+			// the wire, but downgrade overflow to warn so an upstream miscount
+			// doesn't tear down the whole stream. The encoded varint will reflect
+			// the truncated Number value.
+			console.warn(`value larger than 53-bits; use u62 instead (precision lost): ${v.toString()}`);
 		}
 		if (isLeadingOnes(this.version)) {
 			await this.write(Varint.encodeLeadingOnesTo(this.#scratch, v));

--- a/rs/moq-lite/Cargo.toml
+++ b/rs/moq-lite/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.16.2"
+version = "0.16.3"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-lite/src/model/origin.rs
+++ b/rs/moq-lite/src/model/origin.rs
@@ -32,11 +32,17 @@ impl Origin {
 	/// Never encoded for Lite04+: violates the non-zero invariant and would fail to round-trip.
 	pub(crate) const UNKNOWN: Self = Self { id: 0 };
 
-	/// Generate a fresh origin with a random non-zero 62-bit id. Use this for any
+	/// Generate a fresh origin with a random non-zero id. Use this for any
 	/// origin that does not need a stable identity across restarts.
+	///
+	/// TEMPORARY: the wire format allows 62 bits, but older `@moq/lite` JS
+	/// clients decode `AnnounceInterest.exclude_hop` as a u53 (number) and
+	/// throw on anything > 2^53-1. To keep those clients alive against
+	/// fresh relays, we cap the random id at 53 bits. Restore to 62 bits
+	/// once the JS u62 fix has propagated to deployed bundles.
 	pub fn random() -> Self {
 		let mut rng = rand::rng();
-		let id = rng.random_range(1..(1u64 << 62));
+		let id = rng.random_range(1..(1u64 << 53));
 		Self { id }
 	}
 

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary

Browsers connecting to a fresh relay over \`moq-lite-04\` were getting their session torn down ~7ms after the handshake, with \`WebTransportError: The session is closed\` cascading through every in-flight stream. Root cause was a field-width mismatch in JS.

The Rust relay sends its session-level Origin id (62-bit, ~10^18) as \`AnnounceInterest.exclude_hop\` so peers can skip reflected announces. The JS decoder read it via \`r.u53()\`, which throws on anything > \`2^53-1\`. The throw inside \`#runBidi\` was caught by \`stream.writer.reset(err)\` with an \`Error\` object as the reason, which Chrome's WebTransport surfaces as a session-level abort (\`remote error: code=0\`). Everything else followed from there.

### JS

- \`AnnounceInterest.excludeHop\` is now \`bigint\`, encoded/decoded via \`u62\`. (\`js/lite/src/lite/announce.ts\`)
- \`Subscriber.#runAnnounced\` passes \`this.origin\` as \`excludeHop\`, matching the Rust subscriber's \`self.self_origin.id\`. (\`js/lite/src/lite/subscriber.ts\`)
- \`Reader.u53\` / \`Writer.u53\` downgrade overflow from \`throw\` to \`console.warn\` (precision is lost, the warning surfaces the value). A stray u64 on the wire can no longer tear down a stream/session. (\`js/lite/src/stream.ts\`)

### Rust

- \`Origin::random\` **temporarily** caps the random id at 53 bits so older deployed \`@moq/lite\` bundles (still on the buggy u53 decoder) survive a fresh relay. Restore to 62 bits once the JS fix has propagated. (\`rs/moq-lite/src/model/origin.rs\`)

### Version bumps

- \`@moq/lite\` 0.2.3 → 0.2.4
- \`moq-lite\` 0.16.2 → 0.16.3
- \`moq-relay\` 0.11.2 → 0.11.3

## Test plan
- [ ] \`just check\` passes
- [ ] \`just dev\`: web demo connects, no \`session is closed\` cascade, bbb stream renders
- [ ] \`just web serve https://cdn.moq.dev/demo\` against a relay built from this PR: connection stays up
- [ ] Older \`@moq/lite\` bundles still work against a relay from this PR (origin id capped to 53 bits)

> Probe-lifecycle cleanups landed separately in #1426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)