### PR TITLE
Tag audio sources with a kind to drive Opus encoder settings

### DIFF
--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -5,7 +5,7 @@ import type * as Moq from "@moq/net";
 import type { Time } from "@moq/net";
 import { Effect, type Getter, Signal } from "@moq/signals";
 import type * as Capture from "./capture";
-import type { Source } from "./types";
+import { type Kind, normalizeSource, type Source } from "./types";
 
 const GAIN_MIN = 0.001;
 const FADE_TIME = 0.2;
@@ -69,9 +69,10 @@ export class Encoder {
 	#runSource(effect: Effect): void {
 		const values = effect.getAll([this.enabled, this.source]);
 		if (!values) return;
-		const [_, source] = values;
+		const [_, rawSource] = values;
+		const source = normalizeSource(rawSource);
 
-		const settings = source.getSettings();
+		const settings = source.track.getSettings();
 		const overrideSampleRate = effect.get(this.sampleRate);
 		const sampleRate = overrideSampleRate ?? settings.sampleRate;
 
@@ -82,7 +83,7 @@ export class Encoder {
 		effect.cleanup(() => context.close());
 
 		const root = new MediaStreamAudioSourceNode(context, {
-			mediaStream: new MediaStream([source]),
+			mediaStream: new MediaStream([source.track]),
 		});
 		effect.cleanup(() => root.disconnect());
 
@@ -196,8 +197,12 @@ export class Encoder {
 				config = effect.get(this.#config);
 				if (!config) return;
 
-				console.debug("encoding audio", config);
-				encoder.configure(config);
+				const source = effect.get(this.source);
+				const kind: Kind = source ? normalizeSource(source).kind : "auto";
+				const encoderConfig = toEncoderConfig(config, kind);
+
+				console.debug("encoding audio", encoderConfig);
+				encoder.configure(encoderConfig);
 			});
 
 			effect.event(worklet.port, "message", (event: Event) => {
@@ -253,4 +258,32 @@ export class Encoder {
 	close() {
 		this.#signals.close();
 	}
+}
+
+// `application` and `signal` are in the WebCodecs spec but missing from lib.dom.d.ts.
+// https://www.w3.org/TR/webcodecs-opus-codec-registration/#dom-opusencoderconfig
+interface OpusEncoderConfigExt extends OpusEncoderConfig {
+	application?: "voip" | "audio" | "lowdelay";
+	signal?: "auto" | "voice" | "music";
+}
+
+// Build the WebCodecs encoder config from the catalog (decoder) config plus a Kind hint.
+// Opus-only knobs are kept out of the catalog since they only affect encoding.
+function toEncoderConfig(config: Catalog.AudioConfig, kind: Kind): AudioEncoderConfig {
+	const encoderConfig: AudioEncoderConfig = {
+		codec: config.codec,
+		sampleRate: config.sampleRate,
+		numberOfChannels: config.numberOfChannels,
+		bitrate: config.bitrate,
+	};
+
+	if (config.codec === "opus" && kind !== "auto") {
+		const opus: OpusEncoderConfigExt = {
+			application: kind === "voice" ? "voip" : "audio",
+			signal: kind,
+		};
+		encoderConfig.opus = opus;
+	}
+
+	return encoderConfig;
 }

--- a/js/publish/src/audio/types.ts
+++ b/js/publish/src/audio/types.ts
@@ -1,4 +1,21 @@
-export type Source = StreamTrack;
+// The kind of audio being encoded. Drives Opus application/signal settings on the encoder.
+// - "voice": speech (microphone). Opus application=voip + signal=voice.
+// - "music": music or mixed content (screen/tab capture). Opus application=audio + signal=music.
+// - "auto": let the encoder decide. Opus defaults (good for unknown sources like file playback).
+export type Kind = "voice" | "music" | "auto";
+
+// A bare track is accepted for backwards compatibility and treated as kind="auto".
+// Prefer the { track, kind } object form so the encoder can pick the right Opus settings.
+export type Source = StreamTrack | SourceConfig;
+
+export interface SourceConfig {
+	track: StreamTrack;
+	kind: Kind;
+}
+
+export function normalizeSource(source: Source): SourceConfig {
+	return source instanceof MediaStreamTrack ? { track: source as StreamTrack, kind: "auto" } : source;
+}
 
 export type Constraints = Omit<
 	MediaTrackConstraints,

--- a/js/publish/src/audio/types.ts
+++ b/js/publish/src/audio/types.ts
@@ -14,7 +14,8 @@ export interface SourceConfig {
 }
 
 export function normalizeSource(source: Source): SourceConfig {
-	return source instanceof MediaStreamTrack ? { track: source as StreamTrack, kind: "auto" } : source;
+	// Structural check rather than `instanceof MediaStreamTrack` so this stays correct across realms.
+	return "track" in source ? source : { track: source, kind: "auto" };
 }
 
 export type Constraints = Omit<

--- a/js/publish/src/source/file.ts
+++ b/js/publish/src/source/file.ts
@@ -1,5 +1,5 @@
 import { Effect, Signal } from "@moq/signals";
-import type { StreamTrack as AudioStreamTrack } from "../audio/types";
+import type * as Audio from "../audio";
 import type { StreamTrack as VideoStreamTrack } from "../video/types";
 
 export interface FileSourceConfig {
@@ -11,7 +11,7 @@ export class File {
 	file = new Signal<globalThis.File | undefined>(undefined);
 	signals = new Effect();
 
-	source = new Signal<{ video?: VideoStreamTrack; audio?: AudioStreamTrack }>({});
+	source = new Signal<{ video?: VideoStreamTrack; audio?: Audio.Source }>({});
 	enabled: Signal<boolean>;
 
 	constructor(config: FileSourceConfig) {
@@ -107,7 +107,7 @@ export class File {
 			this.source,
 			{
 				video: videoTrack as VideoStreamTrack,
-				audio: audioTrack as AudioStreamTrack,
+				audio: audioTrack ? { track: audioTrack as Audio.StreamTrack, kind: "auto" } : undefined,
 			},
 			{},
 		);

--- a/js/publish/src/source/microphone.ts
+++ b/js/publish/src/source/microphone.ts
@@ -69,7 +69,7 @@ export class Microphone {
 			}
 
 			effect.set(this.device.active, settings.deviceId);
-			effect.set(this.source, track);
+			effect.set(this.source, { track, kind: "voice" });
 		});
 	}
 

--- a/js/publish/src/source/screen.ts
+++ b/js/publish/src/source/screen.ts
@@ -68,7 +68,10 @@ export class Screen {
 			effect.cleanup(() => v?.stop());
 			effect.cleanup(() => a?.stop());
 
-			effect.set(this.source, { video: v, audio: a });
+			effect.set(this.source, {
+				video: v,
+				audio: a ? { track: a, kind: "music" } : undefined,
+			});
 		});
 	}
 

--- a/rs/moq-mux/src/export/mkv.rs
+++ b/rs/moq-mux/src/export/mkv.rs
@@ -550,6 +550,9 @@ fn ensure_legacy(container: &Container, kind: &str, name: &str) -> anyhow::Resul
 		Container::Cmaf { .. } => {
 			anyhow::bail!("MKV export does not support CMAF {} track '{}'", kind, name);
 		}
+		Container::Loc => {
+			anyhow::bail!("MKV export does not support LOC {} track '{}'", kind, name);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `Audio.Kind = 'voice' | 'music' | 'auto'` and reshape `Audio.Source` to `{ track, kind }` so each source self-describes its content type.
- Map kind to Opus `application` + `signal` when configuring the `AudioEncoder` (voice → `voip`/`voice`, music → `audio`/`music`, auto → encoder defaults). Built-in sources tag themselves: Microphone = voice, Screen = music, File = auto.
- Opus-only knobs are kept out of the catalog and composed onto a separate `AudioEncoderConfig` in `toEncoderConfig()`.
- Backwards compatible: `Source = StreamTrack | { track, kind }`. Bare-track callers normalize to `kind: 'auto'`.

## Why

Microphone and screen capture have very different signal characteristics. Opus has dedicated tuning for each via the `application` mode (VoIP pre-emphasis + SILK bias vs. fidelity-focused), and we were ignoring it. Putting the hint on the source means the orchestrator doesn't have to remember to re-set it on every source switch.

## What's not in here

- **DTX is intentionally off.** WebRTC also ships it off-by-default; enabling it interacts with the watch-side jitter buffer (silence gaps, comfort-noise repetition) and needs validation. Tracked in #1445.
- **FEC / `useinbandfec`** also left off pending a future `realtime` flag.

## Test plan

- [ ] `just check` passes (verified locally)
- [ ] Manual: publish from microphone, confirm encoder is configured with `application: voip` (devtools console: "encoding audio …" debug log)
- [ ] Manual: publish from screen capture with audio, confirm `application: audio`
- [ ] Manual: file source publishes without throwing
- [ ] No catalog change in the wire format (opus knobs stay in encoder-only config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)