### PR TITLE
Tighten moq-ffi release pipeline ahead of first publish

### DIFF
--- a/.github/workflows/release-py.yml
+++ b/.github/workflows/release-py.yml
@@ -33,6 +33,21 @@ jobs:
         id: parse
         run: .github/scripts/release.sh parse-version moq-ffi
 
+      # Maturin reads the wheel version from rs/moq-ffi/Cargo.toml (via
+      # `dynamic = ["version"]` in pyproject.toml). If a tag is pushed by
+      # hand without bumping Cargo.toml first, the wheel would ship with
+      # the previous version and PyPI would reject the duplicate upload.
+      - name: Verify Cargo.toml matches tag
+        env:
+          TAG_VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          CARGO_VERSION=$(grep '^version' rs/moq-ffi/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [[ "$TAG_VERSION" != "$CARGO_VERSION" ]]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match rs/moq-ffi/Cargo.toml version ($CARGO_VERSION). Bump Cargo.toml before tagging."
+            exit 1
+          fi
+          echo "Cargo.toml version matches tag: $TAG_VERSION"
+
   build:
     name: Build wheels (${{ matrix.target }})
     needs: [parse-version]
@@ -84,9 +99,36 @@ jobs:
           name: python-${{ matrix.target }}
           path: py/moq-net/dist/*.whl
 
+  sdist:
+    name: Build sdist
+    needs: [parse-version]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: py/moq-net
+          command: sdist
+          args: --out dist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-sdist
+          path: py/moq-net/dist/*.tar.gz
+
   publish:
     name: Publish to PyPI
-    needs: [build]
+    needs: [build, sdist]
     runs-on: ubuntu-latest
     # Skipped until PUBLISH_PYTHON=true is set in repo variables.
     if: vars.PUBLISH_PYTHON == 'true'

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -37,6 +37,9 @@ jobs:
         target:
           - aarch64-apple-ios
           - aarch64-apple-ios-sim
+          # x86_64-apple-ios is the Intel iOS simulator slice (Apple never
+          # shipped Intel iOS devices), still needed for Xcode users on
+          # Intel Macs running the simulator.
           - x86_64-apple-ios
           - universal-apple-darwin
 

--- a/kt/scripts/package.sh
+++ b/kt/scripts/package.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Uses associative arrays (declare -A); not available in Bash 3.2 (the
-# default `/usr/bin/bash` on macOS).
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "Error: kt/scripts/package.sh requires Bash >= 4 (found $BASH_VERSION)" >&2
-    exit 1
-fi
-
 # Assemble the moq-ffi Kotlin package and stage it for publication.
 #
 # Designed to run after the workflow has placed per-target moq-ffi
@@ -60,15 +53,19 @@ rm -rf "$KT_DIR/moq/src/jvmAndAndroidMain/kotlin/uniffi"
 mkdir -p "$KT_DIR/moq/src/androidMain/jniLibs"
 mkdir -p "$KT_DIR/moq/src/jvmMain/resources"
 
-# --- Android JNI libs ---
-declare -A ANDROID_ABIS=(
-    [aarch64-linux-android]=arm64-v8a
-    [armv7-linux-androideabi]=armeabi-v7a
-    [x86_64-linux-android]=x86_64
+# Entries are "<cargo-target>:<...>" so the script stays portable to Bash 3.2
+# (default on macOS), which has no associative arrays.
+
+# --- Android JNI libs --- ("<cargo-target>:<android-abi>")
+ANDROID_ABIS=(
+    "aarch64-linux-android:arm64-v8a"
+    "armv7-linux-androideabi:armeabi-v7a"
+    "x86_64-linux-android:x86_64"
 )
 HAVE_ANDROID_LIBS=false
-for target in "${!ANDROID_ABIS[@]}"; do
-    abi="${ANDROID_ABIS[$target]}"
+for entry in "${ANDROID_ABIS[@]}"; do
+    target="${entry%%:*}"
+    abi="${entry##*:}"
     src="$LIB_DIR/$target/libmoq_ffi.so"
     if [[ -f "$src" ]]; then
         dest="$KT_DIR/moq/src/androidMain/jniLibs/$abi"
@@ -82,18 +79,20 @@ for target in "${!ANDROID_ABIS[@]}"; do
 done
 
 # --- JVM desktop resources (JNA classpath layout) ---
-declare -A JVM_LIBS=(
-    [x86_64-unknown-linux-gnu]="linux-x86-64:libmoq_ffi.so"
-    [aarch64-unknown-linux-gnu]="linux-aarch64:libmoq_ffi.so"
-    [universal-apple-darwin]="darwin:libmoq_ffi.dylib"
-    [aarch64-apple-darwin]="darwin-aarch64:libmoq_ffi.dylib"
-    [x86_64-apple-darwin]="darwin-x86-64:libmoq_ffi.dylib"
-    [x86_64-pc-windows-msvc]="win32-x86-64:moq_ffi.dll"
+# Entries are "<cargo-target>:<jna-dir>:<libname>".
+JVM_LIBS=(
+    "x86_64-unknown-linux-gnu:linux-x86-64:libmoq_ffi.so"
+    "aarch64-unknown-linux-gnu:linux-aarch64:libmoq_ffi.so"
+    "universal-apple-darwin:darwin:libmoq_ffi.dylib"
+    "aarch64-apple-darwin:darwin-aarch64:libmoq_ffi.dylib"
+    "x86_64-apple-darwin:darwin-x86-64:libmoq_ffi.dylib"
+    "x86_64-pc-windows-msvc:win32-x86-64:moq_ffi.dll"
 )
-for target in "${!JVM_LIBS[@]}"; do
-    spec="${JVM_LIBS[$target]}"
-    dir="${spec%%:*}"
-    libname="${spec##*:}"
+for entry in "${JVM_LIBS[@]}"; do
+    target="${entry%%:*}"
+    rest="${entry#*:}"
+    dir="${rest%%:*}"
+    libname="${rest##*:}"
     src="$LIB_DIR/$target/$libname"
     if [[ -f "$src" ]]; then
         dest="$KT_DIR/moq/src/jvmMain/resources/$dir"

--- a/rs/moq-ffi/build.sh
+++ b/rs/moq-ffi/build.sh
@@ -224,8 +224,9 @@ elif [[ "$TARGET" == *"-apple-"* ]]; then
     cp "$TARGET_DIR/libmoq_ffi.dylib" "$PACKAGE_DIR/lib/"
 
 else
+    # Linux: ship the cdylib only. JNA (Kotlin) and maturin (Python) both
+    # consume the .so; nothing in the release pipeline links statically.
     TARGET_DIR="$TARGET_BASE_DIR/$TARGET/release"
-    cp "$TARGET_DIR/libmoq_ffi.a" "$PACKAGE_DIR/lib/"
     cp "$TARGET_DIR/libmoq_ffi.so" "$PACKAGE_DIR/lib/"
 fi
 


### PR DESCRIPTION
## Summary

Five fixes to the moq-ffi release workflows and packaging scripts that I verified after auditing the SPM/PyPI/Maven release paths. SPM's `publish.sh` stub is left untouched — wiring it needs an actual SPM release plan.

- **kt/scripts/package.sh**: drop the bash >= 4 gate. The two `declare -A` associative arrays are now portable colon-encoded parallel arrays, so the script works under macOS's default bash 3.2. Verified runtime under `/bin/bash 3.2.57`. Local Kotlin contributors no longer have to `brew install bash`.
- **release-py.yml**: verify `rs/moq-ffi/Cargo.toml` matches the `moq-ffi-v*` tag before building. Maturin reads the wheel version from Cargo.toml via `dynamic = ["version"]`, so a hand-pushed tag without a Cargo.toml bump would ship a stale wheel and PyPI would reject the upload. Hard-fail in `parse-version` with a clear actionable message instead.
- **release-py.yml**: add an `sdist` job. Maturin's `sdist` command bundles all transitive workspace crates (verified locally: conducer, hang, moq-ffi, moq-msf, moq-mux, moq-native, moq-net at ~349 KB). Publish job now needs both `build` and `sdist`; the existing `pattern: python-*` artifact download picks up both.
- **release-swift.yml**: three-line comment explaining `x86_64-apple-ios` is the Intel iOS simulator slice, since Apple never shipped Intel iOS devices and the name is easy to misread.
- **rs/moq-ffi/build.sh**: stop copying `libmoq_ffi.a` into the Linux package directory. JNA (Kotlin) and maturin (Python) only consume the cdylib; the staticlib was several MB of dead weight in every Linux release asset.

## Test plan

- [x] `bash -n` syntax check both modified shell scripts under `/bin/bash 3.2.57`
- [x] Runtime smoke test of the new parallel-array iteration under bash 3.2
- [x] YAML parse check on both modified workflows
- [x] Local `maturin sdist` run produces a wheel-ready tarball with all workspace crates included
- [ ] Next `moq-ffi-v*` tag exercises the version-verify step and the sdist job in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)