### PR TITLE
ci: drop depot, use native GitHub ARM runners for docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ jobs:
   parse:
     name: Parse tag
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       target: ${{ steps.parse.outputs.target }}
       version: ${{ steps.parse.outputs.version }}
@@ -43,9 +44,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@v3
 
@@ -81,9 +83,7 @@ jobs:
     name: Publish manifest
     needs: [parse, build]
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    permissions: {}
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,51 +11,97 @@ env:
   REGISTRY: docker.io/moqdev
 
 jobs:
-  deploy:
-    name: Release
-
+  parse:
+    name: Parse tag
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
+    outputs:
+      target: ${{ steps.parse.outputs.target }}
+      version: ${{ steps.parse.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
-
-      # Figure out the docker image based on the tag
       - id: parse
         run: |
           ref=${GITHUB_REF#refs/tags/}
           if [[ "$ref" =~ ^([a-z-]+)-v([0-9.]+)$ ]]; then
-            target="${BASH_REMATCH[1]}"
-            version="${BASH_REMATCH[2]}"
-            echo "target=$target" >> $GITHUB_OUTPUT
-            echo "version=$version" >> $GITHUB_OUTPUT
+            echo "target=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+            echo "version=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
           else
             echo "Tag format not recognized." >&2
             exit 1
           fi
 
-      # I'm paying for Depot for faster ARM builds.
-      - uses: depot/setup-action@v1
+  build:
+    name: Build ${{ matrix.platform }}
+    needs: parse
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
 
-      # Login to docker.io
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Build and push multi-arch Docker images using Depot
-      - uses: depot/build-push-action@v1
+      # Build and push by digest. The manifest list is assembled in the merge job.
+      - id: build
+        uses: docker/build-push-action@v6
         with:
-          project: r257ctfqm6
           context: .
-          push: true
-          # Make a smaller image by specifying the package to build
+          platforms: ${{ matrix.platform }}
           build-args: |
-            package=${{ steps.parse.outputs.target }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ steps.parse.outputs.target }}:${{ steps.parse.outputs.version }}
-            ${{ env.REGISTRY }}/${{ steps.parse.outputs.target }}:latest
-          platforms: linux/amd64,linux/arm64
+            package=${{ needs.parse.outputs.target }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ needs.parse.outputs.target }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ strategy.job-index }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Publish manifest
+    needs: [parse, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ needs.parse.outputs.target }}:${{ needs.parse.outputs.version }} \
+            -t ${{ env.REGISTRY }}/${{ needs.parse.outputs.target }}:latest \
+            $(printf "${{ env.REGISTRY }}/${{ needs.parse.outputs.target }}@sha256:%s " *)


### PR DESCRIPTION
## Summary

Depot was only used in `.github/workflows/docker.yml` to get fast ARM builds. GitHub now offers free Linux ARM64 runners for public repos (`ubuntu-24.04-arm`), so the paid depot dependency is no longer needed.

Switches to the standard multi-platform pattern:

- `build` matrix runs amd64 on `ubuntu-latest` and arm64 on `ubuntu-24.04-arm` in parallel (no QEMU)
- Each job pushes by digest and uploads the digest as an artifact
- `merge` job pulls the digests and assembles the multi-arch manifest with `docker buildx imagetools create`, tagging both `:<version>` and `:latest`

Behavior on the published images is unchanged: same registry (`docker.io/moqdev`), same tags, same `linux/amd64` + `linux/arm64` manifest, same trigger tags (`moq-relay-v*`, `moq-cli-v*`, `moq-token-cli-v*`).

## Test plan

- [ ] Cut a throwaway release tag (or trigger via a test branch) and confirm the manifest lists both architectures
- [ ] Verify `docker pull moqdev/moq-relay:<version>` works on both amd64 and arm64 hosts


---
_Generated by [Claude Code](https://claude.ai/code/session_013tLwD2KgE5riqGjdwhXRwx)_