### PR TITLE
Package moq-gst for release via Nix-built tarballs

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -7,6 +7,8 @@ on:
       - 'moq-token-cli-v*'
       - 'moq-cli-v*'
       - 'moq-boy-v*'
+      - 'libmoq-v*'
+      - 'moq-gst-v*'
 
 jobs:
   cache:
@@ -52,4 +54,14 @@ jobs:
       - name: Build and cache moq-boy
         run: |
           nix build .#moq-boy --print-build-logs
+          cachix push kixelated ./result
+
+      - name: Build and cache libmoq
+        run: |
+          nix build .#libmoq --print-build-logs
+          cachix push kixelated ./result
+
+      - name: Build and cache moq-gst
+        run: |
+          nix build .#moq-gst --print-build-logs
           cachix push kixelated ./result

--- a/.github/workflows/moq-gst.yml
+++ b/.github/workflows/moq-gst.yml
@@ -1,9 +1,9 @@
-name: libmoq
+name: moq-gst
 
 on:
   push:
     tags:
-      - "libmoq-v*"
+      - "moq-gst-v*"
 
 permissions:
   contents: read
@@ -19,47 +19,30 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            use_nix: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
-            use_nix: true
           - target: x86_64-apple-darwin
             os: macos-15-intel
-            use_nix: true
           - target: aarch64-apple-darwin
             os: macos-latest
-            use_nix: true
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            use_nix: false
 
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Install Nix
-        if: matrix.use_nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: Configure Nix cache
-        if: matrix.use_nix
-        uses: DeterminateSystems/magic-nix-cache-action@main
-
-      - name: Install Rust (Windows)
-        if: '!matrix.use_nix'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Parse version
         id: parse
         shell: bash
-        run: .github/scripts/release.sh parse-version libmoq
+        run: .github/scripts/release.sh parse-version moq-gst
 
       - name: Build and package
         shell: bash
         run: |
-          ./rs/libmoq/build.sh \
+          ./rs/moq-gst/build.sh \
             --target ${{ matrix.target }} \
             --version ${{ steps.parse.outputs.version }} \
             --output dist
@@ -67,7 +50,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: libmoq-${{ matrix.target }}
+          name: moq-gst-${{ matrix.target }}
           path: dist/*
 
   release:
@@ -84,11 +67,11 @@ jobs:
 
       - name: Parse version
         id: parse
-        run: .github/scripts/release.sh parse-version libmoq
+        run: .github/scripts/release.sh parse-version moq-gst
 
       - name: Find previous tag
         id: prev_tag
-        run: .github/scripts/release.sh prev-tag libmoq
+        run: .github/scripts/release.sh prev-tag moq-gst
 
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -100,6 +83,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
-          RELEASE_TITLE: "libmoq v${{ steps.parse.outputs.version }}"
+          RELEASE_TITLE: "moq-gst v${{ steps.parse.outputs.version }}"
           RELEASE_PREV_TAG: ${{ steps.prev_tag.outputs.tag }}
         run: .github/scripts/release.sh create artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ match version {
 - **Formatting/Linting**: Biome for JS/TS formatting and linting
 - **UI**: Plain Web Components in `@moq/watch/ui` and `@moq/publish/ui`, built directly on `@moq/signals`
 - **Builds**: Nix flake for reproducible builds (optional)
+- **CI**: Prefer building release artifacts inside Nix (`nix build .#pkg`) over relying on runner-provided toolchains and `apt`/`brew` packages. Pinning the build environment in `flake.lock` makes artifacts deterministic and decouples them from drift in GitHub Actions runner images. Reach for the runner-native toolchain only when Nix doesn't fit (e.g. Windows runners).
 - **JS async patterns**: Use `Effect.interval()`, `Effect.timer()`, and `Effect.event()` helpers from `@moq/signals` instead of raw `setInterval`, `setTimeout`, `addEventListener`. These handle cleanup automatically when the Effect is closed.
 
 ## Testing Approach

--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,8 @@
             moq-cli
             moq-token-cli
             moq-boy
+            libmoq
+            moq-gst
             ;
         };
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -66,4 +66,93 @@ in
       hardeningDisable = [ "fortify" ];
     }
   );
+
+  libmoq =
+    let
+      info = crateInfo ../rs/libmoq/Cargo.toml;
+    in
+    craneLib.buildPackage (
+      info
+      // {
+        src = craneLib.cleanCargoSource ../.;
+        cargoExtraArgs = "-p libmoq";
+        doCheck = false;
+        nativeBuildInputs = with final; [ pkg-config ];
+
+        # libmoq is a staticlib; crane's default install phase only handles
+        # binaries. Lay out the artifact tree the way release tarballs and
+        # downstream `find_package(moq)` consumers already expect.
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out/lib/pkgconfig $out/include $out/lib/cmake/moq
+          cp target/release/libmoq.a $out/lib/
+          cp target/include/moq.h $out/include/
+          cp target/pkgconfig/moq.pc $out/lib/pkgconfig/
+
+          major_version="$(echo "${info.version}" | cut -d. -f1)"
+          substitute ${../rs/libmoq/cmake/moq-config.cmake.in} \
+            $out/lib/cmake/moq/moq-config.cmake \
+            --subst-var-by LIB_FILE libmoq.a \
+            --subst-var-by VERSION "${info.version}"
+          substitute ${../rs/libmoq/cmake/moq-config-version.cmake.in} \
+            $out/lib/cmake/moq/moq-config-version.cmake \
+            --subst-var-by VERSION "${info.version}" \
+            --subst-var-by MAJOR_VERSION "$major_version"
+
+          runHook postInstall
+        '';
+      }
+    );
+
+  moq-gst = craneLib.buildPackage (
+    crateInfo ../rs/moq-gst/Cargo.toml
+    // {
+      src = craneLib.cleanCargoSource ../.;
+      cargoExtraArgs = "-p moq-gst";
+      doCheck = false;
+
+      nativeBuildInputs = with final; [ pkg-config ];
+      buildInputs = with final; [
+        gst_all_1.gstreamer
+        gst_all_1.gst-plugins-base
+      ];
+
+      # moq-gst is a cdylib GStreamer plugin. Pick up the produced shared
+      # library; crane's default install phase only handles binaries.
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/lib
+        if [ -f target/release/libgstmoq.dylib ]; then
+          cp target/release/libgstmoq.dylib $out/lib/
+        else
+          cp target/release/libgstmoq.so $out/lib/
+        fi
+
+        runHook postInstall
+      '';
+
+      # Strip nix-store paths so the plugin loads against the user's system
+      # GStreamer rather than the (unavailable on user machines) nix copy.
+      postFixup =
+        if final.stdenv.isDarwin then
+          ''
+            dylib="$out/lib/libgstmoq.dylib"
+            otool -L "$dylib" \
+              | grep -oE '/nix/store/[^ ]+\.dylib' \
+              | sort -u \
+              | while read -r ref; do
+                  install_name_tool -change "$ref" "@rpath/$(basename "$ref")" "$dylib"
+                done
+            install_name_tool -add_rpath /opt/homebrew/lib "$dylib"
+            install_name_tool -add_rpath /usr/local/lib "$dylib"
+            install_name_tool -add_rpath /Library/Frameworks/GStreamer.framework/Libraries "$dylib"
+          ''
+        else
+          ''
+            patchelf --remove-rpath $out/lib/libgstmoq.so
+          '';
+    }
+  );
 }

--- a/rs/libmoq/build.sh
+++ b/rs/libmoq/build.sh
@@ -6,32 +6,25 @@ set -euo pipefail
 #
 # Examples:
 #   ./build.sh                                    # Build for host, detect version from Cargo.toml
-#   ./build.sh --target aarch64-apple-darwin      # Cross-compile for Apple Silicon
+#   ./build.sh --target aarch64-apple-darwin      # Native build (run on matching runner)
+#
+# On Linux and macOS this builds via `nix build .#libmoq` for reproducibility.
+# Windows targets fall back to a direct cargo build because Nix isn't
+# practical to install on the Windows GitHub runner image.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKSPACE_DIR="$(cd "$RS_DIR/.." && pwd)"
 
-# Defaults
 TARGET=""
 VERSION=""
 OUTPUT_DIR="dist"
 
-# Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --target)
-            TARGET="$2"
-            shift 2
-            ;;
-        --version)
-            VERSION="$2"
-            shift 2
-            ;;
-        --output)
-            OUTPUT_DIR="$2"
-            shift 2
-            ;;
+        --target)  TARGET="$2"; shift 2 ;;
+        --version) VERSION="$2"; shift 2 ;;
+        --output)  OUTPUT_DIR="$2"; shift 2 ;;
         -h|--help)
             echo "Usage: $0 [--target TARGET] [--version VERSION] [--output DIR]"
             exit 0
@@ -43,113 +36,52 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Get version from Cargo.toml if not specified
 if [[ -z "$VERSION" ]]; then
     VERSION=$(grep '^version' "$SCRIPT_DIR/Cargo.toml" | head -1 | sed 's/.*"\(.*\)".*/\1/')
     echo "Detected version: $VERSION"
 fi
 
-if [[ "$TARGET" == "universal-apple-darwin" ]]; then
-    if [[ "$(uname)" != "Darwin" ]]; then
-        echo "Error: Universal builds are only supported on macOS" >&2
-        exit 1
-    fi
-    
-    echo "Building libmoq for $TARGET..."
-
-    # Build x86_64
-    echo "Building for x86_64-apple-darwin..."
-    cargo build --release --package libmoq --target x86_64-apple-darwin --manifest-path "$WORKSPACE_DIR/Cargo.toml"
-
-    # Build arm64
-    echo "Building for aarch64-apple-darwin..."
-    cargo build --release --package libmoq --target aarch64-apple-darwin --manifest-path "$WORKSPACE_DIR/Cargo.toml"
-
-    # Define sources for packaging
-    # Use arm64 as the reference for headers/pkgconfig (they should be identical)
-    REF_TARGET="aarch64-apple-darwin"
-    INCLUDE_SOURCE="$WORKSPACE_DIR/target/$REF_TARGET/include/moq.h"
-    PKGCONFIG_SOURCE="$WORKSPACE_DIR/target/$REF_TARGET/pkgconfig/moq.pc"
-    
-    # Libraries to combine
-    LIB_X86="$WORKSPACE_DIR/target/x86_64-apple-darwin/release/libmoq.a"
-    LIB_ARM64="$WORKSPACE_DIR/target/aarch64-apple-darwin/release/libmoq.a"
-    LIB_FILE="libmoq.a"
-
-else
-    # Detect target if not specified
-    if [[ -z "$TARGET" ]]; then
-        TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
-        echo "Detected target: $TARGET"
-    fi
-
-    echo "Building libmoq for $TARGET..."
-
-    # Set up cross-compilation for Linux ARM64
-    if [[ "$TARGET" == "aarch64-unknown-linux-gnu" ]]; then
-        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-    fi
-
-    cargo build --release --package libmoq --target "$TARGET" --manifest-path "$WORKSPACE_DIR/Cargo.toml"
-
-    # Define sources for packaging
-    INCLUDE_SOURCE="$WORKSPACE_DIR/target/$TARGET/include/moq.h"
-    PKGCONFIG_SOURCE="$WORKSPACE_DIR/target/$TARGET/pkgconfig/moq.pc"
-    
-    TARGET_DIR="$WORKSPACE_DIR/target/$TARGET/release"
-    if [[ "$TARGET" == *"-windows-"* ]]; then
-        LIB_SOURCE="$TARGET_DIR/moq.lib"
-        LIB_FILE="moq.lib"
-    else
-        LIB_SOURCE="$TARGET_DIR/libmoq.a"
-        LIB_FILE="libmoq.a"
-    fi
+if [[ -z "$TARGET" ]]; then
+    TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
+    echo "Detected target: $TARGET"
 fi
 
-# Determine paths
 NAME="moq-${VERSION}-${TARGET}"
 PACKAGE_DIR="$OUTPUT_DIR/$NAME"
 
 echo "Packaging $NAME..."
-
-# Clean and create package directory
 rm -rf "$PACKAGE_DIR"
 mkdir -p "$PACKAGE_DIR/include" "$PACKAGE_DIR/lib"
 
-# Copy header
-cp "$INCLUDE_SOURCE" "$PACKAGE_DIR/include/"
+if [[ "$TARGET" == *"-windows-"* ]]; then
+    echo "Building libmoq for $TARGET via cargo (Windows path)..."
+    cargo build --release --package libmoq --target "$TARGET" --manifest-path "$WORKSPACE_DIR/Cargo.toml"
 
-# Copy static library
-if [[ "$TARGET" == "universal-apple-darwin" ]]; then
-    echo "Creating universal binary..."
-    lipo -create "$LIB_X86" "$LIB_ARM64" -output "$PACKAGE_DIR/lib/$LIB_FILE"
+    TARGET_DIR="$WORKSPACE_DIR/target/$TARGET/release"
+    LIB_FILE="moq.lib"
+    cp "$TARGET_DIR/$LIB_FILE" "$PACKAGE_DIR/lib/"
+    cp "$WORKSPACE_DIR/target/$TARGET/include/moq.h" "$PACKAGE_DIR/include/"
+
+    # Generate CMake config files from templates (no pkg-config on Windows).
+    mkdir -p "$PACKAGE_DIR/lib/cmake/moq"
+    MAJOR_VERSION="${VERSION%%.*}"
+    sed -e "s|@LIB_FILE@|${LIB_FILE}|g" \
+        -e "s|@VERSION@|${VERSION}|g" \
+        "$SCRIPT_DIR/cmake/moq-config.cmake.in" > "$PACKAGE_DIR/lib/cmake/moq/moq-config.cmake"
+    sed -e "s|@VERSION@|${VERSION}|g" \
+        -e "s|@MAJOR_VERSION@|${MAJOR_VERSION}|g" \
+        "$SCRIPT_DIR/cmake/moq-config-version.cmake.in" > "$PACKAGE_DIR/lib/cmake/moq/moq-config-version.cmake"
 else
-    cp "$LIB_SOURCE" "$PACKAGE_DIR/lib/"
+    echo "Building libmoq for $TARGET via nix..."
+    RESULT_LINK="$(mktemp -d)/result"
+    nix build "$WORKSPACE_DIR#libmoq" --out-link "$RESULT_LINK"
+
+    # The derivation lays out everything under $out/{lib,include}; copy it
+    # verbatim so the release tarball matches what nix produced.
+    cp -RL "$RESULT_LINK/lib/." "$PACKAGE_DIR/lib/"
+    cp -RL "$RESULT_LINK/include/." "$PACKAGE_DIR/include/"
+    chmod -R u+w "$PACKAGE_DIR"
 fi
-
-# Copy pkg-config file (generated in target/$TARGET/pkgconfig/ by build.rs, not for Windows)
-if [[ "$TARGET" != *"-windows-"* ]]; then
-    mkdir -p "$PACKAGE_DIR/lib/pkgconfig"
-    cp "$PKGCONFIG_SOURCE" "$PACKAGE_DIR/lib/pkgconfig/"
-fi
-
-# Generate CMake config files from templates
-mkdir -p "$PACKAGE_DIR/lib/cmake/moq"
-
-# Extract major version
-MAJOR_VERSION="${VERSION%%.*}"
-
-# Generate moq-config.cmake from template
-sed -e "s|@LIB_FILE@|${LIB_FILE}|g" \
-    -e "s|@VERSION@|${VERSION}|g" \
-    "$SCRIPT_DIR/cmake/moq-config.cmake.in" > "$PACKAGE_DIR/lib/cmake/moq/moq-config.cmake"
-
-# Generate moq-config-version.cmake from template
-sed -e "s|@VERSION@|${VERSION}|g" \
-    -e "s|@MAJOR_VERSION@|${MAJOR_VERSION}|g" \
-    "$SCRIPT_DIR/cmake/moq-config-version.cmake.in" > "$PACKAGE_DIR/lib/cmake/moq/moq-config-version.cmake"
-
-echo "Generated CMake config files from templates"
 
 # Create archive
 cd "$OUTPUT_DIR"
@@ -168,7 +100,6 @@ else
     tar -czvf "$ARCHIVE" "$NAME"
 fi
 
-# Clean up directory, keep archive (use $NAME since we cd'd into $OUTPUT_DIR)
 rm -rf "$NAME"
 
 echo ""

--- a/rs/libmoq/build.sh
+++ b/rs/libmoq/build.sh
@@ -73,7 +73,9 @@ if [[ "$TARGET" == *"-windows-"* ]]; then
         "$SCRIPT_DIR/cmake/moq-config-version.cmake.in" > "$PACKAGE_DIR/lib/cmake/moq/moq-config-version.cmake"
 else
     echo "Building libmoq for $TARGET via nix..."
-    RESULT_LINK="$(mktemp -d)/result"
+    BUILD_TMP="$(mktemp -d)"
+    trap 'rm -rf "$BUILD_TMP"' EXIT
+    RESULT_LINK="$BUILD_TMP/result"
     nix build "$WORKSPACE_DIR#libmoq" --out-link "$RESULT_LINK"
 
     # The derivation lays out everything under $out/{lib,include}; copy it

--- a/rs/moq-gst/README.md
+++ b/rs/moq-gst/README.md
@@ -10,12 +10,51 @@ A [GStreamer](https://gstreamer.freedesktop.org/) plugin for [Media over QUIC](h
 
 Uses [hang](https://github.com/moq-dev/moq/tree/main/rs/hang), [moq-mux](https://github.com/moq-dev/moq/tree/main/rs/moq-mux), and [moq-native](https://github.com/moq-dev/moq/tree/main/rs/moq-native) under the hood, so it can publish CMAF/fMP4 produced by any GStreamer pipeline directly to a MoQ relay.
 
-This crate is not published to crates.io; build it from this repo.
+This crate is not published to crates.io. Pre-built binaries are attached to GitHub releases (see below) or you can build from source.
 
-## Building
+## Install
+
+Download the tarball for your platform from the [releases page](https://github.com/moq-dev/moq/releases?q=moq-gst) and extract `lib/libgstmoq.{so,dylib}` into a directory GStreamer scans for plugins:
+
+- **Linux**: `~/.local/share/gstreamer-1.0/plugins/` (per-user) or `/usr/lib/x86_64-linux-gnu/gstreamer-1.0/` (system-wide). Alternatively, `export GST_PLUGIN_PATH=/path/to/dir`.
+- **macOS**: `~/Library/Application Support/GStreamer/1.0/plugins/`. Alternatively, `export GST_PLUGIN_PATH=/path/to/dir`.
+
+Then verify:
+
+```bash
+gst-inspect-1.0 moq
+```
+
+You should see `moqsink` and `moqsrc` listed.
+
+Available targets:
+
+| target | platform |
+|---|---|
+| `x86_64-unknown-linux-gnu` | Linux (x86_64) |
+| `aarch64-unknown-linux-gnu` | Linux (ARM64) |
+| `x86_64-apple-darwin` | macOS (Intel) |
+| `aarch64-apple-darwin` | macOS (Apple Silicon) |
+
+You need a matching GStreamer runtime installed:
+
+- **Debian/Ubuntu**: `sudo apt install gstreamer1.0-plugins-base gstreamer1.0-plugins-good` (1.24+)
+- **macOS (Homebrew)**: `brew install gstreamer`
+- **macOS (official)**: the .pkg installer from [gstreamer.freedesktop.org](https://gstreamer.freedesktop.org/download/)
+
+The macOS dylib has rpaths pre-baked for the three common install locations (`/opt/homebrew/lib`, `/usr/local/lib`, `/Library/Frameworks/GStreamer.framework/Libraries`). If your GStreamer is somewhere else, set `DYLD_FALLBACK_LIBRARY_PATH` accordingly.
+
+## Building from source
 
 ```bash
 cargo build --release -p moq-gst
 ```
 
-The resulting plugin is at `target/release/libgstmoq.so` (or `.dylib` / `.dll` on macOS / Windows). Point `GST_PLUGIN_PATH` at the containing directory to make it discoverable by `gst-inspect-1.0` and the rest of GStreamer.
+The resulting plugin is at `target/release/libgstmoq.so` (or `.dylib` / `.dll`). Point `GST_PLUGIN_PATH` at the containing directory to make it discoverable.
+
+For a reproducible build matching the release artifacts (Linux + macOS):
+
+```bash
+nix build .#moq-gst
+ls result/lib/
+```

--- a/rs/moq-gst/build.sh
+++ b/rs/moq-gst/build.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and package the moq-gst GStreamer plugin for release.
+# Usage: ./build.sh [--target TARGET] [--version VERSION] [--output DIR]
+#
+# Builds via `nix build .#moq-gst` against the flake-pinned GStreamer so
+# artifacts are reproducible. The produced shared library has nix-store
+# paths stripped (patchelf on Linux, install_name_tool on macOS) so it
+# loads against the user's system GStreamer at runtime.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_DIR="$(cd "$RS_DIR/.." && pwd)"
+
+TARGET=""
+VERSION=""
+OUTPUT_DIR="dist"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --target)  TARGET="$2"; shift 2 ;;
+        --version) VERSION="$2"; shift 2 ;;
+        --output)  OUTPUT_DIR="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: $0 [--target TARGET] [--version VERSION] [--output DIR]"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    VERSION=$(grep '^version' "$SCRIPT_DIR/Cargo.toml" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+    echo "Detected version: $VERSION"
+fi
+
+if [[ -z "$TARGET" ]]; then
+    TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
+    echo "Detected target: $TARGET"
+fi
+
+echo "Building moq-gst for $TARGET via nix..."
+
+RESULT_LINK="$(mktemp -d)/result"
+nix build "$WORKSPACE_DIR#moq-gst" --out-link "$RESULT_LINK"
+
+# Locate the produced shared library (extension differs by platform).
+LIB_FILE=""
+for candidate in libgstmoq.so libgstmoq.dylib; do
+    if [[ -f "$RESULT_LINK/lib/$candidate" ]]; then
+        LIB_FILE="$candidate"
+        break
+    fi
+done
+if [[ -z "$LIB_FILE" ]]; then
+    echo "Error: no libgstmoq.{so,dylib} found in $RESULT_LINK/lib/" >&2
+    exit 1
+fi
+
+NAME="moq-gst-${VERSION}-${TARGET}"
+PACKAGE_DIR="$OUTPUT_DIR/$NAME"
+
+echo "Packaging $NAME..."
+rm -rf "$PACKAGE_DIR"
+mkdir -p "$PACKAGE_DIR/lib"
+
+# Dereference the nix-store symlink and drop perms so the file is writable
+# enough to archive cleanly.
+cp -L "$RESULT_LINK/lib/$LIB_FILE" "$PACKAGE_DIR/lib/$LIB_FILE"
+chmod 0644 "$PACKAGE_DIR/lib/$LIB_FILE"
+
+cp "$SCRIPT_DIR/README.md" "$PACKAGE_DIR/"
+cp "$WORKSPACE_DIR/LICENSE-MIT" "$PACKAGE_DIR/"
+cp "$WORKSPACE_DIR/LICENSE-APACHE" "$PACKAGE_DIR/"
+
+cd "$OUTPUT_DIR"
+ARCHIVE="$NAME.tar.gz"
+tar -czvf "$ARCHIVE" "$NAME"
+rm -rf "$NAME"
+
+echo ""
+echo "Created: $OUTPUT_DIR/$ARCHIVE"
+echo "$ARCHIVE"

--- a/rs/moq-gst/build.sh
+++ b/rs/moq-gst/build.sh
@@ -45,7 +45,9 @@ fi
 
 echo "Building moq-gst for $TARGET via nix..."
 
-RESULT_LINK="$(mktemp -d)/result"
+BUILD_TMP="$(mktemp -d)"
+trap 'rm -rf "$BUILD_TMP"' EXIT
+RESULT_LINK="$BUILD_TMP/result"
 nix build "$WORKSPACE_DIR#moq-gst" --out-link "$RESULT_LINK"
 
 # Locate the produced shared library (extension differs by platform).


### PR DESCRIPTION
## Summary

- New `.github/workflows/moq-gst.yml`: builds the GStreamer plugin on every `moq-gst-v*` tag for `x86_64`/`aarch64` Linux + macOS via `nix build .#moq-gst`, then assembles tarballs and attaches them to a GitHub release.
- `nix/overlay.nix` gains `libmoq` and `moq-gst` derivations and they're re-exported from `flake.nix`. The libmoq derivation lays out the staticlib plus header, pkg-config, and CMake config files in the same on-disk shape the existing release tarballs already publish (so downstream `find_package(moq)` consumers don't notice). The moq-gst derivation strips nix-store paths from the produced cdylib so it loads against the user's system GStreamer:
  - Linux: `patchelf --remove-rpath` (DT_NEEDED stays as the stable SONAME `libgstreamer-1.0.so.0`, which any distro with GStreamer 1.24+ resolves).
  - macOS: `install_name_tool -change /nix/store/... @rpath/...` for each gstreamer dylib reference, plus three pre-baked rpaths covering brew on Apple Silicon, brew on Intel, and the official `.pkg` framework install. Users who put GStreamer somewhere else can set `DYLD_FALLBACK_LIBRARY_PATH`.
- `rs/libmoq/build.sh` rewritten to a thin `nix build` wrapper on Linux/macOS; Windows keeps the existing direct cargo path because Nix on the Windows runner isn't practical. The `universal-apple-darwin` matrix entry is dropped now that we have native per-arch macOS runners.
- `rs/moq-gst/build.sh` (new) is the equivalent thin wrapper for the plugin: `nix build` + tarball assembly with README + LICENSE files.
- `.github/workflows/libmoq.yml` switches Linux/macOS jobs to the Nix path (`DeterminateSystems/nix-installer-action` + `magic-nix-cache-action`) and points `aarch64-unknown-linux-gnu` at the native `ubuntu-24.04-arm` runner.
- `cachix.yml` adds `libmoq-v*` and `moq-gst-v*` triggers and builds both packages, so Cachix users (`cachix use kixelated`) get pre-built artifacts.
- `rs/moq-gst/README.md` gets an Install section walking through download + install location per platform.
- `CLAUDE.md` adds a CI tooling note steering future release pipelines toward `nix build .#pkg` for reproducibility instead of relying on `apt`/`brew` packages on the runner.

## Test plan

Before merging, verify the new workflow end-to-end without committing to a real tag:

- [ ] Add `workflow_dispatch:` to `.github/workflows/moq-gst.yml` on this branch and trigger it; confirm all four matrix jobs go green and that artifacts upload.
- [ ] Push a throwaway tag (`moq-gst-v0.0.0-test`) and confirm the `release` job creates a draft release with four `.tar.gz` files. Delete the test tag/release after.
- [ ] Repeat the dry run for `libmoq.yml` to make sure the nix-converted Linux/macOS jobs still produce tarballs equivalent to the previous cargo-built ones (diff layout against an existing libmoq release).

Local sanity (needs Nix + GStreamer):

- [ ] `nix build .#libmoq`, then verify `result/lib/libmoq.a`, `result/include/moq.h`, `result/lib/pkgconfig/moq.pc`, `result/lib/cmake/moq/moq-config.cmake` all exist.
- [ ] `nix build .#moq-gst`, then `patchelf --print-rpath result/lib/libgstmoq.so` is empty on Linux, and `ldd result/lib/libgstmoq.so` resolves `libgstreamer-1.0.so.0` against `/usr/lib/...` rather than nix store. On macOS, `otool -L` shows `@rpath/...` and `otool -l | grep -A2 LC_RPATH` lists the three pre-baked locations.
- [ ] `./rs/moq-gst/build.sh --output /tmp/dist` → extract the tarball, `export GST_PLUGIN_PATH=$(pwd)/.../lib`, `gst-inspect-1.0 moq` lists `moqsink` and `moqsrc`.

First real release:

- [ ] `git tag moq-gst-v0.2.3 && git push origin moq-gst-v0.2.3`. Confirm all four artifacts attach. Download one on a clean machine with a stock GStreamer install and run `gst-inspect-1.0 moq`.

https://claude.ai/code/session_01658i2aBWSxEZvVggb1aLkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01658i2aBWSxEZvVggb1aLkU)_