### PR TITLE
ci: opt out of Determinate Nix to fix FlakeHub-induced 401s

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -29,6 +29,8 @@ jobs:
           persist-credentials: false
 
       - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
+        with:
+          determinate: false
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,8 @@ jobs:
           persist-credentials: false
 
       - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
+        with:
+          determinate: false
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
       - uses: DeterminateSystems/flake-checker-action@ba1df9ab06e525ea302f2a56f5e182f33cfd14fa # main
 

--- a/.github/workflows/libmoq.yml
+++ b/.github/workflows/libmoq.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Install Nix
         if: matrix.use_nix
         uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
+        with:
+          determinate: false
       - name: Configure Nix cache
         if: matrix.use_nix
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main

--- a/.github/workflows/moq-gst.yml
+++ b/.github/workflows/moq-gst.yml
@@ -33,6 +33,8 @@ jobs:
           persist-credentials: false
 
       - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
+        with:
+          determinate: false
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - name: Parse version

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -27,6 +27,8 @@ jobs:
           persist-credentials: false
 
       - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
+        with:
+          determinate: false
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - name: Setup npm registry

--- a/.github/workflows/release-rs.yml
+++ b/.github/workflows/release-rs.yml
@@ -39,6 +39,8 @@ jobs:
 
       # Install Nix for system dependencies (e.g. ffmpeg)
       - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
+        with:
+          determinate: false
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - name: Release

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
+        with:
+          determinate: false
 
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@5ba4a20ae344a5edd7b97ed3002219974f4d20d7 # main


### PR DESCRIPTION
## Summary

`just ci` keeps dying on Nix flake input fetches with `unable to download 'https://api.github.com/repos/.../tarball/...': HTTP error 401 - Bad credentials`. Earlier in the same job log:

```
##[group]Logging in to FlakeHub
Error: failed to update netrc via determinate-nixd: Login failure: Transient authentication mechanism error
##[warning]FlakeHub Login failure: The process '/usr/local/bin/determinate-nixd' failed with exit code 1
```

The `DeterminateSystems/nix-installer-action` defaults to `determinate: true`, which logs into FlakeHub via `determinate-nixd`. When that login fails (currently very flaky), the action only emits a warning, but the broken token has already been written into nix.conf's `access-tokens`. The next flake input fetch hits api.github.com with bad credentials and gets a 401.

Symptoms span workflows:
- `Check`: 401 from `api.github.com/repos/.../tarball/...` (e.g. run [26339905025](https://github.com/moq-dev/moq/actions/runs/26339905025))
- `Release JS`: `Unable to authenticate to FlakeHub` from `magic-nix-cache-action` (run [26338361978](https://github.com/moq-dev/moq/actions/runs/26338361978))

## Fix

Pass `determinate: false` to `nix-installer-action` in every workflow. That skips the FlakeHub login, the action falls back to upstream Nix with plain `GITHUB_TOKEN`-based `access-tokens`, and `magic-nix-cache-action` falls back to the GitHub Actions cache.

## Test plan

- [ ] CI on this PR passes (this PR exercises `check.yml`).
- [ ] Confirm the `Logging in to FlakeHub` block is gone from the `Install Nix` step's logs and Nix flake input fetches succeed.