### PR TITLE
ci: fix swift toolchain and restore check-swift workflow

### DIFF
--- a/.github/workflows/check-swift.yml
+++ b/.github/workflows/check-swift.yml
@@ -1,0 +1,45 @@
+name: Check Swift
+
+permissions:
+  id-token: write
+  contents: read
+
+# Swift coverage runs on its own macOS workflow because `swift test` needs
+# the macOS toolchain. Gated on Swift sources and `rs/moq-ffi` (which
+# Swift bundles via uniffi).
+on:
+  pull_request:
+    paths:
+      - 'swift/**'
+      - 'rs/moq-ffi/**'
+      - 'justfile'
+      - '.github/workflows/check-swift.yml'
+
+concurrency:
+  group: check-swift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
+        with:
+          determinate: false
+      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      # No FILES arg = force-run; the workflow's paths filter is
+      # already the gate for whether to fire at all.
+      - run: nix develop --command just swift ci

--- a/justfile
+++ b/justfile
@@ -74,8 +74,11 @@ ci BASE="":
 		just swift ci "$files"
 	fi
 
-	# Cheap; always run.
+	# Cheap; always run. `bun install` is needed for remark-cli, since
+	# `just js ci` (where bun deps would otherwise install) is skipped
+	# when the diff has no JS-scoped files.
 	nix flake check
+	bun install --frozen-lockfile
 	bun remark . --quiet --frail
 
 # Auto-fix linting/formatting issues across all languages.

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -2,14 +2,20 @@
 //
 // Swift Package Manager manifest for Moq.
 //
-// The MoqFFI binary target points at an XCFramework attached to the
-// matching moq-ffi-v* GitHub Release. swift/scripts/package.sh rewrites
-// the URL and checksum below as part of the release pipeline before this
-// file is pushed to the moq-dev/moq-swift mirror repo, which is what SPM
-// consumers actually resolve.
+// Three-target layout:
+//   - MoqFFIBinary: the XCFramework attached to the matching
+//     moq-ffi-v* GitHub Release. Provides the C `moqFFI` clang module
+//     (low-level uniffi scaffolding).
+//   - MoqFFI: Swift wrapper that compiles the uniffi-generated
+//     `Sources/MoqFFI/Generated.swift`, which `import moqFFI` and
+//     exposes Swift-native types (MoqClient, MoqSession, etc.).
+//   - Moq: hand-written ergonomic API on top of MoqFFI.
 //
-// For local development pre-release, swap MoqFFI's `.binaryTarget` for
-// `.binaryTarget(name: "MoqFFI", path: "MoqFFI.xcframework")`.
+// swift/scripts/package.sh rewrites the URL and checksum below before
+// this file is pushed to the moq-dev/moq-swift mirror repo, which is
+// what SPM consumers actually resolve. For local pre-release dev,
+// swift/scripts/check.sh swaps the URL-based binaryTarget for a path-
+// based one pointing at MoqFFI.xcframework next to this manifest.
 
 import PackageDescription
 
@@ -28,8 +34,13 @@ let package = Package(
             dependencies: ["MoqFFI"],
             path: "Sources/Moq"
         ),
-        .binaryTarget(
+        .target(
             name: "MoqFFI",
+            dependencies: ["MoqFFIBinary"],
+            path: "Sources/MoqFFI"
+        ),
+        .binaryTarget(
+            name: "MoqFFIBinary",
             url: "https://github.com/moq-dev/moq/releases/download/moq-ffi-vREPLACE_VERSION/MoqFFI.xcframework.zip",
             checksum: "REPLACE_CHECKSUM"
         ),

--- a/swift/scripts/check.sh
+++ b/swift/scripts/check.sh
@@ -74,7 +74,8 @@ env ${xcode_sdk_env[@]+"${xcode_sdk_env[@]}"} xcodebuild -create-xcframework \
 mkdir -p "$SWIFT_DIR/Sources/MoqFFI"
 cp "$BINDGEN_OUT/moq.swift" "$SWIFT_DIR/Sources/MoqFFI/Generated.swift"
 
-# Use a path-based Package.swift for local dev.
+# Use a path-based Package.swift for local dev. Mirrors the three-target
+# layout in swift/Package.swift (Moq -> MoqFFI -> MoqFFIBinary).
 cat > "$SWIFT_DIR/Package.swift" <<EOF
 // swift-tools-version:5.9
 // Auto-rewritten by swift/scripts/check.sh for local dev. Restore via git
@@ -88,7 +89,8 @@ let package = Package(
     products: [.library(name: "Moq", targets: ["Moq"])],
     targets: [
         .target(name: "Moq", dependencies: ["MoqFFI"], path: "Sources/Moq"),
-        .binaryTarget(name: "MoqFFI", path: "MoqFFI.xcframework"),
+        .target(name: "MoqFFI", dependencies: ["MoqFFIBinary"], path: "Sources/MoqFFI"),
+        .binaryTarget(name: "MoqFFIBinary", path: "MoqFFI.xcframework"),
         .testTarget(name: "MoqTests", dependencies: ["Moq"], path: "Tests/MoqTests"),
     ]
 )

--- a/swift/scripts/check.sh
+++ b/swift/scripts/check.sh
@@ -24,6 +24,21 @@ if [[ "$(uname)" != "Darwin" ]]; then
     exit 0
 fi
 
+# `nix develop` on Darwin exports SDKROOT pointing at the nixpkgs-bundled
+# apple-sdk. The swift compiler in PATH (Xcode's, newer than that SDK)
+# refuses to load the stdlib swiftmodules out of that SDK ("this SDK is
+# not supported by the compiler"). Wrap swift/xcodebuild invocations
+# with this so they fall back to `xcrun --show-sdk-path`, which resolves
+# to Xcode's matching SDK. Cargo keeps the nix SDK so nix-toolchain
+# clang/linker still resolve headers and libs from the dev shell.
+xcode_sdk_env=()
+if [[ "${SDKROOT:-}" == /nix/store/* ]]; then
+    xcode_sdk_env+=(-u SDKROOT)
+fi
+if [[ "${DEVELOPER_DIR:-}" == /nix/store/* ]]; then
+    xcode_sdk_env+=(-u DEVELOPER_DIR)
+fi
+
 HOST_TARGET=$(rustc -vV | awk '/^host:/ {print $2}')
 echo "swift check: building moq-ffi for $HOST_TARGET..."
 cargo build --release --package moq-ffi \
@@ -51,7 +66,7 @@ mkdir -p "$HEADERS_DIR"
 cp "$BINDGEN_OUT/moqFFI.h" "$HEADERS_DIR/"
 cp "$BINDGEN_OUT/moqFFI.modulemap" "$HEADERS_DIR/module.modulemap"
 
-xcodebuild -create-xcframework \
+env ${xcode_sdk_env[@]+"${xcode_sdk_env[@]}"} xcodebuild -create-xcframework \
     -library "$STATIC" -headers "$HEADERS_DIR" \
     -output "$LOCAL_XCF"
 
@@ -80,4 +95,4 @@ let package = Package(
 EOF
 
 cd "$SWIFT_DIR"
-swift test
+env ${xcode_sdk_env[@]+"${xcode_sdk_env[@]}"} swift test


### PR DESCRIPTION
## Summary

- Strip nix-pinned `SDKROOT`/`DEVELOPER_DIR` when invoking `swift` and `xcodebuild` inside `swift/scripts/check.sh`. Lets them fall back to `xcrun --show-sdk-path` (Xcode's SDK, matched to the swift compiler in PATH) while cargo keeps the nix SDK for the rest of the dev shell.
- Restore `.github/workflows/check-swift.yml` (held out of #1466 in bc5e78ca pending this toolchain fix). Mirrors the `determinate: false` opt-out added in #1465 so it doesn't trip FlakeHub-induced 401s.

## Background

The first real macOS Swift CI run from #1466 surfaced a long-standing toolchain mismatch: nixpkgs on Darwin pins `apple-sdk` to the Swift 5.10 era, but `macos-latest` ships Xcode 16.4 with Swift 6.1.2. Swift refuses to load older swiftmodules with a newer compiler:

```
failed to build module 'Swift'; this SDK is not supported by the compiler
(the SDK is built with 'Apple Swift version 5.10 ...
while this compiler is 'Apple Swift version 6.1.2 ...'). Please select a
toolchain which matches the SDK.
```

Of the three options on the table (unset nix SDK for swift only / bump apple-sdk in flake.nix / pin Xcode), this is the smallest blast radius. cachix.yml, libmoq.yml, moq-relay.yml, release-rs.yml, etc. all keep their existing nix toolchain pin untouched.

## Test plan

- [x] `bash -n swift/scripts/check.sh` (syntax)
- [x] Verified `${arr[@]+\"${arr[@]}\"}` expansion is safe with empty array under `set -euo pipefail`
- [ ] `check-swift.yml` fires on this PR (touches `swift/**` and the workflow file itself) and passes on macos-latest
- [ ] Confirm subsequent PRs touching only `rs/moq-ffi/**` also trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)