### PR TITLE
ci: replace docker .rpm builds with cargo zigbuild

### DIFF
--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -64,9 +64,11 @@ jobs:
       - name: Set up packaging tools
         uses: ./.github/actions/setup-packaging
 
-      - name: Build (release)
+      - name: Build (release, glibc 2.34)
         shell: bash
-        run: cargo build --release --target ${{ matrix.target }} -p moq-cli
+        # Pin to glibc 2.34 so one binary covers Ubuntu 22.04+ (.deb)
+        # and AlmaLinux/RHEL/Rocky 9+ (.rpm).
+        run: cargo zigbuild --release --target ${{ matrix.target }}.2.34 -p moq-cli
 
       - name: Rename binary
         shell: bash
@@ -111,28 +113,22 @@ jobs:
           ARCH: ${{ matrix.deb-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq
         run: |
-          nfpm pkg --packager deb --config packaging/moq-cli/nfpm.yaml --target dist/
+          # nfpm doesn't expand ${VAR} in contents[].src or templating
+          # there either, so render the env vars in ourselves.
+          envsubst '$VERSION $ARCH $BINARY_PATH' \
+            < packaging/moq-cli/nfpm.yaml > /tmp/nfpm.yaml
+          nfpm pkg --packager deb --config /tmp/nfpm.yaml --target dist/
 
-      - name: Package .rpm (AlmaLinux 9 toolchain)
+      - name: Package .rpm
         shell: bash
         env:
           VERSION: ${{ steps.parse.outputs.version }}
-          RPM_ARCH: ${{ matrix.rpm-arch }}
+          ARCH: ${{ matrix.rpm-arch }}
+          BINARY_PATH: target/${{ matrix.target }}/release/moq
         run: |
-          docker run --rm \
-            -v "$PWD":/work -w /work \
-            almalinux:9 bash -c '
-              set -euo pipefail
-              dnf install -y --quiet gcc make cmake perl pkgconf-pkg-config curl
-              curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs \
-                | sh -s -- -y --default-toolchain stable --profile minimal
-              source $HOME/.cargo/env
-              cargo build --release --target ${{ matrix.target }} -p moq-cli
-              cp target/${{ matrix.target }}/release/moq-cli target/moq.rpm-build
-            '
-          ARCH="$RPM_ARCH" \
-          BINARY_PATH=target/moq.rpm-build \
-            nfpm pkg --packager rpm --config packaging/moq-cli/nfpm.yaml --target dist/
+          envsubst '$VERSION $ARCH $BINARY_PATH' \
+            < packaging/moq-cli/nfpm.yaml > /tmp/nfpm.yaml
+          nfpm pkg --packager rpm --config /tmp/nfpm.yaml --target dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/moq-gst.yml
+++ b/.github/workflows/moq-gst.yml
@@ -56,8 +56,8 @@ jobs:
           name: moq-gst-${{ matrix.target }}
           path: dist/*
 
-  package-deb:
-    name: Package .deb (${{ matrix.target }})
+  package:
+    name: Package .deb/.rpm (${{ matrix.target }})
     runs-on: ${{ matrix.runs-on }}
 
     strategy:
@@ -65,18 +65,25 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
             deb-arch: amd64
             deb-multiarch: x86_64-linux-gnu
+            rpm-arch: x86_64
           - target: aarch64-unknown-linux-gnu
-            runs-on: ubuntu-22.04-arm
+            runs-on: ubuntu-24.04-arm
             deb-arch: arm64
             deb-multiarch: aarch64-linux-gnu
+            rpm-arch: aarch64
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
 
       - name: Set up packaging tools
         uses: ./.github/actions/setup-packaging
@@ -86,32 +93,23 @@ jobs:
         shell: bash
         run: .github/scripts/release.sh parse-version moq-gst
 
-      - name: Build inside Debian 12 (glibc 2.36, gst 1.22)
+      - name: Install GStreamer dev libraries
         shell: bash
-        env:
-          TARGET: ${{ matrix.target }}
         run: |
-          # gstreamer-rs 0.23 needs GStreamer >= 1.22 headers at compile
-          # time; Debian 12 (bookworm) ships 1.22 and glibc 2.36, the
-          # lowest-common-denominator that lets the .deb install on
-          # Debian 12+ and Ubuntu 24.04+.
-          docker run --rm \
-            -v "$PWD":/work -w /work \
-            -e TARGET \
-            debian:12 bash -c '
-              set -euo pipefail
-              export DEBIAN_FRONTEND=noninteractive
-              apt-get update -qq
-              apt-get install -y --no-install-recommends \
-                build-essential pkg-config curl ca-certificates \
-                libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
-              curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs \
-                | sh -s -- -y --default-toolchain stable --profile minimal
-              source $HOME/.cargo/env
-              cargo build --release --target "$TARGET" -p moq-gst
-            '
+          # Ubuntu 24.04 ships GStreamer 1.24, satisfying gstreamer-rs
+          # 0.23's 1.22+ headers requirement. Resulting .so dynamic-links
+          # to libgstreamer-1.0.so.0 (ABI-stable since 1.0).
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 
-      - name: Package via nfpm
+      - name: Build (release, glibc 2.34)
+        shell: bash
+        # Pin glibc to 2.34 so one .so covers Debian 12+/Ubuntu 22.04+
+        # (.deb) and AlmaLinux/RHEL/Rocky 9+ (.rpm).
+        run: cargo zigbuild --release --target ${{ matrix.target }}.2.34 -p moq-gst
+
+      - name: Package .deb
         shell: bash
         env:
           VERSION: ${{ steps.parse.outputs.version }}
@@ -121,64 +119,11 @@ jobs:
           PLUGIN_DIR: /usr/lib/${{ matrix.deb-multiarch }}/gstreamer-1.0
         run: |
           mkdir -p dist
-          nfpm pkg --packager deb --config packaging/moq-gst/nfpm.yaml --target dist/
+          envsubst '$VERSION $ARCH $PKG_NAME $PLUGIN_PATH $PLUGIN_DIR' \
+            < packaging/moq-gst/nfpm.yaml > /tmp/nfpm.yaml
+          nfpm pkg --packager deb --config /tmp/nfpm.yaml --target dist/
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: moq-gst-deb-${{ matrix.deb-arch }}
-          path: dist/*.deb
-
-  package-rpm:
-    name: Package .rpm (${{ matrix.target }})
-    runs-on: ${{ matrix.runs-on }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            runs-on: ubuntu-22.04
-            rpm-arch: x86_64
-          - target: aarch64-unknown-linux-gnu
-            runs-on: ubuntu-22.04-arm
-            rpm-arch: aarch64
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - name: Set up packaging tools
-        uses: ./.github/actions/setup-packaging
-
-      - name: Parse version
-        id: parse
-        shell: bash
-        run: .github/scripts/release.sh parse-version moq-gst
-
-      - name: Build inside AlmaLinux 9 (glibc 2.34)
-        shell: bash
-        env:
-          VERSION: ${{ steps.parse.outputs.version }}
-          RPM_ARCH: ${{ matrix.rpm-arch }}
-          TARGET: ${{ matrix.target }}
-        run: |
-          docker run --rm \
-            -v "$PWD":/work -w /work \
-            -e VERSION -e RPM_ARCH -e TARGET \
-            almalinux:9 bash -c '
-              set -euo pipefail
-              dnf install -y --quiet \
-                gcc make pkgconf-pkg-config curl tar gzip which \
-                gstreamer1-devel gstreamer1-plugins-base-devel
-              curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs \
-                | sh -s -- -y --default-toolchain stable --profile minimal
-              source $HOME/.cargo/env
-              cargo build --release --target "$TARGET" -p moq-gst
-            '
-
-      - name: Package via nfpm
+      - name: Package .rpm
         shell: bash
         env:
           VERSION: ${{ steps.parse.outputs.version }}
@@ -188,17 +133,19 @@ jobs:
           PLUGIN_DIR: /usr/lib64/gstreamer-1.0
         run: |
           mkdir -p dist
-          nfpm pkg --packager rpm --config packaging/moq-gst/nfpm.yaml --target dist/
+          envsubst '$VERSION $ARCH $PKG_NAME $PLUGIN_PATH $PLUGIN_DIR' \
+            < packaging/moq-gst/nfpm.yaml > /tmp/nfpm.yaml
+          nfpm pkg --packager rpm --config /tmp/nfpm.yaml --target dist/
 
-      - name: Upload artifact
+      - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: moq-gst-rpm-${{ matrix.rpm-arch }}
-          path: dist/*.rpm
+          name: moq-gst-pkg-${{ matrix.target }}
+          path: dist/*
 
   release:
     name: Release
-    needs: [build, package-deb, package-rpm]
+    needs: [build, package]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/moq-relay.yml
+++ b/.github/workflows/moq-relay.yml
@@ -67,9 +67,11 @@ jobs:
       - name: Set up packaging tools
         uses: ./.github/actions/setup-packaging
 
-      - name: Build (release)
+      - name: Build (release, glibc 2.34)
         shell: bash
-        run: cargo build --release --target ${{ matrix.target }} -p moq-relay
+        # Pin to glibc 2.34 so one binary covers Ubuntu 22.04+ (.deb)
+        # and AlmaLinux/RHEL/Rocky 9+ (.rpm).
+        run: cargo zigbuild --release --target ${{ matrix.target }}.2.34 -p moq-relay
 
       - name: Package bare binary
         shell: bash
@@ -102,30 +104,20 @@ jobs:
           ARCH: ${{ matrix.deb-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq-relay
         run: |
-          nfpm pkg --packager deb --config packaging/moq-relay/nfpm.yaml --target dist/
+          envsubst '$VERSION $ARCH $BINARY_PATH' \
+            < packaging/moq-relay/nfpm.yaml > /tmp/nfpm.yaml
+          nfpm pkg --packager deb --config /tmp/nfpm.yaml --target dist/
 
-      - name: Package .rpm (AlmaLinux 9 toolchain, glibc 2.34)
+      - name: Package .rpm
         shell: bash
         env:
           VERSION: ${{ steps.parse.outputs.version }}
-          RPM_ARCH: ${{ matrix.rpm-arch }}
+          ARCH: ${{ matrix.rpm-arch }}
+          BINARY_PATH: target/${{ matrix.target }}/release/moq-relay
         run: |
-          # Rebuild inside AlmaLinux 9 so the binary links against its
-          # older glibc and is forward-compatible with RHEL/Rocky/Alma 9+.
-          docker run --rm \
-            -v "$PWD":/work -w /work \
-            almalinux:9 bash -c '
-              set -euo pipefail
-              dnf install -y --quiet gcc make cmake perl pkgconf-pkg-config curl
-              curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs \
-                | sh -s -- -y --default-toolchain stable --profile minimal
-              source $HOME/.cargo/env
-              cargo build --release --target ${{ matrix.target }} -p moq-relay
-              cp target/${{ matrix.target }}/release/moq-relay target/moq-relay.rpm-build
-            '
-          ARCH="$RPM_ARCH" \
-          BINARY_PATH=target/moq-relay.rpm-build \
-            nfpm pkg --packager rpm --config packaging/moq-relay/nfpm.yaml --target dist/
+          envsubst '$VERSION $ARCH $BINARY_PATH' \
+            < packaging/moq-relay/nfpm.yaml > /tmp/nfpm.yaml
+          nfpm pkg --packager rpm --config /tmp/nfpm.yaml --target dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -64,9 +64,11 @@ jobs:
       - name: Set up packaging tools
         uses: ./.github/actions/setup-packaging
 
-      - name: Build (release)
+      - name: Build (release, glibc 2.34)
         shell: bash
-        run: cargo build --release --target ${{ matrix.target }} -p moq-token-cli
+        # Pin to glibc 2.34 so one binary covers Ubuntu 22.04+ (.deb)
+        # and AlmaLinux/RHEL/Rocky 9+ (.rpm).
+        run: cargo zigbuild --release --target ${{ matrix.target }}.2.34 -p moq-token-cli
 
       - name: Package bare binary
         shell: bash
@@ -99,28 +101,20 @@ jobs:
           ARCH: ${{ matrix.deb-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq-token-cli
         run: |
-          nfpm pkg --packager deb --config packaging/moq-token-cli/nfpm.yaml --target dist/
+          envsubst '$VERSION $ARCH $BINARY_PATH' \
+            < packaging/moq-token-cli/nfpm.yaml > /tmp/nfpm.yaml
+          nfpm pkg --packager deb --config /tmp/nfpm.yaml --target dist/
 
-      - name: Package .rpm (AlmaLinux 9 toolchain)
+      - name: Package .rpm
         shell: bash
         env:
           VERSION: ${{ steps.parse.outputs.version }}
-          RPM_ARCH: ${{ matrix.rpm-arch }}
+          ARCH: ${{ matrix.rpm-arch }}
+          BINARY_PATH: target/${{ matrix.target }}/release/moq-token-cli
         run: |
-          docker run --rm \
-            -v "$PWD":/work -w /work \
-            almalinux:9 bash -c '
-              set -euo pipefail
-              dnf install -y --quiet gcc make cmake perl pkgconf-pkg-config curl
-              curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs \
-                | sh -s -- -y --default-toolchain stable --profile minimal
-              source $HOME/.cargo/env
-              cargo build --release --target ${{ matrix.target }} -p moq-token-cli
-              cp target/${{ matrix.target }}/release/moq-token-cli target/moq-token-cli.rpm-build
-            '
-          ARCH="$RPM_ARCH" \
-          BINARY_PATH=target/moq-token-cli.rpm-build \
-            nfpm pkg --packager rpm --config packaging/moq-token-cli/nfpm.yaml --target dist/
+          envsubst '$VERSION $ARCH $BINARY_PATH' \
+            < packaging/moq-token-cli/nfpm.yaml > /tmp/nfpm.yaml
+          nfpm pkg --packager rpm --config /tmp/nfpm.yaml --target dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,13 @@
         packagingDeps = with pkgs; [
           nfpm
           dpkg
+          gettext
+
+          # cargo-zigbuild + zig let CI build a single binary that links
+          # against an older glibc (passed as `<triple>.<glibc>`), so the
+          # same artifact ships in both .deb and .rpm. No docker needed.
+          cargo-zigbuild
+          zig
         ];
 
         # Tools needed to regenerate and sign the apt/rpm repositories.

--- a/packaging/moq-cli/nfpm.yaml
+++ b/packaging/moq-cli/nfpm.yaml
@@ -26,7 +26,7 @@ contents:
 overrides:
   deb:
     depends:
-      - libc6 (>= 2.35)
+      - libc6 (>= 2.34)
   rpm:
     depends:
       - glibc >= 2.34

--- a/packaging/moq-gst/nfpm.yaml
+++ b/packaging/moq-gst/nfpm.yaml
@@ -36,7 +36,7 @@ contents:
 overrides:
   deb:
     depends:
-      - libc6 (>= 2.36)
+      - libc6 (>= 2.34)
       - libgstreamer1.0-0 (>= 1.22)
       - libgstreamer-plugins-base1.0-0 (>= 1.22)
   rpm:

--- a/packaging/moq-relay/nfpm.yaml
+++ b/packaging/moq-relay/nfpm.yaml
@@ -44,7 +44,7 @@ contents:
 overrides:
   deb:
     depends:
-      - libc6 (>= 2.35)
+      - libc6 (>= 2.34)
     recommends:
       - systemd
     suggests:

--- a/packaging/moq-token-cli/nfpm.yaml
+++ b/packaging/moq-token-cli/nfpm.yaml
@@ -26,7 +26,7 @@ contents:
 overrides:
   deb:
     depends:
-      - libc6 (>= 2.35)
+      - libc6 (>= 2.34)
   rpm:
     depends:
       - glibc >= 2.34


### PR DESCRIPTION
## Summary

Two fixes folded together to get the release workflows actually green:

1. **`envsubst` pre-rendering before `nfpm pkg`.** nfpm's `${VAR}` expansion only fires on a small allow-list of top-level fields (`name`, `arch`, `version`); for `contents[].src` and `contents[].dst` the value flows straight into the glob handler, which treats `${BINARY_PATH}` as a literal pattern and fails with `glob failed: ${BINARY_PATH}: no matching files`. `{{ .Env.VAR }}` doesn't help either: nfpm's templating doc lists the same restricted field set. Each `.deb`/`.rpm` step now does `envsubst '$VERSION $ARCH ...' < nfpm.yaml > /tmp/nfpm.yaml` before invoking nfpm.

2. **`cargo zigbuild` in place of the AlmaLinux 9 / Debian 12 docker rebuilds.** The previous `Package .rpm` (and `Package .deb` for moq-gst) reinstalled Rust inside a container on every run just to link against an older glibc. That path was slow (~7-15 min, no cargo cache), fragile (hit `curl-minimal` vs `curl` dnf conflicts, exit-127 surprises), and easy to break invisibly. Replaced with `cargo zigbuild --target <triple>.2.34`, which produces one binary covering Debian 12+, Ubuntu 22.04+, and RHEL/Rocky/Alma 9+. The `.deb` and `.rpm` steps now point nfpm at the same artifact.

For moq-gst the deb and rpm jobs collapse into one `package` job per arch on `ubuntu-24.04` (ships GStreamer 1.24, satisfies gstreamer-rs 0.23's `>= 1.22` headers requirement). The resulting `.so` still dynamic-links to the host's `libgstreamer-1.0.so.0`, matching the existing nfpm `>= 1.22` depends.

## Wiring

- `cargo-zigbuild`, `zig`, and `gettext` added to the `.#packaging` derivation so CI and local `nix develop` users share the toolchain.
- nfpm.yaml `libc6` depends drop from `>= 2.35` / `>= 2.36` to `>= 2.34` to match the zigbuild floor.

## Net diff

9 files, +89 / -153 (Docker block removal more than pays for the new lines).

## Test plan

- [x] `yaml.safe_load` parses cleanly on all touched workflow and nfpm.yaml files.
- [ ] PR dry-run exercises `.deb` and `.rpm` end-to-end for moq-cli, moq-relay, moq-token-cli (moq-gst's workflow has no PR dry-run, so its fix is exercised only on the next `moq-gst-v*` tag).

https://claude.ai/code/session_015J5tVAQ7ESjBhnzdeXfhgX