### PR TITLE
Tighten public APIs ahead of release: non_exhaustive + builders

### DIFF
--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -93,7 +93,7 @@ impl Subscribe {
 		// Fmp4 subscribes to the catalog internally, builds the merged init segment
 		// from the first catalog snapshot, then yields moof+mdat fragments in
 		// timestamp order across tracks.
-		let mut fmp4 = moq_mux::container::fmp4::Export::new(self.broadcast, self.catalog)?
+		let mut fmp4 = moq_mux::container::fmp4::Export::with_catalog_format(self.broadcast, self.catalog)?
 			.with_latency(self.args.max_latency)
 			.with_fragment_duration(self.args.fragment_duration);
 
@@ -111,7 +111,7 @@ impl Subscribe {
 		// Mkv writes EBML + an unknown-size Segment header, then per-fragment
 		// Cluster elements. Avc3/Hev1 sources are transcoded to avc1/hvc1
 		// shape internally (synthesizing avcC/hvcC from inline parameter sets).
-		let mut mkv = moq_mux::container::mkv::Export::new(self.broadcast, self.catalog)?
+		let mut mkv = moq_mux::container::mkv::Export::with_catalog_format(self.broadcast, self.catalog)?
 			.with_latency(self.args.max_latency)
 			.with_fragment_duration(self.args.fragment_duration);
 

--- a/rs/moq-msf/src/lib.rs
+++ b/rs/moq-msf/src/lib.rs
@@ -29,9 +29,15 @@ pub struct Catalog {
 }
 
 /// A single track in the MSF catalog.
+///
+/// Marked `#[non_exhaustive]` because the CMSF/MSF drafts continue to grow
+/// optional fields. External constructors should start from a previously
+/// produced `Track` (e.g. from `Catalog::from_str`) or use struct update
+/// syntax against one.
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Track {
 	/// Unique track name (case-sensitive).
 	pub name: String,
@@ -101,6 +107,36 @@ impl Catalog {
 	#[allow(clippy::should_implement_trait)]
 	pub fn from_str(s: &str) -> Result<Self, serde_json::Error> {
 		serde_json::from_str(s)
+	}
+}
+
+impl Track {
+	/// Construct a track with the required identity fields set and every
+	/// optional field cleared. Fields are `pub`, so callers set whatever they
+	/// need by assignment afterwards.
+	///
+	/// This is the only path external crates have to build a `Track` since the
+	/// type is `#[non_exhaustive]`.
+	pub fn new(name: impl Into<String>, packaging: Packaging) -> Self {
+		Self {
+			name: name.into(),
+			packaging,
+			is_live: false,
+			role: None,
+			codec: None,
+			width: None,
+			height: None,
+			framerate: None,
+			samplerate: None,
+			channel_config: None,
+			bitrate: None,
+			init_data: None,
+			render_group: None,
+			alt_group: None,
+			max_grp_sap_starting_type: None,
+			max_obj_sap_starting_type: None,
+			jitter: None,
+		}
 	}
 }
 

--- a/rs/moq-msf/src/lib.rs
+++ b/rs/moq-msf/src/lib.rs
@@ -31,9 +31,10 @@ pub struct Catalog {
 /// A single track in the MSF catalog.
 ///
 /// Marked `#[non_exhaustive]` because the CMSF/MSF drafts continue to grow
-/// optional fields. External constructors should start from a previously
-/// produced `Track` (e.g. from `Catalog::from_str`) or use struct update
-/// syntax against one.
+/// optional fields. External callers build a track with [`Track::new`] and
+/// then assign whichever optional fields they need; struct-literal
+/// construction (with or without `..base`) is not available outside this
+/// crate.
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/rs/moq-mux/src/catalog/hang/producer.rs
+++ b/rs/moq-mux/src/catalog/hang/producer.rs
@@ -156,25 +156,21 @@ fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 		};
 
 		let sap_type = video_sap_type(&config.codec);
-		tracks.push(moq_msf::Track {
-			name: name.clone(),
-			packaging,
-			is_live: true,
-			role: Some(moq_msf::Role::Video),
-			codec: Some(config.codec.to_string()),
-			width: config.coded_width,
-			height: config.coded_height,
-			framerate: config.framerate,
-			samplerate: None,
-			channel_config: None,
-			bitrate: config.bitrate,
-			init_data,
-			render_group: Some(1),
-			alt_group: if has_multiple_video { Some(1) } else { None },
-			max_grp_sap_starting_type: sap_type,
-			max_obj_sap_starting_type: sap_type,
-			jitter: config.jitter.map(|t| t.as_millis() as f64),
-		});
+		let mut track = moq_msf::Track::new(name.clone(), packaging);
+		track.is_live = true;
+		track.role = Some(moq_msf::Role::Video);
+		track.codec = Some(config.codec.to_string());
+		track.width = config.coded_width;
+		track.height = config.coded_height;
+		track.framerate = config.framerate;
+		track.bitrate = config.bitrate;
+		track.init_data = init_data;
+		track.render_group = Some(1);
+		track.alt_group = if has_multiple_video { Some(1) } else { None };
+		track.max_grp_sap_starting_type = sap_type;
+		track.max_obj_sap_starting_type = sap_type;
+		track.jitter = config.jitter.map(|t| t.as_millis() as f64);
+		tracks.push(track);
 	}
 
 	let has_multiple_audio = catalog.audio.renditions.len() > 1;
@@ -192,25 +188,20 @@ fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 				.map(|d| base64::engine::general_purpose::STANDARD.encode(d.as_ref())),
 		};
 
-		tracks.push(moq_msf::Track {
-			name: name.clone(),
-			packaging,
-			is_live: true,
-			role: Some(moq_msf::Role::Audio),
-			codec: Some(config.codec.to_string()),
-			width: None,
-			height: None,
-			framerate: None,
-			samplerate: Some(config.sample_rate),
-			channel_config: Some(config.channel_count.to_string()),
-			bitrate: config.bitrate,
-			init_data,
-			render_group: Some(1),
-			alt_group: if has_multiple_audio { Some(1) } else { None },
-			max_grp_sap_starting_type: Some(1),
-			max_obj_sap_starting_type: Some(1),
-			jitter: config.jitter.map(|t| t.as_millis() as f64),
-		});
+		let mut track = moq_msf::Track::new(name.clone(), packaging);
+		track.is_live = true;
+		track.role = Some(moq_msf::Role::Audio);
+		track.codec = Some(config.codec.to_string());
+		track.samplerate = Some(config.sample_rate);
+		track.channel_config = Some(config.channel_count.to_string());
+		track.bitrate = config.bitrate;
+		track.init_data = init_data;
+		track.render_group = Some(1);
+		track.alt_group = if has_multiple_audio { Some(1) } else { None };
+		track.max_grp_sap_starting_type = Some(1);
+		track.max_obj_sap_starting_type = Some(1);
+		track.jitter = config.jitter.map(|t| t.as_millis() as f64);
+		tracks.push(track);
 	}
 
 	moq_msf::Catalog { version: 1, tracks }

--- a/rs/moq-mux/src/catalog/msf/consumer.rs
+++ b/rs/moq-mux/src/catalog/msf/consumer.rs
@@ -401,47 +401,29 @@ mod test {
 	use super::*;
 
 	fn video_track(name: &str, packaging: moq_msf::Packaging, init_data: Option<&str>) -> moq_msf::Track {
-		moq_msf::Track {
-			name: name.to_string(),
-			packaging,
-			is_live: true,
-			role: Some(moq_msf::Role::Video),
-			codec: Some("avc1.640028".to_string()),
-			width: Some(1920),
-			height: Some(1080),
-			framerate: Some(30.0),
-			samplerate: None,
-			channel_config: None,
-			bitrate: Some(5_000_000),
-			init_data: init_data.map(str::to_string),
-			render_group: Some(1),
-			alt_group: None,
-			max_grp_sap_starting_type: None,
-			max_obj_sap_starting_type: None,
-			jitter: None,
-		}
+		let mut track = moq_msf::Track::new(name, packaging);
+		track.is_live = true;
+		track.role = Some(moq_msf::Role::Video);
+		track.codec = Some("avc1.640028".to_string());
+		track.width = Some(1920);
+		track.height = Some(1080);
+		track.framerate = Some(30.0);
+		track.bitrate = Some(5_000_000);
+		track.init_data = init_data.map(str::to_string);
+		track.render_group = Some(1);
+		track
 	}
 
 	fn audio_track(name: &str, packaging: moq_msf::Packaging) -> moq_msf::Track {
-		moq_msf::Track {
-			name: name.to_string(),
-			packaging,
-			is_live: true,
-			role: Some(moq_msf::Role::Audio),
-			codec: Some("opus".to_string()),
-			width: None,
-			height: None,
-			framerate: None,
-			samplerate: Some(48_000),
-			channel_config: Some("2".to_string()),
-			bitrate: Some(128_000),
-			init_data: None,
-			render_group: Some(1),
-			alt_group: None,
-			max_grp_sap_starting_type: None,
-			max_obj_sap_starting_type: None,
-			jitter: None,
-		}
+		let mut track = moq_msf::Track::new(name, packaging);
+		track.is_live = true;
+		track.role = Some(moq_msf::Role::Audio);
+		track.codec = Some("opus".to_string());
+		track.samplerate = Some(48_000);
+		track.channel_config = Some("2".to_string());
+		track.bitrate = Some(128_000);
+		track.render_group = Some(1);
+		track
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -65,13 +65,25 @@ struct Fmp4Track {
 }
 
 impl Export {
-	/// Subscribe to `broadcast` and produce fMP4 byte chunks.
+	/// Subscribe to `broadcast` and produce fMP4 byte chunks, using the default
+	/// catalog format ([`CatalogFormat::Hang`]).
 	///
-	/// `catalog_format` selects which catalog track the importer subscribes to
-	/// for track discovery. Both formats end up driving the same internal
-	/// `hang::Catalog`-based pipeline (MSF snapshots are converted on receipt),
-	/// so the only observable difference is which wire catalog is consumed.
-	pub fn new(broadcast: moq_net::BroadcastConsumer, catalog_format: CatalogFormat) -> Result<Self, crate::Error> {
+	/// Use [`with_catalog_format`](Self::with_catalog_format) to subscribe to a
+	/// non-default catalog track (e.g. MSF).
+	pub fn new(broadcast: moq_net::BroadcastConsumer) -> Result<Self, crate::Error> {
+		Self::with_catalog_format(broadcast, CatalogFormat::default())
+	}
+
+	/// Subscribe to `broadcast` and produce fMP4 byte chunks, selecting an
+	/// explicit `catalog_format` for track discovery.
+	///
+	/// Both formats drive the same internal `hang::Catalog`-based pipeline (MSF
+	/// snapshots are converted on receipt), so the only observable difference
+	/// is which wire catalog track is consumed.
+	pub fn with_catalog_format(
+		broadcast: moq_net::BroadcastConsumer,
+		catalog_format: CatalogFormat,
+	) -> Result<Self, crate::Error> {
 		let catalog = CatalogSource::new(&broadcast, catalog_format)?;
 
 		Ok(Self {

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -70,8 +70,7 @@ async fn avc3_source_to_cmaf_export_roundtrip() {
 		.unwrap();
 	track_producer.finish().unwrap();
 
-	let mut exporter =
-		crate::container::fmp4::Export::new(consumer, crate::catalog::CatalogFormat::Hang).expect("new Fmp4");
+	let mut exporter = crate::container::fmp4::Export::new(consumer).expect("new Fmp4");
 
 	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
 		.await
@@ -134,8 +133,7 @@ async fn cmaf_source_to_cmaf_export_passthrough() {
 	let mut buf = BytesMut::from(data.as_slice());
 	let _ = importer.decode(&mut buf);
 
-	let mut exporter =
-		crate::container::fmp4::Export::new(consumer, crate::catalog::CatalogFormat::Hang).expect("new Fmp4");
+	let mut exporter = crate::container::fmp4::Export::new(consumer).expect("new Fmp4");
 
 	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
 		.await

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -152,13 +152,25 @@ impl ClusterBuilder {
 }
 
 impl Export {
-	/// Subscribe to `broadcast` and produce MKV byte chunks.
+	/// Subscribe to `broadcast` and produce MKV byte chunks, using the default
+	/// catalog format ([`CatalogFormat::Hang`]).
 	///
-	/// `catalog_format` selects which catalog track the exporter subscribes to
-	/// for track discovery. Both formats end up driving the same internal
-	/// `hang::Catalog`-based pipeline (MSF snapshots are converted on receipt),
-	/// so the only observable difference is which wire catalog is consumed.
-	pub fn new(broadcast: moq_net::BroadcastConsumer, catalog_format: CatalogFormat) -> Result<Self, crate::Error> {
+	/// Use [`with_catalog_format`](Self::with_catalog_format) to subscribe to a
+	/// non-default catalog track (e.g. MSF).
+	pub fn new(broadcast: moq_net::BroadcastConsumer) -> Result<Self, crate::Error> {
+		Self::with_catalog_format(broadcast, CatalogFormat::default())
+	}
+
+	/// Subscribe to `broadcast` and produce MKV byte chunks, selecting an
+	/// explicit `catalog_format` for track discovery.
+	///
+	/// Both formats drive the same internal `hang::Catalog`-based pipeline (MSF
+	/// snapshots are converted on receipt), so the only observable difference
+	/// is which wire catalog track is consumed.
+	pub fn with_catalog_format(
+		broadcast: moq_net::BroadcastConsumer,
+		catalog_format: CatalogFormat,
+	) -> Result<Self, crate::Error> {
 		let catalog = CatalogSource::new(&broadcast, catalog_format)?;
 
 		Ok(Self {

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -28,7 +28,7 @@ async fn export_header_roundtrip_vp9_opus() {
 	importer.finish().unwrap();
 
 	// Now subscribe via the exporter and pull bytes.
-	let mut exporter = crate::container::mkv::Export::new(consumer, crate::catalog::CatalogFormat::Hang).unwrap();
+	let mut exporter = crate::container::mkv::Export::new(consumer).unwrap();
 
 	// First `next()` should give us the header (EBML + Segment-start + Info + Tracks).
 	let header = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
@@ -153,7 +153,7 @@ async fn export_emits_blocks_for_each_frame() {
 	importer.decode(&mut buf).unwrap();
 	importer.finish().unwrap();
 
-	let mut exporter = crate::container::mkv::Export::new(consumer, crate::catalog::CatalogFormat::Hang)
+	let mut exporter = crate::container::mkv::Export::new(consumer)
 		.unwrap()
 		// Use per-frame clustering so each frame is observable as its own
 		// Cluster chunk; batching is exercised in a dedicated test below.
@@ -251,7 +251,7 @@ async fn export_rejects_cmaf_track() {
 		},
 	);
 
-	let mut exporter = crate::container::mkv::Export::new(consumer, crate::catalog::CatalogFormat::Hang).unwrap();
+	let mut exporter = crate::container::mkv::Export::new(consumer).unwrap();
 	let result = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
 		.await
 		.expect("exporter timed out");
@@ -337,7 +337,7 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 	let mut catalog = catalog;
 	catalog.finish().unwrap();
 
-	let mut exporter = crate::container::mkv::Export::new(consumer, crate::catalog::CatalogFormat::Hang)
+	let mut exporter = crate::container::mkv::Export::new(consumer)
 		.unwrap()
 		.with_fragment_duration(std::time::Duration::ZERO);
 	let mut exported: Vec<u8> = Vec::new();
@@ -472,7 +472,7 @@ async fn export_fragment_duration_batches_blocks() {
 	importer.finish().unwrap();
 	catalog.finish().unwrap();
 
-	let mut exporter = crate::container::mkv::Export::new(consumer, crate::catalog::CatalogFormat::Hang)
+	let mut exporter = crate::container::mkv::Export::new(consumer)
 		.unwrap()
 		.with_fragment_duration(std::time::Duration::from_secs(2));
 	let mut exported: Vec<u8> = Vec::new();

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -467,7 +467,13 @@ impl AuthConfig {
 
 /// The result of a successful authentication, containing the resolved
 /// permissions for a connection.
+///
+/// Marked `#[non_exhaustive]` so additional context fields (cluster tier flags,
+/// rate-limit info, etc.) can be added without bumping the major version.
+/// External consumers must build tokens through library APIs (e.g. via
+/// [`Auth::verify`]) rather than by struct literal.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct AuthToken {
 	/// The root path this token is scoped to.
 	pub root: PathOwned,

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use moq_net::{Origin, OriginConsumer, OriginProducer, Stats, Tier};
 use url::Url;
 
-use crate::{AuthToken, StatsConfig};
+use crate::AuthToken;
 
 /// Configuration for relay clustering.
 ///
@@ -40,10 +40,14 @@ pub struct ClusterConfig {
 /// Local sessions and remote cluster connections all publish into the same
 /// origin. Loop prevention and shortest-path preference come from the
 /// hop list carried on each broadcast (see [`moq_net::Broadcast::hops`]).
+///
+/// Construct with [`Cluster::new`], then attach a QUIC client and (optionally)
+/// a [`Stats`] aggregator with the `with_*` builder methods. A cluster without
+/// a client can serve local sessions but cannot dial remote peers.
 #[derive(Clone)]
 pub struct Cluster {
 	config: ClusterConfig,
-	client: moq_native::Client,
+	client: Option<moq_native::Client>,
 
 	/// All broadcasts, local and remote. Downstream sessions read from here
 	/// (filtered by their auth token) and remote dials both read and write here.
@@ -51,30 +55,46 @@ pub struct Cluster {
 
 	/// Stats aggregator. One instance per relay; sessions pick a tier via
 	/// [`Stats::tier`] at acceptance time so external (non-mTLS) and internal
-	/// (mTLS / cluster peer) traffic land in separate counter sets. When stats
-	/// publishing is disabled, this is a no-op aggregator.
+	/// (mTLS / cluster peer) traffic land in separate counter sets. Defaults
+	/// to [`Stats::disabled`] (a no-op aggregator) until [`with_stats`](Self::with_stats)
+	/// is called.
 	pub stats: Stats,
 }
 
 impl Cluster {
-	/// Creates a new cluster with the given configuration and QUIC client.
-	pub fn new(config: ClusterConfig, stats_config: StatsConfig, client: moq_native::Client) -> Self {
+	/// Creates a new cluster with a fresh origin and no peers, client, or stats.
+	///
+	/// Use [`with_client`](Self::with_client) to enable dialing remote peers
+	/// (required when `config.connect` is non-empty), and
+	/// [`with_stats`](Self::with_stats) to enable metrics publishing.
+	pub fn new(config: ClusterConfig) -> Self {
 		let origin = Origin::random().produce();
 		tracing::info!(origin_id = %origin.id, "cluster initialized");
-		let stats = if stats_config.enabled {
-			let levels = stats_config.levels.unwrap_or(1).max(1);
-			let prefix = stats_config.prefix.clone().unwrap_or_else(|| ".stats".to_string());
-			tracing::info!(prefix, levels, node = ?stats_config.node, "stats publishing enabled");
-			Stats::new(prefix, levels, stats_config.node.clone(), origin.clone())
-		} else {
-			Stats::disabled()
-		};
 		Cluster {
 			config,
-			client,
+			client: None,
 			origin,
-			stats,
+			stats: Stats::disabled(),
 		}
+	}
+
+	/// Attach a QUIC client used to dial cluster peers.
+	///
+	/// Required when `config.connect` is non-empty; [`run`](Self::run) returns
+	/// an error otherwise.
+	pub fn with_client(mut self, client: moq_native::Client) -> Self {
+		self.client = Some(client);
+		self
+	}
+
+	/// Attach a [`Stats`] aggregator. Replaces the default no-op aggregator.
+	///
+	/// Build the value with [`StatsConfig::build`](crate::StatsConfig::build),
+	/// passing [`Self::origin`] so the aggregator publishes through the same
+	/// origin cluster peers read from.
+	pub fn with_stats(mut self, stats: Stats) -> Self {
+		self.stats = stats;
+		self
 	}
 
 	/// Returns an [`OriginConsumer`] scoped to this session's subscribe permissions.
@@ -91,12 +111,19 @@ impl Cluster {
 	/// each connection alive indefinitely with exponential backoff on failure.
 	///
 	/// Completes once all dials have given up; a node with no peers (`connect`
-	/// empty) has no outbound work and returns immediately.
+	/// empty) has no outbound work and returns immediately. Errors when peers
+	/// are configured but no client has been attached via
+	/// [`with_client`](Self::with_client).
 	pub async fn run(self) -> anyhow::Result<()> {
 		if self.config.connect.is_empty() {
 			tracing::info!("no cluster peers configured; running standalone");
 			return Ok(());
 		}
+
+		anyhow::ensure!(
+			self.client.is_some(),
+			"cluster peers configured but no QUIC client attached (call Cluster::with_client)"
+		);
 
 		let token = match &self.config.token {
 			Some(path) => std::fs::read_to_string(path)
@@ -164,10 +191,14 @@ impl Cluster {
 		log_url.set_query(None);
 		tracing::info!(url = %log_url, "dialing cluster peer");
 
-		// Cluster-to-cluster traffic is internal by definition.
-		let session = self
+		// Checked at the start of `run`; per-peer tasks inherit that guarantee.
+		let client = self
 			.client
 			.clone()
+			.context("internal: cluster peer dial without an attached QUIC client")?;
+
+		// Cluster-to-cluster traffic is internal by definition.
+		let session = client
 			.with_publish(self.origin.consume())
 			.with_consume(self.origin.clone())
 			.with_stats(self.stats.tier(Tier::Internal))

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -49,7 +49,9 @@ async fn main() -> anyhow::Result<()> {
 		config.auth.init().await?
 	};
 
-	let cluster = Cluster::new(config.cluster, config.stats, client);
+	let cluster = Cluster::new(config.cluster).with_client(client);
+	let stats = config.stats.build(cluster.origin.clone());
+	let cluster = cluster.with_stats(stats);
 
 	// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
 	let web = Web::new(

--- a/rs/moq-relay/src/stats.rs
+++ b/rs/moq-relay/src/stats.rs
@@ -4,6 +4,7 @@
 //! holds the relay-specific config knobs.
 
 use clap::Args;
+use moq_net::{OriginProducer, Stats};
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the relay's stats publishing.
@@ -53,4 +54,20 @@ pub struct StatsConfig {
 	/// Single-relay deployments can leave this unset.
 	#[arg(long = "stats-node", env = "MOQ_STATS_NODE")]
 	pub node: Option<String>,
+}
+
+impl StatsConfig {
+	/// Build a [`Stats`] aggregator from this config, publishing on `origin`.
+	///
+	/// Returns [`Stats::disabled`] (a no-op aggregator) when [`Self::enabled`]
+	/// is false, so the relay can attach the result unconditionally.
+	pub fn build(&self, origin: OriginProducer) -> Stats {
+		if !self.enabled {
+			return Stats::disabled();
+		}
+		let levels = self.levels.unwrap_or(1).max(1);
+		let prefix = self.prefix.clone().unwrap_or_else(|| ".stats".to_string());
+		tracing::info!(prefix, levels, node = ?self.node, "stats publishing enabled");
+		Stats::new(prefix, levels, self.node.clone(), origin)
+	}
 }


### PR DESCRIPTION
## Summary

Reaction to the breaking changes flagged in the release-plz PR [#1467](https://github.com/moq-dev/moq/pull/1467). Marks wire-format and auth types `#[non_exhaustive]` so additive changes stop counting as breaking, and reshapes a couple of constructors so the breaks land in *this* release instead of the next several.

## Changes

### `moq-msf`
- `Track` is now `#[non_exhaustive]` and gains a `Track::new(name, packaging)` constructor. External callers (currently just `moq-mux`) build a track via `new` + field assignment instead of a struct literal, but future CMSF/MSF optional fields can be added without a major bump.

### `moq-mux`
- `Fmp4::Export::new(broadcast)` and `Mkv::Export::new(broadcast)` now default to `CatalogFormat::Hang`. Callers that need MSF use the new `with_catalog_format(broadcast, format)` constructor.
- `moq-cli` subscribe updated accordingly; tests collapse to `Export::new(consumer)` since they were always asking for Hang.

### `moq-relay`
- `AuthToken` is now `#[non_exhaustive]`. All construction already routes through `AuthToken::unrestricted()` or `Auth::verify()`, so nothing else moved.
- `Cluster` switched to a small builder:
  - `Cluster::new(config)` — fresh origin, no client, `Stats::disabled()`.
  - `.with_client(client)` — required when `config.connect` is non-empty (validated in `run()` with a clear error).
  - `.with_stats(stats)` — replaces the no-op default.
- `Cluster.client` is now `Option<moq_native::Client>`.
- `StatsConfig::build(origin) -> Stats` encapsulates the config-to-aggregator translation, so the relay's `main.rs` calls it unconditionally (it returns `Stats::disabled()` when the config has stats off).

## Test plan

- [x] `cargo check -p moq-msf -p moq-mux -p moq-cli -p moq-relay --all-targets`
- [x] `cargo test -p moq-msf -p moq-mux -p moq-cli -p moq-relay`
- [x] `cargo clippy -p moq-msf -p moq-mux -p moq-cli -p moq-relay --all-targets -- -D warnings`

## Release plz follow-up

This PR intentionally does **not** override versions in `Cargo.toml`. Release-plz will detect the changes here (`Track::new` is genuinely breaking, `Cluster::new` arity changed) and propose new bumps:
- `moq-msf` will likely go to `0.2.0` since `Track::new` replaces struct-literal construction; that's accurate.
- `moq-relay` will still flag breaking changes (per the existing patch-bump-for-relay policy in [#1467](https://github.com/moq-dev/moq/pull/1467)).

The intent is that *subsequent* releases stop tripping the same lints, since the now-`#[non_exhaustive]` types absorb additive changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)