### PR TITLE
fix: update gitignore exception for moved fmp4 test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ node_modules
 *.m4s
 
 # Except these test fixtures, which are committed.
-!rs/moq-mux/src/import/test/*.mp4
+!rs/moq-mux/src/container/fmp4/test_data/*.mp4
 
 # Cloudflare Wrangler
 .wrangler/


### PR DESCRIPTION
## Summary
- The release-plz CI job is failing on main with `the working directory has uncommitted changes` for the committed `*.mp4` test fixtures.
- The fixtures moved from `rs/moq-mux/src/import/test/` to `rs/moq-mux/src/container/fmp4/test_data/`, but the `!` exception in `.gitignore` still pointed at the old path, so the files were both committed and gitignored.
- Updates the exception to the new path. Confirmed locally with `git ls-files -ci --exclude-standard` (now empty).

Failing run: https://github.com/moq-dev/moq/actions/runs/26346376822/job/77556855580

## Test plan
- [ ] Release-plz job passes on this PR / after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)