### PR TITLE
Cachix workflow: fix overlay deps bug + selective tag builds + PR dry-run

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -146,23 +146,29 @@ in
 
       # Strip nix-store paths so the plugin loads against the user's system
       # GStreamer rather than the (unavailable on user machines) nix copy.
+      # The `-f` guard skips crane's deps-only stage, whose $out has no plugin
+      # to patch. (Written by Claude)
       postFixup =
         if final.stdenv.isDarwin then
           ''
             dylib="$out/lib/libgstmoq.dylib"
-            otool -L "$dylib" \
-              | grep -oE '/nix/store/[^ ]+\.dylib' \
-              | sort -u \
-              | while read -r ref; do
-                  install_name_tool -change "$ref" "@rpath/$(basename "$ref")" "$dylib"
-                done
-            install_name_tool -add_rpath /opt/homebrew/lib "$dylib"
-            install_name_tool -add_rpath /usr/local/lib "$dylib"
-            install_name_tool -add_rpath /Library/Frameworks/GStreamer.framework/Libraries "$dylib"
+            if [ -f "$dylib" ]; then
+              otool -L "$dylib" \
+                | grep -oE '/nix/store/[^ ]+\.dylib' \
+                | sort -u \
+                | while read -r ref; do
+                    install_name_tool -change "$ref" "@rpath/$(basename "$ref")" "$dylib"
+                  done
+              install_name_tool -add_rpath /opt/homebrew/lib "$dylib"
+              install_name_tool -add_rpath /usr/local/lib "$dylib"
+              install_name_tool -add_rpath /Library/Frameworks/GStreamer.framework/Libraries "$dylib"
+            fi
           ''
         else
           ''
-            patchelf --remove-rpath $out/lib/libgstmoq.so
+            if [ -f "$out/lib/libgstmoq.so" ]; then
+              patchelf --remove-rpath "$out/lib/libgstmoq.so"
+            fi
           '';
     }
   );


### PR DESCRIPTION
## Summary

Two unrelated CI failures collapsed into one PR.

### 1. Cachix overlay regression (the actual bug)

`craneLib.buildPackage` threads its args into the internal `buildDepsOnly` derivation, so `moq-gst`'s `postFixup` ran on the deps stage too. That stage's `$out` is just `target.tar.zst` with no `lib/libgstmoq.so`, so `patchelf --remove-rpath` (and the macOS `install_name_tool` branch) failed and broke every Cachix tag run that touches the full closure: [moq-cli-v0.7.25](https://github.com/moq-dev/moq/actions/runs/26346586561), [moq-boy-v0.2.12](https://github.com/moq-dev/moq/actions/runs/26346563766), [libmoq-v0.2.16](https://github.com/moq-dev/moq/actions/runs/26346557878).

Bug introduced in [#1453](https://github.com/moq-dev/moq/pull/1453). Fix: guard both branches with `if [ -f ... ]`.

### 2. Cachix workflow design: build only the tagged package + PR dry-run

The old workflow rebuilt **all 6 packages × 2 OSes = 12 jobs** on every tag, so one broken package took down the cachix cache for every other package's release. Now:

- **On tag push:** derive the package from the tag prefix (e.g. `moq-relay-v0.11.5` → `moq-relay`) and build only that one. The name is validated against an allowlist before reaching any shell.
- **On PR** (when `cachix.yml`, `flake.{nix,lock}`, or `nix/**` change): matrix-build every package on Linux with cachix-action's `skipPush: true`. `cachix push` has no `--dry-run` flag, so this is the closest equivalent — exercises the full build path so overlay regressions surface here instead of at a release tag.

Stranded tags (moq-cli-v0.7.25, moq-boy-v0.2.12, libmoq-v0.2.16) will need either a re-tag or just be accepted as cache gaps.

## Test plan

- [ ] `nix build .#moq-gst` succeeds locally on Linux and macOS
- [ ] PR dry-run job succeeds for all 6 packages on this PR
- [ ] Next release tag's Cachix run only builds the matching package

🤖 Generated with [Claude Code](https://claude.com/claude-code)