### PR TITLE
ci(cachix): build only the tagged package

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -41,20 +41,20 @@ jobs:
         with:
           persist-credentials: false
 
-      # Validate against an allowlist so REF_NAME can't slip arbitrary
-      # text into later steps. (Written by Claude)
+      # Full-match REF_NAME against the same <prefix>-v<semver> contract
+      # release.sh enforces, so a malformed tag fails fast instead of
+      # building under a trusted identity. (Written by Claude)
       - name: Derive package from tag
         id: pkg
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |
-          # moq-relay-v0.11.5 -> moq-relay
-          name="${REF_NAME%-v*}"
-          case "$name" in
-            moq-relay|moq-cli|moq-token-cli|moq-boy|libmoq|moq-gst) ;;
-            *) echo "Unrecognized tag prefix: $REF_NAME" >&2; exit 1 ;;
-          esac
-          echo "name=$name" >> "$GITHUB_OUTPUT"
+          re='^(moq-relay|moq-cli|moq-token-cli|moq-boy|libmoq|moq-gst)-v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)$'
+          if [[ ! "$REF_NAME" =~ $re ]]; then
+            echo "Tag format not recognized: $REF_NAME" >&2
+            exit 1
+          fi
+          echo "name=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
 
       - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
         with:

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -9,22 +9,11 @@ on:
       - 'moq-boy-v*'
       - 'libmoq-v*'
       - 'moq-gst-v*'
-  pull_request:
-    paths:
-      - '.github/workflows/cachix.yml'
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'nix/**'
-
-concurrency:
-  group: cachix-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # On a release tag, build and push only the package the tag names. The
-  # tag prefix (e.g. moq-relay) maps 1:1 to a flake attribute.
+  # Build and push only the package the tag names. The tag prefix
+  # (e.g. moq-relay) maps 1:1 to a flake attribute.
   release:
-    if: github.event_name == 'push'
     name: Release (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     permissions:
@@ -43,7 +32,7 @@ jobs:
 
       # Full-match REF_NAME against the same <prefix>-v<semver> contract
       # release.sh enforces, so a malformed tag fails fast instead of
-      # building under a trusted identity. (Written by Claude)
+      # building under a trusted identity.
       - name: Derive package from tag
         id: pkg
         env:
@@ -72,45 +61,3 @@ jobs:
         run: |
           nix build ".#$PACKAGE" --print-build-logs
           cachix push kixelated ./result
-
-  # On a PR that touches the Nix build config, dry-run every package on
-  # Linux to catch overlay regressions before they reach a release tag.
-  # `cachix push` has no --dry-run flag, so we stop at `nix build` and let
-  # cachix-action's `skipPush: true` keep the watch-store off.
-  pr-dry-run:
-    if: github.event_name == 'pull_request'
-    name: Dry-run (${{ matrix.package }})
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - moq-relay
-          - moq-cli
-          - moq-token-cli
-          - moq-boy
-          - libmoq
-          - moq-gst
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
-        with:
-          determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
-
-      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        with:
-          name: kixelated
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          skipPush: true
-
-      - name: Build
-        env:
-          PACKAGE: ${{ matrix.package }}
-        run: nix build ".#$PACKAGE" --print-build-logs

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -9,10 +9,23 @@ on:
       - 'moq-boy-v*'
       - 'libmoq-v*'
       - 'moq-gst-v*'
+  pull_request:
+    paths:
+      - '.github/workflows/cachix.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
+
+concurrency:
+  group: cachix-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  cache:
-    name: Build and push to Cachix (${{ matrix.os }})
+  # On a release tag, build and push only the package the tag names. The
+  # tag prefix (e.g. moq-relay) maps 1:1 to a flake attribute.
+  release:
+    if: github.event_name == 'push'
+    name: Release (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -28,6 +41,21 @@ jobs:
         with:
           persist-credentials: false
 
+      # Validate against an allowlist so REF_NAME can't slip arbitrary
+      # text into later steps. (Written by Claude)
+      - name: Derive package from tag
+        id: pkg
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # moq-relay-v0.11.5 -> moq-relay
+          name="${REF_NAME%-v*}"
+          case "$name" in
+            moq-relay|moq-cli|moq-token-cli|moq-boy|libmoq|moq-gst) ;;
+            *) echo "Unrecognized tag prefix: $REF_NAME" >&2; exit 1 ;;
+          esac
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+
       - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
         with:
           determinate: false
@@ -38,34 +66,51 @@ jobs:
           name: kixelated
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      # Build each package individually so their closures are all cached.
-      # This ensures CDN nodes can download pre-built binaries instead of compiling.
-      - name: Build and cache moq-relay
+      - name: Build and cache
+        env:
+          PACKAGE: ${{ steps.pkg.outputs.name }}
         run: |
-          nix build .#moq-relay --print-build-logs
+          nix build ".#$PACKAGE" --print-build-logs
           cachix push kixelated ./result
 
-      - name: Build and cache moq-cli
-        run: |
-          nix build .#moq-cli --print-build-logs
-          cachix push kixelated ./result
+  # On a PR that touches the Nix build config, dry-run every package on
+  # Linux to catch overlay regressions before they reach a release tag.
+  # `cachix push` has no --dry-run flag, so we stop at `nix build` and let
+  # cachix-action's `skipPush: true` keep the watch-store off.
+  pr-dry-run:
+    if: github.event_name == 'pull_request'
+    name: Dry-run (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - moq-relay
+          - moq-cli
+          - moq-token-cli
+          - moq-boy
+          - libmoq
+          - moq-gst
 
-      - name: Build and cache moq-token-cli
-        run: |
-          nix build .#moq-token-cli --print-build-logs
-          cachix push kixelated ./result
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Build and cache moq-boy
-        run: |
-          nix build .#moq-boy --print-build-logs
-          cachix push kixelated ./result
+      - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
+        with:
+          determinate: false
+      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
-      - name: Build and cache libmoq
-        run: |
-          nix build .#libmoq --print-build-logs
-          cachix push kixelated ./result
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: kixelated
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          skipPush: true
 
-      - name: Build and cache moq-gst
-        run: |
-          nix build .#moq-gst --print-build-logs
-          cachix push kixelated ./result
+      - name: Build
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: nix build ".#$PACKAGE" --print-build-logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ match version {
 
 - Keep things brief and avoid comments if the code is self-explanatory. Reserve comments for the non-obvious WHY: a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise a reader.
 - Comments must reflect the **current** state of the code, not its history. Don't write "X no longer does Y" or "this used to cascade". Describe what the code does today, or delete the comment. Migration context belongs in commit messages and PR descriptions, where it ages with the change rather than rotting in the source.
-- When an LLM leaves a comment, append a short disclaimer like `// Written by Claude` at the end so readers know it wasn't human-authored.
+- When an LLM authors something, append a short disclaimer like `(Written by Claude)` so readers know it wasn't human-authored. Apply this to PR descriptions and PR comments (including replies on review threads), **not** to code comments or doc comments — markers in source rot alongside the code, and commit trailers already carry attribution.
 
 ## Tooling
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -147,7 +147,7 @@ in
       # Strip nix-store paths so the plugin loads against the user's system
       # GStreamer rather than the (unavailable on user machines) nix copy.
       # The `-f` guard skips crane's deps-only stage, whose $out has no plugin
-      # to patch. (Written by Claude)
+      # to patch.
       postFixup =
         if final.stdenv.isDarwin then
           ''


### PR DESCRIPTION
## Summary

Follow-up to [#1476](https://github.com/moq-dev/moq/pull/1476). The old workflow rebuilt **all 6 packages × 2 OSes = 12 jobs** on every release tag, so one broken package took down the cachix cache for every other package's release — that's how the moq-gst overlay bug stranded [moq-cli-v0.7.25](https://github.com/moq-dev/moq/actions/runs/26346586561), [moq-boy-v0.2.12](https://github.com/moq-dev/moq/actions/runs/26346563766), and [libmoq-v0.2.16](https://github.com/moq-dev/moq/actions/runs/26346557878) in one go.

Now: derive the package from the tag prefix (e.g. `moq-relay-v0.11.5` → `moq-relay`) and build only that one. `REF_NAME` is full-matched against the same `<prefix>-v<semver>` regex `release.sh` enforces, so malformed tags (`moq-cli-vfoo`, `moq-cli-v1`, shell-metacharacter variants) fail before reaching `nix build`.

Also drops a stray `(Written by Claude)` marker that landed in `nix/overlay.nix` in [#1476](https://github.com/moq-dev/moq/pull/1476), and clarifies CLAUDE.md that those markers go in PR descriptions / PR comments, never in source.

## Test plan

- [ ] Next release tag's Cachix run only builds the matching package
- [ ] Malformed tag fails at the "Derive package from tag" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)