### PR TITLE
infra: reuse SIGNING_KEY for apt/rpm repo publishing

### DIFF
--- a/.github/workflows/apt-repo.yml
+++ b/.github/workflows/apt-repo.yml
@@ -57,6 +57,6 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          REPO_SIGNING_KEY: ${{ secrets.REPO_SIGNING_KEY }}
-          REPO_SIGNING_KEY_ID: ${{ secrets.REPO_SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
         run: ./infra/apt/publish.sh

--- a/.github/workflows/rpm-repo.yml
+++ b/.github/workflows/rpm-repo.yml
@@ -55,6 +55,6 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          REPO_SIGNING_KEY: ${{ secrets.REPO_SIGNING_KEY }}
-          REPO_SIGNING_KEY_ID: ${{ secrets.REPO_SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
         run: ./infra/rpm/publish.sh

--- a/infra/README.md
+++ b/infra/README.md
@@ -45,26 +45,11 @@ domain, and signing key already exist. To stand them up the first time:
    just infra deploy
    ```
 
-3. **Generate a project signing key** dedicated to package repositories.
-   Keep the private key safe (preferably in a hardware key or sealed
-   secret manager):
-
-   ```bash
-   gpg --batch --gen-key <<EOF
-   %no-protection
-   Key-Type: EDDSA
-   Key-Curve: ed25519
-   Subkey-Type: ECDH
-   Subkey-Curve: cv25519
-   Name-Real: MoQ Project
-   Name-Email: admin@moq.dev
-   Expire-Date: 0
-   %commit
-   EOF
-
-   # Note the long key id for the next step.
-   gpg --list-keys --keyid-format=long admin@moq.dev
-   ```
+3. **Reuse the project GPG signing key** that's already stored in the
+   `SIGNING_KEY` / `SIGNING_PASSWORD` Actions secrets (also used by the
+   Maven Central / Kotlin release workflow). The apt/rpm publish scripts
+   import the key into an ephemeral keyring and auto-detect the long key
+   id, so no separate `KEY_ID` secret is needed.
 
 4. **Upload the public key** to both buckets so users can verify the
    repository signature:
@@ -83,10 +68,8 @@ domain, and signing key already exist. To stand them up the first time:
    - `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY`: R2 API token with
      object read/write on both buckets.
    - `R2_ACCOUNT_ID`: the Cloudflare account id.
-   - `REPO_SIGNING_KEY`: ascii-armored private key
-     (`gpg --export-secret-keys --armor admin@moq.dev`). Shared by both
-     the apt and rpm publish workflows.
-   - `REPO_SIGNING_KEY_ID`: the long key id from step 3.
+   - `SIGNING_KEY` and `SIGNING_PASSWORD`: already configured for the
+     Maven Central release workflow; the apt/rpm publishers reuse them.
 
 After this, every release that publishes a `.deb` or `.rpm` (one of the
 `moq-relay-v*`, `moq-cli-v*`, `moq-token-cli-v*`, `moq-gst-v*` tags)
@@ -111,7 +94,7 @@ from scratch, the publish scripts can be invoked locally:
 gh release download moq-relay-v1.2.3 --dir artifacts --pattern '*.deb'
 ARTIFACTS_DIR=artifacts \
   R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... R2_ACCOUNT_ID=... \
-  REPO_SIGNING_KEY="$(cat private.asc)" REPO_SIGNING_KEY_ID=... \
+  SIGNING_KEY="$(cat private.asc)" SIGNING_PASSWORD=... \
   ./infra/apt/publish.sh
 ```
 

--- a/infra/apt/publish.sh
+++ b/infra/apt/publish.sh
@@ -93,8 +93,15 @@ export GNUPGHOME
 chmod 700 "$GNUPGHOME"
 # GNUPGHOME is removed by the EXIT trap; no need for an explicit `rm -rf`.
 echo "${SIGNING_KEY:?}" | gpg --batch --quiet --import
-KEY_ID=$(gpg --list-secret-keys --with-colons --keyid-format=long \
-    | awk -F: '/^sec:/ { print $5; exit }')
+# Fail loud if SIGNING_KEY ever holds more than one secret. Silently picking
+# the first one would produce signatures from the wrong key.
+mapfile -t KEY_IDS < <(gpg --list-secret-keys --with-colons --keyid-format=long \
+    | awk -F: '/^sec:/ { print $5 }')
+if [[ ${#KEY_IDS[@]} -ne 1 ]]; then
+    echo "ERROR: expected exactly one secret key in SIGNING_KEY, found ${#KEY_IDS[@]}." >&2
+    exit 1
+fi
+KEY_ID="${KEY_IDS[0]}"
 GPG_PASS_ARGS=()
 if [[ -n "${SIGNING_PASSWORD:-}" ]]; then
     GPG_PASS_ARGS=(--pinentry-mode loopback --passphrase "$SIGNING_PASSWORD")

--- a/infra/apt/publish.sh
+++ b/infra/apt/publish.sh
@@ -10,8 +10,8 @@
 #   R2_ACCESS_KEY_ID          R2 API token
 #   R2_SECRET_ACCESS_KEY
 #   R2_ACCOUNT_ID
-#   REPO_SIGNING_KEY           ascii-armored GPG private key
-#   REPO_SIGNING_KEY_ID        long key id used to pick the signing key
+#   SIGNING_KEY               ascii-armored GPG private key (shared with maven publishing)
+#   SIGNING_PASSWORD          optional passphrase for SIGNING_KEY
 #
 # Required tools: rclone, apt-ftparchive (apt-utils), gpg, dpkg-scanpackages.
 
@@ -92,12 +92,17 @@ GNUPGHOME=$(mktemp -d)
 export GNUPGHOME
 chmod 700 "$GNUPGHOME"
 # GNUPGHOME is removed by the EXIT trap; no need for an explicit `rm -rf`.
-echo "${REPO_SIGNING_KEY:?}" | gpg --batch --quiet --import
-KEY_ID="${REPO_SIGNING_KEY_ID:?}"
-gpg --batch --yes --default-key "$KEY_ID" --detach-sign --armor \
+echo "${SIGNING_KEY:?}" | gpg --batch --quiet --import
+KEY_ID=$(gpg --list-secret-keys --with-colons --keyid-format=long \
+    | awk -F: '/^sec:/ { print $5; exit }')
+GPG_PASS_ARGS=()
+if [[ -n "${SIGNING_PASSWORD:-}" ]]; then
+    GPG_PASS_ARGS=(--pinentry-mode loopback --passphrase "$SIGNING_PASSWORD")
+fi
+gpg --batch --yes "${GPG_PASS_ARGS[@]}" --default-key "$KEY_ID" --detach-sign --armor \
     -o "$WORK/dists/$DIST/Release.gpg" \
     "$WORK/dists/$DIST/Release"
-gpg --batch --yes --default-key "$KEY_ID" --clearsign \
+gpg --batch --yes "${GPG_PASS_ARGS[@]}" --default-key "$KEY_ID" --clearsign \
     -o "$WORK/dists/$DIST/InRelease" \
     "$WORK/dists/$DIST/Release"
 

--- a/infra/rpm/publish.sh
+++ b/infra/rpm/publish.sh
@@ -73,8 +73,15 @@ GNUPGHOME=$(mktemp -d)
 export GNUPGHOME
 chmod 700 "$GNUPGHOME"
 echo "${SIGNING_KEY:?}" | gpg --batch --quiet --import
-KEY_ID=$(gpg --list-secret-keys --with-colons --keyid-format=long \
-    | awk -F: '/^sec:/ { print $5; exit }')
+# Fail loud if SIGNING_KEY ever holds more than one secret. Silently picking
+# the first one would produce signatures from the wrong key.
+mapfile -t KEY_IDS < <(gpg --list-secret-keys --with-colons --keyid-format=long \
+    | awk -F: '/^sec:/ { print $5 }')
+if [[ ${#KEY_IDS[@]} -ne 1 ]]; then
+    echo "ERROR: expected exactly one secret key in SIGNING_KEY, found ${#KEY_IDS[@]}." >&2
+    exit 1
+fi
+KEY_ID="${KEY_IDS[0]}"
 GPG_PASS_ARGS=()
 if [[ -n "${SIGNING_PASSWORD:-}" ]]; then
     GPG_PASS_ARGS=(--pinentry-mode loopback --passphrase "$SIGNING_PASSWORD")

--- a/infra/rpm/publish.sh
+++ b/infra/rpm/publish.sh
@@ -9,8 +9,8 @@
 #   R2_ACCESS_KEY_ID          R2 API token
 #   R2_SECRET_ACCESS_KEY
 #   R2_ACCOUNT_ID
-#   REPO_SIGNING_KEY           ascii-armored GPG private key (shared with apt repo)
-#   REPO_SIGNING_KEY_ID        long key id used to pick the signing key
+#   SIGNING_KEY               ascii-armored GPG private key (shared with apt repo and maven publishing)
+#   SIGNING_PASSWORD          optional passphrase for SIGNING_KEY
 #
 # Required tools: rclone, createrepo_c, gpg.
 
@@ -72,15 +72,20 @@ echo ">> Import signing key..."
 GNUPGHOME=$(mktemp -d)
 export GNUPGHOME
 chmod 700 "$GNUPGHOME"
-echo "${REPO_SIGNING_KEY:?}" | gpg --batch --quiet --import
-KEY_ID="${REPO_SIGNING_KEY_ID:?}"
+echo "${SIGNING_KEY:?}" | gpg --batch --quiet --import
+KEY_ID=$(gpg --list-secret-keys --with-colons --keyid-format=long \
+    | awk -F: '/^sec:/ { print $5; exit }')
+GPG_PASS_ARGS=()
+if [[ -n "${SIGNING_PASSWORD:-}" ]]; then
+    GPG_PASS_ARGS=(--pinentry-mode loopback --passphrase "$SIGNING_PASSWORD")
+fi
 
 echo ">> Generate repodata per arch..."
 for arch in "${ARCHES[@]}"; do
     dir="$WORK/${DIST}/${arch}"
     [[ -d "$dir" ]] || continue
     createrepo_c --update --general-compress-type=gz "$dir"
-    gpg --batch --yes --default-key "$KEY_ID" --detach-sign --armor \
+    gpg --batch --yes "${GPG_PASS_ARGS[@]}" --default-key "$KEY_ID" --detach-sign --armor \
         -o "$dir/repodata/repomd.xml.asc" \
         "$dir/repodata/repomd.xml"
 done


### PR DESCRIPTION
## Summary

- Replace the separate `REPO_SIGNING_KEY` / `REPO_SIGNING_KEY_ID` secrets in the apt/rpm publish scripts and workflows with the existing `SIGNING_KEY` (and optional `SIGNING_PASSWORD`) already used by the Maven Central release workflow.
- Auto-detect the long key id from the imported keyring instead of carrying it as a secret. A fresh ephemeral `GNUPGHOME` only ever holds the one imported key.
- Update `infra/README.md` to reflect the shared key and drop the now-unnecessary step that minted a dedicated repo signing key.

## Why

The `apt-repo` / `rpm-repo` workflows were failing on `moq-dev/moq` because none of the `REPO_SIGNING_KEY*` or `R2_*` secrets were ever configured (see the latest [apt-repo run](https://github.com/moq-dev/moq/actions/runs/26349324650/job/77564693488), which aborts on `R2_ACCOUNT_ID: parameter null or not set`). Reusing `SIGNING_KEY` removes one secret to manage and keeps the GPG identity consistent across release surfaces.

The R2 secrets still need to be added separately. After this PR lands, the only secrets required to unblock the workflows are `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, and `R2_SECRET_ACCESS_KEY`.

## Test plan

- [ ] Add the three R2 secrets to `moq-dev/moq`.
- [ ] Run `gh workflow run apt-repo.yml --repo moq-dev/moq -f tag=<existing-deb-tag>` and confirm the run signs the Release file and uploads to `apt-moq-dev`.
- [ ] Same for `rpm-repo.yml` against an existing rpm-bearing tag.

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)