### PR TITLE
hang: non_exhaustive VideoConfig/AudioConfig with constructors

### DIFF
--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -48,28 +48,17 @@ fn create_track(broadcast: &mut moq_net::BroadcastProducer) -> anyhow::Result<mo
 
 	// Example video configuration
 	// In a real application, you would get this from the encoder
-	let video_config = hang::catalog::VideoConfig {
-		codec: hang::catalog::H264 {
-			profile: 0x4D, // Main profile
-			constraints: 0,
-			level: 0x28,  // Level 4.0
-			inline: true, // SPS/PPS inline in bitstream (avc3)
-		}
-		.into(),
-		// Codec-specific data (e.g., SPS/PPS for H.264)
-		// Not needed if you're using annex.b (inline: true)
-		description: None,
-		// There are optional but good to have.
-		coded_width: Some(1920),
-		coded_height: Some(1080),
-		bitrate: Some(5_000_000), // 5 Mbps
-		framerate: Some(30.0),
-		display_ratio_width: None,
-		display_ratio_height: None,
-		optimize_for_latency: None,
-		container: hang::catalog::Container::Legacy,
-		jitter: None,
-	};
+	let mut video_config = hang::catalog::VideoConfig::new(hang::catalog::H264 {
+		profile: 0x4D, // Main profile
+		constraints: 0,
+		level: 0x28,  // Level 4.0
+		inline: true, // SPS/PPS inline in bitstream (avc3)
+	});
+	video_config.coded_width = Some(1920);
+	video_config.coded_height = Some(1080);
+	video_config.bitrate = Some(5_000_000); // 5 Mbps
+	video_config.framerate = Some(30.0);
+	video_config.container = hang::catalog::Container::Legacy;
 
 	// Create a map of video renditions
 	// Multiple renditions allow the viewer to choose based on their capabilities

--- a/rs/hang/src/catalog/audio/mod.rs
+++ b/rs/hang/src/catalog/audio/mod.rs
@@ -49,10 +49,17 @@ impl Audio {
 /// including codec-specific parameters, sample rate, and channel configuration.
 ///
 /// Reference: <https://www.w3.org/TR/webcodecs/#audio-decoder-config>
+///
+/// Marked `#[non_exhaustive]` so additional optional fields can be added
+/// without bumping the major version. External callers build a config with
+/// [`AudioConfig::new`] and then assign whichever optional fields they need;
+/// struct-literal construction (with or without `..base`) is not available
+/// outside this crate.
 #[serde_with::serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct AudioConfig {
 	// The codec, see the registry for details:
 	// https://w3c.github.io/webcodecs/codec_registry.html
@@ -89,4 +96,24 @@ pub struct AudioConfig {
 	/// ex: AAC often uses 1024 samples per frame, so at 44100Hz, this would be 1024/44100 = 23ms
 	#[serde(default)]
 	pub jitter: Option<moq_net::Time>,
+}
+
+impl AudioConfig {
+	/// Construct a config with the required fields set and every optional
+	/// field cleared. `container` defaults to [`Container::default`]. Fields
+	/// are `pub`, so callers set whatever they need by assignment afterwards.
+	///
+	/// This is the only path external crates have to build an `AudioConfig`
+	/// since the type is `#[non_exhaustive]`.
+	pub fn new(codec: impl Into<AudioCodec>, sample_rate: u32, channel_count: u32) -> Self {
+		Self {
+			codec: codec.into(),
+			sample_rate,
+			channel_count,
+			bitrate: None,
+			description: None,
+			container: Container::default(),
+			jitter: None,
+		}
+	}
 }

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -123,43 +123,27 @@ mod test {
 
 		encoded.retain(|c| !c.is_whitespace());
 
+		let mut video_config = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0x00,
+			level: 0x1f,
+			inline: false,
+		});
+		video_config.coded_width = Some(1280);
+		video_config.coded_height = Some(720);
+		video_config.bitrate = Some(6_000_000);
+		video_config.framerate = Some(30.0);
+		video_config.container = Container::Legacy;
+
 		let mut video_renditions = BTreeMap::new();
-		video_renditions.insert(
-			"video".to_string(),
-			VideoConfig {
-				codec: H264 {
-					profile: 0x64,
-					constraints: 0x00,
-					level: 0x1f,
-					inline: false,
-				}
-				.into(),
-				description: None,
-				coded_width: Some(1280),
-				coded_height: Some(720),
-				display_ratio_width: None,
-				display_ratio_height: None,
-				bitrate: Some(6_000_000),
-				framerate: Some(30.0),
-				optimize_for_latency: None,
-				container: Container::Legacy,
-				jitter: None,
-			},
-		);
+		video_renditions.insert("video".to_string(), video_config);
+
+		let mut audio_config = AudioConfig::new(Opus, 48_000, 2);
+		audio_config.bitrate = Some(128_000);
+		audio_config.container = Container::Legacy;
 
 		let mut audio_renditions = BTreeMap::new();
-		audio_renditions.insert(
-			"audio".to_string(),
-			AudioConfig {
-				codec: Opus,
-				sample_rate: 48_000,
-				channel_count: 2,
-				bitrate: Some(128_000),
-				description: None,
-				container: Container::Legacy,
-				jitter: None,
-			},
-		);
+		audio_renditions.insert("audio".to_string(), audio_config);
 
 		let decoded = Catalog {
 			video: Video {

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -78,10 +78,17 @@ pub struct Display {
 /// including codec-specific parameters, resolution, and optional metadata.
 ///
 /// Reference: <https://www.w3.org/TR/webcodecs/#video-decoder-config>
+///
+/// Marked `#[non_exhaustive]` so additional optional fields can be added
+/// without bumping the major version. External callers build a config with
+/// [`VideoConfig::new`] and then assign whichever optional fields they need;
+/// struct-literal construction (with or without `..base`) is not available
+/// outside this crate.
 #[serde_with::serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct VideoConfig {
 	/// The codec, see the registry for details:
 	/// <https://w3c.github.io/webcodecs/codec_registry.html>
@@ -140,4 +147,28 @@ pub struct VideoConfig {
 	/// - If frames are buffered into 2s segments, this would be 2s.
 	#[serde(default)]
 	pub jitter: Option<moq_net::Time>,
+}
+
+impl VideoConfig {
+	/// Construct a config with the required codec set and every optional
+	/// field cleared. `container` defaults to [`Container::default`]. Fields
+	/// are `pub`, so callers set whatever they need by assignment afterwards.
+	///
+	/// This is the only path external crates have to build a `VideoConfig`
+	/// since the type is `#[non_exhaustive]`.
+	pub fn new(codec: impl Into<VideoCodec>) -> Self {
+		Self {
+			codec: codec.into(),
+			description: None,
+			coded_width: None,
+			coded_height: None,
+			display_ratio_width: None,
+			display_ratio_height: None,
+			bitrate: None,
+			framerate: None,
+			optimize_for_latency: None,
+			container: Container::default(),
+			jitter: None,
+		}
+	}
 }

--- a/rs/moq-mux/src/catalog/hang/producer.rs
+++ b/rs/moq-mux/src/catalog/hang/producer.rs
@@ -218,43 +218,27 @@ mod test {
 
 	#[test]
 	fn convert_simple() {
+		let mut video_config = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0x00,
+			level: 0x1f,
+			inline: true,
+		});
+		video_config.coded_width = Some(1280);
+		video_config.coded_height = Some(720);
+		video_config.bitrate = Some(6_000_000);
+		video_config.framerate = Some(30.0);
+		video_config.container = Container::Legacy;
+
 		let mut video_renditions = BTreeMap::new();
-		video_renditions.insert(
-			"video0.avc3".to_string(),
-			VideoConfig {
-				codec: H264 {
-					profile: 0x64,
-					constraints: 0x00,
-					level: 0x1f,
-					inline: true,
-				}
-				.into(),
-				description: None,
-				coded_width: Some(1280),
-				coded_height: Some(720),
-				display_ratio_width: None,
-				display_ratio_height: None,
-				bitrate: Some(6_000_000),
-				framerate: Some(30.0),
-				optimize_for_latency: None,
-				container: Container::Legacy,
-				jitter: None,
-			},
-		);
+		video_renditions.insert("video0.avc3".to_string(), video_config);
+
+		let mut audio_config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+		audio_config.bitrate = Some(128_000);
+		audio_config.container = Container::Legacy;
 
 		let mut audio_renditions = BTreeMap::new();
-		audio_renditions.insert(
-			"audio0".to_string(),
-			AudioConfig {
-				codec: AudioCodec::Opus,
-				sample_rate: 48_000,
-				channel_count: 2,
-				bitrate: Some(128_000),
-				description: None,
-				container: Container::Legacy,
-				jitter: None,
-			},
-		);
+		audio_renditions.insert("audio0".to_string(), audio_config);
 
 		let catalog = hang::Catalog {
 			video: Video {
@@ -304,29 +288,19 @@ mod test {
 
 	#[test]
 	fn convert_with_description() {
+		let mut video_config = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0x00,
+			level: 0x1f,
+			inline: false,
+		});
+		video_config.description = Some(Bytes::from_static(&[0x01, 0x02, 0x03]));
+		video_config.coded_width = Some(1920);
+		video_config.coded_height = Some(1080);
+		video_config.container = Container::Legacy;
+
 		let mut video_renditions = BTreeMap::new();
-		video_renditions.insert(
-			"video0.m4s".to_string(),
-			VideoConfig {
-				codec: H264 {
-					profile: 0x64,
-					constraints: 0x00,
-					level: 0x1f,
-					inline: false,
-				}
-				.into(),
-				description: Some(Bytes::from_static(&[0x01, 0x02, 0x03])),
-				coded_width: Some(1920),
-				coded_height: Some(1080),
-				display_ratio_width: None,
-				display_ratio_height: None,
-				bitrate: None,
-				framerate: None,
-				optimize_for_latency: None,
-				container: Container::Legacy,
-				jitter: None,
-			},
-		);
+		video_renditions.insert("video0.m4s".to_string(), video_config);
 
 		let catalog = hang::Catalog {
 			video: Video {
@@ -353,36 +327,25 @@ mod test {
 
 	#[test]
 	fn convert_cmaf_packaging() {
-		let mut video_renditions = BTreeMap::new();
-		video_renditions.insert(
-			"video0.m4s".to_string(),
-			VideoConfig {
-				codec: H264 {
-					profile: 0x64,
-					constraints: 0x00,
-					level: 0x28,
-					inline: false,
-				}
+		let mut video_config = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0x00,
+			level: 0x28,
+			inline: false,
+		});
+		video_config.coded_width = Some(1920);
+		video_config.coded_height = Some(1080);
+		video_config.container = Container::Cmaf {
+			init: base64::engine::general_purpose::STANDARD
+				.decode("AAAYZ2Z0eXA=")
+				.unwrap()
 				.into(),
-				description: None,
-				coded_width: Some(1920),
-				coded_height: Some(1080),
-				display_ratio_width: None,
-				display_ratio_height: None,
-				bitrate: None,
-				framerate: None,
-				optimize_for_latency: None,
-				container: Container::Cmaf {
-					init: base64::engine::general_purpose::STANDARD
-						.decode("AAAYZ2Z0eXA=")
-						.unwrap()
-						.into(),
-					timescale: None,
-					track_id: None,
-				},
-				jitter: None,
-			},
-		);
+			timescale: None,
+			track_id: None,
+		};
+
+		let mut video_renditions = BTreeMap::new();
+		video_renditions.insert("video0.m4s".to_string(), video_config);
 
 		let catalog = hang::Catalog {
 			video: Video {
@@ -402,43 +365,27 @@ mod test {
 
 	#[test]
 	fn convert_sap_h264_with_jitter() {
+		let mut video_config = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0x00,
+			level: 0x1f,
+			inline: true,
+		});
+		video_config.coded_width = Some(1280);
+		video_config.coded_height = Some(720);
+		video_config.framerate = Some(30.0);
+		video_config.container = Container::Legacy;
+		video_config.jitter = Some(moq_net::Time::from_millis_unchecked(100));
+
 		let mut video_renditions = BTreeMap::new();
-		video_renditions.insert(
-			"video0".to_string(),
-			VideoConfig {
-				codec: H264 {
-					profile: 0x64,
-					constraints: 0x00,
-					level: 0x1f,
-					inline: true,
-				}
-				.into(),
-				description: None,
-				coded_width: Some(1280),
-				coded_height: Some(720),
-				display_ratio_width: None,
-				display_ratio_height: None,
-				bitrate: None,
-				framerate: Some(30.0),
-				optimize_for_latency: None,
-				container: Container::Legacy,
-				jitter: Some(moq_net::Time::from_millis_unchecked(100)),
-			},
-		);
+		video_renditions.insert("video0".to_string(), video_config);
+
+		let mut audio_config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+		audio_config.container = Container::Legacy;
+		audio_config.jitter = Some(moq_net::Time::from_millis_unchecked(40));
 
 		let mut audio_renditions = BTreeMap::new();
-		audio_renditions.insert(
-			"audio0".to_string(),
-			AudioConfig {
-				codec: AudioCodec::Opus,
-				sample_rate: 48_000,
-				channel_count: 2,
-				bitrate: None,
-				description: None,
-				container: Container::Legacy,
-				jitter: Some(moq_net::Time::from_millis_unchecked(40)),
-			},
-		);
+		audio_renditions.insert("audio0".to_string(), audio_config);
 
 		let catalog = hang::Catalog {
 			video: Video {
@@ -473,32 +420,22 @@ mod test {
 	fn convert_sap_h265() {
 		use hang::catalog::H265;
 
+		let mut video_config = VideoConfig::new(H265 {
+			in_band: false,
+			profile_space: 0,
+			profile_idc: 1,
+			profile_compatibility_flags: [0, 0, 0, 0],
+			tier_flag: false,
+			level_idc: 93,
+			constraint_flags: [0, 0, 0, 0, 0, 0],
+		});
+		video_config.coded_width = Some(1920);
+		video_config.coded_height = Some(1080);
+		video_config.framerate = Some(60.0);
+		video_config.container = Container::Legacy;
+
 		let mut video_renditions = BTreeMap::new();
-		video_renditions.insert(
-			"video0".to_string(),
-			VideoConfig {
-				codec: H265 {
-					in_band: false,
-					profile_space: 0,
-					profile_idc: 1,
-					profile_compatibility_flags: [0, 0, 0, 0],
-					tier_flag: false,
-					level_idc: 93,
-					constraint_flags: [0, 0, 0, 0, 0, 0],
-				}
-				.into(),
-				description: None,
-				coded_width: Some(1920),
-				coded_height: Some(1080),
-				display_ratio_width: None,
-				display_ratio_height: None,
-				bitrate: None,
-				framerate: Some(60.0),
-				optimize_for_latency: None,
-				container: Container::Legacy,
-				jitter: None,
-			},
-		);
+		video_renditions.insert("video0".to_string(), video_config);
 
 		let catalog = hang::Catalog {
 			video: Video {
@@ -523,23 +460,11 @@ mod test {
 	fn convert_sap_unknown_codec() {
 		use hang::catalog::VideoCodec;
 
+		let mut video_config = VideoConfig::new(VideoCodec::Unknown("future-codec.01".to_string()));
+		video_config.container = Container::Legacy;
+
 		let mut video_renditions = BTreeMap::new();
-		video_renditions.insert(
-			"video0".to_string(),
-			VideoConfig {
-				codec: VideoCodec::Unknown("future-codec.01".to_string()),
-				description: None,
-				coded_width: None,
-				coded_height: None,
-				display_ratio_width: None,
-				display_ratio_height: None,
-				bitrate: None,
-				framerate: None,
-				optimize_for_latency: None,
-				container: Container::Legacy,
-				jitter: None,
-			},
-		);
+		video_renditions.insert("video0".to_string(), video_config);
 
 		let catalog = hang::Catalog {
 			video: Video {

--- a/rs/moq-mux/src/catalog/msf/consumer.rs
+++ b/rs/moq-mux/src/catalog/msf/consumer.rs
@@ -205,26 +205,22 @@ fn video_config_from_msf(track: &moq_msf::Track) -> anyhow::Result<Option<VideoC
 	let codec = VideoCodec::from_str(codec_str)
 		.with_context(|| format!("MSF video track {:?} has invalid codec {codec_str:?}", track.name))?;
 
-	Ok(Some(VideoConfig {
-		codec,
-		description: legacy_description(track)?,
-		coded_width: track.width,
-		coded_height: track.height,
-		display_ratio_width: None,
-		display_ratio_height: None,
-		bitrate: track.bitrate,
-		framerate: track.framerate,
-		optimize_for_latency: None,
-		container,
-		// Jitter is converted from f64 milliseconds to integer milliseconds.
-		// Fractional milliseconds are truncated (e.g. 15.5ms becomes 15ms).
-		// This is acceptable for the jitter use case where sub-ms precision
-		// is not meaningful.
-		jitter: track
-			.jitter
-			.filter(|v| v.is_finite() && *v >= 0.0)
-			.and_then(|v| moq_net::Time::from_millis(v as u64).ok()),
-	}))
+	let mut config = VideoConfig::new(codec);
+	config.description = legacy_description(track)?;
+	config.coded_width = track.width;
+	config.coded_height = track.height;
+	config.bitrate = track.bitrate;
+	config.framerate = track.framerate;
+	config.container = container;
+	// Jitter is converted from f64 milliseconds to integer milliseconds.
+	// Fractional milliseconds are truncated (e.g. 15.5ms becomes 15ms).
+	// This is acceptable for the jitter use case where sub-ms precision
+	// is not meaningful.
+	config.jitter = track
+		.jitter
+		.filter(|v| v.is_finite() && *v >= 0.0)
+		.and_then(|v| moq_net::Time::from_millis(v as u64).ok());
+	Ok(Some(config))
 }
 
 fn audio_config_from_msf(track: &moq_msf::Track) -> anyhow::Result<Option<AudioConfig>> {
@@ -256,22 +252,19 @@ fn audio_config_from_msf(track: &moq_msf::Track) -> anyhow::Result<Option<AudioC
 		}
 	};
 
-	Ok(Some(AudioConfig {
-		codec,
-		sample_rate,
-		channel_count,
-		bitrate: track.bitrate,
-		description: legacy_description(track)?,
-		container,
-		// Jitter is converted from f64 milliseconds to integer milliseconds.
-		// Fractional milliseconds are truncated (e.g. 15.5ms becomes 15ms).
-		// This is acceptable for the jitter use case where sub-ms precision
-		// is not meaningful.
-		jitter: track
-			.jitter
-			.filter(|v| v.is_finite() && *v >= 0.0)
-			.and_then(|v| moq_net::Time::from_millis(v as u64).ok()),
-	}))
+	let mut config = AudioConfig::new(codec, sample_rate, channel_count);
+	config.bitrate = track.bitrate;
+	config.description = legacy_description(track)?;
+	config.container = container;
+	// Jitter is converted from f64 milliseconds to integer milliseconds.
+	// Fractional milliseconds are truncated (e.g. 15.5ms becomes 15ms).
+	// This is acceptable for the jitter use case where sub-ms precision
+	// is not meaningful.
+	config.jitter = track
+		.jitter
+		.filter(|v| v.is_finite() && *v >= 0.0)
+		.and_then(|v| moq_net::Time::from_millis(v as u64).ok());
+	Ok(Some(config))
 }
 
 /// Audio parameters derived from a track's `init_data`.

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -22,18 +22,14 @@ impl Import {
 	) -> anyhow::Result<Self> {
 		let track = broadcast.unique_track(".aac")?;
 
-		let audio_config = hang::catalog::AudioConfig {
-			codec: hang::catalog::AAC {
+		let mut audio_config = hang::catalog::AudioConfig::new(
+			hang::catalog::AAC {
 				profile: config.profile,
-			}
-			.into(),
-			sample_rate: config.sample_rate,
-			channel_count: config.channel_count,
-			bitrate: None,
-			description: None,
-			container: hang::catalog::Container::Legacy,
-			jitter: None,
-		};
+			},
+			config.sample_rate,
+			config.channel_count,
+		);
+		audio_config.container = hang::catalog::Container::Legacy;
 
 		tracing::debug!(name = ?track.name, config = ?audio_config, "starting track");
 		catalog.lock().audio.renditions.insert(track.name.clone(), audio_config);

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -50,46 +50,36 @@ impl Import {
 	}
 
 	fn init(&mut self, seq_header: &SequenceHeaderObu) -> anyhow::Result<()> {
-		let config = hang::catalog::VideoConfig {
-			coded_width: Some(seq_header.max_frame_width as u32),
-			coded_height: Some(seq_header.max_frame_height as u32),
-			codec: hang::catalog::AV1 {
-				profile: seq_header.seq_profile,
-				level: seq_header
-					.operating_points
-					.first()
-					.map(|op| op.seq_level_idx)
-					.unwrap_or(0),
-				tier: if seq_header
-					.operating_points
-					.first()
-					.map(|op| op.seq_tier)
-					.unwrap_or(false)
-				{
-					'H'
-				} else {
-					'M'
-				},
-				bitdepth: seq_header.color_config.bit_depth as u8,
-				mono_chrome: seq_header.color_config.mono_chrome,
-				chroma_subsampling_x: seq_header.color_config.subsampling_x,
-				chroma_subsampling_y: seq_header.color_config.subsampling_y,
-				chroma_sample_position: seq_header.color_config.chroma_sample_position,
-				color_primaries: seq_header.color_config.color_primaries,
-				transfer_characteristics: seq_header.color_config.transfer_characteristics,
-				matrix_coefficients: seq_header.color_config.matrix_coefficients,
-				full_range: seq_header.color_config.full_color_range,
-			}
-			.into(),
-			description: None,
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: hang::catalog::Container::Legacy,
-			jitter: None,
-		};
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::AV1 {
+			profile: seq_header.seq_profile,
+			level: seq_header
+				.operating_points
+				.first()
+				.map(|op| op.seq_level_idx)
+				.unwrap_or(0),
+			tier: if seq_header
+				.operating_points
+				.first()
+				.map(|op| op.seq_tier)
+				.unwrap_or(false)
+			{
+				'H'
+			} else {
+				'M'
+			},
+			bitdepth: seq_header.color_config.bit_depth as u8,
+			mono_chrome: seq_header.color_config.mono_chrome,
+			chroma_subsampling_x: seq_header.color_config.subsampling_x,
+			chroma_subsampling_y: seq_header.color_config.subsampling_y,
+			chroma_sample_position: seq_header.color_config.chroma_sample_position,
+			color_primaries: seq_header.color_config.color_primaries,
+			transfer_characteristics: seq_header.color_config.transfer_characteristics,
+			matrix_coefficients: seq_header.color_config.matrix_coefficients,
+			full_range: seq_header.color_config.full_color_range,
+		});
+		config.coded_width = Some(seq_header.max_frame_width as u32);
+		config.coded_height = Some(seq_header.max_frame_height as u32);
+		config.container = hang::catalog::Container::Legacy;
 
 		if let Some(old) = &self.config
 			&& old == &config
@@ -121,33 +111,21 @@ impl Import {
 
 	/// Initialize with minimal config if sequence header parsing fails
 	fn init_minimal(&mut self) -> anyhow::Result<()> {
-		let config = hang::catalog::VideoConfig {
-			coded_width: None,
-			coded_height: None,
-			codec: hang::catalog::AV1 {
-				profile: 0,  // Main profile
-				level: 0,    // Unknown
-				tier: 'M',   // Main tier
-				bitdepth: 8, // Assume 8-bit
-				mono_chrome: false,
-				chroma_subsampling_x: true, // 4:2:0
-				chroma_subsampling_y: true,
-				chroma_sample_position: 0,
-				color_primaries: 2,          // Unspecified
-				transfer_characteristics: 2, // Unspecified
-				matrix_coefficients: 2,      // Unspecified
-				full_range: false,
-			}
-			.into(),
-			description: None,
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: hang::catalog::Container::Legacy,
-			jitter: None,
-		};
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::AV1 {
+			profile: 0,  // Main profile
+			level: 0,    // Unknown
+			tier: 'M',   // Main tier
+			bitdepth: 8, // Assume 8-bit
+			mono_chrome: false,
+			chroma_subsampling_x: true, // 4:2:0
+			chroma_subsampling_y: true,
+			chroma_sample_position: 0,
+			color_primaries: 2,          // Unspecified
+			transfer_characteristics: 2, // Unspecified
+			matrix_coefficients: 2,      // Unspecified
+			full_range: false,
+		});
+		config.container = hang::catalog::Container::Legacy;
 
 		let track = self.broadcast.unique_track(".av01")?;
 		tracing::debug!(name = ?track.name, "starting track with minimal config");
@@ -199,34 +177,22 @@ impl Import {
 		let high_bitdepth = ((data[2] >> 6) & 0x01) == 1;
 		let twelve_bit = ((data[2] >> 5) & 0x01) == 1;
 
-		let config = hang::catalog::VideoConfig {
-			// Resolution unknown from av1C - will be updated when first sequence header arrives
-			coded_width: None,
-			coded_height: None,
-			codec: hang::catalog::AV1 {
-				profile: seq_profile,
-				level: seq_level_idx,
-				tier: if tier { 'H' } else { 'M' },
-				bitdepth: super::bitdepth(twelve_bit, high_bitdepth),
-				mono_chrome: ((data[2] >> 4) & 0x01) == 1,
-				chroma_subsampling_x: ((data[2] >> 3) & 0x01) == 1,
-				chroma_subsampling_y: ((data[2] >> 2) & 0x01) == 1,
-				chroma_sample_position: data[2] & 0x03,
-				color_primaries: 1,
-				transfer_characteristics: 1,
-				matrix_coefficients: 1,
-				full_range: false,
-			}
-			.into(),
-			description: None,
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: hang::catalog::Container::Legacy,
-			jitter: None,
-		};
+		// Resolution unknown from av1C - will be updated when first sequence header arrives
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::AV1 {
+			profile: seq_profile,
+			level: seq_level_idx,
+			tier: if tier { 'H' } else { 'M' },
+			bitdepth: super::bitdepth(twelve_bit, high_bitdepth),
+			mono_chrome: ((data[2] >> 4) & 0x01) == 1,
+			chroma_subsampling_x: ((data[2] >> 3) & 0x01) == 1,
+			chroma_subsampling_y: ((data[2] >> 2) & 0x01) == 1,
+			chroma_sample_position: data[2] & 0x03,
+			color_primaries: 1,
+			transfer_characteristics: 1,
+			matrix_coefficients: 1,
+			full_range: false,
+		});
+		config.container = hang::catalog::Container::Legacy;
 
 		if let Some(old) = &self.config
 			&& old == &config

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -138,25 +138,16 @@ impl Import {
 			length_size: avcc.length_size,
 		};
 
-		let config = hang::catalog::VideoConfig {
-			coded_width: avcc.coded_width,
-			coded_height: avcc.coded_height,
-			codec: hang::catalog::H264 {
-				profile: avcc.profile,
-				constraints: avcc.constraints,
-				level: avcc.level,
-				inline: false,
-			}
-			.into(),
-			description: Some(Bytes::copy_from_slice(avcc_bytes)),
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: hang::catalog::Container::Legacy,
-			jitter: None,
-		};
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::H264 {
+			profile: avcc.profile,
+			constraints: avcc.constraints,
+			level: avcc.level,
+			inline: false,
+		});
+		config.coded_width = avcc.coded_width;
+		config.coded_height = avcc.coded_height;
+		config.description = Some(Bytes::copy_from_slice(avcc_bytes));
+		config.container = hang::catalog::Container::Legacy;
 
 		self.swap_config(config, ".avc1")?;
 		buf.advance(buf.remaining());
@@ -379,25 +370,15 @@ impl Import {
 	}
 
 	fn init_from_sps(&mut self, sps: &Sps) -> anyhow::Result<()> {
-		let config = hang::catalog::VideoConfig {
-			coded_width: Some(sps.coded_width),
-			coded_height: Some(sps.coded_height),
-			codec: hang::catalog::H264 {
-				profile: sps.profile,
-				constraints: sps.constraints,
-				level: sps.level,
-				inline: true,
-			}
-			.into(),
-			description: None,
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: hang::catalog::Container::Legacy,
-			jitter: None,
-		};
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::H264 {
+			profile: sps.profile,
+			constraints: sps.constraints,
+			level: sps.level,
+			inline: true,
+		});
+		config.coded_width = Some(sps.coded_width);
+		config.coded_height = Some(sps.coded_height);
+		config.container = hang::catalog::Container::Legacy;
 
 		if let Some(old) = &self.config
 			&& old == &config

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -56,28 +56,21 @@ impl Import {
 		let profile = &sps.rbsp.profile_tier_level.general_profile;
 		let vui_data = sps.rbsp.vui_parameters.as_ref().map(VuiData::new).unwrap_or_default();
 
-		let config = hang::catalog::VideoConfig {
-			coded_width: Some(sps.rbsp.cropped_width() as u32),
-			coded_height: Some(sps.rbsp.cropped_height() as u32),
-			codec: hang::catalog::H265 {
-				in_band: true, // We only support `hev1` with inline SPS/PPS for now
-				profile_space: profile.profile_space,
-				profile_idc: profile.profile_idc,
-				profile_compatibility_flags: profile.profile_compatibility_flag.bits().to_be_bytes(),
-				tier_flag: profile.tier_flag,
-				level_idc: profile.level_idc.context("missing level_idc in SPS")?,
-				constraint_flags: crate::codec::h265::pack_constraint_flags(profile),
-			}
-			.into(),
-			description: None,
-			framerate: vui_data.framerate,
-			bitrate: None,
-			display_ratio_width: vui_data.display_ratio_width,
-			display_ratio_height: vui_data.display_ratio_height,
-			optimize_for_latency: None,
-			container: hang::catalog::Container::Legacy,
-			jitter: None,
-		};
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::H265 {
+			in_band: true, // We only support `hev1` with inline SPS/PPS for now
+			profile_space: profile.profile_space,
+			profile_idc: profile.profile_idc,
+			profile_compatibility_flags: profile.profile_compatibility_flag.bits().to_be_bytes(),
+			tier_flag: profile.tier_flag,
+			level_idc: profile.level_idc.context("missing level_idc in SPS")?,
+			constraint_flags: crate::codec::h265::pack_constraint_flags(profile),
+		});
+		config.coded_width = Some(sps.rbsp.cropped_width() as u32);
+		config.coded_height = Some(sps.rbsp.cropped_height() as u32);
+		config.framerate = vui_data.framerate;
+		config.display_ratio_width = vui_data.display_ratio_width;
+		config.display_ratio_height = vui_data.display_ratio_height;
+		config.container = hang::catalog::Container::Legacy;
 
 		if let Some(old) = &self.config
 			&& old == &config

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -22,15 +22,12 @@ impl Import {
 	) -> anyhow::Result<Self> {
 		let track = broadcast.unique_track(".opus")?;
 
-		let audio_config = hang::catalog::AudioConfig {
-			codec: hang::catalog::AudioCodec::Opus,
-			sample_rate: config.sample_rate,
-			channel_count: config.channel_count,
-			bitrate: None,
-			description: None,
-			container: hang::catalog::Container::Legacy,
-			jitter: None,
-		};
+		let mut audio_config = hang::catalog::AudioConfig::new(
+			hang::catalog::AudioCodec::Opus,
+			config.sample_rate,
+			config.channel_count,
+		);
+		audio_config.container = hang::catalog::Container::Legacy;
 
 		tracing::debug!(name = ?track.name, config = ?audio_config, "starting track");
 		catalog.lock().audio.renditions.insert(track.name.clone(), audio_config);

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -25,28 +25,16 @@ async fn avc3_source_to_cmaf_export_roundtrip() {
 
 	let mut catalog = crate::catalog::hang::Producer::new(&mut producer).unwrap();
 	let track = producer.unique_track(".avc3").unwrap();
-	catalog.lock().video.renditions.insert(
-		track.name.clone(),
-		VideoConfig {
-			coded_width: Some(320),
-			coded_height: Some(240),
-			codec: H264 {
-				profile: 0x42,
-				constraints: 0xc0,
-				level: 0x1f,
-				inline: true,
-			}
-			.into(),
-			description: None,
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: Container::Legacy,
-			jitter: None,
-		},
-	);
+	let mut config = VideoConfig::new(H264 {
+		profile: 0x42,
+		constraints: 0xc0,
+		level: 0x1f,
+		inline: true,
+	});
+	config.coded_width = Some(320);
+	config.coded_height = Some(240);
+	config.container = Container::Legacy;
+	catalog.lock().video.renditions.insert(track.name.clone(), config);
 
 	const SC: &[u8] = &[0, 0, 0, 1];
 	let sps = &[0x67u8, 0x42, 0xc0, 0x1f, 0xde, 0xad, 0xbe, 0xef][..];

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -241,85 +241,53 @@ impl Import {
 				let mut description = BytesMut::new();
 				avcc.encode_body(&mut description)?;
 
-				VideoConfig {
-					coded_width: Some(avc1.visual.width as _),
-					coded_height: Some(avc1.visual.height as _),
-					codec: H264 {
-						profile: avcc.avc_profile_indication,
-						constraints: avcc.profile_compatibility,
-						level: avcc.avc_level_indication,
-						inline: false,
-					}
-					.into(),
-					description: Some(description.freeze()),
-					// TODO: populate these fields
-					framerate: None,
-					bitrate: None,
-					display_ratio_width: None,
-					display_ratio_height: None,
-					optimize_for_latency: None,
-					container,
-					jitter: None,
-				}
+				let mut config = VideoConfig::new(H264 {
+					profile: avcc.avc_profile_indication,
+					constraints: avcc.profile_compatibility,
+					level: avcc.avc_level_indication,
+					inline: false,
+				});
+				config.coded_width = Some(avc1.visual.width as _);
+				config.coded_height = Some(avc1.visual.height as _);
+				config.description = Some(description.freeze());
+				config.container = container;
+				config
 			}
 			mp4_atom::Codec::Hev1(hev1) => self.init_h265(true, &hev1.hvcc, &hev1.visual, container)?,
 			mp4_atom::Codec::Hvc1(hvc1) => self.init_h265(false, &hvc1.hvcc, &hvc1.visual, container)?,
-			mp4_atom::Codec::Vp08(vp08) => VideoConfig {
-				codec: VideoCodec::VP8,
-				description: Default::default(),
-				coded_width: Some(vp08.visual.width as _),
-				coded_height: Some(vp08.visual.height as _),
-				// TODO: populate these fields
-				framerate: None,
-				bitrate: None,
-				display_ratio_width: None,
-				display_ratio_height: None,
-				optimize_for_latency: None,
-				container,
-				jitter: None,
-			},
+			mp4_atom::Codec::Vp08(vp08) => {
+				let mut config = VideoConfig::new(VideoCodec::VP8);
+				config.coded_width = Some(vp08.visual.width as _);
+				config.coded_height = Some(vp08.visual.height as _);
+				config.container = container;
+				config
+			}
 			mp4_atom::Codec::Vp09(vp09) => {
 				// https://github.com/gpac/mp4box.js/blob/325741b592d910297bf609bc7c400fc76101077b/src/box-codecs.js#L238
 				let vpcc = &vp09.vpcc;
 
-				VideoConfig {
-					codec: VP9 {
-						profile: vpcc.profile,
-						level: vpcc.level,
-						bit_depth: vpcc.bit_depth,
-						color_primaries: vpcc.color_primaries,
-						chroma_subsampling: vpcc.chroma_subsampling,
-						transfer_characteristics: vpcc.transfer_characteristics,
-						matrix_coefficients: vpcc.matrix_coefficients,
-						full_range: vpcc.video_full_range_flag,
-					}
-					.into(),
-					description: Default::default(),
-					coded_width: Some(vp09.visual.width as _),
-					coded_height: Some(vp09.visual.height as _),
-					// TODO: populate these fields
-					display_ratio_width: None,
-					display_ratio_height: None,
-					optimize_for_latency: None,
-					bitrate: None,
-					framerate: None,
-					container,
-					jitter: None,
-				}
+				let mut config = VideoConfig::new(VP9 {
+					profile: vpcc.profile,
+					level: vpcc.level,
+					bit_depth: vpcc.bit_depth,
+					color_primaries: vpcc.color_primaries,
+					chroma_subsampling: vpcc.chroma_subsampling,
+					transfer_characteristics: vpcc.transfer_characteristics,
+					matrix_coefficients: vpcc.matrix_coefficients,
+					full_range: vpcc.video_full_range_flag,
+				});
+				config.coded_width = Some(vp09.visual.width as _);
+				config.coded_height = Some(vp09.visual.height as _);
+				config.container = container;
+				config
 			}
-			mp4_atom::Codec::Av01(av01) => VideoConfig {
-				codec: crate::codec::av1::av1_from_av1c(&av01.av1c).into(),
-				description: Default::default(),
-				coded_width: Some(av01.visual.width as _),
-				coded_height: Some(av01.visual.height as _),
-				display_ratio_width: None,
-				display_ratio_height: None,
-				optimize_for_latency: None,
-				bitrate: None,
-				framerate: None,
-				container,
-				jitter: None,
-			},
+			mp4_atom::Codec::Av01(av01) => {
+				let mut config = VideoConfig::new(crate::codec::av1::av1_from_av1c(&av01.av1c));
+				config.coded_width = Some(av01.visual.width as _);
+				config.coded_height = Some(av01.visual.height as _);
+				config.container = container;
+				config
+			}
 			mp4_atom::Codec::Unknown(unknown) => anyhow::bail!("unknown codec: {:?}", unknown),
 			unsupported => anyhow::bail!("unsupported codec: {:?}", unsupported),
 		};
@@ -337,29 +305,20 @@ impl Import {
 		let mut description = BytesMut::new();
 		hvcc.encode_body(&mut description)?;
 
-		Ok(VideoConfig {
-			codec: H265 {
-				in_band,
-				profile_space: hvcc.general_profile_space,
-				profile_idc: hvcc.general_profile_idc,
-				profile_compatibility_flags: hvcc.general_profile_compatibility_flags,
-				tier_flag: hvcc.general_tier_flag,
-				level_idc: hvcc.general_level_idc,
-				constraint_flags: hvcc.general_constraint_indicator_flags,
-			}
-			.into(),
-			description: Some(description.freeze()),
-			coded_width: Some(visual.width as _),
-			coded_height: Some(visual.height as _),
-			// TODO: populate these fields
-			bitrate: None,
-			framerate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container,
-			jitter: None,
-		})
+		let mut config = VideoConfig::new(H265 {
+			in_band,
+			profile_space: hvcc.general_profile_space,
+			profile_idc: hvcc.general_profile_idc,
+			profile_compatibility_flags: hvcc.general_profile_compatibility_flags,
+			tier_flag: hvcc.general_tier_flag,
+			level_idc: hvcc.general_level_idc,
+			constraint_flags: hvcc.general_constraint_indicator_flags,
+		});
+		config.description = Some(description.freeze());
+		config.coded_width = Some(visual.width as _);
+		config.coded_height = Some(visual.height as _);
+		config.container = container;
+		Ok(config)
 	}
 
 	fn init_audio(&mut self, trak: &Trak, moov: &Moov) -> anyhow::Result<AudioConfig> {
@@ -395,26 +354,20 @@ impl Import {
 				}
 				.encode();
 
-				AudioConfig {
-					codec: AAC { profile }.into(),
-					sample_rate,
-					channel_count,
-					bitrate: Some(bitrate.into()),
-					description: Some(description),
-					container,
-					jitter: None,
-				}
+				let mut config = AudioConfig::new(AAC { profile }, sample_rate, channel_count);
+				config.bitrate = Some(bitrate.into());
+				config.description = Some(description);
+				config.container = container;
+				config
 			}
 			mp4_atom::Codec::Opus(opus) => {
-				AudioConfig {
-					codec: AudioCodec::Opus,
-					sample_rate: opus.audio.sample_rate.integer() as _,
-					channel_count: opus.audio.channel_count as _,
-					bitrate: None,
-					description: None, // TODO?
-					container,
-					jitter: None,
-				}
+				let mut config = AudioConfig::new(
+					AudioCodec::Opus,
+					opus.audio.sample_rate.integer() as _,
+					opus.audio.channel_count as _,
+				);
+				config.container = container;
+				config
 			}
 			mp4_atom::Codec::Unknown(unknown) => anyhow::bail!("unknown codec: {:?}", unknown),
 			unsupported => anyhow::bail!("unsupported codec: {:?}", unsupported),

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -224,32 +224,21 @@ async fn export_rejects_cmaf_track() {
 
 	let mut catalog = crate::catalog::hang::Producer::new(&mut producer).unwrap();
 	let track = producer.unique_track(".avc1").unwrap();
-	catalog.lock().video.renditions.insert(
-		track.name.clone(),
-		VideoConfig {
-			coded_width: Some(640),
-			coded_height: Some(480),
-			codec: H264 {
-				profile: 0x64,
-				constraints: 0,
-				level: 0x1f,
-				inline: false,
-			}
-			.into(),
-			description: Some(Bytes::from(vec![0u8; 8])),
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: Container::Cmaf {
-				init: Bytes::from(vec![0u8; 32]),
-				timescale: None,
-				track_id: None,
-			},
-			jitter: None,
-		},
-	);
+	let mut config = VideoConfig::new(H264 {
+		profile: 0x64,
+		constraints: 0,
+		level: 0x1f,
+		inline: false,
+	});
+	config.coded_width = Some(640);
+	config.coded_height = Some(480);
+	config.description = Some(Bytes::from(vec![0u8; 8]));
+	config.container = Container::Cmaf {
+		init: Bytes::from(vec![0u8; 32]),
+		timescale: None,
+		track_id: None,
+	};
+	catalog.lock().video.renditions.insert(track.name.clone(), config);
 
 	let mut exporter = crate::container::mkv::Export::new(consumer).unwrap();
 	let result = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
@@ -275,28 +264,16 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 
 	let mut catalog = crate::catalog::hang::Producer::new(&mut producer).unwrap();
 	let track = producer.unique_track(".avc3").unwrap();
-	catalog.lock().video.renditions.insert(
-		track.name.clone(),
-		VideoConfig {
-			coded_width: Some(320),
-			coded_height: Some(240),
-			codec: H264 {
-				profile: 0x42,
-				constraints: 0xc0,
-				level: 0x1f,
-				inline: true,
-			}
-			.into(),
-			description: None,
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: Container::Legacy,
-			jitter: None,
-		},
-	);
+	let mut config = VideoConfig::new(H264 {
+		profile: 0x42,
+		constraints: 0xc0,
+		level: 0x1f,
+		inline: true,
+	});
+	config.coded_width = Some(320);
+	config.coded_height = Some(240);
+	config.container = Container::Legacy;
+	catalog.lock().video.renditions.insert(track.name.clone(), config);
 
 	// Annex-B start code.
 	const SC: &[u8] = &[0, 0, 0, 1];

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -438,21 +438,15 @@ fn build_video_config(
 		.unwrap_or((None, None));
 
 	let mut config = match codec_id {
-		"V_VP8" => VideoConfig {
-			codec: VideoCodec::VP8,
-			description: None,
-			coded_width: width,
-			coded_height: height,
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: Container::Legacy,
-			jitter: None,
-		},
-		"V_VP9" => VideoConfig {
-			codec: VP9 {
+		"V_VP8" => {
+			let mut config = VideoConfig::new(VideoCodec::VP8);
+			config.coded_width = width;
+			config.coded_height = height;
+			config.container = Container::Legacy;
+			config
+		}
+		"V_VP9" => {
+			let mut config = VideoConfig::new(VP9 {
 				profile: 0,
 				level: 0,
 				bit_depth: 8,
@@ -461,19 +455,12 @@ fn build_video_config(
 				transfer_characteristics: 1,
 				matrix_coefficients: 1,
 				full_range: false,
-			}
-			.into(),
-			description: None,
-			coded_width: width,
-			coded_height: height,
-			framerate: None,
-			bitrate: None,
-			display_ratio_width: None,
-			display_ratio_height: None,
-			optimize_for_latency: None,
-			container: Container::Legacy,
-			jitter: None,
-		},
+			});
+			config.coded_width = width;
+			config.coded_height = height;
+			config.container = Container::Legacy;
+			config
+		}
 		"V_MPEG4/ISO/AVC" => build_h264_config(codec_private)?,
 		"V_MPEGH/ISO/HEVC" => build_h265_config(codec_private)?,
 		"V_AV1" => build_av1_config(codec_private)?,
@@ -519,38 +506,35 @@ fn build_audio_config(
 				(sample_rate, channels)
 			};
 
-			Ok(AudioConfig {
-				codec: AudioCodec::Opus,
-				sample_rate: if cfg_rate > 0 { cfg_rate } else { sample_rate },
-				channel_count: if cfg_channels > 0 { cfg_channels } else { channels },
-				bitrate: None,
-				description: None,
-				container: Container::Legacy,
-				jitter: None,
-			})
+			let mut config = AudioConfig::new(
+				AudioCodec::Opus,
+				if cfg_rate > 0 { cfg_rate } else { sample_rate },
+				if cfg_channels > 0 { cfg_channels } else { channels },
+			);
+			config.container = Container::Legacy;
+			Ok(config)
 		}
 		"A_AAC" => {
 			let priv_data = codec_private.context("A_AAC missing CodecPrivate (AudioSpecificConfig)")?;
 			let mut cursor = priv_data.clone();
 			let cfg = crate::codec::aac::Config::parse(&mut cursor)?;
 
-			Ok(AudioConfig {
-				codec: AAC { profile: cfg.profile }.into(),
-				sample_rate: if cfg.sample_rate > 0 {
+			let mut config = AudioConfig::new(
+				AAC { profile: cfg.profile },
+				if cfg.sample_rate > 0 {
 					cfg.sample_rate
 				} else {
 					sample_rate
 				},
-				channel_count: if cfg.channel_count > 0 {
+				if cfg.channel_count > 0 {
 					cfg.channel_count
 				} else {
 					channels
 				},
-				bitrate: None,
-				description: Some(priv_data.clone()),
-				container: Container::Legacy,
-				jitter: None,
-			})
+			);
+			config.description = Some(priv_data.clone());
+			config.container = Container::Legacy;
+			Ok(config)
 		}
 		other => anyhow::bail!("unsupported audio CodecID: {}", other),
 	}
@@ -560,25 +544,17 @@ fn build_h264_config(codec_private: Option<&Bytes>) -> anyhow::Result<VideoConfi
 	let avcc_bytes = codec_private.context("V_MPEG4/ISO/AVC missing CodecPrivate (AVCDecoderConfigurationRecord)")?;
 	let avcc = crate::codec::h264::Avcc::parse(avcc_bytes)?;
 
-	Ok(VideoConfig {
-		codec: H264 {
-			profile: avcc.profile,
-			constraints: avcc.constraints,
-			level: avcc.level,
-			inline: false,
-		}
-		.into(),
-		description: Some(avcc_bytes.clone()),
-		coded_width: avcc.coded_width,
-		coded_height: avcc.coded_height,
-		framerate: None,
-		bitrate: None,
-		display_ratio_width: None,
-		display_ratio_height: None,
-		optimize_for_latency: None,
-		container: Container::Legacy,
-		jitter: None,
-	})
+	let mut config = VideoConfig::new(H264 {
+		profile: avcc.profile,
+		constraints: avcc.constraints,
+		level: avcc.level,
+		inline: false,
+	});
+	config.description = Some(avcc_bytes.clone());
+	config.coded_width = avcc.coded_width;
+	config.coded_height = avcc.coded_height;
+	config.container = Container::Legacy;
+	Ok(config)
 }
 
 fn build_h265_config(codec_private: Option<&Bytes>) -> anyhow::Result<VideoConfig> {
@@ -589,28 +565,18 @@ fn build_h265_config(codec_private: Option<&Bytes>) -> anyhow::Result<VideoConfi
 	let mut description = BytesMut::new();
 	hvcc.encode_body(&mut description)?;
 
-	Ok(VideoConfig {
-		codec: H265 {
-			in_band: false,
-			profile_space: hvcc.general_profile_space,
-			profile_idc: hvcc.general_profile_idc,
-			profile_compatibility_flags: hvcc.general_profile_compatibility_flags,
-			tier_flag: hvcc.general_tier_flag,
-			level_idc: hvcc.general_level_idc,
-			constraint_flags: hvcc.general_constraint_indicator_flags,
-		}
-		.into(),
-		description: Some(description.freeze()),
-		coded_width: None,
-		coded_height: None,
-		framerate: None,
-		bitrate: None,
-		display_ratio_width: None,
-		display_ratio_height: None,
-		optimize_for_latency: None,
-		container: Container::Legacy,
-		jitter: None,
-	})
+	let mut config = VideoConfig::new(H265 {
+		in_band: false,
+		profile_space: hvcc.general_profile_space,
+		profile_idc: hvcc.general_profile_idc,
+		profile_compatibility_flags: hvcc.general_profile_compatibility_flags,
+		tier_flag: hvcc.general_tier_flag,
+		level_idc: hvcc.general_level_idc,
+		constraint_flags: hvcc.general_constraint_indicator_flags,
+	});
+	config.description = Some(description.freeze());
+	config.container = Container::Legacy;
+	Ok(config)
 }
 
 fn build_av1_config(codec_private: Option<&Bytes>) -> anyhow::Result<VideoConfig> {
@@ -621,17 +587,8 @@ fn build_av1_config(codec_private: Option<&Bytes>) -> anyhow::Result<VideoConfig
 	let mut description = BytesMut::new();
 	av1c.encode_body(&mut description)?;
 
-	Ok(VideoConfig {
-		codec: crate::codec::av1::av1_from_av1c(&av1c).into(),
-		description: Some(description.freeze()),
-		coded_width: None,
-		coded_height: None,
-		framerate: None,
-		bitrate: None,
-		display_ratio_width: None,
-		display_ratio_height: None,
-		optimize_for_latency: None,
-		container: Container::Legacy,
-		jitter: None,
-	})
+	let mut config = VideoConfig::new(crate::codec::av1::av1_from_av1c(&av1c));
+	config.description = Some(description.freeze());
+	config.container = Container::Legacy;
+	Ok(config)
 }


### PR DESCRIPTION
## Summary

- Mark `hang::catalog::VideoConfig` and `AudioConfig` as `#[non_exhaustive]` so additional optional fields can be added without bumping the major version.
- Add `VideoConfig::new(codec)` and `AudioConfig::new(codec, sample_rate, channel_count)` constructors that clear every optional field and default `container` via `Container::default()`. Callers assign whichever optional fields they need afterwards.
- Migrate every in-tree struct-literal site (15 files) across `hang` and `moq-mux` to the new constructors.

## Why

Without `#[non_exhaustive]`, every additive field on these public structs is a SemVer-breaking change for downstream Rust users that construct via struct literals. The previous attempt to add `#[non_exhaustive]` was rolled back because `moq-mux` (a separate crate) could no longer build via struct literals; the `new(...)` constructors are the unblocker.

This follows the pattern established in 9f780fa5 (\"Tighten public APIs ahead of release: non_exhaustive + builders\") for `AuthToken` and `moq_msf::Track`.

## Notes for reviewers

- Required fields per constructor: `VideoConfig::new` only takes `codec` (everything else is optional or has `Default`); `AudioConfig::new` takes `codec`, `sample_rate`, and `channel_count` since the latter two have no sensible default and a wrong value silently distorts playback.
- Both constructors accept `impl Into<{Video,Audio}Codec>`, so callers can pass an `H264 { ... }` (or other variant payload) directly without `.into()`.
- I touched a few sites beyond the original task list — additional struct-literal sites in `rs/moq-mux/src/container/mkv/{import,export_test}.rs` and several test cases in `rs/moq-mux/src/catalog/hang/producer.rs` — because they would otherwise fail to compile against the `#[non_exhaustive]` types.

## Test plan

- [x] `just check` (rustc, clippy -D warnings, fmt, cargo doc, cargo sort, biome, remark)
- [x] `just rs test` — all suites pass, including the catalog roundtrip tests in `hang` and the hang/msf catalog tests in `moq-mux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)