### PR TITLE
relay(stats): allow multi-segment --stats-node values; move cargo-deny to ci

### DIFF
--- a/demo/relay/localhost.toml
+++ b/demo/relay/localhost.toml
@@ -38,7 +38,8 @@ enabled = true
 # the anon prefix, and the broadcast itself.
 levels = 3
 # `node` is the suffix that disambiguates per-relay broadcasts in a cluster.
-# Single-node setups can leave it unset.
+# It can be multi-segment (e.g. `sjc/1`, `sjc/2`) to nest multiple hosts under
+# a shared region key. Single-node setups can leave it unset.
 node = "localhost"
 
 [iroh]

--- a/rs/justfile
+++ b/rs/justfile
@@ -20,12 +20,14 @@ check *args:
 	RUSTDOCFLAGS="-D warnings" cargo doc --no-deps {{ args }}
 	cargo shear
 	cargo sort --workspace --check
-	cargo deny check --show-stats
 
 # Full Rust CI: check + feature edge cases + tests + build. Takes a
 # newline-separated list of changed files; skips if FILES is non-empty
 # and none match the Rust scope. Run `just rs ci` (no FILES) to
 # force-run everything. `cargo publish --dry-run` lives in release-rs.yml.
+#
+# `cargo deny` runs here (not in `check`) so the inner-loop stays fast
+# and devs aren't blocked by a fresh upstream advisory mid-edit.
 ci FILES="":
 	#!/usr/bin/env bash
 	set -euo pipefail
@@ -36,6 +38,7 @@ ci FILES="":
 	just check --workspace
 	cargo check --workspace --no-default-features
 	cargo check --workspace --all-features
+	cargo deny check --show-stats
 	just test --all-features
 	just build
 

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -14,6 +14,8 @@
 //! single shared [`Stats`] via [`Stats::tier`]) which determines which counter
 //! set its bumps land in. Multiple relays in the same cluster origin can
 //! coexist by giving each one a distinct `<node>` suffix on advertised paths.
+//! The suffix itself may be multi-segment (e.g. `sjc/1`, `sjc/2`) so a region
+//! with multiple hosts can nest under a shared region key without colliding.
 //!
 //! Each broadcast contributes to every prefix of its path (within the
 //! configured depth), so publishing `anon/bbb` with `levels = 2` produces:
@@ -143,7 +145,7 @@ pub struct Stats {
 struct StatsInner {
 	prefix: PathOwned,
 	levels: u32,
-	node: Option<String>,
+	node: Option<PathOwned>,
 	origin: OriginProducer,
 	entries: Lock<HashMap<PathOwned, Arc<Level>>>,
 }
@@ -156,7 +158,7 @@ struct Level {
 	internal_subscriber: Counters,
 	task: Lock<Option<()>>,
 	origin: OriginProducer,
-	node: Option<String>,
+	node: Option<PathOwned>,
 	level_key: PathOwned,
 }
 
@@ -191,21 +193,27 @@ impl Stats {
 	///   A broadcast within the configured depth also gets its own dedicated bucket;
 	///   broadcasts deeper than `levels` are truncated.
 	/// * `node` disambiguates broadcasts published by different relays into a shared
-	///   cluster origin. Set this on every node in multi-relay deployments. `None`
-	///   omits the suffix, which is fine for single-relay deployments.
+	///   cluster origin. Set this on every node in multi-relay deployments. The
+	///   value may be multi-segment (e.g. `sjc/1`, `sjc/2`) so a region with
+	///   multiple hosts can nest under a shared region key. `None` (or an empty
+	///   path after normalization) omits the suffix, which is fine for
+	///   single-relay deployments.
 	/// * `origin` is the [`OriginProducer`] that receives `publish_broadcast` calls
 	///   for each stats broadcast.
 	pub fn new(
 		prefix: impl Into<PathOwned>,
 		levels: u32,
-		node: impl Into<Option<String>>,
+		node: impl Into<Option<PathOwned>>,
 		origin: OriginProducer,
 	) -> Self {
+		// An empty path after normalization is indistinguishable from "no node
+		// set"; collapse it so downstream code only sees a single representation.
+		let node = node.into().filter(|p| !p.is_empty());
 		Self {
 			inner: Arc::new(StatsInner {
 				prefix: prefix.into(),
 				levels,
-				node: node.into(),
+				node,
 				origin,
 				entries: Lock::default(),
 			}),
@@ -260,7 +268,7 @@ impl Stats {
 				entries
 					.entry(key.clone())
 					.or_insert_with(|| {
-						let advertised = advertised_path(&self.inner.prefix, &key, self.inner.node.as_deref());
+						let advertised = advertised_path(&self.inner.prefix, &key, self.inner.node.as_ref());
 						Arc::new(Level {
 							advertised,
 							external_publisher: Counters::default(),
@@ -733,7 +741,7 @@ fn write_snapshot(track: &mut crate::TrackProducer, tier: Tier, role: Role, leve
 		level: level.level_key.as_str(),
 		tier: tier.as_str(),
 		role: role.as_str(),
-		node: level.node.as_deref(),
+		node: level.node.as_ref().map(|p| p.as_str()),
 		ts_ms: now_ms(),
 		snapshot,
 	};
@@ -778,7 +786,7 @@ fn level_keys(broadcast: &Path, levels: u32) -> Vec<PathOwned> {
 	(0..=max).map(|i| PathOwned::from(segs[..i].join("/"))).collect()
 }
 
-fn advertised_path(prefix: &Path, level_key: &Path, node: Option<&str>) -> PathOwned {
+fn advertised_path(prefix: &Path, level_key: &Path, node: Option<&Path>) -> PathOwned {
 	// The fixed `prefix` category leaves room for sibling categories (e.g.
 	// `<top-prefix>/nodes/<node>` for host-level stats) under the same prefix.
 	let top = prefix.as_str();
@@ -788,8 +796,10 @@ fn advertised_path(prefix: &Path, level_key: &Path, node: Option<&str>) -> PathO
 		out.push_str(level_key.as_str());
 	}
 	if let Some(node) = node {
+		// `node` is already a normalized path, so multi-segment values like
+		// `sjc/1` nest under the region without any extra handling.
 		out.push('/');
-		out.push_str(node);
+		out.push_str(node.as_str());
 	}
 	PathOwned::from(out)
 }
@@ -831,16 +841,17 @@ mod tests {
 	#[test]
 	fn advertised_path_root_and_nested() {
 		let prefix = Path::new(".stats");
+		let node = PathOwned::from("sjc");
 		assert_eq!(
-			advertised_path(&prefix, &Path::new(""), Some("sjc")).as_str(),
+			advertised_path(&prefix, &Path::new(""), Some(&node)).as_str(),
 			".stats/prefix/sjc"
 		);
 		assert_eq!(
-			advertised_path(&prefix, &Path::new("demo"), Some("sjc")).as_str(),
+			advertised_path(&prefix, &Path::new("demo"), Some(&node)).as_str(),
 			".stats/prefix/demo/sjc"
 		);
 		assert_eq!(
-			advertised_path(&prefix, &Path::new("demo/foo"), Some("sjc")).as_str(),
+			advertised_path(&prefix, &Path::new("demo/foo"), Some(&node)).as_str(),
 			".stats/prefix/demo/foo/sjc"
 		);
 	}
@@ -858,20 +869,62 @@ mod tests {
 	#[test]
 	fn advertised_path_honors_custom_prefix() {
 		let prefix = Path::new("metrics");
+		let node = PathOwned::from("lon");
 		assert_eq!(
-			advertised_path(&prefix, &Path::new(""), Some("lon")).as_str(),
+			advertised_path(&prefix, &Path::new(""), Some(&node)).as_str(),
 			"metrics/prefix/lon"
 		);
 		assert_eq!(
-			advertised_path(&prefix, &Path::new("demo/room"), Some("lon")).as_str(),
+			advertised_path(&prefix, &Path::new("demo/room"), Some(&node)).as_str(),
 			"metrics/prefix/demo/room/lon"
 		);
+	}
+
+	#[test]
+	fn advertised_path_multi_segment_node() {
+		let prefix = Path::new(".stats");
+		let node = PathOwned::from("sjc/1");
+		assert_eq!(
+			advertised_path(&prefix, &Path::new(""), Some(&node)).as_str(),
+			".stats/prefix/sjc/1"
+		);
+		assert_eq!(
+			advertised_path(&prefix, &Path::new("demo"), Some(&node)).as_str(),
+			".stats/prefix/demo/sjc/1"
+		);
+		assert_eq!(
+			advertised_path(&prefix, &Path::new("demo/foo"), Some(&node)).as_str(),
+			".stats/prefix/demo/foo/sjc/1"
+		);
+		// A second host in the same region nests under the shared region key
+		// without colliding with the first.
+		let node2 = PathOwned::from("sjc/2");
+		assert_eq!(
+			advertised_path(&prefix, &Path::new("demo"), Some(&node2)).as_str(),
+			".stats/prefix/demo/sjc/2"
+		);
+	}
+
+	#[test]
+	fn new_normalizes_and_drops_empty_node() {
+		let origin = Origin::random().produce();
+
+		// Trailing slash and a doubled separator both get normalized away.
+		let stats = Stats::new(".stats", 1, Some(PathOwned::from("/sjc//1/")), origin.clone());
+		assert_eq!(stats.inner.node.as_ref().unwrap().as_str(), "sjc/1");
+
+		// Empty / whitespace-only inputs collapse to None so downstream code
+		// only has to handle a single "no node" representation.
+		let stats = Stats::new(".stats", 1, Some(PathOwned::from("")), origin.clone());
+		assert!(stats.inner.node.is_none());
+		let stats = Stats::new(".stats", 1, Some(PathOwned::from("///")), origin);
+		assert!(stats.inner.node.is_none());
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn external_publisher_bumps_external_publisher_counters() {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(".stats", 2, Some("sjc".to_string()), origin);
+		let stats = Stats::new(".stats", 2, Some(PathOwned::from("sjc")), origin);
 		let bs = stats.tier(Tier::External).broadcast("demo/bbb");
 		let pub_role = bs.publisher();
 		let track = pub_role.track("video");
@@ -899,7 +952,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn external_subscriber_bumps_external_subscriber_counters() {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(".stats", 1, Some("sjc".to_string()), origin);
+		let stats = Stats::new(".stats", 1, Some(PathOwned::from("sjc")), origin);
 		let bs = stats.tier(Tier::External).broadcast("demo/bbb");
 		let sub_role = bs.subscriber();
 		let track = sub_role.track("video");
@@ -919,7 +972,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn external_and_internal_tiers_are_independent() {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(".stats", 1, Some("sjc".to_string()), origin);
+		let stats = Stats::new(".stats", 1, Some(PathOwned::from("sjc")), origin);
 		let ext = stats.tier(Tier::External);
 		let int = stats.tier(Tier::Internal);
 
@@ -939,7 +992,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn bumps_fanout_to_all_levels() {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(".stats", 2, Some("sjc".to_string()), origin);
+		let stats = Stats::new(".stats", 2, Some(PathOwned::from("sjc")), origin);
 		let bs = stats.tier(Tier::External).broadcast("demo/bbb");
 		let p = bs.publisher();
 		let track = p.track("video");
@@ -957,7 +1010,7 @@ mod tests {
 		// Our own stats broadcasts (and any sibling category under the same
 		// prefix) must not feed back into the aggregator.
 		let origin = Origin::random().produce();
-		let stats = Stats::new(".stats", 2, Some("sjc".to_string()), origin);
+		let stats = Stats::new(".stats", 2, Some(PathOwned::from("sjc")), origin);
 		let bs = stats.tier(Tier::External).broadcast(".stats/prefix/sjc");
 		assert!(bs.is_empty());
 
@@ -977,7 +1030,7 @@ mod tests {
 		// Subscription-side track creation should not record a broadcast: the
 		// broadcast lifetime is tracked separately by the announce loop.
 		let origin = Origin::random().produce();
-		let stats = Stats::new(".stats", 1, Some("sjc".to_string()), origin);
+		let stats = Stats::new(".stats", 1, Some(PathOwned::from("sjc")), origin);
 		let bs = stats.tier(Tier::External).broadcast("demo/bbb");
 		let track = bs.publisher_track("video");
 		track.bytes(10);
@@ -1009,7 +1062,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn task_spawns_on_first_subscribe_and_announces() {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(".stats", 1, Some("sjc".to_string()), origin.clone());
+		let stats = Stats::new(".stats", 1, Some(PathOwned::from("sjc")), origin.clone());
 		let mut consumer = origin.consume();
 
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
@@ -1031,7 +1084,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn task_spawns_with_node_suffix() {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(".stats", 2, Some("sjc".to_string()), origin.clone());
+		let stats = Stats::new(".stats", 2, Some(PathOwned::from("sjc")), origin.clone());
 		let mut consumer = origin.consume();
 
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
@@ -1080,7 +1133,7 @@ mod tests {
 		// levels=1 + broadcast "foo/bar" → buckets ["", "foo"] (root prefix plus
 		// the first-segment prefix; the broadcast's own path isn't reachable at
 		// this depth, so we get exactly two stats announces).
-		let stats = Stats::new(".stats", 1, Some("sjc".to_string()), origin.clone());
+		let stats = Stats::new(".stats", 1, Some(PathOwned::from("sjc")), origin.clone());
 		let mut consumer = origin.consume();
 
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");

--- a/rs/moq-relay/src/stats.rs
+++ b/rs/moq-relay/src/stats.rs
@@ -4,7 +4,7 @@
 //! holds the relay-specific config knobs.
 
 use clap::Args;
-use moq_net::{OriginProducer, Stats};
+use moq_net::{OriginProducer, PathOwned, Stats};
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the relay's stats publishing.
@@ -51,7 +51,10 @@ pub struct StatsConfig {
 	/// broadcasts when multiple relays share a cluster origin. Without this,
 	/// peer relays would publish to the same `<prefix>/prefix/<level-path>`
 	/// path and the origin's single-source delivery would drop all but one.
-	/// Single-relay deployments can leave this unset.
+	///
+	/// May be multi-segment (e.g. `sjc/1`, `sjc/2`) when a region has multiple
+	/// hosts; the segments nest under a shared region key on the advertised
+	/// path. Single-relay deployments can leave this unset.
 	#[arg(long = "stats-node", env = "MOQ_STATS_NODE")]
 	pub node: Option<String>,
 }
@@ -67,7 +70,8 @@ impl StatsConfig {
 		}
 		let levels = self.levels.unwrap_or(1).max(1);
 		let prefix = self.prefix.clone().unwrap_or_else(|| ".stats".to_string());
-		tracing::info!(prefix, levels, node = ?self.node, "stats publishing enabled");
-		Stats::new(prefix, levels, self.node.clone(), origin)
+		let node = self.node.clone().map(PathOwned::from);
+		tracing::info!(prefix, levels, node = ?node, "stats publishing enabled");
+		Stats::new(prefix, levels, node, origin)
 	}
 }


### PR DESCRIPTION
## Summary

Two small unrelated changes that came up while reviewing `--stats-node`:

- **`relay(stats)`**: treat the `--stats-node` value as a normalized path so multi-host regions can use values like `sjc/1` and `sjc/2` to nest under a shared region key without colliding on the advertised stats path. `Stats::new` now takes `Option<PathOwned>`; trailing/duplicate slashes are trimmed and an empty value after normalization collapses to `None`. Doc comments + the `localhost.toml` example call out the new shape explicitly.
- **`ci(rs)`**: move `cargo deny check --show-stats` from `just rs check` to `just rs ci` so the inner-loop check stays fast and devs aren't blocked mid-edit by a fresh upstream advisory. CI still gets coverage because `.github/workflows/check.yml` invokes `just ci`.

## Test plan

- [x] `cargo test -p moq-net --lib stats::` — 17 tests pass, including new `advertised_path_multi_segment_node` and `new_normalizes_and_drops_empty_node` cases
- [x] `cargo check -p moq-net -p moq-relay`
- [x] `cargo clippy -p moq-net -p moq-relay --all-targets`
- [x] `just rs check` runs clean and no longer invokes `cargo deny`

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)