### PR TITLE
relay(stats): fix TOML stats config silently clobbered by clap update_from

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ match version {
 
 - **Error handling**: Use `thiserror` with `#[from]` for library crates, `anyhow` for binaries. Always add `#[non_exhaustive]` to public `thiserror` enums.
 - Use `anyhow::Context` (`.context("msg")`) instead of `.map_err(|_| anyhow::anyhow!("msg"))` for error conversion
+- **Config flags + TOML merge**: For any `#[arg]` field on a TOML-loadable config, use `Option<T>` (not bare `bool` / `String` / etc.). The TOML→CLI merge clobbers bare fields with their `Default` when the flag is absent, silently overwriting TOML values. See `rs/moq-relay/src/config.rs::tests` for the regression test; add one for any new flag.
 
 ## Comment Conventions
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "moq",

--- a/demo/relay/leaf0.toml
+++ b/demo/relay/leaf0.toml
@@ -48,3 +48,8 @@ key = "root.jwk"
 # Allow anonymous clients to subscribe and publish to the prefixes below.
 subscribe = ["anon", "demo"]
 publish = ["anon", "demo/viewer"]
+
+[stats]
+enabled = true
+levels = 3
+node = "local/leaf0"

--- a/demo/relay/leaf1.toml
+++ b/demo/relay/leaf1.toml
@@ -48,3 +48,8 @@ key = "root.jwk"
 # Allow anonymous clients to subscribe and publish to the prefixes below.
 subscribe = ["anon", "demo"]
 publish = ["anon", "demo/viewer"]
+
+[stats]
+enabled = true
+levels = 3
+node = "local/leaf1"

--- a/demo/relay/localhost.toml
+++ b/demo/relay/localhost.toml
@@ -40,7 +40,7 @@ levels = 3
 # `node` is the suffix that disambiguates per-relay broadcasts in a cluster.
 # It can be multi-segment (e.g. `sjc/1`, `sjc/2`) to nest multiple hosts under
 # a shared region key. Single-node setups can leave it unset.
-node = "localhost"
+node = "local/host"
 
 [iroh]
 # You can optionally enable iroh support for P2P connections.

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -60,18 +60,108 @@ impl Config {
 	/// Parses configuration from CLI arguments, optionally merging with a
 	/// TOML file specified via `--file`. Also initializes the logger.
 	pub fn load() -> anyhow::Result<Self> {
-		// Parse just the CLI arguments initially.
-		let mut config = Config::parse();
-
-		// If a file is provided, load it and merge the CLI arguments.
-		if let Some(file) = config.file {
-			config = toml::from_str(&std::fs::read_to_string(file)?)?;
-			config.update_from(std::env::args());
-		}
-
+		let config = Self::parse_and_merge(std::env::args_os())?;
 		config.log.init();
 		tracing::trace!(?config, "final config");
-
 		Ok(config)
+	}
+
+	/// Pure version of [`Self::load`] without logger init, so tests can drive
+	/// it with synthetic args and inspect the result.
+	///
+	/// Merge order: CLI args (`config.file` and any flags) → TOML file (if
+	/// `--file` is set) → CLI args re-applied so explicit flags / env vars
+	/// override TOML.
+	///
+	/// # Pitfall (see `CLAUDE.md` and `tests` below)
+	///
+	/// The final `update_from` re-runs the clap parser over `args`. For
+	/// fields typed as bare `bool`, an absent CLI flag writes
+	/// `Default::default()` (i.e. `false`) over the TOML value, silently
+	/// disabling settings that the TOML enabled. Type any new flag that
+	/// should be TOML-overridable as `Option<bool>` (or other `Option<T>`)
+	/// — those are left untouched when the CLI arg is absent.
+	pub(crate) fn parse_and_merge<I, T>(args: I) -> anyhow::Result<Self>
+	where
+		I: IntoIterator<Item = T>,
+		T: Into<std::ffi::OsString> + Clone,
+	{
+		let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
+		let mut config = Config::parse_from(&args);
+		if let Some(file) = config.file.clone() {
+			config = toml::from_str(&std::fs::read_to_string(file)?)?;
+			config.update_from(&args);
+		}
+		Ok(config)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Regression test for the clap+TOML interaction documented on
+	/// `Config::parse_and_merge`. A TOML file that enables stats with no
+	/// overriding CLI flag must still produce `stats.enabled == Some(true)`.
+	///
+	/// Before the fix, `stats.enabled` was a bare `bool`. `update_from` would
+	/// re-run the clap parser over args containing no `--stats-enabled`, which
+	/// wrote the default `false` over the TOML's `true`, silently disabling
+	/// stats publishing for any deployment that configured it via TOML.
+	#[test]
+	fn cli_does_not_clobber_toml_stats_enabled() {
+		// SAFETY: clap reads MOQ_STATS_ENABLED via `env = ...`. If the host
+		// environment has it set, the test would pass for the wrong reason.
+		// Clear it for the duration of this test. (Tests run single-threaded
+		// by default at the file level under `cargo test`; if more env-touching
+		// tests land here, consider a Mutex or `temp-env` crate.)
+		// SAFETY: tests run single-threaded per process by default.
+		unsafe { std::env::remove_var("MOQ_STATS_ENABLED") };
+
+		let toml = r#"
+[stats]
+enabled = true
+levels = 3
+node = "localhost"
+"#;
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(
+			config.stats.enabled,
+			Some(true),
+			"TOML's stats.enabled=true must not be clobbered by the CLI re-parse \
+			 (any new bare-bool field on a flatten-derived config will have the same bug; \
+			 type it as Option<bool>)"
+		);
+		assert_eq!(config.stats.levels, Some(3));
+		assert_eq!(config.stats.node.as_deref(), Some("localhost"));
+	}
+
+	/// Explicit CLI flag must still override TOML. Belt-and-suspenders for the
+	/// fix above: making `enabled: Option<bool>` shouldn't break the override
+	/// path.
+	#[test]
+	fn cli_flag_overrides_toml_stats_enabled() {
+		unsafe { std::env::remove_var("MOQ_STATS_ENABLED") };
+
+		let toml = "[stats]\nenabled = true\n";
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("cli-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![
+			std::ffi::OsString::from("moq-relay"),
+			std::ffi::OsString::from(&path),
+			std::ffi::OsString::from("--stats-enabled=false"),
+		];
+		let config = Config::parse_and_merge(args).expect("config load");
+		assert_eq!(config.stats.enabled, Some(false));
 	}
 }

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -58,7 +58,8 @@ pub struct Config {
 
 impl Config {
 	/// Parses configuration from CLI arguments, optionally merging with a
-	/// TOML file specified via `--file`. Also initializes the logger.
+	/// TOML file specified via the positional `file` argument. Also initializes
+	/// the logger.
 	pub fn load() -> anyhow::Result<Self> {
 		let config = Self::parse_and_merge(std::env::args_os())?;
 		config.log.init();
@@ -69,8 +70,8 @@ impl Config {
 	/// Pure version of [`Self::load`] without logger init, so tests can drive
 	/// it with synthetic args and inspect the result.
 	///
-	/// Merge order: CLI args (`config.file` and any flags) → TOML file (if
-	/// `--file` is set) → CLI args re-applied so explicit flags / env vars
+	/// Merge order: CLI args (the positional `file` and any flags) → TOML file
+	/// (if `file` is set) → CLI args re-applied so explicit flags / env vars
 	/// override TOML.
 	///
 	/// # Pitfall (see `CLAUDE.md` and `tests` below)
@@ -98,7 +99,15 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
+	use std::sync::Mutex;
+
 	use super::*;
+
+	/// Serializes tests that touch `MOQ_STATS_ENABLED`. Cargo runs tests in
+	/// parallel within a single binary, and `env::set_var` / `remove_var` are
+	/// not thread-safe with concurrent env reads (which is why they're `unsafe`
+	/// as of Rust 1.80). Any test that mutates this env must hold this lock.
+	static STATS_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 	/// Regression test for the clap+TOML interaction documented on
 	/// `Config::parse_and_merge`. A TOML file that enables stats with no
@@ -110,12 +119,12 @@ mod tests {
 	/// stats publishing for any deployment that configured it via TOML.
 	#[test]
 	fn cli_does_not_clobber_toml_stats_enabled() {
-		// SAFETY: clap reads MOQ_STATS_ENABLED via `env = ...`. If the host
-		// environment has it set, the test would pass for the wrong reason.
-		// Clear it for the duration of this test. (Tests run single-threaded
-		// by default at the file level under `cargo test`; if more env-touching
-		// tests land here, consider a Mutex or `temp-env` crate.)
-		// SAFETY: tests run single-threaded per process by default.
+		let _guard = STATS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// clap reads MOQ_STATS_ENABLED via `env = ...`. If the host environment
+		// has it set, the test would pass for the wrong reason. Clear it for
+		// the duration of this test (lock above serializes with sibling tests).
+		// SAFETY: STATS_ENV_LOCK ensures no other test in this binary touches
+		// this env var concurrently.
 		unsafe { std::env::remove_var("MOQ_STATS_ENABLED") };
 
 		let toml = r#"
@@ -148,6 +157,9 @@ node = "localhost"
 	/// path.
 	#[test]
 	fn cli_flag_overrides_toml_stats_enabled() {
+		let _guard = STATS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: STATS_ENV_LOCK ensures no other test in this binary touches
+		// this env var concurrently.
 		unsafe { std::env::remove_var("MOQ_STATS_ENABLED") };
 
 		let toml = "[stats]\nenabled = true\n";

--- a/rs/moq-relay/src/stats.rs
+++ b/rs/moq-relay/src/stats.rs
@@ -21,6 +21,13 @@ use serde::{Deserialize, Serialize};
 #[group(id = "stats-config")]
 pub struct StatsConfig {
 	/// Master switch for stats publishing. Defaults to false.
+	///
+	/// Typed as `Option<bool>` (not bare `bool`) so a TOML file setting
+	/// `stats.enabled = true` survives `Config::load`'s `update_from` CLI
+	/// re-parse. With a bare `bool`, an absent `--stats-enabled` CLI flag
+	/// writes the `Default::default()` value (`false`) over the TOML value.
+	/// See `tests::cli_does_not_clobber_toml_stats_enabled` and the
+	/// "Config flags + TOML merge" note in `CLAUDE.md`.
 	#[arg(
 		long = "stats-enabled",
 		env = "MOQ_STATS_ENABLED",
@@ -29,7 +36,7 @@ pub struct StatsConfig {
 		require_equals = true,
 		value_parser = clap::value_parser!(bool),
 	)]
-	pub enabled: bool,
+	pub enabled: Option<bool>,
 
 	/// Top-level path under which stats broadcasts are published. Defaults
 	/// to `.stats`. Future stats categories (e.g. host-level node stats)
@@ -65,7 +72,7 @@ impl StatsConfig {
 	/// Returns [`Stats::disabled`] (a no-op aggregator) when [`Self::enabled`]
 	/// is false, so the relay can attach the result unconditionally.
 	pub fn build(&self, origin: OriginProducer) -> Stats {
-		if !self.enabled {
+		if !self.enabled.unwrap_or(false) {
 			return Stats::disabled();
 		}
 		let levels = self.levels.unwrap_or(1).max(1);


### PR DESCRIPTION
## Summary

`Config::load` did: parse CLI → deserialize TOML → `update_from(cli_args)`. That re-runs the clap parser onto the TOML-derived config. For a bare `bool` field with no `--flag` on the CLI, clap writes `Default::default()` (`false`) over the TOML value, silently disabling any setting that was configured only via TOML. `Option<T>` fields survive because `update_from` leaves them untouched when the arg is absent.

This was hitting `StatsConfig.enabled` in particular: a relay launched with `localhost.toml` (which has `[stats] enabled = true`) booted with stats publishing disabled, no warning, no log line. The dashboard's stats subscriber would just sit there forever waiting for announces that never came.

## What's in this PR

1. **The fix** (`rs/moq-relay/src/stats.rs`): `pub enabled: bool` → `pub enabled: Option<bool>`, `unwrap_or(false)` at the call site. Mirrors how `IrohEndpointConfig.enabled` already handles the same merge.

2. **Testable `Config::load`** (`rs/moq-relay/src/config.rs`): split into the public entry point and a pure `parse_and_merge(args)` so tests can drive it with synthetic args (no `std::env::args`, no `log.init()`).

3. **Two regression tests** in `rs/moq-relay/src/config.rs::tests`:
   - `cli_does_not_clobber_toml_stats_enabled` — TOML enables stats, no overriding CLI flag, expects `Some(true)`. This is the test that would have caught the original bug. As a bonus, reverting the field to bare `bool` makes the `assert_eq!(..., Some(true))` line stop compiling, so type-level regressions get caught at build time.
   - `cli_flag_overrides_toml_stats_enabled` — belt-and-suspenders that explicit `--stats-enabled=false` still wins.

4. **CLAUDE.md note** — a new "Config flags + TOML merge (clap pitfall)" bullet under Rust Conventions so future config knobs reach for `Option<T>` by default and add a parallel test.

5. **Demo configs** — enable `[stats]` on `leaf0.toml` / `leaf1.toml`, switch `localhost.toml` from `--stats-node "localhost"` to `"local/host"`, so the demo exercises the multi-segment node path that real cluster deployments use. Also picks up the `configVersion = 0` lockfile bump from newer bun.

## Verification

- `cargo test -p moq-relay --lib` → **77 passed, 0 failed** (2 new tests included).
- End-to-end: `cargo run --bin moq-relay -- localhost.toml` (no flags, no env) now logs `stats publishing enabled prefix=".stats" levels=3 node=Some(Path("local/host"))` on startup. Before the fix, this log line never appeared.

## Test plan

- [ ] CI green (`cargo test`, `cargo fmt`, `cargo clippy`).
- [ ] Manual: `just demo` and confirm stats announces appear on the dashboard's broadcasts page when scoped to `anon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)