### PR TITLE
ci(rpm): skip rclone bucket probe when publishing to R2

### DIFF
--- a/infra/rpm/publish.sh
+++ b/infra/rpm/publish.sh
@@ -28,6 +28,10 @@ export RCLONE_CONFIG_R2_ENDPOINT="https://${R2_ACCOUNT_ID:?}.r2.cloudflarestorag
 export RCLONE_CONFIG_R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID:?}"
 export RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY:?}"
 export RCLONE_CONFIG_R2_ACL=private
+# The R2 token has object read/write but not CreateBucket. rclone normally
+# probes the bucket on writes to a bucket-root key (e.g. moq.repo), which
+# surfaces as a 403 AccessDenied. Skip the probe; the bucket already exists.
+export RCLONE_CONFIG_R2_NO_CHECK_BUCKET=true
 
 WORK=$(mktemp -d)
 GNUPGHOME=""


### PR DESCRIPTION
## Summary

- `infra/rpm/publish.sh` failed in [run 26377814471](https://github.com/moq-dev/moq/actions/runs/26377814471/job/77641193782) on the final step: `rclone copyto $WORK/moq.repo r2:rpm-moq-dev/moq.repo` returned `403 AccessDenied` on `CreateBucket`.
- rclone's S3 backend probes the bucket on the first `Mkdir` it's handed. For a `copyto` whose parent path *is* the bucket itself, that probe falls back to `CreateBucket` if the HEAD doesn't cleanly succeed. The R2 token has object read/write but not bucket-creation permission, so the probe 403s.
- Per-arch uploads (`r2:bucket/el9/$arch/...`) target sub-prefixes, so their `Mkdir` doesn't try to create the bucket. The sibling apt publish script writes only to sub-prefixes too, which is why [the apt run](https://github.com/moq-dev/moq/actions/runs/26377813808) succeeded with the same R2 credentials.
- Fix: set `RCLONE_CONFIG_R2_NO_CHECK_BUCKET=true` so rclone skips the probe entirely. The bucket already exists; we don't need rclone to validate it on every invocation.

## Test plan

- [ ] Re-run the `rpm-repo` workflow on `main` after merge and confirm the "Publish to R2" step succeeds for `moq.repo`, both arch directories, and that `https://rpm.moq.dev/moq.repo` resolves to the freshly written file.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7)