### PR TITLE
js: re-export @moq/net as Net (deprecate Lite/Moq aliases)

### DIFF
--- a/js/hang/src/index.ts
+++ b/js/hang/src/index.ts
@@ -1,3 +1,5 @@
+export * as Net from "@moq/net";
+/** @deprecated Use `Net` instead. */
 export * as Moq from "@moq/net";
 export * as Signals from "@moq/signals";
 export * as Catalog from "./catalog";

--- a/js/publish/src/index.ts
+++ b/js/publish/src/index.ts
@@ -1,3 +1,5 @@
+export * as Net from "@moq/net";
+/** @deprecated Use `Net` instead. */
 export * as Lite from "@moq/net";
 export * as Signals from "@moq/signals";
 export * as Audio from "./audio";

--- a/js/watch/src/index.ts
+++ b/js/watch/src/index.ts
@@ -1,3 +1,5 @@
+export * as Net from "@moq/net";
+/** @deprecated Use `Net` instead. */
 export * as Lite from "@moq/net";
 export * as Signals from "@moq/signals";
 export * as Audio from "./audio";


### PR DESCRIPTION
## Summary

- `@moq/publish`, `@moq/watch`, and `@moq/hang` now re-export `@moq/net` as `Net`.
- The previous `Lite` (publish/watch) and `Moq` (hang) namespaces stay as `@deprecated` aliases for back-compat.

## Why

`Lite` is the old package name (the package is `@moq/net` now), and `@moq/hang` had drifted to a third alias (`Moq`). Standardizing on `Net` keeps the public API consistent with the actual package name across all three downstream packages without breaking existing consumers.

## Test plan

- [x] `bun run --filter @moq/publish --filter @moq/watch --filter @moq/hang check` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)