### PR TITLE
docs(claude): tighten conventions for cross-package sync, tests, comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,13 @@ Key architectural rule: The CDN/relay does not know anything about media. Anythi
                      # libraries can't be split across separately
                      # packaged Python wheels.
 
+/swift/               # Swift wrapper over rs/moq-ffi (SwiftPM)
+/kt/                  # Kotlin wrapper over rs/moq-ffi (Gradle, KMP)
+/go/                  # Go wrapper over rs/moq-ffi (uniffi-bindgen-go)
+                      # swift/kt/go are in-tree source skeletons.
+                      # CI mirrors them to moq-dev/moq-{swift,kotlin,go}
+                      # on each moq-ffi-v* tag.
+
 /demo/                # Demos and test media
   boy/               # MoQ Boy demo (ROM hosting, orchestration justfile)
   relay/             # Relay server configs (relay.toml, root.toml, leaf*.toml)
@@ -157,7 +164,7 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 
 | Change in | Also update |
 |---|---|
-| `rs/moq-ffi` | `rs/libmoq` (C), `py/moq-rs` + Swift/Kotlin/Go wrapper repos, and `doc/lib/{py,swift,kt,go}` |
+| `rs/moq-ffi` | `rs/libmoq`, `py/moq-rs`, `swift/`, `kt/`, `go/`, `doc/lib/{py,swift,kt,go,c}` |
 | `rs/moq-net` wire/API | `js/net`, `doc/concept` |
 | `rs/hang` catalog/container | `js/hang`, `doc/concept` |
 | `rs/moq-token` | `js/token` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,16 @@ match version {
 ## Comment Conventions
 
 - Keep things brief and avoid comments if the code is self-explanatory. Reserve comments for the non-obvious WHY: a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise a reader.
+- Write the way you'd say it out loud, not the way a doc generator would. One short line is almost always enough. Skip throat-clearing like "This function is responsible for...".
 - Comments must reflect the **current** state of the code, not its history. Don't write "X no longer does Y" or "this used to cascade". Describe what the code does today, or delete the comment. Migration context belongs in commit messages and PR descriptions, where it ages with the change rather than rotting in the source.
-- When an LLM authors something, append a short disclaimer like `(Written by Claude)` so readers know it wasn't human-authored. Apply this to PR descriptions and PR comments (including replies on review threads), **not** to code comments or doc comments — markers in source rot alongside the code, and commit trailers already carry attribution.
+
+## AI Attribution
+
+LLM-authored prose visible to humans (PR descriptions, PR comments, review replies) should end with `(Written by Claude)` or similar. Do **not** tag code comments, doc comments, or `/doc` pages: source markers rot. Commit attribution lives in the `Co-Authored-By` trailer, not the commit body.
+
+## Refactor As You Go
+
+A function with 4+ args, or a call site passing the same 3+ values into multiple functions, is a struct waiting to happen. Make the change in the same PR rather than leaving a TODO. Same for repeated tuples returned across modules.
 
 ## Tooling
 
@@ -140,8 +148,28 @@ match version {
 
 - Run `just check` to execute all tests and linting.
 - Run `just fix` to automatically fix formating and easy things.
+- Prefer end-to-end tests (publisher ↔ relay ↔ subscriber, asserting observed bytes) over unit tests when the bug surface crosses modules. Reach for unit tests when the surface is genuinely module-local.
 - Rust tests are integrated within source files
 - Async tests that sleep should call `tokio::time::pause()` at the start to simulate time instantly
+
+## Benchmarks
+
+Performance-sensitive crates (`moq-net`, `hang`, `moq-mux`, `moq-audio`) keep a `benches/` directory using `divan`. When changing a hot path (group dispatch, frame parsing, codec wrap/unwrap), add or update a bench and paste before/after numbers in the PR description.
+
+## Cross-Package Sync
+
+Changes in one area usually need matching updates elsewhere, including docs. If you skip a row, say why in the PR description.
+
+| Change in | Also update |
+|---|---|
+| `rs/moq-ffi` | `rs/libmoq`, `py/moq-rs`, `doc/lib/{py,swift,kt}` |
+| `rs/moq-net` wire/API | `js/net`, `doc/concept` |
+| `rs/hang` catalog/container | `js/hang`, `doc/concept` |
+| `rs/moq-token` | `js/token` |
+| `rs/moq-relay` config/behavior | `doc/bin/relay/` |
+| `rs/moq-cli` | `doc/bin/cli.md` |
+| `rs/moq-gst` | `doc/bin/gstreamer.md` |
+| `js/{watch,publish}` UI/API | `demo/web` if it consumes the API |
 
 ## Workflow
 
@@ -150,8 +178,8 @@ When making changes to the codebase:
 1. Make your code changes
 2. Run `just fix` to auto-format and fix linting issues
 3. Run `just check` to verify everything passes
-4. Update relevant documentation (CLAUDE.md, doc/, README) when making major changes
-5. Add unit tests for any changes that are easy enough to test
+4. Walk the Cross-Package Sync table; update paired packages and docs in the same PR
+5. Add tests (integration first; see Testing Approach)
 6. Commit and push changes
 
 ## PR Reviews

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,13 +148,8 @@ A function with 4+ args, or a call site passing the same 3+ values into multiple
 
 - Run `just check` to execute all tests and linting.
 - Run `just fix` to automatically fix formating and easy things.
-- Prefer end-to-end tests (publisher ↔ relay ↔ subscriber, asserting observed bytes) over unit tests when the bug surface crosses modules. Reach for unit tests when the surface is genuinely module-local.
 - Rust tests are integrated within source files
 - Async tests that sleep should call `tokio::time::pause()` at the start to simulate time instantly
-
-## Benchmarks
-
-Performance-sensitive crates (`moq-net`, `hang`, `moq-mux`, `moq-audio`) keep a `benches/` directory using `divan`. When changing a hot path (group dispatch, frame parsing, codec wrap/unwrap), add or update a bench and paste before/after numbers in the PR description.
 
 ## Cross-Package Sync
 
@@ -162,7 +157,7 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 
 | Change in | Also update |
 |---|---|
-| `rs/moq-ffi` | `rs/libmoq`, `py/moq-rs`, `doc/lib/{py,swift,kt}` |
+| `rs/moq-ffi` | `rs/libmoq` (C), `py/moq-rs` + Swift/Kotlin/Go wrapper repos, and `doc/lib/{py,swift,kt,go}` |
 | `rs/moq-net` wire/API | `js/net`, `doc/concept` |
 | `rs/hang` catalog/container | `js/hang`, `doc/concept` |
 | `rs/moq-token` | `js/token` |
@@ -179,7 +174,7 @@ When making changes to the codebase:
 2. Run `just fix` to auto-format and fix linting issues
 3. Run `just check` to verify everything passes
 4. Walk the Cross-Package Sync table; update paired packages and docs in the same PR
-5. Add tests (integration first; see Testing Approach)
+5. Add tests where they're easy to write
 6. Commit and push changes
 
 ## PR Reviews

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 
 | Change in | Also update |
 |---|---|
-| `rs/moq-ffi` | `rs/libmoq`, `py/moq-rs`, `swift/`, `kt/`, `go/`, `doc/lib/{py,swift,kt,go,c}` |
+| `rs/moq-ffi` | `rs/libmoq`, `{py,swift,kt,go}/`, `doc/lib/{py,swift,kt,go,c}` |
 | `rs/moq-net` wire/API | `js/net`, `doc/concept` |
 | `rs/hang` catalog/container | `js/hang`, `doc/concept` |
 | `rs/moq-token` | `js/token` |


### PR DESCRIPTION
## Summary

Updates `CLAUDE.md` to address recurring failure modes observed in recent contributions:

- **`/doc` drift** and **missed language wrappers** (e.g. touching `moq-ffi` without updating `libmoq` / `py/moq-rs` / Swift / Kotlin docs) — addressed by a new **Cross-Package Sync** table that lists, for each crate, the paired packages and doc pages that must move with it. Workflow step 4 now points at the table instead of vague "update docs when major changes happen" wording.
- **Thin integration coverage** — Testing Approach now explicitly defaults to end-to-end tests (publisher ↔ relay ↔ subscriber, asserting observed bytes), with unit tests reserved for module-local surfaces.
- **N+1-arg functions never refactored** — new short **Refactor As You Go** section: 4+ args or a repeated trio at multiple call sites = struct, in the same PR.
- **Verbose, non-human comments** — added a voice bullet to Comment Conventions ("the way you'd say it out loud, not the way a doc generator would"; skip throat-clearing).
- **Unattributed LLM-authored prose** — promoted from a buried Comment Conventions bullet into its own **AI Attribution** H2, broadened to "LLM-authored prose visible to humans," with an explicit no-tag list (code, doc comments, `/doc` pages).
- **No bench convention** — new **Benchmarks** section naming `divan` for the performance-sensitive crates (`moq-net`, `hang`, `moq-mux`, `moq-audio`) and requiring before/after numbers in the PR description when changing a hot path.

Kept the file lean: +31/-3 lines, 187 total. The Cross-Package Sync table is the load-bearing addition; it should only grow when a real "we missed X" miss happens.

## Notes for reviewer

- The Benchmarks section asserts a convention (`divan`, paste numbers in PR) that has no precedent in the repo yet. Comfortable softening it to a "should" or dropping it until the first `benches/` directory lands, if you'd rather not commit yet.
- AI Attribution is now its own H2 rather than a Comment Conventions bullet, so it's harder to skim past. Same intent as before, slightly broader scope ("prose visible to humans" vs. "PR descriptions and comments").

## Test plan

- [ ] Skim the rendered `CLAUDE.md` on GitHub for any wrapping issues in the new table.
- [ ] Confirm the Cross-Package Sync rows match how the repo is actually laid out (paths under `rs/`, `js/`, `py/`, `doc/`).
- [ ] No em dashes introduced (only the one defining the rule on line 113 remains).

(Written by Claude)