### PR TITLE
moq-ffi: bump to 0.2.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "moq-ffi"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bytes",
  "hang",

--- a/rs/moq-ffi/CHANGELOG.md
+++ b/rs/moq-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14](https://github.com/moq-dev/moq/compare/moq-ffi-v0.2.13...moq-ffi-v0.2.14) - 2026-05-25
+
+### Other
+
+- ci(swift): decouple release manifest from dev Package.swift and gate publish on SPM resolve ([#1502](https://github.com/moq-dev/moq/pull/1502))
+
 ## [0.2.13](https://github.com/moq-dev/moq/compare/moq-ffi-v0.2.12...moq-ffi-v0.2.13) - 2026-05-24
 
 ### Added

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>", "Brian Medley <bpm@bmedley.org>"
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.2.13"
+version = "0.2.14"
 edition = "2024"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]


### PR DESCRIPTION
## Summary

- Manual patch bump of `moq-ffi` from `0.2.13` to `0.2.14`.
- Triggers a fresh `moq-ffi-v*` tag so the new Swift release pipeline from [#1502](https://github.com/moq-dev/moq/pull/1502) (decoupled release manifest, SPM-resolve gate on publish) gets exercised end-to-end.

## Why manual

`release-plz` only detects API/source changes via `cargo semver-checks`, which doesn't inspect binary-only crates. `moq-ffi` is `cdylib`/`staticlib`, so pure CI/packaging changes never trigger an automatic bump and the new Swift workflow would otherwise sit unrun until the next unrelated source change.

## Test plan

- [ ] `just rs release` produces a `moq-ffi-v0.2.14` tag.
- [ ] `release-swift.yml` runs against that tag and the SPM-resolve gate passes before publish.

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)