### PR TITLE
ci(swift): reference staged package by its SPM identity in verify smoke

### DIFF
--- a/swift/scripts/verify.sh
+++ b/swift/scripts/verify.sh
@@ -71,10 +71,11 @@ echo "verify: ---"
 
 # SPM derives a path-based package's identity from the final path
 # component, not from the manifest's `name:` field. Expose the staged
-# dir under the published mirror name ("moq-swift") so the smoke
-# project's `.product(package:)` reference matches the identity real
-# consumers see when depending on github.com/moq-dev/moq-swift.
-PKG_LINK="$WORK/moq-swift"
+# dir under the published mirror name so the smoke project's
+# `.product(package:)` reference matches the identity real consumers
+# see when depending on github.com/moq-dev/moq-swift.
+PKG_IDENTITY="moq-swift"
+PKG_LINK="$WORK/$PKG_IDENTITY"
 ln -s "$STAGED_DIR" "$PKG_LINK"
 
 SMOKE="$WORK/smoke"
@@ -93,7 +94,7 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "Smoke",
-            dependencies: [.product(name: "Moq", package: "moq-swift")],
+            dependencies: [.product(name: "Moq", package: "$PKG_IDENTITY")],
             path: "Sources/Smoke"
         ),
     ]

--- a/swift/scripts/verify.sh
+++ b/swift/scripts/verify.sh
@@ -69,6 +69,14 @@ echo "verify: --- Package.swift ---"
 cat "$STAGED_DIR/Package.swift"
 echo "verify: ---"
 
+# SPM derives a path-based package's identity from the final path
+# component, not from the manifest's `name:` field. Expose the staged
+# dir under the published mirror name ("moq-swift") so the smoke
+# project's `.product(package:)` reference matches the identity real
+# consumers see when depending on github.com/moq-dev/moq-swift.
+PKG_LINK="$WORK/moq-swift"
+ln -s "$STAGED_DIR" "$PKG_LINK"
+
 SMOKE="$WORK/smoke"
 mkdir -p "$SMOKE/Sources/Smoke"
 
@@ -80,12 +88,12 @@ let package = Package(
     name: "Smoke",
     platforms: [.iOS(.v15), .macOS(.v12)],
     dependencies: [
-        .package(path: "$STAGED_DIR"),
+        .package(path: "$PKG_LINK"),
     ],
     targets: [
         .executableTarget(
             name: "Smoke",
-            dependencies: [.product(name: "Moq", package: "Moq")],
+            dependencies: [.product(name: "Moq", package: "moq-swift")],
             path: "Sources/Smoke"
         ),
     ]


### PR DESCRIPTION
## Summary

- Fixes the `Verify staged package resolves` job in [release-swift.yml](.github/workflows/release-swift.yml), which failed on the `moq-ffi-v0.2.14` tag run with `unknown package 'Moq'` ([run 26413362356](https://github.com/moq-dev/moq/actions/runs/26413362356/job/77754167069)).
- The smoke project referenced the staged package as `.product(package: "Moq")`, but SPM derives a path-based package's identity from the final path component (`moq-ffi-0.2.14-swift`), not from the manifest's `name:` field. So the dependency was never findable under the name `"Moq"`.
- Symlink the staged dir to `$WORK/moq-swift` and reference `moq-swift` as the package identity. Matching the published mirror name (`moq-dev/moq-swift`) means the smoke test now exercises the same SPM identity real consumers see.

## Why this matters

The verify step gates the mirror publish, so the `moq-ffi-v0.2.14` release never actually shipped to the Swift mirror. Once this lands the release workflow will need to be retriggered (or a fresh patch tag cut) to publish the artifacts.

## Test plan

- [ ] Re-run release-swift workflow on a tag (or wait for the next moq-ffi release) and confirm the `Verify staged package resolves` job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)