### PR TITLE
moq-native(jemalloc): drop runtime activation; fixes moq-boy startup crash

### DIFF
--- a/rs/moq-native/src/jemalloc.rs
+++ b/rs/moq-native/src/jemalloc.rs
@@ -5,7 +5,8 @@ pub use tikv_jemallocator;
 /// Activate jemalloc heap profiling and listen for SIGUSR1 to dump profiles.
 ///
 /// The dump path is controlled by `MALLOC_CONF=prof_prefix:<path>`.
-/// Returns `Ok(())` if profiling is not available (i.e. MALLOC_CONF=prof:true was not set).
+/// Profiling is a debug aid, so any setup failure is logged and swallowed
+/// rather than propagated. Returns when profiling can't be set up.
 pub async fn run() -> anyhow::Result<()> {
 	let prof_active = b"prof.active\0";
 
@@ -13,16 +14,24 @@ pub async fn run() -> anyhow::Result<()> {
 		Ok(true) => tracing::info!("jemalloc heap profiling is active"),
 		Ok(false) => {
 			tracing::info!("jemalloc profiling compiled in; activating");
-			unsafe { raw::write(prof_active, true) }
-				.map_err(|err| anyhow::anyhow!("failed to activate jemalloc profiling: {err}"))?;
+			if let Err(err) = unsafe { raw::write(prof_active, true) } {
+				tracing::warn!(%err, "failed to activate jemalloc profiling, continuing without it");
+				return Ok(());
+			}
 		}
 		Err(err) => {
-			tracing::debug!(%err, "jemalloc profiling not available — set MALLOC_CONF=prof:true to enable");
+			tracing::debug!(%err, "jemalloc profiling not available. Set MALLOC_CONF=prof:true to enable");
 			return Ok(());
 		}
 	}
 
-	let mut sig = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())?;
+	let mut sig = match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1()) {
+		Ok(sig) => sig,
+		Err(err) => {
+			tracing::warn!(%err, "failed to install SIGUSR1 handler for jemalloc profile dumps");
+			return Ok(());
+		}
+	};
 
 	loop {
 		sig.recv().await;
@@ -30,7 +39,7 @@ pub async fn run() -> anyhow::Result<()> {
 		// Null pointer tells jemalloc to use prof_prefix from MALLOC_CONF.
 		match unsafe { raw::write(b"prof.dump\0", std::ptr::null::<u8>()) } {
 			Ok(()) => tracing::info!("heap profile dumped"),
-			Err(err) => tracing::error!(%err, "failed to dump heap profile"),
+			Err(err) => tracing::warn!(%err, "failed to dump heap profile"),
 		}
 	}
 }

--- a/rs/moq-native/src/jemalloc.rs
+++ b/rs/moq-native/src/jemalloc.rs
@@ -2,36 +2,28 @@ use tikv_jemalloc_ctl::raw;
 
 pub use tikv_jemallocator;
 
-/// Activate jemalloc heap profiling and listen for SIGUSR1 to dump profiles.
+/// Listen for SIGUSR1 and dump a jemalloc heap profile on each signal.
 ///
-/// The dump path is controlled by `MALLOC_CONF=prof_prefix:<path>`.
-/// Profiling is a debug aid, so any setup failure is logged and swallowed
-/// rather than propagated. Returns when profiling can't be set up.
+/// Profiling must be enabled at startup via `MALLOC_CONF=prof:true`
+/// (and typically `prof_active:true` plus a `prof_prefix`). jemalloc
+/// only initializes the profiling backend when `opt.prof` is set at
+/// init; toggling `prof.active` later returns EINVAL.
 pub async fn run() -> anyhow::Result<()> {
-	let prof_active = b"prof.active\0";
-
-	match unsafe { raw::read::<bool>(prof_active) } {
+	match unsafe { raw::read::<bool>(b"prof.active\0") } {
 		Ok(true) => tracing::info!("jemalloc heap profiling is active"),
 		Ok(false) => {
-			tracing::info!("jemalloc profiling compiled in; activating");
-			if let Err(err) = unsafe { raw::write(prof_active, true) } {
-				tracing::warn!(%err, "failed to activate jemalloc profiling, continuing without it");
-				return Ok(());
-			}
+			tracing::info!(
+				"jemalloc profiling compiled in but not active. Set MALLOC_CONF=prof:true,prof_active:true at startup to enable"
+			);
+			return Ok(());
 		}
 		Err(err) => {
-			tracing::debug!(%err, "jemalloc profiling not available. Set MALLOC_CONF=prof:true to enable");
+			tracing::debug!(%err, "jemalloc profiling not available");
 			return Ok(());
 		}
 	}
 
-	let mut sig = match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1()) {
-		Ok(sig) => sig,
-		Err(err) => {
-			tracing::warn!(%err, "failed to install SIGUSR1 handler for jemalloc profile dumps");
-			return Ok(());
-		}
-	};
+	let mut sig = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())?;
 
 	loop {
 		sig.recv().await;
@@ -39,7 +31,7 @@ pub async fn run() -> anyhow::Result<()> {
 		// Null pointer tells jemalloc to use prof_prefix from MALLOC_CONF.
 		match unsafe { raw::write(b"prof.dump\0", std::ptr::null::<u8>()) } {
 			Ok(()) => tracing::info!("heap profile dumped"),
-			Err(err) => tracing::warn!(%err, "failed to dump heap profile"),
+			Err(err) => tracing::error!(%err, "failed to dump heap profile"),
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Root cause of moq-boy crashing on first startup with `jemalloc profiler failed: name or mib specifies an unknown/invalid value`:

[rs/moq-native/src/jemalloc.rs](rs/moq-native/src/jemalloc.rs) had a branch that tried to flip on profiling at runtime:

```rust
Ok(false) => {
    unsafe { raw::write(prof_active, true) }
        .map_err(|err| anyhow::anyhow!("failed to activate jemalloc profiling: {err}"))?;
}
```

But jemalloc only initializes the profiling backend if `opt.prof=true` at init. Writing `prof.active` later returns EINVAL. The branch was dead code in the success case and a crash in the failure case.

moq-relay's nix module sets `MALLOC_CONF=prof:true,prof_active:true` at the systemd unit, so it hits the `Ok(true)` branch and never noticed. moq-boy compiles in the same jemalloc feature but is launched without any MALLOC_CONF wrapper, takes the broken `Ok(false)` path, and crashes. systemd restarts it, restart works fine if the env got applied elsewhere, masking the bug.

This drops the activation attempt entirely. If `prof.active` reads false, log a hint to set `MALLOC_CONF=prof:true,prof_active:true` at startup and return Ok(()).

Closes #1507.

## Test plan

- [x] `cargo check --features jemalloc` on `rs/moq-native` builds cleanly
- [ ] Manual: launch moq-boy without `MALLOC_CONF` (previously crashed; now logs a hint and continues without profiling)
- [ ] Manual: launch moq-relay via the nix unit (already worked, should still work — `Ok(true)` branch unchanged)
- [ ] Manual: launch a binary with `MALLOC_CONF=prof:true,prof_active:true,prof_prefix=/tmp/heap` and send SIGUSR1 — should still dump

## Follow-up (separate PR)

moq-boy probably wants a launcher / nix module mirroring the relay's `MALLOC_CONF` env so heap profiling is opt-in via the same surface as the relay, instead of relying on the caller to set it manually.

(Written by Claude)