### PR TITLE
fix(changelog): repair malformed CHANGELOGs blocking release-plz

### DIFF
--- a/rs/moq-native/CHANGELOG.md
+++ b/rs/moq-native/CHANGELOG.md
@@ -132,18 +132,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace --alpn with --client-version / --server-version ([#1009](https://github.com/moq-dev/moq/pull/1009))
 - Replace tokio::sync::watch with custom Producer/Subscriber ([#996](https://github.com/moq-dev/moq/pull/996))
 
-## [0.13.2](https://github.com/moq-dev/moq/compare/moq-native-v0.13.1...moq-native-v0.13.2) - 2026-03-03
-
-### Fixed
-
-- prevent panic in Server::close() on ctrl+c ([#982](https://github.com/moq-dev/moq/pull/982))
-
-### Other
-
-- Add broadcast integration tests and fix producer cache handling ([#1011](https://github.com/moq-dev/moq/pull/1011))
-- Replace --alpn with --client-version / --server-version ([#1009](https://github.com/moq-dev/moq/pull/1009))
-- Replace tokio::sync::watch with custom Producer/Subscriber ([#996](https://github.com/moq-dev/moq/pull/996))
-
 ## [0.13.0](https://github.com/moq-dev/moq/compare/moq-native-v0.12.2...moq-native-v0.13.0) - 2026-02-12
 
 ### Other

--- a/rs/moq-native/CHANGELOG.md
+++ b/rs/moq-native/CHANGELOG.md
@@ -7,55 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.3](https://github.com/moq-dev/moq/compare/moq-native-v0.8.2...moq-native-v0.8.3) - 2025-09-05
-
-### Added
-
-- *(moq-native)* support raw QUIC sessions with `moql://` URLs ([#578](https://github.com/moq-dev/moq/pull/578))
-
-## [0.8.2](https://github.com/moq-dev/moq/compare/moq-native-v0.8.1...moq-native-v0.8.2) - 2025-09-04
-
-### Other
-
-- Support aws_lc_rs or ring in moq-native ([#574](https://github.com/moq-dev/moq/pull/574))
-
-## [0.8.0](https://github.com/moq-dev/moq/compare/moq-native-v0.7.7...moq-native-v0.8.0) - 2025-09-04
-
-### Other
-
-- Add WebSocket fallback support ([#570](https://github.com/moq-dev/moq/pull/570))
-
-## [0.7.7](https://github.com/moq-dev/moq/compare/moq-native-v0.7.6...moq-native-v0.7.7) - 2025-08-12
-
-### Other
-
-- Less verbose errors, using % instead of ? ([#521](https://github.com/moq-dev/moq/pull/521))
-
-## [0.7.6](https://github.com/moq-dev/moq/compare/moq-native-v0.7.5...moq-native-v0.7.6) - 2025-07-31
-
-### Other
-
-- updated the following local packages: moq-lite
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
 ## [0.15.0](https://github.com/moq-dev/moq/compare/moq-native-v0.14.4...moq-native-v0.15.0) - 2026-05-25
 
 ### Other
 
 - convert to a moq-native example ([#1494](https://github.com/moq-dev/moq/pull/1494))
 - release ([#1475](https://github.com/moq-dev/moq/pull/1475))
-- *(rs)* add cargo-deny and resolve outstanding advisories ([#1486](https://github.com/moq-dev/moq/pull/1486))
-
-## [0.15.0](https://github.com/moq-dev/moq/compare/moq-native-v0.14.4...moq-native-v0.15.0) - 2026-05-24
-
-### Other
-
 - *(rs)* add cargo-deny and resolve outstanding advisories ([#1486](https://github.com/moq-dev/moq/pull/1486))
 
 ## [0.14.4](https://github.com/moq-dev/moq/compare/moq-native-v0.14.3...moq-native-v0.14.4) - 2026-05-23
@@ -256,6 +213,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Fix a potential race with append_group ([#600](https://github.com/moq-dev/moq/pull/600))
+
+## [0.8.3](https://github.com/moq-dev/moq/compare/moq-native-v0.8.2...moq-native-v0.8.3) - 2025-09-05
+
+### Added
+
+- *(moq-native)* support raw QUIC sessions with `moql://` URLs ([#578](https://github.com/moq-dev/moq/pull/578))
+
+## [0.8.2](https://github.com/moq-dev/moq/compare/moq-native-v0.8.1...moq-native-v0.8.2) - 2025-09-04
+
+### Other
+
+- Support aws_lc_rs or ring in moq-native ([#574](https://github.com/moq-dev/moq/pull/574))
+
+## [0.8.0](https://github.com/moq-dev/moq/compare/moq-native-v0.7.7...moq-native-v0.8.0) - 2025-09-04
+
+### Other
+
+- Add WebSocket fallback support ([#570](https://github.com/moq-dev/moq/pull/570))
+
+## [0.7.7](https://github.com/moq-dev/moq/compare/moq-native-v0.7.6...moq-native-v0.7.7) - 2025-08-12
+
+### Other
+
+- Less verbose errors, using % instead of ? ([#521](https://github.com/moq-dev/moq/pull/521))
+
+## [0.7.6](https://github.com/moq-dev/moq/compare/moq-native-v0.7.5...moq-native-v0.7.6) - 2025-07-31
+
+### Other
+
+- updated the following local packages: moq-lite
 
 ## [0.7.5](https://github.com/moq-dev/moq/compare/moq-native-v0.7.4...moq-native-v0.7.5) - 2025-07-22
 

--- a/rs/moq-relay/CHANGELOG.md
+++ b/rs/moq-relay/CHANGELOG.md
@@ -7,75 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.3](https://github.com/moq-dev/moq/compare/moq-relay-v0.9.2...moq-relay-v0.9.3) - 2025-09-05
-
-### Added
-
-- *(moq-native)* support raw QUIC sessions with `moql://` URLs ([#578](https://github.com/moq-dev/moq/pull/578))
-
-### Other
-
-- Fix the web debug endpoints. ([#579](https://github.com/moq-dev/moq/pull/579))
-
-## [0.9.2](https://github.com/moq-dev/moq/compare/moq-relay-v0.9.1...moq-relay-v0.9.2) - 2025-09-04
-
-### Other
-
-- update Cargo.lock dependencies
-
-## [0.8.10](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.9...moq-relay-v0.8.10) - 2025-09-04
-
-### Other
-
-- Add WebSocket fallback support ([#570](https://github.com/moq-dev/moq/pull/570))
-
-## [0.8.9](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.8...moq-relay-v0.8.9) - 2025-08-21
-
-### Other
-
-- Fix clustering. ([#546](https://github.com/moq-dev/moq/pull/546))
-- moq.dev ([#538](https://github.com/moq-dev/moq/pull/538))
-
-## [0.8.8](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.7...moq-relay-v0.8.8) - 2025-08-12
-
-### Other
-
-- Support an array of authorized paths ([#536](https://github.com/moq-dev/moq/pull/536))
-- Revamp the Producer/Consumer API for moq_lite ([#516](https://github.com/moq-dev/moq/pull/516))
-- Another simpler fix for now-or-never ([#526](https://github.com/moq-dev/moq/pull/526))
-- Less verbose errors, using % instead of ? ([#521](https://github.com/moq-dev/moq/pull/521))
-
-## [0.8.7](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.6...moq-relay-v0.8.7) - 2025-07-31
-
-### Other
-
-- Update moq-lite dependency to v0.6.1
-
-## [0.8.6](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.5...moq-relay-v0.8.6) - 2025-07-31
-
-### Other
-
-- Fix paths so they're relative to the root, not root + role. ([#508](https://github.com/moq-dev/moq/pull/508))
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
 ## [0.12.1](https://github.com/moq-dev/moq/compare/moq-relay-v0.12.0...moq-relay-v0.12.1) - 2026-05-25
 
 ### Other
 
 - release ([#1475](https://github.com/moq-dev/moq/pull/1475))
 - *(stats)* fix TOML stats config silently clobbered by clap update_from ([#1491](https://github.com/moq-dev/moq/pull/1491))
-- *(stats)* allow multi-segment --stats-node values; move cargo-deny to ci ([#1489](https://github.com/moq-dev/moq/pull/1489))
-
-## [0.12.1](https://github.com/moq-dev/moq/compare/moq-relay-v0.12.0...moq-relay-v0.12.1) - 2026-05-24
-
-### Other
-
 - *(stats)* allow multi-segment --stats-node values; move cargo-deny to ci ([#1489](https://github.com/moq-dev/moq/pull/1489))
 
 ## [0.12.0](https://github.com/moq-dev/moq/compare/moq-relay-v0.11.5...moq-relay-v0.12.0) - 2026-05-23
@@ -357,6 +294,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Use MaybeSend and MaybeSync for WASM compatibility ([#615](https://github.com/moq-dev/moq/pull/615))
+
+## [0.9.3](https://github.com/moq-dev/moq/compare/moq-relay-v0.9.2...moq-relay-v0.9.3) - 2025-09-05
+
+### Added
+
+- *(moq-native)* support raw QUIC sessions with `moql://` URLs ([#578](https://github.com/moq-dev/moq/pull/578))
+
+### Other
+
+- Fix the web debug endpoints. ([#579](https://github.com/moq-dev/moq/pull/579))
+
+## [0.9.2](https://github.com/moq-dev/moq/compare/moq-relay-v0.9.1...moq-relay-v0.9.2) - 2025-09-04
+
+### Other
+
+- update Cargo.lock dependencies
+
+## [0.8.10](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.9...moq-relay-v0.8.10) - 2025-09-04
+
+### Other
+
+- Add WebSocket fallback support ([#570](https://github.com/moq-dev/moq/pull/570))
+
+## [0.8.9](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.8...moq-relay-v0.8.9) - 2025-08-21
+
+### Other
+
+- Fix clustering. ([#546](https://github.com/moq-dev/moq/pull/546))
+- moq.dev ([#538](https://github.com/moq-dev/moq/pull/538))
+
+## [0.8.8](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.7...moq-relay-v0.8.8) - 2025-08-12
+
+### Other
+
+- Support an array of authorized paths ([#536](https://github.com/moq-dev/moq/pull/536))
+- Revamp the Producer/Consumer API for moq_lite ([#516](https://github.com/moq-dev/moq/pull/516))
+- Another simpler fix for now-or-never ([#526](https://github.com/moq-dev/moq/pull/526))
+- Less verbose errors, using % instead of ? ([#521](https://github.com/moq-dev/moq/pull/521))
+
+## [0.8.7](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.6...moq-relay-v0.8.7) - 2025-07-31
+
+### Other
+
+- Update moq-lite dependency to v0.6.1
+
+## [0.8.6](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.5...moq-relay-v0.8.6) - 2025-07-31
+
+### Other
+
+- Fix paths so they're relative to the root, not root + role. ([#508](https://github.com/moq-dev/moq/pull/508))
 
 ## [0.8.3](https://github.com/moq-dev/moq/compare/moq-relay-v0.8.2...moq-relay-v0.8.3) - 2025-07-22
 

--- a/rs/moq-relay/CHANGELOG.md
+++ b/rs/moq-relay/CHANGELOG.md
@@ -155,12 +155,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - release ([#1168](https://github.com/moq-dev/moq/pull/1168))
 - Drone demo: real-time 2D game with physics ([#1171](https://github.com/moq-dev/moq/pull/1171))
 
-## [0.10.13](https://github.com/moq-dev/moq/compare/moq-relay-v0.10.12...moq-relay-v0.10.13) - 2026-03-31
-
-### Other
-
-- Drone demo: real-time 2D game with physics ([#1171](https://github.com/moq-dev/moq/pull/1171))
-
 ## [0.10.12](https://github.com/moq-dev/moq/compare/moq-relay-v0.10.11...moq-relay-v0.10.12) - 2026-03-26
 
 ### Added
@@ -203,14 +197,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - release ([#1039](https://github.com/moq-dev/moq/pull/1039))
-- Tweak the API to revert some breaking changes. ([#1036](https://github.com/moq-dev/moq/pull/1036))
-- Replace tokio::sync::watch with custom Producer/Subscriber ([#996](https://github.com/moq-dev/moq/pull/996))
-- Increase MAX_STREAMS default and make it configurable ([#955](https://github.com/moq-dev/moq/pull/955))
-
-## [0.10.7](https://github.com/moq-dev/moq/compare/moq-relay-v0.10.6...moq-relay-v0.10.7) - 2026-03-03
-
-### Other
-
 - Tweak the API to revert some breaking changes. ([#1036](https://github.com/moq-dev/moq/pull/1036))
 - Replace tokio::sync::watch with custom Producer/Subscriber ([#996](https://github.com/moq-dev/moq/pull/996))
 - Increase MAX_STREAMS default and make it configurable ([#955](https://github.com/moq-dev/moq/pull/955))


### PR DESCRIPTION
## Summary

- Fixes the `WARN can't determine changes in changelog of package {moq-relay,moq-native}: can't parse changelog` that `Release RS` has been logging in every run.
- Each file had a duplicate `# Changelog ... ## [Unreleased]` header appended below the existing entries (introduced 2025-07-30 in #493). Since then release-plz hasn't been able to tell what's been released, producing duplicate version sections (e.g. two `## [0.12.1]` for moq-relay) and degenerate release-PR entries that only reference the previous release commit instead of the real PRs (visible in the currently-open #1496).
- Each file now has a single header, a single `## [Unreleased]`, and no duplicate version entries. The salvaged 0.7.x/0.8.x entries from the stale top block are reinserted in their proper chronological position so no history is lost.

## Verification

Ran `release-plz update -p moq-relay` against a clean checkout with this fix applied:

- Before: `WARN can't determine changes in changelog of package moq-relay: can't parse changelog`
- After: `moq-relay: next version is 0.12.2 (✓ API compatible changes)`, no warnings, and a properly-formatted entry generated under `## [Unreleased]`.

## Follow-up

Close/regenerate the stale release-plz PR (#1496) after this lands so the next release PR is built from a clean parse.

## Test plan

- [ ] CI's `Release RS` workflow runs cleanly with no `can't parse changelog` warnings.
- [ ] The next release-plz PR contains real per-commit changelog entries for moq-relay and moq-native.

(Written by Claude)