### PR TITLE
moq-native: advertise QUIC preferred_address in the server config

### DIFF
--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -216,6 +216,15 @@ impl QuinnServer {
 		let mut tls = quinn::ServerConfig::with_crypto(Arc::new(tls));
 		tls.transport_config(transport);
 
+		// Advertise the preferred_address transport parameter (RFC 9000 §9.6).
+		// Quinn allocates a fresh CID + reset token for the address during the handshake.
+		if let Some(addr) = config.preferred_v4 {
+			tls.preferred_address_v4(Some(addr));
+		}
+		if let Some(addr) = config.preferred_v6 {
+			tls.preferred_address_v6(Some(addr));
+		}
+
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = quinn::default_runtime().context("no async runtime")?;
 

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -129,6 +129,32 @@ pub struct ServerConfig {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub quic_lb_nonce: Option<usize>,
 
+	/// IPv4 address advertised as the QUIC preferred_address.
+	///
+	/// Supporting clients (Chrome M131+, native Quinn) migrate to this address
+	/// shortly after the handshake completes. Typical use: handshake on an
+	/// anycast IP, steady-state on this host's unicast IP.
+	///
+	/// Only honored by the Quinn backend.
+	#[arg(
+		id = "server-preferred-v4",
+		long = "server-preferred-v4",
+		env = "MOQ_SERVER_PREFERRED_V4"
+	)]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub preferred_v4: Option<net::SocketAddrV4>,
+
+	/// IPv6 address advertised as the QUIC preferred_address.
+	///
+	/// See [`Self::preferred_v4`].
+	#[arg(
+		id = "server-preferred-v6",
+		long = "server-preferred-v6",
+		env = "MOQ_SERVER_PREFERRED_V6"
+	)]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub preferred_v6: Option<net::SocketAddrV6>,
+
 	/// Maximum number of concurrent QUIC streams per connection (both bidi and uni).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -152,6 +152,52 @@ node = "localhost"
 		assert_eq!(config.stats.node.as_deref(), Some("localhost"));
 	}
 
+	/// Serializes tests that touch `MOQ_SERVER_PREFERRED_V4` / `_V6`. Same
+	/// rationale as `STATS_ENV_LOCK`.
+	static PREFERRED_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	/// Regression test for the same clap+TOML clobber bug applied to the
+	/// `preferred_v4` / `preferred_v6` fields on `moq-native::ServerConfig`.
+	/// If either field is ever re-typed as a bare `SocketAddrV4` / `SocketAddrV6`
+	/// (without `Option<>`), the CLI re-parse will overwrite the TOML value
+	/// with `Default::default()` and silently disable the
+	/// preferred_address transport parameter for deployments configured via
+	/// TOML. This test asserts the TOML value survives an absent CLI flag.
+	#[test]
+	fn cli_does_not_clobber_toml_preferred_addresses() {
+		let _guard = PREFERRED_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: PREFERRED_ENV_LOCK ensures no other test in this binary
+		// touches these env vars concurrently.
+		unsafe {
+			std::env::remove_var("MOQ_SERVER_PREFERRED_V4");
+			std::env::remove_var("MOQ_SERVER_PREFERRED_V6");
+		}
+
+		let toml = r#"
+[server]
+preferred_v4 = "192.0.2.1:443"
+preferred_v6 = "[2001:db8::1]:443"
+"#;
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("preferred-toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(
+			config.server.preferred_v4,
+			Some("192.0.2.1:443".parse().unwrap()),
+			"TOML's server.preferred_v4 must not be clobbered by the CLI re-parse"
+		);
+		assert_eq!(
+			config.server.preferred_v6,
+			Some("[2001:db8::1]:443".parse().unwrap()),
+			"TOML's server.preferred_v6 must not be clobbered by the CLI re-parse"
+		);
+	}
+
 	/// Explicit CLI flag must still override TOML. Belt-and-suspenders for the
 	/// fix above: making `enabled: Option<bool>` shouldn't break the override
 	/// path.


### PR DESCRIPTION
## Summary

- Adds `preferred_v4: Option<SocketAddrV4>` and `preferred_v6: Option<SocketAddrV6>` to `moq_native::ServerConfig`, exposed via CLI (`--server-preferred-v{4,6}`), env (`MOQ_SERVER_PREFERRED_V{4,6}`), and TOML (`[server] preferred_v{4,6} = "..."`).
- Plumbs both into `quinn::ServerConfig::preferred_address_v{4,6}` inside `QuinnServer::new`. Quinn handles CID allocation, reset-token generation, and transport-parameter packing.
- Adds a `cli_does_not_clobber_toml_preferred_addresses` regression test in `rs/moq-relay/src/config.rs` to guard the TOML-to-CLI merge behavior documented in `CLAUDE.md`.

## Why

The QUIC `preferred_address` transport parameter (RFC 9000 §9.6) lets a server advertise an alternate address that the client migrates to shortly after the handshake. This unlocks a clean BGP anycast deployment shape:

- Every instance announces a shared anycast `/24` (handshake target).
- Each instance advertises its own per-host unicast IP as `preferred_address`.
- New clients route via anycast to the nearest POP; steady-state connections pin to the unicast IP and survive BGP reconvergence.
- An overloaded host can withdraw the anycast route from BGP without dropping its existing connections, because they are no longer using that address.

Supporting clients today: Chrome M131+ (on by default since November 2024, ~99% migration success per Google's measurements) and any native Quinn client (`moq-cli`, `moq-ffi`-based iOS/Android/Swift/Kotlin). Firefox via neqo has the implementation but I could not confirm the glue layer wires it through; Safari has no public confirmation.

## Out of scope

- Documentation for the deployment pattern (Vultr / OCI BYOIP / BIRD config) lives in a follow-up PR.
- `noq` and `quiche` backends do not expose this API. If either field is set, those backends will silently ignore it. Same shape as the existing `tls.root` (mTLS) flag, which is also Quinn-only.
- Client-side happy-eyeballs and Windows server dual-stack are separate concerns.

## Test plan

- [x] `just check` passes (clippy, tests, docs, shear, sort, remark).
- [x] New regression test `cli_does_not_clobber_toml_preferred_addresses` passes.
- [ ] Manual smoke (optional, reviewer may skip): run `moq-relay --server-bind '[::]:4443' --server-preferred-v4 127.0.0.2:4444` against a loopback alias, connect with `moq-cli`, capture with `tshark -d udp.port==4443,quic -V` and confirm the handshake transport parameters contain the preferred address and the client sends a `PATH_CHALLENGE` to it.

(Written by Claude)