### PR TITLE
moq-net: linger upstream subscriptions across consumer churn (moq-lite)

### DIFF
--- a/rs/conducer/src/weak.rs
+++ b/rs/conducer/src/weak.rs
@@ -123,6 +123,21 @@ impl<T> Weak<T> {
 		self.state.lock().closed
 	}
 
+	/// Wait until the channel is closed.
+	pub async fn closed(&self) {
+		crate::wait(move |waiter| self.poll_closed(waiter)).await
+	}
+
+	fn poll_closed(&self, waiter: &Waiter) -> Poll<()> {
+		let mut state = self.state.lock();
+		if state.closed {
+			return Poll::Ready(());
+		}
+
+		waiter.register(&mut state.waiters);
+		Poll::Pending
+	}
+
 	/// Wait until all consumers have been dropped.
 	///
 	/// Returns `Ok(())` when no consumers remain, or `Err(Ref)` if the channel closes first.

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -630,3 +630,131 @@ async fn broadcast_websocket_fallback() {
 		.expect("server task panicked")
 		.expect("server task failed");
 }
+
+// ── Linger: relay-style subscription reuse ──────────────────────────
+//
+// When the last consumer of an upstream subscription drops, the relay keeps
+// the TrackProducer alive briefly so a returning consumer reuses it instead
+// of triggering a fresh upstream Subscribe. This is the moq-lite linger
+// behavior: on `track.unused()` the subscriber sends `SubscribeUpdate(priority=0)`
+// + FIN, then waits up to LINGER_TIMEOUT for either the upstream to FIN back,
+// the timeout to expire, or a new consumer to arrive (resume with
+// `start_group = max + 1`).
+//
+// Reliably distinguishing the Reused vs Complete vs Cancelled branches from a
+// black-box client test is hard because all three paths converge on the same
+// observable behavior at the consumer (groups eventually flow). What we *can*
+// test cheaply here is the end-to-end smoke: subscribe → drop → resubscribe
+// must keep working, with a fresh group flowing afterwards.
+
+/// Smoke test: dropping the last consumer and resubscribing within the linger
+/// window doesn't wedge the subscription, and groups appended after the resume
+/// still arrive at the new consumer.
+#[tokio::test]
+async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	let mut track = broadcast.create_track(Track::new("video")).expect("create track");
+
+	let mut group0 = track.append_group().expect("append group 0");
+	group0.write_frame(b"a".as_ref()).expect("write frame 0");
+	group0.finish().expect("finish group 0");
+
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some("[::]:0".to_string());
+	server_config.tls.generate = vec!["localhost".into()];
+	server_config.version = vec!["moq-lite-03".parse().unwrap()];
+	let mut server = server_config.init().expect("init server");
+	let addr = server.local_addr().expect("server addr");
+
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume();
+
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	client_config.version = vec!["moq-lite-03".parse().unwrap()];
+	let client = client_config.init().expect("init client");
+	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
+
+	let server_handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("accept");
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let _ = session.closed().await;
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let client = client.with_consume(sub_origin);
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+		.await
+		.expect("connect timeout")
+		.expect("connect failed");
+
+	let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+		.await
+		.expect("announce timeout")
+		.expect("origin closed");
+	assert_eq!(path.as_str(), "test");
+	let bc = bc.expect("expected announce");
+
+	// First subscription: receive group 0.
+	let mut sub1 = bc.subscribe_track(&Track::new("video")).expect("subscribe1");
+	let mut g = tokio::time::timeout(TIMEOUT, sub1.recv_group())
+		.await
+		.expect("recv group 0 timeout")
+		.expect("recv group 0 failed")
+		.expect("track closed early");
+	assert_eq!(g.sequence, 0);
+	let frame = tokio::time::timeout(TIMEOUT, g.read_frame())
+		.await
+		.expect("read frame 0 timeout")
+		.expect("read frame 0 failed")
+		.expect("group closed early");
+	assert_eq!(&*frame, b"a");
+
+	// Drop the only consumer to trigger the linger phase.
+	drop(g);
+	drop(sub1);
+
+	// Yield a few times so the subscriber task can observe `track.unused()` and
+	// enter the linger select. A small real sleep also makes the test less
+	// scheduler-dependent across runtimes.
+	tokio::time::sleep(Duration::from_millis(20)).await;
+
+	// Resubscribe well inside the 5s linger window.
+	let mut sub2 = bc.subscribe_track(&Track::new("video")).expect("subscribe2");
+
+	// A new group published after the resubscribe must reach the consumer
+	// regardless of which linger branch fired.
+	let mut group1 = track.append_group().expect("append group 1");
+	group1.write_frame(b"b".as_ref()).expect("write frame 1");
+	group1.finish().expect("finish group 1");
+
+	let mut saw_group1 = false;
+	for _ in 0..2 {
+		let mut next = tokio::time::timeout(TIMEOUT, sub2.recv_group())
+			.await
+			.expect("recv group timeout")
+			.expect("recv group failed")
+			.expect("track closed early");
+		if next.sequence == 1 {
+			let frame = tokio::time::timeout(TIMEOUT, next.read_frame())
+				.await
+				.expect("read frame 1 timeout")
+				.expect("read frame 1 failed")
+				.expect("group closed early on resume");
+			assert_eq!(&*frame, b"b");
+			saw_group1 = true;
+			break;
+		}
+	}
+	assert!(
+		saw_group1,
+		"expected group 1 to be delivered to the resubscribed consumer"
+	);
+
+	drop(session);
+	server_handle
+		.await
+		.expect("server task panicked")
+		.expect("server task failed");
+}

--- a/rs/moq-net/src/coding/reader.rs
+++ b/rs/moq-net/src/coding/reader.rs
@@ -45,6 +45,15 @@ impl<S: web_transport_trait::RecvStream, V> Reader<S, V> {
 	}
 
 	/// Decode the next message unless the stream is closed.
+	///
+	/// Cancel-safe with the transports we ship (`web_transport_quinn`, `qmux`).
+	/// The only `.await` points are reads from the underlying transport; partial
+	/// bytes accumulate in `self.buffer` and a re-entry resumes decoding from
+	/// the same position, so dropping the future mid-message never desynchronizes
+	/// the stream. This requires the transport's `read_buf` to be cancel-safe
+	/// (Quinn's `RecvStream::read` is documented as such, and qmux's
+	/// `RecvStream::read_chunk` is a `tokio::sync::mpsc::Receiver::recv`).
+	/// New transport impls must preserve this property.
 	pub async fn decode_maybe<T: Decode<V> + Debug>(&mut self) -> Result<Option<T>, Error>
 	where
 		V: Clone,

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -378,14 +378,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Track-level subscriber priority. SUBSCRIBE_UPDATE messages broadcast new values
 		// to both run_track (so future groups inherit the new priority) and serve_group
-		// tasks (so in-flight groups update via PriorityHandle::set_track).
+		// tasks (so in-flight groups update via PriorityHandle::set_track). The Sender
+		// stays in run_subscribe and gets handed to run_track so the same loop that
+		// parses SUBSCRIBE_UPDATEs also fans the new priority out.
 		let (track_priority_tx, track_priority_rx) = tokio::sync::watch::channel(track.priority);
-		// `end_group` is a serving cap, not a subscription terminator: groups with
-		// sequence > cap are held until the subscriber raises the cap (or unsets
-		// it) via SUBSCRIBE_UPDATE, then served in order. Only FIN ends the
-		// subscription. This is what relays use to pause an upstream subscription
-		// across consumer churn without tearing it down.
-		let (end_group_tx, end_group_rx) = tokio::sync::watch::channel(subscribe.end_group);
 
 		let sub = Subscription {
 			session,
@@ -397,25 +393,22 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			version,
 		};
 
-		tokio::select! {
-			res = sub.run_track(track, subscribe.start_group, end_group_rx) => res?,
-			res = Self::run_subscribe_updates(&mut stream.reader, &track_priority_tx, &end_group_tx) => res?,
-		}
+		// `end_group` is a serving cap, not a subscription terminator: groups with
+		// sequence > cap are held in the producer's cache until the subscriber raises
+		// the cap (or unsets it) via SUBSCRIBE_UPDATE, then served in order. Only a
+		// peer FIN actually ends the subscription. This is what lets relays pause an
+		// upstream subscription across consumer churn without tearing it down.
+		sub.run_track(
+			track,
+			subscribe.start_group,
+			subscribe.end_group,
+			&mut stream.reader,
+			&track_priority_tx,
+		)
+		.await?;
 
 		stream.writer.finish()?;
 		stream.writer.closed().await
-	}
-
-	async fn run_subscribe_updates<R: web_transport_trait::RecvStream>(
-		reader: &mut crate::coding::Reader<R, Version>,
-		priority_tx: &tokio::sync::watch::Sender<u8>,
-		end_group_tx: &tokio::sync::watch::Sender<Option<u64>>,
-	) -> Result<(), Error> {
-		while let Some(upd) = reader.decode_maybe::<lite::SubscribeUpdate>().await? {
-			let _ = priority_tx.send(upd.priority);
-			let _ = end_group_tx.send(upd.end_group);
-		}
-		Ok(())
 	}
 }
 
@@ -439,7 +432,9 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		mut self,
 		mut track: TrackConsumer,
 		start_group: Option<u64>,
-		mut end_group: tokio::sync::watch::Receiver<Option<u64>>,
+		initial_end_group: Option<u64>,
+		reader: &mut crate::coding::Reader<S::RecvStream, Version>,
+		track_priority_tx: &tokio::sync::watch::Sender<u8>,
 	) -> Result<(), Error> {
 		let mut tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>> = FuturesUnordered::new();
 
@@ -449,8 +444,8 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		}
 
 		// Apply the initial cap from the original Subscribe. Subsequent updates
-		// arrive via the end_group watch channel and get re-applied below.
-		track.end_at(*end_group.borrow_and_update());
+		// flow through the SubscribeUpdate select arm below.
+		track.end_at(initial_end_group);
 
 		loop {
 			tokio::select! {
@@ -467,18 +462,25 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					match res? {
 						Some(group) => self.spawn_serve(group, &mut tasks),
 						None => {
-							// Track finished; drain in-flight tasks and exit.
+							// Track finished cleanly; drain in-flight tasks and exit.
 							while tasks.next().await.is_some() {}
 							return Ok(());
 						}
 					}
 				}
 
-				Ok(()) = end_group.changed() => {
-					// Re-apply the cap. If it rose, the next loop iteration's
-					// track.next_group() will pick up any cached groups that
-					// fell into range; if it dropped, the consumer parks itself.
-					track.end_at(*end_group.borrow_and_update());
+				// SUBSCRIBE_UPDATE messages share this hot loop; safe because
+				// decode_maybe is cancel-safe given quinn/qmux's cancel-safe
+				// read primitives (see Reader::decode_maybe doc).
+				upd = reader.decode_maybe::<lite::SubscribeUpdate>() => {
+					let Some(upd) = upd? else {
+						// Peer FIN'd — they're done with this subscription. Drop any
+						// in-flight serve_group tasks (don't drain) so half-sent
+						// groups get cancelled rather than completed pointlessly.
+						return Ok(());
+					};
+					let _ = track_priority_tx.send(upd.priority);
+					track.end_at(upd.end_group);
 				}
 			}
 		}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -448,26 +448,30 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 			track.start_at(start_group);
 		}
 
-		// Groups received from the track whose sequence exceeds the current cap.
-		// They stay here (the GroupConsumer keeps the data reachable in the
-		// producer's cache) until the cap rises enough to let them through.
-		let mut held: Vec<GroupConsumer> = Vec::new();
+		// At most one group consumed-but-not-yet-serveable, kept until the cap
+		// rises enough to release it. We deliberately don't accumulate a queue
+		// here: stopping consumption while one is pending bounds publisher-side
+		// memory to a single group regardless of how long the subscriber leaves
+		// the cap below the live head. Anything else the publisher produces
+		// during that window stays in the track's own cache (subject to its
+		// 5-second eviction), which already has a memory bound.
+		let mut pending: Option<GroupConsumer> = None;
 		let mut track_done = false;
 
 		loop {
 			let cap = *end_group.borrow_and_update();
 
-			// Drain held groups the cap now permits, in sequence order so
-			// subscribers see a monotonic stream when they unpause.
-			held.sort_by_key(|g| g.sequence);
-			while held.first().is_some_and(|g| cap.is_none_or(|e| g.sequence <= e)) {
-				let group = held.remove(0);
+			// Release the pending group if the cap now permits it.
+			if let Some(p) = pending.as_ref()
+				&& cap.is_none_or(|e| p.sequence <= e)
+			{
+				let group = pending.take().unwrap();
 				self.spawn_serve(group, &mut tasks);
 			}
 
 			// Once the track has finished and there's nothing left to serve,
 			// drain any in-flight serve tasks and exit.
-			if track_done && held.is_empty() {
+			if track_done && pending.is_none() {
 				while tasks.next().await.is_some() {}
 				return Ok(());
 			}
@@ -479,11 +483,13 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					false
 				} => unreachable!(),
 
-				res = track.recv_group(), if !track_done => {
+				// Only pull from the track when we have somewhere to put the result.
+				// `pending.is_none()` enforces the one-group buffer bound.
+				res = track.recv_group(), if !track_done && pending.is_none() => {
 					match res? {
 						Some(group) => {
 							if cap.is_some_and(|e| group.sequence > e) {
-								held.push(group);
+								pending = Some(group);
 							} else {
 								self.spawn_serve(group, &mut tasks);
 							}
@@ -493,7 +499,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 				}
 
 				Ok(()) = end_group.changed() => {
-					// Loop back to drain any newly-permitted held groups.
+					// Loop back to re-evaluate pending against the new cap.
 				}
 			}
 		}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
-use web_async::FuturesExt;
 use web_transport_trait::Stats;
 
 use crate::{
@@ -381,11 +380,17 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// to both run_track (so future groups inherit the new priority) and serve_group
 		// tasks (so in-flight groups update via PriorityHandle::set_track).
 		let (track_priority_tx, track_priority_rx) = tokio::sync::watch::channel(track.priority);
+		// `end_group` is a serving cap, not a subscription terminator: groups with
+		// sequence > cap are held until the subscriber raises the cap (or unsets
+		// it) via SUBSCRIBE_UPDATE, then served in order. Only FIN ends the
+		// subscription. This is what relays use to pause an upstream subscription
+		// across consumer churn without tearing it down.
+		let (end_group_tx, end_group_rx) = tokio::sync::watch::channel(subscribe.end_group);
 		let track_stats = std::sync::Arc::new(track_stats);
 
 		tokio::select! {
-			res = Self::run_track(session, track, subscribe, priority, track_stats, track_priority_rx, version) => res?,
-			res = Self::run_subscribe_updates(&mut stream.reader, &track_priority_tx) => res?,
+			res = Self::run_track(session, track, subscribe, priority, track_stats, track_priority_rx, end_group_rx, version) => res?,
+			res = Self::run_subscribe_updates(&mut stream.reader, &track_priority_tx, &end_group_tx) => res?,
 		}
 
 		stream.writer.finish()?;
@@ -395,13 +400,16 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	async fn run_subscribe_updates<R: web_transport_trait::RecvStream>(
 		reader: &mut crate::coding::Reader<R, Version>,
 		priority_tx: &tokio::sync::watch::Sender<u8>,
+		end_group_tx: &tokio::sync::watch::Sender<Option<u64>>,
 	) -> Result<(), Error> {
 		while let Some(upd) = reader.decode_maybe::<lite::SubscribeUpdate>().await? {
 			let _ = priority_tx.send(upd.priority);
+			let _ = end_group_tx.send(upd.end_group);
 		}
 		Ok(())
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	async fn run_track(
 		session: S,
 		mut track: TrackConsumer,
@@ -409,49 +417,96 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		priority: PriorityQueue,
 		track_stats: std::sync::Arc<crate::PublisherTrack>,
 		mut track_priority: tokio::sync::watch::Receiver<u8>,
+		mut end_group: tokio::sync::watch::Receiver<Option<u64>>,
 		version: Version,
 	) -> Result<(), Error> {
-		let mut tasks = FuturesUnordered::new();
+		let mut tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>> = FuturesUnordered::new();
 
 		// Start the consumer at the specified sequence, otherwise start at the latest group.
 		if let Some(start_group) = subscribe.start_group.or_else(|| track.latest()) {
 			track.start_at(start_group);
 		}
 
-		loop {
-			let group = tokio::select! {
-				// Poll all active group futures; never matches but keeps them running.
-				true = async {
-					while tasks.next().await.is_some() {}
-					false
-				} => unreachable!(),
-				Some(group) = track.recv_group().transpose() => group,
-				else => return Ok(()),
-			}?;
+		// Groups received from the track whose sequence exceeds the current cap.
+		// They stay here (the GroupConsumer keeps the data reachable in the
+		// producer's cache) until the cap rises enough to let them through.
+		let mut held: Vec<GroupConsumer> = Vec::new();
+		let mut track_done = false;
 
+		// Snapshot for tracing inside the closure (avoids re-borrowing `track` while
+		// we hold `&mut track` for recv_group).
+		let track_name = track.name.clone();
+		let subscribe_id = subscribe.id;
+
+		// Inline helper: spawn a serve_group task onto `tasks`.
+		let spawn_serve = |group: GroupConsumer,
+		                   track_priority: &mut tokio::sync::watch::Receiver<u8>,
+		                   tasks: &mut FuturesUnordered<futures::future::BoxFuture<'static, ()>>| {
 			let sequence = group.sequence;
-			tracing::debug!(subscribe = %subscribe.id, track = %track.name, sequence, "serving group");
+			tracing::debug!(subscribe = subscribe_id, track = %track_name, sequence, "serving group");
 
 			let msg = lite::Group {
-				subscribe: subscribe.id,
+				subscribe: subscribe_id,
 				sequence,
 			};
 
 			// Use the latest priority for new groups so SUBSCRIBE_UPDATE applies to them too.
 			let current_priority = *track_priority.borrow_and_update();
 			let handle = priority.insert(Priority::new(current_priority, sequence));
-			tasks.push(
-				Self::serve_group(
-					session.clone(),
-					msg,
-					handle,
-					group,
-					track_stats.clone(),
-					track_priority.clone(),
-					version,
-				)
-				.map(|_| ()),
+			let fut = Self::serve_group(
+				session.clone(),
+				msg,
+				handle,
+				group,
+				track_stats.clone(),
+				track_priority.clone(),
+				version,
 			);
+			tasks.push(fut.map(|_| ()).boxed());
+		};
+
+		loop {
+			let cap = *end_group.borrow_and_update();
+
+			// Drain held groups the cap now permits, in sequence order so
+			// subscribers see a monotonic stream when they unpause.
+			held.sort_by_key(|g| g.sequence);
+			while held.first().is_some_and(|g| cap.is_none_or(|e| g.sequence <= e)) {
+				let group = held.remove(0);
+				spawn_serve(group, &mut track_priority, &mut tasks);
+			}
+
+			// Once the track has finished and there's nothing left to serve,
+			// drain any in-flight serve tasks and exit.
+			if track_done && held.is_empty() {
+				while tasks.next().await.is_some() {}
+				return Ok(());
+			}
+
+			tokio::select! {
+				// Drive in-flight group futures; never matches because the inner block returns false.
+				true = async {
+					while tasks.next().await.is_some() {}
+					false
+				} => unreachable!(),
+
+				res = track.recv_group(), if !track_done => {
+					match res? {
+						Some(group) => {
+							if cap.is_some_and(|e| group.sequence > e) {
+								held.push(group);
+							} else {
+								spawn_serve(group, &mut track_priority, &mut tasks);
+							}
+						}
+						None => track_done = true,
+					}
+				}
+
+				Ok(()) = end_group.changed() => {
+					// Loop back to drain any newly-permitted held groups.
+				}
+			}
 		}
 	}
 

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use web_transport_trait::Stats;
@@ -386,10 +386,19 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// subscription. This is what relays use to pause an upstream subscription
 		// across consumer churn without tearing it down.
 		let (end_group_tx, end_group_rx) = tokio::sync::watch::channel(subscribe.end_group);
-		let track_stats = std::sync::Arc::new(track_stats);
+
+		let sub = Subscription {
+			session,
+			id: subscribe.id,
+			track_name: Arc::from(track.name.as_str()),
+			track_stats: Arc::new(track_stats),
+			priority,
+			track_priority: track_priority_rx,
+			version,
+		};
 
 		tokio::select! {
-			res = Self::run_track(session, track, subscribe, priority, track_stats, track_priority_rx, end_group_rx, version) => res?,
+			res = sub.run_track(track, subscribe.start_group, end_group_rx) => res?,
 			res = Self::run_subscribe_updates(&mut stream.reader, &track_priority_tx, &end_group_tx) => res?,
 		}
 
@@ -408,22 +417,34 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		}
 		Ok(())
 	}
+}
 
-	#[allow(clippy::too_many_arguments)]
+/// Shared per-subscription state for the publisher side. Cloned (cheaply — every
+/// field is either small or already Arc-backed) for each spawned serve_group task
+/// so each in-flight group reads the latest SUBSCRIBE_UPDATE priority via its own
+/// watch::Receiver.
+#[derive(Clone)]
+struct Subscription<S: web_transport_trait::Session> {
+	session: S,
+	id: u64,
+	track_name: Arc<str>,
+	track_stats: Arc<crate::PublisherTrack>,
+	priority: PriorityQueue,
+	track_priority: tokio::sync::watch::Receiver<u8>,
+	version: Version,
+}
+
+impl<S: web_transport_trait::Session> Subscription<S> {
 	async fn run_track(
-		session: S,
+		mut self,
 		mut track: TrackConsumer,
-		subscribe: &lite::Subscribe<'_>,
-		priority: PriorityQueue,
-		track_stats: std::sync::Arc<crate::PublisherTrack>,
-		mut track_priority: tokio::sync::watch::Receiver<u8>,
+		start_group: Option<u64>,
 		mut end_group: tokio::sync::watch::Receiver<Option<u64>>,
-		version: Version,
 	) -> Result<(), Error> {
 		let mut tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>> = FuturesUnordered::new();
 
 		// Start the consumer at the specified sequence, otherwise start at the latest group.
-		if let Some(start_group) = subscribe.start_group.or_else(|| track.latest()) {
+		if let Some(start_group) = start_group.or_else(|| track.latest()) {
 			track.start_at(start_group);
 		}
 
@@ -433,38 +454,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let mut held: Vec<GroupConsumer> = Vec::new();
 		let mut track_done = false;
 
-		// Snapshot for tracing inside the closure (avoids re-borrowing `track` while
-		// we hold `&mut track` for recv_group).
-		let track_name = track.name.clone();
-		let subscribe_id = subscribe.id;
-
-		// Inline helper: spawn a serve_group task onto `tasks`.
-		let spawn_serve = |group: GroupConsumer,
-		                   track_priority: &mut tokio::sync::watch::Receiver<u8>,
-		                   tasks: &mut FuturesUnordered<futures::future::BoxFuture<'static, ()>>| {
-			let sequence = group.sequence;
-			tracing::debug!(subscribe = subscribe_id, track = %track_name, sequence, "serving group");
-
-			let msg = lite::Group {
-				subscribe: subscribe_id,
-				sequence,
-			};
-
-			// Use the latest priority for new groups so SUBSCRIBE_UPDATE applies to them too.
-			let current_priority = *track_priority.borrow_and_update();
-			let handle = priority.insert(Priority::new(current_priority, sequence));
-			let fut = Self::serve_group(
-				session.clone(),
-				msg,
-				handle,
-				group,
-				track_stats.clone(),
-				track_priority.clone(),
-				version,
-			);
-			tasks.push(fut.map(|_| ()).boxed());
-		};
-
 		loop {
 			let cap = *end_group.borrow_and_update();
 
@@ -473,7 +462,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			held.sort_by_key(|g| g.sequence);
 			while held.first().is_some_and(|g| cap.is_none_or(|e| g.sequence <= e)) {
 				let group = held.remove(0);
-				spawn_serve(group, &mut track_priority, &mut tasks);
+				self.spawn_serve(group, &mut tasks);
 			}
 
 			// Once the track has finished and there's nothing left to serve,
@@ -496,7 +485,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							if cap.is_some_and(|e| group.sequence > e) {
 								held.push(group);
 							} else {
-								spawn_serve(group, &mut track_priority, &mut tasks);
+								self.spawn_serve(group, &mut tasks);
 							}
 						}
 						None => track_done = true,
@@ -510,22 +499,38 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		}
 	}
 
+	fn spawn_serve(
+		&mut self,
+		group: GroupConsumer,
+		tasks: &mut FuturesUnordered<futures::future::BoxFuture<'static, ()>>,
+	) {
+		let sequence = group.sequence;
+		tracing::debug!(subscribe = self.id, track = %self.track_name, sequence, "serving group");
+
+		// Use the latest priority for new groups so SUBSCRIBE_UPDATE applies to them too.
+		let current_priority = *self.track_priority.borrow_and_update();
+		let handle = self.priority.insert(Priority::new(current_priority, sequence));
+		let fut = self.clone().serve_group(sequence, handle, group);
+		tasks.push(fut.map(|_| ()).boxed());
+	}
+
 	async fn serve_group(
-		session: S,
-		msg: lite::Group,
+		mut self,
+		sequence: u64,
 		mut priority: PriorityHandle,
 		mut group: GroupConsumer,
-		track_stats: std::sync::Arc<crate::PublisherTrack>,
-		mut track_priority: tokio::sync::watch::Receiver<u8>,
-		version: Version,
 	) -> Result<(), Error> {
-		let stream = session.open_uni().await.map_err(Error::from_transport)?;
+		let msg = lite::Group {
+			subscribe: self.id,
+			sequence,
+		};
+		let stream = self.session.open_uni().await.map_err(Error::from_transport)?;
 
-		let mut stream = Writer::new(stream, version);
+		let mut stream = Writer::new(stream, self.version);
 		stream.set_priority(priority.current());
 		stream.encode(&lite::DataType::Group).await?;
 		stream.encode(&msg).await?;
-		track_stats.group();
+		self.track_stats.group();
 
 		loop {
 			let frame = tokio::select! {
@@ -536,8 +541,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					stream.set_priority(new_pri);
 					continue;
 				}
-				Ok(()) = track_priority.changed() => {
-					priority.set_track(*track_priority.borrow_and_update());
+				Ok(()) = self.track_priority.changed() => {
+					priority.set_track(*self.track_priority.borrow_and_update());
 					continue;
 				}
 			};
@@ -548,7 +553,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			};
 
 			stream.encode(&frame.size).await?;
-			track_stats.frame();
+			self.track_stats.frame();
 
 			loop {
 				let chunk = tokio::select! {
@@ -559,8 +564,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						stream.set_priority(new_pri);
 						continue;
 					}
-					Ok(()) = track_priority.changed() => {
-						priority.set_track(*track_priority.borrow_and_update());
+					Ok(()) = self.track_priority.changed() => {
+						priority.set_track(*self.track_priority.borrow_and_update());
 						continue;
 					}
 				};
@@ -578,12 +583,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								new_pri = priority.next() => {
 									stream.set_priority(new_pri);
 								}
-								Ok(()) = track_priority.changed() => {
-									priority.set_track(*track_priority.borrow_and_update());
+								Ok(()) = self.track_priority.changed() => {
+									priority.set_track(*self.track_priority.borrow_and_update());
 								}
 							}
 						}
-						track_stats.bytes(n);
+						self.track_stats.bytes(n);
 					}
 					None => break,
 				}
@@ -593,7 +598,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		stream.finish()?;
 		stream.closed().await?;
 
-		tracing::debug!(sequence = %msg.sequence, "finished group");
+		tracing::debug!(sequence, "finished group");
 
 		Ok(())
 	}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -448,34 +448,11 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 			track.start_at(start_group);
 		}
 
-		// At most one group consumed-but-not-yet-serveable, kept until the cap
-		// rises enough to release it. We deliberately don't accumulate a queue
-		// here: stopping consumption while one is pending bounds publisher-side
-		// memory to a single group regardless of how long the subscriber leaves
-		// the cap below the live head. Anything else the publisher produces
-		// during that window stays in the track's own cache (subject to its
-		// 5-second eviction), which already has a memory bound.
-		let mut pending: Option<GroupConsumer> = None;
-		let mut track_done = false;
+		// Apply the initial cap from the original Subscribe. Subsequent updates
+		// arrive via the end_group watch channel and get re-applied below.
+		track.end_at(*end_group.borrow_and_update());
 
 		loop {
-			let cap = *end_group.borrow_and_update();
-
-			// Release the pending group if the cap now permits it.
-			if let Some(p) = pending.as_ref()
-				&& cap.is_none_or(|e| p.sequence <= e)
-			{
-				let group = pending.take().unwrap();
-				self.spawn_serve(group, &mut tasks);
-			}
-
-			// Once the track has finished and there's nothing left to serve,
-			// drain any in-flight serve tasks and exit.
-			if track_done && pending.is_none() {
-				while tasks.next().await.is_some() {}
-				return Ok(());
-			}
-
 			tokio::select! {
 				// Drive in-flight group futures; never matches because the inner block returns false.
 				true = async {
@@ -483,23 +460,25 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					false
 				} => unreachable!(),
 
-				// Only pull from the track when we have somewhere to put the result.
-				// `pending.is_none()` enforces the one-group buffer bound.
-				res = track.recv_group(), if !track_done && pending.is_none() => {
+				// next_group respects the cap set via track.end_at and parks
+				// while the next sequence is above the cap. Groups beyond the
+				// cap stay in the producer's cache (bounded by its 5s eviction).
+				res = track.next_group() => {
 					match res? {
-						Some(group) => {
-							if cap.is_some_and(|e| group.sequence > e) {
-								pending = Some(group);
-							} else {
-								self.spawn_serve(group, &mut tasks);
-							}
+						Some(group) => self.spawn_serve(group, &mut tasks),
+						None => {
+							// Track finished; drain in-flight tasks and exit.
+							while tasks.next().await.is_some() {}
+							return Ok(());
 						}
-						None => track_done = true,
 					}
 				}
 
 				Ok(()) = end_group.changed() => {
-					// Loop back to re-evaluate pending against the new cap.
+					// Re-apply the cap. If it rose, the next loop iteration's
+					// track.next_group() will pick up any cached groups that
+					// fell into range; if it dropped, the consumer parks itself.
+					track.end_at(*end_group.borrow_and_update());
 				}
 			}
 		}

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -59,11 +59,8 @@ struct TrackEntry {
 	stats: Arc<SubscriberTrack>,
 }
 
-/// Result of one round-trip through the upstream subscribe lifecycle.
+/// Result of an upstream subscribe lifecycle.
 enum SessionOutcome {
-	/// A new consumer arrived during the linger window. Restart the subscription
-	/// with `start_group = latest + 1` to avoid the publisher re-serving cached groups.
-	Reused,
 	/// The upstream cleanly FIN'd the subscribe stream — nothing more to deliver.
 	Complete,
 	/// Linger timeout expired without anyone returning, or Lite01/02 hit the no-linger path.
@@ -350,12 +347,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	/// Drive one upstream subscription end-to-end, including linger across consumer churn.
 	///
-	/// The id may change across iterations: if a returning consumer arrives during the linger
-	/// window, a fresh subscribe stream is opened under a new id. Every id this task allocates
-	/// stays mapped in `self.subscribes` (all pointing at the same TrackEntry) until the task
-	/// exits, so any in-flight uni streams from the prior subscription instance still route to
-	/// the producer — late groups hit the duplicate-drop path in `recv_group` instead of the
-	/// unknown-subscription error path.
+	/// On linger entry (last consumer drops) we send `SubscribeUpdate(priority=0,
+	/// end_group=Some(latest))`. The publisher treats `end_group` as a serving cap,
+	/// not a terminator: it holds any groups beyond the cap and resumes when we
+	/// raise it. On resume (a new consumer arrives) we send `SubscribeUpdate(end_group=None)`
+	/// to uncap. The stream stays open across the whole lifecycle — only a timeout
+	/// or a publisher-side close ends it. This avoids the stream-churn / duplicate-fetch
+	/// race that an unsubscribe-and-reissue approach would have.
 	async fn run_subscribe(&mut self, path: PathOwned, broadcast: BroadcastDynamic, mut track: TrackProducer) {
 		// Subscriber-side track stats; counters bump as frames/bytes/groups arrive.
 		// Drop on subscription end records `subscriber.subscriptions_closed`. We use
@@ -364,77 +362,39 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let abs = self.origin.as_ref().unwrap().absolute(&path);
 		let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(&track.name));
 
-		// SubscribeUpdate only exists on Lite03+; older versions skip linger entirely.
-		let supports_linger = !matches!(self.version, Version::Lite01 | Version::Lite02);
+		let id = self.next_id.fetch_add(1, atomic::Ordering::Relaxed);
+		self.subscribes.lock().insert(
+			id,
+			TrackEntry {
+				producer: track.clone(),
+				stats: track_stats.clone(),
+			},
+		);
 
-		// Track every subscribe id this task allocates. Reused leaves the previous
-		// id mapped to the same TrackEntry so late group streams from the lingering
-		// upstream session still route to the producer and the duplicate-drop path
-		// in recv_group, instead of the unknown-subscription error path.
-		let mut active_ids: Vec<u64> = Vec::with_capacity(1);
-		let mut id = self.next_id.fetch_add(1, atomic::Ordering::Relaxed);
-		let mut start_group: Option<u64> = None;
-
-		let result = loop {
-			self.subscribes.lock().insert(
-				id,
-				TrackEntry {
-					producer: track.clone(),
-					stats: track_stats.clone(),
-				},
-			);
-			active_ids.push(id);
-
-			let msg = lite::Subscribe {
-				id,
-				broadcast: path.as_path(),
-				track: (&track.name).into(),
-				priority: track.priority,
-				ordered: true,
-				max_latency: Duration::ZERO,
-				start_group,
-				end_group: None,
-			};
-
-			tracing::info!(
-				id,
-				broadcast = %self.log_path(&path),
-				track = %track.name,
-				?start_group,
-				"subscribe started"
-			);
-
-			let outcome = tokio::select! {
-				err = broadcast.closed() => SessionOutcome::BroadcastClosed(err),
-				res = self.run_subscribe_session(&track, msg, supports_linger) => res,
-			};
-
-			match outcome {
-				SessionOutcome::Reused => {
-					// A new consumer arrived during linger. Allocate a fresh id and
-					// resume after the latest group we already cached. Keep the prior
-					// id in `self.subscribes` so any in-flight uni streams from the
-					// lingering subscription still resolve to this TrackEntry.
-					id = self.next_id.fetch_add(1, atomic::Ordering::Relaxed);
-					start_group = track.latest().and_then(|s| s.checked_add(1));
-					tracing::info!(
-						broadcast = %self.log_path(&path),
-						track = %track.name,
-						?start_group,
-						"subscribe resumed"
-					);
-					continue;
-				}
-				other => break other,
-			}
+		let msg = lite::Subscribe {
+			id,
+			broadcast: path.as_path(),
+			track: (&track.name).into(),
+			priority: track.priority,
+			ordered: true,
+			max_latency: Duration::ZERO,
+			start_group: None,
+			end_group: None,
 		};
 
-		{
-			let mut subs = self.subscribes.lock();
-			for id in active_ids {
-				subs.remove(&id);
-			}
-		}
+		tracing::info!(
+			id,
+			broadcast = %self.log_path(&path),
+			track = %track.name,
+			"subscribe started"
+		);
+
+		let result = tokio::select! {
+			err = broadcast.closed() => SessionOutcome::BroadcastClosed(err),
+			res = self.run_subscribe_session(&track, msg) => res,
+		};
+
+		self.subscribes.lock().remove(&id);
 
 		match result {
 			SessionOutcome::Complete => {
@@ -453,22 +413,20 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				tracing::warn!(broadcast = %self.log_path(&path), track = %track.name, %err, "subscribe error");
 				let _ = track.abort(err);
 			}
-			SessionOutcome::Reused => unreachable!("Reused handled inside loop"),
 		}
 	}
 
-	async fn run_subscribe_session(
-		&self,
-		track: &TrackProducer,
-		msg: lite::Subscribe<'_>,
-		supports_linger: bool,
-	) -> SessionOutcome {
-		// Save the parameters we'd echo back in a SubscribeUpdate before the
-		// borrow-eating encode() call.
+	async fn run_subscribe_session(&self, track: &TrackProducer, msg: lite::Subscribe<'_>) -> SessionOutcome {
+		// Stash the original parameters so SubscribeUpdate messages can echo them
+		// while only varying the linger-related fields (priority, end_group).
+		let original_priority = msg.priority;
 		let ordered = msg.ordered;
 		let max_latency = msg.max_latency;
 		let start_group = msg.start_group;
-		let end_group = msg.end_group;
+
+		// SubscribeUpdate only exists on Lite03+; older versions take the
+		// immediate-FIN path with no linger.
+		let supports_linger = !matches!(self.version, Version::Lite01 | Version::Lite02);
 
 		let mut stream = match Stream::open(&self.session, self.version).await {
 			Ok(s) => s,
@@ -497,66 +455,83 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return SessionOutcome::Error(err);
 		};
 
-		// Phase 1 — serving. Wait for either:
-		// - the last consumer to drop (enter linger), or
-		// - the upstream to close the stream (subscription is over).
-		tokio::select! {
-			_ = track.unused() => {}
-			res = stream.reader.closed() => {
-				return match res {
-					Ok(()) => {
-						let _ = stream.writer.finish();
-						SessionOutcome::Complete
-					}
-					Err(err) => SessionOutcome::Error(err),
-				};
-			}
-		}
-
-		// No linger on Lite01/02 (no SubscribeUpdate): just FIN and report cancellation.
-		if !supports_linger {
-			let _ = stream.writer.finish();
-			return SessionOutcome::Cancelled;
-		}
-
-		// Phase 2 — linger. Drop priority to 0 to tell the publisher we're deprioritized,
-		// FIN the stream so it stops sending new groups, then race three outcomes:
-		// - upstream FINs back (publisher acknowledged): clean Complete
-		// - LINGER_TIMEOUT elapses: tear down, report Cancelled
-		// - track.used() fires (a new consumer arrived): drop the stream and restart
-		let update = lite::SubscribeUpdate {
-			priority: 0,
-			ordered,
-			max_latency,
-			start_group,
-			end_group,
-		};
-		if let Err(err) = stream.writer.encode(&update).await {
-			stream.writer.abort(&err);
-			return SessionOutcome::Error(err);
-		}
-		if let Err(err) = stream.writer.finish() {
-			return SessionOutcome::Error(err);
-		}
-
-		tokio::select! {
-			res = stream.reader.closed() => match res {
-				Ok(()) => SessionOutcome::Complete,
-				Err(err) => SessionOutcome::Error(err),
-			},
-			_ = tokio::time::sleep(LINGER_TIMEOUT) => {
-				stream.writer.abort(&Error::Cancel);
-				SessionOutcome::Cancelled
-			}
-			res = track.used() => {
-				// Drop the stream so QUIC tears down the half-closed channel; the next
-				// loop iteration opens a fresh subscribe with start_group = latest+1.
-				drop(stream);
-				match res {
-					Ok(()) => SessionOutcome::Reused,
-					Err(err) => SessionOutcome::Error(err),
+		// Lifecycle loop: serve → linger → resume → serve → ... → FIN.
+		loop {
+			// Phase 1 — serving. Wait for either:
+			// - the last consumer to drop (enter linger), or
+			// - the upstream to close the stream (subscription is over).
+			tokio::select! {
+				_ = track.unused() => {}
+				res = stream.reader.closed() => {
+					return match res {
+						Ok(()) => {
+							let _ = stream.writer.finish();
+							SessionOutcome::Complete
+						}
+						Err(err) => SessionOutcome::Error(err),
+					};
 				}
 			}
+
+			// No linger on Lite01/02: FIN and report cancellation.
+			if !supports_linger {
+				let _ = stream.writer.finish();
+				return SessionOutcome::Cancelled;
+			}
+
+			// Phase 2 — linger. Send SubscribeUpdate that caps the publisher's
+			// serving cursor at the latest group we've cached, and drops priority
+			// to 0. The publisher holds any group beyond the cap until we resume
+			// or FIN. `unwrap_or(0)` handles the corner case where we subscribed
+			// but haven't received a group yet — capping at 0 is conservative.
+			let cap = track.latest().unwrap_or(0);
+			let pause = lite::SubscribeUpdate {
+				priority: 0,
+				ordered,
+				max_latency,
+				start_group,
+				end_group: Some(cap),
+			};
+			if let Err(err) = stream.writer.encode(&pause).await {
+				stream.writer.abort(&err);
+				return SessionOutcome::Error(err);
+			}
+
+			// Race three outcomes during the linger window:
+			// - publisher closes the stream (it's done): Complete
+			// - timeout expires: FIN and report Cancelled
+			// - a new consumer arrives: send the uncap update and re-enter Phase 1
+			let resume = tokio::select! {
+				res = stream.reader.closed() => {
+					return match res {
+						Ok(()) => SessionOutcome::Complete,
+						Err(err) => SessionOutcome::Error(err),
+					};
+				}
+				_ = tokio::time::sleep(LINGER_TIMEOUT) => {
+					let _ = stream.writer.finish();
+					return SessionOutcome::Cancelled;
+				}
+				res = track.used() => res,
+			};
+			if let Err(err) = resume {
+				return SessionOutcome::Error(err);
+			}
+
+			tracing::info!(track = %track.name, "subscribe resumed");
+
+			let uncap = lite::SubscribeUpdate {
+				priority: original_priority,
+				ordered,
+				max_latency,
+				start_group,
+				end_group: None,
+			};
+			if let Err(err) = stream.writer.encode(&uncap).await {
+				stream.writer.abort(&err);
+				return SessionOutcome::Error(err);
+			}
+			// Loop back to Phase 1.
 		}
 	}
 
@@ -568,15 +543,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
 
 			let group_info = Group { sequence: hdr.sequence };
-			let group = match entry.producer.create_group(group_info) {
-				Ok(g) => g,
-				// Late arrival from a lingering subscription: the same sequence already
-				// landed (either earlier on this subscription or on the previous one
-				// before linger reissued). Silently drop; STOP_SENDING on the dropped
-				// stream tells the publisher not to bother.
-				Err(Error::Duplicate) => return Ok(()),
-				Err(err) => return Err(err),
-			};
+			let group = entry.producer.create_group(group_info)?;
 			(group, entry.producer.clone(), entry.stats.clone())
 		};
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1,6 +1,7 @@
 use std::{
 	collections::{HashMap, hash_map::Entry},
 	sync::{Arc, atomic},
+	time::Duration,
 };
 
 use futures::{StreamExt, stream::FuturesUnordered};
@@ -16,6 +17,11 @@ use crate::{
 use super::Version;
 
 use web_async::Lock;
+
+/// Keep an upstream subscription alive briefly after the last consumer leaves,
+/// so a returning subscriber reuses the same TrackProducer instead of forcing a
+/// fresh fetch (and the publisher re-serving the latest cached group).
+const LINGER_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	pub session: S,
@@ -51,6 +57,21 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 struct TrackEntry {
 	producer: TrackProducer,
 	stats: Arc<SubscriberTrack>,
+}
+
+/// Result of one round-trip through the upstream subscribe lifecycle.
+enum SessionOutcome {
+	/// A new consumer arrived during the linger window. Restart the subscription
+	/// with `start_group = latest + 1` to avoid the publisher re-serving cached groups.
+	Reused,
+	/// The upstream cleanly FIN'd the subscribe stream — nothing more to deliver.
+	Complete,
+	/// Linger timeout expired without anyone returning, or Lite01/02 hit the no-linger path.
+	Cancelled,
+	/// The entire broadcast went away on the publisher side.
+	BroadcastClosed(Error),
+	/// Anything else (wire error, protocol violation, encode failure).
+	Error(Error),
 }
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
@@ -318,19 +339,22 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				_ = self.session.closed() => break,
 			};
 
-			let id = self.next_id.fetch_add(1, atomic::Ordering::Relaxed);
 			let mut this = self.clone();
-
 			let path = path.clone();
 			let broadcast = broadcast.clone();
 			web_async::spawn(async move {
-				this.run_subscribe(id, path, broadcast, track).await;
-				this.subscribes.lock().remove(&id);
+				this.run_subscribe(path, broadcast, track).await;
 			});
 		}
 	}
 
-	async fn run_subscribe(&mut self, id: u64, path: PathOwned, broadcast: BroadcastDynamic, mut track: TrackProducer) {
+	/// Drive one upstream subscription end-to-end, including linger across consumer churn.
+	///
+	/// The id may change across iterations: if a returning consumer arrives during the linger
+	/// window, we open a fresh subscribe stream under a new id (the old id is still routed in
+	/// `self.subscribes` until linger exits, so any in-flight groups for the old subscription
+	/// keep landing on the same producer until the publisher FINs back).
+	async fn run_subscribe(&mut self, path: PathOwned, broadcast: BroadcastDynamic, mut track: TrackProducer) {
 		// Subscriber-side track stats; counters bump as frames/bytes/groups arrive.
 		// Drop on subscription end records `subscriber.subscriptions_closed`. We use
 		// subscriber_track to avoid double-counting broadcasts: the broadcast lifetime
@@ -338,79 +362,189 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let abs = self.origin.as_ref().unwrap().absolute(&path);
 		let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(&track.name));
 
-		self.subscribes.lock().insert(
-			id,
-			TrackEntry {
-				producer: track.clone(),
-				stats: track_stats.clone(),
-			},
-		);
+		// SubscribeUpdate only exists on Lite03+; older versions skip linger entirely.
+		let supports_linger = !matches!(self.version, Version::Lite01 | Version::Lite02);
 
-		let msg = lite::Subscribe {
-			id,
-			broadcast: path.as_path(),
-			track: (&track.name).into(),
-			priority: track.priority,
-			ordered: true,
-			max_latency: std::time::Duration::ZERO,
-			start_group: None,
-			end_group: None,
+		let mut id = self.next_id.fetch_add(1, atomic::Ordering::Relaxed);
+		let mut start_group: Option<u64> = None;
+
+		let result = loop {
+			self.subscribes.lock().insert(
+				id,
+				TrackEntry {
+					producer: track.clone(),
+					stats: track_stats.clone(),
+				},
+			);
+
+			let msg = lite::Subscribe {
+				id,
+				broadcast: path.as_path(),
+				track: (&track.name).into(),
+				priority: track.priority,
+				ordered: true,
+				max_latency: Duration::ZERO,
+				start_group,
+				end_group: None,
+			};
+
+			tracing::info!(
+				id,
+				broadcast = %self.log_path(&path),
+				track = %track.name,
+				?start_group,
+				"subscribe started"
+			);
+
+			let outcome = tokio::select! {
+				err = broadcast.closed() => SessionOutcome::BroadcastClosed(err),
+				res = self.run_subscribe_session(&track, msg, supports_linger) => res,
+			};
+
+			match outcome {
+				SessionOutcome::Reused => {
+					// A new consumer arrived during linger. Drop the lingering subscribe
+					// id and restart with a fresh one, resuming after the latest group we
+					// already cached so the publisher doesn't re-send anything we have.
+					self.subscribes.lock().remove(&id);
+					id = self.next_id.fetch_add(1, atomic::Ordering::Relaxed);
+					start_group = track.latest().and_then(|s| s.checked_add(1));
+					tracing::info!(
+						broadcast = %self.log_path(&path),
+						track = %track.name,
+						?start_group,
+						"subscribe resumed"
+					);
+					continue;
+				}
+				other => break other,
+			}
 		};
 
-		tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "subscribe started");
+		self.subscribes.lock().remove(&id);
 
-		tokio::select! {
-			_ = track.unused() => {
-				tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "subscribe cancelled");
+		match result {
+			SessionOutcome::Complete => {
+				tracing::info!(broadcast = %self.log_path(&path), track = %track.name, "subscribe complete");
+				let _ = track.finish();
+			}
+			SessionOutcome::Cancelled => {
+				tracing::info!(broadcast = %self.log_path(&path), track = %track.name, "subscribe cancelled");
 				let _ = track.abort(Error::Cancel);
 			}
-			err = broadcast.closed() => {
-				tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "broadcast closed");
+			SessionOutcome::BroadcastClosed(err) => {
+				tracing::info!(broadcast = %self.log_path(&path), track = %track.name, %err, "broadcast closed");
 				let _ = track.abort(err);
 			}
-			res = self.run_track(msg) => match res {
-				Ok(()) => {
-					tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "subscribe complete");
-					let _ = track.finish();
-				}
-				Err(err) => {
-					tracing::warn!(id, broadcast = %self.log_path(&path), track = %track.name, %err, "subscribe error");
-					let _ = track.abort(err);
-				}
-			},
+			SessionOutcome::Error(err) => {
+				tracing::warn!(broadcast = %self.log_path(&path), track = %track.name, %err, "subscribe error");
+				let _ = track.abort(err);
+			}
+			SessionOutcome::Reused => unreachable!("Reused handled inside loop"),
 		}
 	}
 
-	async fn run_track(&mut self, msg: lite::Subscribe<'_>) -> Result<(), Error> {
-		let mut stream = Stream::open(&self.session, self.version).await?;
-		stream.writer.encode(&lite::ControlType::Subscribe).await?;
-
-		if let Err(err) = self.run_track_stream(&mut stream, msg).await {
-			stream.writer.abort(&err);
-			return Err(err);
-		}
-
-		stream.writer.finish()?;
-		stream.writer.closed().await
-	}
-
-	async fn run_track_stream(
-		&mut self,
-		stream: &mut Stream<S, Version>,
+	async fn run_subscribe_session(
+		&self,
+		track: &TrackProducer,
 		msg: lite::Subscribe<'_>,
-	) -> Result<(), Error> {
-		stream.writer.encode(&msg).await?;
+		supports_linger: bool,
+	) -> SessionOutcome {
+		// Save the parameters we'd echo back in a SubscribeUpdate before the
+		// borrow-eating encode() call.
+		let ordered = msg.ordered;
+		let max_latency = msg.max_latency;
+		let start_group = msg.start_group;
+		let end_group = msg.end_group;
 
-		// The first response MUST be a SUBSCRIBE_OK.
-		let resp: lite::SubscribeResponse = stream.reader.decode().await?;
-		let lite::SubscribeResponse::Ok(_info) = resp else {
-			return Err(Error::ProtocolViolation);
+		let mut stream = match Stream::open(&self.session, self.version).await {
+			Ok(s) => s,
+			Err(err) => return SessionOutcome::Error(err),
 		};
 
-		// TODO handle additional SUBSCRIBE_OK and SUBSCRIBE_DROP messages.
-		stream.reader.closed().await?;
+		if let Err(err) = stream.writer.encode(&lite::ControlType::Subscribe).await {
+			return SessionOutcome::Error(err);
+		}
 
-		Ok(())
+		if let Err(err) = stream.writer.encode(&msg).await {
+			stream.writer.abort(&err);
+			return SessionOutcome::Error(err);
+		}
+
+		let resp = match stream.reader.decode::<lite::SubscribeResponse>().await {
+			Ok(r) => r,
+			Err(err) => {
+				stream.writer.abort(&err);
+				return SessionOutcome::Error(err);
+			}
+		};
+		let lite::SubscribeResponse::Ok(_info) = resp else {
+			let err = Error::ProtocolViolation;
+			stream.writer.abort(&err);
+			return SessionOutcome::Error(err);
+		};
+
+		// Phase 1 — serving. Wait for either:
+		// - the last consumer to drop (enter linger), or
+		// - the upstream to close the stream (subscription is over).
+		tokio::select! {
+			_ = track.unused() => {}
+			res = stream.reader.closed() => {
+				return match res {
+					Ok(()) => {
+						let _ = stream.writer.finish();
+						SessionOutcome::Complete
+					}
+					Err(err) => SessionOutcome::Error(err),
+				};
+			}
+		}
+
+		// No linger on Lite01/02 (no SubscribeUpdate): just FIN and report cancellation.
+		if !supports_linger {
+			let _ = stream.writer.finish();
+			return SessionOutcome::Cancelled;
+		}
+
+		// Phase 2 — linger. Drop priority to 0 to tell the publisher we're deprioritized,
+		// FIN the stream so it stops sending new groups, then race three outcomes:
+		// - upstream FINs back (publisher acknowledged): clean Complete
+		// - LINGER_TIMEOUT elapses: tear down, report Cancelled
+		// - track.used() fires (a new consumer arrived): drop the stream and restart
+		let update = lite::SubscribeUpdate {
+			priority: 0,
+			ordered,
+			max_latency,
+			start_group,
+			end_group,
+		};
+		if let Err(err) = stream.writer.encode(&update).await {
+			stream.writer.abort(&err);
+			return SessionOutcome::Error(err);
+		}
+		if let Err(err) = stream.writer.finish() {
+			return SessionOutcome::Error(err);
+		}
+
+		tokio::select! {
+			res = stream.reader.closed() => match res {
+				Ok(()) => SessionOutcome::Complete,
+				Err(err) => SessionOutcome::Error(err),
+			},
+			_ = tokio::time::sleep(LINGER_TIMEOUT) => {
+				stream.writer.abort(&Error::Cancel);
+				SessionOutcome::Cancelled
+			}
+			res = track.used() => {
+				// Drop the stream so QUIC tears down the half-closed channel; the next
+				// loop iteration opens a fresh subscribe with start_group = latest+1.
+				drop(stream);
+				match res {
+					Ok(()) => SessionOutcome::Reused,
+					Err(err) => SessionOutcome::Error(err),
+				}
+			}
+		}
 	}
 
 	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
@@ -421,7 +555,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
 
 			let group_info = Group { sequence: hdr.sequence };
-			let group = entry.producer.create_group(group_info)?;
+			let group = match entry.producer.create_group(group_info) {
+				Ok(g) => g,
+				// Late arrival from a lingering subscription: the same sequence already
+				// landed (either earlier on this subscription or on the previous one
+				// before linger reissued). Silently drop; STOP_SENDING on the dropped
+				// stream tells the publisher not to bother.
+				Err(Error::Duplicate) => return Ok(()),
+				Err(err) => return Err(err),
+			};
 			(group, entry.producer.clone(), entry.stats.clone())
 		};
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -463,13 +463,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			tokio::select! {
 				_ = track.unused() => {}
 				res = stream.reader.closed() => {
-					return match res {
-						Ok(()) => {
-							let _ = stream.writer.finish();
-							SessionOutcome::Complete
-						}
-						Err(err) => SessionOutcome::Error(err),
-					};
+					if let Err(err) = res {
+						return SessionOutcome::Error(err);
+					}
+					let _ = stream.writer.finish();
+					return SessionOutcome::Complete;
 				}
 			}
 
@@ -503,10 +501,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			// - a new consumer arrives: send the uncap update and re-enter Phase 1
 			let resume = tokio::select! {
 				res = stream.reader.closed() => {
-					return match res {
-						Ok(()) => SessionOutcome::Complete,
-						Err(err) => SessionOutcome::Error(err),
-					};
+					if let Err(err) = res {
+						return SessionOutcome::Error(err);
+					}
+					return SessionOutcome::Complete;
 				}
 				_ = tokio::time::sleep(LINGER_TIMEOUT) => {
 					let _ = stream.writer.finish();

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -351,9 +351,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// Drive one upstream subscription end-to-end, including linger across consumer churn.
 	///
 	/// The id may change across iterations: if a returning consumer arrives during the linger
-	/// window, we open a fresh subscribe stream under a new id (the old id is still routed in
-	/// `self.subscribes` until linger exits, so any in-flight groups for the old subscription
-	/// keep landing on the same producer until the publisher FINs back).
+	/// window, a fresh subscribe stream is opened under a new id. Every id this task allocates
+	/// stays mapped in `self.subscribes` (all pointing at the same TrackEntry) until the task
+	/// exits, so any in-flight uni streams from the prior subscription instance still route to
+	/// the producer — late groups hit the duplicate-drop path in `recv_group` instead of the
+	/// unknown-subscription error path.
 	async fn run_subscribe(&mut self, path: PathOwned, broadcast: BroadcastDynamic, mut track: TrackProducer) {
 		// Subscriber-side track stats; counters bump as frames/bytes/groups arrive.
 		// Drop on subscription end records `subscriber.subscriptions_closed`. We use
@@ -365,6 +367,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// SubscribeUpdate only exists on Lite03+; older versions skip linger entirely.
 		let supports_linger = !matches!(self.version, Version::Lite01 | Version::Lite02);
 
+		// Track every subscribe id this task allocates. Reused leaves the previous
+		// id mapped to the same TrackEntry so late group streams from the lingering
+		// upstream session still route to the producer and the duplicate-drop path
+		// in recv_group, instead of the unknown-subscription error path.
+		let mut active_ids: Vec<u64> = Vec::with_capacity(1);
 		let mut id = self.next_id.fetch_add(1, atomic::Ordering::Relaxed);
 		let mut start_group: Option<u64> = None;
 
@@ -376,6 +383,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					stats: track_stats.clone(),
 				},
 			);
+			active_ids.push(id);
 
 			let msg = lite::Subscribe {
 				id,
@@ -403,10 +411,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 			match outcome {
 				SessionOutcome::Reused => {
-					// A new consumer arrived during linger. Drop the lingering subscribe
-					// id and restart with a fresh one, resuming after the latest group we
-					// already cached so the publisher doesn't re-send anything we have.
-					self.subscribes.lock().remove(&id);
+					// A new consumer arrived during linger. Allocate a fresh id and
+					// resume after the latest group we already cached. Keep the prior
+					// id in `self.subscribes` so any in-flight uni streams from the
+					// lingering subscription still resolve to this TrackEntry.
 					id = self.next_id.fetch_add(1, atomic::Ordering::Relaxed);
 					start_group = track.latest().and_then(|s| s.checked_add(1));
 					tracing::info!(
@@ -421,7 +429,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		};
 
-		self.subscribes.lock().remove(&id);
+		{
+			let mut subs = self.subscribes.lock();
+			for id in active_ids {
+				subs.remove(&id);
+			}
+		}
 
 		match result {
 			SessionOutcome::Complete => {

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -384,10 +384,14 @@ impl BroadcastConsumer {
 		state.tracks.insert(producer.name.clone(), weak.clone());
 		state.requests.push(producer);
 
-		// Remove the track from the lookup when it's unused.
+		// Remove the track from the lookup once the producer closes. The
+		// producer owner is responsible for closing it (via abort/finish/drop)
+		// when truly done with the track; this lets a producer linger across
+		// transient consumer churn (relay subscription churn) without losing
+		// the lookup entry to a race with auto-cleanup.
 		let consumer_state = self.state.clone();
 		web_async::spawn(async move {
-			let _ = weak.unused().await;
+			weak.closed().await;
 
 			let Some(producer) = consumer_state.produce() else {
 				return;
@@ -578,54 +582,48 @@ mod test {
 	async fn requested_unused() {
 		let mut broadcast = Broadcast::new().produce().dynamic();
 
-		// Subscribe to a track that doesn't exist - this creates a request
+		// Subscribe to a track that doesn't exist - this creates a request.
 		let consumer1 = broadcast.consume().assert_subscribe_track(&Track::new("unknown_track"));
-
-		// Get the requested track producer
-		let producer1 = broadcast.assert_request();
-
-		// The track producer should NOT be unused yet because there's a consumer
+		let mut producer1 = broadcast.assert_request();
 		assert!(
 			producer1.unused().now_or_never().is_none(),
 			"track producer should be used"
 		);
 
-		// Making a new consumer will keep the producer alive
+		// A second subscriber reuses the existing producer (deduplication).
 		let consumer2 = broadcast.consume().assert_subscribe_track(&Track::new("unknown_track"));
 		consumer2.assert_is_clone(&consumer1);
 
-		// Drop the consumer subscription
-		drop(consumer1);
-
-		// The track producer should NOT be unused yet because there's a consumer
+		drop(consumer2);
 		assert!(
 			producer1.unused().now_or_never().is_none(),
 			"track producer should be used"
 		);
 
-		// Drop the second consumer, now the producer should be unused
-		drop(consumer2);
-
-		// BUG: The track producer should become unused after dropping the consumer,
-		// but it won't because the broadcast keeps a reference in the lookup HashMap
-		// This assertion will fail, demonstrating the bug
+		drop(consumer1);
 		assert!(
 			producer1.unused().now_or_never().is_some(),
-			"track producer should be unused after consumer is dropped"
+			"track producer should be unused after all consumers are dropped"
 		);
 
-		// TODO Unfortunately, we need to sleep for a little bit to detect when unused.
+		// While the producer is alive, re-subscribing to the same name reuses
+		// the existing producer (no new request) — this is what lets the relay
+		// linger upstream subscriptions across transient consumer churn.
+		let consumer3 = broadcast.consume().assert_subscribe_track(&Track::new("unknown_track"));
+		consumer3.assert_is_clone(&producer1.consume());
+		broadcast.assert_no_request();
+		drop(consumer3);
+
+		// Aborting the producer triggers cleanup; the next subscribe creates a fresh request.
+		producer1.abort(Error::Cancel).unwrap();
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
-		// Now the cleanup task should have run and we can subscribe again to the unknown track.
-		let consumer3 = broadcast.consume().subscribe_track(&Track::new("unknown_track"));
+		let consumer4 = broadcast.consume().assert_subscribe_track(&Track::new("unknown_track"));
 		let producer2 = broadcast.assert_request();
-
-		// Drop the consumer, now the producer should be unused
-		drop(consumer3);
+		drop(consumer4);
 		assert!(
 			producer2.unused().now_or_never().is_some(),
-			"track producer should be unused after consumer is dropped"
+			"new track producer should be unused after its consumer is dropped"
 		);
 	}
 

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -578,7 +578,7 @@ mod test {
 		track2.assert_group();
 	}
 
-	#[tokio::test]
+	#[tokio::test(start_paused = true)]
 	async fn requested_unused() {
 		let mut broadcast = Broadcast::new().produce().dynamic();
 
@@ -616,7 +616,10 @@ mod test {
 
 		// Aborting the producer triggers cleanup; the next subscribe creates a fresh request.
 		producer1.abort(Error::Cancel).unwrap();
-		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		// Yield to give the spawned cleanup task a chance to run before we
+		// expect its effects below. Using paused time keeps the test
+		// independent of wall-clock scheduling.
+		tokio::time::advance(std::time::Duration::from_millis(1)).await;
 
 		let consumer4 = broadcast.consume().assert_subscribe_track(&Track::new("unknown_track"));
 		let producer2 = broadcast.assert_request();

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -661,12 +661,14 @@ impl TrackConsumer {
 
 	/// Cap the consumer at the specified sequence (inclusive), or remove the cap entirely.
 	///
+	/// Accepts a bare `u64` (cap), `Some(u64)`, or `None` (uncap).
+	///
 	/// Affects [`Self::next_group`] only: groups beyond the cap stay in the producer's
 	/// cache rather than being skipped past, so a later call to [`Self::end_at`] with a
 	/// higher value (or `None`) makes them available again. Lowering the cap below the
 	/// consumer's current cursor parks the consumer until the cap is raised.
-	pub fn end_at(&mut self, sequence: Option<u64>) {
-		self.end_sequence = sequence;
+	pub fn end_at(&mut self, sequence: impl Into<Option<u64>>) {
+		self.end_sequence = sequence.into();
 	}
 
 	/// Return the latest sequence number in the track.
@@ -1069,7 +1071,7 @@ mod test {
 			producer.create_group(Group { sequence: s }).unwrap();
 		}
 
-		consumer.end_at(Some(2));
+		consumer.end_at(2);
 
 		// Groups 0, 1, 2 are within the cap.
 		assert_eq!(
@@ -1101,7 +1103,7 @@ mod test {
 			producer.create_group(Group { sequence: s }).unwrap();
 		}
 
-		consumer.end_at(Some(1));
+		consumer.end_at(1);
 		assert_eq!(
 			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
 			0
@@ -1113,7 +1115,7 @@ mod test {
 		assert!(consumer.next_group().now_or_never().is_none(), "capped at 1");
 
 		// Raise the cap; previously-blocked cached groups become available again.
-		consumer.end_at(Some(4));
+		consumer.end_at(4);
 		assert_eq!(
 			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
 			2
@@ -1161,7 +1163,7 @@ mod test {
 		);
 
 		// Lower the cap below the cursor. New groups beyond the cap are blocked.
-		consumer.end_at(Some(1));
+		consumer.end_at(1);
 		producer.create_group(Group { sequence: 3 }).unwrap();
 		producer.create_group(Group { sequence: 4 }).unwrap();
 		assert!(
@@ -1186,7 +1188,7 @@ mod test {
 		let mut producer = Track::new("test").produce();
 		let mut consumer = producer.consume();
 
-		consumer.end_at(Some(5));
+		consumer.end_at(5);
 
 		// Out-of-order arrivals all within the cap.
 		producer.create_group(Group { sequence: 2 }).unwrap();
@@ -1217,7 +1219,7 @@ mod test {
 		assert!(consumer.next_group().now_or_never().is_none());
 
 		// Raise the cap; cached seq 8 is finally served.
-		consumer.end_at(Some(10));
+		consumer.end_at(10);
 		assert_eq!(
 			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
 			8

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -363,6 +363,11 @@ impl TrackProducer {
 		self.state.read().is_closed()
 	}
 
+	/// Return the latest sequence number successfully appended to the track.
+	pub fn latest(&self) -> Option<u64> {
+		self.state.read().max_sequence
+	}
+
 	/// Return true if this is the same track.
 	pub fn is_clone(&self, other: &Self) -> bool {
 		self.state.same_channel(&other.state)
@@ -420,11 +425,9 @@ impl TrackWeak {
 		}
 	}
 
-	pub async fn unused(&self) -> crate::Result<()> {
-		self.state
-			.unused()
-			.await
-			.map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
+	/// Wait until the underlying track state closes (producer dropped or aborted).
+	pub async fn closed(&self) {
+		self.state.closed().await;
 	}
 
 	pub fn is_clone(&self, other: &Self) -> bool {

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -130,6 +130,61 @@ impl State {
 		}
 	}
 
+	/// Find the smallest-sequence cached group satisfying
+	/// `next_sequence <= seq <= end_sequence (if set)`. Used by
+	/// [`TrackConsumer::next_group`] so the range can be widened (or unset)
+	/// after the fact and previously-skipped cached groups become available
+	/// without scanning past them in arrival order.
+	///
+	/// Returns `Poll::Pending` when no in-range group is currently cached but
+	/// future groups could still arrive in range; returns `Ok(None)` only when
+	/// the track is finalized and no further in-range group is possible.
+	fn poll_next_in_range(&self, next_sequence: u64, end_sequence: Option<u64>) -> Poll<Result<Option<GroupConsumer>>> {
+		// If the end cap is already below where we'd resume, no group can
+		// ever satisfy this call until the cap rises. Pending (not None) so
+		// the consumer is parked rather than told the stream is over.
+		if let Some(end) = end_sequence
+			&& end < next_sequence
+		{
+			if let Some(err) = &self.abort {
+				return Poll::Ready(Err(err.clone()));
+			}
+			return Poll::Pending;
+		}
+
+		let mut best: Option<&GroupProducer> = None;
+		for (group, _) in self.groups.iter().flatten() {
+			if group.sequence < next_sequence {
+				continue;
+			}
+			if let Some(end) = end_sequence
+				&& group.sequence > end
+			{
+				continue;
+			}
+			if best.is_none_or(|b| group.sequence < b.sequence) {
+				best = Some(group);
+			}
+		}
+
+		if let Some(group) = best {
+			return Poll::Ready(Ok(Some(group.consume())));
+		}
+
+		// No in-range group is cached. Decide whether more could ever arrive.
+		if let Some(err) = &self.abort {
+			return Poll::Ready(Err(err.clone()));
+		}
+		// `final_sequence` is one past the last possible sequence. If our
+		// floor is already at/past it, nothing else can land in range.
+		if let Some(fin) = self.final_sequence
+			&& next_sequence >= fin
+		{
+			return Poll::Ready(Ok(None));
+		}
+		Poll::Pending
+	}
+
 	fn poll_get_group(&self, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
 		// Search for the group with the matching sequence, skipping tombstones.
 		for (group, _) in self.groups.iter().flatten() {
@@ -333,6 +388,7 @@ impl TrackProducer {
 			index: 0,
 			min_sequence: 0,
 			next_sequence: 0,
+			end_sequence: None,
 		}
 	}
 
@@ -422,6 +478,7 @@ impl TrackWeak {
 			index: 0,
 			min_sequence: 0,
 			next_sequence: 0,
+			end_sequence: None,
 		}
 	}
 
@@ -447,6 +504,11 @@ pub struct TrackConsumer {
 	/// One past the highest sequence returned by [`Self::next_group`].
 	/// Used only by that method to skip late arrivals; does not affect [`Self::recv_group`].
 	next_sequence: u64,
+	/// Inclusive upper sequence bound for [`Self::next_group`]. `None` means
+	/// no cap. Set by [`Self::end_at`]; can be raised, lowered, or unset at
+	/// any time. Groups beyond the cap stay in the producer's cache and
+	/// become eligible again when the cap rises (or is removed).
+	end_sequence: Option<u64>,
 }
 
 impl std::ops::Deref for TrackConsumer {
@@ -505,18 +567,16 @@ impl TrackConsumer {
 	/// Late arrivals (sequence at or below the last returned) are silently skipped, so this
 	/// produces a monotonically increasing sequence at the cost of dropping out-of-order
 	/// groups. Use [`Self::poll_recv_group`] to see every group in arrival order instead.
+	///
+	/// Honors the cap set by [`Self::end_at`]: groups with sequence past the cap are left
+	/// in the producer's cache and become eligible again if the cap is raised or removed.
 	pub fn poll_next_group(&mut self, waiter: &conducer::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
-		loop {
-			let Some(group) = ready!(self.poll_recv_group(waiter)?) else {
-				return Poll::Ready(Ok(None));
-			};
-			if group.sequence < self.next_sequence {
-				// Late arrival; discard and keep looking.
-				continue;
-			}
-			self.next_sequence = group.sequence.saturating_add(1);
-			return Poll::Ready(Ok(Some(group)));
-		}
+		let floor = self.next_sequence.max(self.min_sequence);
+		let Some(group) = ready!(self.poll(waiter, |state| state.poll_next_in_range(floor, self.end_sequence))?) else {
+			return Poll::Ready(Ok(None));
+		};
+		self.next_sequence = group.sequence.saturating_add(1);
+		Poll::Ready(Ok(Some(group)))
 	}
 
 	/// Return the next group with a higher sequence number than any previously returned.
@@ -597,6 +657,16 @@ impl TrackConsumer {
 	/// Start the consumer at the specified sequence.
 	pub fn start_at(&mut self, sequence: u64) {
 		self.min_sequence = sequence;
+	}
+
+	/// Cap the consumer at the specified sequence (inclusive), or remove the cap entirely.
+	///
+	/// Affects [`Self::next_group`] only: groups beyond the cap stay in the producer's
+	/// cache rather than being skipped past, so a later call to [`Self::end_at`] with a
+	/// higher value (or `None`) makes them available again. Lowering the cap below the
+	/// consumer's current cursor parks the consumer until the cap is raised.
+	pub fn end_at(&mut self, sequence: Option<u64>) {
+		self.end_sequence = sequence;
 	}
 
 	/// Return the latest sequence number in the track.
@@ -967,25 +1037,191 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn recv_group_after_next_group_sees_late_arrivals() {
+	async fn next_group_and_recv_group_use_independent_cursors() {
 		let mut producer = Track::new("test").produce();
 		let mut consumer = producer.consume();
 
+		// Out-of-order arrivals: seq 5 first, then seq 3.
 		producer.create_group(Group { sequence: 5 }).unwrap();
 		producer.create_group(Group { sequence: 3 }).unwrap();
 
-		// Ordered returns seq 5 and advances its internal cursor past it.
+		// next_group is sequence-ordered: it returns the smallest sequence first,
+		// regardless of arrival order.
 		let group = consumer
 			.next_group()
 			.now_or_never()
 			.expect("should not block")
 			.expect("would have errored")
 			.expect("track should not be closed");
-		assert_eq!(group.sequence, 5);
+		assert_eq!(group.sequence, 3);
 
-		// Intermixing: recv_group on the same consumer still returns the late seq 3.
-		// The ordered cursor is separate from the recv_group filter.
-		assert_eq!(consumer.assert_group().sequence, 3);
+		// recv_group is arrival-ordered and uses an independent cursor, so it
+		// still starts at the first arrival.
+		assert_eq!(consumer.assert_group().sequence, 5);
+	}
+
+	#[tokio::test]
+	async fn end_at_caps_next_group() {
+		let mut producer = Track::new("test").produce();
+		let mut consumer = producer.consume();
+
+		for s in 0..6 {
+			producer.create_group(Group { sequence: s }).unwrap();
+		}
+
+		consumer.end_at(Some(2));
+
+		// Groups 0, 1, 2 are within the cap.
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			0
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			1
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			2
+		);
+
+		// Group 3 is beyond the cap: next_group parks even though cached groups exist.
+		assert!(
+			consumer.next_group().now_or_never().is_none(),
+			"capped consumer must block instead of returning out-of-range groups"
+		);
+	}
+
+	#[tokio::test]
+	async fn end_at_release_drains_cached_groups() {
+		let mut producer = Track::new("test").produce();
+		let mut consumer = producer.consume();
+
+		for s in 0..6 {
+			producer.create_group(Group { sequence: s }).unwrap();
+		}
+
+		consumer.end_at(Some(1));
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			0
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			1
+		);
+		assert!(consumer.next_group().now_or_never().is_none(), "capped at 1");
+
+		// Raise the cap; previously-blocked cached groups become available again.
+		consumer.end_at(Some(4));
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			2
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			3
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			4
+		);
+		assert!(consumer.next_group().now_or_never().is_none(), "capped at 4");
+
+		// Remove the cap; everything remaining flows.
+		consumer.end_at(None);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			5
+		);
+		assert!(consumer.next_group().now_or_never().is_none(), "no more groups");
+	}
+
+	#[tokio::test]
+	async fn end_at_lower_than_cursor_parks_consumer() {
+		let mut producer = Track::new("test").produce();
+		let mut consumer = producer.consume();
+
+		for s in 0..3 {
+			producer.create_group(Group { sequence: s }).unwrap();
+		}
+
+		// Drain everything with no cap.
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			0
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			1
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			2
+		);
+
+		// Lower the cap below the cursor. New groups beyond the cap are blocked.
+		consumer.end_at(Some(1));
+		producer.create_group(Group { sequence: 3 }).unwrap();
+		producer.create_group(Group { sequence: 4 }).unwrap();
+		assert!(
+			consumer.next_group().now_or_never().is_none(),
+			"cap is below cursor; nothing returnable until cap rises"
+		);
+
+		// Restoring the cap to no-limit (or any value >= cursor) releases them.
+		consumer.end_at(None);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			3
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			4
+		);
+	}
+
+	#[tokio::test]
+	async fn end_at_toggling_around_late_arrivals() {
+		let mut producer = Track::new("test").produce();
+		let mut consumer = producer.consume();
+
+		consumer.end_at(Some(5));
+
+		// Out-of-order arrivals all within the cap.
+		producer.create_group(Group { sequence: 2 }).unwrap();
+		producer.create_group(Group { sequence: 5 }).unwrap();
+		producer.create_group(Group { sequence: 3 }).unwrap();
+		// One beyond the cap; should be held even though it arrived in the middle.
+		producer.create_group(Group { sequence: 8 }).unwrap();
+		producer.create_group(Group { sequence: 4 }).unwrap();
+
+		// next_group walks in sequence order through everything <= cap.
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			2
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			3
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			4
+		);
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			5
+		);
+		// Now blocked: 8 is still beyond the cap.
+		assert!(consumer.next_group().now_or_never().is_none());
+
+		// Raise the cap; cached seq 8 is finally served.
+		consumer.end_at(Some(10));
+		assert_eq!(
+			consumer.next_group().now_or_never().unwrap().unwrap().unwrap().sequence,
+			8
+		);
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

When the last viewer of a track drops, the upstream subscription used to tear down immediately. A returning viewer milliseconds later triggered a fresh `Subscribe`, and the publisher re-served the latest cached group. Under churn (page reloads, reconnects, toggles) the same group got re-fetched over and over.

This PR keeps the upstream `TrackProducer` alive for up to 5s after the last consumer leaves. On `track.unused()` the lite subscriber sends `SubscribeUpdate(priority = 0)` + FIN upstream and waits for one of:

- **Complete** — the upstream FINs back (subscription is done)
- **Cancelled** — the 5s linger timeout expires (no one came back)
- **Reused** — a returning consumer arrives during the wait; reissue with `start_group = latest + 1` so the publisher doesn't re-send already-cached groups

Late duplicates from the prior subscription round get silently dropped in `recv_group` (the data is already cached locally, so STOP_SENDING is the right move).

Lite01/02 fall back to the old immediate-cancel since they lack `SubscribeUpdate`. IETF transport is unchanged for now.

## Why the broadcast cleanup change

The auto-cleanup spawn in `BroadcastConsumer::subscribe_track` previously fired on `weak.unused()`, which raced the linger logic and yanked the lookup entry the instant consumer count hit 0 — defeating the point of linger. Re-anchored it to `weak.closed()` instead: the producer owner is now responsible for closing the producer (via `abort`/`finish`/drop) once truly done, and that close fires the cleanup eagerly. No in-memory leak of dead broadcasts.

The `requested_unused` test was rewritten to match the new contract: while the producer is alive, re-subscribing to the same name returns the existing producer's consumer (no new request); a fresh request only appears after the producer itself is closed.

## Files

- `rs/conducer/src/weak.rs` — add `Weak::closed()` (mirror of `Producer::closed`)
- `rs/moq-net/src/model/track.rs` — `TrackProducer::latest()`, `TrackWeak::closed()`
- `rs/moq-net/src/model/broadcast.rs` — cleanup spawn waits on `weak.closed()`; test rewrite
- `rs/moq-net/src/lite/subscriber.rs` — restructure `run_subscribe` into a linger loop driving a new `run_subscribe_session`; silently drop `Error::Duplicate` in `recv_group`
- `rs/moq-native/tests/broadcast.rs` — `linger_resubscribe_keeps_flowing_moq_lite_03` smoke test

## Test plan

- [x] `just check`
- [x] `cargo test --workspace --exclude moq-gst --exclude moq-ffi --exclude libmoq` — all green
- [x] Existing `model::broadcast::test::requested_unused` updated and passes against new contract
- [x] New `linger_resubscribe_keeps_flowing_moq_lite_03` end-to-end test passes

## Known caveats

Distinguishing the **Reused** vs **Complete** linger branches from a black-box client test over localhost turned out to be too timing-dependent (the publisher's FIN-back roundtrip races the test thread's resubscribe call). The included test verifies the end-to-end smoke — drop + resub keeps working through the linger window. A more targeted branch-specific test would need either a slow-publisher harness or wire-level interception. (Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)