### PR TITLE
moq-mux: add seek(sequence) on importers for explicit group boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,6 +3744,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "conducer",
+ "futures",
  "h264-parser",
  "hang",
  "m3u8-rs",

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -39,4 +39,5 @@ url = "2"
 webm-iterable = "0.6"
 
 [dev-dependencies]
+futures = "0.3"
 tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -52,6 +52,12 @@ impl Import {
 		Ok(())
 	}
 
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		self.track.seek(sequence)?;
+		Ok(())
+	}
+
 	pub fn decode<T: Buf>(&mut self, buf: &mut T, pts: Option<crate::container::Timestamp>) -> anyhow::Result<()> {
 		let pts = self.pts(pts)?;
 

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -387,6 +387,13 @@ impl Import {
 		Ok(())
 	}
 
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		let track = self.track.as_mut().context("not initialized")?;
+		track.seek(sequence)?;
+		Ok(())
+	}
+
 	pub fn is_initialized(&self) -> bool {
 		self.track.is_some()
 	}

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -458,6 +458,13 @@ impl Import {
 		Ok(())
 	}
 
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		let track = self.track.as_mut().context("not initialized")?;
+		track.seek(sequence)?;
+		Ok(())
+	}
+
 	fn pts(&mut self, hint: Option<crate::container::Timestamp>) -> anyhow::Result<crate::container::Timestamp> {
 		if let Some(pts) = hint {
 			return Ok(pts);

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -327,6 +327,13 @@ impl Import {
 		Ok(())
 	}
 
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		let track = self.track.as_mut().context("not initialized")?;
+		track.seek(sequence)?;
+		Ok(())
+	}
+
 	pub fn is_initialized(&self) -> bool {
 		self.track.is_some()
 	}

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -51,6 +51,12 @@ impl Import {
 		Ok(())
 	}
 
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		self.track.seek(sequence)?;
+		Ok(())
+	}
+
 	pub fn decode<T: Buf>(&mut self, buf: &mut T, pts: Option<crate::container::Timestamp>) -> anyhow::Result<()> {
 		let pts = self.pts(pts)?;
 

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -61,6 +61,9 @@ struct Fmp4Track {
 
 	// The minimum duration between frames for this track.
 	min_duration: Option<Timestamp>,
+
+	// Sequence to use for the next group, set by `Import::seek`.
+	pending_sequence: Option<u64>,
 }
 
 impl Import {
@@ -168,6 +171,7 @@ impl Import {
 					jitter: None,
 					last_timestamp: None,
 					min_duration: None,
+					pending_sequence: None,
 				},
 			);
 		}
@@ -572,7 +576,10 @@ impl Import {
 				if let Some(mut prev) = track.group.take() {
 					prev.finish()?;
 				}
-				track.track.append_group()?
+				match track.pending_sequence.take() {
+					Some(sequence) => track.track.create_group(moq_net::Group { sequence })?,
+					None => track.track.append_group()?,
+				}
 			} else {
 				track.group.take().context("no keyframe at start")?
 			};
@@ -623,6 +630,20 @@ impl Import {
 				g.finish()?;
 			}
 			track.track.finish()?;
+		}
+		Ok(())
+	}
+
+	/// Close the current group on every track and open the next one at `sequence`.
+	///
+	/// Broadcast-wide: every track inside this fMP4 import advances together; per-track
+	/// control is intentionally not exposed.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		for track in self.tracks.values_mut() {
+			if let Some(mut g) = track.group.take() {
+				g.finish()?;
+			}
+			track.pending_sequence = Some(sequence);
 		}
 		Ok(())
 	}

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -1,5 +1,17 @@
+use futures::FutureExt;
 use hang::catalog::Container;
 use mp4_atom::{Decode, Encode};
+
+/// Drain every group currently buffered on the consumer without waiting for new ones.
+/// Used in tests where the producer is still alive after writing.
+#[cfg(test)]
+fn drain_group_sequences(consumer: &mut moq_net::TrackConsumer) -> Vec<u64> {
+	let mut sequences = Vec::new();
+	while let Some(group) = consumer.recv_group().now_or_never().and_then(|r| r.ok().flatten()) {
+		sequences.push(group.sequence);
+	}
+	sequences
+}
 
 fn run_fmp4(data: &[u8]) -> hang::Catalog {
 	let mut broadcast = moq_net::Broadcast::new().produce();
@@ -126,6 +138,65 @@ fn test_vp9_catalog() {
 	let mvex = moov.mvex.as_ref().unwrap();
 	assert_eq!(mvex.trex.len(), 1);
 	assert_eq!(mvex.trex[0].track_id, moov.trak[0].tkhd.track_id);
+}
+
+/// `Import::seek(n)` starts the next group at sequence `n`; subsequent fragments
+/// auto-increment from there.
+#[tokio::test]
+async fn test_seek_sets_initial_sequence() {
+	use mp4_atom::{Any, DecodeMaybe};
+
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let broadcast_consumer = broadcast.consume();
+	let catalog = crate::catalog::hang::Producer::new(&mut broadcast).unwrap();
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone());
+
+	let data = include_bytes!("test_data/bbb.mp4");
+
+	// Walk the file atom-by-atom so we can seek before any fragments are processed.
+	// Init atoms (ftyp/moov) come first; everything after is moof/mdat pairs.
+	let mut init_buf = bytes::BytesMut::new();
+	let mut frag_buf = bytes::BytesMut::new();
+	let mut cursor = std::io::Cursor::new(&data[..]);
+	let mut init_done = false;
+	let mut position = 0;
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).unwrap_or(None) {
+		let end = cursor.position() as usize;
+		let bytes = &data[position..end];
+		match atom {
+			Any::Ftyp(_) | Any::Styp(_) | Any::Moov(_) => init_buf.extend_from_slice(bytes),
+			_ => {
+				init_done = true;
+				frag_buf.extend_from_slice(bytes);
+			}
+		}
+		position = end;
+		if init_done && frag_buf.len() > 1024 {
+			break;
+		}
+	}
+
+	// Decode init so the tracks exist, then seek, then decode the fragments.
+	fmp4.decode(&mut init_buf).unwrap();
+	assert!(fmp4.is_initialized());
+
+	let snap = catalog.snapshot();
+	let video_name = snap.video.renditions.keys().next().expect("video track").clone();
+	let mut video_track = broadcast_consumer
+		.subscribe_track(&moq_net::Track::new(&video_name))
+		.expect("video track should exist");
+
+	fmp4.seek(100).unwrap();
+	// Trailing partial fragments may error; ignore.
+	let _ = fmp4.decode(&mut frag_buf);
+	fmp4.finish().unwrap();
+
+	let sequences = drain_group_sequences(&mut video_track);
+	assert!(!sequences.is_empty(), "expected at least one group");
+	assert_eq!(sequences[0], 100, "first group should land at the seeked sequence");
+	for win in sequences.windows(2) {
+		assert_eq!(win[1], win[0] + 1, "subsequent groups should auto-increment");
+	}
 }
 
 /// E2E test: publish via the fMP4 importer, subscribe to the MSF catalog track,

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -389,6 +389,17 @@ impl Import {
 		Ok(())
 	}
 
+	/// Close the current group on every track and open the next one at `sequence`.
+	///
+	/// Broadcast-wide: every track inside this MKV import advances together; per-track
+	/// control is intentionally not exposed.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		for track in self.tracks.values_mut() {
+			track.track.seek(sequence)?;
+		}
+		Ok(())
+	}
+
 	/// Finish all tracks, flushing current groups.
 	pub fn finish(&mut self) -> anyhow::Result<()> {
 		for track in self.tracks.values_mut() {

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -33,6 +33,10 @@ pub struct Producer<C: Container> {
 	buffer: Vec<Frame>,
 
 	latency: std::time::Duration,
+
+	/// Sequence to use for the next group opened by [`Self::write`].
+	/// Set by [`Self::seek`] and consumed on the next group creation.
+	pending_sequence: Option<u64>,
 }
 
 impl<C: Container> Producer<C> {
@@ -44,6 +48,7 @@ impl<C: Container> Producer<C> {
 			group: None,
 			buffer: Vec::new(),
 			latency: std::time::Duration::ZERO,
+			pending_sequence: None,
 		}
 	}
 
@@ -80,7 +85,10 @@ impl<C: Container> Producer<C> {
 			if !frame.keyframe {
 				return Err(moq_net::Error::ProtocolViolation.into());
 			}
-			self.group = Some(self.inner.append_group()?);
+			self.group = Some(match self.pending_sequence.take() {
+				Some(sequence) => self.inner.create_group(moq_net::Group { sequence })?,
+				None => self.inner.append_group()?,
+			});
 		}
 
 		// Buffer or write the frame.
@@ -112,6 +120,16 @@ impl<C: Container> Producer<C> {
 		if let Some(mut group) = self.group.take() {
 			group.finish()?;
 		}
+		Ok(())
+	}
+
+	/// Close the current group (if any) and open the next group at the given sequence.
+	///
+	/// The next [`write`](Self::write) must be a keyframe and will land in a group with
+	/// `sequence`. Useful for joining mid-stream or signalling a discontinuity.
+	pub fn seek(&mut self, sequence: u64) -> Result<(), C::Error> {
+		self.finish_group()?;
+		self.pending_sequence = Some(sequence);
 		Ok(())
 	}
 
@@ -222,5 +240,44 @@ mod tests {
 
 		let err = producer.write(frame(0, false)).unwrap_err();
 		assert!(matches!(err, crate::Error::Moq(moq_net::Error::ProtocolViolation)));
+	}
+
+	/// Drain all groups from a finished track, returning their sequence numbers.
+	async fn collect_sequences(mut consumer: moq_net::TrackConsumer) -> Vec<u64> {
+		let mut sequences = Vec::new();
+		while let Some(group) = consumer.recv_group().await.unwrap() {
+			sequences.push(group.sequence);
+		}
+		sequences
+	}
+
+	/// `seek(n)` opens the next group at sequence `n`.
+	#[tokio::test]
+	async fn seek_uses_explicit_sequence() {
+		let track = moq_net::Track::new("test").produce();
+		let consumer = track.consume();
+		let mut producer = Producer::new(track, Container::Legacy);
+
+		producer.write(frame(0, true)).unwrap(); // seq 0
+		producer.seek(42).unwrap();
+		producer.write(frame(10_000, true)).unwrap(); // seq 42
+		producer.finish().unwrap();
+
+		assert_eq!(collect_sequences(consumer).await, vec![0, 42]);
+	}
+
+	/// `seek` is consumed on the next group creation; subsequent groups auto-increment from there.
+	#[tokio::test]
+	async fn seek_clears_pending_after_use() {
+		let track = moq_net::Track::new("test").produce();
+		let consumer = track.consume();
+		let mut producer = Producer::new(track, Container::Legacy);
+
+		producer.seek(5).unwrap();
+		producer.write(frame(0, true)).unwrap(); // seq 5
+		producer.write(frame(10_000, true)).unwrap(); // seq 6 (auto-incremented)
+		producer.finish().unwrap();
+
+		assert_eq!(collect_sequences(consumer).await, vec![5, 6]);
 	}
 }

--- a/rs/moq-mux/src/import.rs
+++ b/rs/moq-mux/src/import.rs
@@ -172,6 +172,19 @@ impl Framed {
 		}
 	}
 
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		match self.decoder {
+			FramedKind::H264(ref mut decoder) => decoder.seek(sequence),
+			FramedKind::Fmp4(ref mut decoder) => decoder.seek(sequence),
+			FramedKind::Hev1(ref mut decoder) => decoder.seek(sequence),
+			FramedKind::Av01(ref mut decoder) => decoder.seek(sequence),
+			FramedKind::Aac(ref mut decoder) => decoder.seek(sequence),
+			FramedKind::Opus(ref mut decoder) => decoder.seek(sequence),
+			FramedKind::Mkv(ref mut decoder) => decoder.seek(sequence),
+		}
+	}
+
 	/// Return the single track produced by this importer.
 	pub fn track(&self) -> anyhow::Result<&moq_net::TrackProducer> {
 		match self.decoder {
@@ -352,6 +365,17 @@ impl Stream {
 			StreamKind::Hev1(ref mut decoder) => decoder.finish(),
 			StreamKind::Av01(ref mut decoder) => decoder.finish(),
 			StreamKind::Mkv(ref mut decoder) => decoder.finish(),
+		}
+	}
+
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		match self.decoder {
+			StreamKind::Avc3(ref mut decoder) => decoder.seek(sequence),
+			StreamKind::Fmp4(ref mut decoder) => decoder.seek(sequence),
+			StreamKind::Hev1(ref mut decoder) => decoder.seek(sequence),
+			StreamKind::Av01(ref mut decoder) => decoder.seek(sequence),
+			StreamKind::Mkv(ref mut decoder) => decoder.seek(sequence),
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds `seek(sequence: u64)` to every `moq-mux` importer (and to the underlying `container::Producer<C>`) so callers can open the next group at an explicit sequence instead of always starting at 0. Useful for joining mid-stream and signalling discontinuities.

Default auto-rotate behavior (video → new group on keyframe, AAC/Opus → one frame per group, fMP4 → new group when a `traf` contains a sync sample) is unchanged when `seek` is not invoked, so existing callers (moq-cli, moq-gst, libmoq, moq-ffi, moq-boy, hang) are unaffected.

The standalone AAC/Opus "one-frame-per-group" finalize stays as-is for now. A multi-frame-per-group knob for LL-HLS-style import was discussed and deferred; `seek` alone solves the join/discontinuity case.

## How it works

- `container::Producer<C>` gains a `pending_sequence: Option<u64>` field. `seek(n)` flushes + finishes the current group and stores `Some(n)`. The next `write` opens the new group via `TrackProducer::create_group(Group { sequence: n })` instead of `append_group()`, then clears the pending slot so subsequent groups auto-increment from `n`.
- Codec importers (`h264`, `h265`, `av1`, `aac`, `opus`) forward `seek` to their inner `container::Producer`.
- `container::fmp4::Import` and `container::mkv::Import` fan `seek` out across every per-track entry so all renditions advance together. (Broadcast-wide by design; per-track control intentionally not exposed.)
- `import::Framed` and `import::Stream` dispatchers forward to the contained importer.

## Test plan

- [x] `cargo test -p moq-mux` (144/144 passing, including 2 new unit tests on `container::Producer` and 1 new end-to-end test on `fmp4::Import`).
- [x] `cargo check --all-targets --workspace` (excluding `moq-boy`/`moq-gst` which need system ffmpeg/gstreamer in this sandbox).
- [x] `cargo clippy --all-targets --workspace -- -D warnings` (same exclusions).
- [x] `cargo fmt --all --check`.

(Written by Claude)

https://claude.ai/code/session_01E5uGooj9DFQm7Hc1fy9PYL

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5uGooj9DFQm7Hc1fy9PYL)_