### PR TITLE
moq-net: add Lite05Wip version variant (unadvertised)

### DIFF
--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -3,6 +3,9 @@ export const Version = {
 	DRAFT_02: 0xff0dad02,
 	DRAFT_03: 0xff0dad03,
 	DRAFT_04: 0xff0dad04,
+	/// Work-in-progress placeholder for lite-05. Not advertised as a
+	/// WebTransport subprotocol; callers must opt in explicitly.
+	DRAFT_05_WIP: 0xff0dad05,
 } as const;
 
 export type Version = (typeof Version)[keyof typeof Version];
@@ -17,11 +20,16 @@ export const ALPN_03 = "moq-lite-03";
 /// The ALPN string for Draft04, which uses ALPN-based version negotiation.
 export const ALPN_04 = "moq-lite-04";
 
+/// The ALPN string for the work-in-progress Draft05. Intentionally not
+/// included in the default WebTransport `protocols` list.
+export const ALPN_05_WIP = "moq-lite-05-wip";
+
 const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_01]: "moq-lite-01",
 	[Version.DRAFT_02]: "moq-lite-02",
 	[Version.DRAFT_03]: "moq-lite-03",
 	[Version.DRAFT_04]: "moq-lite-04",
+	[Version.DRAFT_05_WIP]: "moq-lite-05-wip",
 };
 
 export function versionName(v: Version): string {

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, Error, NEGOTIATED,
-	OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
+	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -119,6 +119,22 @@ impl Client {
 					.select(Version::Ietf(ietf::Version::Draft14))
 					.ok_or(Error::Version)?;
 				(v, v.into())
+			}
+			Some(ALPN_LITE_05_WIP) => {
+				self.versions
+					.select(Version::Lite(lite::Version::Lite05Wip))
+					.ok_or(Error::Version)?;
+
+				let recv_bw = lite::start(
+					session.clone(),
+					None,
+					self.publish.clone(),
+					self.consume.clone(),
+					self.stats.clone(),
+					lite::Version::Lite05Wip,
+				)?;
+
+				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -7,6 +7,9 @@ pub enum Version {
 	Lite02,
 	Lite03,
 	Lite04,
+	/// Work-in-progress placeholder for lite-05. Not advertised over ALPN or
+	/// included in default version sets; callers must opt in explicitly.
+	Lite05Wip,
 }
 
 impl fmt::Display for Version {
@@ -16,6 +19,7 @@ impl fmt::Display for Version {
 			Self::Lite02 => write!(f, "moq-lite-02"),
 			Self::Lite03 => write!(f, "moq-lite-03"),
 			Self::Lite04 => write!(f, "moq-lite-04"),
+			Self::Lite05Wip => write!(f, "moq-lite-05-wip"),
 		}
 	}
 }
@@ -27,6 +31,7 @@ impl From<Version> for crate::Version {
 			Version::Lite02 => crate::Version::Lite(Version::Lite02),
 			Version::Lite03 => crate::Version::Lite(Version::Lite03),
 			Version::Lite04 => crate::Version::Lite(Version::Lite04),
+			Version::Lite05Wip => crate::Version::Lite(Version::Lite05Wip),
 		}
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, Error, NEGOTIATED,
-	OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
+	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -118,6 +118,22 @@ impl Server {
 					.select(Version::Ietf(ietf::Version::Draft14))
 					.ok_or(Error::Version)?;
 				(v, v.into())
+			}
+			Some(ALPN_LITE_05_WIP) => {
+				self.versions
+					.select(Version::Lite(lite::Version::Lite05Wip))
+					.ok_or(Error::Version)?;
+
+				let recv_bw = lite::start(
+					session.clone(),
+					None,
+					self.publish.clone(),
+					self.consume.clone(),
+					self.stats.clone(),
+					lite::Version::Lite05Wip,
+				)?;
+
+				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions

--- a/rs/moq-net/src/setup.rs
+++ b/rs/moq-net/src/setup.rs
@@ -76,9 +76,7 @@ impl SetupVersion {
 			Version::Ietf(ietf::Version::Draft15) | Version::Ietf(ietf::Version::Draft16) => Self::Draft15Plus,
 			Version::Ietf(ietf::Version::Draft17) | Version::Ietf(ietf::Version::Draft18) => Self::Modern,
 			Version::Lite(lite::Version::Lite01) | Version::Lite(lite::Version::Lite02) => Self::LiteLegacy,
-			Version::Lite(lite::Version::Lite03 | lite::Version::Lite04 | lite::Version::Lite05Wip) => {
-				Self::Unsupported
-			}
+			Version::Lite(_) => Self::Unsupported,
 		}
 	}
 }

--- a/rs/moq-net/src/setup.rs
+++ b/rs/moq-net/src/setup.rs
@@ -76,7 +76,9 @@ impl SetupVersion {
 			Version::Ietf(ietf::Version::Draft15) | Version::Ietf(ietf::Version::Draft16) => Self::Draft15Plus,
 			Version::Ietf(ietf::Version::Draft17) | Version::Ietf(ietf::Version::Draft18) => Self::Modern,
 			Version::Lite(lite::Version::Lite01) | Version::Lite(lite::Version::Lite02) => Self::LiteLegacy,
-			Version::Lite(lite::Version::Lite03 | lite::Version::Lite04) => Self::Unsupported,
+			Version::Lite(lite::Version::Lite03 | lite::Version::Lite04 | lite::Version::Lite05Wip) => {
+				Self::Unsupported
+			}
 		}
 	}
 }

--- a/rs/moq-net/src/version.rs
+++ b/rs/moq-net/src/version.rs
@@ -15,6 +15,10 @@ pub(crate) const NEGOTIATED: [Version; 3] = [
 ];
 
 /// ALPN strings for supported versions.
+///
+/// Intentionally excludes `ALPN_LITE_05_WIP`: lite-05 is still work-in-progress
+/// and must not be advertised by default. Callers can opt in by including
+/// `Version::Lite(lite::Version::Lite05Wip)` in their [`Versions`] explicitly.
 pub const ALPNS: &[&str] = &[
 	ALPN_LITE_04,
 	ALPN_LITE_03,
@@ -30,6 +34,7 @@ pub const ALPNS: &[&str] = &[
 pub(crate) const ALPN_LITE: &str = "moql";
 pub(crate) const ALPN_LITE_03: &str = "moq-lite-03";
 pub(crate) const ALPN_LITE_04: &str = "moq-lite-04";
+pub(crate) const ALPN_LITE_05_WIP: &str = "moq-lite-05-wip";
 pub(crate) const ALPN_14: &str = "moq-00";
 pub(crate) const ALPN_15: &str = "moqt-15";
 pub(crate) const ALPN_16: &str = "moqt-16";
@@ -52,6 +57,7 @@ impl Version {
 			0xff0dad02 => Some(Self::Lite(lite::Version::Lite02)),
 			0xff0dad03 => Some(Self::Lite(lite::Version::Lite03)),
 			0xff0dad04 => Some(Self::Lite(lite::Version::Lite04)),
+			0xff0dad05 => Some(Self::Lite(lite::Version::Lite05Wip)),
 			0xff00000e => Some(Self::Ietf(ietf::Version::Draft14)),
 			0xff00000f => Some(Self::Ietf(ietf::Version::Draft15)),
 			0xff000010 => Some(Self::Ietf(ietf::Version::Draft16)),
@@ -68,6 +74,7 @@ impl Version {
 			Self::Lite(lite::Version::Lite02) => 0xff0dad02,
 			Self::Lite(lite::Version::Lite03) => 0xff0dad03,
 			Self::Lite(lite::Version::Lite04) => 0xff0dad04,
+			Self::Lite(lite::Version::Lite05Wip) => 0xff0dad05,
 			Self::Ietf(ietf::Version::Draft14) => 0xff00000e,
 			Self::Ietf(ietf::Version::Draft15) => 0xff00000f,
 			Self::Ietf(ietf::Version::Draft16) => 0xff000010,
@@ -85,6 +92,7 @@ impl Version {
 			ALPN_LITE => None, // Multiple versions share this ALPN, need SETUP negotiation
 			ALPN_LITE_03 => Some(Self::Lite(lite::Version::Lite03)),
 			ALPN_LITE_04 => Some(Self::Lite(lite::Version::Lite04)),
+			ALPN_LITE_05_WIP => Some(Self::Lite(lite::Version::Lite05Wip)),
 			ALPN_14 => Some(Self::Ietf(ietf::Version::Draft14)),
 			ALPN_15 => Some(Self::Ietf(ietf::Version::Draft15)),
 			ALPN_16 => Some(Self::Ietf(ietf::Version::Draft16)),
@@ -97,6 +105,7 @@ impl Version {
 	/// Returns the ALPN string for this version.
 	pub fn alpn(&self) -> &'static str {
 		match self {
+			Self::Lite(lite::Version::Lite05Wip) => ALPN_LITE_05_WIP,
 			Self::Lite(lite::Version::Lite04) => ALPN_LITE_04,
 			Self::Lite(lite::Version::Lite03) => ALPN_LITE_03,
 			Self::Lite(lite::Version::Lite01 | lite::Version::Lite02) => ALPN_LITE,
@@ -152,6 +161,7 @@ impl FromStr for Version {
 			"moq-lite-02" => Ok(Self::Lite(lite::Version::Lite02)),
 			"moq-lite-03" => Ok(Self::Lite(lite::Version::Lite03)),
 			"moq-lite-04" => Ok(Self::Lite(lite::Version::Lite04)),
+			"moq-lite-05-wip" => Ok(Self::Lite(lite::Version::Lite05Wip)),
 			"moq-transport-14" => Ok(Self::Ietf(ietf::Version::Draft14)),
 			"moq-transport-15" => Ok(Self::Ietf(ietf::Version::Draft15)),
 			"moq-transport-16" => Ok(Self::Ietf(ietf::Version::Draft16)),


### PR DESCRIPTION
## Summary

- Adds a work-in-progress `Lite05Wip` variant to `lite::Version` (Rust) and `DRAFT_05_WIP` to the JS lite `Version` so future feature work can branch on moq-lite-05.
- Reserves wire code `0xff0dad05` and the ALPN string `moq-lite-05-wip` in both Rust and JS, plus name/`FromStr`/`from_code`/`from_alpn`/`alpn` round-trips.
- Updates the exhaustive `SetupVersion::from_version` match in `rs/moq-net/src/setup.rs` to put `Lite05Wip` in `Unsupported` (same as Lite03/Lite04: no legacy SETUP message).
- Adds `ALPN_LITE_05_WIP` arms in `rs/moq-net/src/{server,client}.rs` so explicit opt-in works end-to-end if someone bumps the ALPN list.

## Why

We want to start landing moq-lite-05 features (gated `match version` arms in encoders/decoders) without exposing the version on the wire yet. Keeping the variant in the codebase but excluding it from `ALPNS` and `Versions::all()` lets that work compile and run in tests without changing default server/client behavior.

## Not advertised

Deliberately omitted (per the \"don't advertise as ALPN\" intent):

- `pub const ALPNS` in `rs/moq-net/src/version.rs` (the QUIC/TLS ALPN list)
- `Versions::all()` (the default version set used for SETUP/ALPN negotiation)
- The WebTransport `protocols` list in `js/net/src/connection/connect.ts`

A doc comment on `ALPNS` calls out the omission so the next reader doesn't \"fix\" it.

All existing per-version `match` arms in `rs/moq-net/src/lite/` and `js/net/src/lite/` already use `_`/`default:` fallthroughs that target the newest behavior, so `Lite05Wip` naturally inherits Lite04-style probe/goaway/hop chain semantics until divergence starts.

## Test plan

- [x] `cargo test -p moq-net` — 327 passed
- [x] `cargo test -p moq-native` — 51 passed (ALPN integration tests still negotiate the existing versions, no new lite-05 path leaks into defaults)
- [x] `just check` — green (rustfmt, clippy `-D warnings`, rustdoc `-D warnings`, biome, JS tests)

(Written by Claude)