### PR TITLE
moq-ffi: bump to 0.2.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "moq-ffi"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bytes",
  "hang",

--- a/rs/moq-ffi/CHANGELOG.md
+++ b/rs/moq-ffi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.15](https://github.com/moq-dev/moq/compare/moq-ffi-v0.2.14...moq-ffi-v0.2.15) - 2026-05-27
+
+### Other
+
+- moq-mux: add seek(sequence) on importers for explicit group boundaries ([#1515](https://github.com/moq-dev/moq/pull/1515))
+- moq-net: add Lite05Wip version variant (unadvertised) ([#1518](https://github.com/moq-dev/moq/pull/1518))
+
 ## [0.2.14](https://github.com/moq-dev/moq/compare/moq-ffi-v0.2.13...moq-ffi-v0.2.14) - 2026-05-25
 
 ### Other

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>", "Brian Medley <bpm@bmedley.org>"
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]


### PR DESCRIPTION
## Summary

Bumps `moq-ffi` to 0.2.15 so the Swift/Kotlin/Go release pipelines pick up:

- moq-net: add `Lite05Wip` version variant (unadvertised) ([#1518](https://github.com/moq-dev/moq/pull/1518))
- moq-mux: add `seek(sequence)` on importers for explicit group boundaries ([#1515](https://github.com/moq-dev/moq/pull/1515))

## Test plan

- [x] `cargo check -p moq-ffi`
- [ ] CI green, then tag `moq-ffi-v0.2.15` to fan out to Swift/Kotlin/Go mirror repos

(Written by Claude)