### PR TITLE
moq-net: cap frame size at 16 MiB on the receive path

### DIFF
--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -86,6 +86,10 @@ pub enum Error {
 	#[error("cache full")]
 	CacheFull,
 
+	/// A frame declared a payload size larger than the receiver accepts.
+	#[error("frame too large")]
+	FrameTooLarge,
+
 	/// A remote error received via a stream/session reset code.
 	#[error("remote error: code={0}")]
 	Remote(u32),
@@ -118,6 +122,7 @@ impl Error {
 			Self::Dropped => 24,
 			Self::Closed => 25,
 			Self::CacheFull => 26,
+			Self::FrameTooLarge => 27,
 			Self::App(app) => *app as u32 + 64,
 			Self::Remote(code) => *code,
 		}

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, hash_map::Entry};
 
 use crate::{
-	Broadcast, BroadcastDynamic, Error, Frame, FrameProducer, Group, GroupProducer, OriginProducer, Path, PathOwned,
-	Track, TrackProducer,
+	Broadcast, BroadcastDynamic, Error, Frame, FrameProducer, Group, GroupProducer, MAX_FRAME_SIZE, OriginProducer,
+	Path, PathOwned, Track, TrackProducer,
 	coding::{Reader, Stream},
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
 	model::BroadcastProducer,
@@ -744,6 +744,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					return Err(Error::Unsupported);
 				}
 			} else {
+				if size > MAX_FRAME_SIZE {
+					tracing::debug!(%size, max = %MAX_FRAME_SIZE, "frame size exceeds limit");
+					return Err(Error::WrongSize);
+				}
 				let mut frame = producer.create_frame(Frame { size })?;
 
 				if let Err(err) = self.run_frame(stream, frame.clone()).await {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -745,8 +745,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				}
 			} else {
 				if size > MAX_FRAME_SIZE {
-					tracing::debug!(%size, max = %MAX_FRAME_SIZE, "frame size exceeds limit");
-					return Err(Error::WrongSize);
+					return Err(Error::FrameTooLarge);
 				}
 				let mut frame = producer.create_frame(Frame { size })?;
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -458,8 +458,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	) -> Result<(), Error> {
 		while let Some(size) = stream.decode_maybe::<u64>().await? {
 			if size > MAX_FRAME_SIZE {
-				tracing::debug!(%size, max = %MAX_FRAME_SIZE, "frame size exceeds limit");
-				return Err(Error::WrongSize);
+				return Err(Error::FrameTooLarge);
 			}
 			let mut frame = group.create_frame(Frame { size })?;
 			track_stats.frame();

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -7,7 +7,7 @@ use futures::{StreamExt, stream::FuturesUnordered};
 
 use crate::{
 	AsPath, BandwidthProducer, Broadcast, BroadcastDynamic, Error, Frame, FrameProducer, Group, GroupProducer,
-	OriginProducer, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer,
+	MAX_FRAME_SIZE, OriginProducer, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer,
 	coding::{Reader, Stream},
 	lite,
 	model::BroadcastProducer,
@@ -457,6 +457,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		track_stats: Arc<SubscriberTrack>,
 	) -> Result<(), Error> {
 		while let Some(size) = stream.decode_maybe::<u64>().await? {
+			if size > MAX_FRAME_SIZE {
+				tracing::debug!(%size, max = %MAX_FRAME_SIZE, "frame size exceeds limit");
+				return Err(Error::WrongSize);
+			}
 			let mut frame = group.create_frame(Frame { size })?;
 			track_stats.frame();
 

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -7,6 +7,13 @@ use bytes::{BufMut, Bytes};
 
 use crate::{Error, Result};
 
+/// Maximum payload size accepted for a single frame on the wire.
+///
+/// The receive path preallocates a buffer from the declared frame size, so an
+/// untrusted peer could otherwise request a multi-gigabyte allocation with a
+/// single varint. Subscribers reject frames whose declared size exceeds this.
+pub const MAX_FRAME_SIZE: u64 = 16 * 1024 * 1024;
+
 /// A chunk of data with an upfront size.
 ///
 /// Note that this is just the header.

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -16,7 +16,7 @@ use crate::{Error, Result};
 // TODO enforce this in [Frame::produce] / [FrameProducer::new] so the limit is
 // guaranteed for every caller, not just the wire decode paths. Blocked on
 // making the constructor fallible (returning [Result]), which is an API break.
-pub const MAX_FRAME_SIZE: u64 = 16 * 1024 * 1024;
+pub(crate) const MAX_FRAME_SIZE: u64 = 16 * 1024 * 1024;
 
 /// A chunk of data with an upfront size.
 ///

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -12,6 +12,10 @@ use crate::{Error, Result};
 /// The receive path preallocates a buffer from the declared frame size, so an
 /// untrusted peer could otherwise request a multi-gigabyte allocation with a
 /// single varint. Subscribers reject frames whose declared size exceeds this.
+///
+// TODO enforce this in [Frame::produce] / [FrameProducer::new] so the limit is
+// guaranteed for every caller, not just the wire decode paths. Blocked on
+// making the constructor fallible (returning [Result]), which is an API break.
 pub const MAX_FRAME_SIZE: u64 = 16 * 1024 * 1024;
 
 /// A chunk of data with an upfront size.


### PR DESCRIPTION
## Summary

Both subscribers (`lite::Subscriber` and `ietf::Subscriber`) decoded the frame size as a `u64` varint and passed it straight to `FrameBuf::new`, which does `vec[0u8; size]`. A peer could send a single varint up to `2^62-1` and force a multi-gigabyte allocation, OOM'ing the relay (or any subscriber).

Control messages were already capped at `u16::MAX` in `coding/reader.rs:104`, but data frames bypassed that. This closes the gap.

- Add `pub(crate) const MAX_FRAME_SIZE: u64 = 16 * 1024 * 1024` in `rs/moq-net/src/model/frame.rs`. TODO above it notes we'd ideally enforce this at `Frame::produce` / `FrameProducer::new`, but that needs a fallible constructor (API break).
- Add `Error::FrameTooLarge` (wire code 27) so peers see a distinct reset code from the pre-existing `WrongSize` (which is for declared-vs-actual byte mismatches).
- Reject larger frames in both `lite/subscriber.rs::run_group` and `ietf/subscriber.rs::run_group` before calling `create_frame`.

16 MiB is well above any reasonable single media sample but small enough that a malicious peer can't exhaust memory with a handful of streams.

## Test plan

- [x] `cargo check -p moq-net`
- [x] `cargo clippy -p moq-net --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moq-net`
- [x] `cargo test -p moq-net --lib` (327 passed)
- [ ] Wire-level integration test for the reject path (would need a Session mock; deferred)

(Written by Claude)