### PR TITLE
docs: route breaking changes and major features to a dev branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,16 +173,30 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 | `rs/moq-gst` | `doc/bin/gstreamer.md` |
 | `js/{watch,publish}` UI/API | `demo/web` if it consumes the API |
 
+## Branch Targeting
+
+Two long-lived branches:
+
+- **`main`**: stable. Bug fixes, small additive changes, docs, refactors that preserve public/wire behavior.
+- **`dev`**: staging branch for disruptive work. Target it for:
+  - Wire-protocol changes (anything under `rs/moq-net`, including `moq-lite` / `moq-transport` framing or draft bumps).
+  - Breaking changes to public APIs in `rs/moq-ffi`, `rs/libmoq`, `rs/moq-net`, `rs/hang`, `js/net`, `js/hang`, or any of the language wrappers under `swift/`, `kt/`, `go/`, `py/`.
+  - Catalog/container format changes in `rs/hang` or `js/hang`.
+  - Major features that need time to settle before shipping.
+
+`dev` periodically merges into `main` (or vice versa) when the batch is ready to ship. When in doubt, target `main`; reviewers will redirect to `dev` if needed. CI (`pull_request:` workflows) runs on PRs against either branch, so no extra setup is needed when you switch the base.
+
 ## Workflow
 
 When making changes to the codebase:
 
-1. Make your code changes
-2. Run `just fix` to auto-format and fix linting issues
-3. Run `just check` to verify everything passes
-4. Walk the Cross-Package Sync table; update paired packages and docs in the same PR
-5. Add tests where they're easy to write
-6. Commit and push changes
+1. Pick the base branch per [Branch Targeting](#branch-targeting) above
+2. Make your code changes
+3. Run `just fix` to auto-format and fix linting issues
+4. Run `just check` to verify everything passes
+5. Walk the Cross-Package Sync table; update paired packages and docs in the same PR
+6. Add tests where they're easy to write
+7. Commit and push changes
 
 ## PR Reviews
 


### PR DESCRIPTION
## Summary

- Add a `Branch Targeting` section to `CLAUDE.md` describing when contributors should base PRs on `main` (stable: bug fixes, small additive changes, docs, behavior-preserving refactors) vs the new `dev` branch (wire-protocol changes, breaking API changes in FFI / libmoq / moq-net / hang / language wrappers, catalog/container format changes, major features that need to settle).
- Insert a step 1 in the `Workflow` checklist so contributors pick a base branch before they start.
- `origin/dev` has been (re-)created from `origin/main` to host this staging branch.

## Why

We want a place to land disruptive work in batches without holding up small PRs against `main`, and without each disruptive PR sitting open on `main` for a long review cycle.

## CI

No workflow changes are needed. Every `pull_request:` trigger in `.github/workflows/` (`check.yml`, `moq-relay.yml`, `moq-cli.yml`, `moq-token-cli.yml`, `libmoq.yml`, `check-swift.yml`) is configured without a `branches:` filter, so PRs targeting `dev` already run the same CI as PRs targeting `main`. The only branch-scoped triggers are `push: branches: [main]` on `release-rs.yml` and `release-js.yml` (release-plz), which intentionally stay scoped to `main`.

## Test plan

- [ ] Open a throwaway PR against `dev` and confirm `check`, path-filtered Rust workflows, and `check-swift` all fire as expected.
- [ ] Confirm `release-rs.yml` / `release-js.yml` do not fire on pushes to `dev`.

(Written by Claude)