### PR TITLE
moq-relay: stop downgrading WebSocket clients to moq-lite-02

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,6 +3856,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "url",
+ "web-transport-trait",
  "wiremock",
 ]
 

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -630,3 +630,153 @@ async fn broadcast_websocket_fallback() {
 		.expect("server task panicked")
 		.expect("server task failed");
 }
+
+// ── ALPN regression guards ──────────────────────────────────────────
+
+/// The newest moq-lite version both sides advertise by default.
+///
+/// Bump this whenever [`moq_net::Versions::all`] gains a newer Lite variant
+/// so the regression tests below keep tracking "the newest", not a frozen value.
+const NEWEST_LITE: &str = "moq-lite-04";
+
+/// Regression guard for the WebSocket ALPN path. Lite02 over WebSocket means
+/// the qmux subprotocol negotiation produced a bare `moql` (or no match)
+/// instead of `moq-lite-04`, which falls through to legacy SETUP negotiation
+/// and picks Lite02. This test fails immediately if that happens.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_websocket_uses_newest_version() {
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	let mut track = broadcast
+		.create_track(Track::new("video"))
+		.expect("failed to create track");
+	let mut group = track.append_group().expect("failed to append group");
+	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.finish().expect("failed to finish group");
+
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some("[::]:0".to_string());
+	server_config.tls.generate = vec!["localhost".into()];
+
+	let ws_listener = moq_native::WebSocketListener::bind("[::]:0".parse().unwrap())
+		.await
+		.expect("failed to bind WebSocket listener");
+	let ws_addr = ws_listener.local_addr().expect("failed to get ws addr");
+
+	let mut server = server_config
+		.init()
+		.expect("failed to init server")
+		.with_websocket(Some(ws_listener));
+
+	let sub_origin = Origin::random().produce();
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	client_config.websocket.delay = None;
+
+	let client = client_config.init().expect("failed to init client");
+	let url: url::Url = format!("ws://localhost:{}", ws_addr.port()).parse().unwrap();
+
+	let expected_version: moq_net::Version = NEWEST_LITE.parse().expect("invalid version");
+
+	let server_handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("no incoming connection");
+		assert_eq!(request.transport(), "websocket");
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		assert_eq!(session.version(), expected_version, "server negotiated stale version");
+		let _broadcast = broadcast;
+		let _track = track;
+		let _ = session.closed().await;
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let client = client.with_consume(sub_origin);
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+		.await
+		.expect("client connect timed out")
+		.expect("client connect failed");
+
+	assert_eq!(session.version(), expected_version, "client negotiated stale version");
+
+	drop(session);
+	server_handle
+		.await
+		.expect("server task panicked")
+		.expect("server task failed");
+}
+
+/// Regression guard for the QUIC vs WebSocket race. With both transports
+/// reachable at the same URL, QUIC must win, since it's lower-latency and
+/// has direct ALPN negotiation. A WebSocket win here means QUIC silently
+/// regressed (and would also tend to drag the version down to Lite02 on
+/// older relays). We bind WebSocket TCP and QUIC UDP to the same port,
+/// then disable the head start so the race is genuine.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_race_quic_wins() {
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	let mut track = broadcast
+		.create_track(Track::new("video"))
+		.expect("failed to create track");
+	let mut group = track.append_group().expect("failed to append group");
+	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.finish().expect("failed to finish group");
+
+	// Bind WebSocket TCP first to pick a random port, then bind QUIC UDP to
+	// the same port. UDP and TCP live in separate kernel namespaces, so this
+	// works on every supported platform.
+	let ws_listener = moq_native::WebSocketListener::bind("[::]:0".parse().unwrap())
+		.await
+		.expect("failed to bind WebSocket listener");
+	let port = ws_listener.local_addr().expect("failed to get ws addr").port();
+
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some(format!("[::]:{port}"));
+	server_config.tls.generate = vec!["localhost".into()];
+
+	let mut server = server_config
+		.init()
+		.expect("failed to init server")
+		.with_websocket(Some(ws_listener));
+
+	let sub_origin = Origin::random().produce();
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	// Zero head start: QUIC has to win on its own merit, not by penalising WS.
+	client_config.websocket.delay = None;
+
+	let client = client_config.init().expect("failed to init client");
+	let url: url::Url = format!("https://localhost:{port}").parse().unwrap();
+
+	let expected_version: moq_net::Version = NEWEST_LITE.parse().expect("invalid version");
+
+	let server_handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("no incoming connection");
+		assert_eq!(
+			request.transport(),
+			"quic",
+			"QUIC lost the race to WebSocket with both reachable",
+		);
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		assert_eq!(session.version(), expected_version, "server negotiated stale version");
+		let _broadcast = broadcast;
+		let _track = track;
+		let _ = session.closed().await;
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let client = client.with_consume(sub_origin);
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+		.await
+		.expect("client connect timed out")
+		.expect("client connect failed");
+
+	assert_eq!(session.version(), expected_version, "client negotiated stale version");
+
+	drop(session);
+	server_handle
+		.await
+		.expect("server task panicked")
+		.expect("server task failed");
+}

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -64,4 +64,5 @@ sd-notify = "0.5"
 [dev-dependencies]
 rcgen = "0.13"
 tempfile = "3"
+web-transport-trait = { workspace = true }
 wiremock = "0.6"

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -187,47 +187,62 @@ mod tests {
 	// Brings `qmux::Session::protocol` and `::closed` into scope.
 	use web_transport_trait::Session as _;
 
+	/// The newest moq ALPN both sides agree on. Derived from the same source
+	/// of truth that `supported_subprotocols` and `qmux::Client::with_protocols`
+	/// consume, so adding a new ALPN doesn't break these tests independently
+	/// of the production logic.
+	fn newest_moq_alpn() -> &'static str {
+		moq_net::ALPNS.first().copied().expect("moq_net::ALPNS is empty")
+	}
+
+	fn preferred_qmux_prefix() -> &'static str {
+		qmux::PREFIXES.first().copied().expect("qmux::PREFIXES is empty")
+	}
+
 	#[test]
 	fn supported_subprotocols_lists_full_matrix() {
 		let list = supported_subprotocols();
 
 		// Newest moq ALPN under the preferred prefix must come first so axum
 		// picks it whenever the client offers it.
-		assert_eq!(list.first().map(String::as_str), Some("qmux-00.moq-lite-04"));
+		let expected_first = format!("{}{}", preferred_qmux_prefix(), newest_moq_alpn());
+		assert_eq!(list.first().map(String::as_str), Some(expected_first.as_str()));
 
 		// Every moq ALPN must appear under every qmux prefix.
-		for &alpn in moq_net::ALPNS {
-			assert!(list.contains(&format!("qmux-00.{alpn}")), "missing qmux-00.{alpn}");
-			assert!(
-				list.contains(&format!("webtransport.{alpn}")),
-				"missing webtransport.{alpn}"
-			);
+		for &prefix in qmux::PREFIXES {
+			for &alpn in moq_net::ALPNS {
+				let entry = format!("{prefix}{alpn}");
+				assert!(list.contains(&entry), "missing {entry}");
+			}
 		}
 
 		// Bare qmux fallbacks must come after every versioned entry so they
 		// only win when the client offers nothing better. The buggy
-		// `["webtransport"]` advertise list would put webtransport first and
+		// `["webtransport"]` advertise list would put a bare entry first and
 		// silently downgrade modern clients to Lite02.
-		let webtransport_idx = list
-			.iter()
-			.position(|s| s == "webtransport")
-			.expect("bare webtransport missing");
 		let last_versioned_idx = list
 			.iter()
 			.rposition(|s| s.contains('.'))
 			.expect("no versioned entries");
-		assert!(
-			webtransport_idx > last_versioned_idx,
-			"bare webtransport must come after every versioned entry, got {list:?}",
-		);
+		for &bare in qmux::ALPNS {
+			let bare_idx = list
+				.iter()
+				.position(|s| s == bare)
+				.unwrap_or_else(|| panic!("missing bare fallback {bare}"));
+			assert!(
+				bare_idx > last_versioned_idx,
+				"bare {bare} must come after every versioned entry, got {list:?}",
+			);
+		}
 	}
 
 	/// End-to-end regression: connect a qmux client offering the full moq
 	/// ALPN list to an axum router that mirrors `serve_ws`'s subprotocol
-	/// wiring. Both client and server must observe `moq-lite-04` on the
-	/// resulting qmux session. A bug in `supported_subprotocols` or in the
-	/// `Bare::with_alpn` plumbing collapses this to `None` / bare
-	/// `webtransport`, and moq-net then downgrades to Lite02 via SETUP.
+	/// wiring. Both client and server must observe the newest moq ALPN
+	/// (`moq_net::ALPNS[0]`) on the resulting qmux session. A bug in
+	/// `supported_subprotocols` or in the `Bare::with_alpn` plumbing
+	/// collapses this to `None` / bare `webtransport`, and moq-net then
+	/// downgrades to Lite02 via SETUP.
 	#[tokio::test]
 	async fn axum_ws_negotiates_newest_moq_alpn() {
 		let (server_alpn_tx, server_alpn_rx) = oneshot::channel::<Option<String>>();
@@ -281,7 +296,7 @@ mod tests {
 
 		assert_eq!(
 			session.protocol(),
-			Some("moq-lite-04"),
+			Some(newest_moq_alpn()),
 			"client side should see the newest moq ALPN, got {:?}",
 			session.protocol(),
 		);
@@ -292,7 +307,7 @@ mod tests {
 			.expect("server alpn channel dropped");
 		assert_eq!(
 			server_alpn.as_deref(),
-			Some("moq-lite-04"),
+			Some(newest_moq_alpn()),
 			"server side should see the newest moq ALPN after Bare::with_alpn",
 		);
 

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -32,7 +32,11 @@ pub(crate) async fn serve_ws(
 		return Ok(landing_response());
 	};
 
-	let ws = ws.protocols(["webtransport"]);
+	// Advertise the full qmux × moq-net subprotocol matrix, with bare qmux
+	// fallbacks last. axum picks the first entry that the client also offered,
+	// so a modern client lands on `qmux-00.moq-lite-04`; old clients still
+	// match `webtransport` or `qmux-00.moql` and negotiate via SETUP.
+	let ws = ws.protocols(supported_subprotocols());
 
 	let params = AuthParams { path, jwt: query.jwt };
 	let token = if mtls.is_some() {
@@ -57,6 +61,10 @@ pub(crate) async fn serve_ws(
 	Ok(ws.on_upgrade(async move |socket| {
 		let id = state.conn_id.fetch_add(1, Ordering::Relaxed);
 
+		// Capture the negotiated subprotocol before we erase the WebSocket type
+		// in the Stream/Sink adapters; qmux needs it to derive the moq version.
+		let alpn = socket.protocol().and_then(|h| h.to_str().ok()).map(str::to_owned);
+
 		// Unfortunately, we need to convert from Axum to Tungstenite.
 		// Axum uses Tungstenite internally, but it's not exposed to avoid semvar issues.
 		let socket = socket
@@ -67,7 +75,7 @@ pub(crate) async fn serve_ws(
 				tungstenite::Error::ConnectionClosed
 			})
 			.with(tungstenite_to_axum);
-		let _ = handle_socket(id, socket, publish, subscribe, stats).await;
+		let _ = handle_socket(id, socket, alpn, publish, subscribe, stats).await;
 	}))
 }
 
@@ -75,6 +83,7 @@ pub(crate) async fn serve_ws(
 async fn handle_socket<T>(
 	_id: u64,
 	socket: T,
+	alpn: Option<String>,
 	publish: Option<OriginProducer>,
 	subscribe: Option<OriginConsumer>,
 	stats: StatsHandle,
@@ -86,8 +95,15 @@ where
 		+ Unpin
 		+ 'static,
 {
-	// Wrap the WebSocket in a WebTransport compatibility layer.
-	let ws = qmux::ws::Bare::new(socket).accept();
+	// Wrap the WebSocket in a WebTransport compatibility layer. We have to
+	// forward the negotiated subprotocol explicitly; axum performed the
+	// upgrade, so qmux can't sniff it from the handshake.
+	let bare = qmux::ws::Bare::new(socket);
+	let bare = match alpn.as_deref() {
+		Some(alpn) => bare.with_alpn(alpn),
+		None => bare,
+	};
+	let ws = bare.accept();
 	let session = moq_net::Server::new()
 		.with_publish(subscribe)
 		.with_consume(publish)
@@ -95,6 +111,27 @@ where
 		.accept(ws)
 		.await?;
 	session.closed().await.map_err(Into::into)
+}
+
+/// Subprotocols to advertise on the WebSocket upgrade.
+///
+/// Generates the cross product of `qmux::PREFIXES` × `moq_net::ALPNS`, with
+/// the bare qmux fallbacks (`qmux-00`, `webtransport`) appended last so
+/// versioned subprotocols always win the exact-string match axum performs.
+/// Without the versioned entries, axum picks bare `webtransport`, qmux can't
+/// resolve a moq version from it, and the relay silently downgrades clients
+/// to Lite02 via SETUP-based negotiation.
+fn supported_subprotocols() -> Vec<String> {
+	let mut out = Vec::with_capacity(qmux::PREFIXES.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
+	for &prefix in qmux::PREFIXES {
+		for &alpn in moq_net::ALPNS {
+			out.push(format!("{prefix}{alpn}"));
+		}
+	}
+	for &alpn in qmux::ALPNS {
+		out.push(alpn.to_string());
+	}
+	out
 }
 
 // https://github.com/tokio-rs/axum/discussions/848#discussioncomment-11443587
@@ -139,4 +176,127 @@ fn tungstenite_to_axum(
 			}
 		})
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use axum::{Router, extract::WebSocketUpgrade, routing::any};
+	use std::sync::Mutex;
+	use tokio::sync::oneshot;
+	// Brings `qmux::Session::protocol` and `::closed` into scope.
+	use web_transport_trait::Session as _;
+
+	#[test]
+	fn supported_subprotocols_lists_full_matrix() {
+		let list = supported_subprotocols();
+
+		// Newest moq ALPN under the preferred prefix must come first so axum
+		// picks it whenever the client offers it.
+		assert_eq!(list.first().map(String::as_str), Some("qmux-00.moq-lite-04"));
+
+		// Every moq ALPN must appear under every qmux prefix.
+		for &alpn in moq_net::ALPNS {
+			assert!(list.contains(&format!("qmux-00.{alpn}")), "missing qmux-00.{alpn}");
+			assert!(
+				list.contains(&format!("webtransport.{alpn}")),
+				"missing webtransport.{alpn}"
+			);
+		}
+
+		// Bare qmux fallbacks must come after every versioned entry so they
+		// only win when the client offers nothing better. The buggy
+		// `["webtransport"]` advertise list would put webtransport first and
+		// silently downgrade modern clients to Lite02.
+		let webtransport_idx = list
+			.iter()
+			.position(|s| s == "webtransport")
+			.expect("bare webtransport missing");
+		let last_versioned_idx = list
+			.iter()
+			.rposition(|s| s.contains('.'))
+			.expect("no versioned entries");
+		assert!(
+			webtransport_idx > last_versioned_idx,
+			"bare webtransport must come after every versioned entry, got {list:?}",
+		);
+	}
+
+	/// End-to-end regression: connect a qmux client offering the full moq
+	/// ALPN list to an axum router that mirrors `serve_ws`'s subprotocol
+	/// wiring. Both client and server must observe `moq-lite-04` on the
+	/// resulting qmux session. A bug in `supported_subprotocols` or in the
+	/// `Bare::with_alpn` plumbing collapses this to `None` / bare
+	/// `webtransport`, and moq-net then downgrades to Lite02 via SETUP.
+	#[tokio::test]
+	async fn axum_ws_negotiates_newest_moq_alpn() {
+		let (server_alpn_tx, server_alpn_rx) = oneshot::channel::<Option<String>>();
+		let server_alpn_tx = Arc::new(Mutex::new(Some(server_alpn_tx)));
+
+		let route = {
+			let server_alpn_tx = server_alpn_tx.clone();
+			any(move |ws: WebSocketUpgrade| {
+				let server_alpn_tx = server_alpn_tx.clone();
+				async move {
+					let ws = ws.protocols(supported_subprotocols());
+					ws.on_upgrade(move |socket| async move {
+						let alpn = socket.protocol().and_then(|h| h.to_str().ok()).map(str::to_owned);
+						let socket = socket
+							.map(axum_to_tungstenite)
+							.sink_map_err(|_| tungstenite::Error::ConnectionClosed)
+							.with(tungstenite_to_axum);
+
+						let bare = qmux::ws::Bare::new(socket);
+						let bare = match alpn.as_deref() {
+							Some(alpn) => bare.with_alpn(alpn),
+							None => bare,
+						};
+						let session = bare.accept();
+						if let Some(tx) = server_alpn_tx.lock().unwrap().take() {
+							let _ = tx.send(session.protocol().map(str::to_owned));
+						}
+						// Hold the session open so the client side stays alive
+						// long enough to observe the negotiated subprotocol.
+						let _ = session.closed().await;
+					})
+				}
+			})
+		};
+
+		let app = Router::new().route("/", route);
+
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+			.await
+			.expect("bind listener");
+		let addr = listener.local_addr().expect("local addr");
+		let server = tokio::spawn(async move {
+			axum::serve(listener, app).await.expect("axum serve");
+		});
+
+		let session = qmux::Client::new()
+			.with_protocols(moq_net::ALPNS)
+			.connect(&format!("ws://{addr}/"))
+			.await
+			.expect("qmux client connect");
+
+		assert_eq!(
+			session.protocol(),
+			Some("moq-lite-04"),
+			"client side should see the newest moq ALPN, got {:?}",
+			session.protocol(),
+		);
+
+		let server_alpn = tokio::time::timeout(std::time::Duration::from_secs(5), server_alpn_rx)
+			.await
+			.expect("server alpn channel timed out")
+			.expect("server alpn channel dropped");
+		assert_eq!(
+			server_alpn.as_deref(),
+			Some("moq-lite-04"),
+			"server side should see the newest moq ALPN after Bare::with_alpn",
+		);
+
+		drop(session);
+		server.abort();
+	}
 }

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -13,7 +13,21 @@ use moq_native::moq_net::{self, Origin, Track};
 use moq_relay::{AuthConfig, Cluster, ClusterConfig, PublicConfig, Web, WebConfig, WebState};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
-const NEWEST_LITE: &str = "moq-lite-04";
+
+/// The newest moq-lite ALPN both sides should converge on. Derived from
+/// `moq_net::ALPNS` so a future bump (e.g. lite-05 promoted out of WIP)
+/// doesn't break this test independently of the production negotiation.
+/// We filter on the `moq-lite-` prefix specifically; the relay smoke test
+/// is asserting lite behavior, not IETF moqt drafts.
+fn newest_lite_version() -> moq_net::Version {
+	moq_net::ALPNS
+		.iter()
+		.copied()
+		.find(|alpn| alpn.starts_with("moq-lite-"))
+		.expect("no moq-lite ALPN in moq_net::ALPNS")
+		.parse()
+		.expect("parse newest lite ALPN as a Version")
+}
 
 /// The shared bootstrap: stand up a relay listening on `127.0.0.1:<free-port>`
 /// with fully public auth, and return the port plus an abort handle for the
@@ -100,7 +114,7 @@ fn client() -> moq_native::Client {
 async fn relay_websocket_round_trip_uses_newest_version() {
 	let (port, web_handle) = spawn_relay().await;
 	let url: url::Url = format!("ws://127.0.0.1:{port}/smoke").parse().expect("parse url");
-	let expected_version: moq_net::Version = NEWEST_LITE.parse().expect("parse version");
+	let expected_version = newest_lite_version();
 
 	// ── publisher ───────────────────────────────────────────────────
 	let pub_origin = Origin::random().produce();

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -1,0 +1,170 @@
+//! End-to-end smoke test through a real moq-relay.
+//!
+//! Stands up the relay's actual axum + auth + cluster stack on a free port,
+//! connects a publisher and a subscriber via WebSocket, and confirms that
+//! a frame round-trips with the newest moq-lite version on both sides. The
+//! version assertion is the regression guard for the
+//! "axum-only-advertises-bare-`webtransport`" bug that silently downgraded
+//! relay clients to moq-lite-02.
+
+use std::{net::TcpListener, sync::atomic::AtomicU64, time::Duration};
+
+use moq_native::moq_net::{self, Origin, Track};
+use moq_relay::{AuthConfig, Cluster, ClusterConfig, PublicConfig, Web, WebConfig, WebState};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+const NEWEST_LITE: &str = "moq-lite-04";
+
+/// The shared bootstrap: stand up a relay listening on `127.0.0.1:<free-port>`
+/// with fully public auth, and return the port plus an abort handle for the
+/// spawned web server.
+async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
+	// Crypto provider is process-global; reinstalls after the first one are
+	// no-ops, but the test binary may run before any other moq code does.
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	// AuthConfig with public Simple([""]) lets any path through. Simple is
+	// deprecated but matches what `simple_public("")` in moq-relay's auth
+	// tests uses, and the relay still honors it.
+	#[allow(deprecated)]
+	let public = PublicConfig::Simple(vec![String::new()]);
+	let mut auth_config = AuthConfig::default();
+	auth_config.public = Some(public);
+	let auth = auth_config.init().await.expect("auth init");
+
+	let cluster = Cluster::new(ClusterConfig::default());
+
+	// moq_native::Server is needed for `tls_info`, even though we never
+	// expose HTTPS or QUIC in this test. Binding QUIC to `[::]:0` picks an
+	// unused UDP port that we ignore.
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some("[::]:0".to_string());
+	server_config.tls.generate = vec!["localhost".into()];
+	let server = server_config.init().expect("server init");
+
+	// Pick a free port for HTTP, then immediately drop the probe listener
+	// so axum_server can bind it. There's a tiny race window where the
+	// kernel could hand the same port to another process, but on localhost
+	// in a single-test process it's safe in practice.
+	let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
+	let port = probe.local_addr().expect("local addr").port();
+	drop(probe);
+
+	let mut web_config = WebConfig::default();
+	web_config.ws = true;
+	web_config.http.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
+
+	let web = Web::new(
+		WebState {
+			auth,
+			cluster,
+			tls_info: server.tls_info(),
+			conn_id: AtomicU64::new(0),
+		},
+		web_config,
+	);
+
+	let handle = tokio::spawn(async move {
+		// `Web::run` only returns on error; in tests we abort it at teardown.
+		let _ = web.run().await;
+	});
+
+	// Wait for axum_server to bind. A short poll is more reliable than a
+	// fixed sleep when CI is slow.
+	let deadline = std::time::Instant::now() + Duration::from_secs(5);
+	loop {
+		if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+			break;
+		}
+		if std::time::Instant::now() >= deadline {
+			panic!("relay http listener never became ready on port {port}");
+		}
+		tokio::time::sleep(Duration::from_millis(25)).await;
+	}
+
+	(port, handle)
+}
+
+fn client() -> moq_native::Client {
+	let mut config = moq_native::ClientConfig::default();
+	config.tls.disable_verify = Some(true);
+	// Zero head start so the WebSocket path runs immediately.
+	config.websocket.delay = None;
+	config.init().expect("client init")
+}
+
+/// Connect a publisher and a subscriber to a real relay over `ws://`, push
+/// one frame end-to-end, and assert both sides see the newest moq-lite ALPN.
+/// Regression for the `serve_ws` downgrade to Lite02.
+#[tokio::test]
+async fn relay_websocket_round_trip_uses_newest_version() {
+	let (port, web_handle) = spawn_relay().await;
+	let url: url::Url = format!("ws://127.0.0.1:{port}/smoke").parse().expect("parse url");
+	let expected_version: moq_net::Version = NEWEST_LITE.parse().expect("parse version");
+
+	// ── publisher ───────────────────────────────────────────────────
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	let mut track = broadcast.create_track(Track::new("video")).expect("create track");
+	let mut group = track.append_group().expect("append group");
+	group.write_frame(b"hello".as_ref()).expect("write frame");
+	group.finish().expect("finish group");
+
+	let pub_session = tokio::time::timeout(
+		TIMEOUT,
+		client().with_publish(pub_origin.consume()).connect(url.clone()),
+	)
+	.await
+	.expect("publisher connect timeout")
+	.expect("publisher connect failed");
+	assert_eq!(
+		pub_session.version(),
+		expected_version,
+		"publisher negotiated stale version"
+	);
+
+	// ── subscriber ──────────────────────────────────────────────────
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume();
+
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consume(sub_origin).connect(url))
+		.await
+		.expect("subscriber connect timeout")
+		.expect("subscriber connect failed");
+	assert_eq!(
+		sub_session.version(),
+		expected_version,
+		"subscriber negotiated stale version"
+	);
+
+	// ── data path ───────────────────────────────────────────────────
+	let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+		.await
+		.expect("announcement timeout")
+		.expect("origin closed");
+	// Auth root for `/smoke` is "smoke"; the broadcast "test" announces underneath.
+	assert_eq!(path.as_str(), "test");
+	let bc = bc.expect("expected announce, got unannounce");
+
+	let mut track_sub = bc.subscribe_track(&Track::new("video")).expect("subscribe_track");
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
+		.await
+		.expect("recv_group timeout")
+		.expect("recv_group failed")
+		.expect("track closed prematurely");
+	let frame = tokio::time::timeout(TIMEOUT, group_sub.read_frame())
+		.await
+		.expect("read_frame timeout")
+		.expect("read_frame failed")
+		.expect("group closed prematurely");
+	assert_eq!(&*frame, b"hello");
+
+	// Hold the producers until after data is read; dropping them earlier
+	// would close the publishing side of the broadcast.
+	drop(track);
+	drop(broadcast);
+
+	drop(pub_session);
+	drop(sub_session);
+	web_handle.abort();
+}


### PR DESCRIPTION
## Summary

Fixes the Android-side report where WebSocket clients were silently negotiated down to `moq-lite-02`. Two compounding bugs in `rs/moq-relay/src/websocket.rs::serve_ws`:

1. `ws.protocols(["webtransport"])` advertised only the bare `webtransport` subprotocol to axum. qmux clients offer the full matrix (`qmux-00.moq-lite-04`, `qmux-00.moq-lite-03`, `qmux-00.moql`, ..., `webtransport`, `webtransport.moq-lite-04`, ...). axum exact-matches and picks the bare `webtransport`, which carries no version.
2. `qmux::ws::Bare::new(socket).accept()` never forwarded the negotiated header to qmux, so even if axum *had* picked a versioned subprotocol, `qmux::Session::protocol()` would still come back `None`.

Both gaps feed into `rs/moq-net/src/server.rs`'s `Some(ALPN_LITE) | None` arm, which falls back to SETUP-based negotiation with `[Lite02, Lite01, Draft14]` and picks Lite02.

## Changes

- New `supported_subprotocols()` builds the cross product of `qmux::PREFIXES` × `moq_net::ALPNS`, with bare qmux fallbacks appended last so versioned subprotocols always win.
- The upgrade callback captures `socket.protocol()` before the Stream/Sink adapters erase the WebSocket type, then threads it into `qmux::ws::Bare::with_alpn(...)`.
- Regression tests in `rs/moq-relay/src/websocket.rs`:
  - `supported_subprotocols_lists_full_matrix` pins the list shape.
  - `axum_ws_negotiates_newest_moq_alpn` runs a minimal axum router that mirrors `serve_ws`'s subprotocol wiring, connects with a qmux client offering `moq_net::ALPNS`, and asserts both sides see `moq-lite-04`.
- New `rs/moq-relay/tests/smoke.rs` (modelled on `rs/moq-native/tests/broadcast.rs`): stands up the relay's full axum + Auth + Cluster stack on a free port with public auth, connects a publisher and subscriber via `ws://`, pushes a frame end-to-end, and asserts both sides see `moq-lite-04`. Covers the full request path (auth verify → cluster scoping → subprotocol negotiation → broadcast announce → frame delivery).
- Regression tests in `rs/moq-native/tests/broadcast.rs` (audit work that confirmed the lower layers were already correct):
  - `broadcast_websocket_uses_newest_version` — direct ws:// connect must negotiate `moq-lite-04`.
  - `broadcast_race_quic_wins` — with QUIC and WebSocket on the same port and zero head start, QUIC must still win.

## Test plan

- [x] `cargo test -p moq-relay`
- [x] `cargo test -p moq-relay --test smoke`
- [x] `cargo test -p moq-native --test broadcast`
- [x] `cargo clippy -p moq-relay --all-targets -- -D warnings`
- [x] `cargo clippy --tests -p moq-native -- -D warnings`
- [x] `cargo fmt --check`

(Written by Claude)