### PR TITLE
js/net: time out SUBSCRIBE_OK to surface browser stream-limit hangs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,16 +173,30 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 | `rs/moq-gst` | `doc/bin/gstreamer.md` |
 | `js/{watch,publish}` UI/API | `demo/web` if it consumes the API |
 
+## Branch Targeting
+
+Two long-lived branches:
+
+- **`main`**: stable. Bug fixes, small additive changes, docs, refactors that preserve public/wire behavior.
+- **`dev`**: staging branch for disruptive work. Target it for:
+  - Wire-protocol changes (anything under `rs/moq-net`, including `moq-lite` / `moq-transport` framing or draft bumps).
+  - Breaking changes to public APIs in `rs/moq-ffi`, `rs/libmoq`, `rs/moq-net`, `rs/hang`, `js/net`, `js/hang`, or any of the language wrappers under `swift/`, `kt/`, `go/`, `py/`.
+  - Catalog/container format changes in `rs/hang` or `js/hang`.
+  - Major features that need time to settle before shipping.
+
+`dev` periodically merges into `main` (or vice versa) when the batch is ready to ship. When in doubt, target `main`; reviewers will redirect to `dev` if needed. CI (`pull_request:` workflows) runs on PRs against either branch, so no extra setup is needed when you switch the base.
+
 ## Workflow
 
 When making changes to the codebase:
 
-1. Make your code changes
-2. Run `just fix` to auto-format and fix linting issues
-3. Run `just check` to verify everything passes
-4. Walk the Cross-Package Sync table; update paired packages and docs in the same PR
-5. Add tests where they're easy to write
-6. Commit and push changes
+1. Pick the base branch per [Branch Targeting](#branch-targeting) above
+2. Make your code changes
+3. Run `just fix` to auto-format and fix linting issues
+4. Run `just check` to verify everything passes
+5. Walk the Cross-Package Sync table; update paired packages and docs in the same PR
+6. Add tests where they're easy to write
+7. Commit and push changes
 
 ## PR Reviews
 

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -27,6 +27,14 @@ import { Version } from "./version.ts";
 // blocks. The timeout turns that into a clear error.
 const SUBSCRIBE_OK_TIMEOUT_MS = 10_000;
 
+// Out-parameter for #openSubscribe: lets the caller observe partial progress
+// (stream opened, trackAlias registered) so it can clean up on timeout even
+// before the setup promise settles.
+type SubscribeSetupState = {
+	stream?: Stream;
+	registeredAlias?: bigint;
+};
+
 /**
  * Handles subscribing to broadcasts using moq-transport protocol.
  * Uses the stream-per-request pattern (real bidi streams for v17, virtual for v14-v16).
@@ -199,54 +207,11 @@ export class Subscriber {
 
 		console.debug(`subscribe start: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
 
-		// Open the stream, send SUBSCRIBE, and wait for SUBSCRIBE_OK under a
-		// timeout. Capture the stream and the registered trackAlias via closure
-		// so the timeout path can clean them up if setup eventually finishes.
-		let opened: Stream | undefined;
-		let registeredAlias: bigint | undefined;
-		const setup = (async (): Promise<{ stream: Stream; alias: bigint }> => {
-			opened = await this.#session.openBi();
-
-			await opened.writer.u53(Subscribe.id);
-			const msg = new Subscribe({
-				requestId,
-				trackNamespace: broadcast,
-				trackName: request.track.name,
-				subscriberPriority: request.priority,
-			});
-			await msg.encode(opened.writer, version);
-			console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
-
-			// Pre-register with requestId so early group uni streams aren't dropped.
-			// The publisher typically uses requestId as the trackAlias.
-			this.#subscribes.set(requestId, request.track);
-			registeredAlias = requestId;
-
-			const respTypeId = await opened.reader.u53();
-			if (respTypeId !== SubscribeOk.id) {
-				let reasonPhrase = "unknown error";
-				try {
-					if (respTypeId === RequestError.id) {
-						const err =
-							version === Version.DRAFT_14
-								? await (await import("./subscribe.ts")).SubscribeError.decode(opened.reader, version)
-								: await RequestError.decode(opened.reader, version);
-						reasonPhrase = `code=${err.errorCode} reason=${err.reasonPhrase}`;
-					}
-				} catch {
-					// Decoding error response failed, use default message
-				}
-				throw new Error(`SUBSCRIBE error: ${reasonPhrase}`);
-			}
-
-			const ok = await SubscribeOk.decode(opened.reader, version);
-			if (ok.trackAlias !== requestId) {
-				this.#subscribes.delete(requestId);
-				this.#subscribes.set(ok.trackAlias, request.track);
-				registeredAlias = ok.trackAlias;
-			}
-			return { stream: opened, alias: ok.trackAlias };
-		})();
+		// Open the stream and wait for SUBSCRIBE_OK under a timeout. State
+		// flows back via `state` so the timeout path can clean up the stream
+		// and any registration if setup eventually finishes.
+		const state: SubscribeSetupState = {};
+		const setup = this.#openSubscribe(state, broadcast, request, requestId);
 
 		let stream: Stream;
 		let trackAlias: bigint;
@@ -269,16 +234,11 @@ export class Subscriber {
 			// and drop any registration so we don't leak. Cover both branches:
 			// setup may resolve late, or reject (e.g. SUBSCRIBE error) after the
 			// stream is already open.
-			setup.then(
-				() => {
-					if (registeredAlias !== undefined) this.#subscribes.delete(registeredAlias);
-					opened?.abort(e);
-				},
-				() => {
-					if (registeredAlias !== undefined) this.#subscribes.delete(registeredAlias);
-					opened?.abort(e);
-				},
-			);
+			const cleanup = () => {
+				if (state.registeredAlias !== undefined) this.#subscribes.delete(state.registeredAlias);
+				state.stream?.abort(e);
+			};
+			setup.then(cleanup, cleanup);
 			return;
 		}
 
@@ -310,6 +270,61 @@ export class Subscriber {
 		} finally {
 			this.#subscribes.delete(trackAlias);
 		}
+	}
+
+	// Opens the subscribe stream, sends SUBSCRIBE, and reads the response.
+	// `state` is populated as soon as the stream opens and again when the
+	// trackAlias is registered, so the caller can clean both up on timeout
+	// even before this promise settles.
+	async #openSubscribe(
+		state: SubscribeSetupState,
+		broadcast: Path.Valid,
+		request: TrackRequest,
+		requestId: bigint,
+	): Promise<{ stream: Stream; alias: bigint }> {
+		const version = this.#session.version;
+
+		state.stream = await this.#session.openBi();
+
+		await state.stream.writer.u53(Subscribe.id);
+		const msg = new Subscribe({
+			requestId,
+			trackNamespace: broadcast,
+			trackName: request.track.name,
+			subscriberPriority: request.priority,
+		});
+		await msg.encode(state.stream.writer, version);
+		console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+
+		// Pre-register with requestId so early group uni streams aren't dropped.
+		// The publisher typically uses requestId as the trackAlias.
+		this.#subscribes.set(requestId, request.track);
+		state.registeredAlias = requestId;
+
+		const respTypeId = await state.stream.reader.u53();
+		if (respTypeId !== SubscribeOk.id) {
+			let reasonPhrase = "unknown error";
+			try {
+				if (respTypeId === RequestError.id) {
+					const err =
+						version === Version.DRAFT_14
+							? await (await import("./subscribe.ts")).SubscribeError.decode(state.stream.reader, version)
+							: await RequestError.decode(state.stream.reader, version);
+					reasonPhrase = `code=${err.errorCode} reason=${err.reasonPhrase}`;
+				}
+			} catch {
+				// Decoding error response failed, use default message
+			}
+			throw new Error(`SUBSCRIBE error: ${reasonPhrase}`);
+		}
+
+		const ok = await SubscribeOk.decode(state.stream.reader, version);
+		if (ok.trackAlias !== requestId) {
+			this.#subscribes.delete(requestId);
+			this.#subscribes.set(ok.trackAlias, request.track);
+			state.registeredAlias = ok.trackAlias;
+		}
+		return { stream: state.stream, alias: ok.trackAlias };
 	}
 
 	/**

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -5,6 +5,7 @@ import * as Path from "../path.ts";
 import type { Reader, Stream } from "../stream.ts";
 import type { Track } from "../track.ts";
 import { error } from "../util/error.ts";
+import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
 import { Frame, type Group as GroupMessage } from "./object.ts";
 import { type Publish, PublishError } from "./publish.ts";
@@ -20,6 +21,11 @@ import {
 	UnsubscribeNamespace,
 } from "./subscribe_namespace.ts";
 import { Version } from "./version.ts";
+
+// Bound on how long stream-open plus SUBSCRIBE_OK may take. Browsers cap
+// concurrent QUIC streams (Chrome ~100); past the cap openBi() silently
+// blocks. The timeout turns that into a clear error.
+const SUBSCRIBE_OK_TIMEOUT_MS = 10_000;
 
 /**
  * Handles subscribing to broadcasts using moq-transport protocol.
@@ -193,97 +199,113 @@ export class Subscriber {
 
 		console.debug(`subscribe start: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
 
-		try {
-			const stream = await this.#session.openBi();
+		// Open the stream, send SUBSCRIBE, and wait for SUBSCRIBE_OK under a
+		// timeout. Capture the stream and the registered trackAlias via closure
+		// so the timeout path can clean them up if setup eventually finishes.
+		let opened: Stream | undefined;
+		let registeredAlias: bigint | undefined;
+		const setup = (async (): Promise<{ stream: Stream; alias: bigint }> => {
+			opened = await this.#session.openBi();
 
-			try {
-				// Write Subscribe
-				await stream.writer.u53(Subscribe.id);
-				const msg = new Subscribe({
-					requestId,
-					trackNamespace: broadcast,
-					trackName: request.track.name,
-					subscriberPriority: request.priority,
-				});
-				await msg.encode(stream.writer, version);
-				console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+			await opened.writer.u53(Subscribe.id);
+			const msg = new Subscribe({
+				requestId,
+				trackNamespace: broadcast,
+				trackName: request.track.name,
+				subscriberPriority: request.priority,
+			});
+			await msg.encode(opened.writer, version);
+			console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
 
-				// Pre-register with requestId so early group uni streams aren't dropped.
-				// The publisher typically uses requestId as the trackAlias.
-				this.#subscribes.set(requestId, request.track);
+			// Pre-register with requestId so early group uni streams aren't dropped.
+			// The publisher typically uses requestId as the trackAlias.
+			this.#subscribes.set(requestId, request.track);
+			registeredAlias = requestId;
 
-				// Read response (SubscribeOk or error)
-				const respTypeId = await stream.reader.u53();
-				if (respTypeId === SubscribeOk.id) {
-					const ok = await SubscribeOk.decode(stream.reader, version);
-					// Update registration to use the actual trackAlias from SubscribeOk
-					if (ok.trackAlias !== requestId) {
-						this.#subscribes.delete(requestId);
-						this.#subscribes.set(ok.trackAlias, request.track);
+			const respTypeId = await opened.reader.u53();
+			if (respTypeId !== SubscribeOk.id) {
+				let reasonPhrase = "unknown error";
+				try {
+					if (respTypeId === RequestError.id) {
+						const err =
+							version === Version.DRAFT_14
+								? await (await import("./subscribe.ts")).SubscribeError.decode(opened.reader, version)
+								: await RequestError.decode(opened.reader, version);
+						reasonPhrase = `code=${err.errorCode} reason=${err.reasonPhrase}`;
 					}
-					console.debug(`subscribe ok: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
-
-					try {
-						// Wait for stream close (= PublishDone) or track close (= local unsubscribe)
-						await Promise.race([stream.reader.closed, request.track.closed]);
-
-						// For v14-v16: send Unsubscribe before closing (removed in v17+)
-						if (
-							version === Version.DRAFT_14 ||
-							version === Version.DRAFT_15 ||
-							version === Version.DRAFT_16
-						) {
-							try {
-								await stream.writer.u53(Unsubscribe.id);
-								const unsub = new Unsubscribe({ requestId });
-								await unsub.encode(stream.writer, version);
-							} catch {
-								// Stream might already be closed
-							}
-						}
-
-						request.track.close();
-						stream.close();
-						console.debug(
-							`subscribe close: id=${requestId} broadcast=${broadcast} track=${request.track.name}`,
-						);
-					} finally {
-						this.#subscribes.delete(ok.trackAlias);
-					}
-				} else {
-					// Clean up pre-registered entry on error
-					this.#subscribes.delete(requestId);
-
-					// Error response
-					let reasonPhrase = "unknown error";
-					try {
-						if (respTypeId === RequestError.id) {
-							// SubscribeError (v14) or RequestError (v15+)
-							const err =
-								version === Version.DRAFT_14
-									? await (await import("./subscribe.ts")).SubscribeError.decode(
-											stream.reader,
-											version,
-										)
-									: await RequestError.decode(stream.reader, version);
-							reasonPhrase = `code=${err.errorCode} reason=${err.reasonPhrase}`;
-						}
-					} catch {
-						// Decoding error response failed, use default message
-					}
-					throw new Error(`SUBSCRIBE error: ${reasonPhrase}`);
+				} catch {
+					// Decoding error response failed, use default message
 				}
-			} catch (err) {
-				this.#subscribes.delete(requestId);
-				stream.abort(error(err));
-				throw err;
+				throw new Error(`SUBSCRIBE error: ${reasonPhrase}`);
 			}
+
+			const ok = await SubscribeOk.decode(opened.reader, version);
+			if (ok.trackAlias !== requestId) {
+				this.#subscribes.delete(requestId);
+				this.#subscribes.set(ok.trackAlias, request.track);
+				registeredAlias = ok.trackAlias;
+			}
+			return { stream: opened, alias: ok.trackAlias };
+		})();
+
+		let stream: Stream;
+		let trackAlias: bigint;
+		try {
+			const result = await withTimeout(
+				setup,
+				SUBSCRIBE_OK_TIMEOUT_MS,
+				`subscribe timed out after ${SUBSCRIBE_OK_TIMEOUT_MS}ms waiting for SUBSCRIBE_OK (browser stream limit reached?)`,
+			);
+			stream = result.stream;
+			trackAlias = result.alias;
+			console.debug(`subscribe ok: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
 		} catch (err) {
 			const e = error(err);
 			request.track.close(e);
 			console.warn(
 				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
 			);
+			// If setup eventually settles after the timeout, abort the stream
+			// and drop any registration so we don't leak.
+			setup.then(
+				() => {
+					if (registeredAlias !== undefined) this.#subscribes.delete(registeredAlias);
+					opened?.abort(e);
+				},
+				() => {
+					if (registeredAlias !== undefined) this.#subscribes.delete(registeredAlias);
+				},
+			);
+			return;
+		}
+
+		try {
+			// Wait for stream close (= PublishDone) or track close (= local unsubscribe)
+			await Promise.race([stream.reader.closed, request.track.closed]);
+
+			// For v14-v16: send Unsubscribe before closing (removed in v17+)
+			if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
+				try {
+					await stream.writer.u53(Unsubscribe.id);
+					const unsub = new Unsubscribe({ requestId });
+					await unsub.encode(stream.writer, version);
+				} catch {
+					// Stream might already be closed
+				}
+			}
+
+			request.track.close();
+			stream.close();
+			console.debug(`subscribe close: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+		} catch (err) {
+			const e = error(err);
+			request.track.close(e);
+			stream.abort(e);
+			console.warn(
+				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
+			);
+		} finally {
+			this.#subscribes.delete(trackAlias);
 		}
 	}
 

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -266,7 +266,9 @@ export class Subscriber {
 				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
 			);
 			// If setup eventually settles after the timeout, abort the stream
-			// and drop any registration so we don't leak.
+			// and drop any registration so we don't leak. Cover both branches:
+			// setup may resolve late, or reject (e.g. SUBSCRIBE error) after the
+			// stream is already open.
 			setup.then(
 				() => {
 					if (registeredAlias !== undefined) this.#subscribes.delete(registeredAlias);
@@ -274,6 +276,7 @@ export class Subscriber {
 				},
 				() => {
 					if (registeredAlias !== undefined) this.#subscribes.delete(registeredAlias);
+					opened?.abort(e);
 				},
 			);
 			return;

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -219,10 +219,11 @@ export class Subscriber {
 				`subscribe error: id=${id} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
 			);
 			// If the stream eventually opens after the timeout, abort it so we
-			// don't leak it. swallow the setup rejection either way.
+			// don't leak it. Cover both branches: setup may resolve late, or it
+			// may reject (e.g. encode/decode failure) after the stream is open.
 			setup.then(
 				() => opened?.abort(e),
-				() => void 0,
+				() => opened?.abort(e),
 			);
 			return;
 		}

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -186,22 +186,11 @@ export class Subscriber {
 
 		const msg = new Subscribe({ id, broadcast, track: request.track.name, priority: request.priority });
 
-		// Open the stream, send SUBSCRIBE, and wait for SUBSCRIBE_OK under a
-		// timeout. If we time out the underlying stream may still finish opening
-		// later, so capture it via closure and abort it once it settles.
-		let opened: Stream | undefined;
-		const setup = (async (): Promise<Stream> => {
-			opened = await Stream.open(this.#quic);
-			await opened.writer.u53(StreamId.Subscribe);
-			await msg.encode(opened.writer, this.version);
-
-			// The first response MUST be a SUBSCRIBE_OK.
-			const resp = await decodeSubscribeResponse(opened.reader, this.version);
-			if (!("ok" in resp)) {
-				throw new Error("first subscribe response must be SUBSCRIBE_OK");
-			}
-			return opened;
-		})();
+		// Open the stream and wait for SUBSCRIBE_OK under a timeout. The stream
+		// handle flows back via `state` so the timeout path can abort it if it
+		// finishes opening after the deadline.
+		const state: { stream?: Stream } = {};
+		const setup = this.#openSubscribe(state, msg);
 
 		let stream: Stream;
 		try {
@@ -222,8 +211,8 @@ export class Subscriber {
 			// don't leak it. Cover both branches: setup may resolve late, or it
 			// may reject (e.g. encode/decode failure) after the stream is open.
 			setup.then(
-				() => opened?.abort(e),
-				() => opened?.abort(e),
+				() => state.stream?.abort(e),
+				() => state.stream?.abort(e),
 			);
 			return;
 		}
@@ -257,6 +246,22 @@ export class Subscriber {
 		} finally {
 			this.#subscribes.delete(id);
 		}
+	}
+
+	// Opens the subscribe stream, sends SUBSCRIBE, and reads SUBSCRIBE_OK.
+	// `state.stream` is populated as soon as the stream opens so the caller
+	// can clean it up on timeout even before this promise settles.
+	async #openSubscribe(state: { stream?: Stream }, msg: Subscribe): Promise<Stream> {
+		state.stream = await Stream.open(this.#quic);
+		await state.stream.writer.u53(StreamId.Subscribe);
+		await msg.encode(state.stream.writer, this.version);
+
+		// The first response MUST be a SUBSCRIBE_OK.
+		const resp = await decodeSubscribeResponse(state.stream.reader, this.version);
+		if (!("ok" in resp)) {
+			throw new Error("first subscribe response must be SUBSCRIBE_OK");
+		}
+		return state.stream;
 	}
 
 	/**

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -8,6 +8,7 @@ import { type Reader, Stream } from "../stream.ts";
 import type * as Time from "../time.ts";
 import type { Track } from "../track.ts";
 import { error } from "../util/error.ts";
+import { withTimeout } from "../util/timeout.ts";
 import { Announce, AnnounceInit, AnnounceInterest } from "./announce.ts";
 import type { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
@@ -15,6 +16,11 @@ import { Probe } from "./probe.ts";
 import { StreamId } from "./stream.ts";
 import { decodeSubscribeResponse, Subscribe, SubscribeUpdate } from "./subscribe.ts";
 import { Version } from "./version.ts";
+
+// Bound on how long stream-open plus SUBSCRIBE_OK may take. Browsers cap
+// concurrent QUIC streams (Chrome ~100); past the cap createBidirectionalStream
+// silently blocks. The timeout turns that into a clear error.
+const SUBSCRIBE_OK_TIMEOUT_MS = 10_000;
 
 /**
  * Options accepted by {@link Subscriber.announced}.
@@ -180,18 +186,48 @@ export class Subscriber {
 
 		const msg = new Subscribe({ id, broadcast, track: request.track.name, priority: request.priority });
 
-		const stream = await Stream.open(this.#quic);
-		await stream.writer.u53(StreamId.Subscribe);
-		await msg.encode(stream.writer, this.version);
+		// Open the stream, send SUBSCRIBE, and wait for SUBSCRIBE_OK under a
+		// timeout. If we time out the underlying stream may still finish opening
+		// later, so capture it via closure and abort it once it settles.
+		let opened: Stream | undefined;
+		const setup = (async (): Promise<Stream> => {
+			opened = await Stream.open(this.#quic);
+			await opened.writer.u53(StreamId.Subscribe);
+			await msg.encode(opened.writer, this.version);
 
-		try {
 			// The first response MUST be a SUBSCRIBE_OK.
-			const resp = await decodeSubscribeResponse(stream.reader, this.version);
+			const resp = await decodeSubscribeResponse(opened.reader, this.version);
 			if (!("ok" in resp)) {
 				throw new Error("first subscribe response must be SUBSCRIBE_OK");
 			}
-			console.debug(`subscribe ok: id=${id} broadcast=${broadcast} track=${request.track.name}`);
+			return opened;
+		})();
 
+		let stream: Stream;
+		try {
+			stream = await withTimeout(
+				setup,
+				SUBSCRIBE_OK_TIMEOUT_MS,
+				`subscribe timed out after ${SUBSCRIBE_OK_TIMEOUT_MS}ms waiting for SUBSCRIBE_OK (browser stream limit reached?)`,
+			);
+			console.debug(`subscribe ok: id=${id} broadcast=${broadcast} track=${request.track.name}`);
+		} catch (err) {
+			const e = error(err);
+			request.track.close(e);
+			this.#subscribes.delete(id);
+			console.warn(
+				`subscribe error: id=${id} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
+			);
+			// If the stream eventually opens after the timeout, abort it so we
+			// don't leak it. swallow the setup rejection either way.
+			setup.then(
+				() => opened?.abort(e),
+				() => void 0,
+			);
+			return;
+		}
+
+		try {
 			// Watch for priority changes and send SUBSCRIBE_UPDATE. Lite01/Lite02
 			// don't carry SUBSCRIBE_UPDATE on the wire, so skip the watcher there
 			// and just wait on the stream/track like before.

--- a/js/net/src/util/index.ts
+++ b/js/net/src/util/index.ts
@@ -1,1 +1,2 @@
 export * from "./error.ts";
+export * from "./timeout.ts";

--- a/js/net/src/util/timeout.test.ts
+++ b/js/net/src/util/timeout.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { TimeoutError, withTimeout } from "./timeout.ts";
+
+test("withTimeout: resolves before deadline", async () => {
+	const result = await withTimeout(Promise.resolve(42), 100, "should not fire");
+	expect(result).toBe(42);
+});
+
+test("withTimeout: rejects with TimeoutError after deadline", async () => {
+	const pending = new Promise<number>(() => {
+		// never settles
+	});
+	await expect(withTimeout(pending, 10, "timed out")).rejects.toBeInstanceOf(TimeoutError);
+});
+
+test("withTimeout: passes through promise rejection", async () => {
+	const failure = Promise.reject(new Error("boom"));
+	await expect(withTimeout(failure, 100, "should not fire")).rejects.toThrow("boom");
+});

--- a/js/net/src/util/timeout.ts
+++ b/js/net/src/util/timeout.ts
@@ -1,0 +1,17 @@
+export class TimeoutError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "TimeoutError";
+	}
+}
+
+// Race `promise` against a timeout. There's no cancellation; if `promise`
+// settles after the timeout fires the caller is responsible for cleaning up
+// any side effects (open streams, etc.) it may produce.
+export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout>;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new TimeoutError(message)), ms);
+	});
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}


### PR DESCRIPTION
## Summary

- Wraps the open-stream + send-SUBSCRIBE + read-SUBSCRIBE_OK sequence in a 10s timeout in both the `lite` and `ietf` subscribers.
- Adds a small `withTimeout` / `TimeoutError` helper under `js/net/src/util/` (used by both subscribers; covered by unit tests).
- On timeout the track is closed with the `TimeoutError` (visible via `track.closed` / the next `readFrame` / `recvGroup` call). If the underlying stream eventually opens after the deadline, it gets aborted so it doesn't leak.

## Why

Chromium-based browsers cap concurrent QUIC streams at ~100. Past the cap, `createBidirectionalStream()` blocks silently with no error, so a subscribe sat in limbo: the track was never closed, no `SUBSCRIBE_OK` ever arrived, and the caller had no way to tell what was wrong. The 10s timeout converts that silent hang into a clear error attributed to a specific track. 10s matches the Rust side's control-stream `MAX_REQUEST_ID` timeout in `rs/moq-net/src/ietf/control.rs`.

## Design notes

- Subscribes still run in parallel within `consume()` (each request gets its own `#runSubscribe`). I considered serializing them at the `broadcast.requested()` loop so the limit surfaces on the *first* offending track rather than all hung tracks failing together, but that would add `N × RTT` startup latency for typical multi-track broadcasts (catalog + video + audio + …). If we'd rather pay that latency cost, the change is a one-liner — happy to follow up.
- No wire/API behavior changes; targeting `main` per the branch-targeting policy.

## Test plan

- [x] `just check` passes (TS, biome, all package tests)
- [x] Unit tests for `withTimeout` (resolves, rejects with `TimeoutError`, passes through rejections)
- [x] Existing `integration.test.ts` flows (lite draft-01/-02/-03, ietf draft-14/-15/-16/-17, subscribe-to-non-existent) still pass
- [ ] Manual sanity check in the browser at >100 streams (would appreciate a reviewer running this)

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)