### PR TITLE
moq-net + moq-relay: adopt @moq/qmux 0.1.1 cross-draft negotiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5298,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "qmux"
-version = "0.0.7"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a625edac9a3021654a955444ca602b7b66b6764c7372196df08af53779ffbe7"
+checksum = "0f6ead7e747d4e07101dad26119542e436ea0d633f878c8794b7da5a1cc71a9b"
 dependencies = [
  "bytes",
  "futures",
@@ -5308,7 +5308,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tracing",
  "web-transport-proto",
  "web-transport-trait",
@@ -7107,9 +7107,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -7118,19 +7118,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -7517,25 +7505,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "rustls",
- "rustls-pki-types",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -7546,6 +7515,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
 ]
@@ -7770,12 +7741,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ moq-mux = { version = "0.5", path = "rs/moq-mux" }
 moq-native = { version = "0.15", path = "rs/moq-native", default-features = false }
 moq-net = { version = "0.1", path = "rs/moq-net" }
 moq-token = { version = "0.6", path = "rs/moq-token" }
-qmux = { version = "0.0.7", default-features = false }
+qmux = { version = "0.1.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 tokio = "1.48"
 web-async = { version = "0.1.3", features = ["tracing"] }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "moq",
@@ -145,7 +144,7 @@
       "name": "@moq/net",
       "version": "0.1.1",
       "dependencies": {
-        "@moq/qmux": "^0.0.6",
+        "@moq/qmux": "^0.1.1",
         "@moq/signals": "workspace:*",
         "async-mutex": "^0.5.0",
       },
@@ -509,7 +508,7 @@
 
     "@moq/publish": ["@moq/publish@workspace:js/publish"],
 
-    "@moq/qmux": ["@moq/qmux@0.0.6", "", {}, "sha512-ISuGz05lUvf1hzHW3Aw3VnsGRJe1w9Qdog3LQ66KS+l+5mzQsPANvW8yOioEe1Z9dJO2G3sAHoGPnzwnsY9SIQ=="],
+    "@moq/qmux": ["@moq/qmux@0.1.1", "", {}, "sha512-ljrQzBiKk3/yQ1+DCmI/F24CYzfePDSt/SUVWNjdtCsOn1CO/9EXHz8CLMlaA1ZFBviAJhWxc4B0CZw6x0E1Wg=="],
 
     "@moq/signals": ["@moq/signals@workspace:js/signals"],
 

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -17,7 +17,7 @@
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {
-		"@moq/qmux": "^0.0.6",
+		"@moq/qmux": "^0.1.1",
 		"@moq/signals": "workspace:*",
 		"async-mutex": "^0.5.0"
 	},

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -1,4 +1,4 @@
-import Session from "@moq/qmux";
+import Session, { type Version as QmuxVersion } from "@moq/qmux";
 import * as Ietf from "../ietf/index.ts";
 import * as Lite from "../lite/index.ts";
 import { Stream } from "../stream.ts";
@@ -335,7 +335,29 @@ async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>):
 	const active = await Promise.race([cancel, timer.then(() => true)]);
 	if (!active) return undefined;
 
-	const quic = new Session(url);
+	// Only moq-transport-18 is pinned to qmux-01 today. Every other ALPN we
+	// support is currently negotiated as `qmux-00.{alpn}` on the wire, but we
+	// don't want to lock that in: set the value to `null` so the polyfill
+	// advertises every QMux draft it knows about and the server picks one.
+	// Insertion order is the negotiation preference on the wire.
+	const versions = {
+		[Lite.ALPN_04]: null,
+		[Lite.ALPN_03]: null,
+		[Lite.ALPN]: null,
+		[Ietf.ALPN.DRAFT_18]: "qmux-01",
+		[Ietf.ALPN.DRAFT_17]: null,
+		[Ietf.ALPN.DRAFT_16]: null,
+		[Ietf.ALPN.DRAFT_15]: null,
+	} as const satisfies Record<string, QmuxVersion | QmuxVersion[] | null>;
+
+	// `withoutProtocol` also advertises bare `qmux-01`, `qmux-00`, and
+	// `webtransport` so we still interop with relays that only know a
+	// wire-format version (today's moq-relay only accepts bare `webtransport`).
+	const quic = new Session(url, {
+		protocols: Object.keys(versions),
+		versions,
+		withoutProtocol: true,
+	});
 
 	// Wait for the WebSocket to connect, or for the cancel promise to resolve.
 	// Close the connection if we lost the race.

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -121,8 +121,13 @@ pub(crate) async fn connect(
 		tokio_tungstenite::Connector::Plain
 	};
 
+	// Each moq ALPN can ride on any QMux draft; pass `&[]` to let the polyfill
+	// expand to every QMux version it knows about. `without_protocol` also
+	// offers the bare ALPNs (`qmux-01`, `qmux-00`, `webtransport`) so we still
+	// interop with relays that only know a wire-format version.
 	let session = qmux::Client::new()
-		.with_protocols(alpns)
+		.with_protocols(alpns.iter().map(|&a| (a, &[] as &[qmux::Version])))
+		.without_protocol()
 		.with_connector(connector)
 		.connect(url.as_str())
 		.await
@@ -150,7 +155,12 @@ impl WebSocketListener {
 
 	pub async fn bind_with_alpns(addr: net::SocketAddr, alpns: &[&str]) -> anyhow::Result<Self> {
 		let listener = tokio::net::TcpListener::bind(addr).await?;
-		let server = qmux::Server::new().with_protocols(alpns);
+		// `&[]` per entry expands to every QMux draft on the wire;
+		// `without_protocol` also accepts legacy clients that only offer a
+		// bare wire-format ALPN (today's moq-net clients still do).
+		let server = qmux::Server::new()
+			.with_protocols(alpns.iter().map(|&a| (a, &[] as &[qmux::Version])))
+			.without_protocol();
 		Ok(Self { listener, server })
 	}
 

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -98,12 +98,12 @@ where
 	// Wrap the WebSocket in a WebTransport compatibility layer. We have to
 	// forward the negotiated subprotocol explicitly; axum performed the
 	// upgrade, so qmux can't sniff it from the handshake.
-	let bare = qmux::ws::Bare::new(socket);
-	let bare = match alpn.as_deref() {
-		Some(alpn) => bare.with_alpn(alpn),
-		None => bare,
+	let upgraded = qmux::ws::Upgraded::new(socket);
+	let upgraded = match alpn.as_deref() {
+		Some(alpn) => upgraded.with_alpn(alpn),
+		None => upgraded,
 	};
-	let ws = bare.accept();
+	let ws = upgraded.accept();
 	// Only set the side the token actually grants. moq-net defaults the
 	// unset side to a fresh no-op origin, which is fine for a
 	// publish-only or subscribe-only token.
@@ -118,19 +118,23 @@ where
 	session.closed().await.map_err(Into::into)
 }
 
+/// QMux wire-format versions that can ride under a `{prefix}.{alpn}` pair.
+/// Newest first so axum's exact-string match picks the freshest one.
+const QMUX_VERSIONS: &[qmux::Version] = &[qmux::Version::QMux01, qmux::Version::QMux00];
+
 /// Subprotocols to advertise on the WebSocket upgrade.
 ///
-/// Generates the cross product of `qmux::PREFIXES` × `moq_net::ALPNS`, with
-/// the bare qmux fallbacks (`qmux-00`, `webtransport`) appended last so
-/// versioned subprotocols always win the exact-string match axum performs.
-/// Without the versioned entries, axum picks bare `webtransport`, qmux can't
-/// resolve a moq version from it, and the relay silently downgrades clients
-/// to Lite02 via SETUP-based negotiation.
+/// Generates the cross product of [`QMUX_VERSIONS`] × `moq_net::ALPNS`, with
+/// the bare qmux fallbacks (`qmux-01`, `qmux-00`, `webtransport`) appended
+/// last so versioned subprotocols always win the exact-string match axum
+/// performs. Without the versioned entries, axum picks bare `webtransport`,
+/// qmux can't resolve a moq version from it, and the relay silently
+/// downgrades clients to Lite02 via SETUP-based negotiation.
 fn supported_subprotocols() -> Vec<String> {
-	let mut out = Vec::with_capacity(qmux::PREFIXES.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
-	for &prefix in qmux::PREFIXES {
+	let mut out = Vec::with_capacity(QMUX_VERSIONS.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
+	for &version in QMUX_VERSIONS {
 		for &alpn in moq_net::ALPNS {
-			out.push(format!("{prefix}{alpn}"));
+			out.push(format!("{}{alpn}", version.prefix()));
 		}
 	}
 	for &alpn in qmux::ALPNS {
@@ -201,7 +205,7 @@ mod tests {
 	}
 
 	fn preferred_qmux_prefix() -> &'static str {
-		qmux::PREFIXES.first().copied().expect("qmux::PREFIXES is empty")
+		QMUX_VERSIONS.first().expect("QMUX_VERSIONS is empty").prefix()
 	}
 
 	#[test]
@@ -213,10 +217,10 @@ mod tests {
 		let expected_first = format!("{}{}", preferred_qmux_prefix(), newest_moq_alpn());
 		assert_eq!(list.first().map(String::as_str), Some(expected_first.as_str()));
 
-		// Every moq ALPN must appear under every qmux prefix.
-		for &prefix in qmux::PREFIXES {
+		// Every moq ALPN must appear under every qmux version's prefix.
+		for &version in QMUX_VERSIONS {
 			for &alpn in moq_net::ALPNS {
-				let entry = format!("{prefix}{alpn}");
+				let entry = format!("{}{alpn}", version.prefix());
 				assert!(list.contains(&entry), "missing {entry}");
 			}
 		}
@@ -266,12 +270,12 @@ mod tests {
 							.sink_map_err(|_| tungstenite::Error::ConnectionClosed)
 							.with(tungstenite_to_axum);
 
-						let bare = qmux::ws::Bare::new(socket);
-						let bare = match alpn.as_deref() {
-							Some(alpn) => bare.with_alpn(alpn),
-							None => bare,
+						let upgraded = qmux::ws::Upgraded::new(socket);
+						let upgraded = match alpn.as_deref() {
+							Some(alpn) => upgraded.with_alpn(alpn),
+							None => upgraded,
 						};
-						let session = bare.accept();
+						let session = upgraded.accept();
 						if let Some(tx) = server_alpn_tx.lock().unwrap().take() {
 							let _ = tx.send(session.protocol().map(str::to_owned));
 						}
@@ -294,7 +298,7 @@ mod tests {
 		});
 
 		let session = qmux::Client::new()
-			.with_protocols(moq_net::ALPNS)
+			.with_protocols(moq_net::ALPNS.iter().map(|&a| (a, &[] as &[qmux::Version])))
 			.connect(&format!("ws://{addr}/"))
 			.await
 			.expect("qmux client connect");


### PR DESCRIPTION
## Summary

Adopts the redesigned `qmux` 0.1.1 (JS and Rust) API ([moq-dev/web-transport#243](https://github.com/moq-dev/web-transport/pull/243)) so a single WebSocket handshake can negotiate every QMux draft moq-net cares about.

### JS (`js/net/src/connection/connect.ts`)

Replaces the single-version fallback with `new Session(url, { protocols, versions, withoutProtocol: true })`. Today only `moq-transport-18` is pinned to `"qmux-01"`; every other ALPN maps to `null` so the polyfill advertises it under every QMux draft it knows about. `withoutProtocol: true` also offers bare `qmux-01`, `qmux-00`, `webtransport` to interop with the current relay which only accepts bare `webtransport`.

Bumps `@moq/qmux` dep range to `^0.1.1`.

### Rust (`rs/moq-relay`, `rs/moq-native`)

- `qmux::ws::Bare` → `qmux::ws::Upgraded` (rename in 0.1.0).
- `qmux::PREFIXES` was dropped in 0.1.0; iterate `[Version::QMux01, Version::QMux00]` and use `Version::prefix()` to build the relay's axum subprotocol cross-product.
- `qmux::Client::with_protocols` / `Server::with_protocols` now take `(alpn, &[Version])` entries; pass `&[]` per ALPN to expand to every QMux draft the crate knows about (mirrors JS `null`).
- Both `Client` and `Server` call `.without_protocol()` so today's `webtransport`-only clients and relays keep working.

Bumps the workspace `qmux` Rust dep to `0.1.1`.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo test -p moq-relay --all-features` (93 unit tests, 1 integration test — all pass; subprotocol matrix + axum ws negotiation regressions still cover the new code paths)
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `bunx tsc --noEmit` in `js/net`
- [ ] Manual: connect from a browser with WebTransport disabled against the current moq-relay; confirm legacy `webtransport` still works via `withoutProtocol`.
- [ ] Manual: connect from the moq-rs client to a relay configured with both qmux-00.* and qmux-01.* and confirm `moq-transport-17` (qmux-00) and `moq-transport-18` (qmux-01) both negotiate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)