### PR TITLE
Add duration-based skipping to the container jitter buffer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ match version {
 - **Error handling**: Use `thiserror` with `#[from]` for library crates, `anyhow` for binaries. Always add `#[non_exhaustive]` to public `thiserror` enums.
 - Use `anyhow::Context` (`.context("msg")`) instead of `.map_err(|_| anyhow::anyhow!("msg"))` for error conversion
 - **Config flags + TOML merge**: For any `#[arg]` field on a TOML-loadable config, use `Option<T>` (not bare `bool` / `String` / etc.). The TOML→CLI merge clobbers bare fields with their `Default` when the flag is absent, silently overwriting TOML values. See `rs/moq-relay/src/config.rs::tests` for the regression test; add one for any new flag.
+- **Optional args**: For a *public* function/builder parameter that's logically optional, take `impl Into<Option<T>>` rather than `Option<T>`. Callers pass `x` or `None` instead of wrapping every value in `Some(x)`. Convert once at the top with `let x = x.into();`. Skip it for private helpers, where the call sites are few and `Some`/`None` is clearer. See `with_fragment_duration` in `rs/moq-mux/src/container/fmp4/export.rs`.
 
 ## Comment Conventions
 

--- a/js/hang/src/container/cmaf/decode.ts
+++ b/js/hang/src/container/cmaf/decode.ts
@@ -107,6 +107,8 @@ export interface Sample {
 	timestamp: number;
 	/** Whether this is a keyframe (sync sample) */
 	keyframe: boolean;
+	/** Sample duration in microseconds (0 when the fragment doesn't carry one) */
+	duration: number;
 }
 
 // Helper to convert Uint8Array to ArrayBuffer for the library
@@ -392,6 +394,7 @@ export function decodeDataSegment(segment: Uint8Array, init: InitSegment): Sampl
 		// PTS = (decode_time + composition_offset) * 1_000_000 / timescale
 		const pts = decodeTime + compositionOffset;
 		const timestamp = Math.round((pts * 1_000_000) / init.timescale);
+		const duration = Math.round((sampleDuration * 1_000_000) / init.timescale);
 
 		// Check if keyframe (sample_is_non_sync_sample flag is bit 16)
 		// If flag is 0, treat as keyframe for safety
@@ -401,6 +404,7 @@ export function decodeDataSegment(segment: Uint8Array, init: InitSegment): Sampl
 			data,
 			timestamp,
 			keyframe,
+			duration,
 		});
 
 		decodeTime += sampleDuration;

--- a/js/hang/src/container/cmaf/format.ts
+++ b/js/hang/src/container/cmaf/format.ts
@@ -15,6 +15,7 @@ export class Format implements ContainerFormat {
 			data: s.data,
 			timestamp: s.timestamp as Time.Micro,
 			keyframe: s.keyframe,
+			duration: s.duration as Time.Micro,
 		}));
 	}
 }

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -486,3 +486,100 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 	expect(frames[1].timestamp).toBe(33_333 as Time.Micro); // 3000/90000 * 1_000_000
 	consumer.close();
 });
+
+test("CmafFormat decodes the per-sample duration", () => {
+	const format = new CmafFormat(TEST_INIT);
+	const segment = encodeDataSegment({
+		data: new Uint8Array([0xca, 0xfe]),
+		timestamp: 0,
+		duration: 3000,
+		keyframe: true,
+		sequence: 0,
+	});
+
+	const [frame] = format.decode(segment);
+	// 3000 ticks / 90000 timescale * 1_000_000 = 33333µs
+	expect(frame.duration).toBe(33_333 as Time.Micro);
+});
+
+// --- Duration skipping ---
+
+// Format whose frames carry a fixed 33ms duration; the timestamp is byte 0 (ms).
+const durationFormat: ContainerFormat = {
+	decode(frame: Uint8Array): Frame[] {
+		return [
+			{
+				data: frame,
+				timestamp: (frame[0] * 1000) as Time.Micro,
+				duration: 33_000 as Time.Micro,
+				keyframe: false,
+			},
+		];
+	},
+};
+
+test("Consumer duration-skips a stalled group once it is covered", async () => {
+	const track = new Track("test");
+	// Latency dwarfs the gap, so only duration coverage can trigger the skip.
+	const consumer = new Consumer(track, { format: durationFormat, latency: 10_000 as Time.Milli });
+
+	// Group 0: one frame at ts=0 lasting 33ms, never closed (stalled).
+	const g0 = new Group(0);
+	g0.writeFrame(new Uint8Array([0]));
+
+	// Group 1: closed, starts exactly where group 0's frame ends.
+	const g1 = new Group(1);
+	g1.writeFrame(new Uint8Array([33]));
+	g1.close();
+
+	track.writeGroup(g0);
+	track.writeGroup(g1);
+	track.close();
+
+	const frames = await drainFrames(consumer, 200);
+	expect(frames.map((f) => f.timestamp as number)).toEqual([0, 33_000]);
+	expect(frames.map((f) => f.group)).toEqual([0, 1]);
+	consumer.close();
+});
+
+test("Consumer does not duration-skip when the gap is not covered", async () => {
+	// Format whose frames last only 10ms, short of the 33ms gap to the next group.
+	const shortFormat: ContainerFormat = {
+		decode(frame: Uint8Array): Frame[] {
+			return [
+				{
+					data: frame,
+					timestamp: (frame[0] * 1000) as Time.Micro,
+					duration: 10_000 as Time.Micro,
+					keyframe: false,
+				},
+			];
+		},
+	};
+
+	const track = new Track("test");
+	const consumer = new Consumer(track, { format: shortFormat, latency: 10_000 as Time.Milli });
+
+	// Group 0 stays open and later receives a second frame; nothing covers the gap,
+	// so that late frame must survive rather than being skipped.
+	const g0 = new Group(0);
+	g0.writeFrame(new Uint8Array([0]));
+
+	const g1 = new Group(1);
+	g1.writeFrame(new Uint8Array([33]));
+	g1.close();
+
+	track.writeGroup(g0);
+	track.writeGroup(g1);
+
+	// Let the consumer settle on group 0, then extend it before closing.
+	await new Promise((resolve) => setTimeout(resolve, 20));
+	g0.writeFrame(new Uint8Array([20]));
+	g0.close();
+	track.close();
+
+	const frames = await drainFrames(consumer, 200);
+	expect(frames.map((f) => f.timestamp as number)).toEqual([0, 20_000, 33_000]);
+	expect(frames.map((f) => f.group)).toEqual([0, 0, 1]);
+	consumer.close();
+});

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -15,6 +15,7 @@ interface Group {
 	consumer: Moq.Group;
 	frames: Frame[]; // decode order
 	latest?: Time.Micro; // The timestamp of the latest known frame
+	end?: Time.Micro; // The furthest presentation point so far, i.e. max(timestamp + duration)
 	done?: boolean; // Set when #runGroup finishes reading all frames
 }
 
@@ -110,6 +111,11 @@ export class Consumer {
 						group.latest = frame.timestamp;
 					}
 
+					const end = (frame.timestamp + (frame.duration ?? 0)) as Time.Micro;
+					if (group.end === undefined || end > group.end) {
+						group.end = end;
+					}
+
 					this.#updateBuffered();
 
 					if (group.consumer.sequence === this.#active) {
@@ -118,6 +124,13 @@ export class Consumer {
 					} else {
 						// Check for latency violations if this is a newer group.
 						this.#checkLatency();
+
+						// A newer group reaching back to where the stalled active group has
+						// already presented means we can advance now instead of waiting.
+						if (this.#tryDurationSkip()) {
+							this.#notify?.();
+							this.#notify = undefined;
+						}
 					}
 				}
 			}
@@ -193,6 +206,31 @@ export class Consumer {
 		}
 	}
 
+	// Skip the stalled active group once it has presented up to where the next group
+	// begins (its furthest frame end reaches the next group's first timestamp). Only
+	// fires when the active group is fully consumed and still open, so we never drop
+	// frames the consumer hasn't seen. Returns true if a group was skipped.
+	#tryDurationSkip(): boolean {
+		if (this.#active === undefined) return false;
+
+		const active = this.#groups[0];
+		if (!active || active.consumer.sequence !== this.#active) return false;
+		if (active.done || active.frames.length > 0 || active.end === undefined) return false;
+
+		const next = this.#groups[1];
+		const nextStart = next?.frames.at(0)?.timestamp;
+		if (!next || nextStart === undefined || active.end < nextStart) return false;
+
+		this.#groups.shift();
+		console.warn(`skipping covered group: ${active.consumer.sequence} -> ${next.consumer.sequence}`);
+		this.#active = next.consumer.sequence;
+
+		active.consumer.close();
+		active.frames.length = 0;
+		this.#updateBuffered();
+		return true;
+	}
+
 	// Returns the next frame in order, along with the group number.
 	// If frame is undefined, the group is done.
 	async next(): Promise<{ frame: Frame | undefined; group: number } | undefined> {
@@ -224,6 +262,11 @@ export class Consumer {
 						return { frame: undefined, group: group.consumer.sequence };
 					}
 				}
+
+				// The active group is stalled with nothing buffered. If a later group
+				// has already been reached by this group's duration, skip ahead now
+				// rather than waiting for the stalled group to resume.
+				if (this.#tryDurationSkip()) continue;
 			}
 
 			if (this.#notify) {

--- a/js/hang/src/container/types.ts
+++ b/js/hang/src/container/types.ts
@@ -4,6 +4,13 @@ export interface Frame {
 	data: Uint8Array;
 	timestamp: Time.Micro;
 	keyframe: boolean;
+
+	// How long this frame occupies the presentation timeline. CMAF carries a
+	// per-sample duration; containers that don't (Legacy) leave it undefined,
+	// which the consumer treats as zero. The consumer adds it to `timestamp` to
+	// learn how far a group has presented, so it can advance to a newer group as
+	// soon as the gap is covered instead of waiting out the latency budget.
+	duration?: Time.Micro;
 }
 
 export interface BufferedRange {

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -108,6 +108,7 @@ async fn run_broadcast(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 		timestamp: moq_net::Timestamp::from_secs(1).unwrap(),
 		payload: Bytes::from_static(b"keyframe NAL data"),
 		keyframe: true,
+		duration: None,
 	};
 	producer.write(frame)?;
 
@@ -117,6 +118,7 @@ async fn run_broadcast(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 		timestamp: moq_net::Timestamp::from_secs(2).unwrap(),
 		payload: Bytes::from_static(b"delta NAL data"),
 		keyframe: false,
+		duration: None,
 	};
 	producer.write(frame)?;
 
@@ -127,6 +129,7 @@ async fn run_broadcast(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 		timestamp: moq_net::Timestamp::from_secs(3).unwrap(),
 		payload: Bytes::from_static(b"keyframe NAL data"),
 		keyframe: true,
+		duration: None,
 	};
 	producer.write(frame)?;
 

--- a/rs/moq-audio/src/producer.rs
+++ b/rs/moq-audio/src/producer.rs
@@ -123,6 +123,7 @@ impl AudioProducer {
 			timestamp,
 			payload,
 			keyframe: true,
+			duration: None,
 		};
 		self.track.write(mux_frame)?;
 		self.track.finish_group()?;

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -76,6 +76,7 @@ impl Import {
 			timestamp: pts,
 			payload: payload.freeze(),
 			keyframe: true,
+			duration: None,
 		};
 
 		self.track.write(frame)?;

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -357,6 +357,7 @@ impl Import {
 			timestamp: pts,
 			payload,
 			keyframe: self.current.contains_keyframe,
+			duration: None,
 		};
 
 		track.write(frame)?;

--- a/rs/moq-mux/src/codec/h264/export.rs
+++ b/rs/moq-mux/src/codec/h264/export.rs
@@ -247,6 +247,7 @@ mod tests {
 			timestamp: moq_net::Timestamp::from_micros(timestamp_us).unwrap(),
 			payload: payload.freeze(),
 			keyframe: false, // Legacy wire format drops this; Consumer reconstructs.
+			duration: None,
 		};
 		<crate::catalog::hang::Container as crate::container::Container>::write(
 			&crate::catalog::hang::Container::Legacy,

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -241,6 +241,7 @@ impl Import {
 			timestamp: pts,
 			payload: data.to_vec().into(),
 			keyframe,
+			duration: None,
 		})?;
 
 		if let Some(jitter) = self.jitter.observe(pts)
@@ -400,6 +401,7 @@ impl Import {
 			timestamp: pts,
 			payload,
 			keyframe,
+			duration: None,
 		})?;
 
 		if let Some(jitter) = self.jitter.observe(pts)

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -299,6 +299,7 @@ impl Import {
 			timestamp: pts,
 			payload,
 			keyframe: self.current.contains_idr,
+			duration: None,
 		};
 
 		track.write(frame)?;

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -75,6 +75,7 @@ impl Import {
 			timestamp: pts,
 			payload: payload.freeze(),
 			keyframe: true,
+			duration: None,
 		};
 
 		self.track.write(frame)?;

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -19,9 +19,15 @@ use super::{Container, Frame};
 /// a group in arrival order, but across groups it advances by sequence number, skipping
 /// stalled or missing groups when the difference between the oldest pending timestamp
 /// and the newest available timestamp exceeds the configured latency. With the default
-/// latency of zero, the consumer skips aggressively — any group that has a newer
+/// latency of zero, the consumer skips aggressively. Any group that has a newer
 /// alternative is dropped. With a non-zero latency, slow groups are tolerated up to that
 /// budget before being skipped.
+///
+/// A stalled group is also skipped early, regardless of the latency budget, once it has
+/// presented up to where the next group begins. CMAF frames carry a per-sample duration,
+/// so a group whose most recent frame ends (timestamp + duration) at or past the next
+/// group's first timestamp has nothing left worth waiting for. Containers without a
+/// duration report zero, which disables this check and falls back to the latency budget.
 ///
 /// Set the latency with [`with_latency`](Self::with_latency) (builder) or
 /// [`set_latency`](Self::set_latency) (mid-stream).
@@ -124,27 +130,28 @@ impl<F: Container> Consumer<F> {
 				self.current += 1
 			}
 
-			// Get the current group's min timestamp as the reference for latency comparison.
-			let oldest_timestamp = if let Some(current) = self.pending.front_mut()
+			// Get the current group's min timestamp (the reference for latency
+			// comparison) and its furthest presentation point (timestamp + duration).
+			let (oldest_timestamp, current_end) = if let Some(current) = self.pending.front_mut()
 				&& current.sequence <= self.current
 			{
 				match current.poll_min_timestamp(waiter, &self.format) {
-					Poll::Ready(Ok(ts)) => Some(std::time::Duration::from(ts)),
-					_ => None,
+					Poll::Ready(Ok(ts)) => (Some(std::time::Duration::from(ts)), current.max_end),
+					_ => (None, None),
 				}
 			} else {
-				None
+				(None, None)
 			};
 
-			// Find the first newer group with data (our skip target).
-			let mut min_idx = None;
+			// Find the first newer group with data (our skip target) and where it starts.
+			let mut next_group = None;
 			for (i, group) in self.pending.iter_mut().enumerate() {
 				if group.sequence <= self.current {
 					continue;
 				}
 
-				if let Poll::Ready(Ok(_)) = group.poll_min_timestamp(waiter, &self.format) {
-					min_idx = Some(i);
+				if let Poll::Ready(Ok(ts)) = group.poll_min_timestamp(waiter, &self.format) {
+					next_group = Some((i, std::time::Duration::from(ts)));
 					break;
 				}
 			}
@@ -162,10 +169,15 @@ impl<F: Container> Consumer<F> {
 				}
 			}
 
-			let should_skip = if min_idx.is_some() {
+			let should_skip = if let Some((_, next_start)) = next_group {
 				if let Some(oldest) = oldest_timestamp {
-					// Current group is blocking: skip if newer groups exceed latency threshold
-					max_timestamp.saturating_sub(oldest) >= self.latency
+					// Current group is blocking. Skip if newer groups have pulled past
+					// the latency budget, or if the current group has already presented
+					// up to where the next group begins (duration coverage) so there's
+					// nothing left worth waiting for.
+					let over_latency = max_timestamp.saturating_sub(oldest) >= self.latency;
+					let covered = current_end.is_some_and(|end| end >= next_start);
+					over_latency || covered
 				} else {
 					// Sequence gap: current group consumed but next sequence missing.
 					// Only skip if track is fully received (no more groups coming).
@@ -175,7 +187,7 @@ impl<F: Container> Consumer<F> {
 				false
 			};
 
-			if let Some(new_idx) = min_idx
+			if let Some((new_idx, _)) = next_group
 				&& should_skip
 			{
 				self.pending.drain(0..new_idx);
@@ -251,6 +263,11 @@ struct GroupBuffer {
 
 	// The maximum timestamp in the group.
 	max_timestamp: Option<Timestamp>,
+
+	// The furthest presentation point reached so far, i.e. max(timestamp + duration).
+	// Equals the max timestamp when the container carries no per-frame duration.
+	// Stored as a wall-clock duration so cross-scale comparisons are cheap.
+	max_end: Option<std::time::Duration>,
 }
 
 impl GroupBuffer {
@@ -261,6 +278,7 @@ impl GroupBuffer {
 			buffered: VecDeque::new(),
 			max_timestamp: None,
 			min_timestamp: None,
+			max_end: None,
 		}
 	}
 
@@ -284,7 +302,7 @@ impl GroupBuffer {
 			return Poll::Ready(Ok(false));
 		};
 
-		for frame in frames {
+		for mut frame in frames {
 			self.min_timestamp = Some(match self.min_timestamp {
 				Some(existing) => existing.min(frame.timestamp),
 				None => frame.timestamp,
@@ -295,16 +313,22 @@ impl GroupBuffer {
 				None => frame.timestamp,
 			});
 
+			// Furthest presentation point, in wall-clock terms so timestamp and
+			// duration can be at different scales without extra conversions. A frame
+			// with no duration contributes only its timestamp.
+			let duration = frame.duration.map(std::time::Duration::from).unwrap_or_default();
+			let end = std::time::Duration::from(frame.timestamp) + duration;
+			self.max_end = Some(match self.max_end {
+				Some(existing) => existing.max(end),
+				None => end,
+			});
+
 			// First frame of a group is always a keyframe by protocol invariant; trust
 			// the container's flag otherwise so CMAF mid-group keyframes survive.
-			let keyframe = frame.keyframe || self.index == 0;
+			frame.keyframe = frame.keyframe || self.index == 0;
 			self.index += 1;
 
-			self.buffered.push_back(Frame {
-				timestamp: frame.timestamp,
-				payload: frame.payload,
-				keyframe,
-			});
+			self.buffered.push_back(frame);
 		}
 
 		Poll::Ready(Ok(true))
@@ -392,6 +416,61 @@ mod tests {
 		track.consume()
 	}
 
+	/// Test-only container that round-trips a per-sample duration on the wire, so the
+	/// duration-based skip can be exercised without building a real CMAF init segment.
+	/// Each frame is `[timestamp_us: u64 LE][duration_us: u64 LE][payload]`.
+	struct DurationWire;
+
+	/// Encode a `[timestamp][duration][payload]` DurationWire frame.
+	fn encode_duration_frame(timestamp: Timestamp, duration: Timestamp) -> Vec<u8> {
+		let mut buf = Vec::with_capacity(18);
+		buf.extend_from_slice(&(timestamp.as_micros() as u64).to_le_bytes());
+		buf.extend_from_slice(&(duration.as_micros() as u64).to_le_bytes());
+		buf.extend_from_slice(&[0xDE, 0xAD]);
+		buf
+	}
+
+	impl ContainerTrait for DurationWire {
+		type Error = crate::Error;
+
+		fn write(&self, group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error> {
+			// The duration tests write frames directly via `write_duration_frame`;
+			// this path just preserves the timestamp with an unknown duration.
+			for frame in frames {
+				group.write_frame(encode_duration_frame(frame.timestamp, ts(0)))?;
+			}
+			Ok(())
+		}
+
+		fn poll_read(
+			&self,
+			group: &mut moq_net::GroupConsumer,
+			waiter: &kio::Waiter,
+		) -> Poll<Result<Option<Vec<Frame>>, Self::Error>> {
+			use bytes::Buf;
+
+			let Some(mut data) = ready!(group.poll_read_frame(waiter)?) else {
+				return Poll::Ready(Ok(None));
+			};
+
+			let timestamp = ts(data.get_u64_le());
+			let duration = ts(data.get_u64_le());
+			let payload = data.copy_to_bytes(data.remaining());
+
+			Poll::Ready(Ok(Some(vec![Frame {
+				timestamp,
+				payload,
+				keyframe: false,
+				duration: Some(duration),
+			}])))
+		}
+	}
+
+	/// Write one DurationWire frame (timestamp and duration in µs) into a group.
+	fn write_duration_frame(group: &mut moq_net::GroupProducer, timestamp: Timestamp, duration: Timestamp) {
+		group.write_frame(encode_duration_frame(timestamp, duration)).unwrap();
+	}
+
 	/// Write a finished group with explicit sequence and timestamps (Container::Legacy format).
 	fn write_group(track: &mut moq_net::TrackProducer, sequence: u64, timestamps: &[Timestamp]) {
 		let mut group = track.create_group(moq_net::Group { sequence }).unwrap();
@@ -400,6 +479,7 @@ mod tests {
 				timestamp,
 				payload: Bytes::from_static(&[0xDE, 0xAD]),
 				keyframe: false,
+				duration: None,
 			};
 			Container::Legacy.write(&mut group, &[frame]).unwrap();
 		}
@@ -496,6 +576,7 @@ mod tests {
 						timestamp: ts(f * 2_000),
 						payload: Bytes::from_static(&[0xDE, 0xAD]),
 						keyframe: false,
+						duration: None,
 					}],
 				)
 				.unwrap();
@@ -535,6 +616,7 @@ mod tests {
 					timestamp: ts(400_000),
 					payload: Bytes::from_static(&[0xDE, 0xAD]),
 					keyframe: false,
+					duration: None,
 				}],
 			)
 			.unwrap();
@@ -571,6 +653,7 @@ mod tests {
 					timestamp: ts(0),
 					payload: Bytes::from_static(&[0xDE, 0xAD]),
 					keyframe: false,
+					duration: None,
 				}],
 			)
 			.unwrap();
@@ -613,6 +696,7 @@ mod tests {
 					timestamp: ts(0),
 					payload: Bytes::from_static(&[0xDE, 0xAD]),
 					keyframe: false,
+					duration: None,
 				}],
 			)
 			.unwrap();
@@ -806,6 +890,7 @@ mod tests {
 					payload: Bytes::from(payload_bytes.clone()),
 
 					keyframe: false,
+					duration: None,
 				}],
 			)
 			.unwrap();
@@ -841,6 +926,7 @@ mod tests {
 					timestamp: ts(0),
 					payload: Bytes::from_static(&[0xDE, 0xAD]),
 					keyframe: false,
+					duration: None,
 				}],
 			)
 			.unwrap();
@@ -923,6 +1009,7 @@ mod tests {
 						timestamp,
 						payload: Bytes::from_static(&[0xDE, 0xAD]),
 						keyframe: false,
+						duration: None,
 					}],
 				)
 				.unwrap();
@@ -974,6 +1061,7 @@ mod tests {
 					timestamp: ts(300_000),
 					payload: Bytes::from_static(&[0xDE, 0xAD]),
 					keyframe: false,
+					duration: None,
 				}],
 			)
 			.unwrap();
@@ -987,6 +1075,7 @@ mod tests {
 						timestamp: ts(400_000),
 						payload: Bytes::from_static(&[0xBE, 0xEF]),
 						keyframe: false,
+						duration: None,
 					}],
 				)
 				.unwrap();
@@ -1060,6 +1149,7 @@ mod tests {
 					payload: Bytes::from_static(&[0xAA]),
 
 					keyframe: false,
+					duration: None,
 				}],
 			)
 			.unwrap();
@@ -1095,6 +1185,7 @@ mod tests {
 					payload: Bytes::from_static(&[0xAA]),
 
 					keyframe: false,
+					duration: None,
 				}],
 			)
 			.unwrap();
@@ -1132,6 +1223,7 @@ mod tests {
 					timestamp: ts(0),
 					payload: Bytes::from_static(&[0xDE, 0xAD]),
 					keyframe: false,
+					duration: None,
 				}],
 			)
 			.unwrap();
@@ -1249,6 +1341,7 @@ mod tests {
 				timestamp: ts(i * 33_333),
 				payload: Bytes::from_static(&[0xDE, 0xAD]),
 				keyframe: false,
+				duration: None,
 			};
 			Container::Legacy.write(&mut group, &[frame]).unwrap();
 		}
@@ -1267,5 +1360,93 @@ mod tests {
 		assert!(!frames[1].keyframe);
 		assert_eq!(frames[2].timestamp, ts(66_666));
 		assert!(!frames[2].keyframe);
+	}
+
+	// ---- Duration Skipping ----
+
+	/// A stalled group whose frame covers up to the next group's start is skipped
+	/// immediately, even with a latency budget far larger than the gap. Without
+	/// duration support the consumer would block on the unfinished group forever.
+	#[tokio::test]
+	async fn duration_skip_advances_to_next_group() {
+		tokio::time::pause();
+		let mut track = moq_net::Track::new("test").produce();
+		let consumer_track = track.consume();
+		// Latency dwarfs the gap, so only duration coverage can trigger the skip.
+		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
+
+		// Group 0: one frame at ts=0 lasting 33ms, never finished.
+		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		write_duration_frame(&mut group0, ts(0), ts(33_000));
+
+		// Group 1: finished, starts exactly where group 0's frame ends.
+		let mut group1 = track.create_group(moq_net::Group { sequence: 1 }).unwrap();
+		write_duration_frame(&mut group1, ts(33_000), ts(33_000));
+		group1.finish().unwrap();
+
+		track.finish().unwrap();
+
+		let frames = tokio::time::timeout(Duration::from_secs(2), async {
+			let mut frames = Vec::new();
+			while let Some(frame) = consumer.read().await.unwrap() {
+				frames.push(frame);
+			}
+			frames
+		})
+		.await
+		.expect("consumer hung — duration skip regression");
+
+		assert_eq!(frames.len(), 2);
+		assert_eq!(frames[0].timestamp, ts(0));
+		assert_eq!(frames[1].timestamp, ts(33_000));
+
+		// group0 is intentionally never finished.
+		drop(group0);
+	}
+
+	/// When the current group's frame ends before the next group begins, there is
+	/// still a gap to cover, so we don't skip early: a late-arriving frame on the
+	/// slow group is delivered rather than dropped.
+	#[tokio::test]
+	async fn duration_below_gap_does_not_skip() {
+		tokio::time::pause();
+		let mut track = moq_net::Track::new("test").produce();
+		let consumer_track = track.consume();
+		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
+
+		// Group 0: frame at ts=0 lasting only 10ms, far short of group 1 at 33ms.
+		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		write_duration_frame(&mut group0, ts(0), ts(10_000));
+
+		// Group 1: finished at 33ms.
+		let mut group1 = track.create_group(moq_net::Group { sequence: 1 }).unwrap();
+		write_duration_frame(&mut group1, ts(33_000), ts(33_000));
+		group1.finish().unwrap();
+		track.finish().unwrap();
+
+		// A second frame lands on group 0 and finishes it after the consumer has
+		// had a chance to (incorrectly) skip.
+		let finisher = tokio::spawn(async move {
+			tokio::time::sleep(Duration::from_millis(20)).await;
+			write_duration_frame(&mut group0, ts(20_000), ts(10_000));
+			group0.finish().unwrap();
+		});
+
+		let frames = tokio::time::timeout(Duration::from_secs(2), async {
+			let mut frames = Vec::new();
+			while let Some(frame) = consumer.read().await.unwrap() {
+				frames.push(frame);
+			}
+			frames
+		})
+		.await
+		.expect("consumer hung");
+
+		// The slow group's late frame survives because nothing covered the gap.
+		assert_eq!(frames.len(), 3);
+		assert_eq!(frames[0].timestamp, ts(0));
+		assert_eq!(frames[1].timestamp, ts(20_000));
+		assert_eq!(frames[2].timestamp, ts(33_000));
+		finisher.await.unwrap();
 	}
 }

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -54,6 +54,7 @@ async fn avc3_source_to_cmaf_export_roundtrip() {
 			timestamp: Timestamp::from_micros(0).unwrap(),
 			payload: keyframe_payload,
 			keyframe: true,
+			duration: None,
 		})
 		.unwrap();
 	track_producer.finish().unwrap();

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -247,14 +247,22 @@ pub(crate) fn decode(data: Bytes, timescale: moq_net::Timescale) -> Result<Vec<F
 			// depends_on_no_other (bits 24-25 == 0x2) means keyframe
 			let keyframe = (flags >> 24) & 0x3 == 0x2;
 
+			// Carry the sample-duration through at the track's scale when present, so
+			// the jitter buffer can use it and an exporter can write it back.
+			let sample_duration = entry.duration.or(default_duration);
+			let duration = sample_duration
+				.map(|d| Timestamp::new(d as u64, timescale))
+				.transpose()?;
+
 			frames.push(Frame {
 				timestamp,
 				payload,
 				keyframe,
+				duration,
 			});
 
 			offset = end;
-			dts += entry.duration.or(default_duration).unwrap_or(0) as u64;
+			dts += sample_duration.unwrap_or(0) as u64;
 		}
 	}
 
@@ -310,9 +318,13 @@ pub(crate) fn encode_fragment(
 		.iter()
 		.map(|f| {
 			let flags = if f.keyframe { 0x0200_0000 } else { 0x0001_0000 };
+			// Write the sample-duration back at the track's scale when we know it, so
+			// fMP4 -> fMP4 round-trips it. Frames without one stay byte-identical.
+			let duration = f.duration.map(|d| d.as_scale(timescale) as u32);
 			mp4_atom::TrunEntry {
 				size: Some(f.payload.len() as u32),
 				flags: Some(flags),
+				duration,
 				..Default::default()
 			}
 		})
@@ -506,5 +518,104 @@ pub(crate) fn default_video_timescale(config: &VideoConfig) -> u64 {
 		(fps * 1000.0) as u64
 	} else {
 		90000
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn ts(micros: u64) -> Timestamp {
+		Timestamp::from_micros(micros).unwrap()
+	}
+
+	#[test]
+	fn decode_reads_trun_sample_duration() {
+		use mp4_atom::Encode;
+
+		// Microsecond timescale so each tick maps 1:1 to the Timestamp's µs.
+		// decode() walks the mdat by sample size and ignores data_offset, so a
+		// hand-built moof+mdat with explicit per-sample durations is enough.
+		let timescale = moq_net::Timescale::MICRO;
+		let moof = mp4_atom::Moof {
+			mfhd: mp4_atom::Mfhd { sequence_number: 0 },
+			traf: vec![mp4_atom::Traf {
+				tfhd: mp4_atom::Tfhd {
+					track_id: 1,
+					..Default::default()
+				},
+				tfdt: Some(mp4_atom::Tfdt {
+					base_media_decode_time: 0,
+				}),
+				trun: vec![mp4_atom::Trun {
+					data_offset: Some(0),
+					entries: vec![
+						mp4_atom::TrunEntry {
+							size: Some(2),
+							duration: Some(33_333),
+							..Default::default()
+						},
+						mp4_atom::TrunEntry {
+							size: Some(2),
+							duration: Some(33_333),
+							..Default::default()
+						},
+					],
+				}],
+				..Default::default()
+			}],
+		};
+
+		let mut buf = Vec::new();
+		moof.encode(&mut buf).unwrap();
+		mp4_atom::Mdat {
+			data: vec![0xDE, 0xAD, 0xBE, 0xEF],
+		}
+		.encode(&mut buf)
+		.unwrap();
+
+		let frames = decode(Bytes::from(buf), timescale).unwrap();
+		assert_eq!(frames.len(), 2);
+		assert_eq!(frames[0].timestamp, ts(0));
+		assert_eq!(frames[0].duration, Some(ts(33_333)));
+		assert_eq!(frames[1].timestamp, ts(33_333));
+		assert_eq!(frames[1].duration, Some(ts(33_333)));
+	}
+
+	#[test]
+	fn duration_round_trips_through_encode() {
+		// A frame with a known duration must survive encode -> decode.
+		let timescale = moq_net::Timescale::MICRO;
+		let input = vec![Frame {
+			timestamp: ts(0),
+			payload: Bytes::from_static(&[0xDE, 0xAD]),
+			keyframe: true,
+			duration: Some(ts(33_333)),
+		}];
+
+		let fragment = encode_fragment(1, timescale, 0, &input).unwrap();
+		let frames = decode(fragment, timescale).unwrap();
+
+		assert_eq!(frames.len(), 1);
+		assert_eq!(frames[0].duration, Some(ts(33_333)));
+	}
+
+	#[test]
+	fn decode_without_duration_reports_none() {
+		// encode_fragment writes no sample-duration for a duration-less frame,
+		// so decode must report None (and output stays byte-identical to before).
+		let timescale = moq_net::Timescale::new(90_000).unwrap();
+		let frames = vec![Frame {
+			timestamp: ts(0),
+			payload: Bytes::from_static(&[0xDE, 0xAD]),
+			keyframe: true,
+			duration: None,
+		}];
+
+		let fragment = encode_fragment(1, timescale, 0, &frames).unwrap();
+		let frames = decode(fragment, timescale).unwrap();
+
+		assert_eq!(frames.len(), 1);
+		assert_eq!(frames[0].duration, None);
 	}
 }

--- a/rs/moq-mux/src/container/legacy/mod.rs
+++ b/rs/moq-mux/src/container/legacy/mod.rs
@@ -48,6 +48,8 @@ impl Container for Wire {
 			// Legacy doesn't carry the keyframe bit on the wire; the
 			// wrapping Consumer fills it in from group position.
 			keyframe: false,
+			// Legacy carries no per-frame duration.
+			duration: None,
 		}])))
 	}
 }

--- a/rs/moq-mux/src/container/loc/mod.rs
+++ b/rs/moq-mux/src/container/loc/mod.rs
@@ -63,6 +63,8 @@ impl Container for Wire {
 			// LOC doesn't carry the keyframe bit on the wire; the
 			// wrapping Consumer fills it in from group position.
 			keyframe: false,
+			// LOC carries no per-frame duration.
+			duration: None,
 		}])))
 	}
 }

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -306,6 +306,7 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 			timestamp: Timestamp::from_micros(0).unwrap(),
 			payload: keyframe_payload,
 			keyframe: true,
+			duration: None,
 		})
 		.unwrap();
 	track_producer
@@ -313,6 +314,7 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 			timestamp: Timestamp::from_micros(33_000).unwrap(),
 			payload: pslice_payload,
 			keyframe: false,
+			duration: None,
 		})
 		.unwrap();
 	track_producer.finish().unwrap();

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -373,6 +373,7 @@ impl Import {
 			timestamp,
 			payload: Bytes::copy_from_slice(payload),
 			keyframe,
+			duration: None,
 		};
 
 		// Manage groups: new group on video keyframe; audio always finishes its group immediately.

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -46,6 +46,16 @@ pub struct Frame {
 	/// order. B-frames may have non-monotonic presentation timestamps.
 	pub timestamp: moq_net::Timestamp,
 
+	/// How long this frame occupies the presentation timeline, in the frame's
+	/// own scale, when the container reports it.
+	///
+	/// CMAF carries a per-sample duration (trun sample-duration); containers
+	/// that don't (Legacy, LOC) leave this `None`. The [`Consumer`] adds it to
+	/// `timestamp` to learn how far a group has presented, so it can advance to
+	/// a newer group as soon as the gap is covered instead of waiting out the
+	/// latency budget.
+	pub duration: Option<moq_net::Timestamp>,
+
 	/// Encoded codec payload.
 	pub payload: Bytes,
 

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -75,9 +75,10 @@ impl<C: Container> Producer<C> {
 	/// A keyframe closes any open group and starts a new one. A non-keyframe extends
 	/// the current group; if no group is open, returns a protocol violation.
 	pub fn write(&mut self, frame: Frame) -> Result<(), C::Error> {
-		// Close the current group on an explicit keyframe.
+		// Close the current group on an explicit keyframe, passing its timestamp so
+		// the previous group's last frame can borrow it as a duration boundary.
 		if frame.keyframe {
-			self.finish_group()?;
+			self.finish_group_at(Some(frame.timestamp))?;
 		}
 
 		// Start a new group if needed; the first frame of a group must be a keyframe.
@@ -108,7 +109,7 @@ impl<C: Container> Producer<C> {
 				let first = iter.next().unwrap();
 				let (min, max) = iter.fold((first, first), |(min, max), d| (min.min(d), max.max(d)));
 				if max.saturating_sub(min) >= self.latency {
-					self.flush()?;
+					self.flush(None)?;
 				}
 			}
 		}
@@ -120,7 +121,14 @@ impl<C: Container> Producer<C> {
 	///
 	/// The next [`write`](Self::write) must be a keyframe.
 	pub fn finish_group(&mut self) -> Result<(), C::Error> {
-		self.flush()?;
+		self.finish_group_at(None)
+	}
+
+	/// Like [`finish_group`](Self::finish_group), but uses `next` (the timestamp of the
+	/// keyframe that rolled the group over) as the duration boundary for the group's
+	/// last frame. See [`flush`](Self::flush).
+	fn finish_group_at(&mut self, next: Option<moq_net::Timestamp>) -> Result<(), C::Error> {
+		self.flush(next)?;
 		if let Some(mut group) = self.group.take() {
 			group.finish()?;
 		}
@@ -138,9 +146,23 @@ impl<C: Container> Producer<C> {
 	}
 
 	/// Flush any buffered frames into the current group without closing it.
-	fn flush(&mut self) -> Result<(), C::Error> {
+	///
+	/// `next`, when given, is the timestamp of the frame that rolled the group over
+	/// (the next keyframe). The buffer's last frame is the only sample whose successor
+	/// wasn't visible when it arrived, so we backfill its duration from `next` here.
+	/// This adds no latency: that frame is already in hand. Containers that don't use
+	/// per-frame durations (Legacy, LOC) ignore it.
+	fn flush(&mut self, next: Option<moq_net::Timestamp>) -> Result<(), C::Error> {
 		if self.buffer.is_empty() {
 			return Ok(());
+		}
+
+		if let Some(next) = next
+			&& let Some(last) = self.buffer.last_mut()
+			&& last.duration.is_none()
+			&& let Ok(duration) = next.checked_sub(last.timestamp)
+		{
+			last.duration = Some(duration);
 		}
 
 		let group = match &mut self.group {
@@ -188,6 +210,7 @@ mod tests {
 			timestamp: Timestamp::from_micros(timestamp_us).unwrap(),
 			payload: Bytes::from_static(&[0xDE, 0xAD]),
 			keyframe,
+			duration: None,
 		}
 	}
 
@@ -283,5 +306,49 @@ mod tests {
 		producer.finish().unwrap();
 
 		assert_eq!(collect_sequences(consumer).await, vec![5, 6]);
+	}
+
+	/// Records the frames handed to each `write`, so tests can inspect the
+	/// durations the producer backfilled. Write-only.
+	#[derive(Clone, Default)]
+	struct Recording(std::rc::Rc<std::cell::RefCell<Vec<Vec<Frame>>>>);
+
+	impl super::Container for Recording {
+		type Error = crate::Error;
+
+		fn write(&self, _group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error> {
+			self.0.borrow_mut().push(frames.to_vec());
+			Ok(())
+		}
+
+		fn poll_read(
+			&self,
+			_group: &mut moq_net::GroupConsumer,
+			_waiter: &kio::Waiter,
+		) -> std::task::Poll<Result<Option<Vec<Frame>>, Self::Error>> {
+			unreachable!("Recording is write-only")
+		}
+	}
+
+	/// The keyframe that rolls a group over backfills the duration of the previous
+	/// group's last frame, without buffering an extra frame.
+	#[tokio::test]
+	async fn keyframe_backfills_last_frame_duration() {
+		let track = moq_net::Track::new("test").produce();
+		let recording = Recording::default();
+		let mut producer = Producer::new(track, recording.clone()).with_latency(std::time::Duration::from_secs(10));
+
+		producer.write(frame(0, true)).unwrap(); // group 0 opens
+		producer.write(frame(33_000, false)).unwrap(); // buffered
+		producer.write(frame(66_000, true)).unwrap(); // rolls group 0 over -> flush with next = 66ms
+		producer.finish().unwrap();
+
+		let writes = recording.0.borrow();
+		let group0 = &writes[0];
+		assert_eq!(group0.len(), 2);
+		// Last frame's duration backfilled from the next keyframe: 66ms - 33ms.
+		assert_eq!(group0[1].duration, Some(Timestamp::from_micros(33_000).unwrap()));
+		// The earlier frame keeps None; only the trailing sample needs the boundary.
+		assert_eq!(group0[0].duration, None);
 	}
 }

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -50,6 +50,7 @@ impl codec::Bridge for Bridge {
 				timestamp: pts,
 				payload: frame.payload,
 				keyframe,
+				duration: None,
 			})
 			.map_err(|err| crate::Error::Other(anyhow::anyhow!("vp8 track write failed: {err}")))?;
 		Ok(())

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -49,6 +49,7 @@ impl codec::Bridge for Bridge {
 				timestamp: pts,
 				payload: frame.payload,
 				keyframe,
+				duration: None,
 			})
 			.map_err(|err| crate::Error::Other(anyhow::anyhow!("vp9 track write failed: {err}")))?;
 		Ok(())


### PR DESCRIPTION
## Summary

The container consumer's jitter buffer advances by group sequence and skips stalled or missing groups once the configured latency budget is exceeded. This adds a third skip trigger driven by frame duration.

CMAF carries a per-sample duration. A stalled group whose most recent frame *ends* (`timestamp + duration`) at or past the next group's first timestamp has nothing left worth waiting for, so we skip it immediately, regardless of the latency budget. Containers that don't carry a duration (Legacy, LOC) leave it `None`, which disables the new check and falls back to the existing latency behavior.

## Changes

- **`Frame` gains an optional `duration`** (`Option<Timestamp>`, in the frame's own scale). The CMAF decoder fills it from the `trun` sample-duration (falling back through `trun → tfhd`), and `encode_fragment` writes it back, so **fMP4 → fMP4 round-trips it**. Other producers construct frames with `None`.
- **Producer backfill (no added latency):** when a keyframe rolls a group over, `Producer` now passes that keyframe's timestamp into the flush, so the previous group's *last* frame can borrow it as a duration boundary. That recovers the one sample whose successor wasn't visible when it arrived. The keyframe is already in hand, so nothing extra is buffered.
- **Consumer** tracks each group's furthest presentation point in wall-clock terms (so timestamp/duration scales needn't match) and skips the active group when a newer group's start is covered. The skip only fires once the active group is fully consumed, so frames the viewer hasn't seen are never dropped.
- **js/hang** is mirrored on the decode + consumer side.

## Why `dev`

Adds a public field to `Frame` (rs/moq-mux) and to `@moq/hang`'s `Frame`. Per branch-targeting, container/API changes target `dev`. Branch is rebased directly on top of `dev`.

## Cross-package sync

| Row | Status |
|---|---|
| `rs/moq-net` wire/API | n/a |
| `rs/hang` ↔ `js/hang` container | done (decode + consumer mirrored) |
| `doc/concept` | no change needed: the docs describe the jitter buffer only at a high level and stay accurate. |

Most of the file count is a one-line `duration: None` per `Frame` constructor, since adding a field makes Rust's exhaustive struct literals require it.

## Test plan

- [x] `cargo test -p moq-mux` (159 passing), incl. `consumer::tests::{duration_skip_advances_to_next_group, duration_below_gap_does_not_skip}`, `fmp4::tests::{decode_reads_trun_sample_duration, duration_round_trips_through_encode, decode_without_duration_reports_none}`, and `producer::tests::keyframe_backfills_last_frame_duration`.
- [x] `cargo clippy -p moq-mux --all-targets` + `cargo fmt` clean; dependent crates build (`moq-audio`, `hang` examples, `libmoq`, `moq-ffi`).
- [x] `bun test` in `js/hang` (26 passing); `tsc --noEmit` clean.

(Written by Claude)