### PR TITLE
Add libmoq catalog producer + raw moq-net track API

### DIFF
--- a/rs/libmoq/CHANGELOG.md
+++ b/rs/libmoq/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Catalog producer API to author renditions directly (`moq_publish_video_config`, `moq_publish_audio_config`, `moq_publish_video_remove`, `moq_publish_audio_remove`), mirroring the consume-side config queries.
+- Raw moq-net track API for arbitrary (non-media) byte tracks, mirroring the moq-ffi primitives:
+  - Publish: `moq_publish_track`, `moq_publish_track_group`, `moq_publish_track_frame`, `moq_publish_group_frame`, `moq_publish_group_close`, `moq_publish_track_close`.
+  - Consume: `moq_consume_track`, `moq_consume_track_frame`, `moq_consume_track_frame_close`, `moq_consume_track_close`.
 
 ## [0.2.17](https://github.com/moq-dev/moq/compare/libmoq-v0.2.16...libmoq-v0.2.17) - 2026-05-24
 

--- a/rs/libmoq/CHANGELOG.md
+++ b/rs/libmoq/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Catalog producer API to author renditions directly (`moq_publish_video_config`, `moq_publish_audio_config`, `moq_publish_video_remove`, `moq_publish_audio_remove`), mirroring the consume-side config queries.
+
 ## [0.2.17](https://github.com/moq-dev/moq/compare/libmoq-v0.2.16...libmoq-v0.2.17) - 2026-05-24
 
 ### Added

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -385,7 +385,7 @@ pub unsafe extern "C" fn moq_publish_video_config(broadcast: u32, config: *const
 
 		let name = unsafe { ffi::parse_str(config.name, config.name_len)? };
 		let codec = unsafe { ffi::parse_str(config.codec, config.codec_len)? };
-		let codec = hang::catalog::VideoCodec::from_str(codec).map_err(|err| Error::Hang(err.into()))?;
+		let codec = hang::catalog::VideoCodec::from_str(codec).map_err(Error::Hang)?;
 
 		let mut video = hang::catalog::VideoConfig::new(codec);
 		if !config.description.is_null() {
@@ -423,7 +423,7 @@ pub unsafe extern "C" fn moq_publish_audio_config(broadcast: u32, config: *const
 
 		let name = unsafe { ffi::parse_str(config.name, config.name_len)? };
 		let codec = unsafe { ffi::parse_str(config.codec, config.codec_len)? };
-		let codec = hang::catalog::AudioCodec::from_str(codec).map_err(|err| Error::Hang(err.into()))?;
+		let codec = hang::catalog::AudioCodec::from_str(codec).map_err(Error::Hang)?;
 
 		let mut audio = hang::catalog::AudioConfig::new(codec, config.sample_rate, config.channel_count);
 		if !config.description.is_null() {

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -359,6 +359,118 @@ pub unsafe extern "C" fn moq_publish_media_frame(
 	})
 }
 
+/// Add or replace a video rendition in a broadcast's catalog.
+///
+/// This is the producer counterpart to [moq_consume_video_config]: instead of
+/// reading a rendition out of a catalog, it writes one into the catalog of a
+/// broadcast created with [moq_publish_create]. The rendition is keyed by
+/// `config.name`; calling this again with the same name replaces it. The
+/// updated catalog is published to subscribers automatically.
+///
+/// The struct fields are read as inputs:
+/// - `name` / `codec` are required (NOT NULL terminated) string slices.
+/// - `description` may be NULL to omit it.
+/// - `coded_width` / `coded_height` may be NULL to omit them.
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that `config` points to a valid [moq_video_config].
+/// - The caller must ensure each non-NULL pointer inside `config` is valid for its length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_video_config(broadcast: u32, config: *const moq_video_config) -> i32 {
+	ffi::enter(move || {
+		let broadcast = ffi::parse_id(broadcast)?;
+		let config = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
+
+		let name = unsafe { ffi::parse_str(config.name, config.name_len)? };
+		let codec = unsafe { ffi::parse_str(config.codec, config.codec_len)? };
+		let codec = hang::catalog::VideoCodec::from_str(codec).map_err(|err| Error::Hang(err.into()))?;
+
+		let mut video = hang::catalog::VideoConfig::new(codec);
+		if !config.description.is_null() {
+			let description = unsafe { ffi::parse_slice(config.description, config.description_len)? };
+			video.description = Some(bytes::Bytes::copy_from_slice(description));
+		}
+		video.coded_width = unsafe { config.coded_width.as_ref() }.copied();
+		video.coded_height = unsafe { config.coded_height.as_ref() }.copied();
+
+		State::lock().publish.video_config(broadcast, name, video)
+	})
+}
+
+/// Add or replace an audio rendition in a broadcast's catalog.
+///
+/// This is the producer counterpart to [moq_consume_audio_config]. The rendition
+/// is keyed by `config.name`; calling this again with the same name replaces it.
+/// The updated catalog is published to subscribers automatically.
+///
+/// The struct fields are read as inputs:
+/// - `name` / `codec` are required (NOT NULL terminated) string slices.
+/// - `sample_rate` / `channel_count` are required.
+/// - `description` may be NULL to omit it.
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that `config` points to a valid [moq_audio_config].
+/// - The caller must ensure each non-NULL pointer inside `config` is valid for its length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_audio_config(broadcast: u32, config: *const moq_audio_config) -> i32 {
+	ffi::enter(move || {
+		let broadcast = ffi::parse_id(broadcast)?;
+		let config = unsafe { config.as_ref() }.ok_or(Error::InvalidPointer)?;
+
+		let name = unsafe { ffi::parse_str(config.name, config.name_len)? };
+		let codec = unsafe { ffi::parse_str(config.codec, config.codec_len)? };
+		let codec = hang::catalog::AudioCodec::from_str(codec).map_err(|err| Error::Hang(err.into()))?;
+
+		let mut audio = hang::catalog::AudioConfig::new(codec, config.sample_rate, config.channel_count);
+		if !config.description.is_null() {
+			let description = unsafe { ffi::parse_slice(config.description, config.description_len)? };
+			audio.description = Some(bytes::Bytes::copy_from_slice(description));
+		}
+
+		State::lock().publish.audio_config(broadcast, name, audio)
+	})
+}
+
+/// Remove a video rendition from a broadcast's catalog by name.
+///
+/// This is a no-op if no rendition with that name exists. The updated catalog is
+/// published to subscribers automatically.
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that name is a valid pointer to name_len bytes of data.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_video_remove(broadcast: u32, name: *const c_char, name_len: usize) -> i32 {
+	ffi::enter(move || {
+		let broadcast = ffi::parse_id(broadcast)?;
+		let name = unsafe { ffi::parse_str(name, name_len)? };
+		State::lock().publish.video_remove(broadcast, name)
+	})
+}
+
+/// Remove an audio rendition from a broadcast's catalog by name.
+///
+/// This is a no-op if no rendition with that name exists. The updated catalog is
+/// published to subscribers automatically.
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that name is a valid pointer to name_len bytes of data.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_audio_remove(broadcast: u32, name: *const c_char, name_len: usize) -> i32 {
+	ffi::enter(move || {
+		let broadcast = ffi::parse_id(broadcast)?;
+		let name = unsafe { ffi::parse_str(name, name_len)? };
+		State::lock().publish.audio_remove(broadcast, name)
+	})
+}
+
 /// Create a catalog consumer for a broadcast.
 ///
 /// The callback is called with a catalog ID when a new catalog is available.

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -471,6 +471,97 @@ pub unsafe extern "C" fn moq_publish_audio_remove(broadcast: u32, name: *const c
 	})
 }
 
+/// Create a raw track on a broadcast for arbitrary byte payloads.
+///
+/// Unlike [moq_publish_media_ordered], this is the bare moq-net primitive: no
+/// codec, container, or catalog framing. Frames written to it are delivered
+/// as-is to subscribers using [moq_consume_track]. Use it for non-media tracks
+/// (control channels, JSON metadata, etc.), or pair it with
+/// [moq_publish_video_config] / [moq_publish_audio_config] to also describe the
+/// track in the catalog.
+///
+/// Returns a non-zero handle to the track on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that name is a valid pointer to name_len bytes of data.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_track(broadcast: u32, name: *const c_char, name_len: usize) -> i32 {
+	ffi::enter(move || {
+		let broadcast = ffi::parse_id(broadcast)?;
+		let name = unsafe { ffi::parse_str(name, name_len)? };
+		State::lock().publish.track(broadcast, name)
+	})
+}
+
+/// Append a new group to a raw track, returning a group producer.
+///
+/// Groups are delivered independently and each may contain any number of frames
+/// written via [moq_publish_group_frame]. Sequence numbers auto-increment.
+///
+/// Returns a non-zero handle to the group on success, or a negative code on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_publish_track_group(track: u32) -> i32 {
+	ffi::enter(move || {
+		let track = ffi::parse_id(track)?;
+		State::lock().publish.track_group(track)
+	})
+}
+
+/// Write a single-frame group to a raw track.
+///
+/// Convenience for the common one-frame-per-group pattern. Equivalent to
+/// appending a group, writing one frame, and finishing it.
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that payload is a valid pointer to payload_size bytes of data.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_track_frame(track: u32, payload: *const u8, payload_size: usize) -> i32 {
+	ffi::enter(move || {
+		let track = ffi::parse_id(track)?;
+		let payload = unsafe { ffi::parse_slice(payload, payload_size)? };
+		State::lock().publish.track_frame(track, payload)
+	})
+}
+
+/// Finish a raw track. No more groups or frames can be written.
+///
+/// Returns a zero on success, or a negative code on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_publish_track_close(track: u32) -> i32 {
+	ffi::enter(move || {
+		let track = ffi::parse_id(track)?;
+		State::lock().publish.track_finish(track)
+	})
+}
+
+/// Write a frame into a raw group created by [moq_publish_track_group].
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that payload is a valid pointer to payload_size bytes of data.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_group_frame(group: u32, payload: *const u8, payload_size: usize) -> i32 {
+	ffi::enter(move || {
+		let group = ffi::parse_id(group)?;
+		let payload = unsafe { ffi::parse_slice(payload, payload_size)? };
+		State::lock().publish.group_frame(group, payload)
+	})
+}
+
+/// Finish a raw group. No more frames can be written.
+///
+/// Returns a zero on success, or a negative code on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_publish_group_close(group: u32) -> i32 {
+	ffi::enter(move || {
+		let group = ffi::parse_id(group)?;
+		State::lock().publish.group_finish(group)
+	})
+}
+
 /// Create a catalog consumer for a broadcast.
 ///
 /// The callback is called with a catalog ID when a new catalog is available.
@@ -678,5 +769,77 @@ pub extern "C" fn moq_consume_close(consume: u32) -> i32 {
 	ffi::enter(move || {
 		let consume = ffi::parse_id(consume)?;
 		State::lock().consume.close(consume)
+	})
+}
+
+/// Subscribe to a raw track by name, delivering each frame's payload as-is.
+///
+/// This is the counterpart to [moq_publish_track]: no catalog lookup or
+/// container parsing. `on_frame` is called with a raw frame ID for each frame
+/// in arrival order. Read each frame with [moq_consume_track_frame] and release
+/// it with [moq_consume_track_frame_close].
+///
+/// Returns a non-zero handle to the track on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that name is a valid pointer to name_len bytes of data.
+/// - The caller must ensure that `on_frame` is valid until [moq_consume_track_close] is called.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_consume_track(
+	broadcast: u32,
+	name: *const c_char,
+	name_len: usize,
+	on_frame: Option<extern "C" fn(user_data: *mut c_void, frame: i32)>,
+	user_data: *mut c_void,
+) -> i32 {
+	ffi::enter(move || {
+		let broadcast = ffi::parse_id(broadcast)?;
+		let name = unsafe { ffi::parse_str(name, name_len)? };
+		let on_frame = unsafe { ffi::OnStatus::new(user_data, on_frame) };
+		State::lock().consume.raw_track(broadcast, name, on_frame)
+	})
+}
+
+/// Read a raw frame's payload delivered via the [moq_consume_track] callback.
+///
+/// Fills `dst.payload` / `dst.payload_size`; the pointer is valid until the
+/// frame is released with [moq_consume_frame_close]. `dst.timestamp_us` and
+/// `dst.keyframe` are reported as 0 / false (not meaningful for raw tracks).
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that `dst` is a valid pointer to a [moq_frame] struct.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_consume_track_frame(frame: u32, dst: *mut moq_frame) -> i32 {
+	ffi::enter(move || {
+		let frame = ffi::parse_id(frame)?;
+		let dst = unsafe { dst.as_mut() }.ok_or(Error::InvalidPointer)?;
+		State::lock().consume.raw_frame(frame, dst)
+	})
+}
+
+/// Close a raw frame and clean up its resources.
+///
+/// Returns a zero on success, or a negative code on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_consume_track_frame_close(frame: u32) -> i32 {
+	ffi::enter(move || {
+		let frame = ffi::parse_id(frame)?;
+		State::lock().consume.raw_frame_close(frame)
+	})
+}
+
+/// Close a raw track consumer and cancel its background task.
+///
+/// Frames already delivered via the callback remain valid until released with
+/// [moq_consume_track_frame_close].
+///
+/// Returns a zero on success, or a negative code on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_consume_track_close(track: u32) -> i32 {
+	ffi::enter(move || {
+		let track = ffi::parse_id(track)?;
+		State::lock().consume.raw_track_close(track)
 	})
 }

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -38,6 +38,12 @@ pub struct Consume {
 
 	/// Buffered frames ready for consumption.
 	frame: NonZeroSlab<moq_mux::container::Frame>,
+
+	/// Raw track consumer tasks (no media/container framing).
+	raw_task: NonZeroSlab<Option<TaskEntry>>,
+
+	/// Buffered raw frames ready for consumption.
+	raw_frame: NonZeroSlab<bytes::Bytes>,
 }
 
 impl Consume {
@@ -348,6 +354,95 @@ impl Consume {
 
 	pub fn close(&mut self, consume: Id) -> Result<(), Error> {
 		self.broadcast.remove(consume).ok_or(Error::BroadcastNotFound)?;
+		Ok(())
+	}
+
+	/// Subscribe to a raw track by name, delivering each frame's payload as-is.
+	///
+	/// No catalog lookup or container parsing. This is the moq-net primitive for
+	/// non-media tracks. `on_frame` is called with a raw frame ID for each frame,
+	/// in arrival order. Frames must be released with [`Self::raw_frame_close`].
+	pub fn raw_track(&mut self, broadcast: Id, name: &str, on_frame: OnStatus) -> Result<Id, Error> {
+		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let track = broadcast.subscribe_track(&moq_net::Track {
+			name: name.to_string(),
+			priority: 0,
+		})?;
+
+		let channel = oneshot::channel();
+		let entry = TaskEntry {
+			close: channel.0,
+			callback: on_frame,
+		};
+		let id = self.raw_task.insert(Some(entry))?;
+
+		tokio::spawn(async move {
+			let res = tokio::select! {
+				res = Self::run_raw(id, track) => res,
+				_ = channel.1 => Ok(()),
+			};
+
+			// The lock is dropped before the callback is invoked.
+			if let Some(entry) = State::lock().consume.raw_task.remove(id).flatten() {
+				entry.callback.call(res);
+			}
+		});
+
+		Ok(id)
+	}
+
+	async fn run_raw(task_id: Id, mut track: moq_net::TrackConsumer) -> Result<(), Error> {
+		// Deliver every frame in sequence order, reading all frames within each
+		// group rather than the one-frame-per-group convenience. This is the
+		// "raw track contents" model: the consumer sees exactly what the
+		// producer wrote, regardless of how it was grouped.
+		while let Some(mut group) = track.next_group().await? {
+			while let Some(payload) = group.read_frame().await? {
+				let mut state = State::lock();
+
+				// Stop if the callback was revoked by close.
+				let Some(Some(entry)) = state.consume.raw_task.get(task_id) else {
+					return Ok(());
+				};
+				let callback = entry.callback;
+
+				let frame_id = state.consume.raw_frame.insert(payload)?;
+				drop(state);
+
+				// The lock is dropped before the callback is invoked.
+				callback.call(Ok(frame_id));
+			}
+		}
+
+		Ok(())
+	}
+
+	pub fn raw_track_close(&mut self, track: Id) -> Result<(), Error> {
+		self.raw_task
+			.get_mut(track)
+			.ok_or(Error::TrackNotFound)?
+			.take()
+			.ok_or(Error::TrackNotFound)?;
+		Ok(())
+	}
+
+	/// Fill `dst` with a raw frame's payload. The pointer is valid until the
+	/// frame is released with [`Self::raw_frame_close`].
+	pub fn raw_frame(&self, frame: Id, dst: &mut moq_frame) -> Result<(), Error> {
+		let payload = self.raw_frame.get(frame).ok_or(Error::FrameNotFound)?;
+
+		*dst = moq_frame {
+			payload: payload.as_ptr(),
+			payload_size: payload.len(),
+			timestamp_us: 0,
+			keyframe: false,
+		};
+
+		Ok(())
+	}
+
+	pub fn raw_frame_close(&mut self, frame: Id) -> Result<(), Error> {
+		self.raw_frame.remove(frame).ok_or(Error::FrameNotFound)?;
 		Ok(())
 	}
 

--- a/rs/libmoq/src/error.rs
+++ b/rs/libmoq/src/error.rs
@@ -75,6 +75,10 @@ pub enum Error {
 	#[error("track not found")]
 	TrackNotFound,
 
+	/// Group producer not found.
+	#[error("group not found")]
+	GroupNotFound,
+
 	/// Frame not found.
 	#[error("frame not found")]
 	FrameNotFound,
@@ -187,6 +191,7 @@ impl ffi::ReturnCode for Error {
 			Error::FrameNotFound => -28,
 			Error::Mux(_) => -29,
 			Error::Audio(_) => -30,
+			Error::GroupNotFound => -31,
 		}
 	}
 }

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -87,36 +87,18 @@ impl Publish {
 	/// Insert or replace a video rendition in the broadcast's catalog.
 	///
 	/// The catalog is republished automatically.
-	pub fn video_config(
-		&mut self,
-		broadcast: Id,
-		name: &str,
-		config: hang::catalog::VideoConfig,
-	) -> Result<(), Error> {
+	pub fn video_config(&mut self, broadcast: Id, name: &str, config: hang::catalog::VideoConfig) -> Result<(), Error> {
 		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
-		catalog
-			.lock()
-			.video
-			.insert(name, config)
-			.map_err(|err| Error::Hang(err.into()))?;
+		catalog.lock().video.insert(name, config).map_err(Error::Hang)?;
 		Ok(())
 	}
 
 	/// Insert or replace an audio rendition in the broadcast's catalog.
 	///
 	/// The catalog is republished automatically.
-	pub fn audio_config(
-		&mut self,
-		broadcast: Id,
-		name: &str,
-		config: hang::catalog::AudioConfig,
-	) -> Result<(), Error> {
+	pub fn audio_config(&mut self, broadcast: Id, name: &str, config: hang::catalog::AudioConfig) -> Result<(), Error> {
 		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
-		catalog
-			.lock()
-			.audio
-			.insert(name, config)
-			.map_err(|err| Error::Hang(err.into()))?;
+		catalog.lock().audio.insert(name, config).map_err(Error::Hang)?;
 		Ok(())
 	}
 

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -83,4 +83,58 @@ impl Publish {
 		decoder.finish().map_err(|err| Error::DecodeFailed(Arc::new(err)))?;
 		Ok(())
 	}
+
+	/// Insert or replace a video rendition in the broadcast's catalog.
+	///
+	/// The catalog is republished automatically.
+	pub fn video_config(
+		&mut self,
+		broadcast: Id,
+		name: &str,
+		config: hang::catalog::VideoConfig,
+	) -> Result<(), Error> {
+		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		catalog
+			.lock()
+			.video
+			.insert(name, config)
+			.map_err(|err| Error::Hang(err.into()))?;
+		Ok(())
+	}
+
+	/// Insert or replace an audio rendition in the broadcast's catalog.
+	///
+	/// The catalog is republished automatically.
+	pub fn audio_config(
+		&mut self,
+		broadcast: Id,
+		name: &str,
+		config: hang::catalog::AudioConfig,
+	) -> Result<(), Error> {
+		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		catalog
+			.lock()
+			.audio
+			.insert(name, config)
+			.map_err(|err| Error::Hang(err.into()))?;
+		Ok(())
+	}
+
+	/// Remove a video rendition from the broadcast's catalog by name.
+	///
+	/// The catalog is republished automatically.
+	pub fn video_remove(&mut self, broadcast: Id, name: &str) -> Result<(), Error> {
+		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		catalog.lock().video.remove(name);
+		Ok(())
+	}
+
+	/// Remove an audio rendition from the broadcast's catalog by name.
+	///
+	/// The catalog is republished automatically.
+	pub fn audio_remove(&mut self, broadcast: Id, name: &str) -> Result<(), Error> {
+		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		catalog.lock().audio.remove(name);
+		Ok(())
+	}
 }

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -12,6 +12,12 @@ pub struct Publish {
 
 	/// Active media encoders/decoders for publishing.
 	media: NonZeroSlab<import::Framed>,
+
+	/// Raw track producers (no media/container/catalog framing).
+	tracks: NonZeroSlab<moq_net::TrackProducer>,
+
+	/// Raw group producers, created from a raw track producer.
+	groups: NonZeroSlab<moq_net::GroupProducer>,
 }
 
 impl Publish {
@@ -117,6 +123,56 @@ impl Publish {
 	pub fn audio_remove(&mut self, broadcast: Id, name: &str) -> Result<(), Error> {
 		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
 		catalog.lock().audio.remove(name);
+		Ok(())
+	}
+
+	/// Create a raw track on a broadcast for arbitrary byte payloads.
+	///
+	/// No codec, container, or catalog framing. This is the moq-net primitive
+	/// for non-media tracks. Pair it with [`Self::video_config`] / [`Self::audio_config`]
+	/// if you want to describe the track in the catalog as well.
+	pub fn track(&mut self, broadcast: Id, name: &str) -> Result<Id, Error> {
+		let (broadcast, _) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let track = broadcast.create_track(moq_net::Track {
+			name: name.to_string(),
+			priority: 0,
+		})?;
+		self.tracks.insert(track)
+	}
+
+	/// Append a new group to a raw track, returning a group producer.
+	pub fn track_group(&mut self, track: Id) -> Result<Id, Error> {
+		let track = self.tracks.get_mut(track).ok_or(Error::TrackNotFound)?;
+		let group = track.append_group()?;
+		self.groups.insert(group)
+	}
+
+	/// Write a single-frame group to a raw track. Convenience for the common
+	/// one-frame-per-group pattern (e.g. status/command tracks).
+	pub fn track_frame(&mut self, track: Id, payload: &[u8]) -> Result<(), Error> {
+		let track = self.tracks.get_mut(track).ok_or(Error::TrackNotFound)?;
+		track.write_frame(bytes::Bytes::copy_from_slice(payload))?;
+		Ok(())
+	}
+
+	/// Finish a raw track. No more groups or frames can be written.
+	pub fn track_finish(&mut self, track: Id) -> Result<(), Error> {
+		let mut track = self.tracks.remove(track).ok_or(Error::TrackNotFound)?;
+		track.finish()?;
+		Ok(())
+	}
+
+	/// Write a frame into a raw group.
+	pub fn group_frame(&mut self, group: Id, payload: &[u8]) -> Result<(), Error> {
+		let group = self.groups.get_mut(group).ok_or(Error::GroupNotFound)?;
+		group.write_frame(bytes::Bytes::copy_from_slice(payload))?;
+		Ok(())
+	}
+
+	/// Finish a raw group. No more frames can be written.
+	pub fn group_finish(&mut self, group: Id) -> Result<(), Error> {
+		let mut group = self.groups.remove(group).ok_or(Error::GroupNotFound)?;
+		group.finish()?;
 		Ok(())
 	}
 }

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -273,6 +273,125 @@ fn publish_catalog_roundtrip() {
 }
 
 #[test]
+fn publish_track_invalid_broadcast() {
+	let name = b"data";
+	assert!(unsafe { moq_publish_track(0, name.as_ptr() as *const c_char, name.len()) } < 0);
+	assert!(moq_publish_track_group(9999) < 0);
+	assert!(unsafe { moq_publish_track_frame(9999, name.as_ptr(), name.len()) } < 0);
+	assert!(unsafe { moq_publish_group_frame(9999, name.as_ptr(), name.len()) } < 0);
+	assert!(moq_publish_track_close(9999) < 0);
+	assert!(moq_publish_group_close(9999) < 0);
+}
+
+#[test]
+fn raw_track_publish_consume() {
+	let origin = id(moq_origin_create());
+	let broadcast = id(moq_publish_create());
+
+	// Describe an audio rendition so the catalog is non-empty. This lets the
+	// catalog handshake below complete, which warms the broadcast connection
+	// before we publish raw frames (otherwise the first frame can race ahead of
+	// the subscription and be dropped under live semantics).
+	let audio_name = b"audio";
+	let audio_codec = b"opus";
+	let audio = moq_audio_config {
+		name: audio_name.as_ptr() as *const c_char,
+		name_len: audio_name.len(),
+		codec: audio_codec.as_ptr() as *const c_char,
+		codec_len: audio_codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		sample_rate: 48000,
+		channel_count: 2,
+	};
+	assert_eq!(unsafe { moq_publish_audio_config(broadcast, &audio) }, 0);
+
+	// Create a raw, non-media track.
+	let track_name = b"data";
+	let track = id(unsafe { moq_publish_track(broadcast, track_name.as_ptr() as *const c_char, track_name.len()) });
+
+	let path = b"raw-track";
+	assert_eq!(
+		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
+		0
+	);
+
+	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
+
+	// Subscribe to the catalog first and wait for it. This forces the broadcast
+	// consumer to actually connect before we publish frames, so the raw track
+	// subscription below lands on a warm broadcast (matching the handshake in
+	// the media publish/consume tests).
+	let catalog_cb = Callback::new();
+	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
+	let catalog_id = id(catalog_cb.recv());
+
+	let frame_cb = Callback::new();
+	let consumer = id(unsafe {
+		moq_consume_track(
+			consume,
+			track_name.as_ptr() as *const c_char,
+			track_name.len(),
+			Some(channel_callback),
+			frame_cb.ptr,
+		)
+	});
+
+	// One-frame-per-group convenience write.
+	let payload = b"hello raw track";
+	assert_eq!(
+		unsafe { moq_publish_track_frame(track, payload.as_ptr(), payload.len()) },
+		0
+	);
+
+	let frame_id = id(frame_cb.recv());
+	let mut frame = moq_frame {
+		payload: std::ptr::null(),
+		payload_size: 0,
+		timestamp_us: 123, // should be overwritten with 0
+		keyframe: true,    // should be overwritten with false
+	};
+	assert_eq!(unsafe { moq_consume_track_frame(frame_id, &mut frame) }, 0);
+	let received = unsafe { std::slice::from_raw_parts(frame.payload, frame.payload_size) };
+	assert_eq!(received, payload);
+	assert_eq!(frame.timestamp_us, 0, "raw frames have no timestamp");
+	assert!(!frame.keyframe, "raw frames have no keyframe flag");
+	assert_eq!(moq_consume_track_frame_close(frame_id), 0);
+
+	// Multi-frame group via the explicit group API.
+	let group = id(moq_publish_track_group(track));
+	let parts: [&[u8]; 2] = [b"part-0", b"part-1"];
+	for part in parts {
+		assert_eq!(unsafe { moq_publish_group_frame(group, part.as_ptr(), part.len()) }, 0);
+	}
+	assert_eq!(moq_publish_group_close(group), 0);
+
+	for expected in parts {
+		let frame_id = id(frame_cb.recv());
+		let mut frame = moq_frame {
+			payload: std::ptr::null(),
+			payload_size: 0,
+			timestamp_us: 0,
+			keyframe: false,
+		};
+		assert_eq!(unsafe { moq_consume_track_frame(frame_id, &mut frame) }, 0);
+		let received = unsafe { std::slice::from_raw_parts(frame.payload, frame.payload_size) };
+		assert_eq!(received, expected);
+		assert_eq!(moq_consume_track_frame_close(frame_id), 0);
+	}
+
+	assert_eq!(moq_consume_track_close(consumer), 0);
+	assert!(moq_consume_track_close(consumer) < 0, "double-close should fail");
+	assert_eq!(moq_publish_track_close(track), 0);
+	assert!(moq_publish_track_close(track) < 0, "double-close should fail");
+	assert_eq!(moq_consume_catalog_free(catalog_id), 0);
+	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
+	assert_eq!(moq_consume_close(consume), 0);
+	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
+#[test]
 fn close_invalid_or_zero_ids() {
 	assert!(moq_origin_close(9999) < 0);
 	assert!(moq_session_close(9999) < 0);

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -288,25 +288,7 @@ fn raw_track_publish_consume() {
 	let origin = id(moq_origin_create());
 	let broadcast = id(moq_publish_create());
 
-	// Describe an audio rendition so the catalog is non-empty. This lets the
-	// catalog handshake below complete, which warms the broadcast connection
-	// before we publish raw frames (otherwise the first frame can race ahead of
-	// the subscription and be dropped under live semantics).
-	let audio_name = b"audio";
-	let audio_codec = b"opus";
-	let audio = moq_audio_config {
-		name: audio_name.as_ptr() as *const c_char,
-		name_len: audio_name.len(),
-		codec: audio_codec.as_ptr() as *const c_char,
-		codec_len: audio_codec.len(),
-		description: std::ptr::null(),
-		description_len: 0,
-		sample_rate: 48000,
-		channel_count: 2,
-	};
-	assert_eq!(unsafe { moq_publish_audio_config(broadcast, &audio) }, 0);
-
-	// Create a raw, non-media track.
+	// A raw, non-media track: arbitrary bytes, no codec/container/catalog.
 	let track_name = b"data";
 	let track = id(unsafe { moq_publish_track(broadcast, track_name.as_ptr() as *const c_char, track_name.len()) });
 
@@ -317,14 +299,6 @@ fn raw_track_publish_consume() {
 	);
 
 	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
-
-	// Subscribe to the catalog first and wait for it. This forces the broadcast
-	// consumer to actually connect before we publish frames, so the raw track
-	// subscription below lands on a warm broadcast (matching the handshake in
-	// the media publish/consume tests).
-	let catalog_cb = Callback::new();
-	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
-	let catalog_id = id(catalog_cb.recv());
 
 	let frame_cb = Callback::new();
 	let consumer = id(unsafe {
@@ -384,8 +358,6 @@ fn raw_track_publish_consume() {
 	assert!(moq_consume_track_close(consumer) < 0, "double-close should fail");
 	assert_eq!(moq_publish_track_close(track), 0);
 	assert!(moq_publish_track_close(track) < 0, "double-close should fail");
-	assert_eq!(moq_consume_catalog_free(catalog_id), 0);
-	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
 	assert_eq!(moq_consume_close(consume), 0);
 	assert_eq!(moq_publish_close(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -117,6 +117,162 @@ fn publish_media_lifecycle() {
 }
 
 #[test]
+fn publish_catalog_config_invalid_broadcast() {
+	let name = "video";
+	let codec = "vp8";
+	let video = moq_video_config {
+		name: name.as_ptr() as *const c_char,
+		name_len: name.len(),
+		codec: codec.as_ptr() as *const c_char,
+		codec_len: codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		coded_width: std::ptr::null(),
+		coded_height: std::ptr::null(),
+	};
+	assert!(unsafe { moq_publish_video_config(0, &video) } < 0);
+
+	let audio_codec = "opus";
+	let audio = moq_audio_config {
+		name: name.as_ptr() as *const c_char,
+		name_len: name.len(),
+		codec: audio_codec.as_ptr() as *const c_char,
+		codec_len: audio_codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		sample_rate: 48000,
+		channel_count: 2,
+	};
+	assert!(unsafe { moq_publish_audio_config(0, &audio) } < 0);
+
+	assert!(unsafe { moq_publish_video_remove(0, name.as_ptr() as *const c_char, name.len()) } < 0);
+	assert!(unsafe { moq_publish_audio_remove(0, name.as_ptr() as *const c_char, name.len()) } < 0);
+}
+
+#[test]
+fn publish_catalog_config_null_pointer() {
+	let broadcast = id(moq_publish_create());
+	assert_eq!(
+		unsafe { moq_publish_video_config(broadcast, std::ptr::null()) },
+		-6,
+		"null config should return InvalidPointer (-6)"
+	);
+	assert_eq!(
+		unsafe { moq_publish_audio_config(broadcast, std::ptr::null()) },
+		-6,
+		"null config should return InvalidPointer (-6)"
+	);
+	assert_eq!(moq_publish_close(broadcast), 0);
+}
+
+#[test]
+fn publish_catalog_roundtrip() {
+	let origin = id(moq_origin_create());
+	let broadcast = id(moq_publish_create());
+
+	// Author the catalog directly instead of via moq_publish_media_ordered.
+	let video_name = "video";
+	let video_codec = "vp8";
+	let width: u32 = 1920;
+	let height: u32 = 1080;
+	let description: &[u8] = &[0x01, 0x02, 0x03];
+	let video = moq_video_config {
+		name: video_name.as_ptr() as *const c_char,
+		name_len: video_name.len(),
+		codec: video_codec.as_ptr() as *const c_char,
+		codec_len: video_codec.len(),
+		description: description.as_ptr(),
+		description_len: description.len(),
+		coded_width: &width,
+		coded_height: &height,
+	};
+	assert_eq!(unsafe { moq_publish_video_config(broadcast, &video) }, 0);
+
+	let audio_name = "audio";
+	let audio_codec = "opus";
+	let audio = moq_audio_config {
+		name: audio_name.as_ptr() as *const c_char,
+		name_len: audio_name.len(),
+		codec: audio_codec.as_ptr() as *const c_char,
+		codec_len: audio_codec.len(),
+		description: std::ptr::null(),
+		description_len: 0,
+		sample_rate: 48000,
+		channel_count: 2,
+	};
+	assert_eq!(unsafe { moq_publish_audio_config(broadcast, &audio) }, 0);
+
+	// Publish and consume the broadcast to verify the catalog round-trips.
+	let path = b"catalog-producer";
+	assert_eq!(
+		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
+		0
+	);
+
+	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
+	let catalog_cb = Callback::new();
+	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
+	let catalog_id = id(catalog_cb.recv());
+
+	// The video rendition we authored comes back through the consume API.
+	let mut video_cfg = moq_video_config {
+		name: std::ptr::null(),
+		name_len: 0,
+		codec: std::ptr::null(),
+		codec_len: 0,
+		description: std::ptr::null(),
+		description_len: 0,
+		coded_width: std::ptr::null(),
+		coded_height: std::ptr::null(),
+	};
+	assert_eq!(unsafe { moq_consume_video_config(catalog_id, 0, &mut video_cfg) }, 0);
+	let codec = unsafe {
+		std::str::from_utf8(std::slice::from_raw_parts(
+			video_cfg.codec as *const u8,
+			video_cfg.codec_len,
+		))
+	}
+	.unwrap();
+	assert_eq!(codec, "vp8");
+	assert_eq!(unsafe { *video_cfg.coded_width }, 1920);
+	assert_eq!(unsafe { *video_cfg.coded_height }, 1080);
+
+	// And so does the audio rendition.
+	let mut audio_cfg = moq_audio_config {
+		name: std::ptr::null(),
+		name_len: 0,
+		codec: std::ptr::null(),
+		codec_len: 0,
+		description: std::ptr::null(),
+		description_len: 0,
+		sample_rate: 0,
+		channel_count: 0,
+	};
+	assert_eq!(unsafe { moq_consume_audio_config(catalog_id, 0, &mut audio_cfg) }, 0);
+	assert_eq!(audio_cfg.sample_rate, 48000);
+	assert_eq!(audio_cfg.channel_count, 2);
+
+	// Removing the video rendition republishes a catalog without it.
+	assert_eq!(
+		unsafe { moq_publish_video_remove(broadcast, video_name.as_ptr() as *const c_char, video_name.len()) },
+		0
+	);
+	let catalog_id2 = id(catalog_cb.recv());
+	assert!(
+		unsafe { moq_consume_video_config(catalog_id2, 0, &mut video_cfg) } < 0,
+		"video rendition should be gone after remove"
+	);
+	assert_eq!(unsafe { moq_consume_audio_config(catalog_id2, 0, &mut audio_cfg) }, 0);
+
+	assert_eq!(moq_consume_catalog_free(catalog_id), 0);
+	assert_eq!(moq_consume_catalog_free(catalog_id2), 0);
+	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
+	assert_eq!(moq_consume_close(consume), 0);
+	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
+#[test]
 fn close_invalid_or_zero_ids() {
 	assert!(moq_origin_close(9999) < 0);
 	assert!(moq_session_close(9999) < 0);


### PR DESCRIPTION
## Summary

Adds two related, additive pieces to libmoq's C API, both mirroring functionality that already exists in `moq-ffi` but was missing from the C bindings. Together they let a C caller describe a broadcast's catalog **and** write/read arbitrary track contents themselves, the producer-side opposite of the existing consume API.

### 1. Catalog producer API

The producer counterpart to `moq_consume_video_config` / `moq_consume_audio_config`. Lets callers author catalog renditions directly instead of relying on `moq_publish_media_ordered` to derive them.

- `moq_publish_video_config(broadcast, const moq_video_config*)` / `moq_publish_audio_config(broadcast, const moq_audio_config*)` — insert or replace a rendition, keyed by `name`.
- `moq_publish_video_remove` / `moq_publish_audio_remove` — remove by name.

These reuse the existing `moq_video_config` / `moq_audio_config` structs as **inputs** (the same structs the consume side fills as outputs), so producer and consumer are mirror images. Each call republishes the catalog automatically via the existing moq-mux catalog `Producer` guard. `description` / `coded_width` / `coded_height` pointers may be `NULL` to omit those fields.

### 2. Raw moq-net track API

The catalog API above only writes *metadata*. To actually feed a track, libmoq previously offered only `moq_publish_media_ordered`, which requires a known `FramedFormat` and owns its own catalog/container. There was no way to publish or consume a **non-media** track (control channel, JSON metadata, or your own encoded bitstream) over the C bindings.

This adds the bare moq-net primitives, mirroring `moq-ffi`'s `publish_track` / `subscribe_track` (broadcast → track → group → frame, raw bytes, no codec/container/catalog):

**Publish:**
- `moq_publish_track(broadcast, name, name_len)` → track handle (`create_track`)
- `moq_publish_track_group(track)` → group handle (`append_group`)
- `moq_publish_track_frame(track, payload, len)` — convenience one-frame-per-group write
- `moq_publish_group_frame(group, payload, len)` / `moq_publish_group_close(group)`
- `moq_publish_track_close(track)`

**Consume:**
- `moq_consume_track(broadcast, name, name_len, on_frame, user_data)` → track handle
- `moq_consume_track_frame(frame, moq_frame*)` — fills `payload`/`payload_size`; `timestamp_us`/`keyframe` are 0/false (not meaningful for raw tracks)
- `moq_consume_track_frame_close(frame)` / `moq_consume_track_close(track)`

The consumer iterates groups in sequence order and delivers **every** frame within each group, so it sees exactly what the producer wrote regardless of grouping. Adds a `GroupNotFound` error code (`-31`).

These two pieces compose: describe a track with `moq_publish_*_config`, then push its frames with `moq_publish_track`/`_frame`.

## Cross-package sync

| Change in | Also updated |
|---|---|
| `rs/libmoq` | `CHANGELOG.md`; doc comments flow into the cbindgen-generated `moq.h` that `doc/lib/c` points at |

Confined to `rs/libmoq` and purely additive (no existing signatures change), so it does not touch `rs/moq-ffi`, the wire/catalog formats, or the language wrappers — and targets `main`.

## Test plan

- [x] `cargo test -p libmoq` — 19 tests pass, including:
  - `publish_catalog_roundtrip`: author video + audio renditions, publish, consume the catalog back (codec, coded dimensions, sample rate, channels), then remove the video rendition and confirm the republished catalog drops it.
  - `raw_track_publish_consume`: publish a raw `data` track, consume it via `moq_consume_track`, verify a one-frame-per-group write and a multi-frame group both round-trip byte-for-byte, and that `timestamp_us`/`keyframe` come back 0/false.
  - invalid-handle and null-pointer tests for both APIs.
- [x] `cargo clippy -p libmoq --all-targets` — clean.
- [x] `cargo fmt -p libmoq -- --check` — clean.
- [x] Generated `moq.h` picks up all new functions (one declaration each).

(Written by Claude)