### PR TITLE
moq-native: fix broadcast linger test broken by AnnounceConsumer split

### DIFF
--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -668,7 +668,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	let addr = server.local_addr().expect("server addr");
 
 	let sub_origin = Origin::random().produce();
-	let mut announcements = sub_origin.consume();
+	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_native::ClientConfig::default();
 	client_config.tls.disable_verify = Some(true);
@@ -689,7 +689,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 		.expect("connect timeout")
 		.expect("connect failed");
 
-	let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+	let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.next())
 		.await
 		.expect("announce timeout")
 		.expect("origin closed");


### PR DESCRIPTION
## Summary

`dev` currently fails to compile its test targets. `cargo check --all-targets` (and therefore `just rs ci` / `just ci`) errors out in `rs/moq-native/tests/broadcast.rs`:

```
error[E0277]: `moq_native::moq_net::AnnounceConsumer` is not a future
   --> rs/moq-native/tests/broadcast.rs:692:19
    |
692 |     let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
    |                      ^^^ `AnnounceConsumer` is not a future
```

The `linger_resubscribe_keeps_flowing_moq_lite_03` test was written against the pre-split `OriginConsumer` API, where `announced()` was an async method you awaited directly. After #1434 split `OriginConsumer` into a cheap read handle plus an `AnnounceConsumer` cursor, `announced()` returns the cursor and the await moved to `AnnounceConsumer::next()`.

This PR makes the test match the other three tests in the file: build the cursor up front with `consume().announced()`, then await `next()`.

```diff
-	let mut announcements = sub_origin.consume();
+	let mut announcements = sub_origin.consume().announced();
...
-	let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+	let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.next())
```

## How did this land on `dev`?

A semantic (logical) merge conflict that no single PR's CI could catch:

- **#1434** "Split OriginConsumer into cheap read handle and announcement cursor" merged into `dev` at **2026-05-28 20:42 UTC**. It changed the `announced()` API shape and updated **all then-existing** call sites.
- **#1514** "linger upstream subscriptions" was opened **05-27** (before #1434 merged) and merged at **05-28 21:58 UTC**, ~76 min later, **without being rebased onto the new API**. It *added* a brand-new test using the old `announced()`-as-future shape.

Each PR was green on its own base. #1434 couldn't update a test that didn't exist yet; #1514 compiled fine because its base still had the async `announced()`. The merge was textually clean (a new test vs. edits to existing call sites, no overlapping lines), so git produced a result that compiles on neither parent's terms and was never CI'd as a combined unit.

GitHub's `pull_request` CI runs against the PR's merge commit *as of the last push*; it does not automatically re-run when the base branch advances. Since #1514 wasn't touched after #1434 landed, its last green check predated the API change, and the merge was allowed because the branch wasn't required to be up to date.

To prevent recurrence, enable **"Require branches to be up to date before merging"** on `dev` (or a merge queue), so the merge commit is recomputed and re-checked against the latest base before merge.

## Test plan

- [x] `cargo clippy -p moq-native --all-targets --all-features -- -D warnings` passes (previously failed to compile)
- [x] `cargo fmt --all --check` clean
- [x] Workspace-wide `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check --no-default-features`, and `cargo doc -D warnings` all green
- [ ] The `broadcast` network tests bind `[::]:0` and need IPv6, which the sandbox lacks (os error 97); they run in CI's network environment.

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xium3WNLnUswJhqEjmdYsT)_