### PR TITLE
moq-relay: scope mTLS grants to the connection URL path

### DIFF
--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -184,9 +184,11 @@ Set `public = ""` to make everything public (development only).
 
 In addition to JWT auth, the relay can authenticate peers via mutual TLS. When
 the server is configured with a trusted root CA, any client that presents a
-certificate chaining to that CA is granted **full access**: root-scoped publish
-and subscribe permissions plus cluster privileges — equivalent to a JWT with
-`publish: ""`, `subscribe: ""`, and `cluster: true`.
+certificate chaining to that CA is granted **full publish and subscribe access
+within the connection URL path**, plus cluster privileges. The URL path scopes
+the grant exactly like a JWT's `root` claim, so a peer dialing `/demo` can only
+publish and subscribe under `demo/`. A peer dialing `/` (as cluster nodes do)
+gets an empty root and unscoped, cluster-wide access.
 
 This is primarily intended for relay-to-relay (clustering) authentication, as a
 simpler alternative to distributing long-lived JWTs.
@@ -202,10 +204,11 @@ key  = ["/etc/moq/server.key"]
 root = ["/etc/moq/peer-ca.pem"]
 ```
 
-The peer's cluster node name is taken from the **first DNS SAN** on its leaf
-certificate, so node identity is cryptographically bound to the cert.
-Certificates without a DNS SAN are still accepted but will not register as
-cluster nodes.
+The certificate is used only to authenticate the peer: the relay verifies the
+chain against the configured CA and reads nothing else from it. A node
+advertises its own identity by setting `--cluster-mesh` to its
+externally-reachable URL, which it publishes on the cluster origin for other
+peers to discover and dial.
 
 Only the `quinn` QUIC backend supports mTLS; configuring `tls.root` with any
 other backend is a startup error.

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -185,10 +185,11 @@ Set `public = ""` to make everything public (development only).
 In addition to JWT auth, the relay can authenticate peers via mutual TLS. When
 the server is configured with a trusted root CA, any client that presents a
 certificate chaining to that CA is granted **full publish and subscribe access
-within the connection URL path**, plus cluster privileges. The URL path scopes
-the grant exactly like a JWT's `root` claim, so a peer dialing `/demo` can only
-publish and subscribe under `demo/`. A peer dialing `/` (as cluster nodes do)
-gets an empty root and unscoped, cluster-wide access.
+within the connection URL path**. The URL path scopes the grant exactly like a
+JWT's `root` claim, so a peer dialing `/demo` can only publish and subscribe
+under `demo/`. A peer dialing `/` (as cluster nodes do) gets an empty root and
+unscoped, cluster-wide access. The token is also flagged as internal, which only
+selects the stats tier used for billing; it grants no extra permissions.
 
 This is primarily intended for relay-to-relay (clustering) authentication, as a
 simpler alternative to distributing long-lived JWTs.

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -1,8 +1,7 @@
 use crate::client::ClientConfig;
-use crate::server::{PeerIdentity, ServerConfig, ServerId, ServerTlsInfo};
+use crate::server::{ServerConfig, ServerId, ServerTlsInfo};
 use crate::tls::{FingerprintVerifier, ServeCerts};
 use anyhow::Context;
-use rustls::pki_types::CertificateDer;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::{net, time};
@@ -139,20 +138,6 @@ impl QuinnClient {
 
 		Ok(session)
 	}
-}
-
-// ── Peer identity extraction ───────────────────────────────────────
-
-fn extract_peer_identity(conn: &quinn::Connection) -> anyhow::Result<Option<PeerIdentity>> {
-	// rustls already validated the client cert chain against our configured
-	// `tls.root` during the handshake, so we just need to report whether one
-	// was presented. The caller uses that as the gate for cluster-level trust.
-	let Some(any) = conn.peer_identity() else {
-		return Ok(None);
-	};
-	any.downcast::<Vec<CertificateDer<'static>>>()
-		.map_err(|_| anyhow::anyhow!("peer identity is not a rustls certificate chain"))?;
-	Ok(Some(PeerIdentity::default()))
 }
 
 // ── Server ──────────────────────────────────────────────────────────
@@ -378,13 +363,14 @@ impl QuinnRequest {
 		}
 	}
 
-	/// Returns the peer's validated client certificate identity, if any.
-	pub fn peer_identity(&self) -> anyhow::Result<Option<PeerIdentity>> {
+	/// Whether the peer presented a client certificate that rustls validated
+	/// against the configured `tls.root` during the handshake.
+	pub fn has_peer_certificate(&self) -> bool {
 		let conn = match self {
 			QuinnRequest::Raw { connection, .. } => connection,
 			QuinnRequest::WebTransport { request, .. } => request.conn(),
 		};
-		extract_peer_identity(conn)
+		conn.peer_identity().is_some()
 	}
 
 	/// Reject the session with a status code.

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -53,9 +53,9 @@ pub struct ServerTlsConfig {
 	/// PEM file(s) of root CAs for validating optional client certificates (mTLS).
 	///
 	/// When set, clients *may* present a certificate during the TLS handshake.
-	/// Valid presentations are exposed via [`Request::peer_identity`] and can be
-	/// used by the application to grant elevated access. Clients that do not
-	/// present a certificate are unaffected.
+	/// Valid presentations are reported via [`Request::has_peer_certificate`]
+	/// and can be used by the application to grant elevated access. Clients that
+	/// do not present a certificate are unaffected.
 	///
 	/// Only supported by the Quinn backend.
 	#[arg(
@@ -539,12 +539,6 @@ impl Server {
 	}
 }
 
-/// The identity of a peer that presented a client certificate during the TLS
-/// handshake, as validated against the configured [`ServerTlsConfig::root`].
-#[derive(Clone, Debug, Default)]
-#[non_exhaustive]
-pub struct PeerIdentity {}
-
 /// An incoming connection that can be accepted or rejected.
 pub(crate) enum RequestKind {
 	#[cfg(feature = "noq")]
@@ -682,23 +676,22 @@ impl Request {
 		}
 	}
 
-	/// Returns the peer's TLS-validated identity, if it presented a client
-	/// certificate during the handshake that chained to a configured
-	/// [`ServerTlsConfig::root`].
+	/// Whether the peer presented a client certificate during the handshake
+	/// that chained to a configured [`ServerTlsConfig::root`].
 	///
-	/// Only the Quinn backend supports mTLS; other backends always return `Ok(None)`.
-	pub fn peer_identity(&self) -> anyhow::Result<Option<PeerIdentity>> {
+	/// Only the Quinn backend supports mTLS; other backends always return `false`.
+	pub fn has_peer_certificate(&self) -> bool {
 		match self.kind {
 			#[cfg(feature = "quinn")]
-			RequestKind::Quinn(ref request) => request.peer_identity(),
+			RequestKind::Quinn(ref request) => request.has_peer_certificate(),
 			#[cfg(feature = "noq")]
-			RequestKind::Noq(_) => Ok(None),
+			RequestKind::Noq(_) => false,
 			#[cfg(feature = "quiche")]
-			RequestKind::Quiche(_) => Ok(None),
+			RequestKind::Quiche(_) => false,
 			#[cfg(feature = "iroh")]
-			RequestKind::Iroh(_) => Ok(None),
+			RequestKind::Iroh(_) => false,
 			#[cfg(feature = "websocket")]
-			RequestKind::WebSocket(_) => Ok(None),
+			RequestKind::WebSocket(_) => false,
 			#[cfg(not(any(
 				feature = "noq",
 				feature = "quinn",
@@ -706,7 +699,7 @@ impl Request {
 				feature = "iroh",
 				feature = "websocket"
 			)))]
-			_ => Ok(None),
+			_ => false,
 		}
 	}
 }

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -489,13 +489,18 @@ pub struct AuthToken {
 
 impl AuthToken {
 	/// Construct a token for a peer that was authenticated at the TLS layer
-	/// via mTLS. These peers are granted full (root-scoped) publish and
-	/// subscribe access and are flagged as internal. The cert's trust chain
-	/// (verified against the configured CA) is the only credential we require
-	/// — DNS SANs and the `?register=` name are no longer consulted.
-	pub fn unrestricted() -> Self {
+	/// via mTLS. These peers are granted full publish and subscribe access
+	/// within `root` and are flagged as internal. The cert's trust chain
+	/// (verified against the configured CA) is the only credential we require;
+	/// nothing else in the cert is inspected.
+	///
+	/// `root` is taken from the connection URL path, the same scoping a JWT
+	/// gets. An mTLS publisher dialing `/demo` therefore announces under
+	/// `demo/`, not the cluster root. Cluster peers dial `/`, so they resolve
+	/// to an empty root and keep unscoped access.
+	pub fn unrestricted(root: PathOwned) -> Self {
 		Self {
-			root: PathOwned::default(),
+			root,
 			subscribe: PathPrefixes::from(vec![Path::new("").to_owned()]),
 			publish: PathPrefixes::from(vec![Path::new("").to_owned()]),
 			internal: true,
@@ -2516,5 +2521,25 @@ api = "https://api.example.com/access"
 		assert!(auth.verify(&params).await.is_err());
 
 		Ok(())
+	}
+
+	#[test]
+	fn unrestricted_scopes_to_root() {
+		// An mTLS publisher dialing "/demo" must announce under the `demo` root,
+		// not the cluster root, so path-scoped subscribers (e.g. `demo/*`) see it.
+		let token = AuthToken::unrestricted(Path::new("/demo").to_owned());
+		assert_eq!(token.root, "demo".as_path());
+		assert_eq!(token.subscribe, vec!["".as_path()]);
+		assert_eq!(token.publish, vec!["".as_path()]);
+		assert!(token.internal);
+	}
+
+	#[test]
+	fn unrestricted_empty_root_is_unscoped() {
+		// Cluster peers dial "/", which normalizes to an empty root, leaving the
+		// grant unscoped across the whole cluster.
+		let token = AuthToken::unrestricted(Path::new("/").to_owned());
+		assert_eq!(token.root, "".as_path());
+		assert!(token.internal);
 	}
 }

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -103,15 +103,10 @@ impl Connection {
 	/// close the request with the mapped HTTP status exactly once.
 	///
 	/// If the client presented a valid mTLS client certificate, JWT is skipped
-	/// and full (cluster) access is granted. The cert's chain to the configured
-	/// CA is the only credential we require.
+	/// and full access is granted within the URL path's root. The cert's chain
+	/// to the configured CA is the only credential we require.
 	async fn authenticate(&self) -> Result<AuthToken, StatusError> {
-		let peer = self.request.peer_identity().map_err(|source| StatusError {
-			status: http::StatusCode::FORBIDDEN,
-			source,
-		})?;
-
-		if peer.is_some() {
+		if self.request.has_peer_certificate() {
 			tracing::debug!("mTLS peer authenticated");
 			// Scope the grant to the URL path, the same root a JWT would resolve
 			// to. Cluster peers dial "/" and so keep an empty (unscoped) root.

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -2,6 +2,7 @@ use crate::{Auth, AuthError, AuthParams, AuthToken, Cluster};
 
 use axum::http;
 use moq_native::Request;
+use moq_net::{Path, PathOwned};
 
 /// An error carrying the HTTP status to send when closing the request.
 ///
@@ -112,7 +113,13 @@ impl Connection {
 
 		if peer.is_some() {
 			tracing::debug!("mTLS peer authenticated");
-			return Ok(AuthToken::unrestricted());
+			// Scope the grant to the URL path, the same root a JWT would resolve
+			// to. Cluster peers dial "/" and so keep an empty (unscoped) root.
+			let root = match self.request.url() {
+				Some(url) => Path::new(&self.auth.params_from_url(url).path).to_owned(),
+				None => PathOwned::default(),
+			};
+			return Ok(AuthToken::unrestricted(root));
 		}
 
 		let params = match self.request.url() {

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -270,9 +270,9 @@ async fn reload_https_config(config: RustlsConfig, cert: PathBuf, key: PathBuf, 
 }
 
 /// Marker inserted as a request extension when rustls verified a client cert
-/// against the configured mTLS CA. We don't carry the cert bytes — "verified
-/// by our CA" is the entire signal we need (mirrors `PeerIdentity` on the QUIC
-/// side).
+/// against the configured mTLS CA. We don't carry the cert bytes. "Verified
+/// by our CA" is the entire signal we need (mirrors `has_peer_certificate` on
+/// the QUIC side).
 #[derive(Clone, Debug)]
 pub(crate) struct MtlsPeer;
 

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -81,9 +81,10 @@ pub struct HttpsConfig {
 	/// PEM file(s) of root CAs for validating optional client certificates (mTLS).
 	///
 	/// When set, clients *may* present a certificate during the TLS handshake.
-	/// A verified peer is granted an unrestricted [`AuthToken`] without a JWT,
-	/// mirroring the QUIC server's `--server-tls-root` behavior. Clients that
-	/// don't present a cert continue through the normal JWT path.
+	/// A verified peer is granted full publish/subscribe access scoped to the
+	/// URL path without a JWT, mirroring the QUIC server's `--server-tls-root`
+	/// behavior. Clients that don't present a cert continue through the normal
+	/// JWT path.
 	///
 	/// In config files, accepts either a single string or a TOML array.
 	#[arg(
@@ -454,7 +455,7 @@ async fn serve_announced(
 		jwt: query.jwt,
 	};
 	let token = if mtls.is_some() {
-		AuthToken::unrestricted()
+		AuthToken::unrestricted(moq_net::Path::new(&params.path).to_owned())
 	} else {
 		state.auth.verify(&params).await?
 	};
@@ -495,7 +496,7 @@ async fn serve_fetch(
 		jwt: params.auth.jwt,
 	};
 	let token = if mtls.is_some() {
-		AuthToken::unrestricted()
+		AuthToken::unrestricted(moq_net::Path::new(&auth.path).to_owned())
 	} else {
 		state.auth.verify(&auth).await?
 	};

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -40,7 +40,7 @@ pub(crate) async fn serve_ws(
 
 	let params = AuthParams { path, jwt: query.jwt };
 	let token = if mtls.is_some() {
-		AuthToken::unrestricted()
+		AuthToken::unrestricted(moq_net::Path::new(&params.path).to_owned())
 	} else {
 		state.auth.verify(&params).await?
 	};


### PR DESCRIPTION
## Summary

- mTLS-authenticated peers were granted `AuthToken::unrestricted()` with an **empty root**, so a publisher dialing `/demo` announced at the cluster root (e.g. `tos.hang`) instead of `demo/tos.hang`. Path-scoped subscribers (`demo/*`) never saw the broadcast.
- `AuthToken::unrestricted(root)` now takes a root derived from the connection URL path, the same scoping a JWT's `root` claim gets. All four mTLS call sites pass the request path: QUIC ([connection.rs](rs/moq-relay/src/connection.rs)), WebSocket ([websocket.rs](rs/moq-relay/src/websocket.rs)), and the HTTP `serve_announced` / `serve_fetch` handlers ([web.rs](rs/moq-relay/src/web.rs)).
- Dropped stale doc/comment claims that node identity comes from the cert's **DNS SAN** and that `?register=` is consulted. The mTLS path validates only the cert chain; node identity comes from `--cluster-mesh`.
- Simplified the mTLS presence check in `moq-native`: the empty `PeerIdentity` struct was a data-less presence flag and `peer_identity() -> Result<Option<PeerIdentity>>` only existed to guard a downcast that can't fail with rustls. Replaced it with `Request::has_peer_certificate() -> bool`, removing the struct, the downcast, and the `Result` plumbing at the call site.

## Why it's safe for the cluster mesh

Cluster peers dial `https://{remote}/`, and `/` normalizes to an empty root, so relay-to-relay keeps unscoped, cluster-wide access exactly as before. Only path-bearing dials get scoped, which is the fix.

## Branch targeting

Targeting `main`: this is a bug fix that preserves the wire protocol and cluster behavior. The public `AuthToken::unrestricted()` and `Request::peer_identity()` signatures change, but both are relay/native-internal with no external consumers. Happy to retarget `dev` if a reviewer prefers.

## Test plan

- [x] `cargo test -p moq-relay --lib` (93 passed; added `unrestricted_scopes_to_root` and `unrestricted_empty_root_is_unscoped`)
- [x] `cargo clippy -p moq-native -p moq-relay --all-targets` clean
- [x] `cargo build -p moq-native -p moq-relay` clean
- [ ] Manual: confirm an mTLS publisher dialing `/demo` announces under `demo/` and a `demo/*` subscriber sees it; confirm cluster mesh (dialing `/`) still gets cluster-wide access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)