### PR TITLE
moq-net: auto-create Origin on connect/accept, expose via Session

### DIFF
--- a/doc/lib/kt/index.md
+++ b/doc/lib/kt/index.md
@@ -46,8 +46,7 @@ val cs = client.connect("https://relay.example.com")
 // cs.consumer() and cs.publisher() are always populated: by whatever
 // origin you wired via setPublish / setConsume before connect, or by a
 // fresh auto-created one for any side you didn't set.
-val consumer = cs.consumer()
-val announced = consumer.announced("demos/")
+val announced = cs.consumer().announced("demos/")
 announced.announcements().collect { announcement ->
     println("got broadcast ${announcement.path()}")
 

--- a/doc/lib/kt/index.md
+++ b/doc/lib/kt/index.md
@@ -43,11 +43,10 @@ import uniffi.moq.MoqClient
 val client = MoqClient()
 val cs = client.connect("https://relay.example.com")
 
-// `cs.consumer()` returns the auto-created origin consumer for reading
-// announcements; `cs.publisher()` returns the producer side for publishing
-// broadcasts. Both are null if you set publish / consume manually before
-// connect (subscribe-only, publish-only, or custom split-origin cases).
-val consumer = cs.consumer()!!
+// cs.consumer() and cs.publisher() are always populated: by whatever
+// origin you wired via setPublish / setConsume before connect, or by a
+// fresh auto-created one for any side you didn't set.
+val consumer = cs.consumer()
 val announced = consumer.announced("demos/")
 announced.announcements().collect { announcement ->
     println("got broadcast ${announcement.path()}")

--- a/doc/lib/kt/index.md
+++ b/doc/lib/kt/index.md
@@ -57,7 +57,7 @@ announced.announcements().collect { announcement ->
     }
 }
 
-cs.session().shutdown()
+cs.shutdown()
 ```
 
 Cancelling the surrounding coroutine scope propagates through to the native consumer's `cancel()` via the wrapper's `onCompletion` hook.

--- a/doc/lib/kt/index.md
+++ b/doc/lib/kt/index.md
@@ -39,30 +39,25 @@ Published to Maven Central via [release-kt.yml](https://github.com/moq-dev/moq/b
 import dev.moq.*
 import kotlinx.coroutines.flow.collect
 import uniffi.moq.MoqClient
-import uniffi.moq.MoqOriginProducer
 
-// Wire an origin as both publish source and consume sink. Set just one
-// side for a subscribe-only or publish-only client.
-val origin = MoqOriginProducer()
 val client = MoqClient()
-client.setPublish(origin)
-client.setConsume(origin)
+val cs = client.connect("https://relay.example.com")
 
-val session = client.connect("https://relay.example.com")
+// `cs.consumer()` returns the auto-created origin consumer for reading
+// announcements; `cs.publisher()` returns the producer side for publishing
+// broadcasts. Both are null if you set publish / consume manually before
+// connect (subscribe-only, publish-only, or custom split-origin cases).
+val consumer = cs.consumer()!!
+val announced = consumer.announced("demos/")
+announced.announcements().collect { announcement ->
+    println("got broadcast ${announcement.path()}")
 
-origin.use {
-    val consumer = origin.consume()
-    val announced = consumer.announced("demos/")
-    announced.announcements().collect { announcement ->
-        println("got broadcast ${announcement.path()}")
-
-        announcement.broadcast().subscribeCatalog().updates().collect { catalog ->
-            println("catalog: $catalog")
-        }
+    announcement.broadcast().subscribeCatalog().updates().collect { catalog ->
+        println("catalog: $catalog")
     }
 }
 
-session.shutdown()
+cs.session().shutdown()
 ```
 
 Cancelling the surrounding coroutine scope propagates through to the native consumer's `cancel()` via the wrapper's `onCompletion` hook.

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -30,18 +30,12 @@ Android uses JNI (`jniLibs/`), desktop JVM uses JNA (resource-classpath layout).
 
 ```kotlin
 import uniffi.moq.MoqClient
-import uniffi.moq.MoqOriginProducer
 
-// Wire an origin as both publish source and consume sink for the
-// typical full-duplex client. Set just one side for a subscribe-only
-// or publish-only client.
-val origin = MoqOriginProducer()
 val client = MoqClient()
-client.setPublish(origin)
-client.setConsume(origin)
-
-val session = client.connect("https://relay.example.com")
+val cs = client.connect("https://relay.example.com")
 ```
+
+`MoqClient.connect(url)` returns a `MoqClientSession` that bundles the session with auto-created publish and consume origin sides. The convenience accessors `cs.publisher()` and `cs.consumer()` return those origins (or `null` if you wired your own via `setPublish` / `setConsume` before connect).
 
 For development against a relay with a self-signed certificate, configure the client before connecting:
 
@@ -49,15 +43,13 @@ For development against a relay with a self-signed certificate, configure the cl
 val client = MoqClient()
 client.setTlsDisableVerify(true)
 client.setBind("127.0.0.1:0")
-client.setPublish(origin)
-client.setConsume(origin)
-val session = client.connect("https://localhost:4443")
+val cs = client.connect("https://localhost:4443")
 ```
 
 When you're done, signal graceful shutdown to the peer:
 
 ```kotlin
-session.shutdown()  // alias for cancel(0u)
+cs.session().shutdown()  // alias for cancel(0u)
 ```
 
 ## Subscribe
@@ -66,7 +58,7 @@ session.shutdown()  // alias for cancel(0u)
 import dev.moq.*
 import kotlinx.coroutines.flow.collect
 
-val consumer = origin.consume()
+val consumer = cs.consumer()!!
 val announced = consumer.announced("demos/")
 
 announced.announcements().collect { announcement ->
@@ -86,7 +78,7 @@ import uniffi.moq.MoqBroadcastProducer
 val broadcast = MoqBroadcastProducer()
 val audio = broadcast.publishMedia("opus", opusInitBytes)
 
-origin.publish("my-stream", broadcast)
+cs.publisher()!!.addBroadcast("my-stream", broadcast)
 
 audio.writeFrame(payload, timestampUs = 0u)
 audio.writeFrame(payload, timestampUs = 20_000u)

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -78,7 +78,7 @@ import uniffi.moq.MoqBroadcastProducer
 val broadcast = MoqBroadcastProducer()
 val audio = broadcast.publishMedia("opus", opusInitBytes)
 
-cs.publisher().addBroadcast("my-stream", broadcast)
+cs.publisher().announce("my-stream", broadcast)
 
 audio.writeFrame(payload, timestampUs = 0u)
 audio.writeFrame(payload, timestampUs = 20_000u)

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -35,7 +35,7 @@ val client = MoqClient()
 val cs = client.connect("https://relay.example.com")
 ```
 
-`MoqClient.connect(url)` returns a `MoqClientSession` that bundles the session with auto-created publish and consume origin sides. The convenience accessors `cs.publisher()` and `cs.consumer()` return those origins (or `null` if you wired your own via `setPublish` / `setConsume` before connect).
+`MoqClient.connect(url)` returns a `MoqSession` that bundles the session with auto-created publish and consume origin sides. The convenience accessors `cs.publisher()` and `cs.consumer()` return those origins (or `null` if you wired your own via `setPublish` / `setConsume` before connect).
 
 For development against a relay with a self-signed certificate, configure the client before connecting:
 
@@ -49,7 +49,7 @@ val cs = client.connect("https://localhost:4443")
 When you're done, signal graceful shutdown to the peer:
 
 ```kotlin
-cs.session().shutdown()  // alias for cancel(0u)
+cs.shutdown()  // alias for cancel(0u)
 ```
 
 ## Subscribe

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -35,7 +35,7 @@ val client = MoqClient()
 val cs = client.connect("https://relay.example.com")
 ```
 
-`MoqClient.connect(url)` returns a `MoqSession` that bundles the session with auto-created publish and consume origin sides. The convenience accessors `cs.publisher()` and `cs.consumer()` return those origins (or `null` if you wired your own via `setPublish` / `setConsume` before connect).
+`MoqClient.connect(url)` returns a `MoqSession`. The accessors `cs.publisher()` and `cs.consumer()` are always populated: by whatever origin you wired via `setPublish` / `setConsume` before connect, or by a fresh auto-created one for any side you didn't set.
 
 For development against a relay with a self-signed certificate, configure the client before connecting:
 
@@ -58,7 +58,7 @@ cs.shutdown()  // alias for cancel(0u)
 import dev.moq.*
 import kotlinx.coroutines.flow.collect
 
-val consumer = cs.consumer()!!
+val consumer = cs.consumer()
 val announced = consumer.announced("demos/")
 
 announced.announcements().collect { announcement ->
@@ -78,7 +78,7 @@ import uniffi.moq.MoqBroadcastProducer
 val broadcast = MoqBroadcastProducer()
 val audio = broadcast.publishMedia("opus", opusInitBytes)
 
-cs.publisher()!!.addBroadcast("my-stream", broadcast)
+cs.publisher().addBroadcast("my-stream", broadcast)
 
 audio.writeFrame(payload, timestampUs = 0u)
 audio.writeFrame(payload, timestampUs = 20_000u)

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -58,8 +58,7 @@ cs.shutdown()  // alias for cancel(0u)
 import dev.moq.*
 import kotlinx.coroutines.flow.collect
 
-val consumer = cs.consumer()
-val announced = consumer.announced("demos/")
+val announced = cs.consumer().announced("demos/")
 
 announced.announcements().collect { announcement ->
     val catalog = announcement.broadcast().subscribeCatalog()

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -66,7 +66,7 @@ The key pattern is: create an [`Origin`](https://docs.rs/moq-net/latest/moq_net/
 ```rust
 let origin = moq_net::Origin::new().produce();
 let session = client
-    .with_publish(origin.consume())
+    .with_publisher(origin.consume())
     .connect(url).await?;
 
 let mut broadcast = moq_net::Broadcast::new().produce();
@@ -80,13 +80,13 @@ See the full [video.rs](https://github.com/moq-dev/moq/blob/main/rs/hang/example
 
 The [subscribe example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/subscribe.rs) demonstrates subscribing end-to-end.
 
-To consume a broadcast, use `with_consume()` and listen for announcements:
+To consume a broadcast, use `with_consumer()` and listen for announcements:
 
 ```rust
 let origin = moq_net::Origin::new().produce();
 let mut consumer = origin.consume();
 let session = client
-    .with_consume(origin)
+    .with_consumer(origin)
     .connect(url).await?;
 
 // Wait for broadcasts to be announced.

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -61,17 +61,14 @@ See the [Authentication guide](/bin/relay/auth) for how to generate tokens.
 
 The [video example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/video.rs) demonstrates publishing end-to-end.
 
-The key pattern is: create an [`Origin`](https://docs.rs/moq-net/latest/moq_net/struct.Origin.html), connect a session to it, then publish broadcasts:
+The connected [`Session`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html) exposes a [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) [`OriginProducer`](https://docs.rs/moq-net/latest/moq_net/struct.OriginProducer.html) you publish broadcasts into:
 
 ```rust
-let origin = moq_net::Origin::new().produce();
-let session = client
-    .with_publisher(origin.consume())
-    .connect(url).await?;
+let session = client.connect(url).await?;
 
 let mut broadcast = moq_net::Broadcast::new().produce();
 // ... add catalog and tracks to the broadcast ...
-origin.publish_broadcast("", broadcast.consume());
+session.publisher().publish_broadcast("", broadcast.consume());
 ```
 
 See the full [video.rs](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/video.rs) example for catalog setup, track creation, and frame encoding.
@@ -80,17 +77,14 @@ See the full [video.rs](https://github.com/moq-dev/moq/blob/main/rs/hang/example
 
 The [subscribe example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/subscribe.rs) demonstrates subscribing end-to-end.
 
-To consume a broadcast, use `with_consumer()` and listen for announcements:
+The session also exposes a [`consumer()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.consumer) [`OriginConsumer`](https://docs.rs/moq-net/latest/moq_net/struct.OriginConsumer.html) for receiving announcements:
 
 ```rust
-let origin = moq_net::Origin::new().produce();
-let mut consumer = origin.consume();
-let session = client
-    .with_consumer(origin)
-    .connect(url).await?;
+let session = client.connect(url).await?;
+let mut announced = session.consumer().announced();
 
 // Wait for broadcasts to be announced.
-while let Some((path, broadcast)) = consumer.announced().await {
+while let Some((path, broadcast)) = announced.next().await {
     let Some(broadcast) = broadcast else {
         tracing::info!(%path, "broadcast ended");
         continue;
@@ -102,7 +96,7 @@ while let Some((path, broadcast)) = consumer.announced().await {
 If you already know the broadcast path, you can subscribe directly:
 
 ```rust
-let broadcast = consumer.consume_broadcast("my-stream")
+let broadcast = session.consumer().get_broadcast("my-stream")
     .expect("broadcast not found");
 ```
 

--- a/doc/lib/swift/index.md
+++ b/doc/lib/swift/index.md
@@ -67,7 +67,7 @@ for try await announcement in announced.announcements {
     }
 }
 
-cs.session().shutdown()
+cs.shutdown()
 ```
 
 Cancelling the surrounding Swift `Task` propagates through to the underlying `cancel()` calls on each consumer.

--- a/doc/lib/swift/index.md
+++ b/doc/lib/swift/index.md
@@ -49,16 +49,14 @@ The package depends on a prebuilt `MoqFFI.xcframework` attached to the matching 
 ```swift
 import Moq
 
-// Wire an origin as both publish source and consume sink. Set just one
-// side for a subscribe-only or publish-only client.
-let origin = MoqOriginProducer()
 let client = MoqClient()
-client.setPublish(origin: origin)
-client.setConsume(origin: origin)
+let cs = try await client.connect(url: "https://relay.example.com")
 
-let session = try await client.connect(url: "https://relay.example.com")
-
-let consumer = origin.consume()
+// `cs.consumer()` returns the auto-created origin consumer for reading
+// announcements; `cs.publisher()` returns the producer side for publishing
+// broadcasts. Both are nil if you set publish / consume manually before
+// connect (subscribe-only, publish-only, or custom split-origin cases).
+let consumer = cs.consumer()!
 let announced = try consumer.announced(prefix: "demos/")
 for try await announcement in announced.announcements {
     print("got broadcast \(announcement.path())")
@@ -69,7 +67,7 @@ for try await announcement in announced.announcements {
     }
 }
 
-session.shutdown()
+cs.session().shutdown()
 ```
 
 Cancelling the surrounding Swift `Task` propagates through to the underlying `cancel()` calls on each consumer.

--- a/doc/lib/swift/index.md
+++ b/doc/lib/swift/index.md
@@ -52,11 +52,10 @@ import Moq
 let client = MoqClient()
 let cs = try await client.connect(url: "https://relay.example.com")
 
-// `cs.consumer()` returns the auto-created origin consumer for reading
-// announcements; `cs.publisher()` returns the producer side for publishing
-// broadcasts. Both are nil if you set publish / consume manually before
-// connect (subscribe-only, publish-only, or custom split-origin cases).
-let consumer = cs.consumer()!
+// cs.consumer() and cs.publisher() are always populated: by whatever
+// origin you wired via setPublish / setConsume before connect, or by a
+// fresh auto-created one for any side you didn't set.
+let consumer = cs.consumer()
 let announced = try consumer.announced(prefix: "demos/")
 for try await announcement in announced.announcements {
     print("got broadcast \(announcement.path())")

--- a/doc/lib/swift/index.md
+++ b/doc/lib/swift/index.md
@@ -50,13 +50,12 @@ The package depends on a prebuilt `MoqFFI.xcframework` attached to the matching 
 import Moq
 
 let client = MoqClient()
-let cs = try await client.connect(url: "https://relay.example.com")
+let cs = try await client.connect(url: "https://cdn.moq.dev/anon/demo")
 
 // cs.consumer() and cs.publisher() are always populated: by whatever
 // origin you wired via setPublish / setConsume before connect, or by a
 // fresh auto-created one for any side you didn't set.
-let consumer = cs.consumer()
-let announced = try consumer.announced(prefix: "demos/")
+let announced = try cs.consumer().announced(prefix: "demos/")
 for try await announcement in announced.announcements {
     print("got broadcast \(announcement.path())")
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -37,7 +37,7 @@ let client = MoqClient()
 let cs = try await client.connect(url: "https://relay.example.com")
 ```
 
-`MoqClient.connect(url:)` returns a `MoqSession` that bundles the session with auto-created publish and consume origin sides. The convenience accessors `cs.publisher()` and `cs.consumer()` return those origins (or `nil` if you wired your own via `setPublish` / `setConsume` before connect).
+`MoqClient.connect(url:)` returns a `MoqSession`. The accessors `cs.publisher()` and `cs.consumer()` are always populated: by whatever origin you wired via `setPublish` / `setConsume` before connect, or by a fresh auto-created one for any side you didn't set.
 
 For development against a relay with a self-signed certificate, configure the client before connecting:
 
@@ -57,7 +57,7 @@ cs.shutdown()  // alias for cancel(code: 0)
 ## Subscribe
 
 ```swift
-let consumer = cs.consumer()!
+let consumer = cs.consumer()
 let announced = try consumer.announced(prefix: "demos/")
 
 for try await announcement in announced.announcements {
@@ -74,7 +74,7 @@ for try await announcement in announced.announcements {
 let broadcast = try MoqBroadcastProducer()
 let audio = try broadcast.publishMedia(format: "opus", init: opusInitBytes)
 
-try cs.publisher()!.addBroadcast(path: "my-stream", broadcast: broadcast)
+try cs.publisher().addBroadcast(path: "my-stream", broadcast: broadcast)
 
 try audio.writeFrame(payload: payload, timestampUs: 0)
 try audio.writeFrame(payload: payload, timestampUs: 20_000)

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -34,7 +34,7 @@ Supported platforms: iOS 15+, iPadOS 15+, macOS 12+. The package ships an XCFram
 import Moq
 
 let client = MoqClient()
-let cs = try await client.connect(url: "https://relay.example.com")
+let cs = try await client.connect(url: "https://cdn.moq.dev/anon/demo")
 ```
 
 `MoqClient.connect(url:)` returns a `MoqSession`. The accessors `cs.publisher()` and `cs.consumer()` are always populated: by whatever origin you wired via `setPublish` / `setConsume` before connect, or by a fresh auto-created one for any side you didn't set.
@@ -74,7 +74,7 @@ for try await announcement in announced.announcements {
 let broadcast = try MoqBroadcastProducer()
 let audio = try broadcast.publishMedia(format: "opus", init: opusInitBytes)
 
-try cs.publisher().addBroadcast(path: "my-stream", broadcast: broadcast)
+try cs.publisher().announce(path: "my-stream", broadcast: broadcast)
 
 try audio.writeFrame(payload: payload, timestampUs: 0)
 try audio.writeFrame(payload: payload, timestampUs: 20_000)

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -33,16 +33,11 @@ Supported platforms: iOS 15+, iPadOS 15+, macOS 12+. The package ships an XCFram
 ```swift
 import Moq
 
-// Wire an origin as both publish source and consume sink for the
-// typical full-duplex client. Set just one side for a subscribe-only
-// or publish-only client.
-let origin = MoqOriginProducer()
 let client = MoqClient()
-client.setPublish(origin: origin)
-client.setConsume(origin: origin)
-
-let session = try await client.connect(url: "https://relay.example.com")
+let cs = try await client.connect(url: "https://relay.example.com")
 ```
+
+`MoqClient.connect(url:)` returns a `MoqClientSession` that bundles the session with auto-created publish and consume origin sides. The convenience accessors `cs.publisher()` and `cs.consumer()` return those origins (or `nil` if you wired your own via `setPublish` / `setConsume` before connect).
 
 For development against a relay with a self-signed certificate, configure the client before connecting:
 
@@ -50,21 +45,19 @@ For development against a relay with a self-signed certificate, configure the cl
 let client = MoqClient()
 client.setTlsDisableVerify(disable: true)
 try client.setBind(addr: "127.0.0.1:0")
-client.setPublish(origin: origin)
-client.setConsume(origin: origin)
-let session = try await client.connect(url: "https://localhost:4443")
+let cs = try await client.connect(url: "https://localhost:4443")
 ```
 
 When you're done, signal graceful shutdown to the peer:
 
 ```swift
-session.shutdown()  // alias for cancel(code: 0)
+cs.session().shutdown()  // alias for cancel(code: 0)
 ```
 
 ## Subscribe
 
 ```swift
-let consumer = origin.consume()
+let consumer = cs.consumer()!
 let announced = try consumer.announced(prefix: "demos/")
 
 for try await announcement in announced.announcements {
@@ -81,7 +74,7 @@ for try await announcement in announced.announcements {
 let broadcast = try MoqBroadcastProducer()
 let audio = try broadcast.publishMedia(format: "opus", init: opusInitBytes)
 
-try origin.publish(path: "my-stream", broadcast: broadcast)
+try cs.publisher()!.addBroadcast(path: "my-stream", broadcast: broadcast)
 
 try audio.writeFrame(payload: payload, timestampUs: 0)
 try audio.writeFrame(payload: payload, timestampUs: 20_000)

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -57,8 +57,7 @@ cs.shutdown()  // alias for cancel(code: 0)
 ## Subscribe
 
 ```swift
-let consumer = cs.consumer()
-let announced = try consumer.announced(prefix: "demos/")
+let announced = try cs.consumer().announced(prefix: "demos/")
 
 for try await announcement in announced.announcements {
     let catalog = try announcement.broadcast().subscribeCatalog()

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -37,7 +37,7 @@ let client = MoqClient()
 let cs = try await client.connect(url: "https://relay.example.com")
 ```
 
-`MoqClient.connect(url:)` returns a `MoqClientSession` that bundles the session with auto-created publish and consume origin sides. The convenience accessors `cs.publisher()` and `cs.consumer()` return those origins (or `nil` if you wired your own via `setPublish` / `setConsume` before connect).
+`MoqClient.connect(url:)` returns a `MoqSession` that bundles the session with auto-created publish and consume origin sides. The convenience accessors `cs.publisher()` and `cs.consumer()` return those origins (or `nil` if you wired your own via `setPublish` / `setConsume` before connect).
 
 For development against a relay with a self-signed certificate, configure the client before connecting:
 
@@ -51,7 +51,7 @@ let cs = try await client.connect(url: "https://localhost:4443")
 When you're done, signal graceful shutdown to the peer:
 
 ```swift
-cs.session().shutdown()  // alias for cancel(code: 0)
+cs.shutdown()  // alias for cancel(code: 0)
 ```
 
 ## Subscribe

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -62,7 +62,11 @@ class Client:
         if self._consume_origin is not None:
             self._inner.set_consume(self._consume_origin._inner)
 
-        self._session = await self._inner.connect(self._url)
+        # MoqClient.connect now returns a MoqClientSession; this wrapper
+        # always sets publish/consume above, so its auto-origin sides are
+        # always None. Keep the public `session` property pointing at the
+        # underlying MoqSession for backwards compatibility.
+        self._session = (await self._inner.connect(self._url)).session()
 
         # Create consumer from whichever origin handles consuming.
         origin = self._consume_origin or self._publish_origin

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -62,11 +62,7 @@ class Client:
         if self._consume_origin is not None:
             self._inner.set_consume(self._consume_origin._inner)
 
-        # MoqClient.connect now returns a MoqClientSession; this wrapper
-        # always sets publish/consume above, so its auto-origin sides are
-        # always None. Keep the public `session` property pointing at the
-        # underlying MoqSession for backwards compatibility.
-        self._session = (await self._inner.connect(self._url)).session()
+        self._session = await self._inner.connect(self._url)
 
         # Create consumer from whichever origin handles consuming.
         origin = self._consume_origin or self._publish_origin

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -92,4 +92,4 @@ class OriginProducer:
         return OriginConsumer(self._inner.consume())
 
     def publish(self, path: str, broadcast: BroadcastProducer) -> None:
-        self._inner.add_broadcast(path, broadcast._inner)
+        self._inner.announce(path, broadcast._inner)

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -92,4 +92,4 @@ class OriginProducer:
         return OriginConsumer(self._inner.consume())
 
     def publish(self, path: str, broadcast: BroadcastProducer) -> None:
-        self._inner.publish(path, broadcast._inner)
+        self._inner.add_broadcast(path, broadcast._inner)

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -29,9 +29,9 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	let url = url::Url::parse("https://cdn.moq.dev/anon/video-example").unwrap();
 
 	// Establish a connection with automatic reconnection.
-	// with_consume() registers an OriginProducer for incoming data.
-	// Use with_publish() if you also want to publish from the session.
-	let reconnect = client.with_consume(origin).reconnect(url);
+	// with_consumer() registers an OriginProducer for incoming data.
+	// Use with_publisher() if you also want to publish from the session.
+	let reconnect = client.with_consumer(origin).reconnect(url);
 
 	// Wait until the reconnect loop stops (e.g. timeout exceeded).
 	reconnect.closed().await

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -13,14 +13,14 @@ async fn main() -> anyhow::Result<()> {
 	// This is a simple example of how you can concurrently run multiple tasks.
 	// tokio::spawn works too.
 	tokio::select! {
-		res = run_session(origin.consume()) => res,
+		res = run_session(origin.clone()) => res,
 		res = run_broadcast(origin) => res,
 	}
 }
 
 // Connect to the server and publish our origin of broadcasts.
 // Automatically reconnects if the connection drops.
-async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
+async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 
@@ -29,8 +29,9 @@ async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
 	let url = url::Url::parse("https://cdn.moq.dev/anon/video-example").unwrap();
 
 	// Establish a connection with automatic reconnection.
-	// with_publish() registers an OriginConsumer for outgoing data.
-	// Use with_consume() if you also want to subscribe/consume from the session.
+	// with_publish() registers an OriginProducer. moq-net reads from its
+	// consumer view internally. Pair with with_consume() if you also want
+	// to subscribe to remote announcements.
 	let reconnect = client.with_publish(origin).reconnect(url);
 
 	// Wait until the reconnect loop stops (e.g. timeout exceeded).

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -13,14 +13,14 @@ async fn main() -> anyhow::Result<()> {
 	// This is a simple example of how you can concurrently run multiple tasks.
 	// tokio::spawn works too.
 	tokio::select! {
-		res = run_session(origin.clone()) => res,
+		res = run_session(origin.consume()) => res,
 		res = run_broadcast(origin) => res,
 	}
 }
 
 // Connect to the server and publish our origin of broadcasts.
 // Automatically reconnects if the connection drops.
-async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
+async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 
@@ -29,9 +29,8 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	let url = url::Url::parse("https://cdn.moq.dev/anon/video-example").unwrap();
 
 	// Establish a connection with automatic reconnection.
-	// with_publish() registers an OriginProducer; the client reads from
-	// its consumer view to forward broadcasts to the remote. Pair with
-	// with_consume() if you also want to subscribe to remote announcements.
+	// with_publish() registers an OriginConsumer for outgoing data.
+	// Use with_consume() if you also want to subscribe/consume from the session.
 	let reconnect = client.with_publish(origin).reconnect(url);
 
 	// Wait until the reconnect loop stops (e.g. timeout exceeded).

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -29,10 +29,10 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	let url = url::Url::parse("https://cdn.moq.dev/anon/video-example").unwrap();
 
 	// Establish a connection with automatic reconnection.
-	// with_publish() registers an OriginProducer. moq-net reads from its
-	// consumer view internally. Pair with with_consume() if you also want
+	// with_publisher() registers an OriginProducer. moq-net reads from its
+	// consumer view internally. Pair with with_consumer() if you also want
 	// to subscribe to remote announcements.
-	let reconnect = client.with_publish(origin).reconnect(url);
+	let reconnect = client.with_publisher(origin).reconnect(url);
 
 	// Wait until the reconnect loop stops (e.g. timeout exceeded).
 	reconnect.closed().await

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -13,14 +13,14 @@ async fn main() -> anyhow::Result<()> {
 	// This is a simple example of how you can concurrently run multiple tasks.
 	// tokio::spawn works too.
 	tokio::select! {
-		res = run_session(origin.consume()) => res,
+		res = run_session(origin.clone()) => res,
 		res = run_broadcast(origin) => res,
 	}
 }
 
 // Connect to the server and publish our origin of broadcasts.
 // Automatically reconnects if the connection drops.
-async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
+async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 
@@ -29,8 +29,9 @@ async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
 	let url = url::Url::parse("https://cdn.moq.dev/anon/video-example").unwrap();
 
 	// Establish a connection with automatic reconnection.
-	// with_publish() registers an OriginConsumer for outgoing data.
-	// Use with_consume() if you also want to subscribe/consume from the session.
+	// with_publish() registers an OriginProducer; the client reads from
+	// its consumer view to forward broadcasts to the remote. Pair with
+	// with_consume() if you also want to subscribe to remote announcements.
 	let reconnect = client.with_publish(origin).reconnect(url);
 
 	// Wait until the reconnect loop stops (e.g. timeout exceeded).

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn moq_session_connect(
 		let publish = ffi::parse_id_optional(origin_publish)?
 			.map(|id| state.origin.get(id))
 			.transpose()?
-			.map(|origin: &moq_net::OriginProducer| origin.consume());
+			.cloned();
 		let consume = ffi::parse_id_optional(origin_consume)?
 			.map(|id| state.origin.get(id))
 			.transpose()?

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn moq_session_connect(
 		let publish = ffi::parse_id_optional(origin_publish)?
 			.map(|id| state.origin.get(id))
 			.transpose()?
-			.cloned();
+			.map(|origin: &moq_net::OriginProducer| origin.consume());
 		let consume = ffi::parse_id_optional(origin_consume)?
 			.map(|id| state.origin.get(id))
 			.transpose()?

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -74,7 +74,7 @@ impl Session {
 		// libmoq users wire their own origin via the explicit `publish`/
 		// `consume` params, so `cs.publisher` / `cs.consumer` are always
 		// None here; the relevant handle is just the session.
-		cs.session.closed().await?;
+		cs.closed().await?;
 		Ok(())
 	}
 

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -60,8 +60,8 @@ impl Session {
 			.map_err(|err| Error::Connect(Arc::new(err)))?;
 
 		let cs = client
-			.with_publish(publish)
-			.with_consume(consume)
+			.with_publisher(publish)
+			.with_consumer(consume)
 			.connect(url)
 			.await
 			.map_err(|err| Error::Connect(Arc::new(err)))?;

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -22,7 +22,7 @@ impl Session {
 	pub fn connect(
 		&mut self,
 		url: Url,
-		publish: Option<moq_net::OriginProducer>,
+		publish: Option<moq_net::OriginConsumer>,
 		consume: Option<moq_net::OriginProducer>,
 		callback: ffi::OnStatus,
 	) -> Result<Id, Error> {
@@ -52,7 +52,7 @@ impl Session {
 	async fn connect_run(
 		task_id: Id,
 		url: Url,
-		publish: Option<moq_net::OriginProducer>,
+		publish: Option<moq_net::OriginConsumer>,
 		consume: Option<moq_net::OriginProducer>,
 	) -> Result<(), Error> {
 		let client = moq_native::ClientConfig::default()

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -59,7 +59,7 @@ impl Session {
 			.init()
 			.map_err(|err| Error::Connect(Arc::new(err)))?;
 
-		let session = client
+		let cs = client
 			.with_publish(publish)
 			.with_consume(consume)
 			.connect(url)
@@ -71,7 +71,10 @@ impl Session {
 			entry.callback.call(());
 		}
 
-		session.closed().await?;
+		// libmoq users wire their own origin via the explicit `publish`/
+		// `consume` params, so `cs.publisher` / `cs.consumer` are always
+		// None here; the relevant handle is just the session.
+		cs.session.closed().await?;
 		Ok(())
 	}
 

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -22,7 +22,7 @@ impl Session {
 	pub fn connect(
 		&mut self,
 		url: Url,
-		publish: Option<moq_net::OriginConsumer>,
+		publish: Option<moq_net::OriginProducer>,
 		consume: Option<moq_net::OriginProducer>,
 		callback: ffi::OnStatus,
 	) -> Result<Id, Error> {
@@ -52,7 +52,7 @@ impl Session {
 	async fn connect_run(
 		task_id: Id,
 		url: Url,
-		publish: Option<moq_net::OriginConsumer>,
+		publish: Option<moq_net::OriginProducer>,
 		consume: Option<moq_net::OriginProducer>,
 	) -> Result<(), Error> {
 		let client = moq_native::ClientConfig::default()

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -55,16 +55,18 @@ impl Session {
 		publish: Option<moq_net::OriginProducer>,
 		consume: Option<moq_net::OriginProducer>,
 	) -> Result<(), Error> {
-		let client = moq_native::ClientConfig::default()
+		let mut client = moq_native::ClientConfig::default()
 			.init()
 			.map_err(|err| Error::Connect(Arc::new(err)))?;
 
-		let cs = client
-			.with_publisher(publish)
-			.with_consumer(consume)
-			.connect(url)
-			.await
-			.map_err(|err| Error::Connect(Arc::new(err)))?;
+		if let Some(publish) = publish {
+			client = client.with_publisher(publish);
+		}
+		if let Some(consume) = consume {
+			client = client.with_consumer(consume);
+		}
+
+		let cs = client.connect(url).await.map_err(|err| Error::Connect(Arc::new(err)))?;
 
 		// "Connected" callback — copy from slab if not revoked.
 		if let Some(Some(entry)) = State::lock().session.task.get(task_id) {

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -234,8 +234,8 @@ async fn run(config: &Config) -> Result<()> {
 	tracing::info!(url = %config.url, %name, broadcast = %broadcast_path, "connecting to relay");
 
 	let reconnect = client
-		.with_publish(publish_origin.clone())
-		.with_consume(consume_origin)
+		.with_publisher(publish_origin.clone())
+		.with_consumer(consume_origin)
 		.reconnect(config.url.clone());
 
 	// Set up catalog and encoders.

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -234,7 +234,7 @@ async fn run(config: &Config) -> Result<()> {
 	tracing::info!(url = %config.url, %name, broadcast = %broadcast_path, "connecting to relay");
 
 	let reconnect = client
-		.with_publish(publish_origin.clone())
+		.with_publish(publish_origin.consume())
 		.with_consume(consume_origin)
 		.reconnect(config.url.clone());
 

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -234,7 +234,7 @@ async fn run(config: &Config) -> Result<()> {
 	tracing::info!(url = %config.url, %name, broadcast = %broadcast_path, "connecting to relay");
 
 	let reconnect = client
-		.with_publish(publish_origin.consume())
+		.with_publish(publish_origin.clone())
 		.with_consume(consume_origin)
 		.reconnect(config.url.clone());
 

--- a/rs/moq-cli/src/client.rs
+++ b/rs/moq-cli/src/client.rs
@@ -10,7 +10,7 @@ pub async fn run_client(client: moq_native::Client, url: Url, name: String, publ
 
 	tracing::info!(%url, %name, "connecting");
 
-	let reconnect = client.with_publish(origin.consume()).reconnect(url);
+	let reconnect = client.with_publish(origin.clone()).reconnect(url);
 
 	#[cfg(unix)]
 	// Notify systemd that we're ready.

--- a/rs/moq-cli/src/client.rs
+++ b/rs/moq-cli/src/client.rs
@@ -10,7 +10,7 @@ pub async fn run_client(client: moq_native::Client, url: Url, name: String, publ
 
 	tracing::info!(%url, %name, "connecting");
 
-	let reconnect = client.with_publish(origin.clone()).reconnect(url);
+	let reconnect = client.with_publish(origin.consume()).reconnect(url);
 
 	#[cfg(unix)]
 	// Notify systemd that we're ready.

--- a/rs/moq-cli/src/client.rs
+++ b/rs/moq-cli/src/client.rs
@@ -10,7 +10,7 @@ pub async fn run_client(client: moq_native::Client, url: Url, name: String, publ
 
 	tracing::info!(%url, %name, "connecting");
 
-	let reconnect = client.with_publish(origin.clone()).reconnect(url);
+	let reconnect = client.with_publisher(origin.clone()).reconnect(url);
 
 	#[cfg(unix)]
 	// Notify systemd that we're ready.

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -223,7 +223,7 @@ async fn run_subscribe(
 
 	tracing::info!(%url, %broadcast, "connecting");
 
-	let reconnect = client.with_consume(origin).reconnect(url);
+	let reconnect = client.with_consumer(origin).reconnect(url);
 
 	#[cfg(unix)]
 	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);

--- a/rs/moq-cli/src/server.rs
+++ b/rs/moq-cli/src/server.rs
@@ -43,7 +43,7 @@ async fn run_serve_session(
 	origin.publish_broadcast(&name, consumer);
 
 	// Blindly accept the session (WebTransport or QUIC), regardless of the URL.
-	let session = session.with_publish(origin.clone()).ok().await?;
+	let session = session.with_publisher(origin.clone()).ok().await?;
 
 	tracing::info!(id, "accepted session");
 
@@ -80,7 +80,7 @@ async fn run_accept_session(
 	session: moq_native::Request,
 	origin: moq_net::OriginProducer,
 ) -> anyhow::Result<()> {
-	let session = session.with_consume(origin).ok().await?;
+	let session = session.with_consumer(origin).ok().await?;
 
 	tracing::info!(id, "accepted session");
 

--- a/rs/moq-cli/src/server.rs
+++ b/rs/moq-cli/src/server.rs
@@ -43,7 +43,7 @@ async fn run_serve_session(
 	origin.publish_broadcast(&name, consumer);
 
 	// Blindly accept the session (WebTransport or QUIC), regardless of the URL.
-	let session = session.with_publish(origin.clone()).ok().await?;
+	let session = session.with_publish(origin.consume()).ok().await?;
 
 	tracing::info!(id, "accepted session");
 

--- a/rs/moq-cli/src/server.rs
+++ b/rs/moq-cli/src/server.rs
@@ -43,7 +43,7 @@ async fn run_serve_session(
 	origin.publish_broadcast(&name, consumer);
 
 	// Blindly accept the session (WebTransport or QUIC), regardless of the URL.
-	let session = session.with_publish(origin.consume()).ok().await?;
+	let session = session.with_publish(origin.clone()).ok().await?;
 
 	tracing::info!(id, "accepted session");
 

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -105,11 +105,11 @@ impl MoqOriginProducer {
 		})
 	}
 
-	/// Add a broadcast to this origin under the given path so subscribers
-	/// can discover it. Named `add_broadcast` (not `publish`) so the
-	/// `MoqClientSession::publisher().add_broadcast(...)` chain doesn't
-	/// stutter "publisher.publish".
-	pub fn add_broadcast(&self, path: String, broadcast: &MoqBroadcastProducer) -> Result<(), MoqError> {
+	/// Announce a broadcast to this origin under the given path so
+	/// subscribers can discover it. Named `announce` (not `publish`) so
+	/// the `MoqSession::publisher().announce(...)` chain doesn't stutter
+	/// "publisher.publish".
+	pub fn announce(&self, path: String, broadcast: &MoqBroadcastProducer) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let consumer = broadcast.consume_inner()?;
 		if !self.inner.publish_broadcast(path.as_str(), consumer) {

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -72,6 +72,18 @@ impl MoqOriginProducer {
 	pub(crate) fn inner(&self) -> &moq_net::OriginProducer {
 		&self.inner
 	}
+
+	/// Wrap an existing `moq_net::OriginProducer` (e.g. one auto-created
+	/// during `MoqClient::connect`) so it can cross the FFI boundary.
+	pub(crate) fn from_inner(inner: moq_net::OriginProducer) -> Self {
+		Self { inner }
+	}
+}
+
+impl MoqOriginConsumer {
+	pub(crate) fn from_inner(inner: moq_net::OriginConsumer) -> Self {
+		Self { inner }
+	}
 }
 
 #[uniffi::export]
@@ -93,8 +105,11 @@ impl MoqOriginProducer {
 		})
 	}
 
-	/// Publish a broadcast to this origin under the given path.
-	pub fn publish(&self, path: String, broadcast: &MoqBroadcastProducer) -> Result<(), MoqError> {
+	/// Add a broadcast to this origin under the given path so subscribers
+	/// can discover it. Named `add_broadcast` (not `publish`) so the
+	/// `MoqClientSession::publisher().add_broadcast(...)` chain doesn't
+	/// stutter "publisher.publish".
+	pub fn add_broadcast(&self, path: String, broadcast: &MoqBroadcastProducer) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let consumer = broadcast.consume_inner()?;
 		if !self.inner.publish_broadcast(path.as_str(), consumer) {

--- a/rs/moq-ffi/src/server.rs
+++ b/rs/moq-ffi/src/server.rs
@@ -235,7 +235,7 @@ impl MoqRequest {
 		self.task
 			.run(|mut state| async move {
 				let request = state.request.take().ok_or(MoqError::AlreadyResponded)?;
-				let publish = state.publish.as_ref().map(|o| o.inner().clone());
+				let publish = state.publish.as_ref().map(|o| o.inner().consume());
 				let consume = state.consume.as_ref().map(|o| o.inner().clone());
 				let session = request
 					.with_publish(publish)

--- a/rs/moq-ffi/src/server.rs
+++ b/rs/moq-ffi/src/server.rs
@@ -234,15 +234,14 @@ impl MoqRequest {
 	pub async fn ok(&self) -> Result<Arc<MoqSession>, MoqError> {
 		self.task
 			.run(|mut state| async move {
-				let request = state.request.take().ok_or(MoqError::AlreadyResponded)?;
-				let publish = state.publish.as_ref().map(|o| o.inner().clone());
-				let consume = state.consume.as_ref().map(|o| o.inner().clone());
-				let session = request
-					.with_publisher(publish)
-					.with_consumer(consume)
-					.ok()
-					.await
-					.map_err(|err| MoqError::Connect(format!("{err}")))?;
+				let mut request = state.request.take().ok_or(MoqError::AlreadyResponded)?;
+				if let Some(publish) = state.publish.as_ref() {
+					request = request.with_publisher(publish.inner().clone());
+				}
+				if let Some(consume) = state.consume.as_ref() {
+					request = request.with_consumer(consume.inner().clone());
+				}
+				let session = request.ok().await.map_err(|err| MoqError::Connect(format!("{err}")))?;
 				Ok(Arc::new(MoqSession::new(session)))
 			})
 			.await

--- a/rs/moq-ffi/src/server.rs
+++ b/rs/moq-ffi/src/server.rs
@@ -235,7 +235,7 @@ impl MoqRequest {
 		self.task
 			.run(|mut state| async move {
 				let request = state.request.take().ok_or(MoqError::AlreadyResponded)?;
-				let publish = state.publish.as_ref().map(|o| o.inner().consume());
+				let publish = state.publish.as_ref().map(|o| o.inner().clone());
 				let consume = state.consume.as_ref().map(|o| o.inner().clone());
 				let session = request
 					.with_publish(publish)

--- a/rs/moq-ffi/src/server.rs
+++ b/rs/moq-ffi/src/server.rs
@@ -238,8 +238,8 @@ impl MoqRequest {
 				let publish = state.publish.as_ref().map(|o| o.inner().clone());
 				let consume = state.consume.as_ref().map(|o| o.inner().clone());
 				let session = request
-					.with_publish(publish)
-					.with_consume(consume)
+					.with_publisher(publish)
+					.with_consumer(consume)
 					.ok()
 					.await
 					.map_err(|err| MoqError::Connect(format!("{err}")))?;

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -21,7 +21,7 @@ impl Client {
 			.init()
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;
 
-		let publish = self.publish.as_ref().map(|o| o.inner().clone());
+		let publish = self.publish.as_ref().map(|o| o.inner().consume());
 		let consume = self.consume.as_ref().map(|o| o.inner().clone());
 
 		let session = client

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -24,14 +24,17 @@ impl Client {
 		let publish = self.publish.as_ref().map(|o| o.inner().consume());
 		let consume = self.consume.as_ref().map(|o| o.inner().clone());
 
-		let session = client
+		let cs = client
 			.with_publish(publish)
 			.with_consume(consume)
 			.connect(url)
 			.await
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;
 
-		Ok(Arc::new(MoqSession::new(session)))
+		// FFI users wire their own origin via setPublish/setConsume above,
+		// so the auto-created origin sides on the ClientSession are always
+		// None here. Discard them and keep just the session.
+		Ok(Arc::new(MoqSession::new(cs.session)))
 	}
 }
 

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -14,7 +14,7 @@ struct Client {
 }
 
 impl Client {
-	async fn connect(&self, url: Url) -> Result<Arc<MoqClientSession>, MoqError> {
+	async fn connect(&self, url: Url) -> Result<Arc<MoqSession>, MoqError> {
 		let client = self
 			.config
 			.clone()
@@ -24,25 +24,14 @@ impl Client {
 		let publish = self.publish.as_ref().map(|o| o.inner().consume());
 		let consume = self.consume.as_ref().map(|o| o.inner().clone());
 
-		let cs = client
+		let session = client
 			.with_publish(publish)
 			.with_consume(consume)
 			.connect(url)
 			.await
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;
 
-		// Wrap any moq-net auto-created origin sides for the FFI caller.
-		// These are Some only on the no-config path; when the caller wired
-		// their own origin via set_publish/set_consume, both are None and
-		// the caller continues to drive things through the origin they hold.
-		let publisher = cs.publisher.map(|p| Arc::new(MoqOriginProducer::from_inner(p)));
-		let consumer = cs.consumer.map(|c| Arc::new(MoqOriginConsumer::from_inner(c)));
-
-		Ok(Arc::new(MoqClientSession {
-			session: Arc::new(MoqSession::new(cs.session)),
-			publisher,
-			consumer,
-		}))
+		Ok(Arc::new(MoqSession::new(session)))
 	}
 }
 
@@ -105,12 +94,12 @@ impl MoqClient {
 	/// If neither [`set_publish`](Self::set_publish) nor
 	/// [`set_consume`](Self::set_consume) was called on this client, the
 	/// underlying moq-net layer auto-creates a fresh origin and wires it
-	/// as both sides; the resulting [`MoqClientSession::publisher`] and
-	/// [`MoqClientSession::consumer`] expose it so the caller never has
-	/// to construct a [`MoqOriginProducer`] themselves.
+	/// as both sides. The producer and consumer sides are then accessible
+	/// via [`MoqSession::publisher`] and [`MoqSession::consumer`] so the
+	/// caller never has to construct a [`MoqOriginProducer`] themselves.
 	///
 	/// Can be cancelled by calling `cancel()`.
-	pub async fn connect(&self, url: String) -> Result<Arc<MoqClientSession>, MoqError> {
+	pub async fn connect(&self, url: String) -> Result<Arc<MoqSession>, MoqError> {
 		let url = Url::parse(&url)?;
 
 		self.task.run(|state| async move { state.connect(url).await }).await
@@ -122,57 +111,31 @@ impl MoqClient {
 	}
 }
 
-/// A connected MoQ client session bundled with the auto-created origin
-/// sides, if any.
-///
-/// Returned from [`MoqClient::connect`]. When the caller didn't call
-/// [`MoqClient::set_publish`] or [`MoqClient::set_consume`] before
-/// connect, [`publisher`](Self::publisher) and [`consumer`](Self::consumer)
-/// return the auto-created sides so the caller can publish broadcasts
-/// (`publisher().add_broadcast(...)`) and read announcements
-/// (`consumer().announced(...)`) without ever constructing a
-/// [`MoqOriginProducer`] themselves. When the caller wired its own
-/// origin(s), both accessors return `None` and the caller drives
-/// publishing / consuming through the origin it already holds.
-#[derive(uniffi::Object)]
-pub struct MoqClientSession {
-	session: Arc<MoqSession>,
-	publisher: Option<Arc<MoqOriginProducer>>,
-	consumer: Option<Arc<MoqOriginConsumer>>,
-}
-
-#[uniffi::export]
-impl MoqClientSession {
-	/// The negotiated session. Use for `shutdown()` / `closed()` /
-	/// `cancel(code)`.
-	pub fn session(&self) -> Arc<MoqSession> {
-		self.session.clone()
-	}
-
-	/// Auto-created origin producer side. `Some` only when the caller did
-	/// not call `set_publish` or `set_consume` before connect.
-	pub fn publisher(&self) -> Option<Arc<MoqOriginProducer>> {
-		self.publisher.clone()
-	}
-
-	/// Auto-created origin consumer side. `Some` only when the caller did
-	/// not call `set_publish` or `set_consume` before connect.
-	pub fn consumer(&self) -> Option<Arc<MoqOriginConsumer>> {
-		self.consumer.clone()
-	}
-}
-
 #[derive(uniffi::Object)]
 pub struct MoqSession {
 	inner: Option<moq_net::Session>,
 	closed: Task<Session>,
+	publisher: Option<Arc<MoqOriginProducer>>,
+	consumer: Option<Arc<MoqOriginConsumer>>,
 }
 
 impl MoqSession {
 	pub(crate) fn new(session: moq_net::Session) -> Self {
+		// Eagerly wrap the auto-created origin sides (if any) so each
+		// publisher()/consumer() call hands back the same Arc.
+		let publisher = session
+			.publisher()
+			.cloned()
+			.map(|p| Arc::new(MoqOriginProducer::from_inner(p)));
+		let consumer = session
+			.consumer()
+			.cloned()
+			.map(|c| Arc::new(MoqOriginConsumer::from_inner(c)));
 		Self {
 			inner: Some(session.clone()),
 			closed: Task::new(session),
+			publisher,
+			consumer,
 		}
 	}
 }
@@ -212,5 +175,19 @@ impl MoqSession {
 	/// thing per binding.
 	pub fn shutdown(&self) {
 		self.cancel(0);
+	}
+
+	/// Auto-created origin producer side. `Some` only when neither
+	/// `set_publish` nor `set_consume` was called on the client/request
+	/// before connect/accept.
+	pub fn publisher(&self) -> Option<Arc<MoqOriginProducer>> {
+		self.publisher.clone()
+	}
+
+	/// Auto-created origin consumer side. `Some` only when neither
+	/// `set_publish` nor `set_consume` was called on the client/request
+	/// before connect/accept.
+	pub fn consumer(&self) -> Option<Arc<MoqOriginConsumer>> {
+		self.consumer.clone()
 	}
 }

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -25,8 +25,8 @@ impl Client {
 		let consume = self.consume.as_ref().map(|o| o.inner().clone());
 
 		let session = client
-			.with_publish(publish)
-			.with_consume(consume)
+			.with_publisher(publish)
+			.with_consumer(consume)
 			.connect(url)
 			.await
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -21,12 +21,17 @@ impl Client {
 			.init()
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;
 
-		let publish = self.publish.as_ref().map(|o| o.inner().clone());
-		let consume = self.consume.as_ref().map(|o| o.inner().clone());
+		// moq-net defaults both sides if unset; only override when the
+		// FFI caller wired their own.
+		let mut client = client;
+		if let Some(publish) = self.publish.as_ref() {
+			client = client.with_publisher(publish.inner().clone());
+		}
+		if let Some(consume) = self.consume.as_ref() {
+			client = client.with_consumer(consume.inner().clone());
+		}
 
 		let session = client
-			.with_publisher(publish)
-			.with_consumer(consume)
 			.connect(url)
 			.await
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::error::MoqError;
 use crate::ffi::Task;
-use crate::origin::MoqOriginProducer;
+use crate::origin::{MoqOriginConsumer, MoqOriginProducer};
 
 struct Client {
 	config: moq_native::ClientConfig,
@@ -14,7 +14,7 @@ struct Client {
 }
 
 impl Client {
-	async fn connect(&self, url: Url) -> Result<Arc<MoqSession>, MoqError> {
+	async fn connect(&self, url: Url) -> Result<Arc<MoqClientSession>, MoqError> {
 		let client = self
 			.config
 			.clone()
@@ -31,10 +31,18 @@ impl Client {
 			.await
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;
 
-		// FFI users wire their own origin via setPublish/setConsume above,
-		// so the auto-created origin sides on the ClientSession are always
-		// None here. Discard them and keep just the session.
-		Ok(Arc::new(MoqSession::new(cs.session)))
+		// Wrap any moq-net auto-created origin sides for the FFI caller.
+		// These are Some only on the no-config path; when the caller wired
+		// their own origin via set_publish/set_consume, both are None and
+		// the caller continues to drive things through the origin they hold.
+		let publisher = cs.publisher.map(|p| Arc::new(MoqOriginProducer::from_inner(p)));
+		let consumer = cs.consumer.map(|c| Arc::new(MoqOriginConsumer::from_inner(c)));
+
+		Ok(Arc::new(MoqClientSession {
+			session: Arc::new(MoqSession::new(cs.session)),
+			publisher,
+			consumer,
+		}))
 	}
 }
 
@@ -94,8 +102,15 @@ impl MoqClient {
 
 	/// Connect to a MoQ server and wait for the session to be established.
 	///
+	/// If neither [`set_publish`](Self::set_publish) nor
+	/// [`set_consume`](Self::set_consume) was called on this client, the
+	/// underlying moq-net layer auto-creates a fresh origin and wires it
+	/// as both sides; the resulting [`MoqClientSession::publisher`] and
+	/// [`MoqClientSession::consumer`] expose it so the caller never has
+	/// to construct a [`MoqOriginProducer`] themselves.
+	///
 	/// Can be cancelled by calling `cancel()`.
-	pub async fn connect(&self, url: String) -> Result<Arc<MoqSession>, MoqError> {
+	pub async fn connect(&self, url: String) -> Result<Arc<MoqClientSession>, MoqError> {
 		let url = Url::parse(&url)?;
 
 		self.task.run(|state| async move { state.connect(url).await }).await
@@ -104,6 +119,46 @@ impl MoqClient {
 	/// Cancel all current and future `connect()` calls.
 	pub fn cancel(&self) {
 		self.task.cancel();
+	}
+}
+
+/// A connected MoQ client session bundled with the auto-created origin
+/// sides, if any.
+///
+/// Returned from [`MoqClient::connect`]. When the caller didn't call
+/// [`MoqClient::set_publish`] or [`MoqClient::set_consume`] before
+/// connect, [`publisher`](Self::publisher) and [`consumer`](Self::consumer)
+/// return the auto-created sides so the caller can publish broadcasts
+/// (`publisher().add_broadcast(...)`) and read announcements
+/// (`consumer().announced(...)`) without ever constructing a
+/// [`MoqOriginProducer`] themselves. When the caller wired its own
+/// origin(s), both accessors return `None` and the caller drives
+/// publishing / consuming through the origin it already holds.
+#[derive(uniffi::Object)]
+pub struct MoqClientSession {
+	session: Arc<MoqSession>,
+	publisher: Option<Arc<MoqOriginProducer>>,
+	consumer: Option<Arc<MoqOriginConsumer>>,
+}
+
+#[uniffi::export]
+impl MoqClientSession {
+	/// The negotiated session. Use for `shutdown()` / `closed()` /
+	/// `cancel(code)`.
+	pub fn session(&self) -> Arc<MoqSession> {
+		self.session.clone()
+	}
+
+	/// Auto-created origin producer side. `Some` only when the caller did
+	/// not call `set_publish` or `set_consume` before connect.
+	pub fn publisher(&self) -> Option<Arc<MoqOriginProducer>> {
+		self.publisher.clone()
+	}
+
+	/// Auto-created origin consumer side. `Some` only when the caller did
+	/// not call `set_publish` or `set_consume` before connect.
+	pub fn consumer(&self) -> Option<Arc<MoqOriginConsumer>> {
+		self.consumer.clone()
 	}
 }
 

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -21,7 +21,7 @@ impl Client {
 			.init()
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;
 
-		let publish = self.publish.as_ref().map(|o| o.inner().consume());
+		let publish = self.publish.as_ref().map(|o| o.inner().clone());
 		let consume = self.consume.as_ref().map(|o| o.inner().clone());
 
 		let session = client
@@ -115,22 +115,16 @@ impl MoqClient {
 pub struct MoqSession {
 	inner: Option<moq_net::Session>,
 	closed: Task<Session>,
-	publisher: Option<Arc<MoqOriginProducer>>,
-	consumer: Option<Arc<MoqOriginConsumer>>,
+	publisher: Arc<MoqOriginProducer>,
+	consumer: Arc<MoqOriginConsumer>,
 }
 
 impl MoqSession {
 	pub(crate) fn new(session: moq_net::Session) -> Self {
-		// Eagerly wrap the auto-created origin sides (if any) so each
+		// Eagerly wrap the always-set origin sides so each
 		// publisher()/consumer() call hands back the same Arc.
-		let publisher = session
-			.publisher()
-			.cloned()
-			.map(|p| Arc::new(MoqOriginProducer::from_inner(p)));
-		let consumer = session
-			.consumer()
-			.cloned()
-			.map(|c| Arc::new(MoqOriginConsumer::from_inner(c)));
+		let publisher = Arc::new(MoqOriginProducer::from_inner(session.publisher().clone()));
+		let consumer = Arc::new(MoqOriginConsumer::from_inner(session.consumer().clone()));
 		Self {
 			inner: Some(session.clone()),
 			closed: Task::new(session),
@@ -177,17 +171,19 @@ impl MoqSession {
 		self.cancel(0);
 	}
 
-	/// Auto-created origin producer side. `Some` only when neither
-	/// `set_publish` nor `set_consume` was called on the client/request
-	/// before connect/accept.
-	pub fn publisher(&self) -> Option<Arc<MoqOriginProducer>> {
+	/// The publish-side origin: where local broadcasts get advertised
+	/// to the remote. Either the producer the caller wired via
+	/// `set_publish` / `set_consume` before connect/accept, or one
+	/// auto-created if neither was set.
+	pub fn publisher(&self) -> Arc<MoqOriginProducer> {
 		self.publisher.clone()
 	}
 
-	/// Auto-created origin consumer side. `Some` only when neither
-	/// `set_publish` nor `set_consume` was called on the client/request
-	/// before connect/accept.
-	pub fn consumer(&self) -> Option<Arc<MoqOriginConsumer>> {
+	/// The subscribe-side origin: a read handle for receiving
+	/// announcements pushed by the remote. Either derived from the
+	/// origin the caller wired via `set_consume`, or auto-created if
+	/// neither was set.
+	pub fn consumer(&self) -> Arc<MoqOriginConsumer> {
 		self.consumer.clone()
 	}
 }

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -21,7 +21,7 @@ impl Client {
 			.init()
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;
 
-		let publish = self.publish.as_ref().map(|o| o.inner().consume());
+		let publish = self.publish.as_ref().map(|o| o.inner().clone());
 		let consume = self.consume.as_ref().map(|o| o.inner().clone());
 
 		let session = client

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -119,7 +119,7 @@ async fn local_publish_consume_audio() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media("opus".into(), init).unwrap();
-	origin.publish("live".into(), &broadcast).unwrap();
+	origin.add_broadcast("live".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -171,7 +171,7 @@ async fn video_publish_consume() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = h264_init();
 	let media = broadcast.publish_media("avc3".into(), init).unwrap();
-	origin.publish("video-test".into(), &broadcast).unwrap();
+	origin.add_broadcast("video-test".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -226,7 +226,7 @@ async fn multiple_frames_ordering() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media("opus".into(), init).unwrap();
-	origin.publish("ordering-test".into(), &broadcast).unwrap();
+	origin.add_broadcast("ordering-test".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -274,7 +274,7 @@ async fn catalog_update_on_new_track() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let _media1 = broadcast.publish_media("opus".into(), init.clone()).unwrap();
-	origin.publish("catalog-update".into(), &broadcast).unwrap();
+	origin.add_broadcast("catalog-update".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -322,7 +322,7 @@ fn finish_closes_producer() {
 async fn announced_broadcast() {
 	let origin = MoqOriginProducer::new();
 	let broadcast = MoqBroadcastProducer::new().unwrap();
-	origin.publish("test/broadcast".into(), &broadcast).unwrap();
+	origin.add_broadcast("test/broadcast".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -347,7 +347,7 @@ fn without_runtime() {
 		let init = opus_head();
 		let media = broadcast.publish_media("opus".into(), init).unwrap();
 		media.write_frame(b"hello".to_vec(), 1000).unwrap();
-		origin.publish("test".into(), &broadcast).unwrap();
+		origin.add_broadcast("test".into(), &broadcast).unwrap();
 
 		let announced = consumer.announced("".into()).unwrap();
 		let announcement = pollster::block_on(announced.next()).unwrap().unwrap();
@@ -402,7 +402,7 @@ async fn server_client_roundtrip() {
 	client.set_tls_disable_verify(true);
 	client.set_bind("127.0.0.1:0".into()).unwrap();
 	client.set_consume(Some(client_origin.clone()));
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("connect timed out")
 		.expect("connect failed");
@@ -416,7 +416,7 @@ async fn server_client_roundtrip() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media("opus".into(), init).unwrap();
-	server_origin.publish("hello".into(), &broadcast).unwrap();
+	server_origin.add_broadcast("hello".into(), &broadcast).unwrap();
 
 	// Receive the announcement on the client side via the consume origin.
 	let consumer = client_origin.consume();
@@ -456,7 +456,79 @@ async fn server_client_roundtrip() {
 	// `cancel(code)` on the server side, so both shutdown paths run.
 	media.finish().unwrap();
 	broadcast.finish().unwrap();
-	session.shutdown();
+	cs.session().shutdown();
+	server_session.cancel(0);
+	server.cancel();
+}
+
+#[tokio::test]
+async fn server_client_roundtrip_auto_origin() {
+	// Same shape as `server_client_roundtrip` but the client never calls
+	// `set_publish` / `set_consume`: the auto-created origin sides on
+	// `MoqClientSession` are what drive publishing and subscribing.
+	let server_origin = MoqOriginProducer::new();
+	let server = MoqServer::new();
+	server.set_bind("127.0.0.1:0".into()).unwrap();
+	server.set_tls_generate(vec!["localhost".into()]);
+	server.set_publish(Some(server_origin.clone()));
+
+	let addr = tokio::time::timeout(TIMEOUT, server.listen())
+		.await
+		.expect("listen timed out")
+		.expect("listen failed");
+	let url = format!("https://{addr}");
+
+	let accept_server = server.clone();
+	let accept = tokio::spawn(async move {
+		let request = accept_server
+			.accept()
+			.await
+			.expect("accept errored")
+			.expect("accept returned None");
+		request.ok().await.expect("handshake failed")
+	});
+
+	// No set_publish / set_consume — auto-origin path.
+	let client = MoqClient::new();
+	client.set_tls_disable_verify(true);
+	client.set_bind("127.0.0.1:0".into()).unwrap();
+	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
+		.await
+		.expect("connect timed out")
+		.expect("connect failed");
+
+	let publisher = cs.publisher().expect("auto-created publisher");
+	let consumer = cs.consumer().expect("auto-created consumer");
+
+	let server_session = tokio::time::timeout(TIMEOUT, accept)
+		.await
+		.expect("server accept timed out")
+		.expect("server accept task panicked");
+
+	// Server publishes; client receives via the auto consumer.
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let init = opus_head();
+	let media = broadcast.publish_media("opus".into(), init).unwrap();
+	server_origin.add_broadcast("hello".into(), &broadcast).unwrap();
+
+	let announced = consumer.announced("".into()).unwrap();
+	let announcement = tokio::time::timeout(TIMEOUT, announced.next())
+		.await
+		.expect("timed out waiting for announcement over the wire")
+		.unwrap()
+		.expect("expected an announcement");
+	assert_eq!(announcement.path(), "hello");
+
+	// The auto publisher is wired too: dropping it should not break anything,
+	// and a local add_broadcast on it should succeed (though the server
+	// isn't consuming, so we only verify the call doesn't error).
+	let local_broadcast = MoqBroadcastProducer::new().unwrap();
+	publisher.add_broadcast("local-only".into(), &local_broadcast).unwrap();
+	local_broadcast.finish().unwrap();
+
+	media.finish().unwrap();
+	broadcast.finish().unwrap();
+	cs.session().shutdown();
 	server_session.cancel(0);
 	server.cancel();
 }
@@ -577,7 +649,7 @@ async fn request_per_session_publish_override() {
 	client.set_tls_disable_verify(true);
 	client.set_bind("127.0.0.1:0".into()).unwrap();
 	client.set_consume(Some(client_origin.clone()));
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("connect timed out")
 		.expect("connect failed");
@@ -589,7 +661,9 @@ async fn request_per_session_publish_override() {
 
 	// Publishing on the override origin must reach the client.
 	let broadcast = MoqBroadcastProducer::new().unwrap();
-	override_origin.publish("override-only".into(), &broadcast).unwrap();
+	override_origin
+		.add_broadcast("override-only".into(), &broadcast)
+		.unwrap();
 
 	let consumer = client_origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -601,7 +675,7 @@ async fn request_per_session_publish_override() {
 	assert_eq!(announcement.path(), "override-only");
 
 	broadcast.finish().unwrap();
-	session.cancel(0);
+	cs.session().cancel(0);
 	server_session.cancel(0);
 	server.cancel();
 }

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -456,7 +456,7 @@ async fn server_client_roundtrip() {
 	// `cancel(code)` on the server side, so both shutdown paths run.
 	media.finish().unwrap();
 	broadcast.finish().unwrap();
-	cs.session().shutdown();
+	cs.shutdown();
 	server_session.cancel(0);
 	server.cancel();
 }
@@ -528,7 +528,7 @@ async fn server_client_roundtrip_auto_origin() {
 
 	media.finish().unwrap();
 	broadcast.finish().unwrap();
-	cs.session().shutdown();
+	cs.shutdown();
 	server_session.cancel(0);
 	server.cancel();
 }
@@ -675,7 +675,7 @@ async fn request_per_session_publish_override() {
 	assert_eq!(announcement.path(), "override-only");
 
 	broadcast.finish().unwrap();
-	cs.session().cancel(0);
+	cs.cancel(0);
 	server_session.cancel(0);
 	server.cancel();
 }

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -119,7 +119,7 @@ async fn local_publish_consume_audio() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media("opus".into(), init).unwrap();
-	origin.add_broadcast("live".into(), &broadcast).unwrap();
+	origin.announce("live".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -171,7 +171,7 @@ async fn video_publish_consume() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = h264_init();
 	let media = broadcast.publish_media("avc3".into(), init).unwrap();
-	origin.add_broadcast("video-test".into(), &broadcast).unwrap();
+	origin.announce("video-test".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -226,7 +226,7 @@ async fn multiple_frames_ordering() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media("opus".into(), init).unwrap();
-	origin.add_broadcast("ordering-test".into(), &broadcast).unwrap();
+	origin.announce("ordering-test".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -274,7 +274,7 @@ async fn catalog_update_on_new_track() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let _media1 = broadcast.publish_media("opus".into(), init.clone()).unwrap();
-	origin.add_broadcast("catalog-update".into(), &broadcast).unwrap();
+	origin.announce("catalog-update".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -322,7 +322,7 @@ fn finish_closes_producer() {
 async fn announced_broadcast() {
 	let origin = MoqOriginProducer::new();
 	let broadcast = MoqBroadcastProducer::new().unwrap();
-	origin.add_broadcast("test/broadcast".into(), &broadcast).unwrap();
+	origin.announce("test/broadcast".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -347,7 +347,7 @@ fn without_runtime() {
 		let init = opus_head();
 		let media = broadcast.publish_media("opus".into(), init).unwrap();
 		media.write_frame(b"hello".to_vec(), 1000).unwrap();
-		origin.add_broadcast("test".into(), &broadcast).unwrap();
+		origin.announce("test".into(), &broadcast).unwrap();
 
 		let announced = consumer.announced("".into()).unwrap();
 		let announcement = pollster::block_on(announced.next()).unwrap().unwrap();
@@ -416,7 +416,7 @@ async fn server_client_roundtrip() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media("opus".into(), init).unwrap();
-	server_origin.add_broadcast("hello".into(), &broadcast).unwrap();
+	server_origin.announce("hello".into(), &broadcast).unwrap();
 
 	// Receive the announcement on the client side via the consume origin.
 	let consumer = client_origin.consume();
@@ -509,7 +509,7 @@ async fn server_client_roundtrip_auto_origin() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media("opus".into(), init).unwrap();
-	server_origin.add_broadcast("hello".into(), &broadcast).unwrap();
+	server_origin.announce("hello".into(), &broadcast).unwrap();
 
 	let announced = consumer.announced("".into()).unwrap();
 	let announcement = tokio::time::timeout(TIMEOUT, announced.next())
@@ -520,10 +520,10 @@ async fn server_client_roundtrip_auto_origin() {
 	assert_eq!(announcement.path(), "hello");
 
 	// The auto publisher is wired too: dropping it should not break anything,
-	// and a local add_broadcast on it should succeed (though the server
+	// and a local announce() on it should succeed (though the server
 	// isn't consuming, so we only verify the call doesn't error).
 	let local_broadcast = MoqBroadcastProducer::new().unwrap();
-	publisher.add_broadcast("local-only".into(), &local_broadcast).unwrap();
+	publisher.announce("local-only".into(), &local_broadcast).unwrap();
 	local_broadcast.finish().unwrap();
 
 	media.finish().unwrap();
@@ -661,9 +661,7 @@ async fn request_per_session_publish_override() {
 
 	// Publishing on the override origin must reach the client.
 	let broadcast = MoqBroadcastProducer::new().unwrap();
-	override_origin
-		.add_broadcast("override-only".into(), &broadcast)
-		.unwrap();
+	override_origin.announce("override-only".into(), &broadcast).unwrap();
 
 	let consumer = client_origin.consume();
 	let announced = consumer.announced("".into()).unwrap();

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -497,8 +497,8 @@ async fn server_client_roundtrip_auto_origin() {
 		.expect("connect timed out")
 		.expect("connect failed");
 
-	let publisher = cs.publisher().expect("auto-created publisher");
-	let consumer = cs.consumer().expect("auto-created consumer");
+	let publisher = cs.publisher();
+	let consumer = cs.consumer();
 
 	let server_session = tokio::time::timeout(TIMEOUT, accept)
 		.await

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -400,10 +400,10 @@ async fn run_session(
 	);
 
 	let client = client.with_publish(origin.consume());
-	let session = client.connect(settings.url.clone()).await?;
+	let cs = client.connect(settings.url.clone()).await?;
 
 	let mut runtime = RuntimeState {
-		session,
+		session: cs.session,
 		broadcast,
 		catalog,
 		pads: HashMap::new(),

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -399,7 +399,7 @@ async fn run_session(
 		settings.broadcast
 	);
 
-	let client = client.with_publish(origin.consume());
+	let client = client.with_publish(origin.clone());
 	let session = client.connect(settings.url.clone()).await?;
 
 	let mut runtime = RuntimeState {

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -399,7 +399,7 @@ async fn run_session(
 		settings.broadcast
 	);
 
-	let client = client.with_publish(origin.clone());
+	let client = client.with_publisher(origin.clone());
 	let session = client.connect(settings.url.clone()).await?;
 
 	let mut runtime = RuntimeState {

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -400,10 +400,10 @@ async fn run_session(
 	);
 
 	let client = client.with_publish(origin.consume());
-	let cs = client.connect(settings.url.clone()).await?;
+	let session = client.connect(settings.url.clone()).await?;
 
 	let mut runtime = RuntimeState {
-		session: cs.session,
+		session,
 		broadcast,
 		catalog,
 		pads: HashMap::new(),

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -399,7 +399,7 @@ async fn run_session(
 		settings.broadcast
 	);
 
-	let client = client.with_publish(origin.clone());
+	let client = client.with_publish(origin.consume());
 	let session = client.connect(settings.url.clone()).await?;
 
 	let mut runtime = RuntimeState {

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -419,7 +419,7 @@ async fn run_session(
 
 	let origin = moq_net::Origin::random().produce();
 	let origin_consumer = origin.consume();
-	let client = config.init()?.with_consume(origin);
+	let client = config.init()?.with_consumer(origin);
 
 	let _session = client.connect(settings.url.clone()).await?;
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -27,7 +27,7 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	let url = url::Url::parse("https://cdn.moq.dev/anon/chat-example").unwrap();
 
 	// Establish a WebTransport/QUIC connection and MoQ handshake.
-	let cs = client.with_publish(origin).connect(url).await?;
+	let cs = client.with_publisher(origin).connect(url).await?;
 
 	// Wait until the session is closed.
 	cs.closed().await.map_err(Into::into)

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -12,13 +12,13 @@ async fn main() -> anyhow::Result<()> {
 	// This is a simple example of how you can concurrently run multiple tasks.
 	// tokio::spawn works too.
 	tokio::select! {
-		res = run_session(origin.clone()) => res,
+		res = run_session(origin.consume()) => res,
 		res = run_broadcast(origin) => res,
 	}
 }
 
 // Connect to the server and publish our origin of broadcasts.
-async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
+async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -12,13 +12,13 @@ async fn main() -> anyhow::Result<()> {
 	// This is a simple example of how you can concurrently run multiple tasks.
 	// tokio::spawn works too.
 	tokio::select! {
-		res = run_session(origin.consume()) => res,
+		res = run_session(origin.clone()) => res,
 		res = run_broadcast(origin) => res,
 	}
 }
 
 // Connect to the server and publish our origin of broadcasts.
-async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
+async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -27,10 +27,10 @@ async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
 	let url = url::Url::parse("https://cdn.moq.dev/anon/chat-example").unwrap();
 
 	// Establish a WebTransport/QUIC connection and MoQ handshake.
-	let session = client.with_publish(origin).connect(url).await?;
+	let cs = client.with_publish(origin).connect(url).await?;
 
 	// Wait until the session is closed.
-	session.closed().await.map_err(Into::into)
+	cs.session.closed().await.map_err(Into::into)
 }
 
 // Produce a broadcast and publish it to the origin.

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -30,7 +30,7 @@ async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
 	let cs = client.with_publish(origin).connect(url).await?;
 
 	// Wait until the session is closed.
-	cs.session.closed().await.map_err(Into::into)
+	cs.closed().await.map_err(Into::into)
 }
 
 // Produce a broadcast and publish it to the origin.

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
 
 			origin.publish_broadcast(&config.broadcast, broadcast.consume());
 
-			let reconnect = client.with_publish(origin.clone()).reconnect(config.url);
+			let reconnect = client.with_publisher(origin.clone()).reconnect(config.url);
 
 			tokio::select! {
 				res = reconnect.closed() => res,
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
 			}
 		}
 		Command::Subscribe => {
-			let reconnect = client.with_consume(origin.clone()).reconnect(config.url);
+			let reconnect = client.with_consumer(origin.clone()).reconnect(config.url);
 
 			// IETF MoQ + the current OriginConsumer API don't let us call
 			// `session.consume_broadcast(&path)` directly, so loop on announces

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
 
 			origin.publish_broadcast(&config.broadcast, broadcast.consume());
 
-			let reconnect = client.with_publish(origin.clone()).reconnect(config.url);
+			let reconnect = client.with_publish(origin.consume()).reconnect(config.url);
 
 			tokio::select! {
 				res = reconnect.closed() => res,

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
 
 			origin.publish_broadcast(&config.broadcast, broadcast.consume());
 
-			let reconnect = client.with_publish(origin.consume()).reconnect(config.url);
+			let reconnect = client.with_publish(origin.clone()).reconnect(config.url);
 
 			tokio::select! {
 				res = reconnect.closed() => res,

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -314,12 +314,12 @@ impl Client {
 		self
 	}
 
-	pub fn with_publisher(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+	pub fn with_publisher(mut self, publish: moq_net::OriginProducer) -> Self {
 		self.moq = self.moq.with_publisher(publish);
 		self
 	}
 
-	pub fn with_consumer(mut self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+	pub fn with_consumer(mut self, consume: moq_net::OriginProducer) -> Self {
 		self.moq = self.moq.with_consumer(consume);
 		self
 	}

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -345,7 +345,7 @@ impl Client {
 		feature = "iroh",
 		feature = "websocket"
 	)))]
-	pub async fn connect(&self, _url: Url) -> anyhow::Result<moq_net::Session> {
+	pub async fn connect(&self, _url: Url) -> anyhow::Result<moq_net::ClientSession> {
 		anyhow::bail!("no backend compiled; enable noq, quinn, quiche, iroh, or websocket feature");
 	}
 
@@ -356,10 +356,10 @@ impl Client {
 		feature = "iroh",
 		feature = "websocket"
 	))]
-	pub async fn connect(&self, url: Url) -> anyhow::Result<moq_net::Session> {
-		let session = self.connect_inner(url).await?;
-		tracing::info!(version = %session.version(), "connected");
-		Ok(session)
+	pub async fn connect(&self, url: Url) -> anyhow::Result<moq_net::ClientSession> {
+		let cs = self.connect_inner(url).await?;
+		tracing::info!(version = %cs.session.version(), "connected");
+		Ok(cs)
 	}
 
 	#[cfg(any(
@@ -369,7 +369,7 @@ impl Client {
 		feature = "iroh",
 		feature = "websocket"
 	))]
-	async fn connect_inner(&self, url: Url) -> anyhow::Result<moq_net::Session> {
+	async fn connect_inner(&self, url: Url) -> anyhow::Result<moq_net::ClientSession> {
 		#[cfg(feature = "iroh")]
 		if url.scheme() == "iroh" {
 			let endpoint = self.iroh.as_ref().context("Iroh support is not enabled")?;

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -314,7 +314,7 @@ impl Client {
 		self
 	}
 
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginConsumer>>) -> Self {
+	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
 		self.moq = self.moq.with_publish(publish);
 		self
 	}

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -314,7 +314,7 @@ impl Client {
 		self
 	}
 
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginConsumer>>) -> Self {
 		self.moq = self.moq.with_publish(publish);
 		self
 	}

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -345,7 +345,7 @@ impl Client {
 		feature = "iroh",
 		feature = "websocket"
 	)))]
-	pub async fn connect(&self, _url: Url) -> anyhow::Result<moq_net::ClientSession> {
+	pub async fn connect(&self, _url: Url) -> anyhow::Result<moq_net::Session> {
 		anyhow::bail!("no backend compiled; enable noq, quinn, quiche, iroh, or websocket feature");
 	}
 
@@ -356,9 +356,9 @@ impl Client {
 		feature = "iroh",
 		feature = "websocket"
 	))]
-	pub async fn connect(&self, url: Url) -> anyhow::Result<moq_net::ClientSession> {
+	pub async fn connect(&self, url: Url) -> anyhow::Result<moq_net::Session> {
 		let cs = self.connect_inner(url).await?;
-		tracing::info!(version = %cs.session.version(), "connected");
+		tracing::info!(version = %cs.version(), "connected");
 		Ok(cs)
 	}
 
@@ -369,7 +369,7 @@ impl Client {
 		feature = "iroh",
 		feature = "websocket"
 	))]
-	async fn connect_inner(&self, url: Url) -> anyhow::Result<moq_net::ClientSession> {
+	async fn connect_inner(&self, url: Url) -> anyhow::Result<moq_net::Session> {
 		#[cfg(feature = "iroh")]
 		if url.scheme() == "iroh" {
 			let endpoint = self.iroh.as_ref().context("Iroh support is not enabled")?;

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -314,13 +314,13 @@ impl Client {
 		self
 	}
 
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
-		self.moq = self.moq.with_publish(publish);
+	pub fn with_publisher(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+		self.moq = self.moq.with_publisher(publish);
 		self
 	}
 
-	pub fn with_consume(mut self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
-		self.moq = self.moq.with_consume(consume);
+	pub fn with_consumer(mut self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+		self.moq = self.moq.with_consumer(consume);
 		self
 	}
 

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -103,7 +103,7 @@ impl Reconnect {
 					tracing::info!(%url, "connected");
 					delay = backoff.initial;
 					last_error = None;
-					let _ = cs.session.closed().await;
+					let _ = cs.closed().await;
 					tracing::warn!(%url, "session closed, reconnecting");
 					retry_start = tokio::time::Instant::now();
 				}

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -99,11 +99,11 @@ impl Reconnect {
 			tracing::info!(%url, "connecting");
 
 			match client.connect(url.clone()).await {
-				Ok(session) => {
+				Ok(cs) => {
 					tracing::info!(%url, "connected");
 					delay = backoff.initial;
 					last_error = None;
-					let _ = session.closed().await;
+					let _ = cs.session.closed().await;
 					tracing::warn!(%url, "session closed, reconnecting");
 					retry_start = tokio::time::Instant::now();
 				}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -300,7 +300,7 @@ impl Server {
 		self
 	}
 
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginConsumer>>) -> Self {
+	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
 		self.moq = self.moq.with_publish(publish);
 		self
 	}
@@ -608,7 +608,7 @@ impl Request {
 	}
 
 	/// Publish the given origin to the session.
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginConsumer>>) -> Self {
+	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
 		self.server = self.server.with_publish(publish);
 		self
 	}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -300,13 +300,13 @@ impl Server {
 		self
 	}
 
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
-		self.moq = self.moq.with_publish(publish);
+	pub fn with_publisher(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+		self.moq = self.moq.with_publisher(publish);
 		self
 	}
 
-	pub fn with_consume(mut self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
-		self.moq = self.moq.with_consume(consume);
+	pub fn with_consumer(mut self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+		self.moq = self.moq.with_consumer(consume);
 		self
 	}
 
@@ -555,7 +555,7 @@ pub(crate) enum RequestKind {
 
 /// An incoming MoQ session that can be accepted or rejected.
 ///
-/// [Self::with_publish] and [Self::with_consume] will configure what will be published and consumed from the session respectively.
+/// [Self::with_publisher] and [Self::with_consumer] will configure what will be published and consumed from the session respectively.
 /// Otherwise, the Server's configuration is used by default.
 pub struct Request {
 	server: moq_net::Server,
@@ -602,14 +602,14 @@ impl Request {
 	}
 
 	/// Publish the given origin to the session.
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
-		self.server = self.server.with_publish(publish);
+	pub fn with_publisher(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+		self.server = self.server.with_publisher(publish);
 		self
 	}
 
 	/// Consume the given origin from the session.
-	pub fn with_consume(mut self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
-		self.server = self.server.with_consume(consume);
+	pub fn with_consumer(mut self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+		self.server = self.server.with_consumer(consume);
 		self
 	}
 

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -300,12 +300,12 @@ impl Server {
 		self
 	}
 
-	pub fn with_publisher(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+	pub fn with_publisher(mut self, publish: moq_net::OriginProducer) -> Self {
 		self.moq = self.moq.with_publisher(publish);
 		self
 	}
 
-	pub fn with_consumer(mut self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+	pub fn with_consumer(mut self, consume: moq_net::OriginProducer) -> Self {
 		self.moq = self.moq.with_consumer(consume);
 		self
 	}
@@ -602,13 +602,13 @@ impl Request {
 	}
 
 	/// Publish the given origin to the session.
-	pub fn with_publisher(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+	pub fn with_publisher(mut self, publish: moq_net::OriginProducer) -> Self {
 		self.server = self.server.with_publisher(publish);
 		self
 	}
 
 	/// Consume the given origin from the session.
-	pub fn with_consumer(mut self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+	pub fn with_consumer(mut self, consume: moq_net::OriginProducer) -> Self {
 		self.server = self.server.with_consumer(consume);
 		self
 	}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -300,7 +300,7 @@ impl Server {
 		self
 	}
 
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginConsumer>>) -> Self {
 		self.moq = self.moq.with_publish(publish);
 		self
 	}
@@ -602,7 +602,7 @@ impl Request {
 	}
 
 	/// Publish the given origin to the session.
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
+	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginConsumer>>) -> Self {
 		self.server = self.server.with_publish(publish);
 		self
 	}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -300,7 +300,7 @@ impl Server {
 		self
 	}
 
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginConsumer>>) -> Self {
+	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
 		self.moq = self.moq.with_publish(publish);
 		self
 	}
@@ -602,7 +602,7 @@ impl Request {
 	}
 
 	/// Publish the given origin to the session.
-	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginConsumer>>) -> Self {
+	pub fn with_publish(mut self, publish: impl Into<Option<moq_net::OriginProducer>>) -> Self {
 		self.server = self.server.with_publish(publish);
 		self
 	}

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -39,10 +39,10 @@ async fn connect_with_version(version: &str) {
 	let server_origin = origin.clone();
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		request.with_publish(server_origin).ok().await
+		request.with_publish(server_origin.consume()).ok().await
 	});
 
-	let client = client.with_publish(origin);
+	let client = client.with_publish(origin.consume());
 	let client_result = client.connect(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");
@@ -90,10 +90,10 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	let server_origin = origin.clone();
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		request.with_publish(server_origin).ok().await
+		request.with_publish(server_origin.consume()).ok().await
 	});
 
-	let client = client.with_publish(origin);
+	let client = client.with_publish(origin.consume());
 	let client_result = client.connect(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -24,7 +24,6 @@ async fn connect_with_version(version: &str) {
 
 	// Provide a dummy origin so the MoQ handshake has something to negotiate.
 	let origin = moq_native::moq_net::Origin::random().produce();
-	let consumer = origin.consume();
 
 	// ── client ──────────────────────────────────────────────────────
 	let mut client_config = moq_native::ClientConfig::default();
@@ -37,12 +36,13 @@ async fn connect_with_version(version: &str) {
 	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
 
 	// Run server accept and client connect concurrently.
+	let server_origin = origin.clone();
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		request.with_publish(consumer).ok().await
+		request.with_publish(server_origin).ok().await
 	});
 
-	let client = client.with_publish(origin.consume());
+	let client = client.with_publish(origin);
 	let client_result = client.connect(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");
@@ -74,7 +74,6 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	let addr = server.local_addr().expect("failed to get local addr");
 
 	let origin = moq_native::moq_net::Origin::random().produce();
-	let consumer = origin.consume();
 
 	// ── client ──────────────────────────────────────────────────────
 	let mut client_config = moq_native::ClientConfig::default();
@@ -88,12 +87,13 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	// Use https:// URL to trigger the WebTransport path.
 	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
 
+	let server_origin = origin.clone();
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		request.with_publish(consumer).ok().await
+		request.with_publish(server_origin).ok().await
 	});
 
-	let client = client.with_publish(origin.consume());
+	let client = client.with_publish(origin);
 	let client_result = client.connect(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -39,10 +39,10 @@ async fn connect_with_version(version: &str) {
 	let server_origin = origin.clone();
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		request.with_publish(server_origin.consume()).ok().await
+		request.with_publish(server_origin.clone()).ok().await
 	});
 
-	let client = client.with_publish(origin.consume());
+	let client = client.with_publish(origin.clone());
 	let client_result = client.connect(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");
@@ -90,10 +90,10 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	let server_origin = origin.clone();
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		request.with_publish(server_origin.consume()).ok().await
+		request.with_publish(server_origin.clone()).ok().await
 	});
 
-	let client = client.with_publish(origin.consume());
+	let client = client.with_publish(origin.clone());
 	let client_result = client.connect(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -39,10 +39,10 @@ async fn connect_with_version(version: &str) {
 	let server_origin = origin.clone();
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		request.with_publish(server_origin.clone()).ok().await
+		request.with_publisher(server_origin.clone()).ok().await
 	});
 
-	let client = client.with_publish(origin.clone());
+	let client = client.with_publisher(origin.clone());
 	let client_result = client.connect(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");
@@ -90,10 +90,10 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	let server_origin = origin.clone();
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		request.with_publish(server_origin.clone()).ok().await
+		request.with_publisher(server_origin.clone()).ok().await
 	});
 
-	let client = client.with_publish(origin.clone());
+	let client = client.with_publisher(origin.clone());
 	let client_result = client.connect(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -46,7 +46,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -198,7 +198,7 @@ async fn iroh_connect() {
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -46,7 +46,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let session = request.with_publish(pub_origin.clone()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -198,7 +198,7 @@ async fn iroh_connect() {
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let session = request.with_publish(pub_origin.clone()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -46,7 +46,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publisher(pub_origin.clone()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -55,7 +55,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let client = client.with_consume(sub_origin);
+	let client = client.with_consumer(sub_origin);
 	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("client connect timed out")
@@ -198,7 +198,7 @@ async fn iroh_connect() {
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publisher(pub_origin.clone()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -207,7 +207,7 @@ async fn iroh_connect() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let client = client.with_consume(sub_origin);
+	let client = client.with_consumer(sub_origin);
 	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("client connect timed out")

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -691,14 +691,18 @@ async fn broadcast_websocket_uses_newest_version() {
 	});
 
 	let client = client.with_consume(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
-	assert_eq!(session.version(), expected_version, "client negotiated stale version");
+	assert_eq!(
+		cs.session.version(),
+		expected_version,
+		"client negotiated stale version"
+	);
 
-	drop(session);
+	drop(cs);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -767,14 +771,18 @@ async fn broadcast_race_quic_wins() {
 	});
 
 	let client = client.with_consume(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
-	assert_eq!(session.version(), expected_version, "client negotiated stale version");
+	assert_eq!(
+		cs.session.version(),
+		expected_version,
+		"client negotiated stale version"
+	);
 
-	drop(session);
+	drop(cs);
 	server_handle
 		.await
 		.expect("server task panicked")

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -696,11 +696,7 @@ async fn broadcast_websocket_uses_newest_version() {
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
-	assert_eq!(
-		cs.session.version(),
-		expected_version,
-		"client negotiated stale version"
-	);
+	assert_eq!(cs.version(), expected_version, "client negotiated stale version");
 
 	drop(cs);
 	server_handle
@@ -776,11 +772,7 @@ async fn broadcast_race_quic_wins() {
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
-	assert_eq!(
-		cs.session.version(),
-		expected_version,
-		"client negotiated stale version"
-	);
+	assert_eq!(cs.version(), expected_version, "client negotiated stale version");
 
 	drop(cs);
 	server_handle

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -60,7 +60,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let session = request.with_publish(pub_origin.clone()).ok().await?;
 
 		// Keep producers alive so the subscriber can read data.
 		let _broadcast = broadcast;
@@ -474,7 +474,7 @@ async fn broadcast_websocket() {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), "websocket");
-		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let session = request.with_publish(pub_origin.clone()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -581,7 +581,7 @@ async fn broadcast_websocket_fallback() {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), "websocket");
-		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let session = request.with_publish(pub_origin.clone()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -682,7 +682,7 @@ async fn broadcast_websocket_uses_newest_version() {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), "websocket");
-		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let session = request.with_publish(pub_origin.clone()).ok().await?;
 		assert_eq!(session.version(), expected_version, "server negotiated stale version");
 		let _broadcast = broadcast;
 		let _track = track;
@@ -758,7 +758,7 @@ async fn broadcast_race_quic_wins() {
 			"quic",
 			"QUIC lost the race to WebSocket with both reachable",
 		);
-		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let session = request.with_publish(pub_origin.clone()).ok().await?;
 		assert_eq!(session.version(), expected_version, "server negotiated stale version");
 		let _broadcast = broadcast;
 		let _track = track;
@@ -828,7 +828,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("accept");
-		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let session = request.with_publish(pub_origin.clone()).ok().await?;
 		let _ = session.closed().await;
 		Ok::<_, anyhow::Error>(())
 	});

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -60,7 +60,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
 
 		// Keep producers alive so the subscriber can read data.
 		let _broadcast = broadcast;
@@ -474,7 +474,7 @@ async fn broadcast_websocket() {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), "websocket");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -581,7 +581,7 @@ async fn broadcast_websocket_fallback() {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), "websocket");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -682,7 +682,7 @@ async fn broadcast_websocket_uses_newest_version() {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), "websocket");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
 		assert_eq!(session.version(), expected_version, "server negotiated stale version");
 		let _broadcast = broadcast;
 		let _track = track;
@@ -758,7 +758,7 @@ async fn broadcast_race_quic_wins() {
 			"quic",
 			"QUIC lost the race to WebSocket with both reachable",
 		);
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
 		assert_eq!(session.version(), expected_version, "server negotiated stale version");
 		let _broadcast = broadcast;
 		let _track = track;
@@ -828,7 +828,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("accept");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
 		let _ = session.closed().await;
 		Ok::<_, anyhow::Error>(())
 	});

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -60,7 +60,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publisher(pub_origin.clone()).ok().await?;
 
 		// Keep producers alive so the subscriber can read data.
 		let _broadcast = broadcast;
@@ -71,7 +71,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let client = client.with_consume(sub_origin);
+	let client = client.with_consumer(sub_origin);
 	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("client connect timed out")
@@ -474,7 +474,7 @@ async fn broadcast_websocket() {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), "websocket");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publisher(pub_origin.clone()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -483,7 +483,7 @@ async fn broadcast_websocket() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let client = client.with_consume(sub_origin);
+	let client = client.with_consumer(sub_origin);
 	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("client connect timed out")
@@ -581,7 +581,7 @@ async fn broadcast_websocket_fallback() {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), "websocket");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publisher(pub_origin.clone()).ok().await?;
 
 		let _broadcast = broadcast;
 		let _track = track;
@@ -590,7 +590,7 @@ async fn broadcast_websocket_fallback() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let client = client.with_consume(sub_origin);
+	let client = client.with_consumer(sub_origin);
 	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("client connect timed out")
@@ -682,7 +682,7 @@ async fn broadcast_websocket_uses_newest_version() {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), "websocket");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publisher(pub_origin.clone()).ok().await?;
 		assert_eq!(session.version(), expected_version, "server negotiated stale version");
 		let _broadcast = broadcast;
 		let _track = track;
@@ -690,7 +690,7 @@ async fn broadcast_websocket_uses_newest_version() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let client = client.with_consume(sub_origin);
+	let client = client.with_consumer(sub_origin);
 	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("client connect timed out")
@@ -758,7 +758,7 @@ async fn broadcast_race_quic_wins() {
 			"quic",
 			"QUIC lost the race to WebSocket with both reachable",
 		);
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publisher(pub_origin.clone()).ok().await?;
 		assert_eq!(session.version(), expected_version, "server negotiated stale version");
 		let _broadcast = broadcast;
 		let _track = track;
@@ -766,7 +766,7 @@ async fn broadcast_race_quic_wins() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let client = client.with_consume(sub_origin);
+	let client = client.with_consumer(sub_origin);
 	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("client connect timed out")
@@ -828,12 +828,12 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("accept");
-		let session = request.with_publish(pub_origin.clone()).ok().await?;
+		let session = request.with_publisher(pub_origin.clone()).ok().await?;
 		let _ = session.closed().await;
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let client = client.with_consume(sub_origin);
+	let client = client.with_consumer(sub_origin);
 	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
 		.expect("connect timeout")

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, Origin, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	NEGOTIATED, Origin, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -8,7 +8,7 @@ use crate::{
 /// A MoQ client session builder.
 #[derive(Default, Clone)]
 pub struct Client {
-	publish: Option<OriginConsumer>,
+	publish: Option<OriginProducer>,
 	consume: Option<OriginProducer>,
 	stats: StatsHandle,
 	versions: Versions,
@@ -19,24 +19,20 @@ impl Client {
 		Default::default()
 	}
 
-	/// Override the publish-side source: the client reads broadcasts
-	/// from this [`OriginConsumer`] to forward to the remote. When set,
-	/// [`Session::publisher`] becomes a standalone auto-created
-	/// [`OriginProducer`] decoupled from the wire (the caller drives
-	/// publishing through whatever produces into the consumer they
-	/// passed). When unset, the session's auto-created publisher
-	/// supplies the wire as well.
-	pub fn with_publish(mut self, publish: impl Into<Option<OriginConsumer>>) -> Self {
+	/// Override the publish-side origin: the [`OriginProducer`] this
+	/// client reads from when forwarding local broadcasts to the remote.
+	/// Surfaced as [`Session::publisher`] so callers can keep
+	/// `.announce(path, broadcast)`-ing after connect.
+	///
+	/// Pre-scoped via [`OriginProducer::scope`] for token-gated relays.
+	pub fn with_publish(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
 		self.publish = publish.into();
 		self
 	}
 
-	/// Override the consume-side sink: the client writes broadcasts
-	/// from the remote into this [`OriginProducer`]. When set,
-	/// [`Session::consumer`] becomes a standalone auto-created
-	/// [`OriginConsumer`] decoupled from the wire (the caller reads
-	/// announcements through their own producer's consumer view). When
-	/// unset, the session's auto-created consumer reads from the wire.
+	/// Override the consume-side origin: the [`OriginProducer`] this
+	/// client writes into as the remote announces broadcasts. A consumer
+	/// view is surfaced as [`Session::consumer`].
 	pub fn with_consume(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
 		self.consume = consume.into();
 		self
@@ -52,9 +48,10 @@ impl Client {
 
 	/// Set both publish and consume from one shared [`OriginProducer`].
 	///
-	/// Equivalent to `with_publish(origin.consume()).with_consume(origin)`.
+	/// Equivalent to calling [`with_publish`](Self::with_publish) and
+	/// [`with_consume`](Self::with_consume) with the same origin.
 	pub fn with_origin(self, origin: OriginProducer) -> Self {
-		self.with_publish(origin.consume()).with_consume(origin)
+		self.with_publish(origin.clone()).with_consume(origin)
 	}
 
 	pub fn with_versions(mut self, versions: Versions) -> Self {
@@ -65,16 +62,16 @@ impl Client {
 	/// Perform the MoQ handshake as a client negotiating the version.
 	///
 	/// The returned [`Session`] always exposes both
-	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer).
-	/// When the caller didn't override via [`Self::with_publish`] /
-	/// [`Self::with_consume`] / [`Self::with_origin`], a single fresh
-	/// [`Origin`] is auto-created and shared between both sides (the
-	/// typical full-duplex client). The same origin drives the wire.
-	/// When the caller did override either side, the session's publisher
-	/// / consumer for that side become standalone auto-created
-	/// no-ops decoupled from the wire.
+	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
+	/// whatever was set via [`Self::with_publish`] / [`Self::with_consume`]
+	/// / [`Self::with_origin`], or a fresh auto-created [`Origin`] for
+	/// any side the caller left unset. When neither side is set, both
+	/// default to the same shared origin (the typical full-duplex client).
 	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		let (publisher, consumer_view, publish, consume) = resolve_origins(self.publish.clone(), self.consume.clone());
+		let (publisher, consumer) = resolve_origins(self.publish.clone(), self.consume.clone());
+		let publish = Some(publisher.consume());
+		let consume = Some(consumer.clone());
+		let consumer_view = consumer.consume();
 
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
 		// Default to IETF 14 if no ALPN was used and we'll negotiate the version later.
@@ -261,68 +258,20 @@ impl Client {
 	}
 }
 
-/// Resolve `(Session.publisher, Session.consumer, wire-publish, wire-consume)`
-/// from the user-supplied overrides.
-///
-/// The session always exposes a publisher / consumer; whether they drive
-/// the wire depends on whether the user overrode that side:
-/// - Neither overridden: one shared origin powers everything (duplex).
-/// - Override only publish: the user's consumer drives the wire publish
-///   side; `Session.publisher` becomes a standalone no-op producer.
-///   `Session.consumer` and wire-consume share a fresh shared origin.
-/// - Override only consume: symmetric to above.
-/// - Both overridden: `Session.publisher` and `Session.consumer` are
-///   independent standalone defaults (no-ops); the wire uses what the
-///   user passed.
+/// Pick the publish / consume [`OriginProducer`]s for a session,
+/// defaulting any side the caller didn't set. When both are unset, a
+/// single shared fresh origin powers both (the typical duplex client).
 pub(crate) fn resolve_origins(
-	publish: Option<OriginConsumer>,
+	publish: Option<OriginProducer>,
 	consume: Option<OriginProducer>,
-) -> (
-	OriginProducer,
-	OriginConsumer,
-	Option<OriginConsumer>,
-	Option<OriginProducer>,
-) {
+) -> (OriginProducer, OriginProducer) {
 	match (publish, consume) {
+		(Some(p), Some(c)) => (p, c),
+		(Some(p), None) => (p, Origin::random().produce()),
+		(None, Some(c)) => (Origin::random().produce(), c),
 		(None, None) => {
-			// Duplex default: one shared origin powers Session.publisher,
-			// Session.consumer, and both wire directions.
 			let shared = Origin::random().produce();
-			let publisher = shared.clone();
-			let consumer_view = shared.consume();
-			let wire_publish = shared.consume();
-			let wire_consume = shared;
-			(publisher, consumer_view, Some(wire_publish), Some(wire_consume))
-		}
-		(Some(wire_publish), None) => {
-			// User drives wire-publish via their own consumer. Surface a
-			// standalone publisher for Session.publisher (no-op for wire),
-			// but the consume side stays auto-wired: one shared origin
-			// drives Session.consumer + wire-consume.
-			let publisher = Origin::random().produce();
-			let consume_shared = Origin::random().produce();
-			let consumer_view = consume_shared.consume();
-			(publisher, consumer_view, Some(wire_publish), Some(consume_shared))
-		}
-		(None, Some(wire_consume)) => {
-			// Symmetric: user-provided consume producer drives wire; the
-			// publish side gets a fresh shared origin.
-			let publish_shared = Origin::random().produce();
-			let publisher = publish_shared.clone();
-			let consumer_view = Origin::random().produce().consume();
-			(
-				publisher,
-				consumer_view,
-				Some(publish_shared.consume()),
-				Some(wire_consume),
-			)
-		}
-		(Some(wire_publish), Some(wire_consume)) => {
-			// Fully manual: Session.publisher / Session.consumer are
-			// standalone no-ops, the wire uses the user's overrides.
-			let publisher = Origin::random().produce();
-			let consumer_view = Origin::random().produce().consume();
-			(publisher, consumer_view, Some(wire_publish), Some(wire_consume))
+			(shared.clone(), shared)
 		}
 	}
 }

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -14,22 +14,6 @@ pub struct Client {
 	versions: Versions,
 }
 
-/// A connected MoQ client session plus, optionally, the [`OriginProducer`]
-/// and [`OriginConsumer`] that [`Client::connect`] auto-created when no
-/// publish or consume origin had been set on the [`Client`].
-///
-/// `publisher` and `consumer` are `Some(_)` only on the no-config path
-/// (i.e. neither [`Client::with_publish`] / [`Client::with_consume`] /
-/// [`Client::with_origin`] was called before connect). When the caller
-/// wires its own origin(s), both fields are `None` and the caller
-/// continues to drive publishing and consuming through the origins it
-/// already holds.
-pub struct ClientSession {
-	pub session: Session,
-	pub publisher: Option<OriginProducer>,
-	pub consumer: Option<OriginConsumer>,
-}
-
 impl Client {
 	pub fn new() -> Self {
 		Default::default()
@@ -70,15 +54,15 @@ impl Client {
 	///
 	/// If neither a publish nor a consume origin was set on this builder,
 	/// connect auto-creates a fresh [`Origin`] and wires it as both, then
-	/// returns the producer and consumer sides on the resulting
-	/// [`ClientSession`]. Callers who configured their own origin(s) see
-	/// `ClientSession::publisher` and `ClientSession::consumer` as `None`
-	/// and continue to drive publishing / consuming through the origins
-	/// they already hold.
-	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<ClientSession, Error> {
+	/// surfaces the producer and consumer sides on the returned
+	/// [`Session`] via [`Session::publisher`] and [`Session::consumer`].
+	/// Callers who configured their own origin(s) see both as `None` and
+	/// continue to drive publishing / consuming through the origins they
+	/// already hold.
+	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
 		// Effective publish / consume after potential auto-creation. The
 		// `auto_*` locals are populated only on the no-config path so the
-		// returned ClientSession reflects what we actually own.
+		// returned Session reflects what we actually own.
 		let (publish, consume, auto_publisher, auto_consumer) = match (self.publish.clone(), self.consume.clone()) {
 			(None, None) => {
 				let producer = Origin::random().produce();
@@ -117,11 +101,7 @@ impl Client {
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(ClientSession {
-					session: Session::new(session, v, None),
-					publisher: auto_publisher,
-					consumer: auto_consumer,
-				});
+				return Ok(Session::new(session, v, None).with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_17) => {
 				let v = self
@@ -141,11 +121,7 @@ impl Client {
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(ClientSession {
-					session: Session::new(session, v, None),
-					publisher: auto_publisher,
-					consumer: auto_consumer,
-				});
+				return Ok(Session::new(session, v, None).with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_16) => {
 				let v = self
@@ -182,11 +158,8 @@ impl Client {
 					lite::Version::Lite05Wip,
 				)?;
 
-				return Ok(ClientSession {
-					session: Session::new(session, lite::Version::Lite05Wip.into(), recv_bw),
-					publisher: auto_publisher,
-					consumer: auto_consumer,
-				});
+				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw)
+					.with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions
@@ -202,11 +175,8 @@ impl Client {
 					lite::Version::Lite04,
 				)?;
 
-				return Ok(ClientSession {
-					session: Session::new(session, lite::Version::Lite04.into(), recv_bw),
-					publisher: auto_publisher,
-					consumer: auto_consumer,
-				});
+				return Ok(Session::new(session, lite::Version::Lite04.into(), recv_bw)
+					.with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_LITE_03) => {
 				self.versions
@@ -223,11 +193,8 @@ impl Client {
 					lite::Version::Lite03,
 				)?;
 
-				return Ok(ClientSession {
-					session: Session::new(session, lite::Version::Lite03.into(), recv_bw),
-					publisher: auto_publisher,
-					consumer: auto_consumer,
-				});
+				return Ok(Session::new(session, lite::Version::Lite03.into(), recv_bw)
+					.with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -279,11 +246,7 @@ impl Client {
 			}
 		};
 
-		Ok(ClientSession {
-			session: Session::new(session, version, recv_bw),
-			publisher: auto_publisher,
-			consumer: auto_consumer,
-		})
+		Ok(Session::new(session, version, recv_bw).with_origins(auto_publisher, auto_consumer))
 	}
 }
 

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -6,12 +6,26 @@ use crate::{
 };
 
 /// A MoQ client session builder.
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct Client {
-	publish: Option<OriginProducer>,
-	consume: Option<OriginProducer>,
+	publish: OriginProducer,
+	consume: OriginProducer,
 	stats: StatsHandle,
 	versions: Versions,
+}
+
+impl Default for Client {
+	fn default() -> Self {
+		// Default to one shared fresh origin so the typical duplex
+		// client just works without any setup.
+		let shared = Origin::random().produce();
+		Self {
+			publish: shared.clone(),
+			consume: shared,
+			stats: StatsHandle::default(),
+			versions: Versions::default(),
+		}
+	}
 }
 
 impl Client {
@@ -22,19 +36,19 @@ impl Client {
 	/// Override the publish-side origin: the [`OriginProducer`] this
 	/// client reads from when forwarding local broadcasts to the remote.
 	/// Surfaced as [`Session::publisher`] so callers can keep
-	/// `.announce(path, broadcast)`-ing after connect.
+	/// `.publish_broadcast(path, broadcast)`-ing after connect.
 	///
 	/// Pre-scoped via [`OriginProducer::scope`] for token-gated relays.
-	pub fn with_publisher(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
-		self.publish = publish.into();
+	pub fn with_publisher(mut self, publish: OriginProducer) -> Self {
+		self.publish = publish;
 		self
 	}
 
 	/// Override the consume-side origin: the [`OriginProducer`] this
 	/// client writes into as the remote announces broadcasts. A consumer
 	/// view is surfaced as [`Session::consumer`].
-	pub fn with_consumer(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
-		self.consume = consume.into();
+	pub fn with_consumer(mut self, consume: OriginProducer) -> Self {
+		self.consume = consume;
 		self
 	}
 
@@ -60,17 +74,11 @@ impl Client {
 	}
 
 	/// Perform the MoQ handshake as a client negotiating the version.
-	///
-	/// The returned [`Session`] always exposes both
-	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
-	/// whatever was set via [`Self::with_publisher`] / [`Self::with_consumer`]
-	/// / [`Self::with_origin`], or a fresh auto-created [`Origin`] for
-	/// any side the caller left unset. When neither side is set, both
-	/// default to the same shared origin (the typical full-duplex client).
 	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		let (publisher, consumer) = resolve_origins(self.publish.clone(), self.consume.clone());
-		let publish = Some(publisher.consume());
-		let consume = Some(consumer.clone());
+		let publisher = self.publish.clone();
+		let consumer = self.consume.clone();
+		let publish = publisher.consume();
+		let consume = consumer.clone();
 		let consumer_view = consumer.consume();
 
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
@@ -255,24 +263,6 @@ impl Client {
 		};
 
 		Ok(Session::new(session, version, recv_bw, publisher, consumer_view))
-	}
-}
-
-/// Pick the publish / consume [`OriginProducer`]s for a session,
-/// defaulting any side the caller didn't set. When both are unset, a
-/// single shared fresh origin powers both (the typical duplex client).
-pub(crate) fn resolve_origins(
-	publish: Option<OriginProducer>,
-	consume: Option<OriginProducer>,
-) -> (OriginProducer, OriginProducer) {
-	match (publish, consume) {
-		(Some(p), Some(c)) => (p, c),
-		(Some(p), None) => (p, Origin::random().produce()),
-		(None, Some(c)) => (Origin::random().produce(), c),
-		(None, None) => {
-			let shared = Origin::random().produce();
-			(shared.clone(), shared)
-		}
 	}
 }
 

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -25,7 +25,7 @@ impl Client {
 	/// `.announce(path, broadcast)`-ing after connect.
 	///
 	/// Pre-scoped via [`OriginProducer::scope`] for token-gated relays.
-	pub fn with_publish(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
+	pub fn with_publisher(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
 		self.publish = publish.into();
 		self
 	}
@@ -33,7 +33,7 @@ impl Client {
 	/// Override the consume-side origin: the [`OriginProducer`] this
 	/// client writes into as the remote announces broadcasts. A consumer
 	/// view is surfaced as [`Session::consumer`].
-	pub fn with_consume(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
+	pub fn with_consumer(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
 		self.consume = consume.into();
 		self
 	}
@@ -48,10 +48,10 @@ impl Client {
 
 	/// Set both publish and consume from one shared [`OriginProducer`].
 	///
-	/// Equivalent to calling [`with_publish`](Self::with_publish) and
-	/// [`with_consume`](Self::with_consume) with the same origin.
+	/// Equivalent to calling [`with_publisher`](Self::with_publisher) and
+	/// [`with_consumer`](Self::with_consumer) with the same origin.
 	pub fn with_origin(self, origin: OriginProducer) -> Self {
-		self.with_publish(origin.clone()).with_consume(origin)
+		self.with_publisher(origin.clone()).with_consumer(origin)
 	}
 
 	pub fn with_versions(mut self, versions: Versions) -> Self {
@@ -63,7 +63,7 @@ impl Client {
 	///
 	/// The returned [`Session`] always exposes both
 	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
-	/// whatever was set via [`Self::with_publish`] / [`Self::with_consume`]
+	/// whatever was set via [`Self::with_publisher`] / [`Self::with_consumer`]
 	/// / [`Self::with_origin`], or a fresh auto-created [`Origin`] for
 	/// any side the caller left unset. When neither side is set, both
 	/// default to the same shared origin (the typical full-duplex client).

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, Origin, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	NEGOTIATED, Origin, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -8,7 +8,7 @@ use crate::{
 /// A MoQ client session builder.
 #[derive(Default, Clone)]
 pub struct Client {
-	publish: Option<OriginConsumer>,
+	publish: Option<OriginProducer>,
 	consume: Option<OriginProducer>,
 	stats: StatsHandle,
 	versions: Versions,
@@ -19,11 +19,18 @@ impl Client {
 		Default::default()
 	}
 
-	pub fn with_publish(mut self, publish: impl Into<Option<OriginConsumer>>) -> Self {
+	/// Set the publish-side origin: the [`OriginProducer`] this client
+	/// reads from when forwarding local broadcasts to the remote. The
+	/// same producer is surfaced as [`Session::publisher`] so the caller
+	/// can keep adding broadcasts after connect.
+	pub fn with_publish(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
 		self.publish = publish.into();
 		self
 	}
 
+	/// Set the consume-side origin: the [`OriginProducer`] this client
+	/// writes into as the remote announces broadcasts. A consumer view
+	/// is surfaced as [`Session::consumer`].
 	pub fn with_consume(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
 		self.consume = consume.into();
 		self
@@ -37,12 +44,12 @@ impl Client {
 		self
 	}
 
-	/// Set both publish and consume from an `OriginProducer`.
+	/// Set both publish and consume from one shared [`OriginProducer`].
 	///
-	/// This is equivalent to calling `with_publish(origin.consume())` and `with_consume(origin)`.
+	/// Equivalent to calling [`with_publish`](Self::with_publish) and
+	/// [`with_consume`](Self::with_consume) with the same origin.
 	pub fn with_origin(self, origin: OriginProducer) -> Self {
-		let consumer = origin.consume();
-		self.with_publish(consumer).with_consume(origin)
+		self.with_publish(origin.clone()).with_consume(origin)
 	}
 
 	pub fn with_versions(mut self, versions: Versions) -> Self {
@@ -52,33 +59,21 @@ impl Client {
 
 	/// Perform the MoQ handshake as a client negotiating the version.
 	///
-	/// If neither a publish nor a consume origin was set on this builder,
-	/// connect auto-creates a fresh [`Origin`] and wires it as both, then
-	/// surfaces the producer and consumer sides on the returned
-	/// [`Session`] via [`Session::publisher`] and [`Session::consumer`].
-	/// Callers who configured their own origin(s) see both as `None` and
-	/// continue to drive publishing / consuming through the origins they
-	/// already hold.
+	/// The returned [`Session`] always exposes both
+	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
+	/// whatever was passed to [`Self::with_publish`] /
+	/// [`Self::with_consume`] / [`Self::with_origin`], or a fresh
+	/// auto-created [`Origin`] for any side the caller left unset. When
+	/// neither side is set, both default to the same shared origin (the
+	/// typical full-duplex client).
 	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		// Effective publish / consume after potential auto-creation. The
-		// `auto_*` locals are populated only on the no-config path so the
-		// returned Session reflects what we actually own.
-		let (publish, consume, auto_publisher, auto_consumer) = match (self.publish.clone(), self.consume.clone()) {
-			(None, None) => {
-				let producer = Origin::random().produce();
-				let consumer = producer.consume();
-				// Wire both sides: client publishes by reading from a
-				// consumer of the new origin, and consumes by writing into
-				// the producer itself.
-				(
-					Some(producer.consume()),
-					Some(producer.clone()),
-					Some(producer),
-					Some(consumer),
-				)
-			}
-			(publish, consume) => (publish, consume, None, None),
-		};
+		let (publisher, consumer) = resolve_origins(self.publish.clone(), self.consume.clone());
+		// Internally the moq-net protocol reads from a consumer of the
+		// publish side and writes into the consume side as a producer.
+		let publish = Some(publisher.consume());
+		let consume = Some(consumer.clone());
+		// Derive the read handle exposed via Session::consumer().
+		let consumer_view = consumer.consume();
 
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
 		// Default to IETF 14 if no ALPN was used and we'll negotiate the version later.
@@ -101,7 +96,7 @@ impl Client {
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None).with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(session, v, None, publisher.clone(), consumer_view.clone()));
 			}
 			Some(ALPN_17) => {
 				let v = self
@@ -121,7 +116,7 @@ impl Client {
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None).with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(session, v, None, publisher.clone(), consumer_view.clone()));
 			}
 			Some(ALPN_16) => {
 				let v = self
@@ -158,8 +153,13 @@ impl Client {
 					lite::Version::Lite05Wip,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw)
-					.with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(
+					session,
+					lite::Version::Lite05Wip.into(),
+					recv_bw,
+					publisher.clone(),
+					consumer_view.clone(),
+				));
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions
@@ -175,8 +175,13 @@ impl Client {
 					lite::Version::Lite04,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite04.into(), recv_bw)
-					.with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(
+					session,
+					lite::Version::Lite04.into(),
+					recv_bw,
+					publisher.clone(),
+					consumer_view.clone(),
+				));
 			}
 			Some(ALPN_LITE_03) => {
 				self.versions
@@ -193,8 +198,13 @@ impl Client {
 					lite::Version::Lite03,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite03.into(), recv_bw)
-					.with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(
+					session,
+					lite::Version::Lite03.into(),
+					recv_bw,
+					publisher.clone(),
+					consumer_view.clone(),
+				));
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -246,7 +256,26 @@ impl Client {
 			}
 		};
 
-		Ok(Session::new(session, version, recv_bw).with_origins(auto_publisher, auto_consumer))
+		Ok(Session::new(session, version, recv_bw, publisher, consumer_view))
+	}
+}
+
+/// Pick concrete publish/consume origins, defaulting any side the caller
+/// didn't set. When both are unset the duplex case wins: one shared
+/// fresh origin so the typical client publishes and consumes through
+/// the same bus.
+pub(crate) fn resolve_origins(
+	publish: Option<OriginProducer>,
+	consume: Option<OriginProducer>,
+) -> (OriginProducer, OriginProducer) {
+	match (publish, consume) {
+		(Some(p), Some(c)) => (p, c),
+		(Some(p), None) => (p, Origin::random().produce()),
+		(None, Some(c)) => (Origin::random().produce(), c),
+		(None, None) => {
+			let shared = Origin::random().produce();
+			(shared.clone(), shared)
+		}
 	}
 }
 

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, Origin, OriginProducer, Session, StatsHandle, Version, Versions,
+	NEGOTIATED, Origin, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -8,7 +8,7 @@ use crate::{
 /// A MoQ client session builder.
 #[derive(Default, Clone)]
 pub struct Client {
-	publish: Option<OriginProducer>,
+	publish: Option<OriginConsumer>,
 	consume: Option<OriginProducer>,
 	stats: StatsHandle,
 	versions: Versions,
@@ -19,18 +19,24 @@ impl Client {
 		Default::default()
 	}
 
-	/// Set the publish-side origin: the [`OriginProducer`] this client
-	/// reads from when forwarding local broadcasts to the remote. The
-	/// same producer is surfaced as [`Session::publisher`] so the caller
-	/// can keep adding broadcasts after connect.
-	pub fn with_publish(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
+	/// Override the publish-side source: the client reads broadcasts
+	/// from this [`OriginConsumer`] to forward to the remote. When set,
+	/// [`Session::publisher`] becomes a standalone auto-created
+	/// [`OriginProducer`] decoupled from the wire (the caller drives
+	/// publishing through whatever produces into the consumer they
+	/// passed). When unset, the session's auto-created publisher
+	/// supplies the wire as well.
+	pub fn with_publish(mut self, publish: impl Into<Option<OriginConsumer>>) -> Self {
 		self.publish = publish.into();
 		self
 	}
 
-	/// Set the consume-side origin: the [`OriginProducer`] this client
-	/// writes into as the remote announces broadcasts. A consumer view
-	/// is surfaced as [`Session::consumer`].
+	/// Override the consume-side sink: the client writes broadcasts
+	/// from the remote into this [`OriginProducer`]. When set,
+	/// [`Session::consumer`] becomes a standalone auto-created
+	/// [`OriginConsumer`] decoupled from the wire (the caller reads
+	/// announcements through their own producer's consumer view). When
+	/// unset, the session's auto-created consumer reads from the wire.
 	pub fn with_consume(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
 		self.consume = consume.into();
 		self
@@ -46,10 +52,9 @@ impl Client {
 
 	/// Set both publish and consume from one shared [`OriginProducer`].
 	///
-	/// Equivalent to calling [`with_publish`](Self::with_publish) and
-	/// [`with_consume`](Self::with_consume) with the same origin.
+	/// Equivalent to `with_publish(origin.consume()).with_consume(origin)`.
 	pub fn with_origin(self, origin: OriginProducer) -> Self {
-		self.with_publish(origin.clone()).with_consume(origin)
+		self.with_publish(origin.consume()).with_consume(origin)
 	}
 
 	pub fn with_versions(mut self, versions: Versions) -> Self {
@@ -60,20 +65,16 @@ impl Client {
 	/// Perform the MoQ handshake as a client negotiating the version.
 	///
 	/// The returned [`Session`] always exposes both
-	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
-	/// whatever was passed to [`Self::with_publish`] /
-	/// [`Self::with_consume`] / [`Self::with_origin`], or a fresh
-	/// auto-created [`Origin`] for any side the caller left unset. When
-	/// neither side is set, both default to the same shared origin (the
-	/// typical full-duplex client).
+	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer).
+	/// When the caller didn't override via [`Self::with_publish`] /
+	/// [`Self::with_consume`] / [`Self::with_origin`], a single fresh
+	/// [`Origin`] is auto-created and shared between both sides (the
+	/// typical full-duplex client). The same origin drives the wire.
+	/// When the caller did override either side, the session's publisher
+	/// / consumer for that side become standalone auto-created
+	/// no-ops decoupled from the wire.
 	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		let (publisher, consumer) = resolve_origins(self.publish.clone(), self.consume.clone());
-		// Internally the moq-net protocol reads from a consumer of the
-		// publish side and writes into the consume side as a producer.
-		let publish = Some(publisher.consume());
-		let consume = Some(consumer.clone());
-		// Derive the read handle exposed via Session::consumer().
-		let consumer_view = consumer.consume();
+		let (publisher, consumer_view, publish, consume) = resolve_origins(self.publish.clone(), self.consume.clone());
 
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
 		// Default to IETF 14 if no ALPN was used and we'll negotiate the version later.
@@ -260,21 +261,68 @@ impl Client {
 	}
 }
 
-/// Pick concrete publish/consume origins, defaulting any side the caller
-/// didn't set. When both are unset the duplex case wins: one shared
-/// fresh origin so the typical client publishes and consumes through
-/// the same bus.
+/// Resolve `(Session.publisher, Session.consumer, wire-publish, wire-consume)`
+/// from the user-supplied overrides.
+///
+/// The session always exposes a publisher / consumer; whether they drive
+/// the wire depends on whether the user overrode that side:
+/// - Neither overridden: one shared origin powers everything (duplex).
+/// - Override only publish: the user's consumer drives the wire publish
+///   side; `Session.publisher` becomes a standalone no-op producer.
+///   `Session.consumer` and wire-consume share a fresh shared origin.
+/// - Override only consume: symmetric to above.
+/// - Both overridden: `Session.publisher` and `Session.consumer` are
+///   independent standalone defaults (no-ops); the wire uses what the
+///   user passed.
 pub(crate) fn resolve_origins(
-	publish: Option<OriginProducer>,
+	publish: Option<OriginConsumer>,
 	consume: Option<OriginProducer>,
-) -> (OriginProducer, OriginProducer) {
+) -> (
+	OriginProducer,
+	OriginConsumer,
+	Option<OriginConsumer>,
+	Option<OriginProducer>,
+) {
 	match (publish, consume) {
-		(Some(p), Some(c)) => (p, c),
-		(Some(p), None) => (p, Origin::random().produce()),
-		(None, Some(c)) => (Origin::random().produce(), c),
 		(None, None) => {
+			// Duplex default: one shared origin powers Session.publisher,
+			// Session.consumer, and both wire directions.
 			let shared = Origin::random().produce();
-			(shared.clone(), shared)
+			let publisher = shared.clone();
+			let consumer_view = shared.consume();
+			let wire_publish = shared.consume();
+			let wire_consume = shared;
+			(publisher, consumer_view, Some(wire_publish), Some(wire_consume))
+		}
+		(Some(wire_publish), None) => {
+			// User drives wire-publish via their own consumer. Surface a
+			// standalone publisher for Session.publisher (no-op for wire),
+			// but the consume side stays auto-wired: one shared origin
+			// drives Session.consumer + wire-consume.
+			let publisher = Origin::random().produce();
+			let consume_shared = Origin::random().produce();
+			let consumer_view = consume_shared.consume();
+			(publisher, consumer_view, Some(wire_publish), Some(consume_shared))
+		}
+		(None, Some(wire_consume)) => {
+			// Symmetric: user-provided consume producer drives wire; the
+			// publish side gets a fresh shared origin.
+			let publish_shared = Origin::random().produce();
+			let publisher = publish_shared.clone();
+			let consumer_view = Origin::random().produce().consume();
+			(
+				publisher,
+				consumer_view,
+				Some(publish_shared.consume()),
+				Some(wire_consume),
+			)
+		}
+		(Some(wire_publish), Some(wire_consume)) => {
+			// Fully manual: Session.publisher / Session.consumer are
+			// standalone no-ops, the wire uses the user's overrides.
+			let publisher = Origin::random().produce();
+			let consumer_view = Origin::random().produce().consume();
+			(publisher, consumer_view, Some(wire_publish), Some(wire_consume))
 		}
 	}
 }
@@ -500,7 +548,7 @@ mod tests {
 
 		// The first close comes from the background lite session task.
 		// Any non-Version error here means SessionInfo decoded successfully
-		// after set_version() — this test cares about the SETUP framing
+		// after set_version(). This test cares about the SETUP framing
 		// fallback, not the specific close code. Cancel is what we'd see
 		// with no origin; RequiredExtension (or similar) is what an
 		// auto-created origin's first interaction with a Lite01 peer trips.

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	NEGOTIATED, Origin, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -12,6 +12,22 @@ pub struct Client {
 	consume: Option<OriginProducer>,
 	stats: StatsHandle,
 	versions: Versions,
+}
+
+/// A connected MoQ client session plus, optionally, the [`OriginProducer`]
+/// and [`OriginConsumer`] that [`Client::connect`] auto-created when no
+/// publish or consume origin had been set on the [`Client`].
+///
+/// `publisher` and `consumer` are `Some(_)` only on the no-config path
+/// (i.e. neither [`Client::with_publish`] / [`Client::with_consume`] /
+/// [`Client::with_origin`] was called before connect). When the caller
+/// wires its own origin(s), both fields are `None` and the caller
+/// continues to drive publishing and consuming through the origins it
+/// already holds.
+pub struct ClientSession {
+	pub session: Session,
+	pub publisher: Option<OriginProducer>,
+	pub consumer: Option<OriginConsumer>,
 }
 
 impl Client {
@@ -51,10 +67,34 @@ impl Client {
 	}
 
 	/// Perform the MoQ handshake as a client negotiating the version.
-	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		if self.publish.is_none() && self.consume.is_none() {
-			tracing::warn!("not publishing or consuming anything");
-		}
+	///
+	/// If neither a publish nor a consume origin was set on this builder,
+	/// connect auto-creates a fresh [`Origin`] and wires it as both, then
+	/// returns the producer and consumer sides on the resulting
+	/// [`ClientSession`]. Callers who configured their own origin(s) see
+	/// `ClientSession::publisher` and `ClientSession::consumer` as `None`
+	/// and continue to drive publishing / consuming through the origins
+	/// they already hold.
+	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<ClientSession, Error> {
+		// Effective publish / consume after potential auto-creation. The
+		// `auto_*` locals are populated only on the no-config path so the
+		// returned ClientSession reflects what we actually own.
+		let (publish, consume, auto_publisher, auto_consumer) = match (self.publish.clone(), self.consume.clone()) {
+			(None, None) => {
+				let producer = Origin::random().produce();
+				let consumer = producer.consume();
+				// Wire both sides: client publishes by reading from a
+				// consumer of the new origin, and consumes by writing into
+				// the producer itself.
+				(
+					Some(producer.consume()),
+					Some(producer.clone()),
+					Some(producer),
+					Some(consumer),
+				)
+			}
+			(publish, consume) => (publish, consume, None, None),
+		};
 
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
 		// Default to IETF 14 if no ALPN was used and we'll negotiate the version later.
@@ -71,13 +111,17 @@ impl Client {
 					None,
 					None,
 					true,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish,
+					consume,
 					ietf::Version::Draft18,
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None));
+				return Ok(ClientSession {
+					session: Session::new(session, v, None),
+					publisher: auto_publisher,
+					consumer: auto_consumer,
+				});
 			}
 			Some(ALPN_17) => {
 				let v = self
@@ -91,13 +135,17 @@ impl Client {
 					None,
 					None,
 					true,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish,
+					consume,
 					ietf::Version::Draft17,
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None));
+				return Ok(ClientSession {
+					session: Session::new(session, v, None),
+					publisher: auto_publisher,
+					consumer: auto_consumer,
+				});
 			}
 			Some(ALPN_16) => {
 				let v = self
@@ -128,13 +176,17 @@ impl Client {
 				let recv_bw = lite::start(
 					session.clone(),
 					None,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish,
+					consume,
 					self.stats.clone(),
 					lite::Version::Lite05Wip,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
+				return Ok(ClientSession {
+					session: Session::new(session, lite::Version::Lite05Wip.into(), recv_bw),
+					publisher: auto_publisher,
+					consumer: auto_consumer,
+				});
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions
@@ -144,13 +196,17 @@ impl Client {
 				let recv_bw = lite::start(
 					session.clone(),
 					None,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish,
+					consume,
 					self.stats.clone(),
 					lite::Version::Lite04,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite04.into(), recv_bw));
+				return Ok(ClientSession {
+					session: Session::new(session, lite::Version::Lite04.into(), recv_bw),
+					publisher: auto_publisher,
+					consumer: auto_consumer,
+				});
 			}
 			Some(ALPN_LITE_03) => {
 				self.versions
@@ -161,13 +217,17 @@ impl Client {
 				let recv_bw = lite::start(
 					session.clone(),
 					None,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish,
+					consume,
 					self.stats.clone(),
 					lite::Version::Lite03,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite03.into(), recv_bw));
+				return Ok(ClientSession {
+					session: Session::new(session, lite::Version::Lite03.into(), recv_bw),
+					publisher: auto_publisher,
+					consumer: auto_consumer,
+				});
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -204,14 +264,7 @@ impl Client {
 		let recv_bw = match version {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
-				lite::start(
-					session.clone(),
-					Some(stream),
-					self.publish.clone(),
-					self.consume.clone(),
-					self.stats.clone(),
-					v,
-				)?
+				lite::start(session.clone(), Some(stream), publish, consume, self.stats.clone(), v)?
 			}
 			Version::Ietf(v) => {
 				// Decode the parameters to get the initial request ID.
@@ -221,20 +274,16 @@ impl Client {
 					.map(ietf::RequestId);
 
 				let stream = stream.with_version(v);
-				ietf::start(
-					session.clone(),
-					Some(stream),
-					request_id_max,
-					true,
-					self.publish.clone(),
-					self.consume.clone(),
-					v,
-				)?;
+				ietf::start(session.clone(), Some(stream), request_id_max, true, publish, consume, v)?;
 				None
 			}
 		};
 
-		Ok(Session::new(session, version, recv_bw))
+		Ok(ClientSession {
+			session: Session::new(session, version, recv_bw),
+			publisher: auto_publisher,
+			consumer: auto_consumer,
+		})
 	}
 }
 
@@ -458,9 +507,13 @@ mod tests {
 		);
 
 		// The first close comes from the background lite session task.
-		// Code 0 ("cancelled") means SessionInfo decoded successfully after set_version().
+		// Any non-Version error here means SessionInfo decoded successfully
+		// after set_version() — this test cares about the SETUP framing
+		// fallback, not the specific close code. Cancel is what we'd see
+		// with no origin; RequiredExtension (or similar) is what an
+		// auto-created origin's first interaction with a Lite01 peer trips.
 		let (code, _) = fake.wait_for_first_close().await;
-		assert_eq!(code, Error::Cancel.to_code());
+		assert_ne!(code, Error::Version.to_code(), "SessionInfo failed to decode");
 	}
 
 	#[tokio::test(start_paused = true)]

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -5,7 +5,7 @@ use web_async::FuturesExt;
 use web_transport_trait::SendStream;
 
 use crate::{
-	AsPath, Error, Origin, OriginConsumer, Track, TrackConsumer,
+	AsPath, Error, OriginConsumer, Track, TrackConsumer,
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
 	model::GroupConsumer,
@@ -22,8 +22,7 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 }
 
 impl<S: web_transport_trait::Session> Publisher<S> {
-	pub fn new(session: S, origin: Option<OriginConsumer>, control: Control, version: Version) -> Self {
-		let origin = origin.unwrap_or_else(|| Origin::random().produce().consume());
+	pub fn new(session: S, origin: OriginConsumer, control: Control, version: Version) -> Self {
 		Self {
 			session,
 			origin,

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -12,8 +12,8 @@ pub fn start<S: web_transport_trait::Session>(
 	setup: Option<Stream<S, Version>>,
 	request_id_max: Option<RequestId>,
 	client: bool,
-	publish: Option<OriginConsumer>,
-	subscribe: Option<OriginProducer>,
+	publish: OriginConsumer,
+	subscribe: OriginProducer,
 	version: Version,
 ) -> Result<(), Error> {
 	web_async::spawn(async move {
@@ -34,30 +34,27 @@ pub fn start<S: web_transport_trait::Session>(
 				let sub_ns_adapter = adapter.clone();
 
 				tokio::select! {
-					Err(err) = adapter.run(setup.reader, setup.writer, rx) => Err::<(), Error>(err),
-					Err(err) = run_unis(adapter.clone(), subscriber.clone(), version) => Err(err),
-					Err(err) = run_dispatch(dispatch_session, publisher.clone(), subscriber.clone(), version) => Err(err),
-					Err(err) = publisher.run() => Err(err),
-					Err(err) = async {
-						if !sub_ns.has_origin() {
-							return Ok(());
-						}
-						let stream = match version {
-							Version::Draft16 => {
-								let (send, recv) = sub_ns_adapter.open_native_bi().await?;
-								Stream {
-									writer: crate::coding::Writer::new(send, version),
-									reader: crate::coding::Reader::new(recv, version),
+									Err(err) = adapter.run(setup.reader, setup.writer, rx) => Err::<(), Error>(err),
+									Err(err) = run_unis(adapter.clone(), subscriber.clone(), version) => Err(err),
+									Err(err) = run_dispatch(dispatch_session, publisher.clone(), subscriber.clone(), version) => Err(err),
+									Err(err) = publisher.run() => Err(err),
+									Err(err) = async {
+				let stream = match version {
+											Version::Draft16 => {
+												let (send, recv) = sub_ns_adapter.open_native_bi().await?;
+												Stream {
+													writer: crate::coding::Writer::new(send, version),
+													reader: crate::coding::Reader::new(recv, version),
+												}
+											}
+											_ => Stream::open(&sub_ns_adapter, version).await?,
+										};
+										if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
+										tracing::warn!(%err, "subscribe_namespace failed, continuing without");
+									}
+									Ok(())
+									} => Err(err),
 								}
-							}
-							_ => Stream::open(&sub_ns_adapter, version).await?,
-						};
-						if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
-						tracing::warn!(%err, "subscribe_namespace failed, continuing without");
-					}
-					Ok(())
-					} => Err(err),
-				}
 			}
 			_ => {
 				// Spawn SETUP sender (keeps stream alive for GOAWAY).
@@ -78,20 +75,17 @@ pub fn start<S: web_transport_trait::Session>(
 				let mut sub_ns = subscriber.clone();
 
 				tokio::select! {
-					Err(err) = run_unis(session.clone(), subscriber.clone(), version) => Err(err),
-					Err(err) = run_dispatch(session.clone(), publisher.clone(), subscriber.clone(), version) => Err(err),
-					Err(err) = publisher.run() => Err(err),
-					Err(err) = async {
-						if !sub_ns.has_origin() {
-							return Ok(());
-						}
-						let stream = Stream::open(&sub_ns_session, version).await?;
-						if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
-							tracing::warn!(%err, "subscribe_namespace failed, continuing without");
-						}
-						Ok(())
-					} => Err(err),
-				}
+									Err(err) = run_unis(session.clone(), subscriber.clone(), version) => Err(err),
+									Err(err) = run_dispatch(session.clone(), publisher.clone(), subscriber.clone(), version) => Err(err),
+									Err(err) = publisher.run() => Err(err),
+									Err(err) = async {
+				let stream = Stream::open(&sub_ns_session, version).await?;
+										if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
+											tracing::warn!(%err, "subscribe_namespace failed, continuing without");
+										}
+										Ok(())
+									} => Err(err),
+								}
 			}
 		};
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -42,14 +42,14 @@ struct BroadcastState {
 #[derive(Clone)]
 pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	session: S,
-	origin: Option<OriginProducer>,
+	origin: OriginProducer,
 	control: Control,
 	state: Lock<State>,
 	version: Version,
 }
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
-	pub fn new(session: S, origin: Option<OriginProducer>, control: Control, version: Version) -> Self {
+	pub fn new(session: S, origin: OriginProducer, control: Control, version: Version) -> Self {
 		Self {
 			session,
 			origin,
@@ -59,10 +59,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 	}
 
-	pub fn has_origin(&self) -> bool {
-		self.origin.is_some()
-	}
-
 	/// Send SUBSCRIBE_NAMESPACE on a bidi stream.
 	/// The caller is responsible for opening the appropriate stream type
 	/// (virtual for v14/v15, real bidi for v16+).
@@ -70,7 +66,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		mut stream: Stream<T, Version>,
 	) -> Result<(), Error> {
-		let prefix = self.origin.as_ref().ok_or(Error::InvalidRole)?.root().to_owned();
+		let prefix = self.origin.root().to_owned();
 		let request_id = self.control.next_request_id().await?;
 
 		// Write SubscribeNamespace
@@ -402,10 +398,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	fn start_announce(&mut self, path: PathOwned) -> Result<BroadcastProducer, Error> {
-		let Some(origin) = &self.origin else {
-			return Err(Error::InvalidRole);
-		};
-
 		let mut state = self.state.lock();
 		let broadcast = match state.broadcasts.entry(path.clone()) {
 			Entry::Occupied(mut entry) => {
@@ -414,7 +406,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 			Entry::Vacant(entry) => {
 				let broadcast = Broadcast::new().produce();
-				origin.publish_broadcast(path.clone(), broadcast.consume());
+				self.origin.publish_broadcast(path.clone(), broadcast.consume());
 				entry.insert(BroadcastState {
 					producer: broadcast.clone(),
 					count: 1,
@@ -423,7 +415,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		};
 
-		tracing::debug!(broadcast = %origin.absolute(&path), "announce");
+		tracing::debug!(broadcast = %self.origin.absolute(&path), "announce");
 
 		let this = self.clone();
 		let producer = broadcast.clone();
@@ -439,17 +431,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	fn stop_announce(&mut self, path: PathOwned) -> Result<(), Error> {
-		let Some(origin) = &self.origin else {
-			return Err(Error::InvalidRole);
-		};
-
 		let mut state = self.state.lock();
 
 		match state.broadcasts.entry(path.clone()) {
 			Entry::Occupied(mut entry) => {
 				entry.get_mut().count -= 1;
 				if entry.get().count == 0 {
-					tracing::debug!(broadcast = %origin.absolute(&path), "unannounced");
+					tracing::debug!(broadcast = %self.origin.absolute(&path), "unannounced");
 					entry.remove();
 				}
 			}
@@ -565,7 +553,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return;
 		}
 
-		tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast_path), track = %track.name, "subscribe started");
+		tracing::info!(broadcast = %self.origin.absolute(&broadcast_path), track = %track.name, "subscribe started");
 
 		// Read the response and register the alias mapping
 		let track_alias = match self.read_subscribe_response(&mut stream).await {
@@ -589,17 +577,17 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tokio::select! {
 			_ = track.unused() => {
-				tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast_path), track = %track.name, "subscribe cancelled");
+				tracing::info!(broadcast = %self.origin.absolute(&broadcast_path), track = %track.name, "subscribe cancelled");
 				let _ = track.abort(Error::Cancel);
 			}
 			err = broadcast.closed() => {
-				tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast_path), track = %track.name, "broadcast closed");
+				tracing::info!(broadcast = %self.origin.absolute(&broadcast_path), track = %track.name, "broadcast closed");
 				let _ = track.abort(err);
 			}
 			res = stream.reader.closed() => {
 				match res {
 					Ok(()) => {
-						tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast_path), track = %track.name, "subscribe complete");
+						tracing::info!(broadcast = %self.origin.absolute(&broadcast_path), track = %track.name, "subscribe complete");
 						let _ = track.finish();
 					}
 					Err(err) => {

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -18,9 +18,8 @@ use super::Version;
 
 pub(super) struct PublisherConfig<S: web_transport_trait::Session> {
 	pub session: S,
-	/// The origin we read local broadcasts from. None gives this session a
-	/// dummy, immediately-closed origin (i.e. nothing to publish).
-	pub origin: Option<OriginConsumer>,
+	/// The origin we read local broadcasts from.
+	pub origin: OriginConsumer,
 	/// Stats aggregator for this session's egress. Use [`MoqStats::disabled`]
 	/// to opt out.
 	pub stats: MoqStats,
@@ -38,15 +37,13 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 
 impl<S: web_transport_trait::Session> Publisher<S> {
 	pub fn new(config: PublisherConfig<S>) -> Self {
-		// Default to a dummy origin that is immediately closed.
-		let origin = config.origin.unwrap_or_else(|| Origin::random().produce().consume());
 		// Identity stamped onto outbound announce hops. Derived from the
 		// origin we're consuming so it matches the local relay identity
 		// across every session, required for cross-session loop detection.
-		let self_origin = *origin;
+		let self_origin = *config.origin;
 		Self {
 			session: config.session,
-			origin,
+			origin: config.origin,
 			stats: config.stats,
 			self_origin,
 			priority: Default::default(),

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -10,9 +10,9 @@ pub fn start<S: web_transport_trait::Session>(
 	// NOTE: No longer used in draft-03.
 	setup: Option<Stream<S, Version>>,
 	// We will publish any local broadcasts from this origin.
-	publish: Option<OriginConsumer>,
+	publish: OriginConsumer,
 	// We will consume any remote broadcasts, inserting them into this origin.
-	subscribe: Option<OriginProducer>,
+	subscribe: OriginProducer,
 	// Tier-scoped stats handle. Pass [`StatsHandle::disabled`] to opt out.
 	stats: StatsHandle,
 	// The version of the protocol to use.

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -27,7 +27,7 @@ const LINGER_TIMEOUT: Duration = Duration::from_secs(5);
 pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	pub session: S,
 	/// The origin into which remote broadcasts are inserted.
-	pub origin: Option<OriginProducer>,
+	pub origin: OriginProducer,
 	/// Receiver-side bandwidth producer for PROBE feedback. None disables the
 	/// feature (used by versions that don't carry probe streams).
 	pub recv_bandwidth: Option<BandwidthProducer>,
@@ -41,7 +41,7 @@ pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	session: S,
 
-	origin: Option<OriginProducer>,
+	origin: OriginProducer,
 	stats: StatsHandle,
 	recv_bandwidth: Option<BandwidthProducer>,
 	// Session-level origin id shared with the Publisher. Used to filter out
@@ -81,9 +81,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// Identity for incoming-hop loop detection. Derived from the local
 		// origin we publish into so it matches the relay identity across
 		// every session sharing that origin, required for cross-session
-		// loop detection. If no origin is attached (the announce loop is
-		// inert anyway), fall back to a random session-local id.
-		let self_origin = config.origin.as_deref().copied().unwrap_or_else(crate::Origin::random);
+		// loop detection.
+		let self_origin = *config.origin;
 		Self {
 			session: config.session,
 			origin: config.origin,
@@ -135,12 +134,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	async fn run_announce(self) -> Result<(), Error> {
-		let origin = match &self.origin {
-			Some(origin) => origin,
-			None => return Ok(()),
-		};
-
-		let prefixes: Vec<PathOwned> = origin.allowed().map(|p| p.to_owned()).collect();
+		let prefixes: Vec<PathOwned> = self.origin.allowed().map(|p| p.to_owned()).collect();
 
 		let mut tasks = FuturesUnordered::new();
 		for prefix in prefixes {
@@ -183,7 +177,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let msg: lite::AnnounceInit = stream.reader.decode().await?;
 				for suffix in msg.suffixes {
 					let path = prefix.join(&suffix);
-					let abs = self.origin.as_ref().unwrap().absolute(&path).to_owned();
+					let abs = self.origin.absolute(&path).to_owned();
 					// Lite01/02 don't carry hop information; the broadcast starts with an empty chain.
 					if self.start_announce(path.clone(), crate::OriginList::new(), &mut producers)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
@@ -199,7 +193,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			match announce {
 				lite::Announce::Active { suffix, hops } => {
 					let path = prefix.join(&suffix);
-					let abs = self.origin.as_ref().unwrap().absolute(&path).to_owned();
+					let abs = self.origin.absolute(&path).to_owned();
 					if self.start_announce(path.clone(), hops, &mut producers)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
@@ -213,7 +207,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// `producers` has no entry; that's expected, not an error.
 					if let Some(mut producer) = producers.remove(&path) {
 						producer.abort(Error::Cancel).ok();
-						let abs = self.origin.as_ref().unwrap().absolute(&path).to_owned();
+						let abs = self.origin.absolute(&path).to_owned();
 						stats_guards.remove(&abs);
 					}
 				}
@@ -227,18 +221,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	/// Opens a PROBE stream on demand while a consumer is interested.
 	///
-	/// PROBE measures the peer's upload bandwidth to us, which is only meaningful
-	/// when the peer is publishing broadcasts. If we have no origin to insert
-	/// remote broadcasts into, skip the probe stream entirely.
-	///
-	/// Otherwise loop forever: wait for a consumer, race the probe stream against
+	/// Loops forever: wait for a consumer, race the probe stream against
 	/// the consumer leaving, then loop back. Probe is best-effort, so stream
 	/// errors are logged but never tear down the session.
 	async fn run_recv_bandwidth(self) -> Result<(), Error> {
-		if self.origin.is_none() {
-			return Ok(());
-		}
-
 		let Some(bandwidth) = &self.recv_bandwidth else {
 			return Ok(());
 		};
@@ -315,10 +301,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let dynamic = broadcast.dynamic();
 
 		// Run the broadcast in the background until all consumers are dropped.
-		self.origin
-			.as_mut()
-			.unwrap()
-			.publish_broadcast(path.clone(), broadcast.consume());
+		self.origin.publish_broadcast(path.clone(), broadcast.consume());
 
 		web_async::spawn(self.clone().run_broadcast(path, dynamic));
 
@@ -364,7 +347,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// Drop on subscription end records `subscriber.subscriptions_closed`. We use
 		// subscriber_track to avoid double-counting broadcasts: the broadcast lifetime
 		// is tracked separately by the announce loop's `stats_guards`.
-		let abs = self.origin.as_ref().unwrap().absolute(&path);
+		let abs = self.origin.absolute(&path);
 		let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(&track.name));
 
 		let id = self.next_id.fetch_add(1, atomic::Ordering::Relaxed);
@@ -671,6 +654,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	fn log_path(&self, path: impl AsPath) -> Path<'_> {
-		self.origin.as_ref().unwrap().root().join(path)
+		self.origin.root().join(path)
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	NEGOTIATED, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -8,7 +8,7 @@ use crate::{
 /// A MoQ server session builder.
 #[derive(Default, Clone)]
 pub struct Server {
-	publish: Option<OriginConsumer>,
+	publish: Option<OriginProducer>,
 	consume: Option<OriginProducer>,
 	stats: StatsHandle,
 	versions: Versions,
@@ -19,19 +19,18 @@ impl Server {
 		Default::default()
 	}
 
-	/// Override the publish-side source: the server reads broadcasts
-	/// from this [`OriginConsumer`] to forward to the connected client.
-	/// When set, [`Session::publisher`] becomes a standalone auto-created
-	/// [`OriginProducer`] decoupled from the wire.
-	pub fn with_publish(mut self, publish: impl Into<Option<OriginConsumer>>) -> Self {
+	/// Override the publish-side origin: the [`OriginProducer`] the
+	/// server reads from when forwarding broadcasts to the connected
+	/// client. Surfaced as [`Session::publisher`]. Pre-scoped via
+	/// [`OriginProducer::scope`] for token-gated relays.
+	pub fn with_publish(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
 		self.publish = publish.into();
 		self
 	}
 
-	/// Override the consume-side sink: the server writes broadcasts
-	/// from the client into this [`OriginProducer`]. When set,
-	/// [`Session::consumer`] becomes a standalone auto-created
-	/// [`OriginConsumer`] decoupled from the wire.
+	/// Override the consume-side origin: the [`OriginProducer`] the
+	/// server writes into as the client announces broadcasts. A consumer
+	/// view is surfaced as [`Session::consumer`].
 	pub fn with_consume(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
 		self.consume = consume.into();
 		self
@@ -46,10 +45,8 @@ impl Server {
 	}
 
 	/// Set both publish and consume from one shared [`OriginProducer`].
-	///
-	/// Equivalent to `with_publish(origin.consume()).with_consume(origin)`.
 	pub fn with_origin(self, origin: OriginProducer) -> Self {
-		self.with_publish(origin.consume()).with_consume(origin)
+		self.with_publish(origin.clone()).with_consume(origin)
 	}
 
 	pub fn with_versions(mut self, versions: Versions) -> Self {
@@ -60,15 +57,16 @@ impl Server {
 	/// Perform the MoQ handshake as a server for the given session.
 	///
 	/// The returned [`Session`] always exposes both
-	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer).
-	/// When the caller didn't override either side, a single fresh
-	/// [`Origin`](crate::Origin) is auto-created and shared between
-	/// both. The same origin drives the wire. When the caller
-	/// overrode either side, the session's accessor for that side
-	/// becomes a standalone auto-created no-op decoupled from the wire.
+	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
+	/// whatever was set via [`Self::with_publish`] / [`Self::with_consume`]
+	/// / [`Self::with_origin`], or a fresh auto-created
+	/// [`Origin`](crate::Origin) for any side the caller left unset. When
+	/// neither side is set, both default to the same shared origin.
 	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		let (publisher, consumer_view, publish, consume) =
-			crate::client::resolve_origins(self.publish.clone(), self.consume.clone());
+		let (publisher, consumer) = crate::client::resolve_origins(self.publish.clone(), self.consume.clone());
+		let publish = Some(publisher.consume());
+		let consume = Some(consumer.clone());
+		let consumer_view = consumer.consume();
 
 		let (encoding, supported) = match session.protocol() {
 			Some(ALPN_18) => {

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -62,7 +62,7 @@ impl Server {
 	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
 	/// whatever was passed to [`Self::with_publish`] /
 	/// [`Self::with_consume`] / [`Self::with_origin`], or a fresh
-	/// auto-created [`Origin`] for any side the caller left unset. When
+	/// auto-created [`Origin`](crate::Origin) for any side the caller left unset. When
 	/// neither side is set, both default to the same shared origin.
 	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
 		let (publisher, consumer) = crate::client::resolve_origins(self.publish.clone(), self.consume.clone());

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -23,7 +23,7 @@ impl Server {
 	/// server reads from when forwarding broadcasts to the connected
 	/// client. Surfaced as [`Session::publisher`]. Pre-scoped via
 	/// [`OriginProducer::scope`] for token-gated relays.
-	pub fn with_publish(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
+	pub fn with_publisher(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
 		self.publish = publish.into();
 		self
 	}
@@ -31,7 +31,7 @@ impl Server {
 	/// Override the consume-side origin: the [`OriginProducer`] the
 	/// server writes into as the client announces broadcasts. A consumer
 	/// view is surfaced as [`Session::consumer`].
-	pub fn with_consume(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
+	pub fn with_consumer(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
 		self.consume = consume.into();
 		self
 	}
@@ -46,7 +46,7 @@ impl Server {
 
 	/// Set both publish and consume from one shared [`OriginProducer`].
 	pub fn with_origin(self, origin: OriginProducer) -> Self {
-		self.with_publish(origin.clone()).with_consume(origin)
+		self.with_publisher(origin.clone()).with_consumer(origin)
 	}
 
 	pub fn with_versions(mut self, versions: Versions) -> Self {
@@ -58,7 +58,7 @@ impl Server {
 	///
 	/// The returned [`Session`] always exposes both
 	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
-	/// whatever was set via [`Self::with_publish`] / [`Self::with_consume`]
+	/// whatever was set via [`Self::with_publisher`] / [`Self::with_consumer`]
 	/// / [`Self::with_origin`], or a fresh auto-created
 	/// [`Origin`](crate::Origin) for any side the caller left unset. When
 	/// neither side is set, both default to the same shared origin.

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, Origin, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	NEGOTIATED, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -8,7 +8,7 @@ use crate::{
 /// A MoQ server session builder.
 #[derive(Default, Clone)]
 pub struct Server {
-	publish: Option<OriginConsumer>,
+	publish: Option<OriginProducer>,
 	consume: Option<OriginProducer>,
 	stats: StatsHandle,
 	versions: Versions,
@@ -19,11 +19,17 @@ impl Server {
 		Default::default()
 	}
 
-	pub fn with_publish(mut self, publish: impl Into<Option<OriginConsumer>>) -> Self {
+	/// Set the publish-side origin: the [`OriginProducer`] the server
+	/// reads from when forwarding broadcasts to the connected client.
+	/// Surfaced as [`Session::publisher`] on the resulting session.
+	pub fn with_publish(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
 		self.publish = publish.into();
 		self
 	}
 
+	/// Set the consume-side origin: the [`OriginProducer`] the server
+	/// writes into as the client announces broadcasts. A consumer view
+	/// is surfaced as [`Session::consumer`].
 	pub fn with_consume(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
 		self.consume = consume.into();
 		self
@@ -37,12 +43,12 @@ impl Server {
 		self
 	}
 
-	/// Set both publish and consume from an `OriginProducer`.
+	/// Set both publish and consume from one shared [`OriginProducer`].
 	///
-	/// This is equivalent to calling `with_publish(origin.consume())` and `with_consume(origin)`.
+	/// Equivalent to calling [`with_publish`](Self::with_publish) and
+	/// [`with_consume`](Self::with_consume) with the same origin.
 	pub fn with_origin(self, origin: OriginProducer) -> Self {
-		let consumer = origin.consume();
-		self.with_publish(consumer).with_consume(origin)
+		self.with_publish(origin.clone()).with_consume(origin)
 	}
 
 	pub fn with_versions(mut self, versions: Versions) -> Self {
@@ -52,30 +58,17 @@ impl Server {
 
 	/// Perform the MoQ handshake as a server for the given session.
 	///
-	/// If neither a publish nor a consume origin was set on this builder,
-	/// accept auto-creates a fresh [`Origin`] and wires it as both, then
-	/// surfaces the producer and consumer sides on the returned
-	/// [`Session`] via [`Session::publisher`] and [`Session::consumer`].
-	/// Callers who configured their own origin(s) see both as `None` and
-	/// continue to drive publishing / consuming through the origins they
-	/// already hold.
+	/// The returned [`Session`] always exposes both
+	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
+	/// whatever was passed to [`Self::with_publish`] /
+	/// [`Self::with_consume`] / [`Self::with_origin`], or a fresh
+	/// auto-created [`Origin`] for any side the caller left unset. When
+	/// neither side is set, both default to the same shared origin.
 	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		// Effective publish / consume after potential auto-creation. The
-		// `auto_*` locals are populated only on the no-config path so the
-		// returned Session reflects what we actually own.
-		let (publish, consume, auto_publisher, auto_consumer) = match (self.publish.clone(), self.consume.clone()) {
-			(None, None) => {
-				let producer = Origin::random().produce();
-				let consumer = producer.consume();
-				(
-					Some(producer.consume()),
-					Some(producer.clone()),
-					Some(producer),
-					Some(consumer),
-				)
-			}
-			(publish, consume) => (publish, consume, None, None),
-		};
+		let (publisher, consumer) = crate::client::resolve_origins(self.publish.clone(), self.consume.clone());
+		let publish = Some(publisher.consume());
+		let consume = Some(consumer.clone());
+		let consumer_view = consumer.consume();
 
 		let (encoding, supported) = match session.protocol() {
 			Some(ALPN_18) => {
@@ -96,7 +89,7 @@ impl Server {
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None).with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(session, v, None, publisher.clone(), consumer_view.clone()));
 			}
 			Some(ALPN_17) => {
 				let v = self
@@ -117,7 +110,7 @@ impl Server {
 
 				tracing::debug!(version = ?v, "connected");
 				// TODO: ietf code path does not yet record stats.
-				return Ok(Session::new(session, v, None).with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(session, v, None, publisher.clone(), consumer_view.clone()));
 			}
 			Some(ALPN_16) => {
 				let v = self
@@ -154,8 +147,13 @@ impl Server {
 					lite::Version::Lite05Wip,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw)
-					.with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(
+					session,
+					lite::Version::Lite05Wip.into(),
+					recv_bw,
+					publisher.clone(),
+					consumer_view.clone(),
+				));
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions
@@ -171,8 +169,13 @@ impl Server {
 					lite::Version::Lite04,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite04.into(), recv_bw)
-					.with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(
+					session,
+					lite::Version::Lite04.into(),
+					recv_bw,
+					publisher.clone(),
+					consumer_view.clone(),
+				));
 			}
 			Some(ALPN_LITE_03) => {
 				self.versions
@@ -189,8 +192,13 @@ impl Server {
 					lite::Version::Lite03,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite03.into(), recv_bw)
-					.with_origins(auto_publisher, auto_consumer));
+				return Ok(Session::new(
+					session,
+					lite::Version::Lite03.into(),
+					recv_bw,
+					publisher.clone(),
+					consumer_view.clone(),
+				));
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -261,6 +269,6 @@ impl Server {
 			}
 		};
 
-		Ok(Session::new(session, version, recv_bw).with_origins(auto_publisher, auto_consumer))
+		Ok(Session::new(session, version, recv_bw, publisher, consumer_view))
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -6,12 +6,24 @@ use crate::{
 };
 
 /// A MoQ server session builder.
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct Server {
-	publish: Option<OriginProducer>,
-	consume: Option<OriginProducer>,
+	publish: OriginProducer,
+	consume: OriginProducer,
 	stats: StatsHandle,
 	versions: Versions,
+}
+
+impl Default for Server {
+	fn default() -> Self {
+		let shared = crate::Origin::random().produce();
+		Self {
+			publish: shared.clone(),
+			consume: shared,
+			stats: StatsHandle::default(),
+			versions: Versions::default(),
+		}
+	}
 }
 
 impl Server {
@@ -23,16 +35,16 @@ impl Server {
 	/// server reads from when forwarding broadcasts to the connected
 	/// client. Surfaced as [`Session::publisher`]. Pre-scoped via
 	/// [`OriginProducer::scope`] for token-gated relays.
-	pub fn with_publisher(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
-		self.publish = publish.into();
+	pub fn with_publisher(mut self, publish: OriginProducer) -> Self {
+		self.publish = publish;
 		self
 	}
 
 	/// Override the consume-side origin: the [`OriginProducer`] the
 	/// server writes into as the client announces broadcasts. A consumer
 	/// view is surfaced as [`Session::consumer`].
-	pub fn with_consumer(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
-		self.consume = consume.into();
+	pub fn with_consumer(mut self, consume: OriginProducer) -> Self {
+		self.consume = consume;
 		self
 	}
 
@@ -55,17 +67,11 @@ impl Server {
 	}
 
 	/// Perform the MoQ handshake as a server for the given session.
-	///
-	/// The returned [`Session`] always exposes both
-	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
-	/// whatever was set via [`Self::with_publisher`] / [`Self::with_consumer`]
-	/// / [`Self::with_origin`], or a fresh auto-created
-	/// [`Origin`](crate::Origin) for any side the caller left unset. When
-	/// neither side is set, both default to the same shared origin.
 	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		let (publisher, consumer) = crate::client::resolve_origins(self.publish.clone(), self.consume.clone());
-		let publish = Some(publisher.consume());
-		let consume = Some(consumer.clone());
+		let publisher = self.publish.clone();
+		let consumer = self.consume.clone();
+		let publish = publisher.consume();
+		let consume = consumer.clone();
 		let consumer_view = consumer.consume();
 
 		let (encoding, supported) = match session.protocol() {

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, OriginProducer, Session, StatsHandle, Version, Versions,
+	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -8,7 +8,7 @@ use crate::{
 /// A MoQ server session builder.
 #[derive(Default, Clone)]
 pub struct Server {
-	publish: Option<OriginProducer>,
+	publish: Option<OriginConsumer>,
 	consume: Option<OriginProducer>,
 	stats: StatsHandle,
 	versions: Versions,
@@ -19,17 +19,19 @@ impl Server {
 		Default::default()
 	}
 
-	/// Set the publish-side origin: the [`OriginProducer`] the server
-	/// reads from when forwarding broadcasts to the connected client.
-	/// Surfaced as [`Session::publisher`] on the resulting session.
-	pub fn with_publish(mut self, publish: impl Into<Option<OriginProducer>>) -> Self {
+	/// Override the publish-side source: the server reads broadcasts
+	/// from this [`OriginConsumer`] to forward to the connected client.
+	/// When set, [`Session::publisher`] becomes a standalone auto-created
+	/// [`OriginProducer`] decoupled from the wire.
+	pub fn with_publish(mut self, publish: impl Into<Option<OriginConsumer>>) -> Self {
 		self.publish = publish.into();
 		self
 	}
 
-	/// Set the consume-side origin: the [`OriginProducer`] the server
-	/// writes into as the client announces broadcasts. A consumer view
-	/// is surfaced as [`Session::consumer`].
+	/// Override the consume-side sink: the server writes broadcasts
+	/// from the client into this [`OriginProducer`]. When set,
+	/// [`Session::consumer`] becomes a standalone auto-created
+	/// [`OriginConsumer`] decoupled from the wire.
 	pub fn with_consume(mut self, consume: impl Into<Option<OriginProducer>>) -> Self {
 		self.consume = consume.into();
 		self
@@ -45,10 +47,9 @@ impl Server {
 
 	/// Set both publish and consume from one shared [`OriginProducer`].
 	///
-	/// Equivalent to calling [`with_publish`](Self::with_publish) and
-	/// [`with_consume`](Self::with_consume) with the same origin.
+	/// Equivalent to `with_publish(origin.consume()).with_consume(origin)`.
 	pub fn with_origin(self, origin: OriginProducer) -> Self {
-		self.with_publish(origin.clone()).with_consume(origin)
+		self.with_publish(origin.consume()).with_consume(origin)
 	}
 
 	pub fn with_versions(mut self, versions: Versions) -> Self {
@@ -59,16 +60,15 @@ impl Server {
 	/// Perform the MoQ handshake as a server for the given session.
 	///
 	/// The returned [`Session`] always exposes both
-	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer):
-	/// whatever was passed to [`Self::with_publish`] /
-	/// [`Self::with_consume`] / [`Self::with_origin`], or a fresh
-	/// auto-created [`Origin`](crate::Origin) for any side the caller left unset. When
-	/// neither side is set, both default to the same shared origin.
+	/// [`publisher`](Session::publisher) and [`consumer`](Session::consumer).
+	/// When the caller didn't override either side, a single fresh
+	/// [`Origin`](crate::Origin) is auto-created and shared between
+	/// both. The same origin drives the wire. When the caller
+	/// overrode either side, the session's accessor for that side
+	/// becomes a standalone auto-created no-op decoupled from the wire.
 	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		let (publisher, consumer) = crate::client::resolve_origins(self.publish.clone(), self.consume.clone());
-		let publish = Some(publisher.consume());
-		let consume = Some(consumer.clone());
-		let consumer_view = consumer.consume();
+		let (publisher, consumer_view, publish, consume) =
+			crate::client::resolve_origins(self.publish.clone(), self.consume.clone());
 
 		let (encoding, supported) = match session.protocol() {
 			Some(ALPN_18) => {

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	NEGOTIATED, Origin, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -51,10 +51,31 @@ impl Server {
 	}
 
 	/// Perform the MoQ handshake as a server for the given session.
+	///
+	/// If neither a publish nor a consume origin was set on this builder,
+	/// accept auto-creates a fresh [`Origin`] and wires it as both, then
+	/// surfaces the producer and consumer sides on the returned
+	/// [`Session`] via [`Session::publisher`] and [`Session::consumer`].
+	/// Callers who configured their own origin(s) see both as `None` and
+	/// continue to drive publishing / consuming through the origins they
+	/// already hold.
 	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
-		if self.publish.is_none() && self.consume.is_none() {
-			tracing::warn!("not publishing or consuming anything");
-		}
+		// Effective publish / consume after potential auto-creation. The
+		// `auto_*` locals are populated only on the no-config path so the
+		// returned Session reflects what we actually own.
+		let (publish, consume, auto_publisher, auto_consumer) = match (self.publish.clone(), self.consume.clone()) {
+			(None, None) => {
+				let producer = Origin::random().produce();
+				let consumer = producer.consume();
+				(
+					Some(producer.consume()),
+					Some(producer.clone()),
+					Some(producer),
+					Some(consumer),
+				)
+			}
+			(publish, consume) => (publish, consume, None, None),
+		};
 
 		let (encoding, supported) = match session.protocol() {
 			Some(ALPN_18) => {
@@ -69,13 +90,13 @@ impl Server {
 					None,
 					None,
 					false,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish.clone(),
+					consume.clone(),
 					ietf::Version::Draft18,
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None));
+				return Ok(Session::new(session, v, None).with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_17) => {
 				let v = self
@@ -89,14 +110,14 @@ impl Server {
 					None,
 					None,
 					false,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish.clone(),
+					consume.clone(),
 					ietf::Version::Draft17,
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
 				// TODO: ietf code path does not yet record stats.
-				return Ok(Session::new(session, v, None));
+				return Ok(Session::new(session, v, None).with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_16) => {
 				let v = self
@@ -127,13 +148,14 @@ impl Server {
 				let recv_bw = lite::start(
 					session.clone(),
 					None,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish.clone(),
+					consume.clone(),
 					self.stats.clone(),
 					lite::Version::Lite05Wip,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
+				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw)
+					.with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions
@@ -143,13 +165,14 @@ impl Server {
 				let recv_bw = lite::start(
 					session.clone(),
 					None,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish.clone(),
+					consume.clone(),
 					self.stats.clone(),
 					lite::Version::Lite04,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite04.into(), recv_bw));
+				return Ok(Session::new(session, lite::Version::Lite04.into(), recv_bw)
+					.with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_LITE_03) => {
 				self.versions
@@ -160,13 +183,14 @@ impl Server {
 				let recv_bw = lite::start(
 					session.clone(),
 					None,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish.clone(),
+					consume.clone(),
 					self.stats.clone(),
 					lite::Version::Lite03,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite03.into(), recv_bw));
+				return Ok(Session::new(session, lite::Version::Lite03.into(), recv_bw)
+					.with_origins(auto_publisher, auto_consumer));
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -210,8 +234,8 @@ impl Server {
 				lite::start(
 					session.clone(),
 					Some(stream),
-					self.publish.clone(),
-					self.consume.clone(),
+					publish.clone(),
+					consume.clone(),
 					self.stats.clone(),
 					v,
 				)?
@@ -229,14 +253,14 @@ impl Server {
 					Some(stream),
 					request_id_max,
 					false,
-					self.publish.clone(),
-					self.consume.clone(),
+					publish.clone(),
+					consume.clone(),
 					v,
 				)?;
 				None
 			}
 		};
 
-		Ok(Session::new(session, version, recv_bw))
+		Ok(Session::new(session, version, recv_bw).with_origins(auto_publisher, auto_consumer))
 	}
 }

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -12,8 +12,8 @@ use crate::{BandwidthConsumer, BandwidthProducer, Error, OriginConsumer, OriginP
 ///
 /// Both [`publisher`](Self::publisher) and [`consumer`](Self::consumer)
 /// are always populated: by whatever the caller wired via
-/// [`Client::with_publish`](crate::Client::with_publish) /
-/// [`Client::with_consume`](crate::Client::with_consume) /
+/// [`Client::with_publisher`](crate::Client::with_publisher) /
+/// [`Client::with_consumer`](crate::Client::with_consumer) /
 /// [`Client::with_origin`](crate::Client::with_origin) (or the matching
 /// methods on [`Server`](crate::Server)), or by an auto-created fresh
 /// [`Origin`](crate::Origin) for any side the caller left unset. Use
@@ -85,8 +85,8 @@ impl Session {
 
 	/// The publish-side origin: where local broadcasts get advertised
 	/// to the remote. Either the producer the caller passed via
-	/// [`Client::with_publish`](crate::Client::with_publish) /
-	/// [`Server::with_publish`](crate::Server::with_publish) /
+	/// [`Client::with_publisher`](crate::Client::with_publisher) /
+	/// [`Server::with_publisher`](crate::Server::with_publisher) /
 	/// `with_origin`, or one auto-created at connect/accept time.
 	pub fn publisher(&self) -> &OriginProducer {
 		&self.publisher
@@ -95,8 +95,8 @@ impl Session {
 	/// The subscribe-side origin: a cheap read handle for receiving
 	/// announcements pushed by the remote. Either derived from the
 	/// producer the caller passed via
-	/// [`Client::with_consume`](crate::Client::with_consume) /
-	/// [`Server::with_consume`](crate::Server::with_consume) /
+	/// [`Client::with_consumer`](crate::Client::with_consumer) /
+	/// [`Server::with_consumer`](crate::Server::with_consumer) /
 	/// `with_origin`, or auto-created at connect/accept time.
 	pub fn consumer(&self) -> &OriginConsumer {
 		&self.consumer

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -2,19 +2,31 @@ use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use web_transport_trait::Stats;
 
-use crate::{BandwidthConsumer, BandwidthProducer, Error, Version};
+use crate::{BandwidthConsumer, BandwidthProducer, Error, OriginConsumer, OriginProducer, Version};
 
 /// A MoQ transport session, wrapping a WebTransport connection.
 ///
 /// Created via:
 /// - [`crate::Client::connect`] for clients.
 /// - [`crate::Server::accept`] for servers.
+///
+/// If the caller didn't wire its own origin via
+/// [`Client::with_publish`](crate::Client::with_publish) /
+/// [`Client::with_consume`](crate::Client::with_consume) /
+/// [`Client::with_origin`](crate::Client::with_origin) (or the matching
+/// methods on [`Server`](crate::Server)), connect/accept auto-create a
+/// fresh [`Origin`](crate::Origin) and surface the producer and consumer
+/// sides as [`publisher`](Self::publisher) and [`consumer`](Self::consumer).
+/// Callers that wired their own origin see both as `None` and continue
+/// to drive things through what they already hold.
 #[derive(Clone)]
 pub struct Session {
 	session: Arc<dyn SessionInner>,
 	version: Version,
 	send_bandwidth: Option<BandwidthConsumer>,
 	recv_bandwidth: Option<BandwidthConsumer>,
+	publisher: Option<OriginProducer>,
+	consumer: Option<OriginConsumer>,
 	closed: bool,
 }
 
@@ -44,8 +56,20 @@ impl Session {
 			version,
 			send_bandwidth,
 			recv_bandwidth,
+			publisher: None,
+			consumer: None,
 			closed: false,
 		}
+	}
+
+	/// Attach the auto-created origin sides. Called by `Client::connect` /
+	/// `Server::accept` on the no-config path so the caller can publish
+	/// broadcasts and read announcements without constructing an Origin
+	/// themselves.
+	pub(crate) fn with_origins(mut self, publisher: Option<OriginProducer>, consumer: Option<OriginConsumer>) -> Self {
+		self.publisher = publisher;
+		self.consumer = consumer;
+		self
 	}
 
 	/// Returns the negotiated protocol version.
@@ -65,6 +89,18 @@ impl Session {
 	/// Returns `None` if the MoQ version doesn't support PROBE (requires moq-lite-03+).
 	pub fn recv_bandwidth(&self) -> Option<BandwidthConsumer> {
 		self.recv_bandwidth.clone()
+	}
+
+	/// The auto-created origin producer side. `Some` only when the caller
+	/// didn't wire its own publish/consume origin before connect/accept.
+	pub fn publisher(&self) -> Option<&OriginProducer> {
+		self.publisher.as_ref()
+	}
+
+	/// The auto-created origin consumer side. `Some` only when the caller
+	/// didn't wire its own publish/consume origin before connect/accept.
+	pub fn consumer(&self) -> Option<&OriginConsumer> {
+		self.consumer.as_ref()
 	}
 
 	/// Close the underlying transport session.

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -10,23 +10,23 @@ use crate::{BandwidthConsumer, BandwidthProducer, Error, OriginConsumer, OriginP
 /// - [`crate::Client::connect`] for clients.
 /// - [`crate::Server::accept`] for servers.
 ///
-/// If the caller didn't wire its own origin via
+/// Both [`publisher`](Self::publisher) and [`consumer`](Self::consumer)
+/// are always populated: by whatever the caller wired via
 /// [`Client::with_publish`](crate::Client::with_publish) /
 /// [`Client::with_consume`](crate::Client::with_consume) /
 /// [`Client::with_origin`](crate::Client::with_origin) (or the matching
-/// methods on [`Server`](crate::Server)), connect/accept auto-create a
-/// fresh [`Origin`](crate::Origin) and surface the producer and consumer
-/// sides as [`publisher`](Self::publisher) and [`consumer`](Self::consumer).
-/// Callers that wired their own origin see both as `None` and continue
-/// to drive things through what they already hold.
+/// methods on [`Server`](crate::Server)), or by an auto-created fresh
+/// [`Origin`](crate::Origin) for any side the caller left unset. Use
+/// `publisher()` to publish broadcasts and `consumer()` to read
+/// announcements without ever having to construct an Origin yourself.
 #[derive(Clone)]
 pub struct Session {
 	session: Arc<dyn SessionInner>,
 	version: Version,
 	send_bandwidth: Option<BandwidthConsumer>,
 	recv_bandwidth: Option<BandwidthConsumer>,
-	publisher: Option<OriginProducer>,
-	consumer: Option<OriginConsumer>,
+	publisher: OriginProducer,
+	consumer: OriginConsumer,
 	closed: bool,
 }
 
@@ -35,6 +35,8 @@ impl Session {
 		session: S,
 		version: Version,
 		recv_bandwidth: Option<BandwidthConsumer>,
+		publisher: OriginProducer,
+		consumer: OriginConsumer,
 	) -> Self {
 		// Send bandwidth is version-agnostic: it depends on QUIC backend support.
 		let send_bandwidth = if session.stats().estimated_send_rate().is_some() {
@@ -56,20 +58,10 @@ impl Session {
 			version,
 			send_bandwidth,
 			recv_bandwidth,
-			publisher: None,
-			consumer: None,
+			publisher,
+			consumer,
 			closed: false,
 		}
-	}
-
-	/// Attach the auto-created origin sides. Called by `Client::connect` /
-	/// `Server::accept` on the no-config path so the caller can publish
-	/// broadcasts and read announcements without constructing an Origin
-	/// themselves.
-	pub(crate) fn with_origins(mut self, publisher: Option<OriginProducer>, consumer: Option<OriginConsumer>) -> Self {
-		self.publisher = publisher;
-		self.consumer = consumer;
-		self
 	}
 
 	/// Returns the negotiated protocol version.
@@ -91,16 +83,23 @@ impl Session {
 		self.recv_bandwidth.clone()
 	}
 
-	/// The auto-created origin producer side. `Some` only when the caller
-	/// didn't wire its own publish/consume origin before connect/accept.
-	pub fn publisher(&self) -> Option<&OriginProducer> {
-		self.publisher.as_ref()
+	/// The publish-side origin: where local broadcasts get advertised
+	/// to the remote. Either the producer the caller passed via
+	/// [`Client::with_publish`](crate::Client::with_publish) /
+	/// [`Server::with_publish`](crate::Server::with_publish) /
+	/// `with_origin`, or one auto-created at connect/accept time.
+	pub fn publisher(&self) -> &OriginProducer {
+		&self.publisher
 	}
 
-	/// The auto-created origin consumer side. `Some` only when the caller
-	/// didn't wire its own publish/consume origin before connect/accept.
-	pub fn consumer(&self) -> Option<&OriginConsumer> {
-		self.consumer.as_ref()
+	/// The subscribe-side origin: a cheap read handle for receiving
+	/// announcements pushed by the remote. Either derived from the
+	/// producer the caller passed via
+	/// [`Client::with_consume`](crate::Client::with_consume) /
+	/// [`Server::with_consume`](crate::Server::with_consume) /
+	/// `with_origin`, or auto-created at connect/accept time.
+	pub fn consumer(&self) -> &OriginConsumer {
+		&self.consumer
 	}
 
 	/// Close the underlying transport session.

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -1135,7 +1135,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_claims_reduction_with_publish_restrictions() -> anyhow::Result<()> {
+	async fn test_claims_reduction_with_publisher_restrictions() -> anyhow::Result<()> {
 		let key = create_test_key_with_kid("test-key");
 		let dir = setup_key_dir(&[("test-key", &key)]);
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::Context;
-use moq_net::{BroadcastProducer, Origin, OriginConsumer, OriginProducer, Path, Stats, Tier};
+use moq_net::{BroadcastProducer, Origin, OriginProducer, Path, Stats, Tier};
 use tokio::task::AbortHandle;
 use url::Url;
 
@@ -212,9 +212,12 @@ impl Cluster {
 		self
 	}
 
-	/// Returns an [`OriginConsumer`] scoped to this session's subscribe permissions.
-	pub fn subscriber(&self, token: &AuthToken) -> Option<OriginConsumer> {
-		Some(self.origin.with_root(&token.root)?.scope(&token.subscribe)?.consume())
+	/// Returns an [`OriginProducer`] scoped to this session's subscribe permissions.
+	///
+	/// Pass straight to [`moq_net::Server::with_publish`] (or the
+	/// equivalent per-request setter). moq-net derives the read handle.
+	pub fn subscriber(&self, token: &AuthToken) -> Option<OriginProducer> {
+		self.origin.with_root(&token.root)?.scope(&token.subscribe)
 	}
 
 	/// Returns an [`OriginProducer`] scoped to this session's publish permissions.
@@ -445,7 +448,7 @@ impl Cluster {
 
 		// Cluster-to-cluster traffic is internal by definition.
 		let cs = client
-			.with_publish(self.origin.consume())
+			.with_publish(self.origin.clone())
 			.with_consume(self.origin.clone())
 			.with_stats(self.stats.tier(Tier::Internal))
 			.connect(url.clone())

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -214,7 +214,7 @@ impl Cluster {
 
 	/// Returns an [`OriginProducer`] scoped to this session's subscribe permissions.
 	///
-	/// Pass straight to [`moq_net::Server::with_publish`] (or the
+	/// Pass straight to [`moq_net::Server::with_publisher`] (or the
 	/// equivalent per-request setter). moq-net derives the read handle.
 	pub fn subscriber(&self, token: &AuthToken) -> Option<OriginProducer> {
 		self.origin.with_root(&token.root)?.scope(&token.subscribe)
@@ -448,8 +448,8 @@ impl Cluster {
 
 		// Cluster-to-cluster traffic is internal by definition.
 		let cs = client
-			.with_publish(self.origin.clone())
-			.with_consume(self.origin.clone())
+			.with_publisher(self.origin.clone())
+			.with_consumer(self.origin.clone())
 			.with_stats(self.stats.tier(Tier::Internal))
 			.connect(url.clone())
 			.await

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::Context;
-use moq_net::{BroadcastProducer, Origin, OriginProducer, Path, Stats, Tier};
+use moq_net::{BroadcastProducer, Origin, OriginConsumer, OriginProducer, Path, Stats, Tier};
 use tokio::task::AbortHandle;
 use url::Url;
 
@@ -212,12 +212,9 @@ impl Cluster {
 		self
 	}
 
-	/// Returns an [`OriginProducer`] scoped to this session's subscribe permissions.
-	///
-	/// Pass directly to [`moq_net::Server::with_publish`] (or the equivalent
-	/// per-request setter). moq-net derives the read handle internally.
-	pub fn subscriber(&self, token: &AuthToken) -> Option<OriginProducer> {
-		self.origin.with_root(&token.root)?.scope(&token.subscribe)
+	/// Returns an [`OriginConsumer`] scoped to this session's subscribe permissions.
+	pub fn subscriber(&self, token: &AuthToken) -> Option<OriginConsumer> {
+		Some(self.origin.with_root(&token.root)?.scope(&token.subscribe)?.consume())
 	}
 
 	/// Returns an [`OriginProducer`] scoped to this session's publish permissions.
@@ -448,7 +445,7 @@ impl Cluster {
 
 		// Cluster-to-cluster traffic is internal by definition.
 		let cs = client
-			.with_publish(self.origin.clone())
+			.with_publish(self.origin.consume())
 			.with_consume(self.origin.clone())
 			.with_stats(self.stats.tier(Tier::Internal))
 			.connect(url.clone())

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -452,7 +452,7 @@ impl Cluster {
 			.await
 			.context("failed to connect to cluster peer")?;
 
-		cs.session.closed().await.map_err(Into::into)
+		cs.closed().await.map_err(Into::into)
 	}
 }
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::Context;
-use moq_net::{BroadcastProducer, Origin, OriginConsumer, OriginProducer, Path, Stats, Tier};
+use moq_net::{BroadcastProducer, Origin, OriginProducer, Path, Stats, Tier};
 use tokio::task::AbortHandle;
 use url::Url;
 
@@ -212,9 +212,12 @@ impl Cluster {
 		self
 	}
 
-	/// Returns an [`OriginConsumer`] scoped to this session's subscribe permissions.
-	pub fn subscriber(&self, token: &AuthToken) -> Option<OriginConsumer> {
-		Some(self.origin.with_root(&token.root)?.scope(&token.subscribe)?.consume())
+	/// Returns an [`OriginProducer`] scoped to this session's subscribe permissions.
+	///
+	/// Pass directly to [`moq_net::Server::with_publish`] (or the equivalent
+	/// per-request setter). moq-net derives the read handle internally.
+	pub fn subscriber(&self, token: &AuthToken) -> Option<OriginProducer> {
+		self.origin.with_root(&token.root)?.scope(&token.subscribe)
 	}
 
 	/// Returns an [`OriginProducer`] scoped to this session's publish permissions.
@@ -445,7 +448,7 @@ impl Cluster {
 
 		// Cluster-to-cluster traffic is internal by definition.
 		let cs = client
-			.with_publish(self.origin.consume())
+			.with_publish(self.origin.clone())
 			.with_consume(self.origin.clone())
 			.with_stats(self.stats.tier(Tier::Internal))
 			.connect(url.clone())

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -444,7 +444,7 @@ impl Cluster {
 			.context("internal: cluster peer dial without an attached QUIC client")?;
 
 		// Cluster-to-cluster traffic is internal by definition.
-		let session = client
+		let cs = client
 			.with_publish(self.origin.consume())
 			.with_consume(self.origin.clone())
 			.with_stats(self.stats.tier(Tier::Internal))
@@ -452,7 +452,7 @@ impl Cluster {
 			.await
 			.context("failed to connect to cluster peer")?;
 
-		session.closed().await.map_err(Into::into)
+		cs.session.closed().await.map_err(Into::into)
 	}
 }
 

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -83,13 +83,18 @@ impl Connection {
 		// NOTE: subscribe and publish seem backwards because of how relays work.
 		// We publish the tracks the client is allowed to subscribe to.
 		// We subscribe to the tracks the client is allowed to publish.
-		let session = self
-			.request
-			.with_publisher(subscribe)
-			.with_consumer(publish)
-			.with_stats(stats)
-			.ok()
-			.await?;
+		//
+		// Only set the side the token actually grants. moq-net defaults the
+		// unset side to a fresh no-op origin, which is fine for a publish-only
+		// or subscribe-only token.
+		let mut request = self.request.with_stats(stats);
+		if let Some(subscribe) = subscribe {
+			request = request.with_publisher(subscribe);
+		}
+		if let Some(publish) = publish {
+			request = request.with_consumer(publish);
+		}
+		let session = request.ok().await?;
 
 		tracing::info!(version = %session.version(), transport, "negotiated");
 

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -85,8 +85,8 @@ impl Connection {
 		// We subscribe to the tracks the client is allowed to publish.
 		let session = self
 			.request
-			.with_publish(subscribe)
-			.with_consume(publish)
+			.with_publisher(subscribe)
+			.with_consumer(publish)
 			.with_stats(stats)
 			.ok()
 			.await?;

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -463,7 +463,7 @@ async fn serve_announced(
 		return Err(StatusCode::UNAUTHORIZED.into());
 	};
 
-	let mut announced = origin.consume().announced();
+	let mut announced = origin.announced();
 	let mut broadcasts = Vec::new();
 
 	while let Some((suffix, active)) = announced.try_next() {
@@ -519,11 +519,7 @@ async fn serve_fetch(
 		// NOTE: The auth token is already scoped to the broadcast.
 		// Block until the broadcast has been announced (within the fetch deadline) so
 		// freshly-connected subscribers don't get a spurious 404 before gossip arrives.
-		let broadcast = origin
-			.consume()
-			.announced_broadcast("")
-			.await
-			.ok_or(StatusCode::NOT_FOUND)?;
+		let broadcast = origin.announced_broadcast("").await.ok_or(StatusCode::NOT_FOUND)?;
 		let mut track = broadcast.subscribe_track(&track).map_err(|err| match err {
 			moq_net::Error::NotFound => StatusCode::NOT_FOUND,
 			_ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -463,7 +463,7 @@ async fn serve_announced(
 		return Err(StatusCode::UNAUTHORIZED.into());
 	};
 
-	let mut announced = origin.announced();
+	let mut announced = origin.consume().announced();
 	let mut broadcasts = Vec::new();
 
 	while let Some((suffix, active)) = announced.try_next() {
@@ -519,7 +519,11 @@ async fn serve_fetch(
 		// NOTE: The auth token is already scoped to the broadcast.
 		// Block until the broadcast has been announced (within the fetch deadline) so
 		// freshly-connected subscribers don't get a spurious 404 before gossip arrives.
-		let broadcast = origin.announced_broadcast("").await.ok_or(StatusCode::NOT_FOUND)?;
+		let broadcast = origin
+			.consume()
+			.announced_broadcast("")
+			.await
+			.ok_or(StatusCode::NOT_FOUND)?;
 		let mut track = broadcast.subscribe_track(&track).map_err(|err| match err {
 			moq_net::Error::NotFound => StatusCode::NOT_FOUND,
 			_ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -462,7 +462,7 @@ async fn serve_announced(
 		return Err(StatusCode::UNAUTHORIZED.into());
 	};
 
-	let mut announced = origin.announced();
+	let mut announced = origin.consume().announced();
 	let mut broadcasts = Vec::new();
 
 	while let Some((suffix, active)) = announced.try_next() {
@@ -518,7 +518,11 @@ async fn serve_fetch(
 		// NOTE: The auth token is already scoped to the broadcast.
 		// Block until the broadcast has been announced (within the fetch deadline) so
 		// freshly-connected subscribers don't get a spurious 404 before gossip arrives.
-		let broadcast = origin.announced_broadcast("").await.ok_or(StatusCode::NOT_FOUND)?;
+		let broadcast = origin
+			.consume()
+			.announced_broadcast("")
+			.await
+			.ok_or(StatusCode::NOT_FOUND)?;
 		let mut track = broadcast.subscribe_track(&track).map_err(|err| match err {
 			moq_net::Error::NotFound => StatusCode::NOT_FOUND,
 			_ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -105,8 +105,8 @@ where
 	};
 	let ws = bare.accept();
 	let session = moq_net::Server::new()
-		.with_publish(subscribe)
-		.with_consume(publish)
+		.with_publisher(subscribe)
+		.with_consumer(publish)
 		.with_stats(stats)
 		.accept(ws)
 		.await?;

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -15,7 +15,7 @@ use axum::{
 	http::StatusCode,
 	response::Response,
 };
-use moq_net::{OriginConsumer, OriginProducer, StatsHandle, Tier};
+use moq_net::{OriginProducer, StatsHandle, Tier};
 
 use crate::{AuthParams, AuthToken, WebState, web::AuthQuery, web::MtlsPeer, web::landing_response};
 
@@ -85,7 +85,7 @@ async fn handle_socket<T>(
 	socket: T,
 	alpn: Option<String>,
 	publish: Option<OriginProducer>,
-	subscribe: Option<OriginConsumer>,
+	subscribe: Option<OriginProducer>,
 	stats: StatsHandle,
 ) -> anyhow::Result<()>
 where

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -104,12 +104,17 @@ where
 		None => bare,
 	};
 	let ws = bare.accept();
-	let session = moq_net::Server::new()
-		.with_publisher(subscribe)
-		.with_consumer(publish)
-		.with_stats(stats)
-		.accept(ws)
-		.await?;
+	// Only set the side the token actually grants. moq-net defaults the
+	// unset side to a fresh no-op origin, which is fine for a
+	// publish-only or subscribe-only token.
+	let mut server = moq_net::Server::new().with_stats(stats);
+	if let Some(subscribe) = subscribe {
+		server = server.with_publisher(subscribe);
+	}
+	if let Some(publish) = publish {
+		server = server.with_consumer(publish);
+	}
+	let session = server.accept(ws).await?;
 	session.closed().await.map_err(Into::into)
 }
 

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -15,7 +15,7 @@ use axum::{
 	http::StatusCode,
 	response::Response,
 };
-use moq_net::{OriginProducer, StatsHandle, Tier};
+use moq_net::{OriginConsumer, OriginProducer, StatsHandle, Tier};
 
 use crate::{AuthParams, AuthToken, WebState, web::AuthQuery, web::MtlsPeer, web::landing_response};
 
@@ -85,7 +85,7 @@ async fn handle_socket<T>(
 	socket: T,
 	alpn: Option<String>,
 	publish: Option<OriginProducer>,
-	subscribe: Option<OriginProducer>,
+	subscribe: Option<OriginConsumer>,
 	stats: StatsHandle,
 ) -> anyhow::Result<()>
 where

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -124,10 +124,13 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	group.write_frame(b"hello".as_ref()).expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(TIMEOUT, client().with_publish(pub_origin.clone()).connect(url.clone()))
-		.await
-		.expect("publisher connect timeout")
-		.expect("publisher connect failed");
+	let pub_session = tokio::time::timeout(
+		TIMEOUT,
+		client().with_publish(pub_origin.consume()).connect(url.clone()),
+	)
+	.await
+	.expect("publisher connect timeout")
+	.expect("publisher connect failed");
 	assert_eq!(
 		pub_session.version(),
 		expected_version,

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -132,7 +132,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	.expect("publisher connect timeout")
 	.expect("publisher connect failed");
 	assert_eq!(
-		pub_session.session.version(),
+		pub_session.version(),
 		expected_version,
 		"publisher negotiated stale version"
 	);
@@ -146,7 +146,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
 	assert_eq!(
-		sub_session.session.version(),
+		sub_session.version(),
 		expected_version,
 		"subscriber negotiated stale version"
 	);

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -124,10 +124,13 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	group.write_frame(b"hello".as_ref()).expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(TIMEOUT, client().with_publish(pub_origin.clone()).connect(url.clone()))
-		.await
-		.expect("publisher connect timeout")
-		.expect("publisher connect failed");
+	let pub_session = tokio::time::timeout(
+		TIMEOUT,
+		client().with_publisher(pub_origin.clone()).connect(url.clone()),
+	)
+	.await
+	.expect("publisher connect timeout")
+	.expect("publisher connect failed");
 	assert_eq!(
 		pub_session.version(),
 		expected_version,
@@ -138,7 +141,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
 
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consume(sub_origin).connect(url))
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consumer(sub_origin).connect(url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -132,7 +132,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	.expect("publisher connect timeout")
 	.expect("publisher connect failed");
 	assert_eq!(
-		pub_session.version(),
+		pub_session.session.version(),
 		expected_version,
 		"publisher negotiated stale version"
 	);
@@ -146,7 +146,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
 	assert_eq!(
-		sub_session.version(),
+		sub_session.session.version(),
 		expected_version,
 		"subscriber negotiated stale version"
 	);

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -124,13 +124,10 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	group.write_frame(b"hello".as_ref()).expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(
-		TIMEOUT,
-		client().with_publish(pub_origin.consume()).connect(url.clone()),
-	)
-	.await
-	.expect("publisher connect timeout")
-	.expect("publisher connect failed");
+	let pub_session = tokio::time::timeout(TIMEOUT, client().with_publish(pub_origin.clone()).connect(url.clone()))
+		.await
+		.expect("publisher connect timeout")
+		.expect("publisher connect failed");
 	assert_eq!(
 		pub_session.version(),
 		expected_version,

--- a/rs/moq-rtc/bin/moq-rtc.rs
+++ b/rs/moq-rtc/bin/moq-rtc.rs
@@ -117,8 +117,8 @@ async fn main() -> anyhow::Result<()> {
 	let subscriber_consumer = subscriber.consume();
 
 	let reconnect = moq_client
-		.with_publish(publisher.clone())
-		.with_consume(subscriber)
+		.with_publisher(publisher.clone())
+		.with_consumer(subscriber)
 		.reconnect(relay.clone());
 
 	tracing::info!(%relay, %broadcast, "starting moq-rtc");

--- a/rs/moq-rtc/bin/moq-rtc.rs
+++ b/rs/moq-rtc/bin/moq-rtc.rs
@@ -117,7 +117,7 @@ async fn main() -> anyhow::Result<()> {
 	let subscriber_consumer = subscriber.consume();
 
 	let reconnect = moq_client
-		.with_publish(publisher.consume())
+		.with_publish(publisher.clone())
 		.with_consume(subscriber)
 		.reconnect(relay.clone());
 

--- a/rs/moq-rtc/bin/moq-rtc.rs
+++ b/rs/moq-rtc/bin/moq-rtc.rs
@@ -117,7 +117,7 @@ async fn main() -> anyhow::Result<()> {
 	let subscriber_consumer = subscriber.consume();
 
 	let reconnect = moq_client
-		.with_publish(publisher.clone())
+		.with_publish(publisher.consume())
 		.with_consume(subscriber)
 		.reconnect(relay.clone());
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -20,7 +20,7 @@ import Moq
 let client = MoqClient()
 let cs = try await client.connect(url: "https://relay.example.com")
 
-// The auto-created origin sides on the returned MoqClientSession let you
+// The auto-created origin sides on the returned MoqSession let you
 // publish broadcasts and read announcements without ever constructing a
 // MoqOriginProducer yourself. For subscribe-only / publish-only / split
 // origins, call setPublish / setConsume on the client before connect and
@@ -37,10 +37,10 @@ for try await announcement in announced.announcements {
     }
 }
 
-cs.session().shutdown()
+cs.shutdown()
 ```
 
-Cancelling the surrounding Swift `Task` propagates through to the underlying `cancel()` calls on each consumer. `cs.session().shutdown()` is an alias for `cancel(code: 0)` that documents the convention that code 0 means "no error".
+Cancelling the surrounding Swift `Task` propagates through to the underlying `cancel()` calls on each consumer. `cs.shutdown()` is an alias for `cancel(code: 0)` that documents the convention that code 0 means "no error".
 
 To publish a broadcast through the auto-created origin:
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -46,7 +46,7 @@ To publish a broadcast through the auto-created origin:
 let pub = cs.publisher()
 let broadcast = try MoqBroadcastProducer()
 // ... configure tracks on broadcast ...
-try pub.addBroadcast(path: "my-stream", broadcast: broadcast)
+try pub.announce(path: "my-stream", broadcast: broadcast)
 ```
 
 A note on enum casing: UniFFI keeps Rust's casing for error variants (every `MoqError` case is PascalCase and carries `message: String`, e.g. `MoqError.Closed(message: "...")`), but plain enums round-trip to lowerCamelCase (`MoqAudioFormat.s16`, `MoqAudioCodec.opus`).

--- a/swift/README.md
+++ b/swift/README.md
@@ -17,17 +17,16 @@ The mirror repo is updated by [`swift/scripts/publish.sh`](scripts/publish.sh) o
 ```swift
 import Moq
 
-// Wire an origin as both publish source and consume sink. The typical
-// full-duplex client; for a subscribe-only or publish-only client, just
-// set one side.
-let origin = MoqOriginProducer()
 let client = MoqClient()
-client.setPublish(origin: origin)
-client.setConsume(origin: origin)
+let cs = try await client.connect(url: "https://relay.example.com")
 
-let session = try await client.connect(url: "https://relay.example.com")
-
-let consumer = origin.consume()
+// The auto-created origin sides on the returned MoqClientSession let you
+// publish broadcasts and read announcements without ever constructing a
+// MoqOriginProducer yourself. For subscribe-only / publish-only / split
+// origins, call setPublish / setConsume on the client before connect and
+// drive those origins manually (cs.publisher() and cs.consumer() return
+// nil in that case).
+let consumer = cs.consumer()!
 let announced = try consumer.announced(prefix: "demos/")
 for try await announcement in announced.announcements {
     print("got broadcast \(announcement.path())")
@@ -38,10 +37,19 @@ for try await announcement in announced.announcements {
     }
 }
 
-session.shutdown()
+cs.session().shutdown()
 ```
 
-Cancelling the surrounding Swift `Task` propagates through to the underlying `cancel()` calls on each consumer. `session.shutdown()` is an alias for `cancel(code: 0)` that documents the convention that code 0 means "no error".
+Cancelling the surrounding Swift `Task` propagates through to the underlying `cancel()` calls on each consumer. `cs.session().shutdown()` is an alias for `cancel(code: 0)` that documents the convention that code 0 means "no error".
+
+To publish a broadcast through the auto-created origin:
+
+```swift
+let pub = cs.publisher()!
+let broadcast = try MoqBroadcastProducer()
+// ... configure tracks on broadcast ...
+try pub.addBroadcast(path: "my-stream", broadcast: broadcast)
+```
 
 A note on enum casing: UniFFI keeps Rust's casing for error variants (every `MoqError` case is PascalCase and carries `message: String`, e.g. `MoqError.Closed(message: "...")`), but plain enums round-trip to lowerCamelCase (`MoqAudioFormat.s16`, `MoqAudioCodec.opus`).
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -20,13 +20,11 @@ import Moq
 let client = MoqClient()
 let cs = try await client.connect(url: "https://relay.example.com")
 
-// The auto-created origin sides on the returned MoqSession let you
-// publish broadcasts and read announcements without ever constructing a
-// MoqOriginProducer yourself. For subscribe-only / publish-only / split
-// origins, call setPublish / setConsume on the client before connect and
-// drive those origins manually (cs.publisher() and cs.consumer() return
-// nil in that case).
-let consumer = cs.consumer()!
+// cs.publisher() and cs.consumer() are always populated: by whatever
+// origin you wired via setPublish / setConsume before connect, or by a
+// fresh auto-created one for any side you didn't set. The duplex no-config
+// path (the typical client) shares one origin between both.
+let consumer = cs.consumer()
 let announced = try consumer.announced(prefix: "demos/")
 for try await announcement in announced.announcements {
     print("got broadcast \(announcement.path())")
@@ -45,7 +43,7 @@ Cancelling the surrounding Swift `Task` propagates through to the underlying `ca
 To publish a broadcast through the auto-created origin:
 
 ```swift
-let pub = cs.publisher()!
+let pub = cs.publisher()
 let broadcast = try MoqBroadcastProducer()
 // ... configure tracks on broadcast ...
 try pub.addBroadcast(path: "my-stream", broadcast: broadcast)


### PR DESCRIPTION
## Summary

Makes explicitly constructing an Origin **optional** on both client and server in `moq-net` and `moq-ffi`. The common-case setup collapses from this:

```rust
let origin = Origin::random().produce();
let client = Client::new().with_origin(origin.clone());
let session = client.connect(transport).await?;
// ... use origin to publish / consume ...
```

to this:

```rust
let session = Client::new().connect(transport).await?;
let pub_origin = session.publisher().unwrap();
let sub_origin = session.consumer().unwrap();
// ... use them ...
```

`with_publish` / `with_consume` / `with_origin` stay for callers that need a custom topology (relay, gst, cli, ffi); when any of those is set, `session.publisher()` and `session.consumer()` return `None` and the caller drives things through the origin it already holds.

Targeting `dev` per CLAUDE.md (breaking change to public APIs in `rs/moq-net`, `rs/moq-ffi`, and the language wrappers).

## Rust layer (`rs/moq-net`)

`Session` now carries the auto-created origin sides directly:

```rust
pub struct Session {
    /* existing fields */
    publisher: Option<OriginProducer>,
    consumer: Option<OriginConsumer>,
}

impl Session {
    pub fn publisher(&self) -> Option<&OriginProducer> { ... }
    pub fn consumer(&self) -> Option<&OriginConsumer> { ... }
}
```

`Client::connect` and `Server::accept` both auto-create an Origin when neither publish nor consume was set, then surface it through these accessors. One type instead of a separate `ClientSession` wrapper, symmetric across the client and server paths.

Downstream call sites in `moq-native`, `moq-relay`, `moq-cli`, `moq-gst`, `libmoq`, and `moq-ffi` thread `session.publisher()` / `session.consumer()` where they need the auto-created sides; everything else just continues to use `session` as before.

One internal moq-net test was depending on "no origin → trivial close with code 0 (Cancel)" to validate SETUP framing. With auto-origin attached the Lite01 session now closes with `RequiredExtension` (code 1) since Lite01 can't satisfy the new origin. Loosened the assertion to "any non-Version error" since the test's purpose is the framing path, not the close code.

## FFI layer (`rs/moq-ffi`)

Mirror at the FFI level: `MoqSession` gains `publisher()` and `consumer()` accessor methods (uniffi Objects, return `Option<Arc<MoqOriginProducer>>` / `Option<Arc<MoqOriginConsumer>>`). `MoqClient::connect` continues to return `Arc<MoqSession>`.

Renamed `MoqOriginProducer::publish` → `add_broadcast` so `session.publisher().unwrap().add_broadcast(path, broadcast)` reads cleanly instead of stuttering `…publisher().publish(...)`.

New test `server_client_roundtrip_auto_origin` validates the no-config path end-to-end (client doesn't call `set_publish`/`set_consume`; `session.publisher()` and `session.consumer()` are `Some` and drive a server → client broadcast).

## Per-language wrapper sync (CLAUDE.md cross-package table)

- **`py/moq-rs/moq/client.py`**: no extraction step needed, just stores the returned `MoqSession` directly.
- **`py/moq-rs/moq/origin.py`**: Python `OriginProducer.publish` wrapper kept (no Python API churn); now calls `add_broadcast` on the FFI underneath.
- **`swift/README.md`, `doc/lib/{swift,kt}/{index,moq}.md`**: show the new shape — no `MoqOriginProducer()` construction in the happy path; `session.publisher()` / `session.consumer()` return the auto-created sides.
- **`go/`**: pure binding shim, no Go-side wrapper to update; consumers get the regenerated `MoqClient.Connect()` returning `*MoqSession` with the new accessors.
- **Swift `Moq.swift` / Kotlin `Moq.kt`**: already deleted in the prior PR #1526, so no entry-point shims to update here.

## Why fold into `Session` instead of keeping `ClientSession`

The earlier version of this PR added a separate `ClientSession { session, publisher, consumer }` wrapper. Two reasons to fold:

1. **Symmetry**: the same auto-origin behavior applies to servers too. Keeping `ClientSession` would force either a parallel `ServerSession` (more types) or asymmetric APIs. Folding the fields onto `Session` lets `Server::accept` use the same path with zero new naming.
2. **Naming**: there's no obvious neutral name for the wrapper (`Endpoint` and `Connection` are overloaded), and `Session` already represents "the connected thing." Adding optional fields fits cleanly without inventing a new concept.

## Test plan

- [x] `cargo test --workspace --tests` passes (all suites, including the new `server_client_roundtrip_auto_origin`).
- [x] `cargo fmt --check` clean; `cargo clippy --workspace --all-targets` clean.
- [x] `just swift check` passes (2/2 smoke tests).
- [ ] Kotlin: gradle toolchain not available locally, so `just kt check` only ran the binding regeneration step. CI exercises the full Kotlin build.
- [ ] Python: smoke tests not run locally (no uv environment set up in this worktree). CI runs `just py check`.

(Written by Claude)