### PR TITLE
flake: use nixfmt instead of deprecated nixfmt-rfc-style

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,7 @@
           shfmt
           actionlint
           taplo
-          nixfmt-rfc-style
+          nixfmt
         ];
 
         # Apply our overlay to get the package definitions


### PR DESCRIPTION
## Summary

- nixpkgs now aliases `nixfmt-rfc-style` to `pkgs.nixfmt` and emits a deprecation warning on flake evaluation. Switch the `lintDeps` attribute to `nixfmt`.

## Notes

The `just check` / `just fix` recipes invoke the `nixfmt` binary directly, which is unchanged by this rename, so behavior is identical. This just silences the eval warning.

## Test plan

- [x] `nix develop --command true` no longer prints the `nixfmt-rfc-style` deprecation warning

(Written by Claude)