### PR TITLE
chore(js): bump JS package versions to publish pending changes

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.6",
+	"version": "0.2.7",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/msf",
 	"type": "module",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "MSF (MOQT Streaming Format) catalog types for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/signals",
 	"type": "module",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "Reactive and safe signals",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",


### PR DESCRIPTION
## Summary

Six published JS packages had source changes merged to `main` *after* their last version bump. The JS release workflow only publishes when a package's `package.json` version differs from what's on npm, so those changes have been sitting unpublished. This patch-bumps each so they republish.

| Package | Bump | Pending change |
|---|---|---|
| `@moq/net` | 0.1.1 → 0.1.2 | `SUBSCRIBE_UPDATE` API (#1396), `Lite05Wip` version variant (#1518), `track.ts` changes |
| `@moq/signals` | 0.1.6 → 0.1.7 | new `Signal.next()` |
| `@moq/hang` | 0.2.6 → 0.2.7 | `export * as Net` (deprecates Lite/Moq alias) |
| `@moq/publish` | 0.2.8 → 0.2.9 | same `Net` re-export |
| `@moq/watch` | 0.2.12 → 0.2.13 | same `Net` re-export |
| `@moq/msf` | 0.1.0 → 0.1.1 | type import fix `@moq/lite` → `@moq/net` |

## Notes for reviewers

- All patch bumps. `@moq/net` is the only one with new runtime API, but the additions are non-breaking so patch is appropriate pre-1.0.
- Dependents (`hang`/`publish`/`watch`/`msf`) consume `@moq/net` via `workspace:^`, so no dependency-range edits were needed.
- `@moq/moq-boy`, `@moq/token`, `@moq/loc` had no source changes since their last publish and were left untouched. `@moq/clock` is `private` and not published.

## Test plan

- [ ] CI green
- [ ] Release-JS dry-run (runs on PR) packs each bumped package without error

(Written by Claude)