### PR TITLE
moq-ffi: route Android logs to logcat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_log-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3697,6 +3703,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-android",
+ "tracing-subscriber",
  "uniffi",
  "url",
 ]
@@ -7214,6 +7222,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-android"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12612be8f868a09c0ceae7113ff26afe79d81a24473a393cb9120ece162e86c0"
+dependencies = [
+ "android_log-sys",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,8 +3703,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-android",
- "tracing-subscriber",
  "uniffi",
  "url",
 ]
@@ -3801,6 +3799,7 @@ dependencies = [
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
+ "tracing-android",
  "tracing-subscriber",
  "tracing-test",
  "url",

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// Optional: Use moq_native to configure a logger.
-	moq_native::Log::new(tracing::Level::DEBUG).init();
+	moq_native::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that the session can publish incoming broadcasts to.
 	let origin = moq_net::Origin::random().produce();

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// Optional: Use moq_native to configure a logger.
-	moq_native::Log::new(tracing::Level::DEBUG).init();
+	moq_native::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that we can publish to and the session can consume from.
 	let origin = moq_net::Origin::random().produce();

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -97,7 +97,8 @@ pub unsafe extern "C" fn moq_log_level(level: *const c_char, level_len: usize) -
 			"" => moq_native::Log::default(),
 			level => moq_native::Log::new(Level::from_str(level)?),
 		}
-		.init();
+		.init()
+		.map_err(|err| Error::InitFailed(std::sync::Arc::new(err)))?;
 
 		Ok(())
 	})

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -439,7 +439,7 @@ fn run_emulator(
 #[tokio::main]
 async fn main() -> Result<()> {
 	let config = Config::parse();
-	config.log.init();
+	config.log.init()?;
 
 	#[cfg(feature = "jemalloc")]
 	let jemalloc = moq_native::jemalloc::run();

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -120,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
 		.expect("failed to install default crypto provider");
 
 	let cli = Cli::parse();
-	cli.log.init();
+	cli.log.init()?;
 
 	#[cfg(feature = "iroh")]
 	let iroh = cli.iroh.bind().await?;

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -19,6 +19,9 @@ crate-type = ["staticlib", "cdylib"]
 name = "uniffi-bindgen"
 path = "./uniffi-bindgen.rs"
 
+[features]
+android-logcat = ["dep:tracing-android", "dep:tracing-subscriber"]
+
 [dependencies]
 bytes = "1"
 hang = { workspace = true }
@@ -29,8 +32,12 @@ moq-net = { workspace = true, features = ["serde"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["macros"] }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 uniffi = { version = "0.31", features = ["cli"] }
 url = "2"
+
+[target.'cfg(target_os = "android")'.dependencies]
+tracing-android = { version = "0.2", optional = true }
 
 [build-dependencies]
 uniffi = { version = "0.31", features = ["build"] }

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -20,7 +20,7 @@ name = "uniffi-bindgen"
 path = "./uniffi-bindgen.rs"
 
 [features]
-android-logcat = ["dep:tracing-android", "dep:tracing-subscriber"]
+android-logcat = ["moq-native/android-logcat"]
 
 [dependencies]
 bytes = "1"
@@ -32,12 +32,8 @@ moq-net = { workspace = true, features = ["serde"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["macros"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 uniffi = { version = "0.31", features = ["cli"] }
 url = "2"
-
-[target.'cfg(target_os = "android")'.dependencies]
-tracing-android = { version = "0.2", optional = true }
 
 [build-dependencies]
 uniffi = { version = "0.31", features = ["build"] }

--- a/rs/moq-ffi/src/log.rs
+++ b/rs/moq-ffi/src/log.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use crate::error::MoqError;
+use tracing::Level;
 
 /// Initialize logging with a level string: "error", "warn", "info", "debug", "trace", or "".
 ///
@@ -8,20 +9,54 @@ use crate::error::MoqError;
 #[uniffi::export]
 pub fn moq_log_level(level: String) -> Result<(), MoqError> {
 	use std::sync::atomic::{AtomicBool, Ordering};
-	use tracing::Level;
 
 	static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
-	let log = match level.as_str() {
-		"" => moq_native::Log::default(),
-		s => moq_native::Log::new(Level::from_str(s)?),
+	let level = match level.as_str() {
+		"" => Level::INFO,
+		s => Level::from_str(s)?,
 	};
 
 	if INITIALIZED.swap(true, Ordering::SeqCst) {
 		return Err(MoqError::Log("logging already initialized".into()));
 	}
 
-	log.init();
+	init_logging(level)?;
 
+	Ok(())
+}
+
+#[cfg(all(target_os = "android", feature = "android-logcat"))]
+fn init_logging(level: Level) -> Result<(), MoqError> {
+	use tracing::level_filters::LevelFilter;
+	use tracing_subscriber::EnvFilter;
+	use tracing_subscriber::Layer;
+	use tracing_subscriber::layer::SubscriberExt;
+	use tracing_subscriber::util::SubscriberInitExt;
+
+	let filter = EnvFilter::builder()
+		.with_default_directive(LevelFilter::from_level(level).into())
+		.from_env_lossy()
+		.add_directive("h2=warn".parse().unwrap())
+		.add_directive("quinn=trace".parse().unwrap())
+		.add_directive("tungstenite=info".parse().unwrap())
+		.add_directive("rustls=info".parse().unwrap())
+		.add_directive("tracing::span=off".parse().unwrap())
+		.add_directive("tracing::span::active=off".parse().unwrap())
+		.add_directive("tokio=info".parse().unwrap())
+		.add_directive("runtime=info".parse().unwrap());
+
+	let logcat_layer = tracing_android::layer("MoQNative")
+		.map_err(|err| MoqError::Log(format!("failed to initialize Android logcat layer: {err}")))?
+		.with_filter(filter);
+
+	tracing_subscriber::registry().with(logcat_layer).init();
+
+	Ok(())
+}
+
+#[cfg(not(all(target_os = "android", feature = "android-logcat")))]
+fn init_logging(level: Level) -> Result<(), MoqError> {
+	moq_native::Log::new(level).init();
 	Ok(())
 }

--- a/rs/moq-ffi/src/log.rs
+++ b/rs/moq-ffi/src/log.rs
@@ -21,42 +21,10 @@ pub fn moq_log_level(level: String) -> Result<(), MoqError> {
 		return Err(MoqError::Log("logging already initialized".into()));
 	}
 
-	init_logging(level)?;
+	moq_native::Log::new(level)
+		.init()
+		.inspect_err(|_| INITIALIZED.store(false, Ordering::SeqCst))
+		.map_err(|err| MoqError::Log(err.to_string()))?;
 
-	Ok(())
-}
-
-#[cfg(all(target_os = "android", feature = "android-logcat"))]
-fn init_logging(level: Level) -> Result<(), MoqError> {
-	use tracing::level_filters::LevelFilter;
-	use tracing_subscriber::EnvFilter;
-	use tracing_subscriber::Layer;
-	use tracing_subscriber::layer::SubscriberExt;
-	use tracing_subscriber::util::SubscriberInitExt;
-
-	let filter = EnvFilter::builder()
-		.with_default_directive(LevelFilter::from_level(level).into())
-		.from_env_lossy()
-		.add_directive("h2=warn".parse().unwrap())
-		.add_directive("quinn=trace".parse().unwrap())
-		.add_directive("tungstenite=info".parse().unwrap())
-		.add_directive("rustls=info".parse().unwrap())
-		.add_directive("tracing::span=off".parse().unwrap())
-		.add_directive("tracing::span::active=off".parse().unwrap())
-		.add_directive("tokio=info".parse().unwrap())
-		.add_directive("runtime=info".parse().unwrap());
-
-	let logcat_layer = tracing_android::layer("MoQNative")
-		.map_err(|err| MoqError::Log(format!("failed to initialize Android logcat layer: {err}")))?
-		.with_filter(filter);
-
-	tracing_subscriber::registry().with(logcat_layer).init();
-
-	Ok(())
-}
-
-#[cfg(not(all(target_os = "android", feature = "android-logcat")))]
-fn init_logging(level: Level) -> Result<(), MoqError> {
-	moq_native::Log::new(level).init();
 	Ok(())
 }

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -32,6 +32,7 @@ jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 websocket = ["dep:qmux"]
 ring = ["rustls/ring", "rcgen?/ring", "quinn?/rustls-ring"]
 tokio-console = ["dep:console-subscriber"]
+android-logcat = ["dep:tracing-android"]
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
@@ -66,6 +67,9 @@ web-transport-noq = { workspace = true, optional = true }
 web-transport-proto = { workspace = true, optional = true }
 web-transport-quiche = { workspace = true, optional = true }
 web-transport-quinn = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "android")'.dependencies]
+tracing-android = { version = "0.2", optional = true }
 
 [dev-dependencies]
 bytes = "1"

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -3,7 +3,7 @@
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	// Optional: Use moq_native to configure a logger.
-	moq_native::Log::new(tracing::Level::DEBUG).init();
+	moq_native::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that we can publish to and the session can consume from.
 	let origin = moq_net::Origin::random().produce();

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -54,7 +54,7 @@ enum Command {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
 	let config = Config::parse();
-	config.log.init();
+	config.log.init()?;
 
 	let client = config.client.init()?;
 

--- a/rs/moq-native/src/log.rs
+++ b/rs/moq-native/src/log.rs
@@ -1,3 +1,5 @@
+#[cfg(all(target_os = "android", feature = "android-logcat"))]
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_with::DisplayFromStr;
 use tracing::Level;
@@ -34,7 +36,7 @@ impl Log {
 		LevelFilter::from_level(self.level)
 	}
 
-	pub fn init(&self) {
+	pub fn init(&self) -> anyhow::Result<()> {
 		let filter = EnvFilter::builder()
 			.with_default_directive(self.level().into()) // Default to our -q/-v args
 			.from_env_lossy() // Allow overriding with RUST_LOG
@@ -47,27 +49,36 @@ impl Log {
 			.add_directive("tokio=info".parse().unwrap())
 			.add_directive("runtime=info".parse().unwrap());
 
-		let fmt_layer = tracing_subscriber::fmt::layer()
-			.with_writer(std::io::stderr)
-			.with_filter(filter);
+		let registry = tracing_subscriber::registry();
+
+		// On Android, route logs to logcat so they can be inspected via ADB/Android Studio.
+		// Everywhere else, format to stderr.
+		#[cfg(all(target_os = "android", feature = "android-logcat"))]
+		let registry = {
+			let logcat_layer = tracing_android::layer("MoQNative")
+				.context("failed to initialize Android logcat layer")?
+				.with_filter(filter);
+			registry.with(logcat_layer)
+		};
+
+		#[cfg(not(all(target_os = "android", feature = "android-logcat")))]
+		let registry = {
+			let fmt_layer = tracing_subscriber::fmt::layer()
+				.with_writer(std::io::stderr)
+				.with_filter(filter);
+			registry.with(fmt_layer)
+		};
 
 		#[cfg(feature = "tokio-console")]
-		{
-			let console_layer = console_subscriber::spawn();
-			tracing_subscriber::registry()
-				.with(fmt_layer)
-				.with(console_layer)
-				.init();
-		}
+		let registry = registry.with(console_subscriber::spawn());
 
-		#[cfg(not(feature = "tokio-console"))]
-		{
-			tracing_subscriber::registry().with(fmt_layer).init();
-		}
+		registry.init();
 
 		// Start deadlock detection thread (only in debug builds)
 		#[cfg(debug_assertions)]
 		std::thread::spawn(Self::deadlock_detector);
+
+		Ok(())
 	}
 
 	#[cfg(debug_assertions)]

--- a/rs/moq-native/src/log.rs
+++ b/rs/moq-native/src/log.rs
@@ -1,4 +1,3 @@
-#[cfg(all(target_os = "android", feature = "android-logcat"))]
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_with::DisplayFromStr;
@@ -40,14 +39,14 @@ impl Log {
 		let filter = EnvFilter::builder()
 			.with_default_directive(self.level().into()) // Default to our -q/-v args
 			.from_env_lossy() // Allow overriding with RUST_LOG
-			.add_directive("h2=warn".parse().unwrap())
-			.add_directive("quinn=info".parse().unwrap())
-			.add_directive("tungstenite=info".parse().unwrap())
-			.add_directive("rustls=info".parse().unwrap())
-			.add_directive("tracing::span=off".parse().unwrap())
-			.add_directive("tracing::span::active=off".parse().unwrap())
-			.add_directive("tokio=info".parse().unwrap())
-			.add_directive("runtime=info".parse().unwrap());
+			.add_directive("h2=warn".parse()?)
+			.add_directive("quinn=info".parse()?)
+			.add_directive("tungstenite=info".parse()?)
+			.add_directive("rustls=info".parse()?)
+			.add_directive("tracing::span=off".parse()?)
+			.add_directive("tracing::span::active=off".parse()?)
+			.add_directive("tokio=info".parse()?)
+			.add_directive("runtime=info".parse()?);
 
 		let registry = tracing_subscriber::registry();
 
@@ -72,7 +71,7 @@ impl Log {
 		#[cfg(feature = "tokio-console")]
 		let registry = registry.with(console_subscriber::spawn());
 
-		registry.init();
+		registry.try_init().context("failed to set global tracing subscriber")?;
 
 		// Start deadlock detection thread (only in debug builds)
 		#[cfg(debug_assertions)]

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -62,7 +62,7 @@ impl Config {
 	/// the logger.
 	pub fn load() -> anyhow::Result<Self> {
 		let config = Self::parse_and_merge(std::env::args_os())?;
-		config.log.init();
+		config.log.init()?;
 		tracing::trace!(?config, "final config");
 		Ok(config)
 	}


### PR DESCRIPTION
While on iOS the logs can be inspected in xcode the same thing can't be said about android. For this particular usecase, this PR adds support for a android locat tracing subscriber so the logs are properly routed and can be inspected using ADB or Android Studio (both using logcat).