### PR TITLE
test/browser: headless-browser smoke client (phase 2)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -47,4 +47,7 @@ jobs:
         with:
           cache-on-failure: true
 
-      - run: nix develop --command just test smoke
+      # Full matrix incl. the headless-browser client. Browser cells are heavier
+      # (Chromium) so the default `just test smoke` stays rust,python; the nightly
+      # exercises everything. --timeout 30 gives Chromium cold-start headroom.
+      - run: nix develop --command just test smoke --publishers rust,python,js-browser --subscribers rust,python,js-browser --timeout 30

--- a/bun.lock
+++ b/bun.lock
@@ -236,6 +236,17 @@
         "vite": "^7.3.1",
       },
     },
+    "test/browser": {
+      "name": "@moq/smoke-browser",
+      "dependencies": {
+        "@moq/publish": "workspace:*",
+        "@moq/watch": "workspace:*",
+      },
+      "devDependencies": {
+        "playwright": "1.58.2",
+        "vite": "^7.3.1",
+      },
+    },
   },
   "trustedDependencies": [
     "@fails-components/webtransport-transport-http3-quiche",
@@ -512,6 +523,8 @@
     "@moq/qmux": ["@moq/qmux@0.0.6", "", {}, "sha512-ISuGz05lUvf1hzHW3Aw3VnsGRJe1w9Qdog3LQ66KS+l+5mzQsPANvW8yOioEe1Z9dJO2G3sAHoGPnzwnsY9SIQ=="],
 
     "@moq/signals": ["@moq/signals@workspace:js/signals"],
+
+    "@moq/smoke-browser": ["@moq/smoke-browser@workspace:test/browser"],
 
     "@moq/token": ["@moq/token@workspace:js/token"],
 
@@ -1241,6 +1254,10 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -1666,6 +1683,8 @@
     "npm-pick-manifest/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,10 @@
           bun
           # Only for NPM publishing
           nodejs_24
+          # Headless Chromium for the cross-language smoke test (test/browser).
+          # Pin the npm `playwright` version to match this driver (see
+          # test/browser/package.json).
+          playwright-driver.browsers
         ];
 
         # Python dependencies
@@ -198,6 +202,9 @@
 
           shellHook = ''
             export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
+            # Use the nix-provided Chromium instead of letting Playwright download one.
+            export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+            export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
           '';
         };
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"js/signals",
 		"demo/boy",
 		"demo/web",
-		"js/moq-boy"
+		"js/moq-boy",
+		"test/browser"
 	]
 }

--- a/py/moq-rs/examples/smoke.py
+++ b/py/moq-rs/examples/smoke.py
@@ -43,7 +43,7 @@ async def publish(url: str, broadcast: str) -> None:
         media.finish()
 
 
-async def _catalog_with_video(consumer):
+async def _catalog_with_video(consumer: moq.BroadcastConsumer) -> moq.Catalog:
     # The catalog is a live track. A lazy publisher (e.g. the browser, which only
     # encodes on demand) may announce video in a *later* update, not the first
     # snapshot, so wait for a catalog that actually has a video track.

--- a/py/moq-rs/examples/smoke.py
+++ b/py/moq-rs/examples/smoke.py
@@ -43,13 +43,21 @@ async def publish(url: str, broadcast: str) -> None:
         media.finish()
 
 
+async def _catalog_with_video(consumer):
+    # The catalog is a live track. A lazy publisher (e.g. the browser, which only
+    # encodes on demand) may announce video in a *later* update, not the first
+    # snapshot, so wait for a catalog that actually has a video track.
+    async for catalog in consumer.subscribe_catalog():
+        if catalog.video:
+            return catalog
+    raise RuntimeError("catalog stream ended without a video track")
+
+
 async def subscribe(url: str, broadcast: str, timeout: float) -> None:
     async with moq.Client(url, tls_verify=False) as client:
         consumer = await asyncio.wait_for(client.announced_broadcast(broadcast), timeout)
-        catalog = await asyncio.wait_for(consumer.catalog(), timeout)
+        catalog = await asyncio.wait_for(_catalog_with_video(consumer), timeout)
 
-        if not catalog.video:
-            raise RuntimeError("catalog has no video track")
         track_name = next(iter(catalog.video))
         video = catalog.video[track_name]
 

--- a/test/browser/driver.ts
+++ b/test/browser/driver.ts
@@ -1,0 +1,96 @@
+// Drives a headless Chromium (nix-provided, channel "chromium" for WebTransport
+// + WebCodecs) against the prebuilt page in dist/. publish streams a fake camera
+// until killed; subscribe exits 0 once the watch element decodes a frame.
+//
+// Build the page once first: `vite build` (the smoke harness does this).
+//
+//   bun driver.ts publish   --url http://127.0.0.1:4443 --broadcast b.hang
+//   bun driver.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { chromium } from "playwright";
+
+const { positionals, values } = parseArgs({
+	allowPositionals: true,
+	options: {
+		url: { type: "string" },
+		broadcast: { type: "string" },
+		timeout: { type: "string", default: "20" },
+	},
+});
+
+const role = positionals[0];
+const url = values.url;
+const broadcast = values.broadcast;
+if ((role !== "publish" && role !== "subscribe") || !url || !broadcast) {
+	console.error("usage: driver.ts publish|subscribe --url U --broadcast B [--timeout S]");
+	process.exit(2);
+}
+const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
+
+// Serve the prebuilt page on localhost (a secure context, so WebTransport /
+// WebCodecs are enabled). A plain static server avoids running concurrent Vite
+// dev servers, which deadlock on the shared dep-optimizer cache.
+const dist = join(new URL(".", import.meta.url).pathname, "dist");
+const server = Bun.serve({
+	port: 0,
+	async fetch(req) {
+		let path = new URL(req.url).pathname;
+		if (path === "/") path = "/index.html";
+		const file = Bun.file(join(dist, path));
+		if (await file.exists()) return new Response(file);
+		return new Response(Bun.file(join(dist, "index.html"))); // SPA fallback
+	},
+});
+const pageUrl = `http://localhost:${server.port}/?role=${role}&url=${encodeURIComponent(url)}&broadcast=${encodeURIComponent(broadcast)}`;
+
+const browser = await chromium.launch({
+	channel: "chromium", // full Chromium (new headless); the headless shell lacks these APIs
+	headless: true,
+	args: [
+		"--use-fake-device-for-media-stream",
+		"--use-fake-ui-for-media-stream",
+		"--autoplay-policy=no-user-gesture-required",
+	],
+});
+
+let code = 1;
+try {
+	const page = await browser.newPage();
+	page.on("console", (m) => console.error(`[page] ${m.text()}`));
+	page.on("pageerror", (e) => console.error(`[page error] ${e.message}`));
+	await page.goto(pageUrl, { waitUntil: "load" });
+
+	if (role === "publish") {
+		console.error(`publishing ${broadcast} (fake camera) to ${url}`);
+		await new Promise(() => {}); // stream until the orchestrator kills us
+	} else {
+		const start = Date.now();
+		const deadline = start + timeoutMs;
+		let frames = 0;
+		let reloaded = false;
+		while (Date.now() < deadline) {
+			frames = await page.evaluate(() => {
+				const w = document.querySelector("moq-watch") as unknown as {
+					backend?: { video?: { stats?: { peek(): { frameCount?: number } | undefined } } };
+				} | null;
+				return w?.backend?.video?.stats?.peek()?.frameCount ?? 0;
+			});
+			if (frames > 0) break;
+			// The watch element gives up if it subscribes to the catalog before the
+			// publisher has announced it (RESET_STREAM). If nothing has decoded by the
+			// halfway mark, reload once to re-subscribe now that the publisher is up.
+			if (!reloaded && Date.now() - start > timeoutMs / 2) {
+				reloaded = true;
+				await page.reload({ waitUntil: "load" }).catch(() => {});
+			}
+			await new Promise((r) => setTimeout(r, 250));
+		}
+		console.error(`decoded ${frames} frames from ${broadcast}`);
+		code = frames > 0 ? 0 : 1;
+	}
+} finally {
+	await browser.close().catch(() => {});
+	server.stop(true);
+}
+process.exit(code);

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>moq smoke</title>
+  </head>
+  <body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@moq/smoke-browser",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@moq/publish": "workspace:*",
+    "@moq/watch": "workspace:*"
+  },
+  "devDependencies": {
+    "playwright": "1.58.2",
+    "vite": "^7.3.1"
+  }
+}

--- a/test/browser/src/main.ts
+++ b/test/browser/src/main.ts
@@ -1,0 +1,31 @@
+// Standalone page for the browser smoke client. Registers the <moq-publish> /
+// <moq-watch> elements (the public API) and configures one based on ?role=.
+// The Playwright driver polls the watch element's decoded-frame stats signal.
+import "@moq/publish/element";
+import "@moq/watch/element";
+
+const params = new URLSearchParams(location.search);
+const role = params.get("role");
+const url = params.get("url") ?? "";
+const broadcast = params.get("broadcast") ?? "";
+
+if (role === "publish") {
+	const el = document.createElement("moq-publish");
+	el.setAttribute("url", url);
+	el.setAttribute("name", broadcast);
+	el.setAttribute("muted", ""); // video only; keep the audio encoder out of it
+	// Chromium's --use-fake-device-for-media-stream feeds getUserMedia a pattern.
+	el.setAttribute("source", "camera");
+	document.body.appendChild(el);
+} else if (role === "subscribe") {
+	const el = document.createElement("moq-watch");
+	el.setAttribute("url", url);
+	el.setAttribute("name", broadcast);
+	// A render target is what makes <moq-watch> actually subscribe to and decode
+	// the video track. @moq/publish only encodes on subscriber demand, so without
+	// this the publisher never produces frames.
+	el.appendChild(document.createElement("canvas"));
+	document.body.appendChild(el);
+} else {
+	throw new Error("missing ?role=publish|subscribe");
+}

--- a/test/browser/vite.config.ts
+++ b/test/browser/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import { workletInline } from "../../js/common/vite-plugin-worklet";
+
+// workletInline handles the `?worklet` imports in @moq/publish; esnext keeps
+// WebCodecs/WebTransport syntax intact.
+export default defineConfig({
+	plugins: [workletInline()],
+	build: { target: "esnext" },
+});

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -15,6 +15,7 @@ SUBSCRIBERS="rust,python"
 TIMEOUT="${SMOKE_TIMEOUT:-20}"
 FPS="${SMOKE_FPS:-30}"
 SIZE="${SMOKE_SIZE:-320x240}"
+WARMUP="${SMOKE_WARMUP:-2}"
 URL="http://127.0.0.1:4443"
 NEGATIVE=0
 
@@ -93,6 +94,10 @@ require_tools() {
         command -v "$t" >/dev/null 2>&1 || missing+=("$t")
     done
     if needs python; then command -v uv >/dev/null 2>&1 || missing+=("uv"); fi
+    if needs js-browser; then
+        command -v bun >/dev/null 2>&1 || missing+=("bun")
+        [[ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ]] || missing+=("PLAYWRIGHT_BROWSERS_PATH (run inside 'nix develop')")
+    fi
     if [[ ${#missing[@]} -gt 0 ]]; then
         echo "error: missing required tools: ${missing[*]}" >&2
         echo "       run inside 'nix develop' (or install them) and retry." >&2
@@ -112,6 +117,12 @@ if needs python; then
     # moq-rs editable wheel (moq-ffi cdylib + uniffi bindings) from py/moq-rs.
     (cd "$REPO_ROOT/py" && uv sync --no-install-workspace)
     (cd "$REPO_ROOT/py/moq-rs" && uv run --no-sync maturin develop --uv)
+fi
+
+if needs js-browser; then
+    echo "preparing browser harness..."
+    (cd "$REPO_ROOT" && bun install)
+    (cd "$REPO_ROOT/test/browser" && bunx vite build)
 fi
 
 if curl -sf "$URL/certificate.sha256" >/dev/null 2>&1; then
@@ -159,6 +170,12 @@ start_publisher() {
             (ffmpeg_h264 | (cd "$REPO_ROOT/py/moq-rs" && uv run --no-sync python examples/smoke.py \
                 publish --url "$URL" --broadcast "$broadcast")) >"$log" 2>&1 &
             ;;
+        js-browser)
+            # Headless Chromium encodes its own H.264 from a fake camera via
+            # WebCodecs (lazily, once a subscriber creates demand).
+            (cd "$REPO_ROOT" && bun test/browser/driver.ts publish \
+                --url "$URL" --broadcast "$broadcast") >"$log" 2>&1 &
+            ;;
         *)
             echo "unknown publisher: $lang" >&2
             return 1
@@ -182,6 +199,11 @@ run_subscriber() {
             (cd "$REPO_ROOT/py/moq-rs" && uv run --no-sync python examples/smoke.py \
                 subscribe --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT")
             ;;
+        js-browser)
+            # Headless Chromium decodes via WebCodecs; exits 0 once a frame lands.
+            (cd "$REPO_ROOT" && bun test/browser/driver.ts subscribe \
+                --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT")
+            ;;
         *)
             echo "unknown subscriber: $lang" >&2
             return 1
@@ -195,6 +217,10 @@ overall=0
 run_round() {
     local pub="$1" broadcast="$2" pub_pid="$3"
     local pids=() names=() i sub
+    # Let the publisher announce the broadcast + catalog before subscribers
+    # connect. Native subscribers tolerate the race, but the browser watch gives
+    # up on a catalog RESET_STREAM if it connects first.
+    [[ -n "$pub_pid" ]] && sleep "$WARMUP"
     for sub in "${SUB_LIST[@]}"; do
         (run_subscriber "$sub" "$broadcast") >"$TMP/$pub-$sub.log" 2>&1 &
         pids+=("$!")


### PR DESCRIPTION
## Summary

Phase 2 of the cross-language smoke test ([#1529](https://github.com/moq-dev/moq/pull/1529) was phase 1). Adds a **headless-browser** client so the smoke test covers the independent **JS/WebCodecs** implementation interoperating with the native Rust/Python clients over WebTransport.

The full `rust` × `python` × `js-browser` matrix passes in **every** direction:

```
rust       → rust ✓   python ✓   js-browser ✓
python     → rust ✓   python ✓   js-browser ✓
js-browser → rust ✓   python ✓   js-browser ✓
```

## How the browser client works

- **nix-provisioned Chromium**: `flake.nix` pulls `playwright-driver.browsers` and sets `PLAYWRIGHT_BROWSERS_PATH` (npm `playwright` pinned to the driver's **1.58.2**) — no Playwright browser download, reproducible.
- **`test/browser/`**: a standalone Vite page using the real `<moq-publish>` / `<moq-watch>` elements, driven by a Playwright runner (`driver.ts`):
  - Launches **full Chromium** with `channel: "chromium"` (the new headless mode — the default `chrome-headless-shell` lacks WebTransport/WebCodecs/`mediaDevices`).
  - **publish**: a fake camera (`--use-fake-device-for-media-stream`) → WebCodecs H.264 encode → streams until killed.
  - **subscribe**: exits 0 once `<moq-watch>`'s `stats` signal reports a decoded frame.
  - Served as a **prebuilt static bundle** (not a live Vite server) to avoid concurrent dep-optimizer deadlocks.

## Things that needed solving (documented in code)

- `<moq-watch>` only subscribes to/decodes video when it has a **render target**, and `@moq/publish` encodes **lazily on demand** — so the subscriber page adds a `<canvas>`.
- `smoke.py` now waits for a catalog **update** that carries a video track (the browser publisher announces video in a later catalog, not the first snapshot).
- The browser watch gives up if it subscribes to the catalog before the publisher announces it (`RESET_STREAM`), so `test/smoke.sh` adds a publisher **warmup** and the driver **reloads once** mid-timeout to recover from the race.

## Defaults & CI

- Default `just test smoke` stays **rust,python** (fast; browser cells spin Chromium).
- `js-browser` is opt-in via `--publishers/--subscribers`; the nightly `smoke.yml` runs the **full matrix** (`--timeout 30`).

## Notes for reviewers

- Validated locally on macOS (full matrix green). The nightly will be the first run on Linux CI Chromium — it's non-blocking (manual + schedule), so any Linux-headless tweaks surface there without gating PRs.
- shfmt / shellcheck / ruff / biome / actionlint / nixfmt all clean.

## Test plan

- [x] `just test smoke --publishers rust,python,js-browser --subscribers rust,python,js-browser --timeout 30` → all 9 cells PASS
- [x] default `just test smoke` (rust,python) still green
- [ ] nightly `smoke.yml` on Linux CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)