### PR TITLE
nix: format moq-relay module with flake-pinned nixfmt 1.2.0

### DIFF
--- a/nix/modules/moq-relay.nix
+++ b/nix/modules/moq-relay.nix
@@ -215,46 +215,45 @@ in
         AmbientCapabilities = lib.optional (cfg.port < 1024) "CAP_NET_BIND_SERVICE";
       };
 
-      environment =
-        {
-          # Enable jemalloc heap profiling; dump with `kill -USR1 <pid>`
-          MALLOC_CONF = "prof:true,prof_active:true,prof_prefix:${cfg.heapDumpPrefix}";
+      environment = {
+        # Enable jemalloc heap profiling; dump with `kill -USR1 <pid>`
+        MALLOC_CONF = "prof:true,prof_active:true,prof_prefix:${cfg.heapDumpPrefix}";
 
-          MOQ_LOG_LEVEL = lib.mkDefault cfg.logLevel;
+        MOQ_LOG_LEVEL = lib.mkDefault cfg.logLevel;
 
-          # Server configuration
-          MOQ_SERVER_BIND = "[::]:${toString cfg.port}";
+        # Server configuration
+        MOQ_SERVER_BIND = "[::]:${toString cfg.port}";
 
-          MOQ_CLIENT_TLS_DISABLE_VERIFY = lib.boolToString cfg.cluster.disableTlsVerify;
-        }
-        // lib.optionalAttrs (cfg.tls.generate != [ ]) {
-          # TLS configuration
-          MOQ_SERVER_TLS_GENERATE = lib.concatStringsSep "," cfg.tls.generate;
-        }
-        // lib.optionalAttrs (cfg.tls.certs != [ ]) {
-          MOQ_SERVER_TLS_CERT = lib.concatMapStringsSep "," (cert: "${cert.chain}") cfg.tls.certs;
-        }
-        // lib.optionalAttrs (cfg.tls.certs != [ ]) {
-          MOQ_SERVER_TLS_KEY = lib.concatMapStringsSep "," (cert: "${cert.key}") cfg.tls.certs;
-        }
-        // lib.optionalAttrs cfg.auth.enable {
-          # Auth configuration
-          MOQ_AUTH_KEY = if cfg.auth.keyFile != null then cfg.auth.keyFile else "${cfg.stateDir}/root.jwk";
-        }
-        // lib.optionalAttrs (cfg.auth.publicPath != null) {
-          MOQ_AUTH_PUBLIC = cfg.auth.publicPath;
-        }
-        // lib.optionalAttrs (cfg.cluster.rootUrl != null) {
-          # Cluster configuration
-          MOQ_CLUSTER_ROOT = cfg.cluster.rootUrl;
-        }
-        // lib.optionalAttrs (cfg.cluster.mode != "none") {
-          MOQ_CLUSTER_TOKEN =
-            if cfg.cluster.tokenFile != null then cfg.cluster.tokenFile else "${cfg.stateDir}/cluster.jwt";
-        }
-        // lib.optionalAttrs (cfg.cluster.nodeUrl != null) {
-          MOQ_CLUSTER_NODE = cfg.cluster.nodeUrl;
-        };
+        MOQ_CLIENT_TLS_DISABLE_VERIFY = lib.boolToString cfg.cluster.disableTlsVerify;
+      }
+      // lib.optionalAttrs (cfg.tls.generate != [ ]) {
+        # TLS configuration
+        MOQ_SERVER_TLS_GENERATE = lib.concatStringsSep "," cfg.tls.generate;
+      }
+      // lib.optionalAttrs (cfg.tls.certs != [ ]) {
+        MOQ_SERVER_TLS_CERT = lib.concatMapStringsSep "," (cert: "${cert.chain}") cfg.tls.certs;
+      }
+      // lib.optionalAttrs (cfg.tls.certs != [ ]) {
+        MOQ_SERVER_TLS_KEY = lib.concatMapStringsSep "," (cert: "${cert.key}") cfg.tls.certs;
+      }
+      // lib.optionalAttrs cfg.auth.enable {
+        # Auth configuration
+        MOQ_AUTH_KEY = if cfg.auth.keyFile != null then cfg.auth.keyFile else "${cfg.stateDir}/root.jwk";
+      }
+      // lib.optionalAttrs (cfg.auth.publicPath != null) {
+        MOQ_AUTH_PUBLIC = cfg.auth.publicPath;
+      }
+      // lib.optionalAttrs (cfg.cluster.rootUrl != null) {
+        # Cluster configuration
+        MOQ_CLUSTER_ROOT = cfg.cluster.rootUrl;
+      }
+      // lib.optionalAttrs (cfg.cluster.mode != "none") {
+        MOQ_CLUSTER_TOKEN =
+          if cfg.cluster.tokenFile != null then cfg.cluster.tokenFile else "${cfg.stateDir}/cluster.jwt";
+      }
+      // lib.optionalAttrs (cfg.cluster.nodeUrl != null) {
+        MOQ_CLUSTER_NODE = cfg.cluster.nodeUrl;
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary

`just ci` fails the nixfmt check on `dev`: commit 94901323 reformatted `nix/modules/moq-relay.nix` with a newer unstable nixfmt whose indentation of the `environment = {...} // lib.optionalAttrs ...` block disagrees with the flake-pinned `nixfmt 1.2.0` that CI actually runs.

This reformats the file with the pinned `nixfmt 1.2.0` so the check passes. It's purely whitespace (the `environment` attrset is de-indented one level).

This is a `dev`-only issue; `main` never had the offending reformat commit.

## Test plan

- [ ] `nix develop --command nixfmt --check nix/modules/moq-relay.nix` passes
- [ ] `nix develop --command just ci` is green

(Written by Claude)