### PR TITLE
claude: load direnv/nix env on session start so Bash uses pinned tools

### DIFF
--- a/.claude/hooks/direnv.sh
+++ b/.claude/hooks/direnv.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Load the project's direnv/nix dev shell into the Claude Code session so Bash
+# tool commands resolve flake-pinned tools (bun, nixfmt, ...) instead of system
+# ones. No-op for anyone without direnv or an .envrc, so non-nix setups are
+# unaffected.
+#
+# direnv only *approves* the .envrc; the actual env is exported into
+# $CLAUDE_ENV_FILE, which Claude Code sources for every later Bash command.
+
+set -u
+
+# Nothing to export into without this; older Claude Code versions won't set it.
+[ -n "${CLAUDE_ENV_FILE:-}" ] || exit 0
+
+command -v direnv >/dev/null 2>&1 || exit 0
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+[ -f .envrc ] || exit 0
+
+# Clear any inherited direnv state so `export` recomputes the full diff. Without
+# this, a stale DIRENV_DIFF from the parent process makes direnv assume the env
+# is already loaded and emit nothing.
+unset DIRENV_DIR DIRENV_DIFF DIRENV_WATCHES DIRENV_FILE DIRENV_LAYOUT
+
+direnv allow . 2>/dev/null
+direnv export bash >> "$CLAUDE_ENV_FILE" 2>/dev/null
+
+exit 0

--- a/.claude/hooks/direnv.sh
+++ b/.claude/hooks/direnv.sh
@@ -14,7 +14,10 @@ set -u
 
 command -v direnv >/dev/null 2>&1 || exit 0
 
-cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+# Require an explicit project dir so we never approve/export a stray .envrc from
+# some unrelated working directory.
+[ -n "${CLAUDE_PROJECT_DIR:-}" ] || exit 0
+cd "$CLAUDE_PROJECT_DIR" || exit 0
 [ -f .envrc ] || exit 0
 
 # Clear any inherited direnv state so `export` recomputes the full diff. Without
@@ -23,6 +26,6 @@ cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
 unset DIRENV_DIR DIRENV_DIFF DIRENV_WATCHES DIRENV_FILE DIRENV_LAYOUT
 
 direnv allow . 2>/dev/null
-direnv export bash >> "$CLAUDE_ENV_FILE" 2>/dev/null
+direnv export bash >>"$CLAUDE_ENV_FILE" 2>/dev/null
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
 	"$schema": "https://json.schemastore.org/claude-code-settings.json",
+	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/direnv.sh"
+					}
+				]
+			}
+		]
+	},
 	"permissions": {
 		"allow": [
 			"Bash(just *)",


### PR DESCRIPTION
## Summary

Claude Code's Bash tool runs commands non-interactively, so direnv's shell hook never fires. Tools resolve to system versions that disagree with the flake-pinned ones CI uses, producing spurious local failures (e.g. nixfmt formatting diffs, missing `CompressionStream` in older bun). `direnv allow` alone doesn't help: it only approves the `.envrc`, it doesn't export the env into later commands.

This adds a `SessionStart` hook that exports the dev-shell environment into `$CLAUDE_ENV_FILE`, which Claude Code sources for every subsequent Bash command. Result: `bun`, `nixfmt`, etc. match what `just ci` runs under nix.

- `.claude/hooks/direnv.sh` loads the env and writes it to `$CLAUDE_ENV_FILE`.
- It clears inherited `DIRENV_*` state first, otherwise a stale `DIRENV_DIFF` makes `direnv export` emit nothing.
- No-op when `direnv`, an `.envrc`, or `$CLAUDE_ENV_FILE` is absent, so non-nix setups are unaffected.

Note: the hook runs `direnv allow` on session start, so opening the repo in Claude Code auto-approves whatever `.envrc` is present. That's a deliberate, mild trust trade-off baked into the committed config.

## Test plan

- [x] Sourcing the hook output in a clean shell yields bun 1.3.11 / nixfmt 1.2.0 from the nix store
- [x] No-op (exit 0, nothing written) when direnv / `.envrc` / `$CLAUDE_ENV_FILE` is missing
- [ ] In a fresh Claude Code session, `bun --version` reports the flake-pinned version without manual `direnv` steps

(Written by Claude)