### PR TITLE
stats: retain entries by liveness instead of a tick retention window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "moq-net"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bytes",
  "conducer",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -163,11 +163,6 @@ prefix = ".stats"
 # Seconds between snapshot publishes (defaults to 1)
 interval = 1
 
-# Number of intervals an entry lingers in the emitted frame after its
-# last observed change (defaults to 1). A short reconnect window keeps
-# the entry visible across brief disconnects.
-retention = 1
-
 # Node identifier appended to the advertised path to disambiguate broadcasts
 # when multiple relays share a cluster origin. May be multi-segment, e.g.
 # "sjc/1" / "sjc/2" for two hosts nested under a shared region key.
@@ -185,9 +180,11 @@ Each stats broadcast carries four tracks, one per `(tier, role)` pair:
 | `internal/subscriber.json`  | internal ingress                            |
 
 Each frame is a JSON object mapping broadcast path to a cumulative
-counter snapshot. An entry surfaces whenever its snapshot differs from
-the last one emitted, and lingers for `retention` intervals past the
-most recent change:
+counter snapshot. An entry surfaces while the broadcast is live (any open
+counter still exceeds its `*_closed` counterpart, so a subscription could
+begin at any moment) and on the tick its snapshot changes. Once every
+counter equals its `*_closed` counterpart no traffic can flow, so the
+entry is dropped:
 
 ```json
 {
@@ -240,9 +237,8 @@ byte-identical to the last emitted frame; new subscribers still pick up
 a baseline immediately via track-latest semantics.
 
 Every flag also accepts an equivalent CLI argument (`--stats-enabled`,
-`--stats-prefix`, `--stats-interval`, `--stats-retention`,
-`--stats-node`) and environment variable (`MOQ_STATS_ENABLED`,
-`MOQ_STATS_PREFIX`, `MOQ_STATS_INTERVAL`, `MOQ_STATS_RETENTION`,
+`--stats-prefix`, `--stats-interval`, `--stats-node`) and environment
+variable (`MOQ_STATS_ENABLED`, `MOQ_STATS_PREFIX`, `MOQ_STATS_INTERVAL`,
 `MOQ_STATS_NODE`).
 
 ### \[iroh]

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -180,11 +180,11 @@ Each stats broadcast carries four tracks, one per `(tier, role)` pair:
 | `internal/subscriber.json`  | internal ingress                            |
 
 Each frame is a JSON object mapping broadcast path to a cumulative
-counter snapshot. An entry surfaces while the broadcast is live (any open
-counter still exceeds its `*_closed` counterpart, so a subscription could
-begin at any moment) and on the tick its snapshot changes. Once every
-counter equals its `*_closed` counterpart no traffic can flow, so the
-entry is dropped:
+counter snapshot. An entry surfaces on any tick where the broadcast is
+live (any open counter still exceeds its `*_closed` counterpart, so a
+subscription could begin at any moment) or its snapshot changed since the
+previous tick. Once every counter equals its `*_closed` counterpart no
+traffic can flow, so the entry is dropped:
 
 ```json
 {

--- a/rs/moq-net/Cargo.toml
+++ b/rs/moq-net/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -31,7 +31,7 @@ impl Client {
 
 	/// Attach a tier-scoped [`StatsHandle`]. Per-broadcast and per-subscription
 	/// counters will be bumped through this handle for the lifetime of the session.
-	/// Pass [`StatsHandle::disabled`] (also the default) to opt out.
+	/// Pass [`StatsHandle::default`] (a no-op handle) to opt out.
 	pub fn with_stats(mut self, stats: StatsHandle) -> Self {
 		self.stats = stats;
 		self

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -22,7 +22,7 @@ pub(super) struct PublisherConfig<S: web_transport_trait::Session> {
 	/// The origin we read local broadcasts from. None gives this session a
 	/// dummy, immediately-closed origin (i.e. nothing to publish).
 	pub origin: Option<OriginConsumer>,
-	/// Stats aggregator for this session's egress. Use [`MoqStats::disabled`]
+	/// Stats aggregator for this session's egress. Use [`MoqStats::default`]
 	/// to opt out.
 	pub stats: MoqStats,
 	pub version: Version,

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -13,7 +13,7 @@ pub fn start<S: web_transport_trait::Session>(
 	publish: Option<OriginConsumer>,
 	// We will consume any remote broadcasts, inserting them into this origin.
 	subscribe: Option<OriginProducer>,
-	// Tier-scoped stats handle. Pass [`StatsHandle::disabled`] to opt out.
+	// Tier-scoped stats handle. Pass [`StatsHandle::default`] to opt out.
 	stats: StatsHandle,
 	// The version of the protocol to use.
 	version: Version,

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -24,7 +24,7 @@ pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	/// Receiver-side bandwidth producer for PROBE feedback. None disables the
 	/// feature (used by versions that don't carry probe streams).
 	pub recv_bandwidth: Option<BandwidthProducer>,
-	/// Stats aggregator for this session's ingress. Use [`StatsHandle::disabled`]
+	/// Stats aggregator for this session's ingress. Use [`StatsHandle::default`]
 	/// to opt out.
 	pub stats: StatsHandle,
 	pub version: Version,

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -31,7 +31,7 @@ impl Server {
 
 	/// Attach a tier-scoped [`StatsHandle`]. Per-broadcast and per-subscription
 	/// counters will be bumped through this handle for the lifetime of the session.
-	/// Pass [`StatsHandle::disabled`] (also the default) to opt out.
+	/// Pass [`StatsHandle::default`] (a no-op handle) to opt out.
 	pub fn with_stats(mut self, stats: StatsHandle) -> Self {
 		self.stats = stats;
 		self

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -13,11 +13,13 @@
 //! Each frame is a JSON object mapping broadcast path to a cumulative
 //! counter snapshot. Tier, role, and node are implied by the track and
 //! broadcast paths, so they aren't repeated inside the frame. An entry
-//! appears in the frame for a given `(tier, role)` whenever its snapshot
-//! differs from what we last emitted; it then lingers for `retention`
-//! intervals past the most recent change so short disconnects don't
-//! immediately erase it. A downstream aggregator computes rates from successive
-//! cumulative snapshots and slices the data however a dashboard wants.
+//! appears in the frame for a given `(tier, role)` while the broadcast is
+//! live (any open counter still exceeds its `*_closed` counterpart, so a
+//! subscription could begin at any moment) and on the tick its snapshot
+//! changes. Once every counter equals its `*_closed` counterpart no
+//! traffic can flow, so the entry is dropped. A downstream aggregator
+//! computes rates from successive cumulative snapshots and slices the data
+//! however a dashboard wants.
 //!
 //! Per-snapshot semantics:
 //!
@@ -63,7 +65,7 @@
 //! `broadcast()` call on any path spawns the snapshot task, which constructs
 //! the stats broadcast, ticks at the configured interval, and writes a frame
 //! per (tier, role) track. The task exits once the entry map has been empty
-//! for `2 * retention` intervals, dropping the broadcast and unannouncing. The
+//! for a couple of intervals, dropping the broadcast and unannouncing. The
 //! next `broadcast()` call respawns it.
 //!
 //! # Idle frame skipping
@@ -217,21 +219,17 @@ pub struct StatsConfig {
 	pub node: Option<PathOwned>,
 	/// How long the snapshot task waits between publishes. Default 1s.
 	pub interval: Duration,
-	/// How many intervals an entry lingers in the emitted frame after its last
-	/// observed change, so a short reconnect window doesn't erase it. Default 1.
-	pub retention: u32,
 }
 
 impl StatsConfig {
 	/// A config publishing on `origin`, with default settings: `.stats` prefix,
-	/// 1s snapshot interval, retention 1, and no node suffix.
+	/// 1s snapshot interval, and no node suffix.
 	pub fn new(origin: OriginProducer) -> Self {
 		Self {
 			origin,
 			prefix: PathOwned::from(".stats"),
 			node: None,
 			interval: Duration::from_secs(1),
-			retention: 1,
 		}
 	}
 
@@ -244,12 +242,6 @@ impl StatsConfig {
 	/// Override the snapshot interval (default 1s).
 	pub fn with_interval(mut self, interval: Duration) -> Self {
 		self.interval = interval;
-		self
-	}
-
-	/// Override the retention window, in intervals (default 1).
-	pub fn with_retention(mut self, retention: u32) -> Self {
-		self.retention = retention;
 		self
 	}
 
@@ -268,7 +260,6 @@ pub struct Stats {
 	prefix: PathOwned,
 	node: Option<PathOwned>,
 	interval: Duration,
-	retention: u32,
 	enabled: bool,
 	shared: Arc<StatsShared>,
 }
@@ -279,10 +270,6 @@ struct StatsShared {
 	origin: OriginProducer,
 	entries: Lock<HashMap<PathOwned, Arc<BroadcastEntry>>>,
 	task: Lock<Option<()>>,
-	/// Monotonic tick counter; `0` is a sentinel meaning "no tick has run yet"
-	/// so a [`SlotState::last_change_tick == 0`] reliably means "never
-	/// observed". Counts up from `1`.
-	tick_counter: AtomicU64,
 }
 
 /// Per-broadcast counters split by side then tier. The two side fields are
@@ -307,7 +294,7 @@ impl BroadcastEntry {
 /// is single-threaded so this needs no atomics; we keep one of these per
 /// `(path, side, tier)` in a task-local map, mirroring the structure of
 /// [`BroadcastEntry`].
-#[derive(Default, Clone)]
+#[derive(Default)]
 struct SlotState {
 	/// Cumulative count of `inactive -> active` subscription transitions on
 	/// this slot since the snapshot task started. Resets to 0 when the
@@ -317,13 +304,8 @@ struct SlotState {
 	/// Cumulative count of `active -> inactive` transitions.
 	derived_broadcasts_closed: u64,
 	/// Last `Snapshot` we wrote to the frame for this slot, used to detect
-	/// changes that warrant re-emission.
+	/// changes that warrant re-emission and to derive `broadcasts` transitions.
 	prev_emitted: Option<Snapshot>,
-	/// Tick index of the most recent change in `prev_emitted`. `0` means
-	/// no change has been observed yet. Drives both the per-slot frame
-	/// inclusion (within `retention` of this) and the global entry
-	/// GC.
-	last_change_tick: u64,
 }
 
 /// Snapshot-task-local mirror of [`BroadcastEntry`]: per-side, per-tier
@@ -360,11 +342,6 @@ impl EntrySnapState {
 			),
 		]
 	}
-
-	/// Walk all four slot states (read-only). Used by GC.
-	fn all_slots(&self) -> impl Iterator<Item = &SlotState> {
-		self.publisher.iter().chain(self.subscriber.iter())
-	}
 }
 
 /// Number of `(side, tier)` slots, matching the four tracks per stats
@@ -388,7 +365,6 @@ impl Stats {
 			prefix,
 			node,
 			interval,
-			retention,
 		} = config;
 		// An empty path after normalization is indistinguishable from "no node
 		// set"; collapse it so downstream code only sees a single representation.
@@ -399,13 +375,11 @@ impl Stats {
 			prefix,
 			node,
 			interval,
-			retention,
 			enabled: true,
 			shared: Arc::new(StatsShared {
 				origin,
 				entries: Lock::default(),
 				task: Lock::new(None),
-				tick_counter: AtomicU64::new(0),
 			}),
 		}
 	}
@@ -418,13 +392,11 @@ impl Stats {
 			prefix: PathOwned::default(),
 			node: None,
 			interval: Duration::from_secs(1),
-			retention: 0,
 			enabled: false,
 			shared: Arc::new(StatsShared {
 				origin: Origin::random().produce(),
 				entries: Lock::default(),
 				task: Lock::new(None),
-				tick_counter: AtomicU64::new(0),
 			}),
 		}
 	}
@@ -759,7 +731,7 @@ fn ensure_task(stats: &Stats) {
 	if slot.is_none() {
 		*slot = Some(());
 		let weak = Arc::downgrade(&stats.shared);
-		spawn(run_publisher(weak, stats.advertised(), stats.interval, stats.retention));
+		spawn(run_publisher(weak, stats.advertised(), stats.interval));
 	}
 }
 
@@ -767,27 +739,11 @@ fn clear_task(shared: &StatsShared) {
 	*shared.task.lock() = None;
 }
 
-/// True iff any of the supplied slots had a snapshot change within the
-/// retention window. Used by both the global-entry GC and the local-state
-/// GC so they agree on lifetime.
-fn within_retention<'a>(slots: impl IntoIterator<Item = &'a SlotState>, current_tick: u64, retention: u32) -> bool {
-	slots
-		.into_iter()
-		.any(|s| s.last_change_tick != 0 && current_tick.saturating_sub(s.last_change_tick) <= retention as u64)
-}
-
 /// Per-tick work for a single `(side, tier)` slot: derive `broadcasts` /
 /// `broadcasts_closed` from subscription transitions, build the emitted
-/// `Snapshot`, update the slot's `prev_emitted` / `last_change_tick`, and
-/// hand the snap to `emit` iff the slot is still within the retention
-/// window of its most recent change.
-fn process_slot(
-	counters: &Counters,
-	slot_state: &mut SlotState,
-	current_tick: u64,
-	retention: u32,
-	mut emit: impl FnMut(Snapshot),
-) {
+/// `Snapshot`, update the slot's `prev_emitted`, and hand the snap to `emit`
+/// iff the slot is live or changed this tick.
+fn process_slot(counters: &Counters, slot_state: &mut SlotState, mut emit: impl FnMut(Snapshot)) {
 	let raw = counters.snapshot();
 
 	// Derive `broadcasts` / `broadcasts_closed` from subscription-active
@@ -828,12 +784,20 @@ fn process_slot(
 		groups: raw.groups,
 	};
 
-	// Include the entry whenever the snapshot differs from the last
-	// emitted one OR we're still within the retention window of the most
-	// recent change. Change-driven inclusion catches bumps since the
-	// previous tick (incl. sub-tick flickers); the retention path lets
-	// idle entries linger so a downstream "currently active" view doesn't
-	// flicker on a single idle tick.
+	// A slot is live while any open counter still exceeds its `*_closed`
+	// counterpart: a guard is held, so a subscription could begin at any
+	// moment. Live slots are emitted every tick so a downstream "currently
+	// active" view always sees the full set. Once every pair is equal no
+	// traffic can flow and the entry is on its way out (the global GC drops
+	// it as soon as the last guard releases its `Arc`).
+	let live = snap.announced != snap.announced_closed
+		|| snap.subscriptions != snap.subscriptions_closed
+		|| snap.broadcasts != snap.broadcasts_closed;
+
+	// Include the entry whenever it's live OR its snapshot changed this
+	// tick. Change-driven inclusion catches bumps since the previous tick
+	// (incl. sub-tick flickers) and emits the final close snapshot on the
+	// tick a slot transitions to fully closed.
 	//
 	// `None` (slot never emitted) is treated as the default Snapshot so a
 	// first-tick all-zeros snap on an unused tier-side slot doesn't count
@@ -843,16 +807,19 @@ fn process_slot(
 	let prev_snap = slot_state.prev_emitted.unwrap_or_default();
 	let changed = snap != prev_snap;
 	if changed {
-		slot_state.last_change_tick = current_tick;
 		slot_state.prev_emitted = Some(snap);
 	}
-	if slot_state.last_change_tick != 0 && current_tick.saturating_sub(slot_state.last_change_tick) <= retention as u64
-	{
+	if live || changed {
 		emit(snap);
 	}
 }
 
-async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval: Duration, retention: u32) {
+/// How many consecutive empty ticks before the snapshot task exits and
+/// unannounces. A small grace avoids spawn/exit churn when broadcasts come
+/// and go between ticks; the next `broadcast()` respawns the task.
+const EMPTY_EXIT_TICKS: u32 = 2;
+
+async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval: Duration) {
 	let Some(shared) = weak.upgrade() else {
 		return;
 	};
@@ -879,9 +846,9 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 	}
 	drop(shared);
 
-	// Per-path snapshot state owned by this task. Mirrors entries we've
-	// seen recently; serves both as the diff source for change detection
-	// and as the authority on which global entries to GC.
+	// Per-path snapshot state owned by this task. Mirrors the global entries
+	// and serves as the diff source for change detection and `broadcasts`
+	// derivation across ticks.
 	let mut local: HashMap<PathOwned, EntrySnapState> = HashMap::new();
 	let mut last_payload: [Vec<u8>; NUM_SLOTS] = Default::default();
 	let mut empty_ticks: u32 = 0;
@@ -896,8 +863,6 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 			return;
 		};
 
-		let current_tick = shared.tick_counter.fetch_add(1, Ordering::Relaxed) + 1;
-
 		// Clone the current entries map into a Vec so we can drop the
 		// global lock before the change-detection pass.
 		let entries: Vec<(PathOwned, Arc<BroadcastEntry>)> = {
@@ -909,38 +874,27 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 		for (path, entry) in &entries {
 			let snap_state = local.entry(path.clone()).or_default();
 			for (i, (_track_name, counters, slot_state)) in snap_state.zip_slots(entry).into_iter().enumerate() {
-				process_slot(counters, slot_state, current_tick, retention, |snap| {
+				process_slot(counters, slot_state, |snap| {
 					frames[i].insert(path.as_str().to_string(), snap);
 				});
 			}
 		}
-		// Build a snapshot of the live path set before dropping `entries`
-		// (the Arc clones we hold inflate strong_count for the GC check).
-		let live: std::collections::HashSet<PathOwned> = entries.iter().map(|(p, _)| p.clone()).collect();
 		drop(entries);
 
-		// GC global entries: keep if any external guard still holds the
-		// Arc, OR our local state shows a recent change. Without the
-		// `strong_count > 1` check a bump racing with GC could land on an
-		// orphaned Arc and be silently lost.
+		// GC global entries: keep only those an external guard still holds.
+		// `strong_count == 1` (just the map's own `Arc`) means no live
+		// publisher/subscriber/track guard remains, so every open counter
+		// has caught up to its `*_closed` counterpart and no traffic can
+		// flow. We can't key this on the counters directly: a held but idle
+		// `BroadcastStats` (all counters equal) must stay so a later bump
+		// isn't lost on an orphaned `Arc`. Then drop local state for any
+		// path that left the map. We already emitted each removed entry's
+		// final snapshot above, so nothing is lost.
 		{
 			let mut map = shared.entries.lock();
-			map.retain(|path, entry| {
-				if Arc::strong_count(entry) > 1 {
-					return true;
-				}
-				local
-					.get(path)
-					.is_some_and(|snap_state| within_retention(snap_state.all_slots(), current_tick, retention))
-			});
+			map.retain(|_, entry| Arc::strong_count(entry) > 1);
+			local.retain(|path, _| map.contains_key(path));
 		}
-
-		// GC local state: drop entries whose global counterpart is gone
-		// AND retention has expired. Bounded growth even if a relay
-		// churns through many transient broadcast paths.
-		local.retain(|path, snap_state| {
-			live.contains(path) || within_retention(snap_state.all_slots(), current_tick, retention)
-		});
 
 		for (((frame, last), track), slot) in frames
 			.iter()
@@ -974,8 +928,7 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 			// learn anything new, drop the broadcast and let the next bump
 			// respawn us. Take the task slot under lock and re-check the map
 			// to avoid racing with a fresh insert.
-			let exit_threshold = retention.saturating_mul(2).max(1);
-			if empty_ticks >= exit_threshold {
+			if empty_ticks >= EMPTY_EXIT_TICKS {
 				let mut slot = shared.task.lock();
 				if shared.entries.lock().is_empty() {
 					*slot = None;
@@ -1032,11 +985,8 @@ mod tests {
 
 	fn test_stats(node: Option<&str>) -> (Stats, OriginProducer) {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(
-			StatsConfig::new(origin.clone())
-				.with_retention(10)
-				.with_node(node.map(|s| PathOwned::from(s.to_string()))),
-		);
+		let stats =
+			Stats::new(StatsConfig::new(origin.clone()).with_node(node.map(|s| PathOwned::from(s.to_string()))));
 		(stats, origin)
 	}
 
@@ -1054,18 +1004,10 @@ mod tests {
 	#[test]
 	fn new_normalizes_and_drops_empty_node() {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(
-			StatsConfig::new(origin.clone())
-				.with_retention(10)
-				.with_node(PathOwned::from("/sjc//1/".to_string())),
-		);
+		let stats = Stats::new(StatsConfig::new(origin.clone()).with_node(PathOwned::from("/sjc//1/".to_string())));
 		assert_eq!(stats.advertised().as_str(), ".stats/node/sjc/1");
 
-		let stats = Stats::new(
-			StatsConfig::new(origin)
-				.with_retention(10)
-				.with_node(PathOwned::from("///".to_string())),
-		);
+		let stats = Stats::new(StatsConfig::new(origin).with_node(PathOwned::from("///".to_string())));
 		assert_eq!(stats.advertised().as_str(), ".stats/node");
 	}
 
@@ -1155,7 +1097,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn task_announces_without_node_suffix() {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(StatsConfig::new(origin.clone()).with_retention(10));
+		let stats = Stats::new(StatsConfig::new(origin.clone()));
 		let mut consumer = origin.consume();
 
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
@@ -1184,94 +1126,54 @@ mod tests {
 	}
 
 	#[tokio::test(start_paused = true)]
-	async fn retention_boundary_after_drop() {
-		// retention=2 lingers exactly 2 idle ticks after the LAST
-		// snapshot change. The drop itself is a change (it bumps
-		// announced_closed/subs_closed/derived broadcasts_closed), so the
-		// retention countdown starts from the tick that observes the drop,
-		// not the tick that observed the open guard.
-		let origin = Origin::random().produce();
-		let stats = Stats::new(
-			StatsConfig::new(origin)
-				.with_retention(2)
-				.with_node(PathOwned::from("sjc".to_string())),
+	async fn live_entry_kept_while_idle() {
+		// A broadcast with a live announce guard but no traffic must stay in
+		// the map indefinitely: announced != announced_closed means a
+		// subscription could still begin at any moment.
+		let (stats, _origin) = test_stats(Some("sjc"));
+		let key = PathOwned::from("foo/bar".to_string());
+		let bs = stats.tier(Tier::External).broadcast("foo/bar");
+		let guard = bs.publisher();
+
+		drive_ticks(5).await;
+		assert!(
+			stats.shared.entries.lock().contains_key(&key),
+			"announced-but-idle broadcast must stay while the guard is held"
 		);
+
+		drop(guard);
+		drop(bs);
+		// announced == announced_closed now, and no guard holds the Arc, so
+		// the entry is dropped on the next tick.
+		drive_ticks(1).await;
+		assert!(
+			!stats.shared.entries.lock().contains_key(&key),
+			"entry dropped once the announce guard closes"
+		);
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn entry_dropped_once_fully_closed() {
+		// Once every open counter equals its `*_closed` counterpart and no
+		// guard holds the Arc, the entry is removed the very next tick.
+		let (stats, _origin) = test_stats(Some("sjc"));
 		let key = PathOwned::from("foo/bar".to_string());
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
 		let track = bs.publisher().track("video");
 
-		// Tick 1: observe open. snapshot changes.
 		drive_ticks(1).await;
+		assert!(
+			stats.shared.entries.lock().contains_key(&key),
+			"live entry present while the track guard is held"
+		);
+
 		drop(track);
 		drop(bs);
-
-		// Tick 2: observe drop. snapshot changes (broadcasts_closed bumps).
-		drive_ticks(1).await;
-		assert!(
-			stats.shared.entries.lock().contains_key(&key),
-			"kept on the tick the drop is observed"
-		);
-		// Tick 3: idle tick 1 after change. diff=1<=2, kept.
-		drive_ticks(1).await;
-		assert!(
-			stats.shared.entries.lock().contains_key(&key),
-			"kept after 1 idle tick (retention=2)"
-		);
-		// Tick 4: idle tick 2. diff=2<=2, kept.
-		drive_ticks(1).await;
-		assert!(
-			stats.shared.entries.lock().contains_key(&key),
-			"kept after 2 idle ticks (retention=2)"
-		);
-		// Tick 5: idle tick 3. diff=3>2, GC'd.
 		drive_ticks(1).await;
 		assert!(
 			!stats.shared.entries.lock().contains_key(&key),
-			"GC'd after 3 idle ticks (retention=2)"
+			"fully-closed entry dropped on the next tick"
 		);
-	}
-
-	#[tokio::test(start_paused = true)]
-	async fn retention_keeps_recently_dropped_entry() {
-		let (stats, _origin) = test_stats(Some("sjc"));
-		let bs = stats.tier(Tier::External).broadcast("foo/bar");
-		let track = bs.publisher().track("video");
-
-		drive_ticks(2).await;
-		drop(track);
-		drop(bs);
-		// Within retention=10. Drop is observed as a change at tick 3,
-		// so we have plenty of ticks left before GC.
-		drive_ticks(3).await;
-
-		assert!(
-			stats
-				.shared
-				.entries
-				.lock()
-				.contains_key(&PathOwned::from("foo/bar".to_string())),
-			"entry must remain in the map within the retention window"
-		);
-	}
-
-	#[tokio::test(start_paused = true)]
-	async fn retention_evicts_after_window() {
-		let origin = Origin::random().produce();
-		let stats = Stats::new(
-			StatsConfig::new(origin)
-				.with_retention(2)
-				.with_node(PathOwned::from("sjc".to_string())),
-		);
-		let bs = stats.tier(Tier::External).broadcast("foo/bar");
-		let track = bs.publisher().track("video");
-
-		drive_ticks(2).await;
-		drop(track);
-		drop(bs);
-		// Far past 2 * retention so the entry is fully aged out.
-		drive_ticks(10).await;
-
-		assert!(stats.shared.entries.lock().is_empty(), "entries should be GC'd");
 	}
 
 	#[tokio::test(start_paused = true)]
@@ -1387,10 +1289,11 @@ mod tests {
 			assert_eq!(raw.subscriptions_closed, 0, "neither dropped yet");
 		}
 
+		// Drop only the track guards; keep `pub_guard` (and `bs`) so the
+		// broadcast stays announced (live) and the entry isn't GC'd before
+		// we can read the raw counters.
 		drop(t1);
 		drop(t2);
-		drop(pub_guard);
-		drop(bs);
 		drive_ticks(1).await;
 
 		// All subs dropped: subscriptions_closed catches up to subscriptions.
@@ -1401,7 +1304,7 @@ mod tests {
 		let entries = stats.shared.entries.lock();
 		let entry = entries
 			.get(&PathOwned::from("foo/bar"))
-			.expect("entry still in retention");
+			.expect("entry still live (publisher guard held)");
 		let raw = entry.publisher[Tier::External.idx()].snapshot();
 		assert_eq!(raw.subscriptions, 2);
 		assert_eq!(raw.subscriptions_closed, 2, "both dropped");

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -54,19 +54,20 @@
 //!
 //! # Disabled stats
 //!
-//! [`Stats::disabled`] (and the matching [`Default`] impl) returns a no-op
-//! aggregator. All counter bumps through it are silently dropped and no
-//! snapshot task is ever spawned, so call sites can hold a [`StatsHandle`]
-//! unconditionally instead of threading an `Option`.
+//! A [`StatsConfig`] with no origin (the default) builds a no-op aggregator:
+//! all counter bumps are silently dropped, no snapshot task spawns, and no
+//! broadcast is published. [`Stats::default`] / [`StatsHandle::default`]
+//! return one, so call sites can hold a [`StatsHandle`] unconditionally
+//! instead of threading an `Option`.
 //!
 //! # Lifecycle
 //!
-//! No background work runs until something happens worth reporting. The first
-//! `broadcast()` call on any path spawns the snapshot task, which constructs
-//! the stats broadcast, ticks at the configured interval, and writes a frame
-//! per (tier, role) track. The task exits once the entry map has been empty
-//! for a couple of intervals, dropping the broadcast and unannouncing. The
-//! next `broadcast()` call respawns it.
+//! When the config has an origin, [`Stats::new`] spawns the snapshot task
+//! immediately, publishes the stats broadcast, and ticks at the configured
+//! interval, writing a frame per (tier, role) track. The broadcast stays
+//! announced for the lifetime of the [`Stats`] aggregator, even while idle
+//! (frames just go to `{}`). The task exits when the last [`Stats`] clone is
+//! dropped (the task holds only a `Weak` to the shared state).
 //!
 //! # Idle frame skipping
 //!
@@ -110,7 +111,7 @@ use std::{
 use serde::Serialize;
 use web_async::{Lock, spawn};
 
-use crate::{AsPath, Broadcast, Origin, OriginProducer, Path, PathOwned, Track, TrackProducer};
+use crate::{AsPath, Broadcast, OriginProducer, Path, PathOwned, Track, TrackProducer};
 
 /// Cumulative atomic counters for a single `(tier, role)` on a broadcast.
 ///
@@ -193,9 +194,12 @@ impl Tier {
 }
 
 /// Settings for a [`Stats`] aggregator. Construct with [`StatsConfig::new`]
-/// (the origin is required) and chain the `with_*` setters (e.g.
-/// `StatsConfig::new(origin).with_prefix(".foo")`), then hand it to
-/// [`Stats::new`].
+/// and chain the `with_*` setters (e.g.
+/// `StatsConfig::new().with_origin(origin).with_prefix(".foo")`), then hand it
+/// to [`Stats::new`].
+///
+/// With no origin set the resulting aggregator is a no-op: bumps are dropped
+/// and no task spawns. Call [`StatsConfig::with_origin`] to publish.
 ///
 /// Distinct from the relay's clap-derived `StatsConfig`, which holds the raw
 /// CLI/TOML knobs and resolves into one of these.
@@ -206,7 +210,8 @@ impl Tier {
 #[non_exhaustive]
 pub struct StatsConfig {
 	/// Origin that receives the stats broadcast's `publish_broadcast` calls.
-	pub origin: OriginProducer,
+	/// When `None`, [`Stats::new`] spawns no task and publishes nothing.
+	pub origin: Option<OriginProducer>,
 	/// Top-level path stats are published under (default `.stats`). The full
 	/// advertised path is `<prefix>/node/<node>` (or `<prefix>/node` when
 	/// `node` is unset).
@@ -222,15 +227,23 @@ pub struct StatsConfig {
 }
 
 impl StatsConfig {
-	/// A config publishing on `origin`, with default settings: `.stats` prefix,
-	/// 1s snapshot interval, and no node suffix.
-	pub fn new(origin: OriginProducer) -> Self {
+	/// A config with default settings: no origin (no-op), `.stats` prefix, 1s
+	/// snapshot interval, and no node suffix. Call [`Self::with_origin`] to
+	/// actually publish.
+	pub fn new() -> Self {
 		Self {
-			origin,
+			origin: None,
 			prefix: PathOwned::from(".stats"),
 			node: None,
 			interval: Duration::from_secs(1),
 		}
+	}
+
+	/// Set the origin to publish the stats broadcast on. Without this the
+	/// aggregator is a no-op.
+	pub fn with_origin(mut self, origin: impl Into<Option<OriginProducer>>) -> Self {
+		self.origin = origin.into();
+		self
 	}
 
 	/// Override the top-level prefix (default `.stats`).
@@ -252,24 +265,28 @@ impl StatsConfig {
 	}
 }
 
+impl Default for StatsConfig {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
 /// Top-level stats aggregator. Cheap to clone (`Arc` inside for the shared
 /// runtime state). One instance per relay; sessions get tier-scoped handles via
 /// [`Stats::tier`]. Build it from a [`StatsConfig`] via [`Stats::new`].
 #[derive(Clone)]
 pub struct Stats {
 	prefix: PathOwned,
-	node: Option<PathOwned>,
-	interval: Duration,
-	enabled: bool,
-	shared: Arc<StatsShared>,
+	/// `None` for a no-op aggregator (config had no origin): bumps are
+	/// dropped and no task was spawned.
+	shared: Option<Arc<StatsShared>>,
 }
 
 /// Runtime state shared by every clone of a [`Stats`] and held by the
-/// snapshot task through a `Weak`.
+/// snapshot task through a `Weak`. Only allocated when an origin is set.
 struct StatsShared {
 	origin: OriginProducer,
 	entries: Lock<HashMap<PathOwned, Arc<BroadcastEntry>>>,
-	task: Lock<Option<()>>,
 }
 
 /// Per-broadcast counters split by side then tier. The two side fields are
@@ -359,6 +376,12 @@ const TRACK_ORDER: [&str; NUM_SLOTS] = [
 
 impl Stats {
 	/// Build a stats aggregator from `config`.
+	///
+	/// When `config` has an origin, this spawns the snapshot task immediately
+	/// and publishes the stats broadcast; the task runs until the last [`Stats`]
+	/// clone is dropped. With no origin the aggregator is a no-op (bumps are
+	/// dropped, nothing is published) and no task spawns, so it's safe to build
+	/// outside an async runtime.
 	pub fn new(config: StatsConfig) -> Self {
 		let StatsConfig {
 			origin,
@@ -371,34 +394,18 @@ impl Stats {
 		// We do this here (not in `with_node`) so a directly-assigned
 		// `config.node` is normalized too.
 		let node = node.filter(|p| !p.is_empty());
-		Self {
-			prefix,
-			node,
-			interval,
-			enabled: true,
-			shared: Arc::new(StatsShared {
+
+		let shared = origin.map(|origin| {
+			let shared = Arc::new(StatsShared {
 				origin,
 				entries: Lock::default(),
-				task: Lock::new(None),
-			}),
-		}
-	}
+			});
+			let advertised = advertised_path(&prefix, node.as_ref().map(|p| p.as_str()));
+			spawn(run_publisher(Arc::downgrade(&shared), advertised, interval));
+			shared
+		});
 
-	/// A no-op aggregator. Counter bumps are silently dropped and no snapshot
-	/// task is ever spawned. Use this when stats are disabled so call sites
-	/// can hold a [`Stats`] (or [`StatsHandle`]) unconditionally.
-	pub fn disabled() -> Self {
-		Self {
-			prefix: PathOwned::default(),
-			node: None,
-			interval: Duration::from_secs(1),
-			enabled: false,
-			shared: Arc::new(StatsShared {
-				origin: Origin::random().produce(),
-				entries: Lock::default(),
-				task: Lock::new(None),
-			}),
-		}
+		Self { prefix, shared }
 	}
 
 	/// Returns the configured top-level prefix.
@@ -406,12 +413,11 @@ impl Stats {
 		&self.prefix
 	}
 
-	/// The path the stats broadcast publishes on. Derived from `prefix` +
-	/// `node` on demand; the snapshot task spawns rarely, so recomputing here
-	/// is cheaper than threading it through the shared state. Only meaningful
-	/// when enabled (a disabled aggregator never spawns a task).
-	fn advertised(&self) -> PathOwned {
-		advertised_path(&self.prefix, self.node.as_ref().map(|p| p.as_str()))
+	/// The shared state, panicking for a no-op aggregator. Tests build with an
+	/// origin so this is always present.
+	#[cfg(test)]
+	fn shared(&self) -> &Arc<StatsShared> {
+		self.shared.as_ref().expect("enabled stats aggregator")
 	}
 
 	/// Returns a tier-scoped handle. Bumps through this handle land in the
@@ -424,10 +430,8 @@ impl Stats {
 	}
 
 	fn entry(&self, path: impl AsPath) -> Option<Arc<BroadcastEntry>> {
-		// Disabled aggregator never allocates state.
-		if !self.enabled {
-			return None;
-		}
+		// No-op aggregator (no origin) never allocates state.
+		let shared = self.shared.as_ref()?;
 		let path = path.as_path();
 		// Skip our own stats broadcasts (and any sibling category under the
 		// same prefix) so serving a stats broadcast doesn't generate more
@@ -436,21 +440,19 @@ impl Stats {
 			return None;
 		}
 		let owned = path.to_owned();
-		let arc = {
-			let mut entries = self.shared.entries.lock();
+		let mut entries = shared.entries.lock();
+		Some(
 			entries
 				.entry(owned)
 				.or_insert_with(|| Arc::new(BroadcastEntry::new()))
-				.clone()
-		};
-		ensure_task(self);
-		Some(arc)
+				.clone(),
+		)
 	}
 }
 
 impl Default for Stats {
 	fn default() -> Self {
-		Self::disabled()
+		Self::new(StatsConfig::new())
 	}
 }
 
@@ -463,11 +465,6 @@ pub struct StatsHandle {
 }
 
 impl StatsHandle {
-	/// A no-op handle. See [`Stats::disabled`].
-	pub fn disabled() -> Self {
-		Stats::disabled().tier(Tier::External)
-	}
-
 	/// The aggregator this handle is tied to.
 	pub fn parent(&self) -> &Stats {
 		&self.stats
@@ -492,8 +489,9 @@ impl StatsHandle {
 }
 
 impl Default for StatsHandle {
+	/// A no-op handle backed by a [`Stats::default`] aggregator.
 	fn default() -> Self {
-		Self::disabled()
+		Stats::default().tier(Tier::External)
 	}
 }
 
@@ -723,22 +721,6 @@ impl Drop for SubscriberTrack {
 	}
 }
 
-fn ensure_task(stats: &Stats) {
-	if !stats.enabled {
-		return;
-	}
-	let mut slot = stats.shared.task.lock();
-	if slot.is_none() {
-		*slot = Some(());
-		let weak = Arc::downgrade(&stats.shared);
-		spawn(run_publisher(weak, stats.advertised(), stats.interval));
-	}
-}
-
-fn clear_task(shared: &StatsShared) {
-	*shared.task.lock() = None;
-}
-
 /// Per-tick work for a single `(side, tier)` slot: derive `broadcasts` /
 /// `broadcasts_closed` from subscription transitions, build the emitted
 /// `Snapshot`, update the slot's `prev_emitted`, and hand the snap to `emit`
@@ -814,11 +796,9 @@ fn process_slot(counters: &Counters, slot_state: &mut SlotState, mut emit: impl 
 	}
 }
 
-/// How many consecutive empty ticks before the snapshot task exits and
-/// unannounces. A small grace avoids spawn/exit churn when broadcasts come
-/// and go between ticks; the next `broadcast()` respawns the task.
-const EMPTY_EXIT_TICKS: u32 = 2;
-
+/// Publishes the stats broadcast and writes a frame per tick. Spawned once by
+/// [`Stats::new`] when an origin is set; runs until every [`Stats`] clone is
+/// dropped (`weak.upgrade()` returns `None`).
 async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval: Duration) {
 	let Some(shared) = weak.upgrade() else {
 		return;
@@ -834,14 +814,12 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 			Ok(t) => tracks.push(t),
 			Err(err) => {
 				tracing::warn!(?err, name, "stats: failed to create track");
-				clear_task(&shared);
 				return;
 			}
 		}
 	}
 	if !shared.origin.publish_broadcast(&advertised, broadcast.consume()) {
 		tracing::warn!(advertised = %advertised, "stats: origin rejected stats broadcast");
-		clear_task(&shared);
 		return;
 	}
 	drop(shared);
@@ -851,7 +829,6 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 	// derivation across ticks.
 	let mut local: HashMap<PathOwned, EntrySnapState> = HashMap::new();
 	let mut last_payload: [Vec<u8>; NUM_SLOTS] = Default::default();
-	let mut empty_ticks: u32 = 0;
 
 	let mut ticker = tokio::time::interval(interval);
 	ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -921,28 +898,7 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 			*last = json;
 		}
 
-		let map_empty = shared.entries.lock().is_empty();
-		if map_empty {
-			empty_ticks = empty_ticks.saturating_add(1);
-			// Once the map has been empty long enough that no consumer could
-			// learn anything new, drop the broadcast and let the next bump
-			// respawn us. Take the task slot under lock and re-check the map
-			// to avoid racing with a fresh insert.
-			if empty_ticks >= EMPTY_EXIT_TICKS {
-				let mut slot = shared.task.lock();
-				if shared.entries.lock().is_empty() {
-					*slot = None;
-					drop(slot);
-					drop(shared);
-					drop(tracks);
-					drop(broadcast);
-					return;
-				}
-				empty_ticks = 0;
-			}
-		} else {
-			empty_ticks = 0;
-		}
+		drop(shared);
 	}
 }
 
@@ -985,8 +941,11 @@ mod tests {
 
 	fn test_stats(node: Option<&str>) -> (Stats, OriginProducer) {
 		let origin = Origin::random().produce();
-		let stats =
-			Stats::new(StatsConfig::new(origin.clone()).with_node(node.map(|s| PathOwned::from(s.to_string()))));
+		let stats = Stats::new(
+			StatsConfig::new()
+				.with_origin(origin.clone())
+				.with_node(node.map(|s| PathOwned::from(s.to_string()))),
+		);
 		(stats, origin)
 	}
 
@@ -1001,14 +960,26 @@ mod tests {
 		assert_eq!(advertised_path(&prefix, Some("lon")).as_str(), "metrics/node/lon");
 	}
 
-	#[test]
-	fn new_normalizes_and_drops_empty_node() {
+	/// The advertised path normalizes a messy node suffix and drops an
+	/// all-empty one. Observed through the announced path, since the task
+	/// announces at construction.
+	async fn announced_path_for_node(node: &str) -> String {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(StatsConfig::new(origin.clone()).with_node(PathOwned::from("/sjc//1/".to_string())));
-		assert_eq!(stats.advertised().as_str(), ".stats/node/sjc/1");
+		let _stats = Stats::new(
+			StatsConfig::new()
+				.with_origin(origin.clone())
+				.with_node(PathOwned::from(node.to_string())),
+		);
+		let mut consumer = origin.consume();
+		tokio::time::advance(Duration::from_millis(1)).await;
+		let (path, _broadcast) = consumer.announced().await.expect("expected announce");
+		path.as_str().to_string()
+	}
 
-		let stats = Stats::new(StatsConfig::new(origin).with_node(PathOwned::from("///".to_string())));
-		assert_eq!(stats.advertised().as_str(), ".stats/node");
+	#[tokio::test(start_paused = true)]
+	async fn new_normalizes_and_drops_empty_node() {
+		assert_eq!(announced_path_for_node("/sjc//1/").await, ".stats/node/sjc/1");
+		assert_eq!(announced_path_for_node("///").await, ".stats/node");
 	}
 
 	#[tokio::test(start_paused = true)]
@@ -1022,7 +993,7 @@ mod tests {
 		let g2 = bs2.publisher().track("video");
 		g2.bytes(7);
 
-		let entries = stats.shared.entries.lock();
+		let entries = stats.shared().entries.lock();
 		let e1 = entries.get(&PathOwned::from("demo/bbb")).expect("entry");
 		let e2 = entries.get(&PathOwned::from("demo/ccc")).expect("entry");
 		assert_eq!(e1.publisher[Tier::External.idx()].bytes.load(Relaxed), 100);
@@ -1040,7 +1011,7 @@ mod tests {
 		let int_track = int.broadcast("demo/bbb").subscriber().track("audio");
 		int_track.bytes(7);
 
-		let entries = stats.shared.entries.lock();
+		let entries = stats.shared().entries.lock();
 		let entry = entries.get(&PathOwned::from("demo/bbb")).expect("entry");
 		assert_eq!(entry.publisher[Tier::External.idx()].bytes.load(Relaxed), 100);
 		assert_eq!(entry.subscriber[Tier::External.idx()].bytes.load(Relaxed), 0);
@@ -1060,12 +1031,15 @@ mod tests {
 		track.bytes(100);
 		drop(track);
 		drop(p);
-		assert!(stats.shared.entries.lock().is_empty());
+		assert!(stats.shared().entries.lock().is_empty());
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn disabled_stats_are_noop() {
-		let stats = Stats::disabled();
+		// A no-op aggregator (no origin) allocates no shared state and never
+		// announces; every handle is empty and bumps are dropped.
+		let stats = Stats::default();
+		assert!(stats.shared.is_none());
 		let bs = stats.tier(Tier::External).broadcast("demo/bbb");
 		assert!(bs.is_empty());
 		let p = bs.publisher();
@@ -1073,7 +1047,6 @@ mod tests {
 		track.bytes(100);
 		drop(track);
 		drop(p);
-		assert!(stats.shared.entries.lock().is_empty());
 	}
 
 	#[tokio::test(start_paused = true)]
@@ -1097,7 +1070,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn task_announces_without_node_suffix() {
 		let origin = Origin::random().produce();
-		let stats = Stats::new(StatsConfig::new(origin.clone()));
+		let stats = Stats::new(StatsConfig::new().with_origin(origin.clone()));
 		let mut consumer = origin.consume();
 
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
@@ -1137,7 +1110,7 @@ mod tests {
 
 		drive_ticks(5).await;
 		assert!(
-			stats.shared.entries.lock().contains_key(&key),
+			stats.shared().entries.lock().contains_key(&key),
 			"announced-but-idle broadcast must stay while the guard is held"
 		);
 
@@ -1147,7 +1120,7 @@ mod tests {
 		// the entry is dropped on the next tick.
 		drive_ticks(1).await;
 		assert!(
-			!stats.shared.entries.lock().contains_key(&key),
+			!stats.shared().entries.lock().contains_key(&key),
 			"entry dropped once the announce guard closes"
 		);
 	}
@@ -1163,7 +1136,7 @@ mod tests {
 
 		drive_ticks(1).await;
 		assert!(
-			stats.shared.entries.lock().contains_key(&key),
+			stats.shared().entries.lock().contains_key(&key),
 			"live entry present while the track guard is held"
 		);
 
@@ -1171,7 +1144,7 @@ mod tests {
 		drop(bs);
 		drive_ticks(1).await;
 		assert!(
-			!stats.shared.entries.lock().contains_key(&key),
+			!stats.shared().entries.lock().contains_key(&key),
 			"fully-closed entry dropped on the next tick"
 		);
 	}
@@ -1282,7 +1255,7 @@ mod tests {
 
 		drive_ticks(2).await;
 		{
-			let entries = stats.shared.entries.lock();
+			let entries = stats.shared().entries.lock();
 			let entry = entries.get(&PathOwned::from("foo/bar")).expect("entry");
 			let raw = entry.publisher[Tier::External.idx()].snapshot();
 			assert_eq!(raw.subscriptions, 2, "two track subs");
@@ -1301,7 +1274,7 @@ mod tests {
 		// broadcasts_closed (which lives in task-local state, not on the
 		// global entry) gets bumped to 1, but we can only see that through
 		// the wire frame. Here we just confirm the raw counters squared up.
-		let entries = stats.shared.entries.lock();
+		let entries = stats.shared().entries.lock();
 		let entry = entries
 			.get(&PathOwned::from("foo/bar"))
 			.expect("entry still live (publisher guard held)");

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -13,13 +13,13 @@
 //! Each frame is a JSON object mapping broadcast path to a cumulative
 //! counter snapshot. Tier, role, and node are implied by the track and
 //! broadcast paths, so they aren't repeated inside the frame. An entry
-//! appears in the frame for a given `(tier, role)` while the broadcast is
-//! live (any open counter still exceeds its `*_closed` counterpart, so a
-//! subscription could begin at any moment) and on the tick its snapshot
-//! changes. Once every counter equals its `*_closed` counterpart no
-//! traffic can flow, so the entry is dropped. A downstream aggregator
-//! computes rates from successive cumulative snapshots and slices the data
-//! however a dashboard wants.
+//! appears in the frame for a given `(tier, role)` on any tick where the
+//! broadcast is live (any open counter still exceeds its `*_closed`
+//! counterpart, so a subscription could begin at any moment) or its
+//! snapshot changed since the previous tick. Once every counter equals its
+//! `*_closed` counterpart no traffic can flow, so the entry is dropped. A
+//! downstream aggregator computes rates from successive cumulative
+//! snapshots and slices the data however a dashboard wants.
 //!
 //! Per-snapshot semantics:
 //!

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -171,7 +171,7 @@ pub struct Cluster {
 	/// Stats aggregator. One instance per relay; sessions pick a tier via
 	/// [`Stats::tier`] at acceptance time so external (non-mTLS) and internal
 	/// (mTLS / cluster peer) traffic land in separate counter sets. Defaults
-	/// to [`Stats::disabled`] (a no-op aggregator) until [`with_stats`](Self::with_stats)
+	/// to a no-op aggregator ([`Stats::default`]) until [`with_stats`](Self::with_stats)
 	/// is called.
 	pub stats: Stats,
 }
@@ -189,7 +189,7 @@ impl Cluster {
 			config,
 			client: None,
 			origin,
-			stats: Stats::disabled(),
+			stats: Stats::default(),
 		}
 	}
 

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -131,7 +131,6 @@ mod tests {
 [stats]
 enabled = true
 interval = 5
-retention = 20
 node = "localhost"
 "#;
 		let dir = std::env::temp_dir().join("moq-relay-config-test");
@@ -149,11 +148,10 @@ node = "localhost"
 			 (any new bare-bool field on a flatten-derived config will have the same bug; \
 			 type it as Option<bool>)"
 		);
-		// New `interval` / `retention` flags must survive the CLI re-parse
-		// the same way. They're typed as `Option<u64>` / `Option<u32>`
-		// rather than bare numeric types for exactly this reason.
+		// The `interval` flag must survive the CLI re-parse the same way.
+		// It's typed as `Option<u64>` rather than a bare numeric type for
+		// exactly this reason.
 		assert_eq!(config.stats.interval, Some(5));
-		assert_eq!(config.stats.retention, Some(20));
 		assert_eq!(config.stats.node.as_deref(), Some("localhost"));
 	}
 

--- a/rs/moq-relay/src/stats.rs
+++ b/rs/moq-relay/src/stats.rs
@@ -16,9 +16,10 @@ use serde::{Deserialize, Serialize};
 /// publishes a single `<prefix>/node/<node>` broadcast (or `<prefix>/node`
 /// when [`Self::node`] is unset) on the cluster origin. Each frame is a
 /// JSON map of broadcast path to a cumulative counter snapshot; an entry
-/// surfaces whenever its snapshot changes, and lingers for
-/// [`Self::retention`] ticks past the most recent change. See
-/// `moq_net::stats` for the per-field semantics.
+/// surfaces while the broadcast is live (any open counter exceeds its
+/// `*_closed` counterpart) and on the tick its snapshot changes, then is
+/// dropped once fully closed. See `moq_net::stats` for the per-field
+/// semantics.
 #[derive(Args, Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 #[non_exhaustive]
@@ -52,12 +53,6 @@ pub struct StatsConfig {
 	#[arg(long = "stats-interval", env = "MOQ_STATS_INTERVAL")]
 	pub interval: Option<u64>,
 
-	/// Number of intervals an entry lingers in the emitted frame after its
-	/// last observed change. Defaults to 1. A short reconnect window keeps
-	/// the entry visible across brief disconnects.
-	#[arg(long = "stats-retention", env = "MOQ_STATS_RETENTION")]
-	pub retention: Option<u32>,
-
 	/// Node identifier appended to the advertised stats path to disambiguate
 	/// broadcasts when multiple relays share a cluster origin. Without this,
 	/// peer relays would publish to the same `<prefix>/node` path and the
@@ -81,14 +76,12 @@ impl StatsConfig {
 		}
 		let prefix = self.prefix.clone().unwrap_or_else(|| ".stats".to_string());
 		let interval = Duration::from_secs(self.interval.unwrap_or(1).max(1));
-		let retention = self.retention.unwrap_or(1).max(1);
 		let node = self.node.clone().map(PathOwned::from);
-		tracing::info!(prefix, interval_secs = interval.as_secs(), retention, node = ?node, "stats publishing enabled");
+		tracing::info!(prefix, interval_secs = interval.as_secs(), node = ?node, "stats publishing enabled");
 		// Fully qualified to disambiguate from this module's clap-derived StatsConfig.
 		let config = moq_net::StatsConfig::new(origin)
 			.with_prefix(prefix)
 			.with_interval(interval)
-			.with_retention(retention)
 			.with_node(node);
 		Stats::new(config)
 	}

--- a/rs/moq-relay/src/stats.rs
+++ b/rs/moq-relay/src/stats.rs
@@ -68,18 +68,19 @@ pub struct StatsConfig {
 impl StatsConfig {
 	/// Build a [`Stats`] aggregator from this config, publishing on `origin`.
 	///
-	/// Returns [`Stats::disabled`] (a no-op aggregator) when [`Self::enabled`]
+	/// Returns a no-op aggregator ([`Stats::default`]) when [`Self::enabled`]
 	/// is false, so the relay can attach the result unconditionally.
 	pub fn build(&self, origin: OriginProducer) -> Stats {
 		if !self.enabled.unwrap_or(false) {
-			return Stats::disabled();
+			return Stats::default();
 		}
 		let prefix = self.prefix.clone().unwrap_or_else(|| ".stats".to_string());
 		let interval = Duration::from_secs(self.interval.unwrap_or(1).max(1));
 		let node = self.node.clone().map(PathOwned::from);
 		tracing::info!(prefix, interval_secs = interval.as_secs(), node = ?node, "stats publishing enabled");
 		// Fully qualified to disambiguate from this module's clap-derived StatsConfig.
-		let config = moq_net::StatsConfig::new(origin)
+		let config = moq_net::StatsConfig::new()
+			.with_origin(origin)
 			.with_prefix(prefix)
 			.with_interval(interval)
 			.with_node(node);


### PR DESCRIPTION
## Summary

Replaces the time-based `retention` knob in the stats aggregator with a state-based rule:

- An entry is emitted into the frame **while it's live** (any open counter still exceeds its `*_closed` counterpart, so a subscription could begin at any moment) and on the tick its snapshot changes.
- Once every counter equals its `*_closed` counterpart, no traffic can flow, so the entry is dropped immediately rather than lingering for N idle ticks.

This keeps a "currently active broadcasts" dashboard view accurate: previously a still-announced but idle broadcast fell out of the frame after `retention` idle ticks even though a subscription could still arrive.

## Why

The old retention window was a time-based heuristic to smooth reconnect flicker. Keying on `announced != announced_closed` (and the other open/closed pairs) is a more precise signal for "this broadcast can still carry traffic", which is what the metric actually wants to express.

## Notes for reviewers

- The global GC keeps the `Arc::strong_count(entry) > 1` check. That's the race-safe realization of "fully closed": `strong_count == 1` means no live guard holds the entry, which (after `process_slot` runs each tick) is exactly when every open/closed pair is equal. It also avoids dropping a held-but-idle `BroadcastStats` handle whose later bump would otherwise land on an orphaned `Arc` and be lost.
- The on-the-wire frame format is unchanged (same `Snapshot` fields), so no `js/net` counterpart needed updating.
- **Breaking change** to `moq_net::StatsConfig` (`retention` / `with_retention` removed) and the relay's `--stats-retention` / `MOQ_STATS_RETENTION` flag. Targeting `main` per request despite the public-API change.

## Changes

- `rs/moq-net/src/stats.rs`: liveness-based emission/GC; removed `retention`, `tick_counter`, `last_change_tick`, `within_retention`, `all_slots`, and the per-tick `live` path set; task exit now uses an `EMPTY_EXIT_TICKS` constant.
- `rs/moq-relay/src/stats.rs`: dropped the `--stats-retention` flag.
- `rs/moq-relay/src/config.rs`: updated the TOML-merge regression test.
- `doc/bin/relay/config.md`: removed the retention knob; updated emission description.

## Test plan

- [x] `cargo test -p moq-net stats::` — 16 passed (incl. new `live_entry_kept_while_idle` and `entry_dropped_once_fully_closed`)
- [x] `cargo test -p moq-relay cli_does_not_clobber` — passed
- [x] `cargo clippy -p moq-net -p moq-relay --all-targets` — clean

(Written by Claude)