### PR TITLE
go: ship moq.h and linux staticlibs so the Go module builds for consumers

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -173,18 +173,22 @@ jobs:
           path: bindings-raw
 
       - name: Flatten bindings layout
-        # uniffi-bindgen-go emits uniffi/moq/moq.go; package.sh expects moq/moq.go.
+        # uniffi-bindgen-go emits moq/{moq.go,moq.h} (some versions nest it
+        # under uniffi/). package.sh expects bindings/moq/. Copy the whole
+        # dir so the generated C header (moq.h, #include'd by moq.go's cgo
+        # preamble) travels with it.
         run: |
-          mkdir -p bindings/moq
-          if [[ -f bindings-raw/uniffi/moq/moq.go ]]; then
-            cp bindings-raw/uniffi/moq/moq.go bindings/moq/moq.go
-          elif [[ -f bindings-raw/moq/moq.go ]]; then
-            cp bindings-raw/moq/moq.go bindings/moq/moq.go
+          if [[ -d bindings-raw/uniffi/moq ]]; then
+            cp -R bindings-raw/uniffi/moq bindings-moq
+          elif [[ -d bindings-raw/moq ]]; then
+            cp -R bindings-raw/moq bindings-moq
           else
-            echo "Error: could not locate moq.go under bindings-raw/" >&2
+            echo "Error: could not locate moq bindings dir under bindings-raw/" >&2
             find bindings-raw -type f
             exit 1
           fi
+          mkdir -p bindings
+          mv bindings-moq bindings/moq
 
       - name: Package
         env:

--- a/go/scripts/check.sh
+++ b/go/scripts/check.sh
@@ -87,11 +87,10 @@ echo "go check: generating bindings..."
 uniffi-bindgen-go --library "$CDYLIB" --out-dir "$STAGE_BINDINGS"
 
 # Re-shape bindings dir to match package.sh's --bindings-dir expectation
-# (which wants moq/moq.go directly). uniffi-bindgen-go emits
-# uniffi/moq/moq.go by default; flatten if so.
-if [[ -f "$STAGE_BINDINGS/uniffi/moq/moq.go" && ! -f "$STAGE_BINDINGS/moq/moq.go" ]]; then
-    mkdir -p "$STAGE_BINDINGS/moq"
-    cp "$STAGE_BINDINGS/uniffi/moq/moq.go" "$STAGE_BINDINGS/moq/moq.go"
+# (which wants moq/ directly). Some uniffi-bindgen-go versions nest under
+# uniffi/moq/; copy the whole dir so moq.h rides along with moq.go.
+if [[ -d "$STAGE_BINDINGS/uniffi/moq" && ! -d "$STAGE_BINDINGS/moq" ]]; then
+    cp -R "$STAGE_BINDINGS/uniffi/moq" "$STAGE_BINDINGS/moq"
 fi
 
 echo "go check: assembling module..."

--- a/go/scripts/package.sh
+++ b/go/scripts/package.sh
@@ -105,12 +105,21 @@ for license in LICENSE-MIT LICENSE-APACHE; do
 done
 
 # --- 2. Generated uniffi-bindgen-go output ---
+# uniffi-bindgen-go emits both moq.go and a C header moq.h. moq.go's cgo
+# preamble does `#include <moq.h>`, so the header must ship alongside it or
+# consumers hit `fatal error: 'moq.h' file not found` on `go build`.
 GENERATED_GO="$BINDINGS_DIR/moq/moq.go"
+GENERATED_H="$BINDINGS_DIR/moq/moq.h"
 [[ -f "$GENERATED_GO" ]] || {
     echo "Error: uniffi-bindgen-go output not found at $GENERATED_GO" >&2
     exit 1
 }
+[[ -f "$GENERATED_H" ]] || {
+    echo "Error: generated C header not found at $GENERATED_H" >&2
+    exit 1
+}
 cp "$GENERATED_GO" "$PKG_STAGE/moq/moq.go"
+cp "$GENERATED_H" "$PKG_STAGE/moq/moq.h"
 
 # --- 3. Per-target static libraries ---
 # Entries are "<cargo-target>:<goos>_<goarch>:<libname>"; the GOOS/GOARCH

--- a/rs/moq-ffi/build.sh
+++ b/rs/moq-ffi/build.sh
@@ -235,10 +235,11 @@ elif [[ "$TARGET" == *"-apple-"* ]]; then
     cp "$TARGET_DIR/libmoq_ffi.dylib" "$PACKAGE_DIR/lib/"
 
 else
-    # Linux: ship the cdylib only. JNA (Kotlin) and maturin (Python) both
-    # consume the .so; nothing in the release pipeline links statically.
+    # Linux: ship both the cdylib (.so, consumed by JNA/Kotlin and
+    # maturin/Python) and the staticlib (.a, linked by the Go module's cgo).
     TARGET_DIR="$TARGET_BASE_DIR/$TARGET/release"
     cp "$TARGET_DIR/libmoq_ffi.so" "$PACKAGE_DIR/lib/"
+    cp "$TARGET_DIR/libmoq_ffi.a" "$PACKAGE_DIR/lib/"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

The published `github.com/moq-dev/moq-go` module (mirror populated by `release-go.yml` on `moq-ffi-v*` tags) was un-buildable for consumers. Verified against `v0.2.15` from the Go module proxy. Two gaps in the release **packaging** path (not the local check path):

- **Missing C header.** `uniffi-bindgen-go` emits both `moq.go` and `moq.h`, and the generated `moq.go` has `// #include <moq.h>` in its cgo preamble. Every staging step only carried `moq.go`, so `CGO_ENABLED=1 go build` failed with `fatal error: 'moq.h' file not found`.
- **Missing linux libs.** `rs/moq-ffi/build.sh`'s linux leg shipped only the `.so` cdylib (an old comment claimed nothing links statically). Go links the `.a` staticlib via cgo, so `package.sh` logged `go lib linux_amd64: skipped, …/libmoq_ffi.a missing` and the published module had no linux archive, despite `cgo.go` LDFLAGS and the docs claiming linux/amd64 + linux/arm64 support.

## Changes

- `rs/moq-ffi/build.sh` — linux leg now copies `libmoq_ffi.a` alongside the `.so` (cargo already produces it; crate-type is `["staticlib","cdylib"]`).
- `go/scripts/package.sh` — copies `moq.h` next to `moq.go`, and now *requires* it (fails loudly if absent, same as `moq.go`).
- `go/scripts/check.sh` and `.github/workflows/release-go.yml` — bindings flatten steps copy the whole `moq/` dir instead of cherry-picking `moq.go`, so the header survives even if a future uniffi version nests output under `uniffi/`.

This was discovered while building the `moq-dev/smoke` interop repo, whose Go cell currently fails for this reason.

## Reviewer notes

- `rs/moq-ffi/build.sh` is shared by `release-kt.yml` and `release-swift.yml` too. The extra `.a` in the linux `lib/` is inert for them (kt consumes the `.so` via JNA; swift is apple-only). `libmoq.yml` and `moq-gst.yml` use their own build scripts and are unaffected.
- The local `just go check` actually hit the same missing-`moq.h` bug when run; this fixes that path as well, so it's no longer a false-positive.

## Test plan

- [x] `bash -n` clean on `package.sh`, `check.sh`, `build.sh`
- [x] `actionlint` clean on `release-go.yml`
- [x] `just go check` passes end-to-end: `moq.h` is staged and `go vet`/`go build`/`go test` succeed (linux libs show "skipped" locally since only the host darwin target is built — populated in CI's per-target legs)
- [ ] CI `release-go.yml` dry-run produces a module containing `moq/moq.h` and `moq/lib/{linux_amd64,linux_arm64}/libmoq_ffi.a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)