### PR TITLE
ci: pin released cachix paths so consumers don't fall back to building

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -58,6 +58,13 @@ jobs:
       - name: Build and cache
         env:
           PACKAGE: ${{ steps.pkg.outputs.name }}
+          OS: ${{ matrix.os }}
         run: |
           nix build ".#$PACKAGE" --print-build-logs
           cachix push kixelated ./result
+          # Pin so released paths are exempt from GC, otherwise a consumer
+          # pinning a few-weeks-old tag silently falls back to building once
+          # the cache GCs the path. keep-revisions bounds storage for the
+          # free plan; the pin name is per package+OS so each platform keeps
+          # its own last-N releases instead of clobbering the other's.
+          cachix pin kixelated "$PACKAGE-$OS" ./result --keep-revisions 10


### PR DESCRIPTION
## Summary

The `.github/workflows/cachix.yml` release job only ran `cachix push` for built artifacts, leaving those store paths subject to the cache's normal garbage collection. Once a path was GC'd, any consumer pinning a few-weeks-old release tag silently fell back to building from source instead of pulling the cached closure.

This adds a `cachix pin` after the push so released paths are exempt from GC:

- Keyed per **package + OS** (`"$PACKAGE-$OS"`) so the two matrix runners (`ubuntu-latest`, `macos-latest`) don't clobber each other's pins.
- `--keep-revisions 10` bounds storage to fit the cachix **free plan** while keeping the last 10 releases per package per platform hittable.

`matrix.os` is passed through `env: OS` and referenced as quoted `"$OS"` (the safe pattern for workflow inputs); the tag is already validated against a strict semver regex earlier in the job.

## Why

Without pinning, the cache is best-effort and decays. Consumers pinning older-but-still-current tags pay an expensive from-source build, defeating the point of publishing to cachix. Pinning makes the retention window explicit and predictable.

## Reviewer notes

- Tune `--keep-revisions 10` up/down to trade retention window against cache storage on the free plan.
- Alternatives considered: permanent per-tag pins (strongest guarantee, unbounded growth), a larger cachix plan, or a self-hosted cache. Bounded per-package revisions is the cheapest fix that addresses the silent-fallback problem.

## Test plan

- [ ] Cut a release tag and confirm the workflow runs `cachix pin` successfully after `cachix push`.
- [ ] Verify the pin appears in the `kixelated` cache and survives a GC cycle.
- [ ] Confirm both `ubuntu-latest` and `macos-latest` pins coexist (no clobbering).

(Written by Claude)