### PR TITLE
ci: scrub nix-store libiconv from macOS release binaries

### DIFF
--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/moq-cli.yml"
       - ".github/scripts/release.sh"
       - "rs/scripts/package-binary.sh"
+      - "rs/scripts/scrub-macho.sh"
       - "packaging/moq-cli/**"
       - ".github/actions/setup-packaging/**"
 

--- a/.github/workflows/moq-relay.yml
+++ b/.github/workflows/moq-relay.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/moq-relay.yml"
       - ".github/scripts/release.sh"
       - "rs/scripts/package-binary.sh"
+      - "rs/scripts/scrub-macho.sh"
       - "packaging/moq-relay/**"
       - ".github/actions/setup-packaging/**"
 

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/moq-token-cli.yml"
       - ".github/scripts/release.sh"
       - "rs/scripts/package-binary.sh"
+      - "rs/scripts/scrub-macho.sh"
       - "packaging/moq-token-cli/**"
       - ".github/actions/setup-packaging/**"
 

--- a/rs/moq-gst/scrub.sh
+++ b/rs/moq-gst/scrub.sh
@@ -18,6 +18,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <path-to-libgstmoq.{so,dylib}>" >&2
     exit 2
@@ -32,57 +34,17 @@ fi
 scrub_macos() {
     local dylib="$1"
 
-    # Rewrite every absolute LC_LOAD_DYLIB outside system dirs to
-    # @rpath/<basename>. Allowlist (not "grep nix") so we also catch
-    # any non-nix leakage we haven't predicted.
-    # `tail -n +2` skips line 1, the dylib's own LC_ID_DYLIB.
-    otool -L "$dylib" |
-        tail -n +2 |
-        awk '{print $1}' |
-        { grep -vE '^(@|/usr/lib/|/System/)' || true; } |
-        sort -u |
-        while read -r ref; do
-            install_name_tool -change "$ref" "@rpath/$(basename "$ref")" "$dylib"
-        done
-
-    # Strip LC_RPATH entries under /nix.
-    otool -l "$dylib" |
-        awk '/^ *cmd LC_RPATH$/{f=1; next} f && /^ *path /{print $2; f=0}' |
-        { grep '^/nix/' || true; } |
-        while read -r rp; do
-            install_name_tool -delete_rpath "$rp" "$dylib"
-        done
-
-    # /opt/homebrew + /usr/local cover homebrew on ARM and Intel; the
-    # Framework path covers the official .pkg installer; /usr/lib lets
-    # dyld resolve system libs (libiconv, libc++) via dyld_shared_cache
-    # at @rpath substitution time.
-    install_name_tool -add_rpath /opt/homebrew/lib "$dylib"
-    install_name_tool -add_rpath /usr/local/lib "$dylib"
-    install_name_tool -add_rpath /Library/Frameworks/GStreamer.framework/Libraries "$dylib"
-    install_name_tool -add_rpath /usr/lib "$dylib"
-
-    # Whitelist assertion: every LC_LOAD_DYLIB must resolve via @rpath,
-    # @loader_path, @executable_path, /usr/lib, or /System.
-    local bad
-    bad="$(otool -L "$dylib" |
-        tail -n +2 |
-        awk '{print $1}' |
-        { grep -vE '^(@|/usr/lib/|/System/)' || true; })"
-    if [[ -n "$bad" ]]; then
-        echo "Error: $dylib has non-portable LC_LOAD_DYLIB entries:" >&2
-        echo "$bad" >&2
-        exit 1
-    fi
-    local bad_rp
-    bad_rp="$(otool -l "$dylib" |
-        awk '/^ *cmd LC_RPATH$/{f=1; next} f && /^ *path /{print $2; f=0}' |
-        { grep '^/nix/' || true; })"
-    if [[ -n "$bad_rp" ]]; then
-        echo "Error: $dylib has /nix LC_RPATH entries:" >&2
-        echo "$bad_rp" >&2
-        exit 1
-    fi
+    # The shared Mach-O scrub does the LC_LOAD_DYLIB rewrite, /nix LC_RPATH
+    # strip, and the no-/nix assertion. We just pass the rpaths a GStreamer
+    # plugin needs: /opt/homebrew + /usr/local cover homebrew on ARM and
+    # Intel, the Framework path covers the official .pkg installer, and
+    # /usr/lib lets dyld resolve system libs (libiconv, libc++) via the
+    # dyld_shared_cache at @rpath substitution time.
+    "$SCRIPT_DIR/../scripts/scrub-macho.sh" "$dylib" \
+        /opt/homebrew/lib \
+        /usr/local/lib \
+        /Library/Frameworks/GStreamer.framework/Libraries \
+        /usr/lib
 }
 
 scrub_linux() {

--- a/rs/scripts/package-binary.sh
+++ b/rs/scripts/package-binary.sh
@@ -105,6 +105,64 @@ mkdir -p "$PACKAGE_DIR/bin"
 cp -L "$BIN_FILE" "$PACKAGE_DIR/bin/$CRATE"
 chmod 0755 "$PACKAGE_DIR/bin/$CRATE"
 
+# On macOS the nix toolchain links the nix-store copy of libiconv, whose
+# absolute path doesn't exist on a user's Mac, so dyld aborts at startup
+# (the brew channel's "Library not loaded: /nix/store/.../libiconv.2.dylib").
+# Rewrite every non-system LC_LOAD_DYLIB to @rpath/<basename>, strip leaked
+# /nix rpaths, and add /usr/lib so dyld resolves them from the system dyld
+# shared cache (where libiconv et al live) like a plain `cargo build` does.
+# See rs/moq-gst/scrub.sh for the same treatment on the GStreamer plugin.
+if [[ "$(uname)" == "Darwin" ]]; then
+    bin="$PACKAGE_DIR/bin/$CRATE"
+
+    # tail -n +2 drops otool's header line (the binary's own path).
+    otool -L "$bin" |
+        tail -n +2 |
+        awk '{print $1}' |
+        { grep -vE '^(@|/usr/lib/|/System/)' || true; } |
+        sort -u |
+        while read -r ref; do
+            install_name_tool -change "$ref" "@rpath/$(basename "$ref")" "$bin"
+        done
+
+    otool -l "$bin" |
+        awk '/^ *cmd LC_RPATH$/{f=1; next} f && /^ *path /{print $2; f=0}' |
+        { grep '^/nix/' || true; } |
+        while read -r rp; do
+            install_name_tool -delete_rpath "$rp" "$bin"
+        done
+    install_name_tool -add_rpath /usr/lib "$bin"
+
+    # Whitelist assertion: nothing may resolve through /nix anymore, so this
+    # can't silently ship again.
+    bad="$(otool -L "$bin" |
+        tail -n +2 |
+        awk '{print $1}' |
+        { grep -vE '^(@|/usr/lib/|/System/)' || true; })"
+    if [[ -n "$bad" ]]; then
+        echo "Error: $bin has non-portable LC_LOAD_DYLIB entries:" >&2
+        echo "$bad" >&2
+        exit 1
+    fi
+    bad_rp="$(otool -l "$bin" |
+        awk '/^ *cmd LC_RPATH$/{f=1; next} f && /^ *path /{print $2; f=0}' |
+        { grep '^/nix/' || true; })"
+    if [[ -n "$bad_rp" ]]; then
+        echo "Error: $bin has /nix LC_RPATH entries:" >&2
+        echo "$bad_rp" >&2
+        exit 1
+    fi
+
+    # Prove dyld actually loads the scrubbed binary. host==target is enforced
+    # above, so it runs natively; --help triggers dyld's dependency load (the
+    # exact step that aborted on a clean Mac) before clap exits 0.
+    if ! "$bin" --help >/dev/null 2>&1; then
+        echo "Error: scrubbed $bin failed to launch (dyld load failure?)." >&2
+        otool -L "$bin" >&2
+        exit 1
+    fi
+fi
+
 if [[ -f "$CRATE_DIR/README.md" ]]; then
     cp "$CRATE_DIR/README.md" "$PACKAGE_DIR/"
 fi

--- a/rs/scripts/package-binary.sh
+++ b/rs/scripts/package-binary.sh
@@ -108,50 +108,12 @@ chmod 0755 "$PACKAGE_DIR/bin/$CRATE"
 # On macOS the nix toolchain links the nix-store copy of libiconv, whose
 # absolute path doesn't exist on a user's Mac, so dyld aborts at startup
 # (the brew channel's "Library not loaded: /nix/store/.../libiconv.2.dylib").
-# Rewrite every non-system LC_LOAD_DYLIB to @rpath/<basename>, strip leaked
-# /nix rpaths, and add /usr/lib so dyld resolves them from the system dyld
-# shared cache (where libiconv et al live) like a plain `cargo build` does.
-# See rs/moq-gst/scrub.sh for the same treatment on the GStreamer plugin.
+# Rewrite the leaked paths to load from the system dyld shared cache (via
+# /usr/lib), like a plain `cargo build` does. scrub-macho.sh also asserts no
+# /nix path survives, so this can't silently ship again.
 if [[ "$(uname)" == "Darwin" ]]; then
     bin="$PACKAGE_DIR/bin/$CRATE"
-
-    # tail -n +2 drops otool's header line (the binary's own path).
-    otool -L "$bin" |
-        tail -n +2 |
-        awk '{print $1}' |
-        { grep -vE '^(@|/usr/lib/|/System/)' || true; } |
-        sort -u |
-        while read -r ref; do
-            install_name_tool -change "$ref" "@rpath/$(basename "$ref")" "$bin"
-        done
-
-    otool -l "$bin" |
-        awk '/^ *cmd LC_RPATH$/{f=1; next} f && /^ *path /{print $2; f=0}' |
-        { grep '^/nix/' || true; } |
-        while read -r rp; do
-            install_name_tool -delete_rpath "$rp" "$bin"
-        done
-    install_name_tool -add_rpath /usr/lib "$bin"
-
-    # Whitelist assertion: nothing may resolve through /nix anymore, so this
-    # can't silently ship again.
-    bad="$(otool -L "$bin" |
-        tail -n +2 |
-        awk '{print $1}' |
-        { grep -vE '^(@|/usr/lib/|/System/)' || true; })"
-    if [[ -n "$bad" ]]; then
-        echo "Error: $bin has non-portable LC_LOAD_DYLIB entries:" >&2
-        echo "$bad" >&2
-        exit 1
-    fi
-    bad_rp="$(otool -l "$bin" |
-        awk '/^ *cmd LC_RPATH$/{f=1; next} f && /^ *path /{print $2; f=0}' |
-        { grep '^/nix/' || true; })"
-    if [[ -n "$bad_rp" ]]; then
-        echo "Error: $bin has /nix LC_RPATH entries:" >&2
-        echo "$bad_rp" >&2
-        exit 1
-    fi
+    "$SCRIPT_DIR/scrub-macho.sh" "$bin"
 
     # Prove dyld actually loads the scrubbed binary. host==target is enforced
     # above, so it runs natively; --help triggers dyld's dependency load (the

--- a/rs/scripts/scrub-macho.sh
+++ b/rs/scripts/scrub-macho.sh
@@ -59,8 +59,14 @@ otool -l "$macho" |
         install_name_tool -delete_rpath "$rp" "$macho"
     done
 
+# install_name_tool -add_rpath errors (and aborts the script under set -e)
+# if the rpath is already present, so skip ones that already exist.
+existing_rpaths="$(otool -l "$macho" |
+    awk '/^ *cmd LC_RPATH$/{f=1; next} f && /^ *path /{print $2; f=0}')"
 for rp in "${rpaths[@]}"; do
-    install_name_tool -add_rpath "$rp" "$macho"
+    if ! grep -Fxq "$rp" <<<"$existing_rpaths"; then
+        install_name_tool -add_rpath "$rp" "$macho"
+    fi
 done
 
 # Whitelist assertion: every LC_LOAD_DYLIB must resolve via @rpath,

--- a/rs/scripts/scrub-macho.sh
+++ b/rs/scripts/scrub-macho.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Rewrite a macOS Mach-O file (executable or .dylib) so it loads against
+# the system / user-installed libraries instead of the nix-store copies it
+# was linked against. The nix toolchain links its own libiconv (and
+# friends) by absolute /nix/store path, which doesn't exist on a user's
+# Mac, so dyld aborts at startup.
+#
+# Every absolute LC_LOAD_DYLIB outside /usr/lib and /System is rewritten to
+# @rpath/<basename>, every /nix LC_RPATH is stripped, and the rpaths passed
+# as arguments are added so dyld can find the libraries. /usr/lib lets dyld
+# resolve system libs (libiconv, libc++) via the dyld_shared_cache at
+# @rpath substitution time. Asserts nothing resolves through /nix afterward.
+#
+# Usage:
+#   scrub-macho.sh <macho-file> [rpath ...]
+#
+# With no rpaths, defaults to /usr/lib (enough for a plain binary whose only
+# leak is the system-cache libiconv). Callers that ship into a plugin host
+# (e.g. moq-gst) pass their install prefixes too.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <macho-file> [rpath ...]" >&2
+    exit 2
+fi
+
+macho="$1"
+shift
+rpaths=("$@")
+if [[ ${#rpaths[@]} -eq 0 ]]; then
+    rpaths=(/usr/lib)
+fi
+
+if [[ ! -f "$macho" ]]; then
+    echo "Error: $macho does not exist" >&2
+    exit 2
+fi
+
+# Rewrite every absolute LC_LOAD_DYLIB outside system dirs to
+# @rpath/<basename>. Allowlist (not "grep nix") so we also catch any
+# non-nix leakage we haven't predicted. `tail -n +2` skips line 1: a
+# dylib's own LC_ID_DYLIB, or an executable's "<path>:" header.
+otool -L "$macho" |
+    tail -n +2 |
+    awk '{print $1}' |
+    { grep -vE '^(@|/usr/lib/|/System/)' || true; } |
+    sort -u |
+    while read -r ref; do
+        install_name_tool -change "$ref" "@rpath/$(basename "$ref")" "$macho"
+    done
+
+# Strip LC_RPATH entries under /nix.
+otool -l "$macho" |
+    awk '/^ *cmd LC_RPATH$/{f=1; next} f && /^ *path /{print $2; f=0}' |
+    { grep '^/nix/' || true; } |
+    while read -r rp; do
+        install_name_tool -delete_rpath "$rp" "$macho"
+    done
+
+for rp in "${rpaths[@]}"; do
+    install_name_tool -add_rpath "$rp" "$macho"
+done
+
+# Whitelist assertion: every LC_LOAD_DYLIB must resolve via @rpath,
+# @loader_path, @executable_path, /usr/lib, or /System.
+bad="$(otool -L "$macho" |
+    tail -n +2 |
+    awk '{print $1}' |
+    { grep -vE '^(@|/usr/lib/|/System/)' || true; })"
+if [[ -n "$bad" ]]; then
+    echo "Error: $macho has non-portable LC_LOAD_DYLIB entries:" >&2
+    echo "$bad" >&2
+    exit 1
+fi
+
+bad_rp="$(otool -l "$macho" |
+    awk '/^ *cmd LC_RPATH$/{f=1; next} f && /^ *path /{print $2; f=0}' |
+    { grep '^/nix/' || true; })"
+if [[ -n "$bad_rp" ]]; then
+    echo "Error: $macho has /nix LC_RPATH entries:" >&2
+    echo "$bad_rp" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

The macOS release binaries (`moq-relay`, `moq-cli`, `moq-token-cli`) are built with `nix build` in `rs/scripts/package-binary.sh`. The nix toolchain links its own store copy of libiconv, so the shipped binary carries `LC_LOAD_DYLIB → /nix/store/…/libiconv.2.dylib` — a path that doesn't exist on a user's Mac, so dyld aborts at startup.

This broke the `brew` channel entirely (surfaced by the moq-dev/smoke nightly):

```
$ brew install moq-dev/tap/moq-relay && moq-relay
dyld[]: Library not loaded: /nix/store/xvmhkpvfvmy4sfdkqwg9inq3qkpnx81b-libiconv-109.100.2/lib/libiconv.2.dylib
  Referenced from: /opt/homebrew/Cellar/moq-relay/0.12.3/bin/moq-relay
  Reason: tried: '...' (no such file), ...
```

The cargo-built binary is fine (it links the system `/usr/lib/libiconv.2.dylib`); only the nix-built release/brew binary leaks. All three binaries ship from the same darwin path, so all three were affected.

## Fix

Add a Darwin-only scrub in `package-binary.sh` right after the binary is copied out of the nix store:

1. Rewrite every non-system `LC_LOAD_DYLIB` to `@rpath/<basename>`.
2. Strip any leaked `/nix` `LC_RPATH`, then add `/usr/lib` so dyld resolves `@rpath/libiconv.2.dylib` from the system dyld shared cache (where libiconv lives) — exactly what a plain `cargo build` produces.
3. **Whitelist assertion**: fail the build if any dependency or rpath still resolves through `/nix`, so this can't silently ship again.
4. **Launch smoke test**: run `--help` (`host == target` is already enforced, so it runs natively) to prove dyld actually loads the scrubbed binary — the exact failure mode that shipped.

## Shared `scrub-macho.sh`

The macOS Mach-O logic above was nearly identical to the existing `rs/moq-gst/scrub.sh` (the moq-gst plugin had the same `/nix` leak). Rather than duplicate it, the common core is extracted into **`rs/scripts/scrub-macho.sh`**, parameterized by the rpaths to add:

- `package-binary.sh` calls it with the default `/usr/lib` (a plain binary's only leak resolves via the shared cache), then runs the `--help` launch check.
- `rs/moq-gst/scrub.sh` delegates its macOS path to the same script, passing the GStreamer prefixes (`/opt/homebrew/lib`, `/usr/local/lib`, the `.framework` Libraries dir, `/usr/lib`); it keeps its Linux `patchelf` path and extension dispatch.

The shared script produces identical load commands and rpaths to the previous inline versions for both callers, so the moq-gst release path is behavior-preserving.

The three binary workflows gain `rs/scripts/scrub-macho.sh` in their `pull_request` path filters so a future edit to the shared script re-triggers the macOS packaging dry-run.

## Verification

Validated against the real broken artifact, `moq-relay-0.12.3-aarch64-apple-darwin.tar.gz`, through the extracted `scrub-macho.sh`:

- **Before**: only non-system dependency is `/nix/store/xvmhkpvfvmy4sfdkqwg9inq3qkpnx81b-libiconv-109.100.2/lib/libiconv.2.dylib`, no rpaths.
- **After scrub** (default `/usr/lib`): only non-system dependency is `@rpath/libiconv.2.dylib`, `/usr/lib` rpath added, **0** `/nix` references, and `moq-relay --help` exits 0.
- **gst rpath set**: passing the four GStreamer prefixes adds all four rpaths in order, matching the previous `scrub_macos` exactly.

`shellcheck` clean on all three scripts. The full `nix build` couldn't run in the dev sandbox (no pty for nix's builder), so verification used the downloaded release artifact, which is the ground-truth broken binary. CI's `build-tarball-macos` job runs the scrub + assertion + launch test on a real macOS runner.

## Test plan

- [x] Scrub + assertion + `--help` launch verified against the real 0.12.3 release binary via `scrub-macho.sh` (0 `/nix` refs, exits 0)
- [x] gst multi-rpath invocation verified (four rpaths added in order, assertion passes)
- [x] `shellcheck` clean on `scrub-macho.sh`, `package-binary.sh`, `moq-gst/scrub.sh`
- [ ] CI `build-tarball-macos` (moq-relay / moq-cli / moq-token-cli) passes on the PR dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)