### PR TITLE
moq-rs: close FFI parity gaps and smooth subscribe ergonomics

### DIFF
--- a/doc/lib/py/moq-net.md
+++ b/doc/lib/py/moq-net.md
@@ -55,8 +55,8 @@ Supported codec formats include `opus`, `avc3`, `hev1`, `av01`, `vp09`, and othe
 ```python
 async for announcement in client.announced("prefix/"):
     catalog = await announcement.broadcast.catalog()
-    track_name = next(iter(catalog.audio))
-    consumer = announcement.broadcast.subscribe_media(track_name, catalog.audio[track_name].container, max_latency_ms=10_000)
+    track_name, track = next(iter(catalog.audio.items()))
+    consumer = announcement.broadcast.subscribe_media(track_name, track)
 
     async for frame in consumer:
         ...

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -21,13 +21,14 @@ import asyncio
 import moq
 
 async def main():
-    async with moq.Client("https://relay.quic.video") as client:
+    async with moq.connect("https://relay.quic.video") as client:
         async for announcement in client.announced():
             catalog = await announcement.broadcast.catalog()
 
-            for name in catalog.audio:
-                async for frame in announcement.broadcast.subscribe_media(name):
-                    print(f"Got frame: {len(frame.payload)} bytes, ts={frame.timestamp_us}")
+            for name, track in catalog.audio.items():
+                async with announcement.broadcast.subscribe_media(name, track) as frames:
+                    async for frame in frames:
+                        print(f"Got frame: {len(frame.payload)} bytes, ts={frame.timestamp_us}")
 
 asyncio.run(main())
 ```
@@ -61,7 +62,7 @@ asyncio.run(main())
 
 ```python
 import asyncio
-import moq_lite as moq
+import moq
 
 async def main():
     async with moq.Server("127.0.0.1:4443", tls_generate=["localhost"]) as server:
@@ -99,7 +100,9 @@ client = moq.Client(
 
 ### Connection
 
+- **`connect(url, *, tls_verify=True, bind=None, publish=None, subscribe=None)`**. Shorthand for `Client(...)`; use as `async with moq.connect(url) as client:`.
 - **`Client(url, *, tls_verify=True, bind=None, publish=None, subscribe=None)`**. Async context manager for connecting to a relay.
+  - `.session`. The established `Session` (or `None` before connecting / after exit).
 - **`Server(bind="[::]:443", *, tls_cert=(), tls_key=(), tls_generate=(), publish=None, subscribe=None)`**. Async context manager + async iterator of incoming `Request`s.
   - `.local_addr`. The bound address (useful when binding to port `0`).
   - `.cert_fingerprints()`. SHA-256 fingerprints of the configured TLS certificates, for `serverCertificateHashes` browser cert pinning.
@@ -107,9 +110,13 @@ client = moq.Client(
 - **`Request`**. An incoming session, yielded by `async for request in server`.
   - `.url`, `.transport`. Properties.
   - `.set_publish(origin)`, `.set_consume(origin)`. Per-request overrides.
-  - `await .ok()`. Complete the handshake, returns a session (hold it to keep the connection alive).
+  - `await .ok() → Session`. Complete the handshake (hold the result to keep the connection alive).
   - `await .close(code)`. Reject with an HTTP status code.
   - `.cancel()`. Cancel an in-flight `ok()`/`close()` call.
+- **`Session`**. An established connection. Holding it keeps the connection alive; it is also an `async with` context manager that shuts down on exit.
+  - `await .closed()`. Wait until the session closes.
+  - `.cancel(code)`, `.shutdown()`. Close with an error code, or gracefully (code 0).
+  - `.publisher() → OriginProducer`, `.consumer() → OriginConsumer`. The wired origin sides.
 
 ### Publishing
 
@@ -124,10 +131,12 @@ client = moq.Client(
 
 - **`BroadcastConsumer`**. Subscribe to tracks within a broadcast.
   - `.subscribe_catalog() → CatalogConsumer`
-  - `.subscribe_media(name, max_latency_ms=10000) → MediaConsumer`
+  - `.subscribe_media(name, track, max_latency_ms=10000) → MediaConsumer`. `track` is the catalog record (e.g. `catalog.video[name]`); its container tells the decoder how to parse the bitstream.
   - `await .catalog() → Catalog` (convenience)
 - **`CatalogConsumer`**. Async iterator of `Catalog`.
 - **`MediaConsumer`**. Async iterator of `Frame`.
+
+All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsumer`, `GroupConsumer`) are async context managers; exiting `async with` cancels the subscription.
 
 ### Origin (advanced)
 
@@ -145,6 +154,12 @@ client = moq.Client(
 - **`Audio`**. `.codec`, `.sample_rate`, `.channel_count`, `.bitrate`, `.description`.
 - **`Video`**. `.codec`, `.coded: Dimensions`, `.display_ratio`, `.bitrate`, `.framerate`, `.description`.
 - **`Dimensions`**. `.width: int`, `.height: int`.
+- **`Container`**. The catalog container enum, carried on each `Video`/`Audio` record.
+
+### Logging and errors
+
+- **`log_level(level="info")`**. Initialize logging for the underlying Rust layer (`"error"`, `"warn"`, `"info"`, `"debug"`, `"trace"`). Call once per process.
+- **`Error`**. The exception raised by all operations. Catch a specific case via its variants, e.g. `except moq.Error.AlreadyResponded:` or `except moq.Error.Cancelled:`.
 
 ## See Also
 

--- a/py/moq-rs/examples/smoke.py
+++ b/py/moq-rs/examples/smoke.py
@@ -61,7 +61,7 @@ async def subscribe(url: str, broadcast: str, timeout: float) -> None:
         track_name = next(iter(catalog.video))
         video = catalog.video[track_name]
 
-        media = consumer.subscribe_media(track_name, video.container, MAX_LATENCY_MS)
+        media = consumer.subscribe_media(track_name, video, MAX_LATENCY_MS)
 
         total = 0
 

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -3,16 +3,24 @@
 Real-time pub/sub with built-in caching, fan-out, and prioritization.
 """
 
-from ._uniffi import MoqSession as Session
-from .client import Client
+from ._uniffi import MoqError as Error
+from .client import Client, connect
+from .log import log_level
 from .origin import Announced, AnnouncedBroadcast, Announcement, OriginConsumer, OriginProducer
-from .publish import AudioProducer, BroadcastProducer, GroupProducer, MediaProducer, TrackProducer
+from .publish import (
+    AudioProducer,
+    BroadcastProducer,
+    GroupProducer,
+    MediaProducer,
+    MediaStreamProducer,
+    TrackProducer,
+)
 from .server import Request, Server, Transport
+from .session import Session
 from .subscribe import (
     AudioConsumer,
     BroadcastConsumer,
     CatalogConsumer,
-    Container,
     GroupConsumer,
     MediaConsumer,
     TrackConsumer,
@@ -26,6 +34,7 @@ from .types import (
     AudioFormat,
     AudioFrame,
     Catalog,
+    Container,
     Dimensions,
     Frame,
     Video,
@@ -51,11 +60,13 @@ __all__ = [
     "Client",
     "Container",
     "Dimensions",
+    "Error",
     "Frame",
     "GroupConsumer",
     "GroupProducer",
     "MediaConsumer",
     "MediaProducer",
+    "MediaStreamProducer",
     "OriginConsumer",
     "OriginProducer",
     "Request",
@@ -65,4 +76,6 @@ __all__ = [
     "TrackProducer",
     "Transport",
     "Video",
+    "connect",
+    "log_level",
 ]

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ._uniffi import MoqClient
 from .origin import Announced, AnnouncedBroadcast, OriginConsumer, OriginProducer
 from .publish import BroadcastProducer
+from .session import Session
 
 
 class Client:
@@ -47,7 +48,7 @@ class Client:
 
         self._consumer: OriginConsumer | None = None
         self._inner: MoqClient | None = None
-        self._session = None
+        self._session: Session | None = None
 
     async def __aenter__(self):
         self._inner = MoqClient()
@@ -62,7 +63,7 @@ class Client:
         if self._consume_origin is not None:
             self._inner.set_consume(self._consume_origin._inner)
 
-        self._session = await self._inner.connect(self._url)
+        self._session = Session(await self._inner.connect(self._url))
 
         # Create consumer from whichever origin handles consuming.
         origin = self._consume_origin or self._publish_origin
@@ -95,5 +96,24 @@ class Client:
         return self._consumer.announced_broadcast(path)
 
     @property
-    def session(self):
+    def session(self) -> Session | None:
+        """The established session, or `None` before connecting / after exit."""
         return self._session
+
+
+def connect(
+    url: str,
+    *,
+    tls_verify: bool = True,
+    bind: str | None = None,
+    publish: OriginProducer | None = None,
+    subscribe: OriginProducer | None = None,
+) -> Client:
+    """Shorthand for constructing a :class:`Client`.
+
+    Use it directly as an async context manager:
+
+        async with moq.connect("https://relay.example.com") as client:
+            ...
+    """
+    return Client(url, tls_verify=tls_verify, bind=bind, publish=publish, subscribe=subscribe)

--- a/py/moq-rs/moq/log.py
+++ b/py/moq-rs/moq/log.py
@@ -1,0 +1,15 @@
+"""Logging configuration for the underlying Rust layer."""
+
+from __future__ import annotations
+
+from ._uniffi import moq_log_level
+
+
+def log_level(level: str = "info") -> None:
+    """Initialize tracing/logging for the underlying Rust layer.
+
+    `level` is one of "error", "warn", "info", "debug", "trace" (empty string
+    defaults to "info"). Can only be called once per process; calling it again
+    raises `moq.Error`.
+    """
+    moq_log_level(level)

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -88,6 +88,13 @@ class OriginProducer:
     def __init__(self) -> None:
         self._inner = MoqOriginProducer()
 
+    @classmethod
+    def _from_inner(cls, inner: MoqOriginProducer) -> OriginProducer:
+        """Wrap an existing FFI producer (e.g. the one a `Session` owns)."""
+        self = cls.__new__(cls)
+        self._inner = inner
+        return self
+
     def consume(self) -> OriginConsumer:
         return OriginConsumer(self._inner.consume())
 

--- a/py/moq-rs/moq/server.py
+++ b/py/moq-rs/moq/server.py
@@ -6,9 +6,10 @@ import asyncio
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Literal
 
-from ._uniffi import MoqRequest, MoqServer, MoqSession
+from ._uniffi import MoqRequest, MoqServer
 from .origin import OriginProducer
 from .publish import BroadcastProducer
+from .session import Session
 
 Transport = Literal["quic", "iroh", "websocket"]
 
@@ -44,19 +45,19 @@ class Request:
         server's configured consume origin if unset."""
         self._inner.set_consume(origin._inner if origin is not None else None)
 
-    async def ok(self) -> MoqSession:
+    async def ok(self) -> Session:
         """Complete the MoQ handshake and return the established session.
 
         The caller must hold the returned session to keep the connection
-        alive; dropping it closes the session. Raises `MoqError.AlreadyResponded`
+        alive; dropping it closes the session. Raises `Error.AlreadyResponded`
         if `ok()` or `close()` has already been called.
         """
-        return await self._inner.ok()
+        return Session(await self._inner.ok())
 
     async def close(self, code: int = 404) -> None:
         """Reject the session with the given HTTP status code.
 
-        Raises `MoqError.AlreadyResponded` if `ok()` or `close()` has already
+        Raises `Error.AlreadyResponded` if `ok()` or `close()` has already
         been called.
         """
         await self._inner.close(code)

--- a/py/moq-rs/moq/session.py
+++ b/py/moq-rs/moq/session.py
@@ -1,0 +1,50 @@
+"""Session wrapper — an established MoQ connection."""
+
+from __future__ import annotations
+
+from ._uniffi import MoqSession
+from .origin import OriginConsumer, OriginProducer
+
+
+class Session:
+    """An established MoQ connection, returned by `Client` and `Request.ok()`.
+
+    Hold the session to keep the connection alive; dropping it closes the
+    connection. As an async context manager it shuts down gracefully on exit:
+
+        session = await request.ok()
+        async with session:
+            await session.closed()
+    """
+
+    def __init__(self, inner: MoqSession) -> None:
+        self._inner = inner
+
+    async def __aenter__(self) -> Session:
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        self.shutdown()
+
+    async def closed(self) -> None:
+        """Wait until the session is closed by either side."""
+        await self._inner.closed()
+
+    def cancel(self, code: int) -> None:
+        """Close the session with the given error code."""
+        self._inner.cancel(code)
+
+    def shutdown(self) -> None:
+        """Graceful shutdown; equivalent to `cancel(0)` (0 means no error)."""
+        self._inner.shutdown()
+
+    def publisher(self) -> OriginProducer:
+        """The publish-side origin: where local broadcasts are advertised to
+        the remote. Either the origin wired before connect/accept, or one
+        auto-created if none was set."""
+        return OriginProducer._from_inner(self._inner.publisher())
+
+    def consumer(self) -> OriginConsumer:
+        """The subscribe-side origin: a read handle for announcements pushed by
+        the remote."""
+        return OriginConsumer(self._inner.consumer())

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from ._uniffi import (
-    Container,
     MoqAudioConsumer,
     MoqBroadcastConsumer,
     MoqCatalogConsumer,
@@ -11,7 +10,7 @@ from ._uniffi import (
     MoqMediaConsumer,
     MoqTrackConsumer,
 )
-from .types import Audio, AudioDecoderOutput, AudioFrame, Catalog, Frame
+from .types import Audio, AudioDecoderOutput, AudioFrame, Catalog, Frame, Video
 
 
 class MediaConsumer:
@@ -19,6 +18,12 @@ class MediaConsumer:
 
     def __init__(self, inner: MoqMediaConsumer) -> None:
         self._inner = inner
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        self.cancel()
 
     def __aiter__(self):
         return self
@@ -44,6 +49,12 @@ class GroupConsumer:
         """The sequence number of this group within the track."""
         return self._inner.sequence()
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        self.cancel()
+
     def __aiter__(self):
         return self
 
@@ -67,6 +78,12 @@ class TrackConsumer:
 
     def __init__(self, inner: MoqTrackConsumer) -> None:
         self._inner = inner
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        self.cancel()
 
     def __aiter__(self):
         return self
@@ -122,6 +139,12 @@ class AudioConsumer:
     def __init__(self, inner: MoqAudioConsumer) -> None:
         self._inner = inner
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        self.cancel()
+
     def __aiter__(self):
         return self
 
@@ -140,6 +163,12 @@ class CatalogConsumer:
 
     def __init__(self, inner: MoqCatalogConsumer) -> None:
         self._inner = inner
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        self.cancel()
 
     def __aiter__(self):
         return self
@@ -167,8 +196,15 @@ class BroadcastConsumer:
         """Subscribe to a track — receive arbitrary byte payloads."""
         return TrackConsumer(self._inner.subscribe_track(name))
 
-    def subscribe_media(self, name: str, container: Container, max_latency_ms: int) -> MediaConsumer:
-        return MediaConsumer(self._inner.subscribe_media(name, container, max_latency_ms))
+    def subscribe_media(self, name: str, track: Video | Audio, max_latency_ms: int = 10000) -> MediaConsumer:
+        """Subscribe to a media track, delivering frames in decode order.
+
+        ``track`` is the catalog entry for this track (e.g.
+        ``catalog.video[name]``); its ``container`` describes how to parse the
+        bitstream, so the caller doesn't construct a :class:`Container` by hand.
+        ``max_latency_ms`` bounds buffering before a stalled GoP is skipped.
+        """
+        return MediaConsumer(self._inner.subscribe_media(name, track.container, max_latency_ms))
 
     def subscribe_audio(
         self,

--- a/py/moq-rs/moq/types.py
+++ b/py/moq-rs/moq/types.py
@@ -1,6 +1,9 @@
 """Re-export moq-ffi record types without the Moq prefix."""
 
 from ._uniffi import (
+    Container as Container,
+)
+from ._uniffi import (
     MoqAudio as Audio,
 )
 from ._uniffi import (
@@ -43,6 +46,7 @@ __all__ = [
     "AudioFormat",
     "AudioFrame",
     "Catalog",
+    "Container",
     "Dimensions",
     "Frame",
     "Video",

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -110,7 +110,7 @@ async def test_local_publish_consume_audio():
         assert audio.sample_rate == 48000
         assert audio.channel_count == 2
 
-        media_consumer = announcement.broadcast.subscribe_media(track_name, audio.container, 10_000)
+        media_consumer = announcement.broadcast.subscribe_media(track_name, audio, 10_000)
 
         payload = b"opus audio payload data"
         media.write_frame(payload, 1_000_000)
@@ -144,7 +144,7 @@ async def test_video_publish_consume():
         assert video.coded.width == 1280
         assert video.coded.height == 720
 
-        media_consumer = announcement.broadcast.subscribe_media(track_name, video.container, 10_000)
+        media_consumer = announcement.broadcast.subscribe_media(track_name, video, 10_000)
 
         keyframe = bytes([0x00, 0x00, 0x00, 0x01, 0x65, 0xAA, 0xBB, 0xCC])
         media.write_frame(keyframe, 0)
@@ -169,7 +169,7 @@ async def test_multiple_frames_ordering():
         catalog = await announcement.broadcast.catalog()
         track_name = list(catalog.audio.keys())[0]
         audio = catalog.audio[track_name]
-        media_consumer = announcement.broadcast.subscribe_media(track_name, audio.container, 10_000)
+        media_consumer = announcement.broadcast.subscribe_media(track_name, audio, 10_000)
 
         timestamps = [0, 20_000, 40_000, 60_000, 80_000]
         for i, ts in enumerate(timestamps):
@@ -321,6 +321,43 @@ def test_raw_parallel_groups():
     g0.write_frame(b"a1")
     g0.finish()
     g1.finish()
+
+
+def test_public_api_exports():
+    """The ergonomic surface is reachable from the top-level package, so users
+    never have to import the private `moq._uniffi` module."""
+    assert issubclass(moq.Error, Exception)
+    # Flat-error variants are accessible as attributes for selective catching.
+    assert hasattr(moq.Error, "AlreadyResponded")
+    assert hasattr(moq.Error, "Cancelled")
+    assert callable(moq.log_level)
+    assert isinstance(moq.connect("https://example.com"), moq.Client)
+
+
+async def test_subscribe_media_default_latency_and_context_manager():
+    """subscribe_media takes the catalog record directly and defaults the
+    latency; the returned consumer is also an async context manager."""
+    origin = moq.OriginProducer()
+    broadcast = moq.BroadcastProducer()
+    media = broadcast.publish_media("opus", opus_head())
+    origin.publish("live", broadcast)
+
+    consumer = origin.consume()
+
+    async for announcement in consumer.announced():
+        catalog = await announcement.broadcast.catalog()
+        track_name, audio = next(iter(catalog.audio.items()))
+
+        # No container argument, no explicit latency.
+        payload = b"opus audio payload data"
+        media.write_frame(payload, 1_000_000)
+
+        async with announcement.broadcast.subscribe_media(track_name, audio) as media_consumer:
+            async for frame in media_consumer:
+                assert frame.payload == payload
+                break
+
+        break
 
 
 async def test_raw_publish_consume():

--- a/py/moq-rs/tests/test_server.py
+++ b/py/moq-rs/tests/test_server.py
@@ -52,7 +52,7 @@ async def test_server_client_roundtrip():
                     track_name, audio = next(iter(catalog.audio.items()))
                     assert audio.codec == "opus"
 
-                    media_consumer = announcement.broadcast.subscribe_media(track_name, audio.container, 10_000)
+                    media_consumer = announcement.broadcast.subscribe_media(track_name, audio, 10_000)
 
                     payload = b"hello over the wire"
                     media.write_frame(payload, 1_000_000)


### PR DESCRIPTION
## Summary

Audited the `moq-rs` Python wrapper against the full `moq-ffi` UniFFI surface. A few capabilities were only reachable by importing the private `moq._uniffi` module, and the most-used subscribe call had some rough edges. This closes those gaps and makes the re-exports explicit so the public API stands on its own.

### Parity (now reachable from the top-level `moq` package)

- **`Error`** — re-exports the `MoqError` exception. Catch everything via `except moq.Error`, or a specific case via `except moq.Error.AlreadyResponded` / `except moq.Error.Cancelled`. (Wrapper docstrings already referenced `MoqError.*` but the symbol wasn't importable.)
- **`log_level()`** — wraps the `moq_log_level` free function, the only way to set the Rust layer's tracing level. It wasn't exposed anywhere.
- **`Session`** — wraps the raw `MoqSession` (the one object that previously leaked through unwrapped). Adds `closed()` / `cancel(code)` / `shutdown()`, `async with` graceful shutdown, and `publisher()` / `consumer()`. `Client.session` and `Request.ok()` now return it.
- **`MediaStreamProducer`** — was fully implemented but missing from `__init__` / `__all__`, so the type couldn't be imported.

### Ergonomics

- **`subscribe_media(name, track, max_latency_ms=10000)`** now takes the catalog record directly (matching `subscribe_audio`) and reads its container internally, so callers no longer hand-build a `Container`. `max_latency_ms` now defaults. **(Breaking signature change — hence `dev`.)**
- All consumers (`Media` / `Track` / `Catalog` / `Audio` / `Group`) are now async context managers; exiting `async with` cancels the subscription. Previously only `Announced` / `AnnouncedBroadcast` were.
- Top-level **`connect(url, ...)`** shorthand for `Client(...)`.
- Moved the `Container` re-export alongside the other type aliases in `types.py`.

### Deliberately skipped

Adding `__repr__` to the re-exported records. uniffi's generated `__str__` already stringifies them, and the obvious `__repr__ = __str__` would interpolate the **entire** `payload` / `data` bytes for every media `Frame` on the hot path. A truncating repr would mean per-record custom code that rots, for marginal REPL value.

## Test plan

- [x] `just py check` (ruff + ruff format + `maturin develop` + pyright: 0 errors)
- [x] `just py test` — 35 passed (existing 33 updated for the new `subscribe_media` signature + 2 new: top-level exports, default-latency `subscribe_media` via `async with`)
- [x] Smoke-checked all new public symbols resolve and `Error` / `Session` / `log_level` behave at runtime

## Cross-package sync

- Updated `py/moq-rs/README.md` (fixed stale `subscribe_media` arity and the `import moq_lite` typo, documented the new surface).
- Updated `doc/lib/py/moq-net.md` `subscribe_media` example.
- No `rs/moq-ffi` changes — this is wrapper-only; the FFI surface is unchanged.

(Written by Claude)