### PR TITLE
moq-net: wire session stats into the IETF protocol path

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -218,7 +218,7 @@ Field semantics:
 - `subscriptions` / `subscriptions_closed`: cumulative count of
   track-level subscription guards opened and dropped.
 - `bytes` / `frames` / `groups`: cumulative payload counters from the
-  lite session loops.
+  session loops (both the `moq-lite` and IETF `moq-transport` paths).
 
 Tier, role, and node are implied by the track and broadcast paths, so
 they aren't repeated inside the frame. Counters are cumulative and

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -73,6 +73,7 @@ impl Client {
 					true,
 					self.publish.clone(),
 					self.consume.clone(),
+					self.stats.clone(),
 					ietf::Version::Draft18,
 				)?;
 
@@ -93,6 +94,7 @@ impl Client {
 					true,
 					self.publish.clone(),
 					self.consume.clone(),
+					self.stats.clone(),
 					ietf::Version::Draft17,
 				)?;
 
@@ -228,6 +230,7 @@ impl Client {
 					true,
 					self.publish.clone(),
 					self.consume.clone(),
+					self.stats.clone(),
 					v,
 				)?;
 				None

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -5,7 +5,7 @@ use web_async::FuturesExt;
 use web_transport_trait::SendStream;
 
 use crate::{
-	AsPath, Error, Origin, OriginConsumer, Track, TrackConsumer,
+	AsPath, Error, Origin, OriginConsumer, StatsHandle, Track, TrackConsumer,
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
 	model::GroupConsumer,
@@ -18,16 +18,30 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 	session: S,
 	origin: OriginConsumer,
 	control: Control,
+	stats: StatsHandle,
+	/// Per-session egress broadcast-subscription tracker. Each downstream
+	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts
+	/// the distinct sessions (viewers) watching each broadcast.
+	broadcasts: crate::SessionBroadcasts,
 	version: Version,
 }
 
 impl<S: web_transport_trait::Session> Publisher<S> {
-	pub fn new(session: S, origin: Option<OriginConsumer>, control: Control, version: Version) -> Self {
+	pub fn new(
+		session: S,
+		origin: Option<OriginConsumer>,
+		control: Control,
+		stats: StatsHandle,
+		version: Version,
+	) -> Self {
 		let origin = origin.unwrap_or_else(|| Origin::random().produce().consume());
+		let broadcasts = stats.publisher_broadcasts();
 		Self {
 			session,
 			origin,
 			control,
+			stats,
+			broadcasts,
 			version,
 		}
 	}
@@ -105,6 +119,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		tracing::info!(id = %request_id, broadcast = %absolute, track = %track_name, "subscribe started");
 
+		// Per-track subscription guard (bumps `subscriptions`). Taken before
+		// validation so a stale/invalid SUBSCRIBE still counts as an attempt,
+		// matching the lite path. The per-(session, broadcast) `broadcasts`
+		// sentinel that counts viewers is taken only once the subscription is
+		// validated and active, below.
+		let track_stats = std::sync::Arc::new(self.stats.broadcast(&absolute).publisher_track(&track_name));
+
 		// We just received a subscribe for this exact namespace, so the peer must have already
 		// seen the announcement — synchronous lookup is appropriate here.
 		let Some(broadcast) = self.origin.get_broadcast(&msg.track_namespace) else {
@@ -127,6 +148,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			}
 		};
 
+		// Subscription is now active: count this session as a viewer of the
+		// broadcast. Dropping this guard (subscription end) releases it.
+		let _broadcast_sub = self.broadcasts.subscribe(&absolute);
+
 		// Send SubscribeOk on the stream
 		stream.writer.encode(&ietf::SubscribeOk::ID).await?;
 		stream
@@ -142,7 +167,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Run the track, cancelling on reader close (Unsubscribe or stream close)
 		let res = tokio::select! {
-			res = self.run_track(track, request_id) => res,
+			res = self.run_track(track, request_id, track_stats) => res,
 			_ = stream.reader.closed() => Ok(()),
 			_ = self.session.closed() => Ok(()),
 		};
@@ -217,7 +242,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// Serve a track using FuturesUnordered for unlimited concurrent groups.
-	async fn run_track(&self, mut track: TrackConsumer, request_id: RequestId) -> Result<(), Error> {
+	async fn run_track(
+		&self,
+		mut track: TrackConsumer,
+		request_id: RequestId,
+		track_stats: std::sync::Arc<crate::PublisherTrack>,
+	) -> Result<(), Error> {
 		let mut tasks = FuturesUnordered::new();
 
 		loop {
@@ -242,7 +272,17 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				flags: Default::default(),
 			};
 
-			tasks.push(Self::run_group(self.session.clone(), msg, track.priority, group, self.version).map(|_| ()));
+			tasks.push(
+				Self::run_group(
+					self.session.clone(),
+					msg,
+					track.priority,
+					group,
+					track_stats.clone(),
+					self.version,
+				)
+				.map(|_| ()),
+			);
 		}
 	}
 
@@ -251,6 +291,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		msg: ietf::GroupHeader,
 		priority: u8,
 		mut group: GroupConsumer,
+		track_stats: std::sync::Arc<crate::PublisherTrack>,
 		version: Version,
 	) -> Result<(), Error> {
 		let mut stream = session.open_uni().await.map_err(Error::from_transport)?;
@@ -259,6 +300,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let mut stream = Writer::new(stream, version);
 
 		stream.encode(&msg).await?;
+		track_stats.group();
 
 		loop {
 			let frame = tokio::select! {
@@ -282,6 +324,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 			// Write the size of the frame.
 			stream.encode(&frame.size).await?;
+			track_stats.frame();
 
 			if frame.size == 0 {
 				// Have to write the object status too.
@@ -297,7 +340,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 					match chunk? {
 						Some(mut chunk) => {
+							let n = chunk.len() as u64;
 							stream.write_all(&mut chunk).await?;
+							track_stats.bytes(n);
 						}
 						None => break,
 					}
@@ -438,7 +483,11 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	/// Outgoing PublishNamespace: announce each namespace via a bidi stream.
 	async fn run_announce(mut self) -> Result<(), Error> {
-		let mut namespace_streams: HashMap<crate::PathOwned, (RequestId, Stream<S, Version>)> = HashMap::new();
+		// Each accepted namespace holds a `publisher()` announce guard (bumps
+		// `announced` / `announced_closed`) alongside its stream, so dropping the
+		// tuple on unannounce or cleanup records the close.
+		let mut namespace_streams: HashMap<crate::PathOwned, (RequestId, Stream<S, Version>, crate::PublisherStats)> =
+			HashMap::new();
 
 		loop {
 			let announced = tokio::select! {
@@ -455,6 +504,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 			if active.is_some() {
 				tracing::debug!(broadcast = %self.origin.absolute(&path), "announce");
+				let absolute = self.origin.absolute(&path).to_owned();
 
 				let request_id = self.control.next_request_id().await?;
 				let mut stream = Stream::open(&self.session, self.version).await?;
@@ -479,7 +529,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					(Version::Draft14, ietf::PublishNamespaceOk::ID) => {
 						let msg = ietf::PublishNamespaceOk::decode_msg(&mut data, self.version)?;
 						tracing::debug!(message = ?msg, "publish namespace ok");
-						namespace_streams.insert(suffix, (request_id, stream));
+						let guard = self.stats.broadcast(&absolute).publisher();
+						namespace_streams.insert(suffix, (request_id, stream, guard));
 					}
 					(Version::Draft14, ietf::PublishNamespaceError::ID) => {
 						let msg = ietf::PublishNamespaceError::decode_msg(&mut data, self.version)?;
@@ -489,7 +540,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					(_, ietf::RequestOk::ID) => {
 						let msg = ietf::RequestOk::decode_msg(&mut data, self.version)?;
 						tracing::debug!(message = ?msg, "publish namespace ok");
-						namespace_streams.insert(suffix, (request_id, stream));
+						let guard = self.stats.broadcast(&absolute).publisher();
+						namespace_streams.insert(suffix, (request_id, stream, guard));
 					}
 					(_, ietf::RequestError::ID) => {
 						let msg = ietf::RequestError::decode_msg(&mut data, self.version)?;
@@ -499,7 +551,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				}
 			} else {
 				tracing::debug!(broadcast = %self.origin.absolute(&path), "unannounce");
-				if let Some((request_id, mut stream)) = namespace_streams.remove(&suffix) {
+				if let Some((request_id, mut stream, _stats)) = namespace_streams.remove(&suffix) {
 					// v14-16 sends PublishNamespaceDone; v17+ just closes the stream.
 					match self.version {
 						Version::Draft14 | Version::Draft15 | Version::Draft16 => {
@@ -519,7 +571,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		}
 
 		// Clean up remaining streams
-		for (suffix, (request_id, mut stream)) in namespace_streams {
+		for (suffix, (request_id, mut stream, _stats)) in namespace_streams {
 			match self.version {
 				Version::Draft14 | Version::Draft15 | Version::Draft16 => {
 					let _ = stream

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -1,5 +1,5 @@
 use crate::{
-	Error, OriginConsumer, OriginProducer,
+	Error, OriginConsumer, OriginProducer, StatsHandle,
 	coding::{Encode, Reader, Stream, Writer},
 	ietf::{self, FetchHeader, RequestId},
 	setup,
@@ -7,6 +7,9 @@ use crate::{
 
 use super::{Control, Message, Publisher, Subscriber, Version, adapter::ControlStreamAdapter};
 
+// Handshake dispatcher: each argument is an independent session parameter, so
+// bundling them into a config struct would just add indirection.
+#[allow(clippy::too_many_arguments)]
 pub fn start<S: web_transport_trait::Session>(
 	session: S,
 	setup: Option<Stream<S, Version>>,
@@ -14,6 +17,8 @@ pub fn start<S: web_transport_trait::Session>(
 	client: bool,
 	publish: Option<OriginConsumer>,
 	subscribe: Option<OriginProducer>,
+	// Tier-scoped stats handle. Pass [`StatsHandle::default`] to opt out.
+	stats: StatsHandle,
 	version: Version,
 ) -> Result<(), Error> {
 	web_async::spawn(async move {
@@ -26,8 +31,8 @@ pub fn start<S: web_transport_trait::Session>(
 				let control = Control::new(request_id_max, client);
 				let adapter = ControlStreamAdapter::new(session.clone(), tx, control.clone(), version);
 
-				let publisher = Publisher::new(adapter.clone(), publish, control.clone(), version);
-				let subscriber = Subscriber::new(adapter.clone(), subscribe, control, version);
+				let publisher = Publisher::new(adapter.clone(), publish, control.clone(), stats.clone(), version);
+				let subscriber = Subscriber::new(adapter.clone(), subscribe, control, stats, version);
 
 				let dispatch_session = adapter.clone();
 				let mut sub_ns = subscriber.clone();
@@ -71,8 +76,8 @@ pub fn start<S: web_transport_trait::Session>(
 				});
 
 				let control = Control::new(None, client);
-				let publisher = Publisher::new(session.clone(), publish, control.clone(), version);
-				let subscriber = Subscriber::new(session.clone(), subscribe, control, version);
+				let publisher = Publisher::new(session.clone(), publish, control.clone(), stats.clone(), version);
+				let subscriber = Subscriber::new(session.clone(), subscribe, control, stats, version);
 
 				let sub_ns_session = session.clone();
 				let mut sub_ns = subscriber.clone();

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, hash_map::Entry};
 
+use std::sync::Arc;
+
 use crate::{
 	Broadcast, BroadcastDynamic, Error, Frame, FrameProducer, Group, GroupProducer, MAX_FRAME_SIZE, OriginProducer,
-	Path, PathOwned, Track, TrackProducer,
+	Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, Track, TrackProducer,
 	coding::{Reader, Stream},
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
 	model::BroadcastProducer,
@@ -30,6 +32,9 @@ struct State {
 struct TrackState {
 	producer: TrackProducer,
 	alias: Option<u64>,
+	/// Subscriber-side track stats; counters bump as frames/bytes/groups arrive.
+	/// Dropping on subscription end records `subscriptions_closed`.
+	stats: Arc<SubscriberTrack>,
 }
 
 struct BroadcastState {
@@ -37,6 +42,10 @@ struct BroadcastState {
 
 	// active number of PUBLISH or PUBLISH_NAMESPACE messages.
 	count: usize,
+
+	/// Subscriber-side announce guard (bumps `announced` / `announced_closed`),
+	/// held for as long as the broadcast is announced into our origin.
+	_stats: SubscriberStats,
 }
 
 #[derive(Clone)]
@@ -44,16 +53,30 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	session: S,
 	origin: Option<OriginProducer>,
 	control: Control,
+	stats: StatsHandle,
+	/// Per-session ingress broadcast-subscription tracker. Each upstream
+	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts the
+	/// distinct upstream sessions feeding each broadcast.
+	broadcasts: crate::SessionBroadcasts,
 	state: Lock<State>,
 	version: Version,
 }
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
-	pub fn new(session: S, origin: Option<OriginProducer>, control: Control, version: Version) -> Self {
+	pub fn new(
+		session: S,
+		origin: Option<OriginProducer>,
+		control: Control,
+		stats: StatsHandle,
+		version: Version,
+	) -> Self {
+		let broadcasts = stats.subscriber_broadcasts();
 		Self {
 			session,
 			origin,
 			control,
+			stats,
+			broadcasts,
 			state: Default::default(),
 			version,
 		}
@@ -230,6 +253,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let res = self.write_publish_ok(&mut stream, &msg).await;
 
 		if res.is_ok() {
+			// PUBLISH is the peer feeding us a broadcast, so count this session as
+			// an active upstream feed for the lifetime of the publish. The guard
+			// drops (releasing `broadcasts_closed`) when the stream closes below.
+			let abs = match &self.origin {
+				Some(origin) => origin.absolute(&msg.track_namespace).to_owned(),
+				None => msg.track_namespace.to_owned(),
+			};
+			let _broadcast_sub = self.broadcasts.subscribe(&abs);
+
 			// Wait for PublishDone or stream close
 			let _ = stream.reader.closed().await;
 		}
@@ -406,6 +438,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Err(Error::InvalidRole);
 		};
 
+		let abs = origin.absolute(&path).to_owned();
+
 		let mut state = self.state.lock();
 		let broadcast = match state.broadcasts.entry(path.clone()) {
 			Entry::Occupied(mut entry) => {
@@ -418,6 +452,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				entry.insert(BroadcastState {
 					producer: broadcast.clone(),
 					count: 1,
+					_stats: self.stats.broadcast(&abs).subscriber(),
 				});
 				broadcast
 			}
@@ -468,12 +503,19 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 		.produce();
 
+		let abs = match &self.origin {
+			Some(origin) => origin.absolute(&msg.track_namespace).to_owned(),
+			None => msg.track_namespace.to_owned(),
+		};
+		let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(&msg.track_name));
+
 		let mut state = self.state.lock();
 		match state.subscribes.entry(request_id) {
 			Entry::Vacant(entry) => {
 				entry.insert(TrackState {
 					producer: track.clone(),
 					alias: Some(msg.track_alias),
+					stats: track_stats,
 				});
 			}
 			Entry::Occupied(_) => return Err(Error::Duplicate),
@@ -540,6 +582,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		};
 
+		let abs = self
+			.origin
+			.as_ref()
+			.expect("origin set by start_announce")
+			.absolute(&broadcast_path)
+			.to_owned();
+		let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(&track.name));
+
 		// Pre-register the track so group data arriving before SubscribeOk can be routed.
 		// The publisher uses request_id.0 as track_alias, and recv_group falls back to
 		// RequestId(track_alias) when no alias mapping exists, so this works.
@@ -550,6 +600,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				TrackState {
 					producer: track.clone(),
 					alias: None,
+					stats: track_stats,
 				},
 			);
 		}
@@ -586,6 +637,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				return;
 			}
 		};
+
+		// Upstream confirmed (SubscribeOk), so this session is now actively feeding
+		// the broadcast: take the `broadcasts` sentinel for the subscription's
+		// lifetime. It drops (releasing `broadcasts_closed`) when this fn returns.
+		let _broadcast_sub = self.broadcasts.subscribe(&abs);
 
 		tokio::select! {
 			_ = track.unused() => {
@@ -675,7 +731,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Err(Error::Unsupported);
 		}
 
-		let (mut producer, track) = {
+		let (mut producer, track, track_stats) = {
 			let mut state = self.state.lock();
 			let request_id = match state.aliases.get(&group.track_alias) {
 				Some(request_id) => *request_id,
@@ -690,13 +746,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				sequence: group.group_id,
 			};
 			let producer = track.producer.create_group(group_info)?;
-			(producer, track.producer.clone())
+			(producer, track.producer.clone(), track.stats.clone())
 		};
+
+		// Bump groups counter for this incoming group on the subscriber side.
+		track_stats.group();
 
 		let res = tokio::select! {
 			err = track.closed() => Err(err),
 			err = producer.closed() => Err(err),
-			res = self.run_group(group, stream, producer.clone()) => res,
+			res = self.run_group(group, stream, producer.clone(), track_stats.clone()) => res,
 		};
 
 		match res {
@@ -720,6 +779,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		group: ietf::GroupHeader,
 		stream: &mut Reader<S::RecvStream, Version>,
 		mut producer: GroupProducer,
+		track_stats: Arc<SubscriberTrack>,
 	) -> Result<(), Error> {
 		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
 			if id_delta != 0 {
@@ -737,6 +797,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let status: u64 = stream.decode().await?;
 				if status == 0 {
 					let mut frame = producer.create_frame(Frame { size: 0 })?;
+					track_stats.frame();
 					frame.finish()?;
 				} else if status == 3 && !group.flags.has_end {
 					break;
@@ -748,8 +809,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					return Err(Error::FrameTooLarge);
 				}
 				let mut frame = producer.create_frame(Frame { size })?;
+				track_stats.frame();
 
-				if let Err(err) = self.run_frame(stream, frame.clone()).await {
+				if let Err(err) = self.run_frame(stream, frame.clone(), &track_stats).await {
 					let _ = frame.abort(err.clone());
 					return Err(err);
 				}
@@ -765,12 +827,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
 		mut frame: FrameProducer,
+		track_stats: &SubscriberTrack,
 	) -> Result<(), Error> {
 		// FrameProducer impls BufMut; read_buf writes stream bytes directly into
 		// the per-frame buffer (see lite/subscriber.rs run_frame for rationale).
 		while bytes::BufMut::has_remaining_mut(&frame) {
 			match stream.read_buf(&mut frame).await? {
-				Some(n) if n > 0 => {}
+				Some(n) if n > 0 => {
+					track_stats.bytes(n as u64);
+				}
 				_ => return Err(Error::WrongSize),
 			}
 		}

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -71,6 +71,7 @@ impl Server {
 					false,
 					self.publish.clone(),
 					self.consume.clone(),
+					self.stats.clone(),
 					ietf::Version::Draft18,
 				)?;
 
@@ -91,11 +92,11 @@ impl Server {
 					false,
 					self.publish.clone(),
 					self.consume.clone(),
+					self.stats.clone(),
 					ietf::Version::Draft17,
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				// TODO: ietf code path does not yet record stats.
 				return Ok(Session::new(session, v, None));
 			}
 			Some(ALPN_16) => {
@@ -231,6 +232,7 @@ impl Server {
 					false,
 					self.publish.clone(),
 					self.consume.clone(),
+					self.stats.clone(),
 					v,
 				)?;
 				None

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -37,7 +37,7 @@
 //! * `subscriptions` / `subscriptions_closed`: cumulative count of
 //!   track-level subscription guards opened/dropped.
 //! * `bytes` / `frames` / `groups`: cumulative payload counters bumped from
-//!   the lite session loops.
+//!   the session loops (both lite and IETF).
 //!
 //! Counters are strictly monotonic (only `fetch_add`); a counter going
 //! backwards across snapshots means the underlying entry was garbage


### PR DESCRIPTION
## Summary

The `Stats`/`StatsHandle` aggregator (the `announced`, `broadcasts`, `subscriptions`, and `bytes`/`frames`/`groups` counters published on `.stats/node/<node>` and consumed by the dashboard for viewer counts / billing) was only fed by the **moq-lite** session loops.

Any relay session negotiated to an **IETF draft** (`moq-transport`) built its `Publisher`/`Subscriber` with no `StatsHandle` (`ietf/session.rs` constructed them positionally without one, unlike `lite/session.rs`). So an IETF session contributed **zero** to every counter — the dashboard "viewers" metric and any billing built on these counters silently undercounted / excluded IETF clients. This was pre-existing, not a regression (there was even a `// TODO: ietf code path does not yet record stats` in `server.rs`).

This PR wires the existing aggregator into the IETF path, mirroring the lite implementation exactly. No new counters, no wire-format or public-API changes — `ietf` is a private module, and the counters are wire-format agnostic so the same bumps apply uniformly across draft 14–18.

## What changed

- **Threading**: added a `stats: StatsHandle` arg to `ietf::start` and passed it into `Publisher::new` / `Subscriber::new`; updated all 6 `ietf::start` call sites in `client.rs` / `server.rs`; removed the stale TODO.
- **Publisher (egress)**: announce guards via `.broadcast(path).publisher()` held in `namespace_streams`; per-track guards via `publisher_track()`; the per-(session, broadcast) `broadcasts` viewer sentinel via `SessionBroadcasts::subscribe()` once a subscription is active; `group()`/`frame()`/`bytes()` bumps through `run_track` → `run_group`.
- **Subscriber (ingress)**: announce guards via `.subscriber()` tied to `BroadcastState` lifetime; per-track guards via `subscriber_track()` stored in `TrackState`; the `broadcasts` sentinel after the upstream `SubscribeOk` (and after `PublishOk` on the PUBLISH path); `group()`/`frame()`/`bytes()` bumps through `recv_group` → `run_group` → `run_frame`.
- **Docs**: updated `rs/moq-net/src/stats.rs` and `doc/bin/relay/config.md` payload-counter notes that claimed counters came only from "the lite session loops".

The 8-arg `ietf::start` handshake dispatcher tripped `clippy::too_many_arguments`; since it mirrors `lite::start`'s positional style and each arg is an independent session parameter, it gets a scoped `#[allow]` with a justification rather than a config-struct detour.

## Test plan

- [x] `cargo build -p moq-net`
- [x] `cargo test -p moq-net` — 327 passed, 0 failed
- [x] `cargo clippy -p moq-net -p moq-relay --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)