### PR TITLE
nix: declare the Cachix cache in the flake and document the tagged-release caveat

### DIFF
--- a/doc/setup/linux.md
+++ b/doc/setup/linux.md
@@ -76,8 +76,18 @@ If your distro doesn't have a native package on offer:
   `aarch64-unknown-linux-gnu` variants.
 - **Docker**: `docker pull docker.io/moqdev/moq-relay:latest`. Multi-arch
   images for `linux/amd64` and `linux/arm64`.
-- **Nix**: the project ships a flake. `nix profile install github:moq-dev/moq#moq-relay`,
-  or use the binary cache at `kixelated.cachix.org` to skip building from source.
+- **Nix**: the project ships a flake. The Cachix cache at `kixelated.cachix.org`
+  serves pre-built binaries, but only tagged releases are pushed, so pin the
+  ref to a recent tag and accept the flake's cache config to skip building from
+  source:
+
+  ```bash
+  nix run github:moq-dev/moq/moq-relay-v0.12.4#moq-relay --accept-flake-config
+  ```
+
+  An unpinned `github:moq-dev/moq#moq-relay` tracks the default branch, which
+  is not cached and compiles from source. To trust the cache permanently
+  instead of per-command, run `cachix use kixelated` once.
 - **Arch Linux**: a community-maintained PKGBUILD lives in the AUR
   (`moq-relay-bin`). The project doesn't maintain it directly; treat it as
   community supported.

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,18 @@
 {
   description = "MoQ - Media over QUIC";
 
-  # For pre-built binaries (faster builds), add our Cachix cache to your Nix config:
-  #   extra-substituters = https://kixelated.cachix.org
-  #   extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
+  # Pre-built binaries live in our Cachix cache. Only tagged releases are
+  # pushed (CI fires on moq-relay-v*, moq-cli-v*, etc.), so pin the flake ref
+  # to a recent tag to get a hit. The default branch HEAD is not cached and
+  # builds from source:
+  #   nix run github:moq-dev/moq/moq-relay-v0.12.4#moq-relay --accept-flake-config
   #
-  # Or run: cachix use kixelated
+  # --accept-flake-config opts into the nixConfig below for one command. To
+  # trust the cache permanently instead, run: cachix use kixelated
+  nixConfig = {
+    extra-substituters = [ "https://kixelated.cachix.org" ];
+    extra-trusted-public-keys = [ "kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=" ];
+  };
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,9 @@
   # trust the cache permanently instead, run: cachix use kixelated
   nixConfig = {
     extra-substituters = [ "https://kixelated.cachix.org" ];
-    extra-trusted-public-keys = [ "kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=" ];
+    extra-trusted-public-keys = [
+      "kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk="
+    ];
   };
 
   inputs = {


### PR DESCRIPTION
## Summary

Makes `nix run github:moq-dev/moq#moq-relay` actually benefit from our Cachix cache, and documents the one caveat that previously bit consumers silently: **only tagged releases are cached.**

- **`flake.nix`**: added a `nixConfig` block declaring `kixelated.cachix.org` as an `extra-substituters` + `extra-trusted-public-keys`. With it, `nix run ... --accept-flake-config` consults the binary cache automatically, no manual `nix.conf` edit or prior `cachix use` required. The old comment is replaced with one that spells out the tagged-releases-only behavior and the pin-to-a-tag pattern.
- **`doc/setup/linux.md`**: the Nix bullet previously just said "use the binary cache to skip building from source." It now notes that only tagged releases are pushed, shows the pinned `--accept-flake-config` command, and warns that the unpinned form tracks the default branch and compiles from source.

## Why

`cachix.yml` only fires on `moq-relay-v*` / `moq-cli-v*` / sibling tags and pins the last 10 revisions per package+OS. So a plain `nix run github:moq-dev/moq#moq-relay` resolves to the default-branch HEAD, which is never in the cache and falls back to building from source even when the substituter is configured. To get a cache hit you have to pin the flake ref to a recent tag:

```bash
nix run github:moq-dev/moq/moq-relay-v0.12.4#moq-relay --accept-flake-config
```

## Reviewer notes

- `--accept-flake-config` is required because Nix won't silently apply substituters from an untrusted flake. `cachix use kixelated` (once) is the permanent alternative; both are documented.
- The examples hardcode `v0.12.4` (current latest), which will go stale as new releases are tagged. Open to a follow-up that tracks "latest stable" instead of a pinned version if you'd prefer doc examples not need a bump each release.
- Docs/flake only, no wire or API change, so this targets `main`.

(Written by Claude)