### PR TITLE
relay: dedup mesh dials with a URL-order tiebreaker

### DIFF
--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -45,6 +45,8 @@ mesh    = "us-west.example.com:4443"
 
 Each node with `mesh` set creates a broadcast carrying its address, which other nodes pick up. `connect` is optional once gossip is running, but you still need at least one connection somewhere (either you dial a peer or a peer dials you) for the advertisement to flow.
 
+When two gossiping nodes discover each other, only one of them dials: the node with the lexicographically-smaller URL is the client, the larger is the server. The session is bidirectional, so a single connection carries announcements both ways and the pair avoids opening two redundant links. This tiebreaker applies only to gossip-discovered peers; an explicit `connect` entry always dials.
+
 A relay with `mesh` set and no `connect` is a passive rendezvous: it sits and waits for inbound connections, then helps everyone else find each other.
 
 ## Authentication

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -24,6 +24,16 @@ const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 /// within sub-milliseconds) plus reasonable churn from a peer restart.
 const STALE_AFTER: Duration = Duration::from_secs(60);
 
+/// Mesh tiebreaker for gossip-discovered peers. In a full mesh both peers
+/// discover each other and would each open a dial, leaving two redundant
+/// sessions. The session is bidirectional (we publish *and* consume on it), so
+/// one suffices. Break the symmetry on URL order: only dial peers that sort
+/// after us, making the lexicographically-smaller node the client and the
+/// larger the server. The skipped side still gets the connection inbound.
+fn should_dial(self_url: &str, peer: &str) -> bool {
+	peer > self_url
+}
+
 /// One entry in [`DialMap`]. `is_static` flags peers seeded from
 /// `--cluster-connect`; those keep retrying forever even if their gossip
 /// registration goes away (operator intent says "always dial"). Gossip-discovered
@@ -337,7 +347,9 @@ impl Cluster {
 	}
 
 	/// Watch `.internal/origins/*` for peer registrations and dial each newly-
-	/// announced URL. Unannounces don't abort immediately — they just mark the
+	/// announced URL that sorts after our own (see [`should_dial`]); the peer on
+	/// the other side of that comparison dials us, so each pair opens one session
+	/// instead of two. Unannounces don't abort immediately. They just mark the
 	/// entry as "pending cleanup" with a timestamp. A periodic sweep evicts
 	/// entries whose unannounce has stuck for [`STALE_AFTER`]. The "prefer
 	/// shorter hop" path in OriginProducer delivers reannouncements as
@@ -359,7 +371,9 @@ impl Cluster {
 				ann = consumer.announced() => {
 					let Some((relative, announced)) = ann else { return; };
 					let peer = relative.as_str();
-					if peer == self_url {
+					// Skip self and any peer we lose the tiebreaker to; that side
+					// dials us instead, so each pair forms a single session.
+					if !should_dial(&self_url, peer) {
 						continue;
 					}
 					let peer = peer.to_owned();
@@ -540,6 +554,18 @@ mod tests {
 		assert!(dialed.contains("flap:4443"));
 		// Second mark_announced has nothing to clear.
 		assert!(!dialed.mark_announced("flap:4443"));
+	}
+
+	/// The mesh tiebreaker only dials peers that sort after us, so exactly one
+	/// side of each pair opens the dial. Self never dials self.
+	#[test]
+	fn should_dial_prefers_larger_url() {
+		// Smaller hostname is the client: it dials the larger.
+		assert!(should_dial("a.example.com:4443", "b.example.com:4443"));
+		// Larger hostname is the server: it waits for the inbound dial.
+		assert!(!should_dial("b.example.com:4443", "a.example.com:4443"));
+		// Never dial self.
+		assert!(!should_dial("self.example.com:4443", "self.example.com:4443"));
 	}
 
 	/// Setting `cluster.root` (the removed flag) at startup must surface a migration


### PR DESCRIPTION
## Summary

When `--cluster-mesh` is used, two gossiping relays discover each other and **each** opens a dial, leaving two redundant sessions that both carry announcements. The cluster session is already bidirectional (every dial does `with_publish` + `with_consume`), so one connection suffices. This wastes an outbound link per pair.

This adds a tiebreaker so only one side dials. A gossip-discovered peer is dialed only if its URL sorts **after** ours:

```rust
fn should_dial(self_url: &str, peer: &str) -> bool {
    peer > self_url
}
```

The lexicographically-smaller node is the client, the larger is the server. The skipped side still gets the connection inbound, so announcements flow both ways over the single session. This replaces the old `peer == self_url` self-skip (`peer > peer` is false, so self-equality is still handled).

Scope: the tiebreaker governs **gossip-discovered** peers only. Explicit `--cluster-connect` entries always dial (operator intent), and passive-rendezvous links go through the static path, so no rendezvous connection can be stranded.

## Changes

- `rs/moq-relay/src/cluster.rs`: add `should_dial`, use it in `run_discovery`, update the surrounding doc comment.
- `doc/bin/relay/cluster.md`: document the client/server tiebreaker under Auto-discovery.

## Test plan

- [x] `cargo test -p moq-relay cluster` (12 passed, incl. new `should_dial_prefers_larger_url`)
- [x] `cargo clippy -p moq-relay --all-targets` clean

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiNPtKRGDykLu7hVYxvHig)_