### PR TITLE
moq-net: deterministic route tie-break for equal-length paths

### DIFF
--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -7,7 +7,7 @@ description: Run multiple moq-relay instances across multiple hosts/regions
 
 Relays can be joined together to proxy announcements and subscriptions between each other. A viewer talks to whichever relay is closest; if their broadcast lives somewhere else in the cluster, the local relay fetches it from a neighbor and caches it.
 
-A broadcast carries a small hop list as it travels. Each relay it passes through adds itself to the list, which is how loops are caught and how the network picks the shortest path when there's more than one.
+A broadcast carries a small hop list as it travels. Each relay it passes through adds itself to the list, which is how loops are caught and how the network picks the shortest path when there's more than one. When two paths are the same length, every relay breaks the tie the same way (a hash of the broadcast name and hop list), so the whole cluster converges on one route instead of flapping between equals.
 
 ## Topology
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -241,11 +241,13 @@ struct OriginBroadcast {
 fn route_key(name: &Path, hops: &OriginList) -> (usize, u64) {
 	// FNV-1a, not the std hasher: its output is fixed across Rust versions and
 	// builds, which matters when nodes run mismatched binaries during a rolling
-	// deploy and still need to agree on the same route.
-	const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+	// deploy and still need to agree on the same route. SEED is a custom basis
+	// (any nonzero u64 works, the textbook one is just as arbitrary); FNV_PRIME is
+	// the standard FNV-64 prime and should stay put.
+	const SEED: u64 = 0x420_C0DEC_B00B;
 	const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
-	let mut hash = FNV_OFFSET;
+	let mut hash = SEED;
 	for &byte in name.as_str().as_bytes() {
 		hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
 	}

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -231,6 +231,33 @@ struct OriginBroadcast {
 	backup: VecDeque<BroadcastConsumer>,
 }
 
+/// Ordering key used to pick the active route among broadcasts at the same path.
+///
+/// Lower wins. Shorter hop chains sort first; equal-length chains are broken by a
+/// deterministic hash of the broadcast name and hop chain, so every node in the
+/// cluster, given the same candidate routes, converges on the same winner instead
+/// of relying on arrival order. Mixing the name in spreads equal-length routes
+/// across different upstreams rather than funneling every broadcast onto one.
+fn route_key(name: &Path, hops: &OriginList) -> (usize, u64) {
+	// FNV-1a, not the std hasher: its output is fixed across Rust versions and
+	// builds, which matters when nodes run mismatched binaries during a rolling
+	// deploy and still need to agree on the same route.
+	const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+	const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+	let mut hash = FNV_OFFSET;
+	for &byte in name.as_str().as_bytes() {
+		hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
+	}
+	for hop in hops {
+		for &byte in &hop.id.to_le_bytes() {
+			hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
+		}
+	}
+
+	(hops.len(), hash)
+}
+
 /// One coalesced update queued for an `OriginConsumer`.
 ///
 /// At most one entry exists per path, so a slow consumer's pending set is bounded
@@ -421,8 +448,9 @@ impl OriginNode {
 			// Not using entry to avoid allocating a string most of the time.
 			self.entry(dir).lock().publish(&full, broadcast, &relative);
 		} else if let Some(existing) = &mut self.broadcast {
-			// This node is a leaf with an existing broadcast. Prefer the shorter or equal hop path;
-			// on ties, the newer broadcast wins, since the previous one may be about to close.
+			// This node is a leaf with an existing broadcast. Prefer the route with the
+			// lower ordering key (shorter hop chain, deterministic hash on ties), so every
+			// node converges on the same route regardless of the order announces arrive.
 			//
 			// Drop duplicates (same underlying broadcast delivered via multiple links) so the
 			// backup queue can't accumulate clones of the active entry and trigger redundant
@@ -431,14 +459,15 @@ impl OriginNode {
 				return;
 			}
 
-			if broadcast.hops.len() <= existing.active.hops.len() {
+			if route_key(&full, &broadcast.hops) < route_key(&full, &existing.active.hops) {
 				let old = existing.active.clone();
 				existing.active = broadcast.clone();
 				existing.backup.push_back(old);
 
 				self.notify.lock().reannounce(full, broadcast);
 			} else {
-				// Longer path: keep as a backup in case the active one drops.
+				// Loses the ordering (longer path, or the tie-break): keep as a backup
+				// in case the active one drops.
 				existing.backup.push_back(broadcast.clone());
 			}
 		} else {
@@ -518,13 +547,13 @@ impl OriginNode {
 			// Okay so it must be the active broadcast or else we fucked up.
 			assert!(entry.active.is_clone(&broadcast));
 
-			// Promote the backup with the shortest hop chain so we keep preferring short paths.
-			// Ties break toward the oldest (FIFO) since min_by_key returns the first minimum.
+			// Promote the backup with the lowest ordering key, the same rule used when
+			// publishing, so the route a node heals to still matches its peers.
 			let best = entry
 				.backup
 				.iter()
 				.enumerate()
-				.min_by_key(|(_, b)| b.hops.len())
+				.min_by_key(|(_, b)| route_key(&full, &b.hops))
 				.map(|(i, _)| i);
 			if let Some(idx) = best {
 				let active = entry.backup.remove(idx).expect("index in range");
@@ -677,8 +706,10 @@ impl OriginProducer {
 	///
 	/// The broadcast will be unannounced when it is closed.
 	/// If there is already a broadcast with the same path, the new one replaces the active only
-	/// if its hop path is shorter or equal; otherwise it is queued as a backup.
-	/// When the active broadcast closes, the backup with the shortest hop path is promoted and
+	/// if it has a shorter hop path, or an equal-length path that wins a deterministic tie-break
+	/// (a hash of the broadcast name and hop chain); otherwise it is queued as a backup. The
+	/// tie-break is identical on every node, so a cluster converges on the same route.
+	/// When the active broadcast closes, the backup that wins the same ordering is promoted and
 	/// reannounced. Backups that close before being promoted are silently dropped.
 	///
 	/// Returns false if the broadcast is not allowed to be published.
@@ -1117,11 +1148,9 @@ mod tests {
 		origin.publish_broadcast("test", consumer3.clone());
 		assert!(consumer.get_broadcast("test").is_some());
 
-		// On equal hop lengths, each new publish replaces the active and reannounces.
-		// Because the consumer hasn't drained between publishes, the stale announces
-		// collapse with their following unannounces and only the final active broadcast
-		// is delivered.
-		consumer.assert_next("test", &consumer3);
+		// Identical (empty) hop chains tie on the deterministic key, so the first publish
+		// stays active and the rest queue as backups. No churn, no reannounce.
+		consumer.assert_next("test", &consumer1);
 		consumer.assert_next_wait();
 
 		// Drop a backup, nothing should change.
@@ -1134,17 +1163,17 @@ mod tests {
 		consumer.assert_next_wait();
 
 		// Drop the active, we should reannounce with the remaining backup.
-		drop(broadcast3);
+		drop(broadcast1);
 
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 
 		assert!(consumer.get_broadcast("test").is_some());
 		consumer.assert_next_none("test");
-		consumer.assert_next("test", &consumer1);
+		consumer.assert_next("test", &consumer3);
 
 		// Drop the final broadcast, we should unannounce.
-		drop(broadcast1);
+		drop(broadcast3);
 
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
@@ -1178,6 +1207,40 @@ mod tests {
 		// Wait for the cleanup async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 		assert!(origin.consume().get_broadcast("test").is_none());
+	}
+
+	#[tokio::test]
+	async fn test_deterministic_tiebreak() {
+		tokio::time::pause();
+
+		// Build a broadcast carrying a specific hop chain.
+		fn route(ids: &[u64]) -> BroadcastProducer {
+			let hops = OriginList::try_from(ids.iter().copied().map(Origin::from).collect::<Vec<_>>()).unwrap();
+			Broadcast { hops }.produce()
+		}
+
+		// Resolve the active route for "test" after publishing both routes in the given order.
+		fn winner(first: &[u64], second: &[u64]) -> OriginList {
+			let origin = Origin::random().produce();
+			let a = route(first);
+			let b = route(second);
+			origin.publish_broadcast("test", a.consume());
+			origin.publish_broadcast("test", b.consume());
+			let hops = origin.consume().get_broadcast("test").unwrap().hops.clone();
+			// Keep the producers alive until after we read the active route.
+			drop((a, b));
+			hops
+		}
+
+		// Two routes with equal hop counts but distinct chains. The winner is decided by
+		// the deterministic key, not arrival order, so both publish orders converge.
+		let forward = winner(&[10, 20], &[30, 40]);
+		let reverse = winner(&[30, 40], &[10, 20]);
+		assert_eq!(forward, reverse, "tie-break must not depend on publish order");
+
+		// A strictly shorter chain always wins regardless of the hash.
+		assert_eq!(winner(&[10, 20], &[30]).len(), 1);
+		assert_eq!(winner(&[30], &[10, 20]).len(), 1);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -244,7 +244,7 @@ fn route_key(name: &Path, hops: &OriginList) -> (usize, u64) {
 	// deploy and still need to agree on the same route. SEED is a custom basis
 	// (any nonzero u64 works, the textbook one is just as arbitrary); FNV_PRIME is
 	// the standard FNV-64 prime and should stay put.
-	const SEED: u64 = 0x420_C0DEC_B00B;
+	const SEED: u64 = 0x420C0DECB00B; // 420 C0DEC B00B
 	const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
 	let mut hash = SEED;


### PR DESCRIPTION
## Summary

When two announcements compete for the same broadcast path with **equal hop counts**, the relay used to keep whichever arrived most recently (`broadcast.hops.len() <= existing.active.hops.len()`, newest wins on a tie). Arrival order differs per node, so relays in a cluster could pick different routes for the same broadcast and flap between equal-length paths.

This makes the tie-break deterministic so every node, given the same candidate routes, converges on the same winner.

## What changed

- Added `route_key(name, hops) -> (usize, u64)` in `rs/moq-net/src/model/origin.rs`. The key is `(hop_count, hash)` where `hash` is **FNV-1a over the broadcast name + hop chain**. Comparison is lexicographic:
  - a strictly shorter hop chain still wins;
  - equal-length chains are broken by the **lowest hash**.
- Both call sites now use the same key:
  - `publish` replaces the active route only when `route_key(challenger) < route_key(active)`, then reannounces downstream.
  - `remove` promotes the backup with the lowest `route_key` when the active route closes, so healing stays consistent with peers.
- On an exact key tie (genuinely identical hop chains, e.g. same-origin publishers) the incumbent stays active — no churn.

## Why FNV-1a instead of the std hasher

`DefaultHasher`'s output is explicitly not stable across Rust versions. During a rolling deploy, mismatched binaries must still agree on a route, so the hash needs to be fixed across versions and builds. FNV-1a is small and well-defined.

## Why mix the name in

Including the broadcast name (not just the hops) spreads equal-length routes across different upstreams instead of funneling every broadcast onto the same one — cheap load distribution across equal-cost paths.

## Cross-package sync

- `js/net` is a pure client and does **not** do relay-style route selection (it only tracks hops for loop detection), so no JS change is needed.
- Updated `doc/bin/relay/cluster.md` to describe the deterministic tie-break.

## Test plan

- [x] Updated `test_duplicate` — identical empty hop chains now keep the *first* publish active rather than the newest.
- [x] Added `test_deterministic_tiebreak` — asserts the winning route is identical whether the two routes are published forward or reversed, and that a strictly shorter chain still wins.
- [x] `cargo test -p moq-net` — 328 passed.
- [x] `cargo clippy -p moq-net --all-targets` — clean.

This is behavior-only; the wire format (the hop list) is unchanged, so it targets `main`. Happy to redirect to `dev` if reviewers prefer.

(Written by Claude)