### PR TITLE
moq-relay: add --cluster-connect-api and split cluster identity from gossip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ match version {
 - **Error handling**: Use `thiserror` with `#[from]` for library crates, `anyhow` for binaries. Always add `#[non_exhaustive]` to public `thiserror` enums.
 - Use `anyhow::Context` (`.context("msg")`) instead of `.map_err(|_| anyhow::anyhow!("msg"))` for error conversion
 - **Config flags + TOML merge**: For any `#[arg]` field on a TOML-loadable config, use `Option<T>` (not bare `bool` / `String` / etc.). The TOML→CLI merge clobbers bare fields with their `Default` when the flag is absent, silently overwriting TOML values. See `rs/moq-relay/src/config.rs::tests` for the regression test; add one for any new flag.
+- **Prefer `if let` / `let ... else` over an unwrapping `match`**: a `match` whose only job is to unwrap (`Ok(v) => v` / `Some(v) => v`) reads cleaner as `if let Some(v) = x { ... }` or `let Some(v) = x else { ... };`. Matching on an `Option`/`Result` just to bind the inner value is the tell. Keep `match` when both arms do real work or you need the `Err` / `None` payload.
 
 ## Comment Conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3010,6 +3019,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,6 +3422,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,6 +3659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3845,6 +3895,7 @@ dependencies = [
  "moq-native",
  "moq-net",
  "moq-token",
+ "notify",
  "qmux",
  "rcgen 0.13.2",
  "reqwest 0.12.28",
@@ -4290,6 +4341,33 @@ dependencies = [
  "socket2",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -35,17 +35,41 @@ Pick the shape that matches your traffic. Linear chains are great for fanout; sm
 
 ## Auto-discovery
 
-Listing every peer by hand can get tedious in larger clusters. Set `cluster.mesh` to this relay's own URL and connected peers will discover and dial it back automatically:
+Listing every peer by hand can get tedious in larger clusters. Tell the relay its own URL with `cluster.node`, then enable gossip with `cluster.mesh`; connected peers will discover and dial it back automatically:
 
 ```toml
 [cluster]
 connect = ["us-east.example.com:4443"]
-mesh    = "us-west.example.com:4443"
+node    = "us-west.example.com:4443"
+mesh    = true
 ```
 
-Each node with `mesh` set creates a broadcast carrying its address, which other nodes pick up. `connect` is optional once gossip is running, but you still need at least one connection somewhere (either you dial a peer or a peer dials you) for the advertisement to flow.
+`node` is this relay's identity (its externally-reachable URL); `mesh` is a boolean that turns gossip on. Each gossiping node creates a broadcast carrying its `node` address, which other nodes pick up. `connect` is optional once gossip is running, but you still need at least one connection somewhere (either you dial a peer or a peer dials you) for the advertisement to flow. Enabling `mesh` without `node` is an error, since there'd be no address to advertise.
 
-A relay with `mesh` set and no `connect` is a passive rendezvous: it sits and waits for inbound connections, then helps everyone else find each other.
+A relay with `node` + `mesh` and no `connect` is a passive rendezvous: it sits and waits for inbound connections, then helps everyone else find each other.
+
+## Dynamic peer lists
+
+`cluster.connect` is fixed at startup, so adding or removing a node means editing every affected config and restarting. When you'd rather keep the topology somewhere external and change it without a redeploy, point `cluster.connect_api` at an HTTP(S) endpoint or a local file:
+
+```toml
+[cluster]
+connect_api = "https://api.example.com/cluster/connect"
+mesh        = "us-west.example.com:4443"
+```
+
+The source returns a bare JSON array of peer hostnames:
+
+```json
+["eu-west.example.com:4443", "us-east.example.com:4443"]
+```
+
+The relay reconciles that list against its live dials: new entries are dialed, entries that disappear are dropped. It composes with `connect` (static seeds that are never reconciled away) and `mesh` (gossip). The relay's own `node` value, when set, is sent as a `?node=` query parameter so the endpoint can return the peers for that specific node; for mTLS-gated endpoints the cluster client certificate identifies the caller as well.
+
+- **HTTP(S) URL**: polled, with the re-poll cadence taken from the response's `Cache-Control` reuse window (`max-age` plus any `stale-while-revalidate`; default 30s, floored at 5s). Conditional revalidation (`ETag` / `Last-Modified`) and stale-if-error (serving the last cached body when a revalidation request fails) are handled by the underlying HTTP cache, so transient endpoint blips don't churn the dial set.
+- **Local file** (a path or `file://` URL): re-read whenever its mtime changes.
+
+If a fetch fails or returns garbage, the relay logs and keeps the last good list rather than tearing the cluster down. This keeps the moq-relay binary generic: all routing decisions (which node connects where) live in whatever service answers the endpoint.
 
 ## Authentication
 
@@ -58,13 +82,13 @@ See [Authentication](/bin/relay/auth) for the full setup.
 
 ## Migration from older configs
 
-`cluster.root` and `cluster.node` were both removed. If a config still sets either flag, the relay errors at startup with a message pointing at the replacements:
+`cluster.root` was removed; setting it errors at startup with a message pointing at the replacement. `cluster.mesh` is now a boolean gossip toggle (it used to take this relay's URL); the URL moved to `cluster.node`.
 
 | Old | New |
 |---|---|
-| `root = "rendezvous:4443"` + `node = "us-east:4443"` | `connect = ["rendezvous:4443"]` + `mesh = "us-east:4443"` |
-| `root = "rendezvous:4443"` only | `mesh = "rendezvous:4443"` (passive rendezvous) |
-| `node = "us-east:4443"` | `mesh = "us-east:4443"` |
+| `root = "rendezvous:4443"` + `node = "us-east:4443"` | `connect = ["rendezvous:4443"]` + `node = "us-east:4443"` + `mesh = true` |
+| `root = "rendezvous:4443"` only | `node = "rendezvous:4443"` + `mesh = true` (passive rendezvous) |
+| `mesh = "us-east:4443"` | `node = "us-east:4443"` + `mesh = true` |
 
 ## Next steps
 

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -84,7 +84,7 @@ See [Authentication](/bin/relay/auth) for the full setup.
 
 ## Migration from older configs
 
-`cluster.root` was removed; setting it errors at startup with a message pointing at the replacement. `cluster.mesh` is now a boolean gossip toggle (it used to take this relay's URL); the URL moved to `cluster.node`.
+`cluster.root` was removed; setting it errors at startup with a message pointing at the replacement. `cluster.mesh` is now a boolean gossip toggle (it used to take this relay's URL); the URL moved to `cluster.node`. The old `mesh = "<url>"` form still works for backwards compatibility: it enables gossip and is treated as `cluster.node`, with a deprecation warning (or an error if it conflicts with an explicit `cluster.node`).
 
 | Old | New |
 |---|---|

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -67,7 +67,7 @@ The source returns a bare JSON array of peer hostnames:
 The relay reconciles that list against its live dials: new entries are dialed, entries that disappear are dropped. It composes with `connect` (static seeds that are never reconciled away) and `mesh` (gossip). The relay's own `node` value, when set, is sent as a `?node=` query parameter so the endpoint can return the peers for that specific node; for mTLS-gated endpoints the cluster client certificate identifies the caller as well.
 
 - **HTTP(S) URL**: polled, with the re-poll cadence taken from the response's `Cache-Control` reuse window (`max-age` plus any `stale-while-revalidate`; default 30s, floored at 5s). Conditional revalidation (`ETag` / `Last-Modified`) and stale-if-error (serving the last cached body when a revalidation request fails) are handled by the underlying HTTP cache, so transient endpoint blips don't churn the dial set.
-- **Local file** (a path or `file://` URL): re-read whenever its mtime changes.
+- **Local file** (a path or `file://` URL): watched via OS filesystem notifications (inotify / FSEvents / kqueue), with a periodic re-check as a safety net.
 
 If a fetch fails or returns garbage, the relay logs and keeps the last good list rather than tearing the cluster down. This keeps the moq-relay binary generic: all routing decisions (which node connects where) live in whatever service answers the endpoint.
 

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -123,9 +123,17 @@ Clustering configuration for multi-relay deployments.
 # Peers this relay dials. The topology is whatever you draw with these links.
 connect = ["us-east.example.com:4443"]
 
-# Optional. Set to this relay's own URL to advertise it so other peers find
-# you automatically.
-mesh = "us-west.example.com:4443"
+# Optional. This relay's own externally-reachable URL (identity). Advertised to
+# peers when gossip is on, and sent to connect_api as ?node=.
+node = "us-west.example.com:4443"
+
+# Optional. Enable gossip discovery: advertise `node` so peers find you
+# automatically. Boolean; requires `node` to be set.
+mesh = true
+
+# Optional. Fetch the peer list from an HTTP(S) endpoint or local file (a JSON
+# array of hostnames) and reconcile it at runtime, no restart needed.
+connect_api = "https://api.example.com/cluster/connect"
 
 # JWT used for outbound cluster dials (alternative to mTLS).
 token = "cluster.jwt"

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -42,6 +42,7 @@ jsonwebtoken = "10"
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
 moq-net = { workspace = true, features = ["serde"] }
 moq-token = { workspace = true, features = ["tokio"] }
+notify = "8"
 qmux = { workspace = true, features = ["ws"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 reqwest-middleware = "0.4"

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use axum::http;
-use http_cache_reqwest::{Cache, CacheMode, HttpCache, HttpCacheOptions, MokaManager};
 #[cfg(test)]
 use moq_net::AsPath;
 use moq_net::{Path, PathOwned, PathPrefixes};
@@ -810,19 +809,7 @@ impl Auth {
 	}
 
 	fn build_client(tls: &rustls::ClientConfig) -> anyhow::Result<ClientWithMiddleware> {
-		let client = reqwest::Client::builder()
-			.timeout(std::time::Duration::from_secs(10))
-			.use_preconfigured_tls(tls.clone())
-			.build()
-			.context("failed to build HTTP client")?;
-
-		Ok(reqwest_middleware::ClientBuilder::new(client)
-			.with(Cache(HttpCache {
-				mode: CacheMode::Default,
-				manager: MokaManager::default(),
-				options: HttpCacheOptions::default(),
-			}))
-			.build())
+		crate::http_client::build(tls)
 	}
 }
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -1,5 +1,5 @@
 use std::{
-	collections::HashMap,
+	collections::{HashMap, HashSet},
 	path::PathBuf,
 	sync::{Arc, Mutex},
 	time::{Duration, Instant},
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::Context;
 use moq_net::{BroadcastProducer, Origin, OriginConsumer, OriginProducer, Path, Stats, Tier};
+use reqwest_middleware::ClientWithMiddleware;
 use tokio::task::AbortHandle;
 use url::Url;
 
@@ -24,14 +25,37 @@ const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 /// within sub-milliseconds) plus reasonable churn from a peer restart.
 const STALE_AFTER: Duration = Duration::from_secs(60);
 
-/// One entry in [`DialMap`]. `is_static` flags peers seeded from
-/// `--cluster-connect`; those keep retrying forever even if their gossip
-/// registration goes away (operator intent says "always dial"). Gossip-discovered
-/// peers carry an `unannounced_at` timestamp that the periodic sweep uses to
-/// decide when a peer has truly left vs. is just flapping between paths.
+/// Re-poll cadence for `--cluster-connect-api` when the response carries no
+/// `Cache-Control` reuse window (`max-age` / `stale-while-revalidate`).
+const CONNECT_API_DEFAULT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Floor on the `--cluster-connect-api` poll cadence, so a tiny (or zero) reuse
+/// window can't spin the relay into a tight fetch loop.
+const CONNECT_API_MIN_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How often a local `--cluster-connect-api` file is stat'd for mtime changes.
+const CONNECT_API_FILE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How a dial was sourced, which decides how it's torn down.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum DialSource {
+	/// Seeded from `--cluster-connect`. Dialed forever (operator intent says
+	/// "always dial"); never swept or reconciled away.
+	Static,
+	/// Discovered via gossip on `.internal/origins/*`. Aborted by the periodic
+	/// stale-sweep once its unannounce has stuck for [`STALE_AFTER`].
+	Gossip,
+	/// Supplied by `--cluster-connect-api`. Added/removed by reconciling against
+	/// each fetched peer list; immune to the gossip stale-sweep.
+	Api,
+}
+
+/// One entry in [`DialMap`]. Gossip-discovered peers carry an `unannounced_at`
+/// timestamp that the periodic sweep uses to decide when a peer has truly left
+/// vs. is just flapping between paths.
 struct DialEntry {
 	handle: AbortHandle,
-	is_static: bool,
+	source: DialSource,
 	unannounced_at: Option<Instant>,
 }
 
@@ -52,24 +76,24 @@ impl DialMap {
 	/// Record a new dial under `peer`. Caller is responsible for spawning the
 	/// task and passing its [`AbortHandle`]. Replaces any existing entry (callers
 	/// should check [`Self::contains`] first; this is just defensive).
-	fn insert(&self, peer: String, handle: AbortHandle, is_static: bool) {
+	fn insert(&self, peer: String, handle: AbortHandle, source: DialSource) {
 		self.inner.lock().expect("dial map poisoned").insert(
 			peer,
 			DialEntry {
 				handle,
-				is_static,
+				source,
 				unannounced_at: None,
 			},
 		);
 	}
 
-	/// Mark a gossip peer as unannounced if it isn't already. No-op for static
-	/// peers or unknown URLs. Idempotent: a repeat unannounce while a timestamp
-	/// is already pending doesn't reset the clock.
+	/// Mark a gossip peer as unannounced if it isn't already. No-op for static /
+	/// API peers or unknown URLs. Idempotent: a repeat unannounce while a
+	/// timestamp is already pending doesn't reset the clock.
 	fn mark_unannounced(&self, peer: &str, now: Instant) {
 		let mut map = self.inner.lock().expect("dial map poisoned");
 		if let Some(entry) = map.get_mut(peer) {
-			if !entry.is_static {
+			if entry.source == DialSource::Gossip {
 				entry.unannounced_at.get_or_insert(now);
 			}
 		}
@@ -84,12 +108,12 @@ impl DialMap {
 	}
 
 	/// Abort and remove gossip-discovered entries whose unannounce has persisted
-	/// for at least `threshold`. Static peers are skipped, as are entries that
-	/// are currently announced (`unannounced_at == None`).
+	/// for at least `threshold`. Static / API peers are skipped, as are entries
+	/// that are currently announced (`unannounced_at == None`).
 	fn sweep_stale(&self, now: Instant, threshold: Duration) {
 		let mut map = self.inner.lock().expect("dial map poisoned");
 		map.retain(|peer, entry| {
-			if entry.is_static {
+			if entry.source != DialSource::Gossip {
 				return true;
 			}
 			let Some(at) = entry.unannounced_at else { return true };
@@ -102,13 +126,32 @@ impl DialMap {
 			}
 		});
 	}
+
+	/// Reconcile the set of [`DialSource::Api`] dials against `desired`: abort and
+	/// drop API dials no longer listed, and return the desired peers not yet
+	/// dialed (the caller spawns those and re-inserts them as [`DialSource::Api`]).
+	/// Static / Gossip dials, and peers already dialed via any source, are left
+	/// untouched (dialing dedupes by URL).
+	fn reconcile_api(&self, desired: &HashSet<String>) -> Vec<String> {
+		let mut map = self.inner.lock().expect("dial map poisoned");
+		map.retain(|peer, entry| {
+			if entry.source == DialSource::Api && !desired.contains(peer) {
+				tracing::info!(%peer, "peer dropped from cluster-connect-api; abandoning dial");
+				entry.handle.abort();
+				return false;
+			}
+			true
+		});
+		desired.iter().filter(|p| !map.contains_key(*p)).cloned().collect()
+	}
 }
 
 /// Configuration for relay clustering.
 ///
-/// [`Self::connect`] lists peers to dial. [`Self::mesh`] is optional: when set, this
-/// relay advertises its own URL so other peers discover and dial it. Set both to
-/// join an existing cluster; set mesh alone to act as a passive rendezvous.
+/// [`Self::connect`] / [`Self::connect_api`] list peers to dial. [`Self::node`] is
+/// this relay's own URL (identity); [`Self::mesh`] enables gossip, advertising that
+/// URL so other peers discover and dial it. Set `node` + `mesh` with no `connect`
+/// to act as a passive rendezvous.
 ///
 /// Hop-based routing on broadcasts prevents announcement loops regardless of topology.
 #[serde_with::serde_as]
@@ -130,20 +173,48 @@ pub struct ClusterConfig {
 	#[serde_as(as = "serde_with::OneOrMany<_>")]
 	pub connect: Vec<String>,
 
-	/// This relay's own externally-reachable URL. When set, the relay publishes its
-	/// address on the cluster origin so other peers can discover and dial it. Pair
-	/// with [`Self::connect`] to reach an initial peer who will gossip your address
-	/// onward, or set alone for passive rendezvous.
-	#[arg(id = "cluster-mesh", long = "cluster-mesh", env = "MOQ_CLUSTER_MESH")]
-	pub mesh: Option<String>,
+	/// Fetch the list of peers to dial from an HTTP(S) URL or a local file,
+	/// reloading at runtime without a restart. The source returns a JSON array
+	/// of peer hostnames: `["a.pop.example", "b.pop.example"]`. An http(s) URL is
+	/// polled (the re-poll cadence follows `Cache-Control` `max-age` +
+	/// `stale-while-revalidate`, with conditional revalidation and stale-if-error
+	/// handled by the shared cache client); a local path is re-read when its mtime
+	/// changes. This relay's own [`Self::node`] value, when set, is sent as a
+	/// `?node=` query param so the server can return this node's peers. The relay
+	/// keeps the last good list if a fetch fails. Composes with [`Self::connect`]
+	/// and [`Self::mesh`].
+	#[arg(
+		id = "cluster-connect-api",
+		long = "cluster-connect-api",
+		env = "MOQ_CLUSTER_CONNECT_API"
+	)]
+	pub connect_api: Option<String>,
+
+	/// This relay's own externally-reachable URL (identity). Sent to
+	/// [`Self::connect_api`] as a `?node=` query param so the endpoint can return
+	/// this node's peers, and advertised to other relays when [`Self::mesh`] gossip
+	/// is enabled. On its own it neither opens nor accepts a connection.
+	#[arg(id = "cluster-node", long = "cluster-node", env = "MOQ_CLUSTER_NODE")]
+	pub node: Option<String>,
+
+	/// Enable gossip discovery: advertise this relay's [`Self::node`] URL on the
+	/// cluster origin so peers can find and dial it (and so this relay discovers
+	/// peers the same way). Requires [`Self::node`]. Boolean flag: pass
+	/// `--cluster-mesh` to enable.
+	#[arg(
+		id = "cluster-mesh",
+		long = "cluster-mesh",
+		env = "MOQ_CLUSTER_MESH",
+		default_missing_value = "true",
+		num_args = 0..=1,
+		require_equals = true,
+		value_parser = clap::value_parser!(bool),
+	)]
+	pub mesh: Option<bool>,
 
 	/// Use the token in this file when connecting to other nodes.
 	#[arg(id = "cluster-token", long = "cluster-token", env = "MOQ_CLUSTER_TOKEN")]
 	pub token: Option<PathBuf>,
-
-	/// Removed; present only to emit a migration error. Use [`Self::mesh`] instead.
-	#[arg(id = "cluster-node", long = "cluster-node", env = "MOQ_CLUSTER_NODE", hide = true)]
-	pub node: Option<String>,
 
 	/// Removed; present only to emit a migration error. Use [`Self::connect`] instead.
 	#[arg(id = "cluster-root", long = "cluster-root", env = "MOQ_CLUSTER_ROOT", hide = true)]
@@ -163,6 +234,11 @@ pub struct ClusterConfig {
 pub struct Cluster {
 	config: ClusterConfig,
 	client: Option<moq_native::Client>,
+
+	/// Client TLS config used to build the `--cluster-connect-api` HTTP client, so
+	/// peer-list fetches present the same cluster cert the QUIC dials do. `Arc` so
+	/// cloning a `Cluster` per connection stays cheap.
+	client_tls: Option<Arc<rustls::ClientConfig>>,
 
 	/// All broadcasts, local and remote. Downstream sessions read from here
 	/// (filtered by their auth token) and remote dials both read and write here.
@@ -188,6 +264,7 @@ impl Cluster {
 		Cluster {
 			config,
 			client: None,
+			client_tls: None,
 			origin,
 			stats: Stats::default(),
 		}
@@ -199,6 +276,15 @@ impl Cluster {
 	/// an error otherwise.
 	pub fn with_client(mut self, client: moq_native::Client) -> Self {
 		self.client = Some(client);
+		self
+	}
+
+	/// Attach the client TLS config used for `--cluster-connect-api` peer-list
+	/// fetches. Required when `config.connect_api` is set; pass the same config
+	/// used to build the QUIC [`with_client`](Self::with_client) so the endpoint
+	/// sees this relay's cluster certificate.
+	pub fn with_client_tls(mut self, tls: rustls::ClientConfig) -> Self {
+		self.client_tls = Some(Arc::new(tls));
 		self
 	}
 
@@ -225,35 +311,34 @@ impl Cluster {
 	/// Runs the cluster event loop.
 	///
 	/// Modes are derived from config: standalone (no work) returns immediately;
-	/// passive rendezvous (`mesh` only) parks after publishing self-registration
-	/// and does not require a QUIC client; active (`connect` non-empty) dials
-	/// peers and, if `mesh` is also set, runs gossip discovery.
+	/// passive rendezvous (`node` + `mesh` gossip, no peers to dial) parks after
+	/// publishing self-registration and does not require a QUIC client; active
+	/// (`connect` / `connect_api` set) dials peers and, when `mesh` gossip is on,
+	/// also advertises `node` and runs discovery.
 	///
-	/// Bails when removed flags `cluster.root` / `cluster.node` are set, or when
-	/// `connect` is non-empty but no client was attached via
-	/// [`with_client`](Self::with_client).
+	/// Bails when the removed flag `cluster.root` is set, when `mesh` gossip is on
+	/// without `node`, or when peers are configured to dial but no client was
+	/// attached via [`with_client`](Self::with_client).
 	pub async fn run(self) -> anyhow::Result<()> {
 		if let Some(root) = &self.config.root {
 			anyhow::bail!(
 				"`cluster.root` / `--cluster-root` was removed (value: {root:?}). \
-				 Use `--cluster-connect <peer-url>` to dial cluster peers, and \
-				 optionally `--cluster-mesh <self-url>` to gossip this relay's address \
-				 so other peers can discover and dial it. \
-				 See https://doc.moq.dev/bin/relay/cluster."
-			);
-		}
-		if let Some(node) = &self.config.node {
-			anyhow::bail!(
-				"`cluster.node` / `--cluster-node` was renamed (value: {node:?}). \
-				 Use `--cluster-connect <peer-url>` to dial cluster peers, and \
-				 optionally `--cluster-mesh <self-url>` to gossip this relay's address \
-				 so other peers can discover and dial it. \
+				 Use `--cluster-connect <peer-url>` to dial cluster peers. To gossip \
+				 this relay's address, set `--cluster-node <self-url>` and enable \
+				 `--cluster-mesh`. \
 				 See https://doc.moq.dev/bin/relay/cluster."
 			);
 		}
 
-		let has_outbound = !self.config.connect.is_empty();
-		let has_work = has_outbound || self.config.mesh.is_some();
+		let gossip = self.config.mesh.unwrap_or(false);
+		anyhow::ensure!(
+			!gossip || self.config.node.is_some(),
+			"`--cluster-mesh` (gossip) requires `--cluster-node <self-url>` so there's an address to advertise. \
+			 See https://doc.moq.dev/bin/relay/cluster."
+		);
+
+		let has_outbound = !self.config.connect.is_empty() || self.config.connect_api.is_some();
+		let has_work = has_outbound || gossip;
 		if !has_work {
 			tracing::info!("no cluster peers configured; running standalone");
 			return Ok(());
@@ -297,25 +382,42 @@ impl Cluster {
 					tracing::warn!(%err, peer = %peer_for_task, "cluster peer connection ended");
 				}
 			});
-			dialed.insert(peer, handle, true);
+			dialed.insert(peer, handle, DialSource::Static);
+		}
+
+		if let Some(source) = self.config.connect_api.clone() {
+			let tls = self
+				.client_tls
+				.clone()
+				.context("cluster.connect_api set but no client TLS attached (call Cluster::with_client_tls)")?;
+			let http = crate::http_client::build(&tls)?;
+			let this = self.clone();
+			let token = token.clone();
+			let dialed = dialed.clone();
+			let node = self.config.node.clone();
+			tasks.spawn(async move {
+				this.run_connect_api(source, node, token, dialed, http).await;
+			});
 		}
 
 		// Held in scope so the registration stays announced until `run` exits.
-		// Discovery is paired with it: a mesh-only relay (passive rendezvous) has
+		// Discovery is paired with it: a gossip-only relay (passive rendezvous) has
 		// nothing to discover, so we only run it when we also have an outbound peer.
-		let _self_registration: Option<BroadcastProducer> = if let Some(mesh) = self.config.mesh.as_deref() {
-			let path = Path::new(MESH_PREFIX).join(mesh);
+		let _self_registration: Option<BroadcastProducer> = if gossip {
+			// Checked above: gossip requires `node`.
+			let node = self.config.node.as_deref().expect("gossip requires --cluster-node");
+			let path = Path::new(MESH_PREFIX).join(node);
 			let broadcast = self
 				.origin
 				.create_broadcast(&path)
 				.expect(".internal/origins is within the relay origin's root");
-			tracing::info!(url = %mesh, %path, "advertising cluster mesh URL");
+			tracing::info!(url = %node, %path, "advertising cluster node URL");
 
 			if has_outbound {
 				let this = self.clone();
 				let token = token.clone();
 				let dialed = dialed.clone();
-				let self_url = mesh.to_owned();
+				let self_url = node.to_owned();
 				tasks.spawn(async move {
 					this.run_discovery(self_url, token, dialed).await;
 				});
@@ -380,7 +482,7 @@ impl Cluster {
 									tracing::warn!(%err, peer = %peer_for_task, "cluster peer connection ended");
 								}
 							});
-							dialed.insert(peer, handle.abort_handle(), false);
+							dialed.insert(peer, handle.abort_handle(), DialSource::Gossip);
 						}
 						None => {
 							dialed.mark_unannounced(&peer, Instant::now());
@@ -391,6 +493,147 @@ impl Cluster {
 					dialed.sweep_stale(Instant::now(), STALE_AFTER);
 				}
 			}
+		}
+	}
+
+	/// Drive `--cluster-connect-api`: an http(s) URL is polled, a local path (or
+	/// `file://` URL) is watched for mtime changes. Either way the source yields a
+	/// JSON array of peer hostnames that's reconciled into the shared dial map.
+	async fn run_connect_api(
+		self,
+		source: String,
+		node: Option<String>,
+		token: String,
+		dialed: DialMap,
+		http: ClientWithMiddleware,
+	) {
+		match Url::parse(&source) {
+			Ok(url) if matches!(url.scheme(), "http" | "https") => {
+				self.run_connect_api_http(url, node, token, dialed, http).await;
+			}
+			Ok(url) if url.scheme() == "file" => match url.to_file_path() {
+				Ok(path) => self.run_connect_api_file(path, node, token, dialed).await,
+				Err(()) => tracing::error!(%source, "cluster.connect_api file URL is not a valid local path"),
+			},
+			// Anything that isn't a URL we recognize is treated as a filesystem path.
+			_ => {
+				self.run_connect_api_file(PathBuf::from(&source), node, token, dialed)
+					.await
+			}
+		}
+	}
+
+	/// Poll an http(s) endpoint for the peer list. The re-poll cadence follows the
+	/// response's `Cache-Control` reuse window (`max-age` + `stale-while-revalidate`).
+	/// Fails static: a failed fetch logs and keeps the current dials rather than
+	/// tearing the cluster down.
+	async fn run_connect_api_http(
+		&self,
+		url: Url,
+		node: Option<String>,
+		token: String,
+		dialed: DialMap,
+		http: ClientWithMiddleware,
+	) {
+		loop {
+			let mut req_url = url.clone();
+			if let Some(node) = &node {
+				req_url.query_pairs_mut().append_pair("node", node);
+			}
+
+			let sleep_for = match Self::fetch_peer_list(&http, req_url).await {
+				Ok((list, revalidate)) => {
+					self.apply_peer_list(list, &node, &token, &dialed);
+					revalidate
+						.unwrap_or(CONNECT_API_DEFAULT_INTERVAL)
+						.max(CONNECT_API_MIN_INTERVAL)
+				}
+				Err(err) => {
+					tracing::warn!(%err, "cluster.connect_api fetch failed; keeping current peers");
+					CONNECT_API_DEFAULT_INTERVAL
+				}
+			};
+
+			tokio::time::sleep(sleep_for).await;
+		}
+	}
+
+	/// Watch a local peer-list file, reconciling whenever its mtime changes. Fails
+	/// static: a missing or malformed file keeps the current dials.
+	async fn run_connect_api_file(&self, path: PathBuf, node: Option<String>, token: String, dialed: DialMap) {
+		let mut last_mtime = None;
+		loop {
+			match std::fs::metadata(&path).and_then(|m| m.modified()) {
+				Ok(mtime) if last_mtime != Some(mtime) => match std::fs::read_to_string(&path) {
+					Ok(body) => match serde_json::from_str::<Vec<String>>(&body) {
+						Ok(list) => {
+							last_mtime = Some(mtime);
+							self.apply_peer_list(list, &node, &token, &dialed);
+						}
+						Err(err) => {
+							tracing::warn!(%err, ?path, "cluster.connect_api file is not a JSON array; keeping current peers")
+						}
+					},
+					Err(err) => {
+						tracing::warn!(%err, ?path, "failed to read cluster.connect_api file; keeping current peers")
+					}
+				},
+				Ok(_) => {} // unchanged
+				Err(err) => tracing::warn!(%err, ?path, "cluster.connect_api file unavailable; keeping current peers"),
+			}
+
+			tokio::time::sleep(CONNECT_API_FILE_INTERVAL).await;
+		}
+	}
+
+	/// Fetch and parse the peer list, returning it alongside the reuse window
+	/// derived from the response's `Cache-Control` header (`max-age` plus any
+	/// `stale-while-revalidate`). The shared cache client also handles conditional
+	/// revalidation and stale-if-error (serving the cached body when revalidation
+	/// fails), so transient endpoint blips don't disturb the dial set.
+	async fn fetch_peer_list(http: &ClientWithMiddleware, url: Url) -> anyhow::Result<(Vec<String>, Option<Duration>)> {
+		let response = http
+			.get(url)
+			.send()
+			.await
+			.context("cluster.connect_api request failed")?
+			.error_for_status()
+			.context("cluster.connect_api returned an error status")?;
+
+		let revalidate = response
+			.headers()
+			.get(reqwest::header::CACHE_CONTROL)
+			.and_then(|value| value.to_str().ok())
+			.and_then(revalidate_after);
+		let body = response
+			.text()
+			.await
+			.context("failed to read cluster.connect_api body")?;
+		let list =
+			serde_json::from_str(&body).context("cluster.connect_api response is not a JSON array of hostnames")?;
+		Ok((list, revalidate))
+	}
+
+	/// Reconcile a freshly fetched peer list into the dial map: dial peers that
+	/// are new and drop API peers that disappeared. The relay's own [`node`] URL
+	/// is filtered out so it never dials itself.
+	fn apply_peer_list(&self, list: Vec<String>, node: &Option<String>, token: &str, dialed: &DialMap) {
+		let desired: HashSet<String> = list
+			.into_iter()
+			.filter(|peer| Some(peer.as_str()) != node.as_deref())
+			.collect();
+
+		for peer in dialed.reconcile_api(&desired) {
+			tracing::info!(%peer, "cluster.connect_api peer; dialing");
+			let this = self.clone();
+			let token = token.to_string();
+			let peer_for_task = peer.clone();
+			let handle = tokio::spawn(async move {
+				if let Err(err) = this.run_remote(&peer_for_task, token).await {
+					tracing::warn!(%err, peer = %peer_for_task, "cluster peer connection ended");
+				}
+			});
+			dialed.insert(peer, handle.abort_handle(), DialSource::Api);
 		}
 	}
 
@@ -455,6 +698,28 @@ impl Cluster {
 	}
 }
 
+/// How long a fetched peer list may be reused before the relay revalidates,
+/// from a `Cache-Control` value: `max-age` plus any `stale-while-revalidate`
+/// window (RFC 5861). Within that combined window the background poller keeps
+/// serving the current list. `None` if neither directive is present (the caller
+/// falls back to a default interval). The `http-cache` layer doesn't parse
+/// `stale-while-revalidate` itself, so we fold it into the poll cadence here.
+fn revalidate_after(cache_control: &str) -> Option<Duration> {
+	let seconds = |name: &str| {
+		cache_control.split(',').find_map(|directive| {
+			let value = directive.trim().strip_prefix(name)?.trim_start().strip_prefix('=')?;
+			value.trim().parse::<u64>().ok()
+		})
+	};
+
+	match (seconds("max-age"), seconds("stale-while-revalidate")) {
+		(None, None) => None,
+		(max_age, swr) => Some(Duration::from_secs(
+			max_age.unwrap_or(0).saturating_add(swr.unwrap_or(0)),
+		)),
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -470,7 +735,7 @@ mod tests {
 	#[tokio::test]
 	async fn sweep_preserves_static_peer() {
 		let dialed = DialMap::default();
-		dialed.insert("static-peer:4443".into(), placeholder_handle(), true);
+		dialed.insert("static-peer:4443".into(), placeholder_handle(), DialSource::Static);
 
 		let long_ago = Instant::now() - Duration::from_secs(3600);
 		dialed.mark_unannounced("static-peer:4443", long_ago);
@@ -485,7 +750,7 @@ mod tests {
 	async fn sweep_evicts_stale_gossip_peer() {
 		let dialed = DialMap::default();
 		let now = Instant::now();
-		dialed.insert("gone:4443".into(), placeholder_handle(), false);
+		dialed.insert("gone:4443".into(), placeholder_handle(), DialSource::Gossip);
 		dialed.mark_unannounced("gone:4443", now - STALE_AFTER - Duration::from_secs(1));
 
 		dialed.sweep_stale(now, STALE_AFTER);
@@ -501,7 +766,7 @@ mod tests {
 	async fn sweep_keeps_recently_unannounced_peer() {
 		let dialed = DialMap::default();
 		let now = Instant::now();
-		dialed.insert("flapping:4443".into(), placeholder_handle(), false);
+		dialed.insert("flapping:4443".into(), placeholder_handle(), DialSource::Gossip);
 		dialed.mark_unannounced("flapping:4443", now - Duration::from_millis(50));
 
 		dialed.sweep_stale(now, STALE_AFTER);
@@ -513,7 +778,7 @@ mod tests {
 	#[tokio::test]
 	async fn sweep_keeps_currently_announced_peer() {
 		let dialed = DialMap::default();
-		dialed.insert("healthy:4443".into(), placeholder_handle(), false);
+		dialed.insert("healthy:4443".into(), placeholder_handle(), DialSource::Gossip);
 		// No mark_unannounced -> stays announced.
 
 		dialed.sweep_stale(Instant::now(), STALE_AFTER);
@@ -528,7 +793,7 @@ mod tests {
 	async fn mark_announced_cancels_pending_sweep() {
 		let dialed = DialMap::default();
 		let now = Instant::now();
-		dialed.insert("flap:4443".into(), placeholder_handle(), false);
+		dialed.insert("flap:4443".into(), placeholder_handle(), DialSource::Gossip);
 		dialed.mark_unannounced("flap:4443", now - STALE_AFTER - Duration::from_secs(1));
 
 		assert!(
@@ -542,8 +807,78 @@ mod tests {
 		assert!(!dialed.mark_announced("flap:4443"));
 	}
 
+	/// `reconcile_api` drops API dials missing from the desired set, reports the
+	/// newly desired ones for the caller to spawn, and never touches Static or
+	/// Gossip dials (even when they're absent from the API list).
+	#[tokio::test]
+	async fn reconcile_api_adds_and_removes_only_api() {
+		let dialed = DialMap::default();
+		dialed.insert("static:4443".into(), placeholder_handle(), DialSource::Static);
+		dialed.insert("gossip:4443".into(), placeholder_handle(), DialSource::Gossip);
+		dialed.insert("api-keep:4443".into(), placeholder_handle(), DialSource::Api);
+		dialed.insert("api-drop:4443".into(), placeholder_handle(), DialSource::Api);
+
+		// Desired: keep one existing API peer, drop the other, add a new one.
+		// Static/Gossip peers are not in the list but must survive.
+		let desired: HashSet<String> = ["api-keep:4443".to_string(), "api-new:4443".to_string()]
+			.into_iter()
+			.collect();
+		let mut to_add = dialed.reconcile_api(&desired);
+		to_add.sort();
+
+		assert_eq!(to_add, vec!["api-new:4443".to_string()]);
+		assert!(dialed.contains("api-keep:4443"));
+		assert!(!dialed.contains("api-drop:4443"), "dropped API peer must be removed");
+		assert!(dialed.contains("static:4443"), "static peer must survive reconcile");
+		assert!(dialed.contains("gossip:4443"), "gossip peer must survive reconcile");
+	}
+
+	/// A peer already dialed via another source is not re-reported for dialing,
+	/// so the API reconcile can't open a duplicate connection.
+	#[tokio::test]
+	async fn reconcile_api_dedupes_against_other_sources() {
+		let dialed = DialMap::default();
+		dialed.insert("shared:4443".into(), placeholder_handle(), DialSource::Static);
+
+		let desired: HashSet<String> = ["shared:4443".to_string()].into_iter().collect();
+		assert!(dialed.reconcile_api(&desired).is_empty());
+		assert!(dialed.contains("shared:4443"));
+	}
+
+	/// The peer-list wire format is a bare JSON array of host strings.
+	#[test]
+	fn peer_list_parses_as_string_array() {
+		let body = r#"["a.pop.example", "b.pop.example:4443"]"#;
+		let list: Vec<String> = serde_json::from_str(body).expect("parse peer list");
+		assert_eq!(
+			list,
+			vec!["a.pop.example".to_string(), "b.pop.example:4443".to_string()]
+		);
+	}
+
+	/// The poll cadence is `max-age` plus any `stale-while-revalidate` window, so
+	/// the relay keeps serving the cached list across that whole span before
+	/// revalidating. Neither directive present -> fall back to the default.
+	#[test]
+	fn revalidate_after_sums_max_age_and_swr() {
+		assert_eq!(revalidate_after("max-age=300"), Some(Duration::from_secs(300)));
+		assert_eq!(
+			revalidate_after("public, max-age=30, stale-while-revalidate=60"),
+			Some(Duration::from_secs(90))
+		);
+		assert_eq!(
+			revalidate_after("stale-while-revalidate=60"),
+			Some(Duration::from_secs(60))
+		);
+		assert_eq!(revalidate_after("max-age = 15"), Some(Duration::from_secs(15)));
+		assert_eq!(revalidate_after("no-cache"), None);
+		assert_eq!(revalidate_after(""), None);
+		// `s-maxage` must not be mistaken for `max-age`.
+		assert_eq!(revalidate_after("s-maxage=99"), None);
+	}
+
 	/// Setting `cluster.root` (the removed flag) at startup must surface a migration
-	/// message that names both the replacement flags.
+	/// message that names the replacement flags.
 	#[tokio::test]
 	async fn cluster_root_errors_with_migration_message() {
 		let config = ClusterConfig {
@@ -554,21 +889,20 @@ mod tests {
 		let msg = format!("{err}");
 		assert!(msg.contains("cluster.root"), "missing cluster.root in: {msg}");
 		assert!(msg.contains("--cluster-connect"), "missing --cluster-connect in: {msg}");
-		assert!(msg.contains("--cluster-mesh"), "missing --cluster-mesh in: {msg}");
+		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
 	}
 
-	/// Setting `cluster.node` (the renamed flag) at startup must surface a migration
-	/// message that names both replacement flags.
+	/// Enabling gossip (`--cluster-mesh`) without `--cluster-node` has no address to
+	/// advertise, so it must fail fast with a message naming the missing flag.
 	#[tokio::test]
-	async fn cluster_node_errors_with_migration_message() {
+	async fn gossip_without_node_errors() {
 		let config = ClusterConfig {
-			node: Some("legacy-node.example.com:4443".to_string()),
+			mesh: Some(true),
 			..Default::default()
 		};
 		let err = Cluster::new(config).run().await.expect_err("should error");
 		let msg = format!("{err}");
-		assert!(msg.contains("cluster.node"), "missing cluster.node in: {msg}");
-		assert!(msg.contains("--cluster-connect"), "missing --cluster-connect in: {msg}");
+		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
 		assert!(msg.contains("--cluster-mesh"), "missing --cluster-mesh in: {msg}");
 	}
 
@@ -592,33 +926,15 @@ mod tests {
 		assert!(format!("{err}").contains("cluster.root"));
 	}
 
-	/// `cluster.node` parsed from TOML triggers the same migration error.
-	#[test]
-	fn cluster_node_toml_parses_then_errors() {
-		let toml = "[cluster]\nnode = \"legacy-node.example.com:4443\"\n";
-		let dir = std::env::temp_dir().join("moq-relay-cluster-test");
-		std::fs::create_dir_all(&dir).unwrap();
-		let path = dir.join("cluster-node-toml.toml");
-		std::fs::write(&path, toml).unwrap();
-
-		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
-		let config = Config::parse_and_merge(args).expect("config load");
-		assert_eq!(config.cluster.node.as_deref(), Some("legacy-node.example.com:4443"));
-
-		let rt = tokio::runtime::Runtime::new().unwrap();
-		let err = rt
-			.block_on(Cluster::new(config.cluster).run())
-			.expect_err("should error");
-		assert!(format!("{err}").contains("cluster.node"));
-	}
-
-	/// A relay configured with only `cluster.mesh` (passive rendezvous) must run
-	/// without a QUIC client, publish its self-registration on the cluster origin,
-	/// and keep that registration alive (i.e. not exit and drop the broadcast).
+	/// A relay configured with `cluster.node` + `cluster.mesh` gossip and no peers
+	/// (passive rendezvous) must run without a QUIC client, publish its
+	/// self-registration on the cluster origin, and keep that registration alive
+	/// (i.e. not exit and drop the broadcast).
 	#[tokio::test(start_paused = true)]
 	async fn passive_rendezvous_runs_without_client_and_advertises_self() {
 		let cluster = Cluster::new(ClusterConfig {
-			mesh: Some("rendezvous.example.com:4443".to_string()),
+			node: Some("rendezvous.example.com:4443".to_string()),
+			mesh: Some(true),
 			..Default::default()
 		});
 
@@ -648,18 +964,41 @@ mod tests {
 		handle.abort();
 	}
 
-	/// `cluster.mesh` round-trips through TOML and CLI.
+	/// `cluster.node` (identity) and the boolean `cluster.mesh` (gossip toggle)
+	/// round-trip through TOML and survive the CLI re-parse when no flags override
+	/// them. `mesh` is `Option<bool>` for exactly that clobber-safety.
 	#[test]
-	fn cluster_mesh_round_trips() {
-		let toml = "[cluster]\nmesh = \"us-east.example.com:4443\"\nconnect = [\"root.example.com:4443\"]\n";
+	fn cluster_node_and_mesh_round_trip() {
+		let toml =
+			"[cluster]\nnode = \"us-east.example.com:4443\"\nmesh = true\nconnect = [\"root.example.com:4443\"]\n";
 		let dir = std::env::temp_dir().join("moq-relay-cluster-test");
 		std::fs::create_dir_all(&dir).unwrap();
-		let path = dir.join("cluster-mesh-toml.toml");
+		let path = dir.join("cluster-node-mesh-toml.toml");
 		std::fs::write(&path, toml).unwrap();
 
 		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
 		let config = Config::parse_and_merge(args).expect("config load");
-		assert_eq!(config.cluster.mesh.as_deref(), Some("us-east.example.com:4443"));
+		assert_eq!(config.cluster.node.as_deref(), Some("us-east.example.com:4443"));
+		assert_eq!(config.cluster.mesh, Some(true));
 		assert_eq!(config.cluster.connect, vec!["root.example.com:4443".to_string()]);
+	}
+
+	/// `cluster.connect_api` set in TOML must survive the CLI re-parse when no
+	/// `--cluster-connect-api` flag is passed (same clap+TOML clobber pitfall the
+	/// config tests guard, which is why the field is `Option<String>`).
+	#[test]
+	fn cluster_connect_api_survives_toml_merge() {
+		let toml = "[cluster]\nconnect_api = \"https://api.example.com/cluster/connect\"\n";
+		let dir = std::env::temp_dir().join("moq-relay-cluster-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("cluster-connect-api-toml.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+		assert_eq!(
+			config.cluster.connect_api.as_deref(),
+			Some("https://api.example.com/cluster/connect")
+		);
 	}
 }

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -68,7 +68,7 @@ enum DialSource {
 /// The set of [`DialSource`]s currently keeping a dial alive.
 #[derive(Clone, Copy, Default)]
 struct DialSources {
-	static_: bool,
+	seeded: bool,
 	gossip: bool,
 	api: bool,
 }
@@ -76,7 +76,7 @@ struct DialSources {
 impl DialSources {
 	fn set(&mut self, source: DialSource) {
 		match source {
-			DialSource::Static => self.static_ = true,
+			DialSource::Static => self.seeded = true,
 			DialSource::Gossip => self.gossip = true,
 			DialSource::Api => self.api = true,
 		}
@@ -84,14 +84,14 @@ impl DialSources {
 
 	fn clear(&mut self, source: DialSource) {
 		match source {
-			DialSource::Static => self.static_ = false,
+			DialSource::Static => self.seeded = false,
 			DialSource::Gossip => self.gossip = false,
 			DialSource::Api => self.api = false,
 		}
 	}
 
 	fn any(&self) -> bool {
-		self.static_ || self.gossip || self.api
+		self.seeded || self.gossip || self.api
 	}
 }
 
@@ -125,27 +125,24 @@ impl DialMap {
 	/// peer at once" race without leaking a task.
 	fn insert(&self, peer: String, handle: AbortHandle, source: DialSource) {
 		let mut map = self.inner.lock().expect("dial map poisoned");
-		match map.get_mut(&peer) {
-			Some(entry) => {
-				entry.sources.set(source);
-				if source == DialSource::Gossip {
-					entry.unannounced_at = None;
-				}
-				drop(map);
-				handle.abort();
+		if let Some(entry) = map.get_mut(&peer) {
+			entry.sources.set(source);
+			if source == DialSource::Gossip {
+				entry.unannounced_at = None;
 			}
-			None => {
-				let mut sources = DialSources::default();
-				sources.set(source);
-				map.insert(
-					peer,
-					DialEntry {
-						handle,
-						sources,
-						unannounced_at: None,
-					},
-				);
-			}
+			drop(map);
+			handle.abort();
+		} else {
+			let mut sources = DialSources::default();
+			sources.set(source);
+			map.insert(
+				peer,
+				DialEntry {
+					handle,
+					sources,
+					unannounced_at: None,
+				},
+			);
 		}
 	}
 
@@ -200,8 +197,15 @@ impl DialMap {
 	/// peers not yet dialed (the caller spawns those and re-inserts them).
 	fn reconcile_api(&self, desired: &HashSet<String>) -> Vec<String> {
 		let mut map = self.inner.lock().expect("dial map poisoned");
+
+		// One mutable pass: set the API source on listed peers, release it from the
+		// rest (aborting only those nothing else wants).
 		map.retain(|peer, entry| {
-			if !entry.sources.api || desired.contains(peer) {
+			if desired.contains(peer) {
+				entry.sources.set(DialSource::Api);
+				return true;
+			}
+			if !entry.sources.api {
 				return true;
 			}
 			entry.sources.clear(DialSource::Api);
@@ -215,15 +219,10 @@ impl DialMap {
 			}
 		});
 
+		// Whatever's left in `desired` but absent from the map needs a fresh dial.
 		desired
 			.iter()
-			.filter(|peer| match map.get_mut(*peer) {
-				Some(entry) => {
-					entry.sources.set(DialSource::Api);
-					false
-				}
-				None => true,
-			})
+			.filter(|peer| !map.contains_key(*peer))
 			.cloned()
 			.collect()
 	}
@@ -284,7 +283,12 @@ pub struct ClusterConfig {
 	/// Enable gossip discovery: advertise this relay's [`Self::node`] URL on the
 	/// cluster origin so peers can find and dial it (and so this relay discovers
 	/// peers the same way). Requires [`Self::node`]. Boolean flag: pass
-	/// `--cluster-mesh` to enable.
+	/// `--cluster-mesh` (or `=true` / `=false`).
+	///
+	/// Kept as a string for backwards compatibility: `--cluster-mesh` used to take
+	/// this relay's URL. A non-boolean value is treated as a legacy [`Self::node`]
+	/// (with a deprecation warning), or an error if it conflicts with an explicit
+	/// `--cluster-node`. Accepts a TOML boolean or string.
 	#[arg(
 		id = "cluster-mesh",
 		long = "cluster-mesh",
@@ -292,9 +296,9 @@ pub struct ClusterConfig {
 		default_missing_value = "true",
 		num_args = 0..=1,
 		require_equals = true,
-		value_parser = clap::value_parser!(bool),
 	)]
-	pub mesh: Option<bool>,
+	#[serde(default, deserialize_with = "deserialize_bool_or_string")]
+	pub mesh: Option<String>,
 
 	/// Use the token in this file when connecting to other nodes.
 	#[arg(id = "cluster-token", long = "cluster-token", env = "MOQ_CLUSTER_TOKEN")]
@@ -392,6 +396,36 @@ impl Cluster {
 		self.origin.with_root(&token.root)?.scope(&token.publish)
 	}
 
+	/// Resolve whether gossip is on and which URL this relay advertises, from
+	/// `cluster.node` and the (string-typed) `cluster.mesh` toggle.
+	///
+	/// `mesh` is `"true"` / `"false"` normally. For backwards compatibility a
+	/// non-boolean value is the legacy "advertise this URL" form: it turns gossip
+	/// on and supplies the node URL (with a deprecation warning), unless it
+	/// conflicts with an explicit `cluster.node`, which is an error.
+	fn resolve_mesh(&self) -> anyhow::Result<(bool, Option<String>)> {
+		let node = self.config.node.clone();
+		match self.config.mesh.as_deref() {
+			None => Ok((false, node)),
+			Some("true") => Ok((true, node)),
+			Some("false") => Ok((false, node)),
+			Some(legacy) => {
+				tracing::warn!(
+					value = %legacy,
+					"`--cluster-mesh` is now a boolean; treating the value as `--cluster-node` for backwards \
+					 compatibility. Set `--cluster-node <url>` and `--cluster-mesh` instead."
+				);
+				match &node {
+					Some(node) if node != legacy => anyhow::bail!(
+						"`--cluster-mesh` was given URL {legacy:?}, which conflicts with `--cluster-node` {node:?}. \
+						 `--cluster-mesh` is now a boolean; set the address only via `--cluster-node`."
+					),
+					_ => Ok((true, Some(legacy.to_owned()))),
+				}
+			}
+		}
+	}
+
 	/// Runs the cluster event loop.
 	///
 	/// Modes are derived from config: standalone (no work) returns immediately;
@@ -414,9 +448,9 @@ impl Cluster {
 			);
 		}
 
-		let gossip = self.config.mesh.unwrap_or(false);
+		let (gossip, node) = self.resolve_mesh()?;
 		anyhow::ensure!(
-			!gossip || self.config.node.is_some(),
+			!gossip || node.is_some(),
 			"`--cluster-mesh` (gossip) requires `--cluster-node <self-url>` so there's an address to advertise. \
 			 See https://doc.moq.dev/bin/relay/cluster."
 		);
@@ -478,7 +512,7 @@ impl Cluster {
 			let this = self.clone();
 			let token = token.clone();
 			let dialed = dialed.clone();
-			let node = self.config.node.clone();
+			let node = node.clone();
 			tasks.spawn(async move {
 				this.run_connect_api(source, node, token, dialed).await;
 			});
@@ -489,7 +523,7 @@ impl Cluster {
 		// nothing to discover, so we only run it when we also have an outbound peer.
 		let _self_registration: Option<BroadcastProducer> = if gossip {
 			// Checked above: gossip requires `node`.
-			let node = self.config.node.as_deref().expect("gossip requires --cluster-node");
+			let node = node.as_deref().expect("gossip requires --cluster-node");
 			let path = Path::new(MESH_PREFIX).join(node);
 			let broadcast = self
 				.origin
@@ -653,22 +687,19 @@ impl Cluster {
 		}
 	}
 
-	/// Watch a local peer-list file, reconciling whenever it changes. Prefers OS
-	/// filesystem notifications (inotify / FSEvents / kqueue via `notify`), with a
-	/// periodic re-check as a safety net for missed events and network filesystems.
-	/// Fails static: a missing or malformed file keeps the current dials.
+	/// Watch a local peer-list file, reconciling whenever it changes. Uses OS
+	/// filesystem notifications (inotify / FSEvents / kqueue via `notify`), falling
+	/// back to polling only if a watcher can't be created. Fails static: a missing
+	/// or malformed file keeps the current dials.
 	async fn run_connect_api_file(&self, path: PathBuf, node: Option<String>, token: String, dialed: DialMap) {
 		let mut last_seen_mtime = None;
 		self.reload_connect_api_file(&path, &mut last_seen_mtime, &node, &token, &dialed);
 
-		let mut tick = tokio::time::interval(CONNECT_API_FILE_INTERVAL);
-		tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-		tick.tick().await; // Consume the immediate first tick; we just loaded.
-
 		// Watch the parent directory, not the file: editors and `mv` replace the
 		// file by atomic rename, which swaps its inode and would drop a watch set
-		// directly on it.
-		let watcher = path.parent().and_then(|dir| {
+		// directly on it. The channel bridges notify's off-runtime callback to this
+		// async task, where reconciling can spawn dials on the tokio runtime.
+		let watch = path.parent().and_then(|dir| {
 			let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 			let mut watcher = notify::recommended_watcher(move |event| {
 				let _ = tx.send(event);
@@ -678,24 +709,25 @@ impl Cluster {
 			Some((watcher, rx))
 		});
 
-		if let Some((_watcher, mut events)) = watcher {
-			loop {
-				tokio::select! {
-					event = events.recv() => match event {
-						Some(Ok(_)) => {}
-						Some(Err(err)) => tracing::warn!(%err, ?path, "cluster.connect_api file watcher error"),
-						None => break, // watcher gone; drop to polling below
-					},
-					_ = tick.tick() => {}
+		match watch {
+			// The mtime check in reload coalesces the duplicate events notify emits
+			// per change and ignores activity on other files in the directory.
+			Some((_watcher, mut events)) => {
+				while let Some(event) = events.recv().await {
+					if let Err(err) = event {
+						tracing::warn!(%err, ?path, "cluster.connect_api file watcher error");
+						continue;
+					}
+					self.reload_connect_api_file(&path, &mut last_seen_mtime, &node, &token, &dialed);
 				}
-				self.reload_connect_api_file(&path, &mut last_seen_mtime, &node, &token, &dialed);
 			}
-		}
-
-		// Polling fallback: no watcher could be created, or it stopped.
-		loop {
-			tick.tick().await;
-			self.reload_connect_api_file(&path, &mut last_seen_mtime, &node, &token, &dialed);
+			None => {
+				let mut tick = tokio::time::interval(CONNECT_API_FILE_INTERVAL);
+				loop {
+					tick.tick().await;
+					self.reload_connect_api_file(&path, &mut last_seen_mtime, &node, &token, &dialed);
+				}
+			}
 		}
 	}
 
@@ -712,12 +744,9 @@ impl Cluster {
 		token: &str,
 		dialed: &DialMap,
 	) {
-		let mtime = match std::fs::metadata(path).and_then(|m| m.modified()) {
-			Ok(mtime) => mtime,
-			Err(err) => {
-				tracing::warn!(%err, ?path, "cluster.connect_api file unavailable; keeping current peers");
-				return;
-			}
+		let Ok(mtime) = std::fs::metadata(path).and_then(|m| m.modified()) else {
+			tracing::warn!(?path, "cluster.connect_api file unavailable; keeping current peers");
+			return;
 		};
 		if *last_seen_mtime == Some(mtime) {
 			return;
@@ -873,6 +902,30 @@ fn revalidate_after(cache_control: &str) -> Option<Duration> {
 /// treated as a local file path, which needs no TLS client).
 fn connect_api_is_http(source: &str) -> bool {
 	Url::parse(source).is_ok_and(|url| matches!(url.scheme(), "http" | "https"))
+}
+
+/// Deserialize a field that accepts either a TOML boolean or string into an
+/// `Option<String>` (booleans become `"true"` / `"false"`). Lets `cluster.mesh`
+/// take the modern `mesh = true` form or the legacy `mesh = "<url>"` form.
+fn deserialize_bool_or_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	use serde::Deserialize as _;
+
+	#[derive(serde::Deserialize)]
+	#[serde(untagged)]
+	enum BoolOrString {
+		Bool(bool),
+		Str(String),
+	}
+
+	Ok(
+		Option::<BoolOrString>::deserialize(deserializer)?.map(|value| match value {
+			BoolOrString::Bool(value) => value.to_string(),
+			BoolOrString::Str(value) => value,
+		}),
+	)
 }
 
 #[cfg(test)]
@@ -1102,7 +1155,7 @@ mod tests {
 	#[tokio::test]
 	async fn gossip_without_node_errors() {
 		let config = ClusterConfig {
-			mesh: Some(true),
+			mesh: Some("true".to_string()),
 			..Default::default()
 		};
 		let err = Cluster::new(config).run().await.expect_err("should error");
@@ -1139,7 +1192,7 @@ mod tests {
 	async fn passive_rendezvous_runs_without_client_and_advertises_self() {
 		let cluster = Cluster::new(ClusterConfig {
 			node: Some("rendezvous.example.com:4443".to_string()),
-			mesh: Some(true),
+			mesh: Some("true".to_string()),
 			..Default::default()
 		});
 
@@ -1169,9 +1222,9 @@ mod tests {
 		handle.abort();
 	}
 
-	/// `cluster.node` (identity) and the boolean `cluster.mesh` (gossip toggle)
-	/// round-trip through TOML and survive the CLI re-parse when no flags override
-	/// them. `mesh` is `Option<bool>` for exactly that clobber-safety.
+	/// `cluster.node` (identity) and `cluster.mesh` (gossip toggle) round-trip
+	/// through TOML and survive the CLI re-parse when no flags override them.
+	/// `mesh` is a string (clobber-safe) that accepts a TOML boolean.
 	#[test]
 	fn cluster_node_and_mesh_round_trip() {
 		let toml =
@@ -1184,8 +1237,35 @@ mod tests {
 		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
 		let config = Config::parse_and_merge(args).expect("config load");
 		assert_eq!(config.cluster.node.as_deref(), Some("us-east.example.com:4443"));
-		assert_eq!(config.cluster.mesh, Some(true));
+		// A TOML boolean deserializes into the string form.
+		assert_eq!(config.cluster.mesh.as_deref(), Some("true"));
 		assert_eq!(config.cluster.connect, vec!["root.example.com:4443".to_string()]);
+	}
+
+	/// The legacy `--cluster-mesh <url>` form (now a boolean) is honored for
+	/// backwards compatibility: it enables gossip and supplies the node URL.
+	#[test]
+	fn legacy_mesh_url_enables_gossip_as_node() {
+		let cluster = Cluster::new(ClusterConfig {
+			mesh: Some("rendezvous.example.com:4443".to_string()),
+			..Default::default()
+		});
+		let (gossip, node) = cluster.resolve_mesh().expect("legacy mesh url resolves");
+		assert!(gossip);
+		assert_eq!(node.as_deref(), Some("rendezvous.example.com:4443"));
+	}
+
+	/// A legacy mesh URL that disagrees with an explicit `--cluster-node` is a
+	/// conflict, not a silent pick.
+	#[test]
+	fn legacy_mesh_url_conflicting_with_node_errors() {
+		let cluster = Cluster::new(ClusterConfig {
+			mesh: Some("a.example.com:4443".to_string()),
+			node: Some("b.example.com:4443".to_string()),
+			..Default::default()
+		});
+		let err = cluster.resolve_mesh().expect_err("conflict should error");
+		assert!(format!("{err}").contains("conflicts with"), "got: {err}");
 	}
 
 	/// `cluster.connect_api` set in TOML must survive the CLI re-parse when no

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::Context;
 use moq_net::{BroadcastProducer, Origin, OriginConsumer, OriginProducer, Path, Stats, Tier};
+use notify::Watcher;
 use reqwest_middleware::ClientWithMiddleware;
 use tokio::task::AbortHandle;
 use url::Url;
@@ -33,29 +34,63 @@ const CONNECT_API_DEFAULT_INTERVAL: Duration = Duration::from_secs(30);
 /// window can't spin the relay into a tight fetch loop.
 const CONNECT_API_MIN_INTERVAL: Duration = Duration::from_secs(5);
 
-/// How often a local `--cluster-connect-api` file is stat'd for mtime changes.
+/// Safety-net re-check interval for a local `--cluster-connect-api` file, backing
+/// up the OS filesystem watcher (and the sole mechanism if no watcher can be made).
 const CONNECT_API_FILE_INTERVAL: Duration = Duration::from_secs(5);
 
-/// How a dial was sourced, which decides how it's torn down.
+/// A mechanism that wants a dial kept alive. A single peer can be wanted by more
+/// than one at once (e.g. gossiped *and* listed by `--cluster-connect-api`), so
+/// [`DialEntry`] tracks a set of these and only tears the dial down when the last
+/// one releases it.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum DialSource {
-	/// Seeded from `--cluster-connect`. Dialed forever (operator intent says
-	/// "always dial"); never swept or reconciled away.
+	/// Seeded from `--cluster-connect`. Never released, so the dial retries forever
+	/// (operator intent says "always dial").
 	Static,
-	/// Discovered via gossip on `.internal/origins/*`. Aborted by the periodic
+	/// Discovered via gossip on `.internal/origins/*`. Released by the periodic
 	/// stale-sweep once its unannounce has stuck for [`STALE_AFTER`].
 	Gossip,
-	/// Supplied by `--cluster-connect-api`. Added/removed by reconciling against
-	/// each fetched peer list; immune to the gossip stale-sweep.
+	/// Supplied by `--cluster-connect-api`. Released when a fetched peer list no
+	/// longer contains the peer.
 	Api,
 }
 
-/// One entry in [`DialMap`]. Gossip-discovered peers carry an `unannounced_at`
-/// timestamp that the periodic sweep uses to decide when a peer has truly left
-/// vs. is just flapping between paths.
+/// The set of [`DialSource`]s currently keeping a dial alive.
+#[derive(Clone, Copy, Default)]
+struct DialSources {
+	static_: bool,
+	gossip: bool,
+	api: bool,
+}
+
+impl DialSources {
+	fn set(&mut self, source: DialSource) {
+		match source {
+			DialSource::Static => self.static_ = true,
+			DialSource::Gossip => self.gossip = true,
+			DialSource::Api => self.api = true,
+		}
+	}
+
+	fn clear(&mut self, source: DialSource) {
+		match source {
+			DialSource::Static => self.static_ = false,
+			DialSource::Gossip => self.gossip = false,
+			DialSource::Api => self.api = false,
+		}
+	}
+
+	fn any(&self) -> bool {
+		self.static_ || self.gossip || self.api
+	}
+}
+
+/// One entry in [`DialMap`]. `unannounced_at` carries the gossip stale timer; the
+/// sweep uses it to decide when the gossip source has truly gone vs. is just
+/// flapping between paths. It's only meaningful while `sources.gossip` is set.
 struct DialEntry {
 	handle: AbortHandle,
-	source: DialSource,
+	sources: DialSources,
 	unannounced_at: Option<Instant>,
 }
 
@@ -73,76 +108,114 @@ impl DialMap {
 		self.inner.lock().expect("dial map poisoned").contains_key(peer)
 	}
 
-	/// Record a new dial under `peer`. Caller is responsible for spawning the
-	/// task and passing its [`AbortHandle`]. Replaces any existing entry (callers
-	/// should check [`Self::contains`] first; this is just defensive).
+	/// Record a freshly-spawned dial for `peer` under `source`. If `peer` is
+	/// already dialed, add `source` to its set and abort the redundant `handle`
+	/// (the existing dial stands, since dialing dedupes by URL). Always spawn the
+	/// task first, then call this: it resolves the "two sources discover the same
+	/// peer at once" race without leaking a task.
 	fn insert(&self, peer: String, handle: AbortHandle, source: DialSource) {
-		self.inner.lock().expect("dial map poisoned").insert(
-			peer,
-			DialEntry {
-				handle,
-				source,
-				unannounced_at: None,
-			},
-		);
+		let mut map = self.inner.lock().expect("dial map poisoned");
+		match map.get_mut(&peer) {
+			Some(entry) => {
+				entry.sources.set(source);
+				if source == DialSource::Gossip {
+					entry.unannounced_at = None;
+				}
+				drop(map);
+				handle.abort();
+			}
+			None => {
+				let mut sources = DialSources::default();
+				sources.set(source);
+				map.insert(
+					peer,
+					DialEntry {
+						handle,
+						sources,
+						unannounced_at: None,
+					},
+				);
+			}
+		}
 	}
 
-	/// Mark a gossip peer as unannounced if it isn't already. No-op for static /
-	/// API peers or unknown URLs. Idempotent: a repeat unannounce while a
-	/// timestamp is already pending doesn't reset the clock.
+	/// Add `source` to an already-dialed `peer` (no-op if absent). Used when a
+	/// peer reached via one source is also discovered via another, without opening
+	/// a second dial. Adding [`DialSource::Gossip`] also clears any pending
+	/// unannounce; returns whether such a timestamp was cleared (a reannounce).
+	fn add_source(&self, peer: &str, source: DialSource) -> bool {
+		let mut map = self.inner.lock().expect("dial map poisoned");
+		let Some(entry) = map.get_mut(peer) else { return false };
+		entry.sources.set(source);
+		source == DialSource::Gossip && entry.unannounced_at.take().is_some()
+	}
+
+	/// Start the gossip stale timer on `peer` if it isn't already pending. No-op
+	/// unless the peer is currently wanted by gossip. Idempotent: a repeat
+	/// unannounce while a timestamp is pending doesn't reset the clock.
 	fn mark_unannounced(&self, peer: &str, now: Instant) {
 		let mut map = self.inner.lock().expect("dial map poisoned");
 		if let Some(entry) = map.get_mut(peer) {
-			if entry.source == DialSource::Gossip {
+			if entry.sources.gossip {
 				entry.unannounced_at.get_or_insert(now);
 			}
 		}
 	}
 
-	/// Clear any pending-unannounce on `peer`. Returns `true` if a timestamp was
-	/// actually cleared (useful for callers that want to log the reannounce).
-	fn mark_announced(&self, peer: &str) -> bool {
-		let mut map = self.inner.lock().expect("dial map poisoned");
-		map.get_mut(peer)
-			.is_some_and(|entry| entry.unannounced_at.take().is_some())
-	}
-
-	/// Abort and remove gossip-discovered entries whose unannounce has persisted
-	/// for at least `threshold`. Static / API peers are skipped, as are entries
-	/// that are currently announced (`unannounced_at == None`).
+	/// Release the gossip source from entries whose unannounce has stuck for at
+	/// least `threshold`, aborting the dial only if no other source still wants it.
 	fn sweep_stale(&self, now: Instant, threshold: Duration) {
 		let mut map = self.inner.lock().expect("dial map poisoned");
 		map.retain(|peer, entry| {
-			if entry.source != DialSource::Gossip {
+			let Some(at) = entry.unannounced_at else { return true };
+			if now.duration_since(at) < threshold {
 				return true;
 			}
-			let Some(at) = entry.unannounced_at else { return true };
-			if now.duration_since(at) >= threshold {
+			entry.unannounced_at = None;
+			entry.sources.clear(DialSource::Gossip);
+			if entry.sources.any() {
+				tracing::debug!(%peer, "peer no longer gossiped; still wanted by another source");
+				true
+			} else {
 				tracing::info!(%peer, "peer no longer gossiped; abandoning dial");
 				entry.handle.abort();
 				false
-			} else {
-				true
 			}
 		});
 	}
 
-	/// Reconcile the set of [`DialSource::Api`] dials against `desired`: abort and
-	/// drop API dials no longer listed, and return the desired peers not yet
-	/// dialed (the caller spawns those and re-inserts them as [`DialSource::Api`]).
-	/// Static / Gossip dials, and peers already dialed via any source, are left
-	/// untouched (dialing dedupes by URL).
+	/// Reconcile the API source against `desired`: release [`DialSource::Api`] from
+	/// entries no longer listed (aborting only those nothing else wants), mark the
+	/// API source on already-dialed peers that are listed, and return the desired
+	/// peers not yet dialed (the caller spawns those and re-inserts them).
 	fn reconcile_api(&self, desired: &HashSet<String>) -> Vec<String> {
 		let mut map = self.inner.lock().expect("dial map poisoned");
 		map.retain(|peer, entry| {
-			if entry.source == DialSource::Api && !desired.contains(peer) {
+			if !entry.sources.api || desired.contains(peer) {
+				return true;
+			}
+			entry.sources.clear(DialSource::Api);
+			if entry.sources.any() {
+				tracing::debug!(%peer, "peer dropped from cluster-connect-api; still wanted by another source");
+				true
+			} else {
 				tracing::info!(%peer, "peer dropped from cluster-connect-api; abandoning dial");
 				entry.handle.abort();
-				return false;
+				false
 			}
-			true
 		});
-		desired.iter().filter(|p| !map.contains_key(*p)).cloned().collect()
+
+		desired
+			.iter()
+			.filter(|peer| match map.get_mut(*peer) {
+				Some(entry) => {
+					entry.sources.set(DialSource::Api);
+					false
+				}
+				None => true,
+			})
+			.cloned()
+			.collect()
 	}
 }
 
@@ -178,8 +251,9 @@ pub struct ClusterConfig {
 	/// of peer hostnames: `["a.pop.example", "b.pop.example"]`. An http(s) URL is
 	/// polled (the re-poll cadence follows `Cache-Control` `max-age` +
 	/// `stale-while-revalidate`, with conditional revalidation and stale-if-error
-	/// handled by the shared cache client); a local path is re-read when its mtime
-	/// changes. This relay's own [`Self::node`] value, when set, is sent as a
+	/// handled by the shared cache client); a local path is watched via OS
+	/// filesystem notifications (with a periodic re-check fallback). This relay's
+	/// own [`Self::node`] value, when set, is sent as a
 	/// `?node=` query param so the server can return this node's peers. The relay
 	/// keeps the last good list if a fetch fails. Composes with [`Self::connect`]
 	/// and [`Self::mesh`].
@@ -386,17 +460,17 @@ impl Cluster {
 		}
 
 		if let Some(source) = self.config.connect_api.clone() {
-			let tls = self
-				.client_tls
-				.clone()
-				.context("cluster.connect_api set but no client TLS attached (call Cluster::with_client_tls)")?;
-			let http = crate::http_client::build(&tls)?;
+			// Only http(s) sources need the TLS client; a local file doesn't.
+			anyhow::ensure!(
+				!connect_api_is_http(&source) || self.client_tls.is_some(),
+				"cluster.connect_api with an http(s) URL needs client TLS (call Cluster::with_client_tls)"
+			);
 			let this = self.clone();
 			let token = token.clone();
 			let dialed = dialed.clone();
 			let node = self.config.node.clone();
 			tasks.spawn(async move {
-				this.run_connect_api(source, node, token, dialed, http).await;
+				this.run_connect_api(source, node, token, dialed).await;
 			});
 		}
 
@@ -411,7 +485,7 @@ impl Cluster {
 				.origin
 				.create_broadcast(&path)
 				.expect(".internal/origins is within the relay origin's root");
-			tracing::info!(url = %node, %path, "advertising cluster node URL");
+			tracing::info!(%node, %path, "advertising cluster node URL");
 
 			if has_outbound {
 				let this = self.clone();
@@ -468,7 +542,9 @@ impl Cluster {
 					match announced {
 						Some(_) => {
 							if dialed.contains(&peer) {
-								if dialed.mark_announced(&peer) {
+								// Already dialed (possibly via another source). Mark gossip as
+								// a wanter and cancel any pending stale-sweep.
+								if dialed.add_source(&peer, DialSource::Gossip) {
 									tracing::debug!(%peer, "reannounce within sweep window; keeping dial");
 								}
 								continue;
@@ -497,18 +573,23 @@ impl Cluster {
 	}
 
 	/// Drive `--cluster-connect-api`: an http(s) URL is polled, a local path (or
-	/// `file://` URL) is watched for mtime changes. Either way the source yields a
-	/// JSON array of peer hostnames that's reconciled into the shared dial map.
-	async fn run_connect_api(
-		self,
-		source: String,
-		node: Option<String>,
-		token: String,
-		dialed: DialMap,
-		http: ClientWithMiddleware,
-	) {
+	/// `file://` URL) is watched for changes. Either way the source yields a JSON
+	/// array of peer hostnames that's reconciled into the shared dial map.
+	async fn run_connect_api(self, source: String, node: Option<String>, token: String, dialed: DialMap) {
 		match Url::parse(&source) {
 			Ok(url) if matches!(url.scheme(), "http" | "https") => {
+				// Validated in `run`: an http(s) source has client TLS attached.
+				let tls = self
+					.client_tls
+					.as_ref()
+					.expect("http(s) connect_api source requires client TLS");
+				let http = match crate::http_client::build(tls) {
+					Ok(http) => http,
+					Err(err) => {
+						tracing::error!(%err, "cluster.connect_api: failed to build HTTP client");
+						return;
+					}
+				};
 				self.run_connect_api_http(url, node, token, dialed, http).await;
 			}
 			Ok(url) if url.scheme() == "file" => match url.to_file_path() {
@@ -558,31 +639,84 @@ impl Cluster {
 		}
 	}
 
-	/// Watch a local peer-list file, reconciling whenever its mtime changes. Fails
-	/// static: a missing or malformed file keeps the current dials.
+	/// Watch a local peer-list file, reconciling whenever it changes. Prefers OS
+	/// filesystem notifications (inotify / FSEvents / kqueue via `notify`), with a
+	/// periodic re-check as a safety net for missed events and network filesystems.
+	/// Fails static: a missing or malformed file keeps the current dials.
 	async fn run_connect_api_file(&self, path: PathBuf, node: Option<String>, token: String, dialed: DialMap) {
 		let mut last_mtime = None;
-		loop {
-			match std::fs::metadata(&path).and_then(|m| m.modified()) {
-				Ok(mtime) if last_mtime != Some(mtime) => match std::fs::read_to_string(&path) {
-					Ok(body) => match serde_json::from_str::<Vec<String>>(&body) {
-						Ok(list) => {
-							last_mtime = Some(mtime);
-							self.apply_peer_list(list, &node, &token, &dialed);
-						}
-						Err(err) => {
-							tracing::warn!(%err, ?path, "cluster.connect_api file is not a JSON array; keeping current peers")
-						}
-					},
-					Err(err) => {
-						tracing::warn!(%err, ?path, "failed to read cluster.connect_api file; keeping current peers")
-					}
-				},
-				Ok(_) => {} // unchanged
-				Err(err) => tracing::warn!(%err, ?path, "cluster.connect_api file unavailable; keeping current peers"),
-			}
+		self.reload_connect_api_file(&path, &mut last_mtime, &node, &token, &dialed);
 
-			tokio::time::sleep(CONNECT_API_FILE_INTERVAL).await;
+		let mut tick = tokio::time::interval(CONNECT_API_FILE_INTERVAL);
+		tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+		tick.tick().await; // Consume the immediate first tick; we just loaded.
+
+		// Watch the parent directory, not the file: editors and `mv` replace the
+		// file by atomic rename, which swaps its inode and would drop a watch set
+		// directly on it.
+		let watcher = path.parent().and_then(|dir| {
+			let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+			let mut watcher = notify::recommended_watcher(move |event| {
+				let _ = tx.send(event);
+			})
+			.ok()?;
+			watcher.watch(dir, notify::RecursiveMode::NonRecursive).ok()?;
+			Some((watcher, rx))
+		});
+
+		if let Some((_watcher, mut events)) = watcher {
+			loop {
+				tokio::select! {
+					event = events.recv() => match event {
+						Some(Ok(_)) => {}
+						Some(Err(err)) => tracing::warn!(%err, ?path, "cluster.connect_api file watcher error"),
+						None => break, // watcher gone; drop to polling below
+					},
+					_ = tick.tick() => {}
+				}
+				self.reload_connect_api_file(&path, &mut last_mtime, &node, &token, &dialed);
+			}
+		}
+
+		// Polling fallback: no watcher could be created, or it stopped.
+		loop {
+			tick.tick().await;
+			self.reload_connect_api_file(&path, &mut last_mtime, &node, &token, &dialed);
+		}
+	}
+
+	/// Re-read the peer-list file and reconcile if its mtime changed since the last
+	/// successful load. Any read/parse error keeps the current dials.
+	fn reload_connect_api_file(
+		&self,
+		path: &std::path::Path,
+		last_mtime: &mut Option<std::time::SystemTime>,
+		node: &Option<String>,
+		token: &str,
+		dialed: &DialMap,
+	) {
+		let mtime = match std::fs::metadata(path).and_then(|m| m.modified()) {
+			Ok(mtime) => mtime,
+			Err(err) => {
+				tracing::warn!(%err, ?path, "cluster.connect_api file unavailable; keeping current peers");
+				return;
+			}
+		};
+		if *last_mtime == Some(mtime) {
+			return;
+		}
+
+		match std::fs::read_to_string(path) {
+			Ok(body) => match serde_json::from_str::<Vec<String>>(&body) {
+				Ok(list) => {
+					*last_mtime = Some(mtime);
+					self.apply_peer_list(list, node, token, dialed);
+				}
+				Err(err) => {
+					tracing::warn!(%err, ?path, "cluster.connect_api file is not a JSON array; keeping current peers")
+				}
+			},
+			Err(err) => tracing::warn!(%err, ?path, "failed to read cluster.connect_api file; keeping current peers"),
 		}
 	}
 
@@ -720,6 +854,12 @@ fn revalidate_after(cache_control: &str) -> Option<Duration> {
 	}
 }
 
+/// Whether a `--cluster-connect-api` source is an http(s) URL (otherwise it's
+/// treated as a local file path, which needs no TLS client).
+fn connect_api_is_http(source: &str) -> bool {
+	Url::parse(source).is_ok_and(|url| matches!(url.scheme(), "http" | "https"))
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -790,21 +930,59 @@ mod tests {
 	/// the entry survives even if the original unannounce was old enough to
 	/// otherwise trigger eviction.
 	#[tokio::test]
-	async fn mark_announced_cancels_pending_sweep() {
+	async fn reannounce_cancels_pending_sweep() {
 		let dialed = DialMap::default();
 		let now = Instant::now();
 		dialed.insert("flap:4443".into(), placeholder_handle(), DialSource::Gossip);
 		dialed.mark_unannounced("flap:4443", now - STALE_AFTER - Duration::from_secs(1));
 
+		// Re-adding the gossip source (a reannounce) clears the pending sweep.
 		assert!(
-			dialed.mark_announced("flap:4443"),
+			dialed.add_source("flap:4443", DialSource::Gossip),
 			"should report a cleared pending-sweep"
 		);
 		dialed.sweep_stale(now, STALE_AFTER);
 
 		assert!(dialed.contains("flap:4443"));
-		// Second mark_announced has nothing to clear.
-		assert!(!dialed.mark_announced("flap:4443"));
+		// A second reannounce has nothing to clear.
+		assert!(!dialed.add_source("flap:4443", DialSource::Gossip));
+	}
+
+	/// A peer wanted by both gossip and the API survives losing either source: the
+	/// dial is only torn down once the last source releases it.
+	#[tokio::test]
+	async fn multi_source_peer_survives_until_last_release() {
+		let dialed = DialMap::default();
+		let now = Instant::now();
+		// Gossiped first, then also appears in the API list.
+		dialed.insert("both:4443".into(), placeholder_handle(), DialSource::Gossip);
+		let desired: HashSet<String> = ["both:4443".to_string()].into_iter().collect();
+		assert!(
+			dialed.reconcile_api(&desired).is_empty(),
+			"already dialed; no new spawn"
+		);
+
+		// Dropped from the API list -> still wanted by gossip.
+		assert!(dialed.reconcile_api(&HashSet::new()).is_empty());
+		assert!(dialed.contains("both:4443"), "gossip still wants it");
+
+		// Now gossip goes stale too -> the dial is finally released.
+		dialed.mark_unannounced("both:4443", now - STALE_AFTER - Duration::from_secs(1));
+		dialed.sweep_stale(now, STALE_AFTER);
+		assert!(!dialed.contains("both:4443"));
+	}
+
+	/// `insert` for an already-dialed peer merges the source onto the existing
+	/// entry (and aborts the redundant handle) rather than opening a second dial.
+	#[tokio::test]
+	async fn insert_merges_redundant_dial() {
+		let dialed = DialMap::default();
+		dialed.insert("p:4443".into(), placeholder_handle(), DialSource::Gossip);
+		dialed.insert("p:4443".into(), placeholder_handle(), DialSource::Api);
+
+		// Dropping the API source leaves the gossip source holding the dial.
+		assert!(dialed.reconcile_api(&HashSet::new()).is_empty());
+		assert!(dialed.contains("p:4443"), "gossip source still holds the dial");
 	}
 
 	/// `reconcile_api` drops API dials missing from the desired set, reports the

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -658,8 +658,8 @@ impl Cluster {
 	/// periodic re-check as a safety net for missed events and network filesystems.
 	/// Fails static: a missing or malformed file keeps the current dials.
 	async fn run_connect_api_file(&self, path: PathBuf, node: Option<String>, token: String, dialed: DialMap) {
-		let mut last_mtime = None;
-		self.reload_connect_api_file(&path, &mut last_mtime, &node, &token, &dialed);
+		let mut last_seen_mtime = None;
+		self.reload_connect_api_file(&path, &mut last_seen_mtime, &node, &token, &dialed);
 
 		let mut tick = tokio::time::interval(CONNECT_API_FILE_INTERVAL);
 		tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -688,23 +688,26 @@ impl Cluster {
 					},
 					_ = tick.tick() => {}
 				}
-				self.reload_connect_api_file(&path, &mut last_mtime, &node, &token, &dialed);
+				self.reload_connect_api_file(&path, &mut last_seen_mtime, &node, &token, &dialed);
 			}
 		}
 
 		// Polling fallback: no watcher could be created, or it stopped.
 		loop {
 			tick.tick().await;
-			self.reload_connect_api_file(&path, &mut last_mtime, &node, &token, &dialed);
+			self.reload_connect_api_file(&path, &mut last_seen_mtime, &node, &token, &dialed);
 		}
 	}
 
 	/// Re-read the peer-list file and reconcile if its mtime changed since the last
-	/// successful load. Any read/parse error keeps the current dials.
+	/// attempt. `last_seen_mtime` advances as soon as a new mtime is observed (not
+	/// only on success), so a malformed file isn't reread and re-warned every tick.
+	/// Any read/parse error keeps the current dials; the next real edit bumps the
+	/// mtime and triggers a fresh attempt.
 	fn reload_connect_api_file(
 		&self,
 		path: &std::path::Path,
-		last_mtime: &mut Option<std::time::SystemTime>,
+		last_seen_mtime: &mut Option<std::time::SystemTime>,
 		node: &Option<String>,
 		token: &str,
 		dialed: &DialMap,
@@ -716,16 +719,14 @@ impl Cluster {
 				return;
 			}
 		};
-		if *last_mtime == Some(mtime) {
+		if *last_seen_mtime == Some(mtime) {
 			return;
 		}
+		*last_seen_mtime = Some(mtime);
 
 		match std::fs::read_to_string(path) {
 			Ok(body) => match serde_json::from_str::<Vec<String>>(&body) {
-				Ok(list) => {
-					*last_mtime = Some(mtime);
-					self.apply_peer_list(list, node, token, dialed);
-				}
+				Ok(list) => self.apply_peer_list(list, node, token, dialed),
 				Err(err) => {
 					tracing::warn!(%err, ?path, "cluster.connect_api file is not a JSON array; keeping current peers")
 				}

--- a/rs/moq-relay/src/http_client.rs
+++ b/rs/moq-relay/src/http_client.rs
@@ -1,0 +1,24 @@
+use anyhow::Context;
+use http_cache_reqwest::{Cache, CacheMode, HttpCache, HttpCacheOptions, MokaManager};
+use reqwest_middleware::ClientWithMiddleware;
+
+/// Build a reqwest client with RFC-compliant HTTP caching (honors `Cache-Control`,
+/// `ETag`, `Last-Modified`) over the given TLS config. The client presents the
+/// supplied client certificate, so an mTLS-gated endpoint can identify the relay.
+///
+/// Shared by auth (JWK / public-API fetches) and cluster (peer-list polling).
+pub(crate) fn build(tls: &rustls::ClientConfig) -> anyhow::Result<ClientWithMiddleware> {
+	let client = reqwest::Client::builder()
+		.timeout(std::time::Duration::from_secs(10))
+		.use_preconfigured_tls(tls.clone())
+		.build()
+		.context("failed to build HTTP client")?;
+
+	Ok(reqwest_middleware::ClientBuilder::new(client)
+		.with(Cache(HttpCache {
+			mode: CacheMode::Default,
+			manager: MokaManager::default(),
+			options: HttpCacheOptions::default(),
+		}))
+		.build())
+}

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -11,6 +11,7 @@ mod auth;
 mod cluster;
 mod config;
 mod connection;
+mod http_client;
 mod stats;
 mod web;
 #[cfg(feature = "websocket")]

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -49,7 +49,9 @@ async fn main() -> anyhow::Result<()> {
 		config.auth.init().await?
 	};
 
-	let cluster = Cluster::new(config.cluster).with_client(client);
+	let cluster = Cluster::new(config.cluster)
+		.with_client(client)
+		.with_client_tls(config.client.tls.build()?);
 	let stats = config.stats.build(cluster.origin.clone());
 	let cluster = cluster.with_stats(stats);
 


### PR DESCRIPTION
## Summary

Adds `--cluster-connect-api` so a relay can fetch its cluster peer list from an external source and reconcile dials at runtime, without a redeploy. The relay stays topology-agnostic: it dials whatever hostnames the source returns, so all routing decisions (which node connects where) live in whatever service answers the endpoint.

Also splits cluster identity from the gossip toggle, which `--cluster-mesh` previously conflated.

### `--cluster-connect-api`
- Value is an `http(s)` URL or a local file (a path or `file://` URL).
- Returns a bare JSON array of peer hostnames: `["a.pop.example", "b.pop.example"]`.
- Reconciles against live dials: new peers dialed, dropped peers aborted. Composes with static `--cluster-connect` (never reconciled away) and gossip.
- HTTP: polled, with the re-poll cadence following `Cache-Control` (`max-age` + `stale-while-revalidate`). Conditional revalidation (ETag / Last-Modified) and stale-if-error come from the shared HTTP cache client.
- File: re-read when its mtime changes.
- Fails static: a failed fetch keeps the last good list, so a control-plane blip never tears down the cluster.
- The relay's `--cluster-node` value is sent as `?node=`, and the cluster mTLS client cert identifies the caller, so the endpoint can return per-node peer lists.

### Identity vs gossip
- `--cluster-node <url>` (re-added): this relay's own URL / identity. Used for `?node=` and as the address gossip advertises.
- `--cluster-mesh` is now a boolean gossip toggle (it previously took a URL). Enabling it without `--cluster-node` errors at startup. This is a breaking change to a recently-added flag (`#1504`).

### Other
- New `http_client` module factored out of `auth.rs`, reused for the peer-list poller.
- Docs: `doc/bin/relay/cluster.md`, `doc/bin/relay/config.md`.

## Follow-ups (not in this PR)
- The `/cluster/connect` endpoint itself (proprietary routing over the node inventory) lives in moq-pro.
- True non-blocking stale-while-revalidate: `http-cache` does not parse the SWR directive, so the cadence honors it but a stale fetch still revalidates synchronously on the poll task. Tracked as a follow-up.

## Test plan
- [x] `cargo test -p moq-relay` (97 pass; new tests cover DialMap API reconcile, config round-trip, SWR cadence parsing, gossip-requires-node)
- [x] `cargo clippy -p moq-relay --all-targets` clean
- [ ] Manual: `--cluster-connect-api file:///tmp/peers.json`, edit the file, confirm dials reconcile; HTTP endpoint with `Cache-Control` + a 5xx to confirm fail-static

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)