### PR TITLE
moq-lite-05: add AnnounceOk message (responder origin + initial active count)

### DIFF
--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -64,6 +64,9 @@ This is extremely useful for conference rooms, as you can live discover when par
 It's also useful for individual broadcasts as you can get notifications it comes online or goes offline (no spamming F5).
 The [moq-relay clustering](/bin/relay/cluster) feature actually uses this to discover other nodes in the cluster AND what broadcasts are available on each node.
 
+The peer first replies with the set of broadcasts that are currently live, then streams updates as they change.
+This initial set is a discrete batch: the latest draft reports how many entries to expect up front, so a freshly connected session can wait until that snapshot has fully arrived before listing what's available, rather than racing the gossip.
+
 ### Subscriptions
 
 All data transfers are initiated by subscriptions.

--- a/js/net/src/connection/accept.ts
+++ b/js/net/src/connection/accept.ts
@@ -29,6 +29,8 @@ export async function accept(transport: WebTransport, url: URL, props?: AcceptPr
 		return acceptSetup(transport, url, Ietf.Version.DRAFT_16);
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
 		return acceptSetup(transport, url, Ietf.Version.DRAFT_15);
+	} else if (protocol === Lite.ALPN_05_WIP) {
+		return new Lite.Connection(url, transport, Lite.Version.DRAFT_05_WIP, undefined);
 	} else if (protocol === Lite.ALPN_04) {
 		return new Lite.Connection(url, transport, Lite.Version.DRAFT_04, undefined);
 	} else if (protocol === Lite.ALPN_03) {

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -111,6 +111,9 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
 		setupVersion = Ietf.Version.DRAFT_15;
+	} else if (protocol === Lite.ALPN_05_WIP) {
+		// moq-lite draft-05 (WIP) doesn't use a session stream, so we return immediately.
+		return new Lite.Connection(url, session, Lite.Version.DRAFT_05_WIP, undefined);
 	} else if (protocol === Lite.ALPN_04) {
 		// moq-lite draft-04 doesn't use a session stream, so we return immediately.
 		return new Lite.Connection(url, session, Lite.Version.DRAFT_04, undefined);
@@ -193,6 +196,8 @@ async function connectTransport(url: URL, session: WebTransport): Promise<Establ
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
 		setupVersion = Ietf.Version.DRAFT_15;
+	} else if (protocol === Lite.ALPN_05_WIP) {
+		return new Lite.Connection(url, session, Lite.Version.DRAFT_05_WIP, undefined);
 	} else if (protocol === Lite.ALPN_04) {
 		return new Lite.Connection(url, session, Lite.Version.DRAFT_04, undefined);
 	} else if (protocol === Lite.ALPN_03) {

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -64,6 +64,12 @@ test("integration: lite draft-03", async () => {
 	await runPublishSubscribeFlow(Lite.ALPN_03);
 });
 
+test("integration: lite draft-05-wip", async () => {
+	// Exercises AnnounceOk: the announce flow only completes if the subscriber
+	// reads the publisher's AnnounceOk before the initial Announce messages.
+	await runPublishSubscribeFlow(Lite.ALPN_05_WIP);
+});
+
 test("integration: ietf draft-14", async () => {
 	await runPublishSubscribeFlow("", Ietf.Version.DRAFT_14);
 });

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -185,3 +185,52 @@ export class AnnounceInit {
 		return Message.decode(r, AnnounceInit.#decode);
 	}
 }
+
+/// Sent by the publisher as the first message on an announce stream, before any
+/// individual Announce messages. Lite05+ only; the successor to AnnounceInit.
+///
+/// `origin` is the responder's origin id, which the subscriber stamps onto each
+/// announce's hop chain (the publisher no longer stamps itself). `active` is the
+/// number of initial Announce messages that follow immediately.
+export class AnnounceOk {
+	origin: Origin;
+	active: number;
+
+	constructor(origin: Origin, active: number) {
+		this.origin = origin;
+		this.active = active;
+	}
+
+	static #guard(version: Version) {
+		switch (version) {
+			case Version.DRAFT_05_WIP:
+				break;
+			default:
+				throw new Error("announce ok not supported for this version");
+		}
+	}
+
+	async #encode(w: Writer) {
+		await w.u62(this.origin);
+		await w.u53(this.active);
+	}
+
+	static async #decode(r: Reader): Promise<AnnounceOk> {
+		const raw = await r.u62();
+		// A zero responder id is never legitimate; it would stamp a placeholder onto chains.
+		if (raw === 0n) throw new Error("announce ok origin must be non-zero");
+		const origin = OriginSchema.parse(raw);
+		const active = await r.u53();
+		return new AnnounceOk(origin, active);
+	}
+
+	async encode(w: Writer, version: Version): Promise<void> {
+		AnnounceOk.#guard(version);
+		return Message.encode(w, this.#encode.bind(this));
+	}
+
+	static async decode(r: Reader, version: Version): Promise<AnnounceOk> {
+		AnnounceOk.#guard(version);
+		return Message.decode(r, AnnounceOk.#decode);
+	}
+}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -6,7 +6,7 @@ import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
 import type { Track } from "../track.ts";
 import { error } from "../util/error.ts";
-import { Announce, AnnounceInit, type AnnounceInterest } from "./announce.ts";
+import { Announce, AnnounceInit, type AnnounceInterest, AnnounceOk } from "./announce.ts";
 import { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
 import { Probe } from "./probe.ts";
@@ -106,6 +106,10 @@ export class Publisher {
 			active.add(suffix);
 		}
 
+		// Lite05+ reports our origin once via AnnounceOk; the subscriber stamps it
+		// onto each announce, so we no longer put it in the per-announce hop list.
+		const selfHops = this.version === Version.DRAFT_05_WIP ? [] : [this.origin];
+
 		switch (this.version) {
 			case Version.DRAFT_01:
 			case Version.DRAFT_02: {
@@ -113,10 +117,20 @@ export class Publisher {
 				await init.encode(stream.writer, this.version);
 				break;
 			}
-			default:
-				// Draft03+: send individual Announce messages for initial state.
+			case Version.DRAFT_05_WIP: {
+				// Report our origin id and the count of initial announces that follow.
+				const ok = new AnnounceOk(this.origin, active.size);
+				await ok.encode(stream.writer, this.version);
 				for (const suffix of active) {
-					const wire = new Announce({ suffix, active: true, hops: [this.origin] });
+					const wire = new Announce({ suffix, active: true, hops: selfHops });
+					await wire.encode(stream.writer, this.version);
+				}
+				break;
+			}
+			default:
+				// Draft03/04: send individual Announce messages for initial state.
+				for (const suffix of active) {
+					const wire = new Announce({ suffix, active: true, hops: selfHops });
 					await wire.encode(stream.writer, this.version);
 				}
 				break;
@@ -147,7 +161,7 @@ export class Publisher {
 			// Announce any new broadcasts.
 			for (const added of newActive.difference(active)) {
 				console.debug(`announce: broadcast=${added} active=true`);
-				const wire = new Announce({ suffix: added, active: true, hops: [this.origin] });
+				const wire = new Announce({ suffix: added, active: true, hops: selfHops });
 				await wire.encode(stream.writer, this.version);
 			}
 

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -106,10 +106,6 @@ export class Publisher {
 			active.add(suffix);
 		}
 
-		// Lite05+ reports our origin once via AnnounceOk; the subscriber stamps it
-		// onto each announce, so we no longer put it in the per-announce hop list.
-		const selfHops = this.version === Version.DRAFT_05_WIP ? [] : [this.origin];
-
 		switch (this.version) {
 			case Version.DRAFT_01:
 			case Version.DRAFT_02: {
@@ -118,19 +114,20 @@ export class Publisher {
 				break;
 			}
 			case Version.DRAFT_05_WIP: {
-				// Report our origin id and the count of initial announces that follow.
+				// Report our origin id once via AnnounceOk and the count of initial announces
+				// that follow; the subscriber stamps our origin onto each hop chain, so we omit it.
 				const ok = new AnnounceOk(this.origin, active.size);
 				await ok.encode(stream.writer, this.version);
 				for (const suffix of active) {
-					const wire = new Announce({ suffix, active: true, hops: selfHops });
+					const wire = new Announce({ suffix, active: true });
 					await wire.encode(stream.writer, this.version);
 				}
 				break;
 			}
 			default:
-				// Draft03/04: send individual Announce messages for initial state.
+				// Draft03/04: send individual Announce messages, stamping our origin as a hop.
 				for (const suffix of active) {
-					const wire = new Announce({ suffix, active: true, hops: selfHops });
+					const wire = new Announce({ suffix, active: true, hops: [this.origin] });
 					await wire.encode(stream.writer, this.version);
 				}
 				break;
@@ -158,10 +155,12 @@ export class Publisher {
 				newActive.add(suffix);
 			}
 
-			// Announce any new broadcasts.
+			// Announce any new broadcasts. Lite05+ reports our origin once via AnnounceOk, so
+			// the subscriber stamps it onto each hop chain; older versions stamp it here.
 			for (const added of newActive.difference(active)) {
 				console.debug(`announce: broadcast=${added} active=true`);
-				const wire = new Announce({ suffix: added, active: true, hops: selfHops });
+				const hops = this.version === Version.DRAFT_05_WIP ? [] : [this.origin];
+				const wire = new Announce({ suffix: added, active: true, hops });
 				await wire.encode(stream.writer, this.version);
 			}
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -10,7 +10,7 @@ import type * as Time from "../time.ts";
 import type { Track } from "../track.ts";
 import { error } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
-import { Announce, AnnounceInit, AnnounceInterest } from "./announce.ts";
+import { Announce, AnnounceInit, AnnounceInterest, AnnounceOk } from "./announce.ts";
 import type { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
 import { Probe } from "./probe.ts";
@@ -119,6 +119,15 @@ export class Subscriber {
 			await stream.writer.u53(StreamId.Announce);
 			await msg.encode(stream.writer, this.version);
 
+			// Lite05+: the publisher reports its own origin id before any announces.
+			// It no longer stamps itself onto each hop chain, so we append it here to
+			// keep the ignoreSelf loop check seeing the full chain.
+			let responderOrigin: Origin | undefined;
+			if (this.version === Version.DRAFT_05_WIP) {
+				const ok = await AnnounceOk.decode(stream.reader, this.version);
+				responderOrigin = ok.origin;
+			}
+
 			switch (this.version) {
 				case Version.DRAFT_01:
 				case Version.DRAFT_02: {
@@ -148,8 +157,11 @@ export class Subscriber {
 				if (announce instanceof Error) throw announce;
 
 				// Optionally drop reflected announces so callers asking for
-				// "someone else's broadcasts" don't re-see their own publishes.
-				if (options.ignoreSelf && announce.hops.includes(this.origin)) {
+				// "someone else's broadcasts" don't re-see their own publishes. In
+				// Lite05 the sender's origin arrives via AnnounceOk, not in each hop
+				// list, so fold it back in before checking.
+				const hops = responderOrigin !== undefined ? [...announce.hops, responderOrigin] : announce.hops;
+				if (options.ignoreSelf && hops.includes(this.origin)) {
 					continue;
 				}
 

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -150,7 +150,7 @@ impl Client {
 					.select(Version::Lite(lite::Version::Lite05Wip))
 					.ok_or(Error::Version)?;
 
-				let (recv_bw, synced) = lite::start(
+				let (recv_bw, connecting) = lite::start(
 					session.clone(),
 					None,
 					publish,
@@ -161,7 +161,7 @@ impl Client {
 
 				// Block until the initial announce set has landed (Lite05 reports it
 				// via AnnounceOk + N), so a synchronous get_broadcast() won't race it.
-				let _ = synced.await;
+				connecting.ready().await;
 
 				return Ok(Session::new(
 					session,
@@ -176,7 +176,7 @@ impl Client {
 					.select(Version::Lite(lite::Version::Lite04))
 					.ok_or(Error::Version)?;
 
-				let (recv_bw, synced) = lite::start(
+				let (recv_bw, connecting) = lite::start(
 					session.clone(),
 					None,
 					publish,
@@ -186,7 +186,7 @@ impl Client {
 				)?;
 
 				// Lite04 has no initial-set boundary, so this resolves immediately.
-				let _ = synced.await;
+				connecting.ready().await;
 
 				return Ok(Session::new(
 					session,
@@ -202,7 +202,7 @@ impl Client {
 					.ok_or(Error::Version)?;
 
 				// Starting with draft-03, there's no more SETUP control stream.
-				let (recv_bw, synced) = lite::start(
+				let (recv_bw, connecting) = lite::start(
 					session.clone(),
 					None,
 					publish,
@@ -212,7 +212,7 @@ impl Client {
 				)?;
 
 				// Lite03 has no initial-set boundary, so this resolves immediately.
-				let _ = synced.await;
+				connecting.ready().await;
 
 				return Ok(Session::new(
 					session,
@@ -257,12 +257,12 @@ impl Client {
 		let recv_bw = match version {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
-				let (recv_bw, synced) =
+				let (recv_bw, connecting) =
 					lite::start(session.clone(), Some(stream), publish, consume, self.stats.clone(), v)?;
 
 				// Block until the initial announce set has landed (for versions that
 				// report one); resolves immediately otherwise.
-				let _ = synced.await;
+				connecting.ready().await;
 
 				recv_bw
 			}

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -150,7 +150,7 @@ impl Client {
 					.select(Version::Lite(lite::Version::Lite05Wip))
 					.ok_or(Error::Version)?;
 
-				let recv_bw = lite::start(
+				let (recv_bw, synced) = lite::start(
 					session.clone(),
 					None,
 					publish,
@@ -158,6 +158,10 @@ impl Client {
 					self.stats.clone(),
 					lite::Version::Lite05Wip,
 				)?;
+
+				// Block until the initial announce set has landed (Lite05 reports it
+				// via AnnounceOk + N), so a synchronous get_broadcast() won't race it.
+				let _ = synced.await;
 
 				return Ok(Session::new(
 					session,
@@ -172,7 +176,7 @@ impl Client {
 					.select(Version::Lite(lite::Version::Lite04))
 					.ok_or(Error::Version)?;
 
-				let recv_bw = lite::start(
+				let (recv_bw, synced) = lite::start(
 					session.clone(),
 					None,
 					publish,
@@ -180,6 +184,9 @@ impl Client {
 					self.stats.clone(),
 					lite::Version::Lite04,
 				)?;
+
+				// Lite04 has no initial-set boundary, so this resolves immediately.
+				let _ = synced.await;
 
 				return Ok(Session::new(
 					session,
@@ -195,7 +202,7 @@ impl Client {
 					.ok_or(Error::Version)?;
 
 				// Starting with draft-03, there's no more SETUP control stream.
-				let recv_bw = lite::start(
+				let (recv_bw, synced) = lite::start(
 					session.clone(),
 					None,
 					publish,
@@ -203,6 +210,9 @@ impl Client {
 					self.stats.clone(),
 					lite::Version::Lite03,
 				)?;
+
+				// Lite03 has no initial-set boundary, so this resolves immediately.
+				let _ = synced.await;
 
 				return Ok(Session::new(
 					session,
@@ -247,7 +257,14 @@ impl Client {
 		let recv_bw = match version {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
-				lite::start(session.clone(), Some(stream), publish, consume, self.stats.clone(), v)?
+				let (recv_bw, synced) =
+					lite::start(session.clone(), Some(stream), publish, consume, self.stats.clone(), v)?;
+
+				// Block until the initial announce set has landed (for versions that
+				// report one); resolves immediately otherwise.
+				let _ = synced.await;
+
+				recv_bw
 			}
 			Version::Ietf(v) => {
 				// Decode the parameters to get the initial request ID.

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -196,6 +196,48 @@ impl Message for AnnounceInit<'_> {
 	}
 }
 
+/// Sent by the publisher as the first message on an announce stream, before any
+/// individual Announce messages. Lite05+ only; the successor to [`AnnounceInit`].
+///
+/// `origin` is the responder's session origin id. In Lite05 the publisher no
+/// longer stamps it onto each Announce's hop chain; the subscriber appends it on
+/// receipt instead. `active` is the number of currently-active broadcasts the
+/// publisher sends as the initial set immediately after this message, letting the
+/// receiver block until the initial set has arrived.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AnnounceOk {
+	pub origin: Origin,
+	pub active: u64,
+}
+
+impl Message for AnnounceOk {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		match version {
+			Version::Lite05Wip => {}
+			_ => return Err(DecodeError::Version),
+		}
+
+		let origin = Origin::decode(r, version)?;
+		if origin.id == 0 {
+			// A zero responder id is never legitimate; it would stamp UNKNOWN onto chains.
+			return Err(DecodeError::InvalidValue);
+		}
+		let active = u64::decode(r, version)?;
+		Ok(Self { origin, active })
+	}
+
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		match version {
+			Version::Lite05Wip => {}
+			_ => return Err(EncodeError::Version),
+		}
+
+		self.origin.encode(w, version)?;
+		self.active.encode(w, version)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -246,5 +288,67 @@ mod tests {
 			matches!(Announce::decode(&mut slice, version), Err(DecodeError::InvalidValue)),
 			"restart status must be rejected before lite-05"
 		);
+	}
+
+	fn round_trip(msg: &AnnounceOk) -> AnnounceOk {
+		let mut buf = bytes::BytesMut::new();
+		msg.encode(&mut buf, Version::Lite05Wip).unwrap();
+		let mut slice = &buf[..];
+		let got = AnnounceOk::decode(&mut slice, Version::Lite05Wip).unwrap();
+		assert!(slice.is_empty(), "trailing bytes after decode");
+		got
+	}
+
+	#[test]
+	fn announce_ok_round_trip() {
+		let msg = AnnounceOk {
+			origin: Origin { id: 42 },
+			active: 3,
+		};
+		assert_eq!(round_trip(&msg), msg);
+	}
+
+	#[test]
+	fn announce_ok_zero_active() {
+		let msg = AnnounceOk {
+			origin: Origin { id: 7 },
+			active: 0,
+		};
+		assert_eq!(round_trip(&msg), msg);
+	}
+
+	#[test]
+	fn announce_ok_rejects_old_versions() {
+		let msg = AnnounceOk {
+			origin: Origin { id: 1 },
+			active: 0,
+		};
+		let mut buf = bytes::BytesMut::new();
+		assert!(matches!(
+			msg.encode(&mut buf, Version::Lite04),
+			Err(EncodeError::Version)
+		));
+	}
+
+	#[test]
+	fn announce_ok_rejects_zero_origin() {
+		// Encode a well-formed message then patch the origin to 0 on the wire.
+		let mut buf = bytes::BytesMut::new();
+		AnnounceOk {
+			origin: Origin { id: 1 },
+			active: 0,
+		}
+		.encode(&mut buf, Version::Lite05Wip)
+		.unwrap();
+		// origin id 1 sits right after the size prefix; rewrite it to 0.
+		let bytes = &buf[..];
+		let mut patched = bytes.to_vec();
+		// size(1 byte) | origin varint(1 byte = 0x01) | active varint(1 byte)
+		patched[1] = 0x00;
+		let mut slice = &patched[..];
+		assert!(matches!(
+			AnnounceOk::decode(&mut slice, Version::Lite05Wip),
+			Err(DecodeError::InvalidValue)
+		));
 	}
 }

--- a/rs/moq-net/src/lite/connecting.rs
+++ b/rs/moq-net/src/lite/connecting.rs
@@ -1,0 +1,81 @@
+//! Tracks a session's connection progress so `connect()` can block until it's done.
+//!
+//! Today "connecting" means every announce-prefix stream has received its initial
+//! set (AnnounceInit for Lite01/02, AnnounceOk + N for Lite05). It's deliberately
+//! generic so future work (e.g. extension negotiation) can register additional
+//! steps that must finish before a session is considered connected.
+//!
+//! Backed by `kio`: each in-flight step holds a [`ConnectingProducer`], and the
+//! session is connected once they've all been dropped (which closes the channel).
+//! A step drops its producer when it finishes — or, on an early error, when it goes
+//! out of scope — so a failed step can't hang `connect()`. Exposes both a synchronous
+//! poll API and an async one; prefer `kio` over `tokio` primitives for new async state
+//! so we keep both available.
+
+use std::task::Poll;
+
+use kio::{Consumer, Producer, Waiter};
+
+/// Producer side: hold one per in-flight connection step (e.g. one per announce
+/// prefix). Clone it to add a step; drop it to mark that step done. The session is
+/// connected once every producer has been dropped.
+///
+/// The inner producer exists purely for its `Clone` (adds a step) and `Drop` (closes
+/// the channel when the last one goes); it is never read, hence the allow.
+#[derive(Clone)]
+pub(super) struct ConnectingProducer(#[allow(dead_code)] Producer<()>);
+
+/// Consumer side: returned by [`crate::lite::start`] and awaited by `connect()`.
+pub(crate) struct Connecting(Consumer<()>);
+
+impl Connecting {
+	/// Create a producer/consumer pair. The consumer reports "connected" once every
+	/// [`ConnectingProducer`] (the original plus any clones) has been dropped.
+	pub(super) fn new() -> (ConnectingProducer, Self) {
+		let producer = Producer::new(());
+		let consumer = producer.consume();
+		(ConnectingProducer(producer), Self(consumer))
+	}
+
+	/// Poll for connection completion: ready once every step's producer has dropped.
+	pub(crate) fn poll_ready(&self, waiter: &Waiter) -> Poll<()> {
+		self.0.poll_closed(waiter)
+	}
+
+	/// Await connection completion. Resolves immediately when there are no steps.
+	pub(crate) async fn ready(&self) {
+		kio::wait(|waiter| self.poll_ready(waiter)).await;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn ready_once_every_producer_dropped() {
+		let (producer, connecting) = Connecting::new();
+		let noop = kio::Waiter::noop();
+		let second = producer.clone();
+		assert!(
+			connecting.poll_ready(&noop).is_pending(),
+			"not ready while a producer lives"
+		);
+		drop(producer);
+		assert!(connecting.poll_ready(&noop).is_pending(), "still a clone outstanding");
+		drop(second);
+		assert!(
+			connecting.poll_ready(&noop).is_ready(),
+			"ready once the last producer drops"
+		);
+	}
+
+	#[test]
+	fn ready_when_sole_producer_dropped() {
+		// No steps registered (a version with no initial-set boundary, or an empty
+		// origin): dropping the only producer resolves immediately.
+		let (producer, connecting) = Connecting::new();
+		drop(producer);
+		assert!(connecting.poll_ready(&kio::Waiter::noop()).is_ready());
+	}
+}

--- a/rs/moq-net/src/lite/mod.rs
+++ b/rs/moq-net/src/lite/mod.rs
@@ -5,6 +5,7 @@
 //! Specification: [<https://github.com/moq-dev/drafts>]
 
 mod announce;
+mod connecting;
 mod fetch;
 mod goaway;
 mod group;
@@ -21,6 +22,7 @@ mod subscriber;
 mod version;
 
 pub use announce::*;
+pub(crate) use connecting::*;
 #[allow(unused_imports)]
 pub use fetch::*;
 #[allow(unused_imports)]

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -229,8 +229,59 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				let announce_init = lite::AnnounceInit { suffixes: init };
 				stream.writer.encode(&announce_init).await?;
 			}
+			Version::Lite05Wip => {
+				// Drain the current active set synchronously (like the Lite01/02 path),
+				// stashing suffix+hops so we can both COUNT them for AnnounceOk and re-send
+				// them afterward. The receiver stamps our origin onto each hop chain, so we
+				// forward the stored chain as-is (no self push here).
+				let mut initial: Vec<(crate::PathOwned, OriginList)> = Vec::new();
+				while let Some((path, event)) = announced.try_next() {
+					let suffix = path
+						.strip_prefix(&prefix)
+						.expect("origin returned invalid path")
+						.to_owned();
+					let absolute = origin.absolute(&path).to_owned();
+
+					match event.broadcast() {
+						Some(broadcast) => {
+							let hops = &broadcast.hops;
+							// Apply the same exclude_hop and reflected-announce skips as the live
+							// loop so the count matches exactly what we send (minus the self push).
+							if exclude_hop != 0 && hops.iter().any(|h| h.id == exclude_hop) {
+								continue;
+							}
+							if hops.contains(&self_origin) {
+								continue;
+							}
+							tracing::debug!(broadcast = %absolute, "announce");
+							let guard = stats.broadcast(&absolute).publisher();
+							stats_guards.entry(absolute).or_insert(guard);
+							initial.retain(|(s, _)| s != &suffix);
+							initial.push((suffix, hops.clone()));
+						}
+						None => {
+							// A potential race: a just-announced path already unannounced.
+							tracing::debug!(broadcast = %absolute, "unannounce");
+							stats_guards.remove(&absolute);
+							initial.retain(|(s, _)| s != &suffix);
+						}
+					}
+				}
+
+				// Report our origin id (stamped onto hops by the receiver, not us)
+				// and the count of initial announces that follow immediately.
+				let ok = lite::AnnounceOk {
+					origin: self_origin,
+					active: initial.len() as u64,
+				};
+				stream.writer.encode(&ok).await?;
+
+				for (suffix, hops) in initial {
+					stream.writer.encode(&lite::Announce::Active { suffix, hops }).await?;
+				}
+			}
 			_ => {
-				// Lite03+: no more announce init.
+				// Lite03/Lite04: no announce init, no AnnounceOk.
 			}
 		}
 
@@ -250,7 +301,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 						match event {
 							crate::Announced::Active(active) => {
-								let Some(hops) = Self::prepare_active_hops(&active.hops, self_origin, exclude_hop, &absolute) else {
+								let Some(hops) = Self::prepare_active_hops(&active.hops, self_origin, exclude_hop, version, &absolute) else {
 									continue;
 								};
 								tracing::debug!(broadcast = %absolute, "announce");
@@ -263,7 +314,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								// On lite-05+ a restart travels as a duplicate ANNOUNCE (a second
 								// `Active` for an already-announced path). Older versions never defined
 								// that, so split it into an unannounce followed by a fresh announce.
-								match Self::prepare_active_hops(&active.hops, self_origin, exclude_hop, &absolute) {
+								match Self::prepare_active_hops(&active.hops, self_origin, exclude_hop, version, &absolute) {
 									Some(hops) => {
 										tracing::debug!(broadcast = %absolute, "restart");
 										// Continuity: keep the existing stats guard (no close + reopen).
@@ -308,6 +359,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		hops: &OriginList,
 		self_origin: Origin,
 		exclude_hop: u64,
+		version: Version,
 		absolute: &crate::Path,
 	) -> Option<OriginList> {
 		if exclude_hop != 0 && hops.iter().any(|h| h.id == exclude_hop) {
@@ -319,7 +371,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			return None;
 		}
 		let mut hops = hops.clone();
-		if hops.push(self_origin).is_err() {
+		// Lite05+ moves the self-stamp to the receiver, which appends our id (reported
+		// once via AnnounceOk) on receipt. Older versions stamp it here, dropping if the
+		// chain is full.
+		if !matches!(version, Version::Lite05Wip) && hops.push(self_origin).is_err() {
 			tracing::warn!(broadcast = %absolute, "dropping announce; hop chain at MAX_HOPS (possible loop)");
 			return None;
 		}

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -1,24 +1,21 @@
-use tokio::sync::oneshot;
-
 use crate::{
 	BandwidthConsumer, BandwidthProducer, Error, OriginConsumer, OriginProducer, StatsHandle, coding::Stream,
 	lite::SessionInfo,
 };
 
-use super::{Publisher, PublisherConfig, Subscriber, SubscriberConfig, SyncLatch, Version};
+use super::{Connecting, Publisher, PublisherConfig, Subscriber, SubscriberConfig, Version};
 
 /// Start a lite session.
 ///
-/// Returns the receive-bandwidth consumer (if any) and a `synced` receiver that
-/// resolves once the initial announce set has been inserted into the subscribe
-/// origin, letting `connect()` block past the startup race. The receiver fires
-/// immediately when there is nothing to wait on (no subscribe origin, or a version
-/// without an initial-set boundary).
+/// Returns the receive-bandwidth consumer (if any) and a [`Connecting`] handle that
+/// becomes ready once the initial announce set has been inserted into the subscribe
+/// origin, letting `connect()` block past the startup race. It is ready immediately
+/// when there is nothing to wait on (a version without an initial-set boundary).
 pub fn start<S: web_transport_trait::Session>(
 	session: S,
-	// The stream used to setup the session, after exchanging setup messages.
+	// The stream used to set up the session, after exchanging setup messages.
 	// NOTE: No longer used in draft-03.
-	setup: Option<Stream<S, Version>>,
+	setup_stream: Option<Stream<S, Version>>,
 	// We will publish any local broadcasts from this origin.
 	publish: OriginConsumer,
 	// We will consume any remote broadcasts, inserting them into this origin.
@@ -27,7 +24,7 @@ pub fn start<S: web_transport_trait::Session>(
 	stats: StatsHandle,
 	// The version of the protocol to use.
 	version: Version,
-) -> Result<(Option<BandwidthConsumer>, oneshot::Receiver<()>), Error> {
+) -> Result<(Option<BandwidthConsumer>, Connecting), Error> {
 	let recv_bw = BandwidthProducer::new();
 
 	let recv_bw_consumer = match version {
@@ -40,16 +37,15 @@ pub fn start<S: web_transport_trait::Session>(
 		_ => Some(recv_bw),
 	};
 
-	// Connect-sync latch. Only block on the initial set for versions with an
-	// initial-set boundary (AnnounceInit for Lite01/02, AnnounceOk for Lite05);
-	// otherwise fire now so connect() doesn't block. An empty subscribe origin still
-	// resolves immediately because the subscriber arms the latch with a prefix count
-	// of zero.
-	let (synced_latch, synced_rx) = SyncLatch::new();
-	let sub_synced = if matches!(version, Version::Lite01 | Version::Lite02 | Version::Lite05Wip) {
-		Some(synced_latch)
+	// Connection-progress tracker. Only block on the initial set for versions with an
+	// initial-set boundary (AnnounceInit for Lite01/02, AnnounceOk for Lite05). For other
+	// versions we drop the producer here, which closes the channel and makes
+	// `Connecting::ready` resolve immediately. An empty subscribe origin also resolves
+	// immediately because the subscriber arms with a prefix count of zero.
+	let (connecting_producer, connecting) = Connecting::new();
+	let sub_connecting = if matches!(version, Version::Lite01 | Version::Lite02 | Version::Lite05Wip) {
+		Some(connecting_producer)
 	} else {
-		synced_latch.fire();
 		None
 	};
 
@@ -69,15 +65,14 @@ pub fn start<S: web_transport_trait::Session>(
 		origin: subscribe,
 		recv_bandwidth: recv_bw_for_sub,
 		stats,
-		synced: sub_synced,
 		version,
 	});
 
 	web_async::spawn(async move {
 		let res = tokio::select! {
-			Err(res) = run_session(setup) => Err(res),
+			Err(res) = run_session(setup_stream) => Err(res),
 			res = publisher.run() => res,
-			res = subscriber.run() => res,
+			res = subscriber.run(sub_connecting) => res,
 		};
 
 		match res {
@@ -96,7 +91,7 @@ pub fn start<S: web_transport_trait::Session>(
 		}
 	});
 
-	Ok((recv_bw_consumer, synced_rx))
+	Ok((recv_bw_consumer, connecting))
 }
 
 // TODO do something useful with this

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -1,9 +1,19 @@
+use tokio::sync::oneshot;
+
 use crate::{
 	BandwidthConsumer, BandwidthProducer, Error, OriginConsumer, OriginProducer, StatsHandle, coding::Stream,
 	lite::SessionInfo,
 };
 
-use super::{Publisher, PublisherConfig, Subscriber, SubscriberConfig, Version};
+use super::{Publisher, PublisherConfig, Subscriber, SubscriberConfig, SyncLatch, Version};
+
+/// Start a lite session.
+///
+/// Returns the receive-bandwidth consumer (if any) and a `synced` receiver that
+/// resolves once the initial announce set has been inserted into the subscribe
+/// origin, letting `connect()` block past the startup race. The receiver fires
+/// immediately when there is nothing to wait on (no subscribe origin, or a version
+/// without an initial-set boundary).
 pub fn start<S: web_transport_trait::Session>(
 	session: S,
 	// The stream used to setup the session, after exchanging setup messages.
@@ -17,7 +27,7 @@ pub fn start<S: web_transport_trait::Session>(
 	stats: StatsHandle,
 	// The version of the protocol to use.
 	version: Version,
-) -> Result<Option<BandwidthConsumer>, Error> {
+) -> Result<(Option<BandwidthConsumer>, oneshot::Receiver<()>), Error> {
 	let recv_bw = BandwidthProducer::new();
 
 	let recv_bw_consumer = match version {
@@ -28,6 +38,19 @@ pub fn start<S: web_transport_trait::Session>(
 	let recv_bw_for_sub = match version {
 		Version::Lite01 | Version::Lite02 => None,
 		_ => Some(recv_bw),
+	};
+
+	// Connect-sync latch. Only block on the initial set for versions with an
+	// initial-set boundary (AnnounceInit for Lite01/02, AnnounceOk for Lite05);
+	// otherwise fire now so connect() doesn't block. An empty subscribe origin still
+	// resolves immediately because the subscriber arms the latch with a prefix count
+	// of zero.
+	let (synced_latch, synced_rx) = SyncLatch::new();
+	let sub_synced = if matches!(version, Version::Lite01 | Version::Lite02 | Version::Lite05Wip) {
+		Some(synced_latch)
+	} else {
+		synced_latch.fire();
+		None
 	};
 
 	// Publisher and Subscriber each derive their identity from their own
@@ -46,6 +69,7 @@ pub fn start<S: web_transport_trait::Session>(
 		origin: subscribe,
 		recv_bandwidth: recv_bw_for_sub,
 		stats,
+		synced: sub_synced,
 		version,
 	});
 
@@ -72,7 +96,7 @@ pub fn start<S: web_transport_trait::Session>(
 		}
 	});
 
-	Ok(recv_bw_consumer)
+	Ok((recv_bw_consumer, synced_rx))
 }
 
 // TODO do something useful with this

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -15,84 +15,14 @@ use crate::{
 	model::BroadcastProducer,
 };
 
-use super::Version;
+use super::{ConnectingProducer, Version};
 
-use tokio::sync::oneshot;
 use web_async::Lock;
 
 /// Keep an upstream subscription alive briefly after the last consumer leaves,
 /// so a returning subscriber reuses the same TrackProducer instead of forcing a
 /// fresh fetch (and the publisher re-serving the latest cached group).
 const LINGER_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// One-shot latch that fires once every announce-prefix stream has received its
-/// initial set (AnnounceInit for Lite01/02, AnnounceOk + N for Lite05). Lets
-/// `connect()` block until the initial broadcasts are available locally.
-pub(super) struct SyncLatch {
-	remaining: atomic::AtomicUsize,
-	sender: std::sync::Mutex<Option<oneshot::Sender<()>>>,
-}
-
-impl SyncLatch {
-	/// Create a latch and its completion receiver. The latch starts unarmed;
-	/// call [`SyncLatch::arm`] once the prefix count is known.
-	pub(super) fn new() -> (Arc<Self>, oneshot::Receiver<()>) {
-		let (tx, rx) = oneshot::channel();
-		let latch = Arc::new(Self {
-			remaining: atomic::AtomicUsize::new(0),
-			sender: std::sync::Mutex::new(Some(tx)),
-		});
-		(latch, rx)
-	}
-
-	/// Set the number of prefix streams that must complete before firing. Fires
-	/// immediately if `count` is zero. Called once, before any prefix task starts.
-	pub(super) fn arm(&self, count: usize) {
-		self.remaining.store(count, atomic::Ordering::Release);
-		if count == 0 {
-			self.fire();
-		}
-	}
-
-	/// Record one prefix stream's initial set as complete, firing when the last lands.
-	fn complete_one(&self) {
-		if self.remaining.fetch_sub(1, atomic::Ordering::AcqRel) == 1 {
-			self.fire();
-		}
-	}
-
-	/// Fire the latch. Idempotent: the sender is taken on the first call.
-	pub(super) fn fire(&self) {
-		if let Some(tx) = self.sender.lock().unwrap().take() {
-			let _ = tx.send(());
-		}
-	}
-}
-
-/// Ensures a prefix stream reports exactly one completion to its [`SyncLatch`],
-/// even if it errors before receiving its full initial set, so `connect()` can't
-/// hang waiting on a stream that died early.
-struct PrefixSyncGuard {
-	latch: Option<Arc<SyncLatch>>,
-}
-
-impl PrefixSyncGuard {
-	fn new(latch: Option<Arc<SyncLatch>>) -> Self {
-		Self { latch }
-	}
-
-	fn complete(&mut self) {
-		if let Some(latch) = self.latch.take() {
-			latch.complete_one();
-		}
-	}
-}
-
-impl Drop for PrefixSyncGuard {
-	fn drop(&mut self) {
-		self.complete();
-	}
-}
 
 pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	pub session: S,
@@ -104,10 +34,6 @@ pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	/// Stats aggregator for this session's ingress. Use [`StatsHandle::default`]
 	/// to opt out.
 	pub stats: StatsHandle,
-	/// Connect-sync latch fired once every announce-prefix stream has its initial
-	/// set. None when there is nothing to wait on (no origin, or a version with no
-	/// initial-set boundary), in which case the caller's receiver fires immediately.
-	pub synced: Option<Arc<SyncLatch>>,
 	pub version: Version,
 }
 
@@ -125,8 +51,6 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	self_origin: crate::Origin,
 	subscribes: Lock<HashMap<u64, TrackEntry>>,
 	next_id: Arc<atomic::AtomicU64>,
-	// Connect-sync latch; see SubscriberConfig::synced.
-	synced: Option<Arc<SyncLatch>>,
 	version: Version,
 }
 
@@ -167,15 +91,19 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			self_origin,
 			subscribes: Default::default(),
 			next_id: Default::default(),
-			synced: config.synced,
 			version: config.version,
 		}
 	}
 
-	pub async fn run(self) -> Result<(), Error> {
+	/// `connecting` is the connection-progress producer for this session (None for
+	/// versions with no initial-set boundary). It is threaded through the announce path
+	/// rather than stored on `Subscriber`: the struct is cloned for several long-lived
+	/// tasks (`bw`, `run_uni`), and any clone retaining a producer would keep the channel
+	/// open and hang `connect()`.
+	pub async fn run(self, connecting: Option<ConnectingProducer>) -> Result<(), Error> {
 		let bw = self.clone();
 		tokio::select! {
-			Err(err) = self.clone().run_announce() => Err(err),
+			Err(err) = self.clone().run_announce(connecting) => Err(err),
 			res = self.run_uni() => res,
 			Err(err) = bw.run_recv_bandwidth() => Err(err),
 		}
@@ -210,19 +138,18 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	async fn run_announce(self) -> Result<(), Error> {
+	async fn run_announce(self, connecting: Option<ConnectingProducer>) -> Result<(), Error> {
 		let prefixes: Vec<PathOwned> = self.origin.allowed().map(|p| p.to_owned()).collect();
-
-		// Each prefix stream reports once when its initial set lands; the latch
-		// fires (unblocking connect) when the last one does.
-		if let Some(latch) = &self.synced {
-			latch.arm(prefixes.len());
-		}
 
 		let mut tasks = FuturesUnordered::new();
 		for prefix in prefixes {
-			tasks.push(self.clone().run_announce_prefix(prefix));
+			tasks.push(self.clone().run_announce_prefix(prefix, connecting.clone()));
 		}
+
+		// Each prefix holds its own producer clone; drop ours so the channel closes (and
+		// connect() unblocks) once the last prefix finishes its initial set. With no
+		// prefixes, this is the only producer, so the session is connected now.
+		drop(connecting);
 
 		while let Some(result) = tasks.next().await {
 			result?;
@@ -231,7 +158,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	async fn run_announce_prefix(mut self, prefix: PathOwned) -> Result<(), Error> {
+	async fn run_announce_prefix(
+		mut self,
+		prefix: PathOwned,
+		mut connecting: Option<ConnectingProducer>,
+	) -> Result<(), Error> {
 		let mut stream = Stream::open(&self.session, self.version).await?;
 		stream.writer.encode(&lite::ControlType::Announce).await?;
 
@@ -266,6 +197,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// fanned-out level keys line up with the absolute broadcast paths a
 		// dashboard sees on the origin.
 
+		// `connecting` is a local (a param), not a `self` field, so the `self.clone()` that
+		// start_announce uses to spawn long-lived broadcast tasks doesn't carry the producer
+		// (which would keep the channel open for the broadcast's lifetime). Dropping it marks
+		// this prefix connected; on an early error it drops via scope exit, so a failed prefix
+		// can't hang connect().
+
 		match self.version {
 			Version::Lite01 | Version::Lite02 => {
 				let msg: lite::AnnounceInit = stream.reader.decode().await?;
@@ -283,24 +220,24 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		}
 
-		// Report this prefix's initial set to the connect-sync latch. Lite01/02
-		// delivered it via AnnounceInit (consumed just above); Lite05 delivers
-		// `initial_count` Announce::Active counted in the loop below; Lite03/04 have
-		// no boundary (latch is None, so this is inert). The guard also fires on an
-		// early stream error, so connect() never hangs.
-		let mut synced = PrefixSyncGuard::new(self.synced.clone());
+		// Release the producer once this prefix's initial set is in. Lite01/02 delivered it
+		// via AnnounceInit (consumed just above); Lite05 delivers `initial_count`
+		// Announce::Active counted in the loop below; Lite03/04 have no boundary (already None).
 		let mut initial_remaining = match self.version {
 			Version::Lite01 | Version::Lite02 => {
-				synced.complete();
+				connecting.take();
 				0
 			}
 			Version::Lite05Wip => {
 				if initial_count == 0 {
-					synced.complete();
+					connecting.take();
 				}
 				initial_count
 			}
-			_ => 0,
+			_ => {
+				connecting.take();
+				0
+			}
 		};
 
 		while let Some(announce) = stream.reader.decode_maybe::<lite::Announce>().await? {
@@ -323,11 +260,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					} else if self.start_announce(path.clone(), hops, responder_origin, &mut producers)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
-					// The first `initial_count` Active messages are the initial set.
+					// The first `initial_count` Active messages are the initial set; once
+					// they're all in, drop our producer to mark this prefix connected.
 					if initial_remaining > 0 {
 						initial_remaining -= 1;
 						if initial_remaining == 0 {
-							synced.complete();
+							connecting.take();
 						}
 					}
 				}
@@ -853,49 +791,5 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	fn log_path(&self, path: impl AsPath) -> Path<'_> {
 		self.origin.root().join(path)
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn sync_latch_fires_after_all_prefixes() {
-		let (latch, mut rx) = SyncLatch::new();
-		latch.arm(2);
-		assert!(rx.try_recv().is_err(), "should not fire before any prefix completes");
-		latch.complete_one();
-		assert!(rx.try_recv().is_err(), "should not fire after only 1 of 2");
-		latch.complete_one();
-		assert_eq!(rx.try_recv(), Ok(()), "should fire once the last prefix completes");
-	}
-
-	#[test]
-	fn sync_latch_zero_fires_immediately() {
-		let (latch, mut rx) = SyncLatch::new();
-		latch.arm(0);
-		assert_eq!(rx.try_recv(), Ok(()), "arm(0) should fire immediately");
-	}
-
-	#[test]
-	fn prefix_guard_completes_on_drop() {
-		// A prefix that errors before its initial set must still release connect().
-		let (latch, mut rx) = SyncLatch::new();
-		latch.arm(1);
-		drop(PrefixSyncGuard::new(Some(latch.clone())));
-		assert_eq!(rx.try_recv(), Ok(()), "dropping the guard should complete the prefix");
-	}
-
-	#[test]
-	fn prefix_guard_completes_once() {
-		let (latch, mut rx) = SyncLatch::new();
-		latch.arm(1);
-		let mut guard = PrefixSyncGuard::new(Some(latch.clone()));
-		guard.complete();
-		assert_eq!(rx.try_recv(), Ok(()), "explicit completion should fire");
-		// A second completion (and the eventual Drop) must not over-decrement.
-		guard.complete();
-		drop(guard);
 	}
 }

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -17,12 +17,82 @@ use crate::{
 
 use super::Version;
 
+use tokio::sync::oneshot;
 use web_async::Lock;
 
 /// Keep an upstream subscription alive briefly after the last consumer leaves,
 /// so a returning subscriber reuses the same TrackProducer instead of forcing a
 /// fresh fetch (and the publisher re-serving the latest cached group).
 const LINGER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One-shot latch that fires once every announce-prefix stream has received its
+/// initial set (AnnounceInit for Lite01/02, AnnounceOk + N for Lite05). Lets
+/// `connect()` block until the initial broadcasts are available locally.
+pub(super) struct SyncLatch {
+	remaining: atomic::AtomicUsize,
+	sender: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+}
+
+impl SyncLatch {
+	/// Create a latch and its completion receiver. The latch starts unarmed;
+	/// call [`SyncLatch::arm`] once the prefix count is known.
+	pub(super) fn new() -> (Arc<Self>, oneshot::Receiver<()>) {
+		let (tx, rx) = oneshot::channel();
+		let latch = Arc::new(Self {
+			remaining: atomic::AtomicUsize::new(0),
+			sender: std::sync::Mutex::new(Some(tx)),
+		});
+		(latch, rx)
+	}
+
+	/// Set the number of prefix streams that must complete before firing. Fires
+	/// immediately if `count` is zero. Called once, before any prefix task starts.
+	pub(super) fn arm(&self, count: usize) {
+		self.remaining.store(count, atomic::Ordering::Release);
+		if count == 0 {
+			self.fire();
+		}
+	}
+
+	/// Record one prefix stream's initial set as complete, firing when the last lands.
+	fn complete_one(&self) {
+		if self.remaining.fetch_sub(1, atomic::Ordering::AcqRel) == 1 {
+			self.fire();
+		}
+	}
+
+	/// Fire the latch. Idempotent: the sender is taken on the first call.
+	pub(super) fn fire(&self) {
+		if let Some(tx) = self.sender.lock().unwrap().take() {
+			let _ = tx.send(());
+		}
+	}
+}
+
+/// Ensures a prefix stream reports exactly one completion to its [`SyncLatch`],
+/// even if it errors before receiving its full initial set, so `connect()` can't
+/// hang waiting on a stream that died early.
+struct PrefixSyncGuard {
+	latch: Option<Arc<SyncLatch>>,
+}
+
+impl PrefixSyncGuard {
+	fn new(latch: Option<Arc<SyncLatch>>) -> Self {
+		Self { latch }
+	}
+
+	fn complete(&mut self) {
+		if let Some(latch) = self.latch.take() {
+			latch.complete_one();
+		}
+	}
+}
+
+impl Drop for PrefixSyncGuard {
+	fn drop(&mut self) {
+		self.complete();
+	}
+}
 
 pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	pub session: S,
@@ -34,6 +104,10 @@ pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	/// Stats aggregator for this session's ingress. Use [`StatsHandle::default`]
 	/// to opt out.
 	pub stats: StatsHandle,
+	/// Connect-sync latch fired once every announce-prefix stream has its initial
+	/// set. None when there is nothing to wait on (no origin, or a version with no
+	/// initial-set boundary), in which case the caller's receiver fires immediately.
+	pub synced: Option<Arc<SyncLatch>>,
 	pub version: Version,
 }
 
@@ -51,6 +125,8 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	self_origin: crate::Origin,
 	subscribes: Lock<HashMap<u64, TrackEntry>>,
 	next_id: Arc<atomic::AtomicU64>,
+	// Connect-sync latch; see SubscriberConfig::synced.
+	synced: Option<Arc<SyncLatch>>,
 	version: Version,
 }
 
@@ -91,6 +167,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			self_origin,
 			subscribes: Default::default(),
 			next_id: Default::default(),
+			synced: config.synced,
 			version: config.version,
 		}
 	}
@@ -136,6 +213,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	async fn run_announce(self) -> Result<(), Error> {
 		let prefixes: Vec<PathOwned> = self.origin.allowed().map(|p| p.to_owned()).collect();
 
+		// Each prefix stream reports once when its initial set lands; the latch
+		// fires (unblocking connect) when the last one does.
+		if let Some(latch) = &self.synced {
+			latch.arm(prefixes.len());
+		}
+
 		let mut tasks = FuturesUnordered::new();
 		for prefix in prefixes {
 			tasks.push(self.clone().run_announce_prefix(prefix));
@@ -161,6 +244,17 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		};
 		stream.writer.encode(&msg).await?;
 
+		// Lite05+: the publisher reports its own origin id (which we stamp onto every
+		// received Announce's hop chain, since it no longer does so itself) plus the
+		// count of initial active announces that follow immediately.
+		let (responder_origin, initial_count) = match self.version {
+			Version::Lite05Wip => {
+				let ok: lite::AnnounceOk = stream.reader.decode().await?;
+				(Some(ok.origin), ok.active)
+			}
+			_ => (None, 0),
+		};
+
 		let mut producers = HashMap::new();
 		// Per-broadcast subscriber-side stats guards. Dropping the guard records
 		// `subscriber.broadcasts_closed`. We only insert a guard when start_announce
@@ -179,7 +273,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					let path = prefix.join(&suffix);
 					let abs = self.origin.absolute(&path).to_owned();
 					// Lite01/02 don't carry hop information; the broadcast starts with an empty chain.
-					if self.start_announce(path.clone(), crate::OriginList::new(), &mut producers)? {
+					if self.start_announce(path.clone(), crate::OriginList::new(), responder_origin, &mut producers)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
 				}
@@ -188,6 +282,26 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				// Lite03+: no AnnounceInit, initial state comes via Announce messages.
 			}
 		}
+
+		// Report this prefix's initial set to the connect-sync latch. Lite01/02
+		// delivered it via AnnounceInit (consumed just above); Lite05 delivers
+		// `initial_count` Announce::Active counted in the loop below; Lite03/04 have
+		// no boundary (latch is None, so this is inert). The guard also fires on an
+		// early stream error, so connect() never hangs.
+		let mut synced = PrefixSyncGuard::new(self.synced.clone());
+		let mut initial_remaining = match self.version {
+			Version::Lite01 | Version::Lite02 => {
+				synced.complete();
+				0
+			}
+			Version::Lite05Wip => {
+				if initial_count == 0 {
+					synced.complete();
+				}
+				initial_count
+			}
+			_ => 0,
+		};
 
 		while let Some(announce) = stream.reader.decode_maybe::<lite::Announce>().await? {
 			match announce {
@@ -198,7 +312,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						// lite-05+ only: a duplicate ANNOUNCE for an already-announced path is a RESTART;
 						// atomically replace the broadcast. Older versions fall through to start_announce,
 						// which rejects the duplicate (Error::Duplicate).
-						if self.restart_announce(path.clone(), hops, &mut producers)? {
+						if self.restart_announce(path.clone(), hops, responder_origin, &mut producers)? {
 							// Continuity: keep the existing stats guard if present.
 							stats_guards
 								.entry(abs.clone())
@@ -206,8 +320,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						} else {
 							stats_guards.remove(&abs);
 						}
-					} else if self.start_announce(path.clone(), hops, &mut producers)? {
+					} else if self.start_announce(path.clone(), hops, responder_origin, &mut producers)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
+					}
+					// The first `initial_count` Active messages are the initial set.
+					if initial_remaining > 0 {
+						initial_remaining -= 1;
+						if initial_remaining == 0 {
+							synced.complete();
+						}
 					}
 				}
 				lite::Announce::Ended { suffix, .. } => {
@@ -284,9 +405,26 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	fn start_announce(
 		&mut self,
 		path: PathOwned,
-		hops: crate::OriginList,
+		mut hops: crate::OriginList,
+		// Lite05+: the announce sender's origin id (from AnnounceOk). The sender no
+		// longer stamps itself onto the chain, so we append it here to reconstruct
+		// the full `[src...sender]` chain Lite04 stored. None for older versions,
+		// where the sender already appended itself.
+		responder_origin: Option<crate::Origin>,
 		producers: &mut HashMap<PathOwned, BroadcastProducer>,
 	) -> Result<bool, Error> {
+		if let Some(responder) = responder_origin {
+			// If the chain is already full, drop the announce — the same decision
+			// the Lite04 sender makes at its push site.
+			if hops.push(responder).is_err() {
+				tracing::warn!(
+					broadcast = %self.log_path(&path),
+					"dropping announce; hop chain at MAX_HOPS (possible loop)",
+				);
+				return Ok(false);
+			}
+		}
+
 		// Drop announces that already passed through us — this connection is
 		// a reflection, not a new path. Peers should be filtering via
 		// AnnounceInterest.exclude_hop, but Lite03 peers can't, so this is
@@ -329,11 +467,19 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	fn restart_announce(
 		&mut self,
 		path: PathOwned,
-		hops: crate::OriginList,
+		mut hops: crate::OriginList,
+		// Lite05+: the announce sender's origin id (from AnnounceOk), appended here to
+		// rebuild the full chain since the sender no longer stamps itself. None for older
+		// versions. See `start_announce`.
+		responder_origin: Option<crate::Origin>,
 		producers: &mut HashMap<PathOwned, BroadcastProducer>,
 	) -> Result<bool, Error> {
-		// Reflected loop: the replacement passed through us. Retire the broadcast.
-		if hops.contains(&self.self_origin) {
+		// Reflected loop (or a full chain): the replacement can't be used here. Retire the broadcast.
+		let reflected = match responder_origin {
+			Some(responder) => hops.push(responder).is_err() || hops.contains(&self.self_origin),
+			None => hops.contains(&self.self_origin),
+		};
+		if reflected {
 			tracing::debug!(broadcast = %self.log_path(&path), "dropping reflected restart");
 			if let Some(mut old) = producers.remove(&path) {
 				old.abort(Error::Cancel).ok();
@@ -707,5 +853,49 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	fn log_path(&self, path: impl AsPath) -> Path<'_> {
 		self.origin.root().join(path)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn sync_latch_fires_after_all_prefixes() {
+		let (latch, mut rx) = SyncLatch::new();
+		latch.arm(2);
+		assert!(rx.try_recv().is_err(), "should not fire before any prefix completes");
+		latch.complete_one();
+		assert!(rx.try_recv().is_err(), "should not fire after only 1 of 2");
+		latch.complete_one();
+		assert_eq!(rx.try_recv(), Ok(()), "should fire once the last prefix completes");
+	}
+
+	#[test]
+	fn sync_latch_zero_fires_immediately() {
+		let (latch, mut rx) = SyncLatch::new();
+		latch.arm(0);
+		assert_eq!(rx.try_recv(), Ok(()), "arm(0) should fire immediately");
+	}
+
+	#[test]
+	fn prefix_guard_completes_on_drop() {
+		// A prefix that errors before its initial set must still release connect().
+		let (latch, mut rx) = SyncLatch::new();
+		latch.arm(1);
+		drop(PrefixSyncGuard::new(Some(latch.clone())));
+		assert_eq!(rx.try_recv(), Ok(()), "dropping the guard should complete the prefix");
+	}
+
+	#[test]
+	fn prefix_guard_completes_once() {
+		let (latch, mut rx) = SyncLatch::new();
+		latch.arm(1);
+		let mut guard = PrefixSyncGuard::new(Some(latch.clone()));
+		guard.complete();
+		assert_eq!(rx.try_recv(), Ok(()), "explicit completion should fire");
+		// A second completion (and the eventual Drop) must not over-decrement.
+		guard.complete();
+		drop(guard);
 	}
 }

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -887,7 +887,10 @@ impl OriginConsumer {
 	/// later. Subscribers should watch [`BroadcastConsumer::closed`] to react to that.
 	///
 	/// Prefer this over [`Self::get_broadcast`] when you know the exact path you want but
-	/// cannot guarantee the announcement has already been received.
+	/// cannot guarantee the announcement has already been received. With moq-lite-05 (and
+	/// the older Lite01/02) `connect()` already blocks until the initial announce set lands,
+	/// so [`Self::get_broadcast`] is race-free for broadcasts that were live at connect time;
+	/// this method is still needed to wait for a broadcast that comes online *after* connect.
 	pub async fn announced_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();
 

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -143,7 +143,7 @@ impl Server {
 					.ok_or(Error::Version)?;
 
 				// Server side never blocks on the initial set; discard the synced receiver.
-				let (recv_bw, _synced) = lite::start(
+				let (recv_bw, _connecting) = lite::start(
 					session.clone(),
 					None,
 					publish.clone(),
@@ -165,7 +165,7 @@ impl Server {
 					.select(Version::Lite(lite::Version::Lite04))
 					.ok_or(Error::Version)?;
 
-				let (recv_bw, _synced) = lite::start(
+				let (recv_bw, _connecting) = lite::start(
 					session.clone(),
 					None,
 					publish.clone(),
@@ -188,7 +188,7 @@ impl Server {
 					.ok_or(Error::Version)?;
 
 				// Starting with draft-03, there's no more SETUP control stream.
-				let (recv_bw, _synced) = lite::start(
+				let (recv_bw, _connecting) = lite::start(
 					session.clone(),
 					None,
 					publish.clone(),
@@ -244,7 +244,7 @@ impl Server {
 		let recv_bw = match version {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
-				let (recv_bw, _synced) = lite::start(
+				let (recv_bw, _connecting) = lite::start(
 					session.clone(),
 					Some(stream),
 					publish.clone(),

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -142,7 +142,8 @@ impl Server {
 					.select(Version::Lite(lite::Version::Lite05Wip))
 					.ok_or(Error::Version)?;
 
-				let recv_bw = lite::start(
+				// Server side never blocks on the initial set; discard the synced receiver.
+				let (recv_bw, _synced) = lite::start(
 					session.clone(),
 					None,
 					publish.clone(),
@@ -164,7 +165,7 @@ impl Server {
 					.select(Version::Lite(lite::Version::Lite04))
 					.ok_or(Error::Version)?;
 
-				let recv_bw = lite::start(
+				let (recv_bw, _synced) = lite::start(
 					session.clone(),
 					None,
 					publish.clone(),
@@ -187,7 +188,7 @@ impl Server {
 					.ok_or(Error::Version)?;
 
 				// Starting with draft-03, there's no more SETUP control stream.
-				let recv_bw = lite::start(
+				let (recv_bw, _synced) = lite::start(
 					session.clone(),
 					None,
 					publish.clone(),
@@ -243,14 +244,15 @@ impl Server {
 		let recv_bw = match version {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
-				lite::start(
+				let (recv_bw, _synced) = lite::start(
 					session.clone(),
 					Some(stream),
 					publish.clone(),
 					consume.clone(),
 					self.stats.clone(),
 					v,
-				)?
+				)?;
+				recv_bw
 			}
 			Version::Ietf(v) => {
 				// Decode the client's parameters to get their max request ID.


### PR DESCRIPTION
## Summary

Adds an `AnnounceOk` message to the moq-lite-05 announce stream, sent once by the publisher right after it reads `AnnounceInterest` and before any `Announce`. It does two things:

1. **Reports the responder's origin id once** instead of stamping it onto the trailing hop of every `Announce`. That id is identical for every announce on a session, so re-encoding it per-message is pure waste. In Lite05 a node no longer stamps its *own* origin onto a chain; the **receiver** stamps the *remote* sender's origin (from `AnnounceOk`) on receipt. The stored hop chain is byte-identical to Lite04, so loop detection / shortest-path selection are unchanged.
2. **Reports `active: N`**, the count of currently-active broadcasts, followed by exactly `N` initial `Announce::Active`. This gives the announce stream a discrete initial-set boundary (the successor to `AnnounceInit`).

The count lets `connect()` **block until the initial set has landed**, closing the startup race where a synchronous `get_broadcast()` right after connect could miss broadcasts that were live but not yet gossiped. A `SyncLatch` fires once every announce-prefix stream has its initial set, generalized across both boundaries — `AnnounceInit` (Lite01/02) and `AnnounceOk + N` (Lite05); Lite03/04 have no boundary and resolve immediately. `OriginConsumer::announced_broadcast()` is **kept** — it still serves the distinct "wait for a broadcast that comes online *after* connect" case.

This is opt-in: `Lite05Wip` is not advertised over ALPN or in the default version set, so nothing negotiates it by default.

## Why

The trailing self-hop is redundant on every announce, and Lite03+ had no way to know when the initial set was complete. `AnnounceOk` fixes both with one message.

## JS mirror

`@moq/net` mirrors the wire: `AnnounceOk` message, no-self-hop send, and the subscriber re-appending the responder origin (so the `ignoreSelf` filter still sees the full chain). It also wires `ALPN_05_WIP` into `connect`/`accept`, which previously had **no** Lite05 negotiation branch at all.

JS does **not** add connect-blocking: its `Connection` is pull-based (`announced()` opens the announce stream lazily and `consume(path)` subscribes directly without consulting announcements), so the synchronous `get_broadcast()` race doesn't exist there.

## Notes for reviewers

- Targets `dev` per the wire-protocol branch convention. Rebased onto `dev`, which had substantially reworked these files (`AnnounceConsumer` split, `Session::new` gaining publisher/consumer args, restart/REANNOUNCE semantics, its own lite-05 additions). Integrated with all of those:
  - The publisher's self-stamp now lives in `prepare_active_hops`, made version-aware so Lite05 skips it.
  - Both `start_announce` and `restart_announce` take the responder origin and append it (with MAX_HOPS handling) on the receive side.
- The IETF draft / spec is being updated separately.

## Test plan

- [x] `AnnounceOk` round-trip / old-version reject / zero-active / zero-origin reject (rs)
- [x] `SyncLatch` unit tests: arm/complete, arm(0), guard-fires-on-drop, idempotent completion (rs)
- [x] Existing restart/REANNOUNCE tests still pass (336 moq-net tests, 93 moq-relay incl. smoke)
- [x] New `integration: lite draft-05-wip` end-to-end test exercises `AnnounceOk` over the wire (js)
- [x] `just rs check` (clippy + fmt + tests) and `just js check` (biome + tsc + tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)