### PR TITLE
moq-net: split TrackConsumer into a track handle + TrackSubscriber

### DIFF
--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -125,7 +125,7 @@ Subscribe to a media track and read frames using [`OrderedConsumer`](https://doc
 ```rust
 let track_consumer = broadcast
     .consume_track(&track_name)
-    .subscribe(moq_net::Subscription::new(1))
+    .subscribe(moq_net::Subscription::default().with_priority(1))
     .await?;
 let mut ordered = hang::container::OrderedConsumer::new(
     track_consumer,

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -107,7 +107,8 @@ Subscribe to it using [`CatalogConsumer`](https://docs.rs/hang/latest/hang/catal
 
 ```rust
 let catalog_track = broadcast
-    .subscribe_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_subscription())
+    .consume_track(hang::Catalog::DEFAULT_NAME)
+    .subscribe(hang::Catalog::default_subscription())
     .await?;
 let mut catalog = hang::CatalogConsumer::new(catalog_track);
 let info = catalog.next().await?.expect("no catalog");
@@ -123,7 +124,8 @@ Subscribe to a media track and read frames using [`OrderedConsumer`](https://doc
 
 ```rust
 let track_consumer = broadcast
-    .subscribe_track(&track_name, moq_net::Subscription::new(1))
+    .consume_track(&track_name)
+    .subscribe(moq_net::Subscription::new(1))
     .await?;
 let mut ordered = hang::container::OrderedConsumer::new(
     track_consumer,

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -52,8 +52,8 @@ async fn run_subscribe(consumer: moq_net::OriginConsumer) -> anyhow::Result<()> 
 
 	// Read the catalog to discover available tracks.
 	let catalog_track = broadcast
-		.subscribe_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_subscription())
-		.ok()
+		.consume_track(hang::Catalog::DEFAULT_NAME)
+		.subscribe(hang::Catalog::default_subscription())
 		.await?;
 	let mut catalog = moq_mux::catalog::hang::Consumer::new(catalog_track);
 
@@ -77,14 +77,11 @@ async fn run_subscribe(consumer: moq_net::OriginConsumer) -> anyhow::Result<()> 
 
 	// Subscribe to the video track.
 	let track_consumer = broadcast
-		.subscribe_track(
-			name,
-			moq_net::Subscription {
-				priority: 1,
-				..Default::default()
-			},
-		)
-		.ok()
+		.consume_track(name)
+		.subscribe(moq_net::Subscription {
+			priority: 1,
+			..Default::default()
+		})
 		.await?;
 	let mut ordered = moq_mux::container::Consumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
 		.with_latency(Duration::from_millis(500));

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -84,10 +84,7 @@ impl Catalog {
 	/// The subscription preferences used for the catalog track (high priority so
 	/// it preempts media tracks).
 	pub fn default_subscription() -> moq_net::Subscription {
-		moq_net::Subscription {
-			priority: 100,
-			..Default::default()
-		}
+		moq_net::Subscription::default().with_priority(100)
 	}
 }
 

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -64,16 +64,13 @@ impl Consume {
 		};
 		let id = self.catalog_task.insert(Some(entry))?;
 
-		// `subscribe_track` now blocks on SUBSCRIBE_OK, so run it inside the task
+		// `subscribe` blocks on SUBSCRIBE_OK, so run it inside the task
 		// to keep this entrypoint non-blocking.
 		tokio::spawn(async move {
 			let res = async move {
 				let catalog = broadcast
-					.subscribe_track(
-						hang::catalog::Catalog::DEFAULT_NAME,
-						hang::catalog::Catalog::default_subscription(),
-					)
-					.ok()
+					.consume_track(hang::catalog::Catalog::DEFAULT_NAME)
+					.subscribe(hang::catalog::Catalog::default_subscription())
 					.await?;
 				Self::run_catalog(on_catalog, broadcast.clone(), catalog.into(), channel.1).await
 			}
@@ -249,18 +246,15 @@ impl Consume {
 		};
 		let id = self.track_task.insert(Some(entry))?;
 
-		// `subscribe_track` now blocks on SUBSCRIBE_OK, so run it inside the task.
+		// `subscribe` blocks on SUBSCRIBE_OK, so run it inside the task.
 		tokio::spawn(async move {
 			let res = async move {
 				let track = broadcast
-					.subscribe_track(
-						&name,
-						moq_net::Subscription {
-							priority: 1,
-							..Default::default()
-						},
-					)
-					.ok()
+					.consume_track(&name)
+					.subscribe(moq_net::Subscription {
+						priority: 1,
+						..Default::default()
+					})
 					.await?;
 				let track = moq_mux::container::Consumer::new(track, moq_mux::catalog::hang::Container::Legacy)
 					.with_latency(latency);
@@ -304,18 +298,15 @@ impl Consume {
 		};
 		let id = self.track_task.insert(Some(entry))?;
 
-		// `subscribe_track` now blocks on SUBSCRIBE_OK, so run it inside the task.
+		// `subscribe` blocks on SUBSCRIBE_OK, so run it inside the task.
 		tokio::spawn(async move {
 			let res = async move {
 				let track = broadcast
-					.subscribe_track(
-						&name,
-						moq_net::Subscription {
-							priority: 2,
-							..Default::default()
-						},
-					)
-					.ok()
+					.consume_track(&name)
+					.subscribe(moq_net::Subscription {
+						priority: 2,
+						..Default::default()
+					})
 					.await?;
 				let track = moq_mux::container::Consumer::new(track, moq_mux::catalog::hang::Container::Legacy)
 					.with_latency(latency);
@@ -413,12 +404,12 @@ impl Consume {
 		};
 		let id = self.raw_task.insert(Some(entry))?;
 
-		// `subscribe_track` now blocks on SUBSCRIBE_OK, so run it inside the task.
+		// `subscribe` blocks on SUBSCRIBE_OK, so run it inside the task.
 		tokio::spawn(async move {
 			let res = async move {
 				let track = broadcast
-					.subscribe_track(&name, moq_net::Subscription::default())
-					.ok()
+					.consume_track(&name)
+					.subscribe(moq_net::Subscription::default())
 					.await?;
 				Self::run_raw(on_frame, track, channel.1).await
 			}
@@ -437,7 +428,7 @@ impl Consume {
 
 	async fn run_raw(
 		callback: OnStatus,
-		mut track: moq_net::TrackConsumer,
+		mut track: moq_net::TrackSubscriber,
 		mut close: oneshot::Receiver<()>,
 	) -> Result<(), Error> {
 		// Deliver every frame in sequence order, reading all frames within each

--- a/rs/moq-audio/src/consumer.rs
+++ b/rs/moq-audio/src/consumer.rs
@@ -54,8 +54,8 @@ impl AudioConsumer {
 
 		let name = name.into();
 		let track = broadcast
-			.subscribe_track(&name, moq_net::Subscription::default())
-			.ok()
+			.consume_track(&name)
+			.subscribe(moq_net::Subscription::default())
 			.await?;
 		let mut track = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 		if let Some(latency) = output.latency_max {

--- a/rs/moq-boy/src/input.rs
+++ b/rs/moq-boy/src/input.rs
@@ -100,8 +100,8 @@ async fn handle_viewer_commands(
 	cmd_tx: &tokio::sync::mpsc::Sender<Command>,
 ) -> anyhow::Result<()> {
 	let mut track = broadcast
-		.subscribe_track("command", moq_net::Subscription::default())
-		.ok()
+		.consume_track("command")
+		.subscribe(moq_net::Subscription::default())
 		.await?;
 
 	while let Some(mut group) = track.recv_group().await? {

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -84,11 +84,8 @@ impl MoqBroadcastConsumer {
 	pub async fn subscribe_catalog(&self) -> Result<Arc<MoqCatalogConsumer>, MoqError> {
 		let track = self
 			.inner
-			.subscribe_track(
-				hang::catalog::Catalog::DEFAULT_NAME,
-				hang::catalog::Catalog::default_subscription(),
-			)
-			.ok()
+			.consume_track(hang::catalog::Catalog::DEFAULT_NAME)
+			.subscribe(hang::catalog::Catalog::default_subscription())
 			.await?;
 		let consumer = moq_mux::catalog::hang::Consumer::from(track);
 		Ok(Arc::new(MoqCatalogConsumer {
@@ -102,8 +99,8 @@ impl MoqBroadcastConsumer {
 	pub async fn subscribe_track(&self, name: String) -> Result<Arc<MoqTrackConsumer>, MoqError> {
 		let track = self
 			.inner
-			.subscribe_track(&name, moq_net::Subscription::default())
-			.ok()
+			.consume_track(&name)
+			.subscribe(moq_net::Subscription::default())
 			.await?;
 		Ok(Arc::new(MoqTrackConsumer::new(track)))
 	}
@@ -126,8 +123,8 @@ impl MoqBroadcastConsumer {
 			.map_err(|e| MoqError::Codec(format!("invalid container: {e}")))?;
 		let track = self
 			.inner
-			.subscribe_track(&name, moq_net::Subscription::default())
-			.ok()
+			.consume_track(&name)
+			.subscribe(moq_net::Subscription::default())
 			.await?;
 		let latency = std::time::Duration::from_millis(max_latency_ms);
 		let consumer = moq_mux::container::Consumer::new(track, media).with_latency(latency);
@@ -140,7 +137,7 @@ impl MoqBroadcastConsumer {
 // ---- Track Consumer ----
 
 struct TrackInner {
-	track: moq_net::TrackConsumer,
+	track: moq_net::TrackSubscriber,
 }
 
 impl TrackInner {
@@ -163,7 +160,7 @@ pub struct MoqTrackConsumer {
 }
 
 impl MoqTrackConsumer {
-	pub(crate) fn new(track: moq_net::TrackConsumer) -> Self {
+	pub(crate) fn new(track: moq_net::TrackSubscriber) -> Self {
 		Self {
 			task: Task::new(TrackInner { track }),
 		}

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -433,11 +433,8 @@ async fn run_session(
 	};
 
 	let catalog_track = broadcast
-		.subscribe_track(
-			hang::catalog::Catalog::DEFAULT_NAME,
-			hang::catalog::Catalog::default_subscription(),
-		)
-		.ok()
+		.consume_track(hang::catalog::Catalog::DEFAULT_NAME)
+		.subscribe(hang::catalog::Catalog::default_subscription())
 		.await?;
 	let mut catalog = moq_mux::catalog::hang::Consumer::new(catalog_track);
 	let catalog = catalog.next().await?.context("catalog missing")?.clone();
@@ -452,8 +449,8 @@ async fn run_session(
 		let caps = video_caps(&config)?;
 		let endpoint = request_pad(&control_tx, descriptor.clone(), caps).await?;
 		let track_consumer = broadcast
-			.subscribe_track(&track_name, moq_net::Subscription::default())
-			.ok()
+			.consume_track(&track_name)
+			.subscribe(moq_net::Subscription::default())
 			.await?;
 		let track = moq_mux::container::Consumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
 			.with_latency(Duration::from_secs(1));
@@ -468,8 +465,8 @@ async fn run_session(
 		let caps = audio_caps(&config)?;
 		let endpoint = request_pad(&control_tx, descriptor.clone(), caps).await?;
 		let track_consumer = broadcast
-			.subscribe_track(&track_name, moq_net::Subscription::default())
-			.ok()
+			.consume_track(&track_name)
+			.subscribe(moq_net::Subscription::default())
 			.await?;
 		let track = moq_mux::container::Consumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
 			.with_latency(Duration::from_secs(1));

--- a/rs/moq-mux/src/catalog/consumer.rs
+++ b/rs/moq-mux/src/catalog/consumer.rs
@@ -26,15 +26,15 @@ impl Consumer {
 		Ok(match format {
 			CatalogFormat::Hang => {
 				let track = broadcast
-					.subscribe_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_subscription())
-					.ok()
+					.consume_track(hang::Catalog::DEFAULT_NAME)
+					.subscribe(hang::Catalog::default_subscription())
 					.await?;
 				Self::Hang(super::hang::Consumer::new(track))
 			}
 			CatalogFormat::Msf => {
 				let track = broadcast
-					.subscribe_track(moq_msf::DEFAULT_NAME, moq_net::Subscription::default())
-					.ok()
+					.consume_track(moq_msf::DEFAULT_NAME)
+					.subscribe(moq_net::Subscription::default())
 					.await?;
 				Self::Msf(super::msf::Consumer::new(track))
 			}

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -6,18 +6,18 @@ use crate::Result;
 
 /// A catalog consumer, used to receive catalog updates and discover tracks.
 ///
-/// This wraps a `moq_net::TrackConsumer` and automatically deserializes JSON
+/// This wraps a `moq_net::TrackSubscriber` and automatically deserializes JSON
 /// catalog data to discover available audio and video tracks in a broadcast.
 #[derive(Clone)]
 pub struct Consumer {
 	/// Access to the underlying track consumer.
-	pub track: moq_net::TrackConsumer,
+	pub track: moq_net::TrackSubscriber,
 	group: Option<moq_net::GroupConsumer>,
 }
 
 impl Consumer {
 	/// Create a new catalog consumer from a MoQ track consumer.
-	pub fn new(track: moq_net::TrackConsumer) -> Self {
+	pub fn new(track: moq_net::TrackSubscriber) -> Self {
 		Self { track, group: None }
 	}
 
@@ -60,8 +60,8 @@ impl Consumer {
 	}
 }
 
-impl From<moq_net::TrackConsumer> for Consumer {
-	fn from(inner: moq_net::TrackConsumer) -> Self {
+impl From<moq_net::TrackSubscriber> for Consumer {
+	fn from(inner: moq_net::TrackSubscriber) -> Self {
 		Self::new(inner)
 	}
 }

--- a/rs/moq-mux/src/catalog/msf/consumer.rs
+++ b/rs/moq-mux/src/catalog/msf/consumer.rs
@@ -14,7 +14,7 @@ use crate::catalog::msf::Error;
 /// so the rest of the pipeline only deals with hang types.
 pub struct Consumer {
 	/// Access to the underlying track consumer.
-	pub track: moq_net::TrackConsumer,
+	pub track: moq_net::TrackSubscriber,
 	group: Option<moq_net::GroupConsumer>,
 }
 
@@ -22,7 +22,7 @@ impl Consumer {
 	/// Create a new MSF catalog consumer from a MoQ track consumer.
 	///
 	/// The track is expected to carry MSF catalog payloads (track name [`moq_msf::DEFAULT_NAME`]).
-	pub fn new(track: moq_net::TrackConsumer) -> Self {
+	pub fn new(track: moq_net::TrackSubscriber) -> Self {
 		Self { track, group: None }
 	}
 
@@ -68,8 +68,8 @@ impl Consumer {
 	}
 }
 
-impl From<moq_net::TrackConsumer> for Consumer {
-	fn from(inner: moq_net::TrackConsumer) -> Self {
+impl From<moq_net::TrackSubscriber> for Consumer {
+	fn from(inner: moq_net::TrackSubscriber) -> Self {
 		Self::new(inner)
 	}
 }

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -8,7 +8,7 @@ use super::{Container, Frame};
 /// Decode a moq-lite track into a stream of media [`Frame`]s in latency-bounded
 /// presentation order.
 ///
-/// `Consumer` wraps a [`moq_net::TrackConsumer`] and a [`Container`]
+/// `Consumer` wraps a [`moq_net::TrackSubscriber`] and a [`Container`]
 /// format implementation, typically
 /// [`catalog::hang::Container`](crate::catalog::hang::Container). Yields
 /// decoded frames via [`read`](Self::read).
@@ -32,7 +32,7 @@ use super::{Container, Frame};
 /// Set the latency with [`with_latency`](Self::with_latency) (builder) or
 /// [`set_latency`](Self::set_latency) (mid-stream).
 pub struct Consumer<F: Container> {
-	track: moq_net::TrackConsumer,
+	track: moq_net::TrackSubscriber,
 
 	format: F,
 
@@ -52,7 +52,7 @@ pub struct Consumer<F: Container> {
 
 impl<F: Container> Consumer<F> {
 	/// Create a new Consumer wrapping the given moq-lite consumer.
-	pub fn new(track: moq_net::TrackConsumer, format: F) -> Self {
+	pub fn new(track: moq_net::TrackSubscriber, format: F) -> Self {
 		Self {
 			track,
 			format,
@@ -412,7 +412,7 @@ mod tests {
 	}
 
 	/// Subscribe to a track with default preferences (test helper).
-	fn subscribe_default(track: &moq_net::TrackProducer) -> moq_net::TrackConsumer {
+	fn subscribe_default(track: &moq_net::TrackProducer) -> moq_net::TrackSubscriber {
 		track.subscribe_default()
 	}
 

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -5,7 +5,7 @@ use mp4_atom::{Decode, Encode};
 /// Drain every group currently buffered on the consumer without waiting for new ones.
 /// Used in tests where the producer is still alive after writing.
 #[cfg(test)]
-fn drain_group_sequences(consumer: &mut moq_net::TrackConsumer) -> Vec<u64> {
+fn drain_group_sequences(consumer: &mut moq_net::TrackSubscriber) -> Vec<u64> {
 	let mut sequences = Vec::new();
 	while let Some(group) = consumer.recv_group().now_or_never().and_then(|r| r.ok().flatten()) {
 		sequences.push(group.sequence);
@@ -183,8 +183,8 @@ async fn test_seek_sets_initial_sequence() {
 	let snap = catalog.snapshot();
 	let video_name = snap.video.renditions.keys().next().expect("video track").clone();
 	let mut video_track = broadcast_consumer
-		.subscribe_track(&video_name, moq_net::Subscription::default())
-		.ok()
+		.consume_track(&video_name)
+		.subscribe(moq_net::Subscription::default())
 		.await
 		.expect("video track should exist");
 
@@ -211,7 +211,7 @@ async fn test_seek_sets_initial_sequence() {
 #[tokio::test]
 async fn test_msf_catalog_roundtrip() {
 	let mut broadcast = moq_net::Broadcast::new().produce();
-	// Take the consumer before adding tracks; subscribe_track is called after the
+	// Take the consumer before adding tracks; consume_track is called after the
 	// MSF catalog track has been created by `catalog::Producer::new`.
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::hang::Producer::new(&mut broadcast).unwrap();
@@ -223,8 +223,8 @@ async fn test_msf_catalog_roundtrip() {
 	let _ = fmp4.decode(&mut buf);
 
 	let track = consumer
-		.subscribe_track(moq_msf::DEFAULT_NAME, moq_net::Subscription::default())
-		.ok()
+		.consume_track(moq_msf::DEFAULT_NAME)
+		.subscribe(moq_net::Subscription::default())
 		.await
 		.expect("MSF catalog track should exist");
 	let mut msf = crate::catalog::msf::Consumer::new(track);

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -184,7 +184,7 @@ impl<C: Container> Producer<C> {
 	}
 
 	/// Create a consumer for this track.
-	pub fn consume(&self) -> moq_net::TrackConsumer {
+	pub fn consume(&self) -> moq_net::TrackSubscriber {
 		self.inner.subscribe_default()
 	}
 }
@@ -215,7 +215,7 @@ mod tests {
 	}
 
 	/// Drain all groups from a finished track, returning their frame counts.
-	async fn collect_groups(mut consumer: moq_net::TrackConsumer) -> Vec<usize> {
+	async fn collect_groups(mut consumer: moq_net::TrackSubscriber) -> Vec<usize> {
 		let mut groups = Vec::new();
 		while let Some(mut group) = consumer.recv_group().await.unwrap() {
 			let mut count = 0;
@@ -270,7 +270,7 @@ mod tests {
 	}
 
 	/// Drain all groups from a finished track, returning their sequence numbers.
-	async fn collect_sequences(mut consumer: moq_net::TrackConsumer) -> Vec<u64> {
+	async fn collect_sequences(mut consumer: moq_net::TrackSubscriber) -> Vec<u64> {
 		let mut sequences = Vec::new();
 		while let Some(group) = consumer.recv_group().await.unwrap() {
 			sequences.push(group.sequence);

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -48,7 +48,7 @@ impl VideoTransform {
 
 /// A subscription that resolves on first poll, then the live consumer.
 enum SourceState {
-	/// Waiting for `subscribe_track` to resolve (blocks on the publisher's response).
+	/// Waiting for the subscription to resolve (blocks on the publisher's SUBSCRIBE_OK).
 	Subscribing(moq_net::TrackPending),
 	/// The resolved consumer, reading frames.
 	Active(Consumer<HangContainer>),
@@ -82,7 +82,11 @@ impl ExportSource {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
 		Ok(Self {
-			state: SourceState::Subscribing(broadcast.subscribe_track(name, moq_net::Subscription::default())),
+			state: SourceState::Subscribing(
+				broadcast
+					.consume_track(name)
+					.subscribe_pending(moq_net::Subscription::default()),
+			),
 			media: Some(media),
 			latency,
 			transform,
@@ -104,7 +108,11 @@ impl ExportSource {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
 		Ok(Self {
-			state: SourceState::Subscribing(broadcast.subscribe_track(name, moq_net::Subscription::default())),
+			state: SourceState::Subscribing(
+				broadcast
+					.consume_track(name)
+					.subscribe_pending(moq_net::Subscription::default()),
+			),
 			media: Some(media),
 			latency,
 			transform: None,
@@ -124,7 +132,11 @@ impl ExportSource {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
 		Ok(Self {
-			state: SourceState::Subscribing(broadcast.subscribe_track(name, moq_net::Subscription::default())),
+			state: SourceState::Subscribing(
+				broadcast
+					.consume_track(name)
+					.subscribe_pending(moq_net::Subscription::default()),
+			),
 			media: Some(media),
 			latency,
 			transform: None,

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -85,7 +85,7 @@ impl ExportSource {
 			state: SourceState::Subscribing(
 				broadcast
 					.consume_track(name)
-					.subscribe_pending(moq_net::Subscription::default()),
+					.subscribe(moq_net::Subscription::default()),
 			),
 			media: Some(media),
 			latency,
@@ -111,7 +111,7 @@ impl ExportSource {
 			state: SourceState::Subscribing(
 				broadcast
 					.consume_track(name)
-					.subscribe_pending(moq_net::Subscription::default()),
+					.subscribe(moq_net::Subscription::default()),
 			),
 			media: Some(media),
 			latency,
@@ -135,7 +135,7 @@ impl ExportSource {
 			state: SourceState::Subscribing(
 				broadcast
 					.consume_track(name)
-					.subscribe_pending(moq_net::Subscription::default()),
+					.subscribe(moq_net::Subscription::default()),
 			),
 			media: Some(media),
 			latency,

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -102,8 +102,7 @@ async fn main() -> anyhow::Result<()> {
 						Some(broadcast) => {
 							tracing::info!(broadcast = %path, "broadcast is online, subscribing to track");
 							let track = broadcast
-								.subscribe_track(&track, moq_net::Subscription::default())
-								.ok()
+								.consume_track(&track).subscribe(moq_net::Subscription::default())
 								.await?;
 							clock = Some(Subscriber::new(track));
 						}
@@ -189,11 +188,11 @@ impl Publisher {
 }
 
 struct Subscriber {
-	track: TrackConsumer,
+	track: TrackSubscriber,
 }
 
 impl Subscriber {
-	fn new(track: TrackConsumer) -> Self {
+	fn new(track: TrackSubscriber) -> Self {
 		Self { track }
 	}
 

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -70,10 +70,10 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	let bc = bc.broadcast().expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
-		.subscribe_track("video", moq_native::moq_net::Subscription::default())
-		.ok()
+		.consume_track("video")
+		.subscribe(moq_native::moq_net::Subscription::default())
 		.await
-		.expect("subscribe_track failed");
+		.expect("consume_track failed");
 
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
@@ -224,10 +224,10 @@ async fn iroh_connect() {
 	let bc = bc.broadcast().expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
-		.subscribe_track("video", moq_native::moq_net::Subscription::default())
-		.ok()
+		.consume_track("video")
+		.subscribe(moq_native::moq_net::Subscription::default())
 		.await
-		.expect("subscribe_track failed");
+		.expect("consume_track failed");
 
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -88,10 +88,10 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 
 	// Subscribe to the track.
 	let mut track_sub = bc
-		.subscribe_track("video", moq_native::moq_net::Subscription::default())
-		.ok()
+		.consume_track("video")
+		.subscribe(moq_native::moq_net::Subscription::default())
 		.await
-		.expect("subscribe_track failed");
+		.expect("consume_track failed");
 
 	// Read one group.
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
@@ -502,10 +502,10 @@ async fn broadcast_websocket() {
 
 	// Subscribe to the track.
 	let mut track_sub = bc
-		.subscribe_track("video", moq_native::moq_net::Subscription::default())
-		.ok()
+		.consume_track("video")
+		.subscribe(moq_native::moq_net::Subscription::default())
 		.await
-		.expect("subscribe_track failed");
+		.expect("consume_track failed");
 
 	// Read one group.
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
@@ -611,10 +611,10 @@ async fn broadcast_websocket_fallback() {
 
 	// Subscribe to the track.
 	let mut track_sub = bc
-		.subscribe_track("video", moq_native::moq_net::Subscription::default())
-		.ok()
+		.consume_track("video")
+		.subscribe(moq_native::moq_net::Subscription::default())
 		.await
-		.expect("subscribe_track failed");
+		.expect("consume_track failed");
 
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
@@ -854,8 +854,8 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 
 	// First subscription: receive group 0.
 	let mut sub1 = bc
-		.subscribe_track("video", moq_native::moq_net::Subscription::default())
-		.ok()
+		.consume_track("video")
+		.subscribe(moq_native::moq_net::Subscription::default())
 		.await
 		.expect("subscribe1");
 	let mut g = tokio::time::timeout(TIMEOUT, sub1.recv_group())
@@ -882,8 +882,8 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 
 	// Resubscribe well inside the 5s linger window.
 	let mut sub2 = bc
-		.subscribe_track("video", moq_native::moq_net::Subscription::default())
-		.ok()
+		.consume_track("video")
+		.subscribe(moq_native::moq_net::Subscription::default())
 		.await
 		.expect("subscribe2");
 

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -5,7 +5,7 @@ use web_async::FuturesExt;
 use web_transport_trait::SendStream;
 
 use crate::{
-	AsPath, Error, OriginConsumer, Subscription, TrackConsumer,
+	AsPath, Error, OriginConsumer, Subscription, TrackSubscriber,
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
 	model::GroupConsumer,
@@ -117,7 +117,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			..Default::default()
 		};
 
-		let track = match broadcast.subscribe_track(&msg.track_name, subscription).ok().await {
+		let track = match broadcast.consume_track(&msg.track_name).subscribe(subscription).await {
 			Ok(track) => track,
 			Err(err) => {
 				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())
@@ -216,7 +216,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// Serve a track using FuturesUnordered for unlimited concurrent groups.
-	async fn run_track(&self, mut track: TrackConsumer, request_id: RequestId) -> Result<(), Error> {
+	async fn run_track(&self, mut track: TrackSubscriber, request_id: RequestId) -> Result<(), Error> {
 		let mut tasks = FuturesUnordered::new();
 
 		loop {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -509,7 +509,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	async fn run_subscribe(&mut self, broadcast_path: Path<'_>, broadcast: BroadcastDynamic, request: TrackRequest) {
 		// Accept right away: IETF group data can arrive before SubscribeOk, so we
 		// need the producer in place to route it. This also unblocks the
-		// downstream subscriber's `subscribe_track`.
+		// downstream subscriber's `consume_track`.
 		let name = request.name().to_string();
 		let mut track = match request.accept(Track::new(name)) {
 			Ok(track) => track,

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -5,7 +5,7 @@ use web_transport_trait::Stats;
 
 use crate::{
 	AnnounceConsumer, AsPath, BroadcastConsumer, Compression, Error, Origin, OriginConsumer, OriginList,
-	StatsHandle as MoqStats, TrackConsumer,
+	StatsHandle as MoqStats, TrackSubscriber,
 	coding::{Stream, Writer},
 	lite::{
 		self,
@@ -394,7 +394,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		};
 
 		let broadcast = consumer.ok_or(Error::NotFound)?;
-		let track = broadcast.subscribe_track(&subscribe.track, subscription).ok().await?;
+		let track = broadcast
+			.consume_track(&subscribe.track)
+			.subscribe(subscription)
+			.await?;
 
 		// Compress only when the producer marked the track worth it and the
 		// negotiated draft understands the SUBSCRIBE_OK codec field. Older drafts
@@ -478,7 +481,7 @@ struct Subscription<S: web_transport_trait::Session> {
 impl<S: web_transport_trait::Session> Subscription<S> {
 	async fn run_track(
 		mut self,
-		mut track: TrackConsumer,
+		mut track: TrackSubscriber,
 		start_group: Option<u64>,
 		initial_end_group: Option<u64>,
 		reader: &mut crate::coding::Reader<S::RecvStream, Version>,

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -310,7 +310,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// Create the dynamic handler BEFORE publishing, so that consumers
 		// see dynamic >= 1 immediately when they receive the announcement.
 		// Otherwise there's a race on multi-threaded runtimes where a consumer
-		// can call subscribe_track() before dynamic is incremented, getting NotFound.
+		// can call consume_track() before dynamic is incremented, getting NotFound.
 		let dynamic = broadcast.dynamic();
 
 		// Run the broadcast in the background until all consumers are dropped.
@@ -446,7 +446,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// Open the upstream subscribe stream, wait for SUBSCRIBE_OK, then accept the
 	/// pending request (unblocking the downstream subscriber) and run the linger
 	/// lifecycle. The producer is created only after SUBSCRIBE_OK, so a downstream
-	/// `subscribe_track` resolves exactly when the upstream confirms.
+	/// a downstream `subscribe` resolves exactly when the upstream confirms.
 	async fn run_subscribe_session(
 		&self,
 		id: u64,

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -4,7 +4,7 @@ use std::{
 	task::{Poll, ready},
 };
 
-use crate::{Error, Subscription, TrackConsumer, TrackProducer, model::track::TrackWeak};
+use crate::{Error, Subscription, TrackProducer, TrackSubscriber, model::track::TrackWeak};
 
 use super::{OriginList, Track};
 
@@ -37,7 +37,7 @@ impl Broadcast {
 /// a [`kio`] channel so subscribers can `poll_ok` it without tokio. The consumer
 /// is created at accept time so it counts toward the producer immediately, before
 /// the subscriber even polls.
-type PendingSlot = Option<Result<TrackConsumer, Error>>;
+type PendingSlot = Option<Result<TrackSubscriber, Error>>;
 
 /// One waiting subscriber: its preferences and the producer side of its resolver channel.
 type Resolver = (Subscription, kio::Producer<PendingSlot>);
@@ -149,7 +149,7 @@ impl BroadcastProducer {
 	/// track's [`TrackProducer`]) is responsible for keeping the track alive;
 	/// when all producers are dropped, the entry becomes closed and is
 	/// eventually evicted.
-	pub fn insert_track(&mut self, track: TrackConsumer) -> Result<(), Error> {
+	pub fn insert_track(&mut self, track: TrackSubscriber) -> Result<(), Error> {
 		let mut state = modify(&self.state)?;
 		state.insert_track(track.weak())
 	}
@@ -346,24 +346,24 @@ impl Drop for TrackRequest {
 	}
 }
 
-/// A pending subscription returned by [`BroadcastConsumer::subscribe_track`].
+/// A pending subscription returned by [`BroadcastConsumer::consume_track`].
 ///
 /// The subscription isn't live until the publisher accepts it (for the wire,
 /// SUBSCRIBE_OK). Drive it with [`Self::poll_ok`] inside a `kio` poll loop, or
-/// await [`Self::ok`]; both yield the [`TrackConsumer`] (or an error).
+/// await [`Self::ok`]; both yield the [`TrackSubscriber`] (or an error).
 pub struct TrackPending {
 	inner: TrackPendingInner,
 }
 
 enum TrackPendingInner {
 	/// Resolved synchronously: the track already existed, or it failed immediately.
-	Ready(Result<TrackConsumer, Error>),
+	Ready(Result<TrackSubscriber, Error>),
 	/// Waiting for the publisher to accept or deny via the dynamic handler.
 	Waiting(kio::Consumer<PendingSlot>),
 }
 
 impl TrackPending {
-	fn ready(result: Result<TrackConsumer, Error>) -> Self {
+	fn ready(result: Result<TrackSubscriber, Error>) -> Self {
 		Self {
 			inner: TrackPendingInner::Ready(result),
 		}
@@ -375,8 +375,8 @@ impl TrackPending {
 		}
 	}
 
-	/// Poll for the resolved [`TrackConsumer`], without blocking.
-	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<TrackConsumer, Error>> {
+	/// Poll for the resolved [`TrackSubscriber`], without blocking.
+	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<TrackSubscriber, Error>> {
 		match &self.inner {
 			TrackPendingInner::Ready(result) => Poll::Ready(result.clone()),
 			TrackPendingInner::Waiting(consumer) => match consumer.poll(waiter, |slot| match &**slot {
@@ -395,7 +395,7 @@ impl TrackPending {
 	}
 
 	/// Block until the publisher accepts the subscription, returning the consumer.
-	pub async fn ok(self) -> Result<TrackConsumer, Error> {
+	pub async fn ok(self) -> Result<TrackSubscriber, Error> {
 		kio::wait(|waiter| self.poll_ok(waiter)).await
 	}
 }
@@ -417,7 +417,7 @@ impl Clone for BroadcastDynamic {
 		// Mirror `new`: bump `state.dynamic` so each live handle is counted.
 		// Without this, deriving Clone would let `Drop` decrement past `new`'s
 		// single increment and prematurely flip `dynamic` to zero, causing
-		// future `subscribe_track` calls to return `NotFound`.
+		// future `consume_track` calls to return `NotFound`.
 		if let Ok(mut state) = self.state.write() {
 			state.dynamic += 1;
 		}
@@ -571,20 +571,28 @@ impl Deref for BroadcastConsumer {
 }
 
 impl BroadcastConsumer {
-	/// Subscribe to a track on this broadcast.
+	/// Get a handle to a track on this broadcast.
 	///
-	/// Returns a [`TrackPending`] immediately; poll it with [`TrackPending::poll_ok`]
-	/// (or await [`TrackPending::ok`]) to get the [`TrackConsumer`] once the
-	/// publisher accepts the subscription. Reuses a live producer if one is already
-	/// publishing the track (the pending resolves right away), otherwise queues a
-	/// dynamic request served via [`BroadcastDynamic::requested_track`] and
-	/// [`TrackRequest::accept`] (for the wire this is SUBSCRIBE_OK). Resolves to
-	/// [`Error::NotFound`] if no dynamic producer exists to handle the request.
+	/// This is a cheap, synchronous lookup that returns a [`TrackConsumer`] bound
+	/// to `name`. Nothing is sent to the publisher yet: call
+	/// [`TrackConsumer::subscribe`] to open a live subscription (blocking on
+	/// SUBSCRIBE_OK), or hold the handle and subscribe later.
+	pub fn consume_track(&self, name: &str) -> TrackConsumer {
+		TrackConsumer {
+			broadcast: self.clone(),
+			name: name.to_string(),
+		}
+	}
+
+	/// Register a subscription for `name` and return a [`TrackPending`] that
+	/// resolves once the publisher accepts it.
 	///
-	/// The returned [`TrackConsumer`] carries the publisher's [`Track`]; the given
-	/// [`Subscription`] is this subscriber's preferences and feeds the producer's
-	/// [`TrackProducer::subscription`] aggregate.
-	pub fn subscribe_track(&self, name: &str, subscription: Subscription) -> TrackPending {
+	/// Reuses a live producer if one is already publishing the track (the pending
+	/// resolves right away), otherwise queues a dynamic request served via
+	/// [`BroadcastDynamic::requested_track`] and [`TrackRequest::accept`] (for the
+	/// wire this is SUBSCRIBE_OK). Resolves to [`Error::NotFound`] if no dynamic
+	/// producer exists to handle the request.
+	fn request_subscribe(&self, name: &str, subscription: Subscription) -> TrackPending {
 		// Upgrade to a temporary producer so we can modify the state.
 		let Some(producer) = self.state.produce() else {
 			let err = self.state.read().abort.clone().unwrap_or(Error::Dropped);
@@ -654,6 +662,43 @@ impl BroadcastConsumer {
 	}
 }
 
+/// A handle to a single track within a broadcast.
+///
+/// Obtained from [`BroadcastConsumer::consume_track`]. Holding it sends nothing
+/// to the publisher; it just names a track you can [`subscribe`](Self::subscribe)
+/// to (a live, ongoing stream of groups) later. The same handle can be subscribed
+/// to multiple times, and clones are cheap.
+// TODO: add `fetch` for one-shot retrieval of a past group range.
+#[derive(Clone)]
+pub struct TrackConsumer {
+	broadcast: BroadcastConsumer,
+	name: String,
+}
+
+impl TrackConsumer {
+	/// The track name this handle is bound to.
+	pub fn name(&self) -> &str {
+		&self.name
+	}
+
+	/// Open a live subscription, blocking until the publisher accepts it
+	/// (SUBSCRIBE_OK on the wire).
+	///
+	/// The returned [`TrackSubscriber`] carries the publisher's [`Track`] and reads
+	/// its groups; `subscription` is this subscriber's preferences and feeds the
+	/// producer's [`TrackProducer::subscription`] aggregate. Concurrent subscribers
+	/// to the same name coalesce onto one request.
+	pub async fn subscribe(&self, subscription: Subscription) -> Result<TrackSubscriber, Error> {
+		self.subscribe_pending(subscription).ok().await
+	}
+
+	/// Like [`Self::subscribe`], but returns the unresolved [`TrackPending`] so a
+	/// poll-based caller can drive it via [`TrackPending::poll_ok`].
+	pub fn subscribe_pending(&self, subscription: Subscription) -> TrackPending {
+		self.broadcast.request_subscribe(&self.name, subscription)
+	}
+}
+
 #[cfg(test)]
 impl BroadcastConsumer {
 	pub fn assert_not_closed(&self) {
@@ -673,10 +718,12 @@ mod test {
 	/// a publisher accepts). Returns the [`TrackPending`] to resolve after accepting.
 	macro_rules! subscribe_pending {
 		($consumer:expr, $name:expr) => {{
-			let pending = $consumer.subscribe_track($name, Subscription::default());
+			let pending = $consumer
+				.consume_track($name)
+				.subscribe_pending(Subscription::default());
 			assert!(
 				pending.poll_ok(&kio::Waiter::noop()).is_pending(),
-				"subscribe_track should stay pending until the request is accepted"
+				"consume_track should stay pending until the request is accepted"
 			);
 			pending
 		}};
@@ -695,8 +742,8 @@ mod test {
 
 		// The track already exists, so subscribe resolves immediately.
 		let mut track1_sub = consumer
-			.subscribe_track("track1", Subscription::default())
-			.ok()
+			.consume_track("track1")
+			.subscribe(Subscription::default())
 			.await
 			.unwrap();
 		track1_sub.assert_group();
@@ -706,8 +753,8 @@ mod test {
 
 		let consumer2 = producer.consume();
 		let mut track2_consumer = consumer2
-			.subscribe_track("track2", Subscription::default())
-			.ok()
+			.consume_track("track2")
+			.subscribe(Subscription::default())
 			.await
 			.unwrap();
 		track2_consumer.assert_no_group();
@@ -728,8 +775,8 @@ mod test {
 		// Create a new track and insert it into the broadcast (resolves immediately).
 		let track1 = producer.assert_create_track(&Track::new("track1"));
 		let track1c = consumer
-			.subscribe_track("track1", Subscription::default())
-			.ok()
+			.consume_track("track1")
+			.subscribe(Subscription::default())
 			.await
 			.unwrap();
 
@@ -783,7 +830,10 @@ mod test {
 		assert!(track4_fut.ok().await.is_err());
 
 		// With no dynamic producer left, new subscribes fail outright.
-		let track5 = consumer2.subscribe_track("track3", Subscription::default()).ok().await;
+		let track5 = consumer2
+			.consume_track("track3")
+			.subscribe(Subscription::default())
+			.await;
 		assert!(track5.is_err(), "should have errored");
 	}
 
@@ -835,8 +885,8 @@ mod test {
 
 		// A second subscriber reuses the live producer (fast path / dedup).
 		let consumer2 = bc
-			.subscribe_track("unknown_track", Subscription::default())
-			.ok()
+			.consume_track("unknown_track")
+			.subscribe(Subscription::default())
 			.await
 			.unwrap();
 		consumer2.assert_is_clone(&consumer1);
@@ -857,8 +907,8 @@ mod test {
 		// it (no new request) — this is what lets the relay linger upstream
 		// subscriptions across transient consumer churn.
 		let consumer3 = bc
-			.subscribe_track("unknown_track", Subscription::default())
-			.ok()
+			.consume_track("unknown_track")
+			.subscribe(Subscription::default())
 			.await
 			.unwrap();
 		consumer3.assert_is_clone(&producer1.subscribe_default());
@@ -884,7 +934,7 @@ mod test {
 	// `state.dynamic` to zero. The relay's lite subscriber clones the
 	// dynamic per spawned subscribe; if Clone skipped the increment, the
 	// first finished subscribe would tear down the broadcast and any
-	// follow-up `subscribe_track` would return `NotFound`.
+	// follow-up `consume_track` would return `NotFound`.
 	#[tokio::test]
 	async fn dynamic_clone_keeps_alive() {
 		let broadcast = Broadcast::new().produce().dynamic();

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -346,13 +346,17 @@ impl Drop for TrackRequest {
 	}
 }
 
-/// A pending subscription returned by [`BroadcastConsumer::consume_track`].
+/// A pending subscription returned by [`TrackConsumer::subscribe`].
 ///
 /// The subscription isn't live until the publisher accepts it (for the wire,
-/// SUBSCRIBE_OK). Drive it with [`Self::poll_ok`] inside a `kio` poll loop, or
-/// await [`Self::ok`]; both yield the [`TrackSubscriber`] (or an error).
+/// SUBSCRIBE_OK). It implements [`Future`], so `.await` it to get the
+/// [`TrackSubscriber`] (or an error). Poll-based callers can instead drive it
+/// with [`Self::poll_ok`] inside a `kio` poll loop.
 pub struct TrackPending {
 	inner: TrackPendingInner,
+	/// Kept alive between `Future::poll` calls so its registration in the
+	/// resolver channel stays valid until the next poll replaces it.
+	waiter: Option<kio::Waiter>,
 }
 
 enum TrackPendingInner {
@@ -366,12 +370,14 @@ impl TrackPending {
 	fn ready(result: Result<TrackSubscriber, Error>) -> Self {
 		Self {
 			inner: TrackPendingInner::Ready(result),
+			waiter: None,
 		}
 	}
 
 	fn waiting(consumer: kio::Consumer<PendingSlot>) -> Self {
 		Self {
 			inner: TrackPendingInner::Waiting(consumer),
+			waiter: None,
 		}
 	}
 
@@ -393,10 +399,17 @@ impl TrackPending {
 			},
 		}
 	}
+}
 
-	/// Block until the publisher accepts the subscription, returning the consumer.
-	pub async fn ok(self) -> Result<TrackSubscriber, Error> {
-		kio::wait(|waiter| self.poll_ok(waiter)).await
+impl std::future::Future for TrackPending {
+	type Output = Result<TrackSubscriber, Error>;
+
+	fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+		let this = self.get_mut();
+		// Replacing drops the previous waiter, freeing its slot so poll_ok's
+		// register call can recycle it (see `kio::wait`).
+		this.waiter = Some(kio::Waiter::new(cx.waker().clone()));
+		this.poll_ok(this.waiter.as_ref().unwrap())
 	}
 }
 
@@ -681,20 +694,17 @@ impl TrackConsumer {
 		&self.name
 	}
 
-	/// Open a live subscription, blocking until the publisher accepts it
-	/// (SUBSCRIBE_OK on the wire).
+	/// Open a live subscription.
 	///
-	/// The returned [`TrackSubscriber`] carries the publisher's [`Track`] and reads
-	/// its groups; `subscription` is this subscriber's preferences and feeds the
-	/// producer's [`TrackProducer::subscription`] aggregate. Concurrent subscribers
-	/// to the same name coalesce onto one request.
-	pub async fn subscribe(&self, subscription: Subscription) -> Result<TrackSubscriber, Error> {
-		self.subscribe_pending(subscription).ok().await
-	}
-
-	/// Like [`Self::subscribe`], but returns the unresolved [`TrackPending`] so a
-	/// poll-based caller can drive it via [`TrackPending::poll_ok`].
-	pub fn subscribe_pending(&self, subscription: Subscription) -> TrackPending {
+	/// Returns a [`TrackPending`] that resolves once the publisher accepts the
+	/// subscription (SUBSCRIBE_OK on the wire). `.await` it for the
+	/// [`TrackSubscriber`], which carries the publisher's [`Track`] and reads its
+	/// groups; or drive it with [`TrackPending::poll_ok`] from a poll loop.
+	///
+	/// `subscription` is this subscriber's preferences and feeds the producer's
+	/// [`TrackProducer::subscription`] aggregate. Concurrent subscribers to the
+	/// same name coalesce onto one request.
+	pub fn subscribe(&self, subscription: Subscription) -> TrackPending {
 		self.broadcast.request_subscribe(&self.name, subscription)
 	}
 }
@@ -718,9 +728,7 @@ mod test {
 	/// a publisher accepts). Returns the [`TrackPending`] to resolve after accepting.
 	macro_rules! subscribe_pending {
 		($consumer:expr, $name:expr) => {{
-			let pending = $consumer
-				.consume_track($name)
-				.subscribe_pending(Subscription::default());
+			let pending = $consumer.consume_track($name).subscribe(Subscription::default());
 			assert!(
 				pending.poll_ok(&kio::Waiter::noop()).is_pending(),
 				"consume_track should stay pending until the request is accepted"
@@ -787,7 +795,7 @@ mod test {
 		producer.abort(Error::Cancel).unwrap();
 
 		// track2 was a pending dynamic request, so its subscribe surfaces the abort.
-		assert!(track2_fut.ok().await.is_err());
+		assert!(track2_fut.await.is_err());
 
 		// track1's producer is held outside the broadcast, so it survives.
 		assert!(!track1.is_closed());
@@ -812,8 +820,8 @@ mod test {
 
 		// Accept it, which resolves both waiting subscribers.
 		let mut track3 = request.accept(Track::new("track1")).unwrap();
-		let mut track1 = track1_fut.ok().await.unwrap();
-		let mut track2 = track2_fut.ok().await.unwrap();
+		let mut track1 = track1_fut.await.unwrap();
+		let mut track2 = track2_fut.await.unwrap();
 
 		track1.assert_not_closed();
 		track1.assert_is_clone(&track2);
@@ -827,7 +835,7 @@ mod test {
 		// A pending request is cancelled when the dynamic producer is dropped.
 		let track4_fut = subscribe_pending!(consumer, "track2");
 		drop(producer);
-		assert!(track4_fut.ok().await.is_err());
+		assert!(track4_fut.await.is_err());
 
 		// With no dynamic producer left, new subscribes fail outright.
 		let track5 = consumer2
@@ -845,7 +853,7 @@ mod test {
 		// Subscribe to a track and serve it.
 		let track1_fut = subscribe_pending!(consumer, "track1");
 		let mut producer1 = broadcast.assert_request().accept(Track::new("track1")).unwrap();
-		let track1 = track1_fut.ok().await.unwrap();
+		let track1 = track1_fut.await.unwrap();
 
 		// Close the producer (simulating publisher disconnect).
 		producer1.append_group().unwrap();
@@ -858,7 +866,7 @@ mod test {
 		// Subscribe again to the same track: should get a NEW producer, not the stale one.
 		let track2_fut = subscribe_pending!(consumer, "track1");
 		let mut producer2 = broadcast.assert_request().accept(Track::new("track1")).unwrap();
-		let mut track2 = track2_fut.ok().await.unwrap();
+		let mut track2 = track2_fut.await.unwrap();
 		track2.assert_not_closed();
 		track2.assert_not_clone(&track1);
 
@@ -875,7 +883,7 @@ mod test {
 		// Subscribe to a track that doesn't exist yet, then serve it.
 		let c1_fut = subscribe_pending!(bc, "unknown_track");
 		let mut producer1 = broadcast.assert_request().accept(Track::new("unknown_track")).unwrap();
-		let consumer1 = c1_fut.ok().await.unwrap();
+		let consumer1 = c1_fut.await.unwrap();
 
 		// The producer should NOT be unused yet because there's a consumer.
 		assert!(
@@ -922,7 +930,7 @@ mod test {
 
 		let c4_fut = subscribe_pending!(bc, "unknown_track");
 		let producer2 = broadcast.assert_request().accept(Track::new("unknown_track")).unwrap();
-		let consumer4 = c4_fut.ok().await.unwrap();
+		let consumer4 = c4_fut.await.unwrap();
 		drop(consumer4);
 		assert!(
 			producer2.unused().now_or_never().is_some(),

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1,14 +1,14 @@
-//! A track is a collection of semi-reliable and semi-ordered streams, split into a [TrackProducer] and [TrackConsumer] handle.
+//! A track is a collection of semi-reliable and semi-ordered streams, split into a [TrackProducer] and [TrackSubscriber] handle.
 //!
 //! A [TrackProducer] creates streams with a sequence number and priority.
 //! The sequence number is used to determine the order of streams, while the priority is used to determine which stream to transmit first.
 //! This may seem counter-intuitive, but is designed for live streaming where the newest streams may be higher priority.
 //! A cloned [TrackProducer] can be used to create streams in parallel, but will error if a duplicate sequence number is used.
 //!
-//! A [TrackConsumer] may not receive all streams in order or at all.
+//! A [TrackSubscriber] may not receive all streams in order or at all.
 //! These streams are meant to be transmitted over congested networks and the key to MoQ Transport is to not block on them.
 //! Streams will be cached for a potentially limited duration added to the unreliable nature.
-//! A cloned [TrackConsumer] will receive a copy of all new streams going forward (fanout).
+//! A cloned [TrackSubscriber] will receive a copy of all new streams going forward (fanout).
 //!
 //! The track is closed with [Error] when all writers or readers are dropped.
 
@@ -31,7 +31,7 @@ const MAX_GROUP_AGE: Duration = Duration::from_secs(5);
 ///
 /// These are fixed by the publisher when the track is created and don't change
 /// while the track is alive. A subscriber learns them via
-/// [`BroadcastConsumer::subscribe_track`](crate::BroadcastConsumer::subscribe_track),
+/// [`BroadcastConsumer::consume_track`](crate::BroadcastConsumer::consume_track),
 /// which returns the publisher's [`Track`] once the subscription is accepted.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -83,7 +83,7 @@ impl From<String> for Track {
 /// Each subscriber holds its own [`Subscription`]; the publisher observes an
 /// aggregate across all live subscribers via [`TrackProducer::subscription`].
 /// A subscriber can change its preferences after the fact with
-/// [`TrackConsumer::update`].
+/// [`TrackSubscriber::update`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Subscription {
 	/// Delivery priority. Higher values preempt lower ones when bandwidth is constrained.
@@ -198,7 +198,7 @@ impl State {
 
 	/// Find the smallest-sequence cached group satisfying
 	/// `next_sequence <= seq <= end_sequence (if set)`. Used by
-	/// [`TrackConsumer::next_group`] so the range can be widened (or unset)
+	/// [`TrackSubscriber::next_group`] so the range can be widened (or unset)
 	/// after the fact and previously-skipped cached groups become available
 	/// without scanning past them in arrival order.
 	///
@@ -501,16 +501,16 @@ impl TrackProducer {
 		Ok(())
 	}
 
-	/// Create a new consumer for the track with the given subscriber preferences.
+	/// Subscribe to the track in-process with the given subscriber preferences.
 	///
 	/// The preferences feed the producer's [`Self::subscription`] aggregate and
-	/// can be changed later via [`TrackConsumer::update`].
-	pub fn subscribe(&self, subscription: Subscription) -> TrackConsumer {
+	/// can be changed later via [`TrackSubscriber::update`].
+	pub fn subscribe(&self, subscription: Subscription) -> TrackSubscriber {
 		let subscription = Arc::new(Mutex::new(subscription));
 		if let Ok(mut state) = self.state.write() {
 			state.subscriptions.push(Arc::downgrade(&subscription));
 		}
-		TrackConsumer {
+		TrackSubscriber {
 			info: self.info.clone(),
 			state: self.state.consume(),
 			subscription,
@@ -521,8 +521,8 @@ impl TrackProducer {
 		}
 	}
 
-	/// Create a new consumer for the track with default ([`Subscription::default`]) preferences.
-	pub fn subscribe_default(&self) -> TrackConsumer {
+	/// Subscribe to the track in-process with default ([`Subscription::default`]) preferences.
+	pub fn subscribe_default(&self) -> TrackSubscriber {
 		self.subscribe(Subscription::default())
 	}
 
@@ -614,7 +614,7 @@ impl TrackWeak {
 		self.state.is_closed()
 	}
 
-	pub fn subscribe(&self, subscription: Subscription) -> TrackConsumer {
+	pub fn subscribe(&self, subscription: Subscription) -> TrackSubscriber {
 		let subscription = Arc::new(Mutex::new(subscription));
 		// Register the preference if the producer is still alive so it shows up
 		// in the aggregate; otherwise the consumer will just observe close.
@@ -623,7 +623,7 @@ impl TrackWeak {
 		{
 			state.subscriptions.push(Arc::downgrade(&subscription));
 		}
-		TrackConsumer {
+		TrackSubscriber {
 			info: self.info.clone(),
 			state: self.state.consume(),
 			subscription,
@@ -644,13 +644,17 @@ impl TrackWeak {
 	}
 }
 
-/// A consumer for a track, used to read groups.
+/// A live subscription to a track, used to read its groups.
+///
+/// Created via [`TrackConsumer::subscribe`](crate::TrackConsumer::subscribe), or
+/// directly from a [`TrackProducer`] for an in-process track. Carries this
+/// subscriber's [`Subscription`] preferences, which feed the producer's aggregate.
 #[derive(Clone)]
-pub struct TrackConsumer {
+pub struct TrackSubscriber {
 	info: Track,
 	state: kio::Consumer<State>,
 	/// This subscriber's preferences, shared with the producer's aggregate.
-	/// Cloning a consumer shares the same preferences (one subscription, fanned out).
+	/// Cloning a subscriber shares the same preferences (one subscription, fanned out).
 	subscription: Arc<Mutex<Subscription>>,
 	/// Arrival-order cursor used by [`Self::recv_group`].
 	index: usize,
@@ -666,7 +670,7 @@ pub struct TrackConsumer {
 	end_sequence: Option<u64>,
 }
 
-impl std::ops::Deref for TrackConsumer {
+impl std::ops::Deref for TrackSubscriber {
 	type Target = Track;
 
 	fn deref(&self) -> &Self::Target {
@@ -674,7 +678,7 @@ impl std::ops::Deref for TrackConsumer {
 	}
 }
 
-impl TrackConsumer {
+impl TrackSubscriber {
 	// A helper to automatically apply Dropped if the state is closed without an error.
 	fn poll<F, R>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<R>>
 	where
@@ -794,7 +798,7 @@ impl TrackConsumer {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
 
-	/// Whether `other` was cloned from this consumer (shares the same underlying state).
+	/// Whether `other` was cloned from this subscriber (shares the same underlying state).
 	pub fn is_clone(&self, other: &Self) -> bool {
 		self.state.same_channel(&other.state)
 	}
@@ -854,7 +858,7 @@ impl TrackConsumer {
 use futures::FutureExt;
 
 #[cfg(test)]
-impl TrackConsumer {
+impl TrackSubscriber {
 	pub fn assert_group(&mut self) -> GroupConsumer {
 		self.recv_group()
 			.now_or_never()

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -113,6 +113,38 @@ impl Default for Subscription {
 	}
 }
 
+impl Subscription {
+	/// Set the delivery priority, returning `self` for chaining.
+	pub fn with_priority(mut self, priority: u8) -> Self {
+		self.priority = priority;
+		self
+	}
+
+	/// Set whether groups are delivered in sequence order, returning `self` for chaining.
+	pub fn with_ordered(mut self, ordered: bool) -> Self {
+		self.ordered = ordered;
+		self
+	}
+
+	/// Set how long to wait for a group before skipping it, returning `self` for chaining.
+	pub fn with_stale(mut self, stale: Duration) -> Self {
+		self.stale = stale;
+		self
+	}
+
+	/// Set the first group to deliver, returning `self` for chaining.
+	pub fn with_group_start(mut self, group_start: impl Into<Option<u64>>) -> Self {
+		self.group_start = group_start.into();
+		self
+	}
+
+	/// Set the last group to deliver (inclusive), returning `self` for chaining.
+	pub fn with_group_end(mut self, group_end: impl Into<Option<u64>>) -> Self {
+		self.group_end = group_end.into();
+		self
+	}
+}
+
 #[derive(Default)]
 struct State {
 	/// Groups in arrival order. `None` entries are tombstones for evicted groups.

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -1160,8 +1160,8 @@ mod tests {
 		let (_path, event) = consumer.next().await.expect("expected announce");
 		let broadcast = event.broadcast().expect("active");
 		let track = broadcast
-			.subscribe_track("publisher.json", Subscription::default())
-			.ok()
+			.consume_track("publisher.json")
+			.subscribe(Subscription::default())
 			.await
 			.expect("subscribe");
 		let frame = read_frame(track).await;
@@ -1187,8 +1187,8 @@ mod tests {
 		let (_path, event) = consumer.next().await.expect("announce");
 		let broadcast = event.broadcast().expect("active");
 		let track = broadcast
-			.subscribe_track("publisher.json", Subscription::default())
-			.ok()
+			.consume_track("publisher.json")
+			.subscribe(Subscription::default())
 			.await
 			.expect("subscribe");
 		let frame = read_frame(track).await;
@@ -1219,8 +1219,8 @@ mod tests {
 		let (_path, event) = consumer.next().await.expect("announce");
 		let broadcast = event.broadcast().expect("active");
 		let track = broadcast
-			.subscribe_track("publisher.json", Subscription::default())
-			.ok()
+			.consume_track("publisher.json")
+			.subscribe(Subscription::default())
 			.await
 			.expect("subscribe");
 		let frame = read_frame(track).await;
@@ -1297,8 +1297,8 @@ mod tests {
 
 		// External publisher slot SHOULD include foo/bar.
 		let pub_track = broadcast
-			.subscribe_track("publisher.json", Subscription::default())
-			.ok()
+			.consume_track("publisher.json")
+			.subscribe(Subscription::default())
 			.await
 			.expect("subscribe");
 		assert!(
@@ -1310,8 +1310,8 @@ mod tests {
 		// each must be `{}`, not `{"foo/bar": {all zeros}}`.
 		for name in ["subscriber.json", "internal/publisher.json", "internal/subscriber.json"] {
 			let t = broadcast
-				.subscribe_track(name, Subscription::default())
-				.ok()
+				.consume_track(name)
+				.subscribe(Subscription::default())
 				.await
 				.expect("subscribe");
 			let frame = read_frame(t).await;
@@ -1352,7 +1352,7 @@ mod tests {
 		);
 	}
 
-	async fn read_frame(mut track: crate::TrackConsumer) -> BTreeMap<String, Snapshot> {
+	async fn read_frame(mut track: crate::TrackSubscriber) -> BTreeMap<String, Snapshot> {
 		let bytes = track.read_frame().await.expect("ok").expect("frame");
 		serde_json::from_slice(&bytes).expect("json parse")
 	}

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -520,8 +520,8 @@ async fn serve_fetch(
 			.await
 			.ok_or(StatusCode::NOT_FOUND)?;
 		let mut track = broadcast
-			.subscribe_track(&track, moq_net::Subscription::default())
-			.ok()
+			.consume_track(&track)
+			.subscribe(moq_net::Subscription::default())
 			.await
 			.map_err(|err| match err {
 				moq_net::Error::NotFound => StatusCode::NOT_FOUND,

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -161,10 +161,10 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let bc = bc.broadcast().expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
-		.subscribe_track("video", moq_native::moq_net::Subscription::default())
-		.ok()
+		.consume_track("video")
+		.subscribe(moq_native::moq_net::Subscription::default())
 		.await
-		.expect("subscribe_track");
+		.expect("consume_track");
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
 		.expect("recv_group timeout")

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -80,8 +80,8 @@ impl Track {
 	pub async fn opus(broadcast: &moq_net::BroadcastConsumer, name: &str) -> Result<Self> {
 		let container = moq_mux::catalog::hang::Container::Legacy;
 		let track = broadcast
-			.subscribe_track(name, moq_net::Subscription::default())
-			.ok()
+			.consume_track(name)
+			.subscribe(moq_net::Subscription::default())
 			.await?;
 		let consumer = moq_mux::container::Consumer::new(track, container);
 		Ok(Self {
@@ -96,8 +96,8 @@ impl Track {
 	pub async fn video(broadcast: &moq_net::BroadcastConsumer, name: &str, config: &VideoConfig) -> Result<Self> {
 		let container: moq_mux::catalog::hang::Container = (&config.container).try_into()?;
 		let track = broadcast
-			.subscribe_track(name, moq_net::Subscription::default())
-			.ok()
+			.consume_track(name)
+			.subscribe(moq_net::Subscription::default())
 			.await?;
 		let consumer = moq_mux::container::Consumer::new(track, container);
 

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -52,8 +52,8 @@ impl EgressSource {
 	/// which takes the receiver via [`Self::take_writes`].
 	pub async fn new(broadcast: moq_net::BroadcastConsumer) -> Result<Self> {
 		let catalog_track = broadcast
-			.subscribe_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_subscription())
-			.ok()
+			.consume_track(hang::Catalog::DEFAULT_NAME)
+			.subscribe(hang::Catalog::default_subscription())
 			.await?;
 		let mut consumer = moq_mux::catalog::hang::Consumer::new(catalog_track);
 		let catalog = consumer
@@ -83,7 +83,7 @@ impl EgressSource {
 	/// the codec's negotiated RTP clock. The pump subscribes to a matching
 	/// catalog rendition and forwards every frame as a [`WriteRequest`].
 	pub fn on_track(&mut self, mid: Mid, codec: Codec, pt: Pt, clock_rate: Frequency) -> Result<()> {
-		// `subscribe_track` now blocks on SUBSCRIBE_OK, so pick + subscribe inside
+		// the `subscribe` call blocks on SUBSCRIBE_OK, so pick + subscribe inside
 		// the pump task to keep this str0m callback non-blocking.
 		let tx = self.writes_tx.clone();
 		let broadcast = self.broadcast.clone();


### PR DESCRIPTION
## Summary

Picks up the next step after #1540. Separates *a handle to a track you can subscribe to* from *a live subscription you read from*, and moves the SUBSCRIBE_OK await off the broadcast lookup and onto the subscription itself.

- **Rename** the old read+demand handle `TrackConsumer` → **`TrackSubscriber`**. It keeps everything (`recv_group`/`next_group`/`read_frame`, `update`, `subscription`) and still carries the per-subscriber `Subscription` that feeds the producer's aggregate.
- **Add** a new lightweight **`TrackConsumer { broadcast, name }`**: a cheap, cloneable handle that names a track but sends nothing until you call it.
  - `async fn subscribe(Subscription) -> Result<TrackSubscriber>` blocks on SUBSCRIBE_OK.
  - `subscribe_pending(Subscription) -> TrackPending` for poll-based callers (moq-mux's container `source.rs`).
  - `fetch` is reserved (`TODO`) for one-shot range retrieval; not added yet.
- **`BroadcastConsumer::subscribe_track(name, sub) -> TrackPending`** becomes **`consume_track(name) -> TrackConsumer`**; the await now lives on `.subscribe()`:

```rust
let track: TrackConsumer = broadcast.consume_track("video");
let sub: TrackSubscriber = track.subscribe(Subscription { priority: 5, ..Default::default() }).await?;
sub.recv_group().await?;
```

All ~30 call sites across the workspace migrated.

## Cross-package

- **FFI (`moq-ffi` / `libmoq`)**: unchanged surface. `MoqBroadcastConsumer::subscribe_track` keeps its name and async signature; only its internal `self.inner.consume_track(...)` calls were renamed. No py/swift/kt/go regeneration needed.
- **`js/net`**: no change. Wire format is unchanged, and it has its own `subscribe(name, priority)` API.
- **docs**: updated the Rust example in `doc/lib/rs/env/native.md`. Python doc examples are unchanged (FFI API unchanged).

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets` clean (via pinned nix toolchain)
- [x] `cargo test` for `moq-net` (328), `moq-native`, `moq-relay`, `moq-mux` — all pass
- [x] `cargo fmt` via nix

## Follow-ups (not in this PR)

- The `stale` field in `aggregate_subscription` looks inverted (forwards the *soonest* skip deadline upstream rather than the *most patient* subscriber's). Flagged for a separate change once confirmed.
- SUBSCRIBE_UPDATE aggregate plumbing: the relay still doesn't re-aggregate downstream preferences and push an upstream SUBSCRIBE_UPDATE when they change.

(Written by Claude)