### PR TITLE
moq-native,relay: don't advertise the illegal qmux-00.moqt-18 pair

### DIFF
--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -121,12 +121,13 @@ pub(crate) async fn connect(
 		tokio_tungstenite::Connector::Plain
 	};
 
-	// Each moq ALPN can ride on any QMux draft; pass `&[]` to let the polyfill
-	// expand to every QMux version it knows about. `without_protocol` also
-	// offers the bare ALPNs (`qmux-01`, `qmux-00`, `webtransport`) so we still
-	// interop with relays that only know a wire-format version.
+	// Most moq ALPNs can ride on any QMux draft (`&[]` lets the polyfill expand
+	// to every version it knows). `qmux_versions_for` pins the few that the spec
+	// restricts. `without_protocol` also offers the bare ALPNs (`qmux-01`,
+	// `qmux-00`, `webtransport`) so we still interop with relays that only know a
+	// wire-format version.
 	let session = qmux::Client::new()
-		.with_protocols(alpns.iter().map(|&a| (a, &[] as &[qmux::Version])))
+		.with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))))
 		.without_protocol()
 		.with_connector(connector)
 		.connect(url.as_str())
@@ -137,6 +138,18 @@ pub(crate) async fn connect(
 	WEBSOCKET_WON.lock().unwrap().insert(key);
 
 	Ok(session)
+}
+
+/// The QMux drafts a moq ALPN is allowed to ride on, for `qmux::*::with_protocols`.
+///
+/// moq-transport-18 requires qmux-01, so we never offer `qmux-00.moqt-18` (an
+/// illegal pair). This mirrors the policy in `js/net`'s `connect.ts`. Every other
+/// ALPN returns `&[]`, which qmux expands to every draft it knows about.
+fn qmux_versions_for(alpn: &str) -> &'static [qmux::Version] {
+	match alpn {
+		"moqt-18" => &[qmux::Version::QMux01],
+		_ => &[],
+	}
 }
 
 /// Listens for incoming WebSocket connections on a TCP port.
@@ -155,11 +168,11 @@ impl WebSocketListener {
 
 	pub async fn bind_with_alpns(addr: net::SocketAddr, alpns: &[&str]) -> anyhow::Result<Self> {
 		let listener = tokio::net::TcpListener::bind(addr).await?;
-		// `&[]` per entry expands to every QMux draft on the wire;
-		// `without_protocol` also accepts legacy clients that only offer a
-		// bare wire-format ALPN (today's moq-net clients still do).
+		// `qmux_versions_for` returns `&[]` (every QMux draft) for ALPNs the spec
+		// doesn't restrict; `without_protocol` also accepts legacy clients that
+		// only offer a bare wire-format ALPN (today's moq-net clients still do).
 		let server = qmux::Server::new()
-			.with_protocols(alpns.iter().map(|&a| (a, &[] as &[qmux::Version])))
+			.with_protocols(alpns.iter().map(|&a| (a, qmux_versions_for(a))))
 			.without_protocol();
 		Ok(Self { listener, server })
 	}
@@ -181,6 +194,29 @@ impl WebSocketListener {
 				)
 			}
 			Err(e) => Some(Err(e.into())),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn moqt_18_pins_to_qmux01() {
+		// The "moqt-18" literal in `qmux_versions_for` must stay the IETF
+		// draft-18 ALPN; otherwise the pin silently stops matching.
+		assert_eq!(
+			moq_net::Version::from_alpn("moqt-18").map(|v| v.code()),
+			Some(0xff000012)
+		);
+		assert_eq!(qmux_versions_for("moqt-18"), &[qmux::Version::QMux01]);
+
+		// Everything else stays unrestricted (qmux expands `&[]` to all drafts).
+		for &alpn in moq_net::ALPNS {
+			if alpn != "moqt-18" {
+				assert!(qmux_versions_for(alpn).is_empty(), "{alpn} should not be pinned");
+			}
 		}
 	}
 }

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -200,8 +200,8 @@ fn tungstenite_to_axum(
 mod tests {
 	use super::*;
 	use axum::{Router, extract::WebSocketUpgrade, routing::any};
-	use std::sync::Mutex;
-	use tokio::sync::oneshot;
+	use std::time::Duration;
+	use tokio::sync::mpsc;
 	// Brings `qmux::Session::protocol` and `::closed` into scope.
 	use web_transport_trait::Session as _;
 
@@ -265,57 +265,83 @@ mod tests {
 		}
 	}
 
-	/// End-to-end regression: connect a qmux client offering the full moq
-	/// ALPN list to an axum router that mirrors `serve_ws`'s subprotocol
-	/// wiring. Both client and server must observe the newest moq ALPN
-	/// (`moq_net::ALPNS[0]`) on the resulting qmux session. A bug in
-	/// `supported_subprotocols` or in the `Bare::with_alpn` plumbing
-	/// collapses this to `None` / bare `webtransport`, and moq-net then
-	/// downgrades to Lite02 via SETUP.
-	#[tokio::test]
-	async fn axum_ws_negotiates_newest_moq_alpn() {
-		let (server_alpn_tx, server_alpn_rx) = oneshot::channel::<Option<String>>();
-		let server_alpn_tx = Arc::new(Mutex::new(Some(server_alpn_tx)));
+	/// What a single accepted WebSocket connection negotiated, as seen by the server.
+	#[derive(Debug)]
+	struct Observed {
+		/// Raw `Sec-WebSocket-Protocol` axum selected (keeps the `qmux-XX.` prefix).
+		wire: Option<String>,
+		/// The moq app ALPN qmux derived from it (prefix stripped, `None` for bare).
+		app: Option<String>,
+	}
 
-		let route = {
-			let server_alpn_tx = server_alpn_tx.clone();
-			any(move |ws: WebSocketUpgrade| {
-				let server_alpn_tx = server_alpn_tx.clone();
-				async move {
-					let ws = ws.protocols(supported_subprotocols());
-					ws.on_upgrade(move |socket| async move {
-						let alpn = socket.protocol().and_then(|h| h.to_str().ok()).map(str::to_owned);
-						let socket = socket
-							.map(axum_to_tungstenite)
-							.sink_map_err(|_| tungstenite::Error::ConnectionClosed)
-							.with(tungstenite_to_axum);
+	/// Spawn an axum server that mirrors `serve_ws`'s subprotocol wiring.
+	///
+	/// Returns its address and a receiver yielding one [`Observed`] per accepted
+	/// connection, in acceptance order.
+	async fn spawn_test_server() -> (std::net::SocketAddr, mpsc::UnboundedReceiver<Observed>) {
+		let (tx, rx) = mpsc::unbounded_channel::<Observed>();
 
-						let upgraded = qmux::ws::Upgraded::new(socket);
-						let upgraded = match alpn.as_deref() {
-							Some(alpn) => upgraded.with_alpn(alpn),
-							None => upgraded,
-						};
-						let session = upgraded.accept();
-						if let Some(tx) = server_alpn_tx.lock().unwrap().take() {
-							let _ = tx.send(session.protocol().map(str::to_owned));
-						}
-						// Hold the session open so the client side stays alive
-						// long enough to observe the negotiated subprotocol.
-						let _ = session.closed().await;
-					})
-				}
-			})
-		};
+		let route = any(move |ws: WebSocketUpgrade| {
+			let tx = tx.clone();
+			async move {
+				let ws = ws.protocols(supported_subprotocols());
+				ws.on_upgrade(move |socket| async move {
+					let wire = socket.protocol().and_then(|h| h.to_str().ok()).map(str::to_owned);
+					let socket = socket
+						.map(axum_to_tungstenite)
+						.sink_map_err(|_| tungstenite::Error::ConnectionClosed)
+						.with(tungstenite_to_axum);
+
+					let upgraded = qmux::ws::Upgraded::new(socket);
+					let upgraded = match wire.as_deref() {
+						Some(alpn) => upgraded.with_alpn(alpn),
+						None => upgraded,
+					};
+					let session = upgraded.accept();
+					let _ = tx.send(Observed {
+						wire,
+						app: session.protocol().map(str::to_owned),
+					});
+					// Hold the session open so the client stays alive long enough
+					// to observe the negotiated subprotocol.
+					let _ = session.closed().await;
+				})
+			}
+		});
 
 		let app = Router::new().route("/", route);
-
 		let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
 			.await
 			.expect("bind listener");
 		let addr = listener.local_addr().expect("local addr");
-		let server = tokio::spawn(async move {
+		tokio::spawn(async move {
 			axum::serve(listener, app).await.expect("axum serve");
 		});
+		(addr, rx)
+	}
+
+	async fn next_observed(rx: &mut mpsc::UnboundedReceiver<Observed>) -> Observed {
+		tokio::time::timeout(Duration::from_secs(5), rx.recv())
+			.await
+			.expect("server did not report a connection")
+			.expect("server channel closed")
+	}
+
+	/// Split an advertised `{qmux-XX.}{moq-alpn}` pair into its parts, or `None`
+	/// for a bare fallback (`qmux-01`, `qmux-00`, `webtransport`).
+	fn split_pair(entry: &str) -> Option<(qmux::Version, &str)> {
+		QMUX_VERSIONS
+			.iter()
+			.find_map(|&v| entry.strip_prefix(v.prefix()).map(|app| (v, app)))
+	}
+
+	/// End-to-end regression: a qmux client offering the full moq ALPN list must
+	/// land on the newest moq ALPN (`moq_net::ALPNS[0]`) on both sides. A bug in
+	/// `supported_subprotocols` or the `with_alpn` plumbing collapses this to
+	/// `None` / bare `webtransport`, and moq-net then downgrades to Lite02.
+	#[tokio::test]
+	async fn axum_ws_negotiates_newest_moq_alpn() {
+		let (addr, mut rx) = spawn_test_server().await;
 
 		let session = qmux::Client::new()
 			.with_protocols(moq_net::ALPNS.iter().map(|&a| (a, &[] as &[qmux::Version])))
@@ -330,17 +356,59 @@ mod tests {
 			session.protocol(),
 		);
 
-		let server_alpn = tokio::time::timeout(std::time::Duration::from_secs(5), server_alpn_rx)
-			.await
-			.expect("server alpn channel timed out")
-			.expect("server alpn channel dropped");
+		let observed = next_observed(&mut rx).await;
 		assert_eq!(
-			server_alpn.as_deref(),
+			observed.app.as_deref(),
 			Some(newest_moq_alpn()),
-			"server side should see the newest moq ALPN after Bare::with_alpn",
+			"server side should see the newest moq ALPN after with_alpn",
 		);
 
 		drop(session);
-		server.abort();
+	}
+
+	/// Every versioned `(qmux, moq)` pair we advertise must be acceptable: a
+	/// client offering exactly that pair negotiates it end-to-end. Conversely,
+	/// the excluded `qmux-00.moqt-18` pair must never be selected, even when a
+	/// client explicitly offers it.
+	#[tokio::test]
+	async fn every_advertised_pair_is_acceptable() {
+		let (addr, mut rx) = spawn_test_server().await;
+		let url = format!("ws://{addr}/");
+
+		for entry in supported_subprotocols() {
+			// Bare fallbacks can't be offered in isolation via the qmux client API;
+			// they're covered by `axum_ws_negotiates_newest_moq_alpn`.
+			let Some((version, app)) = split_pair(&entry) else {
+				continue;
+			};
+
+			let session = qmux::Client::new()
+				.with_protocol(app, &[version])
+				.connect(&url)
+				.await
+				.unwrap_or_else(|e| panic!("server rejected advertised pair {entry}: {e}"));
+
+			let observed = next_observed(&mut rx).await;
+			assert_eq!(
+				observed.wire.as_deref(),
+				Some(entry.as_str()),
+				"offered advertised pair {entry}, but server negotiated {:?}",
+				observed.wire,
+			);
+			drop(session);
+		}
+
+		// The illegal pair is advertised by nobody. A client offering only
+		// `qmux-00.moqt-18` finds no match, and qmux surfaces the empty
+		// subprotocol selection as a failed handshake rather than a silent
+		// downgrade to a different version.
+		let result = qmux::Client::new()
+			.with_protocol("moqt-18", &[qmux::Version::QMux00])
+			.connect(&url)
+			.await;
+		assert!(
+			result.is_err(),
+			"server must reject the illegal qmux-00.moqt-18 pair, but the handshake succeeded",
+		);
 	}
 }

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -130,10 +130,16 @@ const QMUX_VERSIONS: &[qmux::Version] = &[qmux::Version::QMux01, qmux::Version::
 /// performs. Without the versioned entries, axum picks bare `webtransport`,
 /// qmux can't resolve a moq version from it, and the relay silently
 /// downgrades clients to Lite02 via SETUP-based negotiation.
+///
+/// `qmux-00.moqt-18` is excluded: moq-transport-18 requires qmux-01, so that
+/// pair is illegal (matches `js/net`'s `connect.ts`).
 fn supported_subprotocols() -> Vec<String> {
 	let mut out = Vec::with_capacity(QMUX_VERSIONS.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
 	for &version in QMUX_VERSIONS {
 		for &alpn in moq_net::ALPNS {
+			if version == qmux::Version::QMux00 && alpn == QMUX01_ONLY_ALPN {
+				continue;
+			}
 			out.push(format!("{}{alpn}", version.prefix()));
 		}
 	}
@@ -142,6 +148,9 @@ fn supported_subprotocols() -> Vec<String> {
 	}
 	out
 }
+
+/// moq-transport-18 requires qmux-01, so we never pair it with qmux-00.
+const QMUX01_ONLY_ALPN: &str = "moqt-18";
 
 // https://github.com/tokio-rs/axum/discussions/848#discussioncomment-11443587
 
@@ -210,6 +219,12 @@ mod tests {
 
 	#[test]
 	fn supported_subprotocols_lists_full_matrix() {
+		// Guard the literal: it must stay the IETF draft-18 ALPN (wire 0xff000012).
+		assert_eq!(
+			moq_net::Version::from_alpn(QMUX01_ONLY_ALPN).map(|v| v.code()),
+			Some(0xff000012)
+		);
+
 		let list = supported_subprotocols();
 
 		// Newest moq ALPN under the preferred prefix must come first so axum
@@ -217,10 +232,15 @@ mod tests {
 		let expected_first = format!("{}{}", preferred_qmux_prefix(), newest_moq_alpn());
 		assert_eq!(list.first().map(String::as_str), Some(expected_first.as_str()));
 
-		// Every moq ALPN must appear under every qmux version's prefix.
+		// Every moq ALPN must appear under every qmux version's prefix, except
+		// the illegal `qmux-00.moqt-18` pair (moq-transport-18 needs qmux-01).
 		for &version in QMUX_VERSIONS {
 			for &alpn in moq_net::ALPNS {
 				let entry = format!("{}{alpn}", version.prefix());
+				if version == qmux::Version::QMux00 && alpn == QMUX01_ONLY_ALPN {
+					assert!(!list.contains(&entry), "illegal pair {entry} must not be advertised");
+					continue;
+				}
 				assert!(list.contains(&entry), "missing {entry}");
 			}
 		}


### PR DESCRIPTION
## Summary

moq-transport-18 requires qmux-01, so `qmux-00.moqt-18` is an illegal WebSocket subprotocol pair. On `dev` the Rust side advertised the full `{qmux-01, qmux-00} × moq_net::ALPNS` matrix (relay) and offered every draft per ALPN (`&[]`, native client/listener), which produces that illegal pair. `js/net`'s `connect.ts` already pins draft-18 to qmux-01, so the Rust side was the outlier; this brings it in line.

- **`rs/moq-native/src/websocket.rs`**: add a private `qmux_versions_for(alpn)` helper that pins `moqt-18` to `qmux-01` and returns `&[]` (every draft) for all other ALPNs. Used by both the WebSocket client `connect()` and the `WebSocketListener`.
- **`rs/moq-relay/src/websocket.rs`**: `supported_subprotocols()` skips the `qmux-00.moqt-18` cell of the matrix.
- Each crate guards the `"moqt-18"` literal with a test asserting it stays the IETF draft-18 ALPN (wire `0xff000012`), so the pin can't silently rot.

No new public API. `js/net` already encodes this policy, so no JS change is needed.

## Background

This supersedes #1513, which added a `moq-net` version→qmux policy mapping (`QmuxVersion`, `qmux_versions()`, `QMUX_ALPNS`, `QMUX_ALPN_STRINGS`, etc.) as a workaround for qmux 0.1.0. `dev`'s qmux 0.1.1 `with_protocols(alpn, &[Version])` API plus the full-matrix `supported_subprotocols()` already handle qmux negotiation, so that surface is redundant. The only real gap was the one illegal pair, which this fixes minimally.

## Test plan

- [x] `cargo test -p moq-native -p moq-relay --lib websocket::` — passes, including:
  - `moqt_18_pins_to_qmux01` / `supported_subprotocols_lists_full_matrix`: the pin and the advertised matrix (with the illegal pair excluded), plus draft-18 literal drift guards.
  - `every_advertised_pair_is_acceptable`: spins up the axum WebSocket handler and, for **every** versioned `(qmux, moq)` pair we advertise, connects a client offering exactly that pair and asserts it negotiates end-to-end; also asserts offering `qmux-00.moqt-18` fails the handshake.
  - `axum_ws_negotiates_newest_moq_alpn`: existing newest-ALPN regression, refactored onto a shared `spawn_test_server` harness.
- [x] `cargo fmt -p moq-native -p moq-relay -- --check` clean.
- [x] `cargo clippy -p moq-native -p moq-relay --all-targets -- -D warnings` clean.

(Written by Claude)