### PR TITLE
moq-native: enable WebSocket keep-alive on the client path

### DIFF
--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -124,6 +124,7 @@ pub(crate) async fn connect(
 	let session = qmux::Client::new()
 		.with_protocols(alpns)
 		.with_connector(connector)
+		.with_keep_alive(qmux::KeepAlive::default()) // 5s ping / 30s deadline — parity with QUIC
 		.connect(url.as_str())
 		.await
 		.context("failed to connect WebSocket")?;


### PR DESCRIPTION
## What

Wire `qmux::KeepAlive::default()` (5s ping / 30s deadline) into the WebSocket **client** connect builder in `rs/moq-native/src/websocket.rs`:

```rust
let session = qmux::Client::new()
    .with_protocols(alpns)
    .with_connector(connector)
    .with_keep_alive(qmux::KeepAlive::default()) // 5s ping / 30s deadline — parity with QUIC
    .connect(url.as_str())
    .await
```

## Why

Previously the client WebSocket had no keep-alive, so a half-dead connection (network drop, NAT timeout, dead peer) would hang indefinitely — `session.closed()` never resolved, the reconnect loop never fired, and recovery required a process restart.

With keep-alive wired up, a half-dead WebSocket misses pings, hits the 30s deadline, the transport closes, `session.closed()` resolves, and the **existing** reconnect machinery re-establishes the session automatically. This brings the WebSocket client to parity with the QUIC path's liveness behavior.

The machinery and sensible defaults (`KeepAlive::default()` = 5s/30s, per `qmux` 0.0.7) already existed and the server accept path already used them — they just weren't wired up on the client side.

## Testing

- `cargo check -p moq-native` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)