### PR TITLE
js: re-export Hang from @moq/publish and @moq/watch

### DIFF
--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/src/index.ts
+++ b/js/publish/src/index.ts
@@ -1,3 +1,4 @@
+export * as Hang from "@moq/hang";
 export * as Net from "@moq/net";
 /** @deprecated Use `Net` instead. */
 export * as Lite from "@moq/net";

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/src/index.ts
+++ b/js/watch/src/index.ts
@@ -1,3 +1,4 @@
+export * as Hang from "@moq/hang";
 export * as Net from "@moq/net";
 /** @deprecated Use `Net` instead. */
 export * as Lite from "@moq/net";
@@ -10,6 +11,7 @@ export * as Location from "./location";
 export * as Mse from "./mse";
 export * from "./preview";
 export * from "./sync";
+export * as User from "./user";
 export * as Video from "./video";
 
 // NOTE: element is not exported from this module


### PR DESCRIPTION
## Summary

- Re-export the `@moq/hang` namespace as `Hang` from both `@moq/publish` and `@moq/watch` entry points, following the existing `Net`/`Signals` re-export pattern. Consumers can now reach `Hang.Catalog`, `Hang.Container`, etc. directly: `import { Hang } from "@moq/watch"`.
- Export the previously-unreachable `User` module from `@moq/watch`, mirroring `@moq/publish` which already exports it. `watch/src/user.ts` was a complete standalone module (`Info` + `Props`) that was never re-exported and not imported internally.
- Patch bump both packages: `@moq/publish` 0.2.9 → 0.2.10, `@moq/watch` 0.2.13 → 0.2.14.

Both packages already declared `@moq/hang` as a workspace dependency. `tsc --noEmit` passes for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)