### PR TITLE
docs: prefer esm.sh over jsDelivr for no-build CDN usage

### DIFF
--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -21,15 +21,15 @@ npm add @moq/publish
 ### No-build CDN usage
 
 For quick demos or single-page embeds where a bundler is overkill, load the
-package straight from jsDelivr with the `+esm` endpoint. jsDelivr transforms
-the published file and rewrites bare imports (like `@moq/hang`, `@moq/net`)
-to other `+esm` URLs, so it loads in the browser with no import map or local
-build step:
+package straight from [esm.sh](https://esm.sh). esm.sh serves the package as a
+browser-ready ESM module and rewrites bare imports (like `@moq/hang`,
+`@moq/net`) to other esm.sh URLs, so it loads in the browser with no import map
+or local build step:
 
 ```html
 <script type="module">
-    import "https://cdn.jsdelivr.net/npm/@moq/publish/element.js/+esm";
-    import "https://cdn.jsdelivr.net/npm/@moq/publish/ui/index.js/+esm";
+    import "https://esm.sh/@moq/publish/element";
+    import "https://esm.sh/@moq/publish/ui";
 </script>
 
 <moq-publish-ui>
@@ -39,9 +39,10 @@ build step:
 </moq-publish-ui>
 ```
 
-Pin a version range in the URL for production — e.g.
-`https://cdn.jsdelivr.net/npm/@moq/publish@0.2/element.js/+esm`. [esm.sh](https://esm.sh)
-(`https://esm.sh/@moq/publish/element`) works the same way if you prefer it.
+Pin a version range in the URL for production, e.g.
+`https://esm.sh/@moq/publish@0.2/element`. jsDelivr's `+esm` endpoint
+(`https://cdn.jsdelivr.net/npm/@moq/publish/element.js/+esm`) works the same way
+if you prefer it.
 
 For anything beyond embedding on a static page, install the package and use
 a real bundler (the examples below).

--- a/doc/lib/js/@moq/watch.md
+++ b/doc/lib/js/@moq/watch.md
@@ -21,15 +21,15 @@ npm add @moq/watch
 ### No-build CDN usage
 
 For quick demos or single-page embeds where a bundler is overkill, load the
-package straight from jsDelivr with the `+esm` endpoint. jsDelivr transforms
-the published file and rewrites bare imports (like `@moq/hang`, `@moq/net`)
-to other `+esm` URLs, so it loads in the browser with no import map or local
-build step:
+package straight from [esm.sh](https://esm.sh). esm.sh serves the package as a
+browser-ready ESM module and rewrites bare imports (like `@moq/hang`,
+`@moq/net`) to other esm.sh URLs, so it loads in the browser with no import map
+or local build step:
 
 ```html
 <script type="module">
-    import "https://cdn.jsdelivr.net/npm/@moq/watch/element.js/+esm";
-    import "https://cdn.jsdelivr.net/npm/@moq/watch/ui/index.js/+esm";
+    import "https://esm.sh/@moq/watch/element";
+    import "https://esm.sh/@moq/watch/ui";
 </script>
 
 <moq-watch-ui>
@@ -40,8 +40,9 @@ build step:
 ```
 
 Pin a version range in the URL for production, e.g.
-`https://cdn.jsdelivr.net/npm/@moq/watch@0.2/element.js/+esm`. [esm.sh](https://esm.sh)
-(`https://esm.sh/@moq/watch/element`) works the same way if you prefer it.
+`https://esm.sh/@moq/watch@0.2/element`. jsDelivr's `+esm` endpoint
+(`https://cdn.jsdelivr.net/npm/@moq/watch/element.js/+esm`) works the same way
+if you prefer it.
 
 For anything beyond embedding on a static page, install the package and use
 a real bundler (the examples below).

--- a/doc/lib/js/env/web.md
+++ b/doc/lib/js/env/web.md
@@ -17,15 +17,15 @@ description: Web Components API reference
 ## Loading From a CDN (No Bundler)
 
 For quick demos or embeds on a static page, both `@moq/watch` and
-`@moq/publish` can be loaded straight from jsDelivr with no build step.
-Appending `/+esm` to the URL tells jsDelivr to transform the file and
-rewrite bare imports (like `@moq/hang`, `@moq/net`) to other `+esm`
-URLs, so it loads in the browser without an import map:
+`@moq/publish` can be loaded straight from [esm.sh](https://esm.sh) with no
+build step. esm.sh serves each package as a browser-ready ESM module and
+rewrites bare imports (like `@moq/hang`, `@moq/net`) to other esm.sh URLs, so
+it loads in the browser without an import map:
 
 ```html
 <script type="module">
-    import "https://cdn.jsdelivr.net/npm/@moq/watch/element.js/+esm";
-    import "https://cdn.jsdelivr.net/npm/@moq/publish/element.js/+esm";
+    import "https://esm.sh/@moq/watch/element";
+    import "https://esm.sh/@moq/publish/element";
 </script>
 
 <moq-watch url="https://relay.example.com/anon" name="room/alice.hang">
@@ -33,13 +33,14 @@ URLs, so it loads in the browser without an import map:
 </moq-watch>
 ```
 
-Pin a version range in the URL for production — e.g.
-`https://cdn.jsdelivr.net/npm/@moq/watch@0.2/element.js/+esm`. [esm.sh](https://esm.sh)
-(`https://esm.sh/@moq/watch/element`) works the same way if you prefer it.
+Pin a version range in the URL for production, e.g.
+`https://esm.sh/@moq/watch@0.2/element`. jsDelivr's `+esm` endpoint
+(`https://cdn.jsdelivr.net/npm/@moq/watch/element.js/+esm`) works the same way
+if you prefer it.
 
 This is the fastest way to try MoQ in a blog post or demo page, but for
 real apps you should [install the packages](#available-components) and
-use a bundler — you'll get tree-shaking, offline dev, and no dependency
+use a bundler. You'll get tree-shaking, offline dev, and no dependency
 on a third-party CDN's availability.
 
 ## Available Components

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -19,15 +19,15 @@ npm add @moq/publish
 
 ### No-build CDN usage
 
-For quick demos or embeds where a bundler is overkill, jsDelivr's `+esm`
-endpoint will transform the published npm package into a browser-ready ESM
-module — bare imports like `@moq/hang` are automatically rewritten to
-other `+esm` URLs. No build step or import map required:
+For quick demos or embeds where a bundler is overkill, esm.sh serves the
+published npm package as a browser-ready ESM module. Bare imports like
+`@moq/hang` are automatically rewritten to other esm.sh URLs. No build step or
+import map required:
 
 ```html
 <script type="module">
-    import "https://cdn.jsdelivr.net/npm/@moq/publish/element.js/+esm";
-    import "https://cdn.jsdelivr.net/npm/@moq/publish/ui/element.js/+esm";
+    import "https://esm.sh/@moq/publish/element";
+    import "https://esm.sh/@moq/publish/ui";
 </script>
 
 <moq-publish-ui>
@@ -37,9 +37,10 @@ other `+esm` URLs. No build step or import map required:
 </moq-publish-ui>
 ```
 
-Pin a version range in the URL for production — e.g.
-`https://cdn.jsdelivr.net/npm/@moq/publish@0.2/element.js/+esm`. esm.sh
-(`https://esm.sh/@moq/publish/element`) works the same way if you prefer it.
+Pin a version range in the URL for production, e.g.
+`https://esm.sh/@moq/publish@0.2/element`. jsDelivr's `+esm` endpoint
+(`https://cdn.jsdelivr.net/npm/@moq/publish/element.js/+esm`) works the same way
+if you prefer it.
 
 For anything beyond embedding on a static page you should install the
 package and use a real bundler (the examples below).

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -19,15 +19,15 @@ npm add @moq/watch
 
 ### No-build CDN usage
 
-For quick demos or embeds where a bundler is overkill, jsDelivr's `+esm`
-endpoint will transform the published npm package into a browser-ready ESM
-module — bare imports like `@moq/hang` are automatically rewritten to
-other `+esm` URLs. No build step or import map required:
+For quick demos or embeds where a bundler is overkill, esm.sh serves the
+published npm package as a browser-ready ESM module. Bare imports like
+`@moq/hang` are automatically rewritten to other esm.sh URLs. No build step or
+import map required:
 
 ```html
 <script type="module">
-    import "https://cdn.jsdelivr.net/npm/@moq/watch/element.js/+esm";
-    import "https://cdn.jsdelivr.net/npm/@moq/watch/ui/element.js/+esm";
+    import "https://esm.sh/@moq/watch/element";
+    import "https://esm.sh/@moq/watch/ui";
 </script>
 
 <moq-watch-ui>
@@ -37,9 +37,10 @@ other `+esm` URLs. No build step or import map required:
 </moq-watch-ui>
 ```
 
-Pin a version range in the URL for production — e.g.
-`https://cdn.jsdelivr.net/npm/@moq/watch@0.2/element.js/+esm`. esm.sh
-(`https://esm.sh/@moq/watch/element`) works the same way if you prefer it.
+Pin a version range in the URL for production, e.g.
+`https://esm.sh/@moq/watch@0.2/element`. jsDelivr's `+esm` endpoint
+(`https://cdn.jsdelivr.net/npm/@moq/watch/element.js/+esm`) works the same way
+if you prefer it.
 
 For anything beyond embedding on a static page you should install the
 package and use a real bundler (the examples below).


### PR DESCRIPTION
## Summary

Swaps the recommended no-build CDN in the `@moq/watch` and `@moq/publish` docs and READMEs from jsDelivr to esm.sh. jsDelivr is kept as the "works the same way if you prefer it" alternative.

## Why

- **Cleaner URLs.** `https://esm.sh/@moq/watch/element` vs `https://cdn.jsdelivr.net/npm/@moq/watch/element.js/+esm`.
- **Correct subpath resolution.** esm.sh resolves `/ui` straight from the package `exports` map (`"./ui"`). The old jsDelivr snippets pointed at built file paths that disagreed between the docs (`ui/index.js`) and the READMEs (`ui/element.js`); both are now consistent and match the actual export.
- **Style fix.** Dropped the em dashes that lived in these sections, per the project's no-em-dash rule.

## Files changed

- `doc/lib/js/@moq/watch.md`
- `doc/lib/js/@moq/publish.md`
- `doc/lib/js/env/web.md`
- `js/watch/README.md`
- `js/publish/README.md`

## Reviewer note

esm.sh transpiles `@moq/*` on the fly and rewrites the transitive bare imports (`@moq/hang`, `@moq/net`, etc.). Worth a quick live load of one snippet to confirm the dependency graph (including hang's WebCodecs worker imports) resolves cleanly before relying on it in published docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)