### PR TITLE
moq-net: add per-track cache age (SUBSCRIBE_OK), reconcile draft field order, port timescale to js/net

### DIFF
--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -102,6 +102,9 @@ Each Subscription consists of a few properties:
 - **Group Order**: The order in which groups are delivered. Defaults to descending; higher IDs are delivered first.
 - **Group Timeout**: The maximum duration to keep old groups in cache/transit. Defaults to 30 seconds.
 
+The publisher also caps how long it retains old groups via a per-track **cache** age, announced in `SUBSCRIBE_OK` so relays re-serve with the same window.
+A subscriber's Group Timeout can only be smaller than this cache age, since a group can't be waited for longer than it's kept around.
+
 By utilizing these properties, you can choose how your application behaves during congestion.
 For example, consider a conference room with Alice and Bob:
 

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -203,7 +203,9 @@ export class Publisher {
 			const compression =
 				track.compress && supportsCompression(this.version) ? Compression.Deflate : Compression.None;
 
-			const info = new SubscribeOk({ priority: msg.priority, compression });
+			// Announce the publisher's cache window so a relay re-serves with the
+			// same eviction bound. Pre-lite-05 peers ignore it.
+			const info = new SubscribeOk({ priority: msg.priority, compression, cache: track.cache });
 			await encodeSubscribeResponse(stream.writer, { ok: info }, this.version);
 
 			console.debug(`publish ok: broadcast=${msg.broadcast} track=${track.name}`);

--- a/js/net/src/lite/subscribe.test.ts
+++ b/js/net/src/lite/subscribe.test.ts
@@ -29,7 +29,7 @@ async function roundtrip(version: Version, ok: SubscribeOk): Promise<SubscribeOk
 	return SubscribeOk.decode(reader, version);
 }
 
-test("SubscribeOk: compression and cache round-trip on draft-05", async () => {
+test("SubscribeOk: timescale, cache, and compression round-trip on draft-05", async () => {
 	const ok = new SubscribeOk({
 		priority: 7,
 		ordered: true,
@@ -37,20 +37,23 @@ test("SubscribeOk: compression and cache round-trip on draft-05", async () => {
 		startGroup: 3,
 		compression: Compression.Deflate,
 		cache: 10000,
+		timescale: 90000,
 	});
 
 	const got = await roundtrip(Version.DRAFT_05_WIP, ok);
 	expect(got.compression).toBe(Compression.Deflate);
 	expect(got.cache).toBe(10000);
+	expect(got.timescale).toBe(90000);
 	expect(got.priority).toBe(7);
 	expect(got.ordered).toBe(true);
 	expect(got.startGroup).toBe(3);
 });
 
-test("SubscribeOk: compression and cache fields are absent before draft-05", async () => {
-	// draft-04 has no compression/cache varints on the wire, so they decode to defaults.
-	const ok = new SubscribeOk({ priority: 7, compression: Compression.Deflate, cache: 10000 });
+test("SubscribeOk: timescale, cache, and compression fields are absent before draft-05", async () => {
+	// draft-04 has no draft-05 trailing varints, so they decode to defaults.
+	const ok = new SubscribeOk({ priority: 7, compression: Compression.Deflate, cache: 10000, timescale: 90000 });
 	const got = await roundtrip(Version.DRAFT_04, ok);
 	expect(got.compression).toBe(Compression.None);
 	expect(got.cache).toBe(DEFAULT_CACHE_MS);
+	expect(got.timescale).toBe(0);
 });

--- a/js/net/src/lite/subscribe.test.ts
+++ b/js/net/src/lite/subscribe.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { Compression } from "../compression.ts";
 import { Reader, Writer } from "../stream.ts";
+import { DEFAULT_CACHE_MS } from "../track.ts";
 import { SubscribeOk } from "./subscribe.ts";
 import { Version } from "./version.ts";
 
@@ -28,25 +29,28 @@ async function roundtrip(version: Version, ok: SubscribeOk): Promise<SubscribeOk
 	return SubscribeOk.decode(reader, version);
 }
 
-test("SubscribeOk: compression round-trips on draft-05", async () => {
+test("SubscribeOk: compression and cache round-trip on draft-05", async () => {
 	const ok = new SubscribeOk({
 		priority: 7,
 		ordered: true,
 		maxLatency: 250,
 		startGroup: 3,
 		compression: Compression.Deflate,
+		cache: 10000,
 	});
 
 	const got = await roundtrip(Version.DRAFT_05_WIP, ok);
 	expect(got.compression).toBe(Compression.Deflate);
+	expect(got.cache).toBe(10000);
 	expect(got.priority).toBe(7);
 	expect(got.ordered).toBe(true);
 	expect(got.startGroup).toBe(3);
 });
 
-test("SubscribeOk: compression field is absent before draft-05", async () => {
-	// draft-04 has no compression varint on the wire, so it always decodes as None.
-	const ok = new SubscribeOk({ priority: 7, compression: Compression.Deflate });
+test("SubscribeOk: compression and cache fields are absent before draft-05", async () => {
+	// draft-04 has no compression/cache varints on the wire, so they decode to defaults.
+	const ok = new SubscribeOk({ priority: 7, compression: Compression.Deflate, cache: 10000 });
 	const got = await roundtrip(Version.DRAFT_04, ok);
 	expect(got.compression).toBe(Compression.None);
+	expect(got.cache).toBe(DEFAULT_CACHE_MS);
 });

--- a/js/net/src/lite/subscribe.ts
+++ b/js/net/src/lite/subscribe.ts
@@ -183,6 +183,14 @@ export class SubscribeOk {
 	 * evicting them. Draft-05+ only; older drafts assume {@link DEFAULT_CACHE_MS}.
 	 */
 	cache: number;
+	/**
+	 * Per-frame timestamp scale (units per second) advertised by the publisher.
+	 * `0` means no per-frame timestamps on the wire (frame headers omit them).
+	 * Draft-05+ only; older drafts are always `0`. This implementation doesn't
+	 * yet produce per-frame timestamps, so publishers always send `0`; subscribers
+	 * read the delta to stay in sync with a timestamped (e.g. Rust) publisher.
+	 */
+	timescale: number;
 
 	constructor({
 		priority = 0,
@@ -192,6 +200,7 @@ export class SubscribeOk {
 		endGroup = undefined,
 		compression = Compression.None,
 		cache = DEFAULT_CACHE_MS,
+		timescale = 0,
 	}: {
 		priority?: number;
 		ordered?: boolean;
@@ -200,6 +209,7 @@ export class SubscribeOk {
 		endGroup?: number;
 		compression?: Compression;
 		cache?: number;
+		timescale?: number;
 	}) {
 		this.priority = priority;
 		this.ordered = ordered;
@@ -208,6 +218,7 @@ export class SubscribeOk {
 		this.endGroup = endGroup;
 		this.compression = compression;
 		this.cache = cache;
+		this.timescale = timescale;
 	}
 
 	async #encode(w: Writer, version: Version) {
@@ -232,8 +243,10 @@ export class SubscribeOk {
 				await w.u53(this.maxLatency);
 				await w.u53(this.startGroup !== undefined ? this.startGroup + 1 : 0);
 				await w.u53(this.endGroup !== undefined ? this.endGroup + 1 : 0);
-				await w.u53(this.compression);
+				// Order matches draft-lcurley-moq-lite-05 SUBSCRIBE_OK: Timescale, Cache, Compression.
+				await w.u53(this.timescale);
 				await w.u53(this.cache);
+				await w.u53(this.compression);
 				break;
 		}
 	}
@@ -246,6 +259,7 @@ export class SubscribeOk {
 		let endGroup: number | undefined;
 		let compression: Compression = Compression.None;
 		let cache: number = DEFAULT_CACHE_MS;
+		let timescale = 0;
 
 		switch (version) {
 			case Version.DRAFT_02:
@@ -268,8 +282,10 @@ export class SubscribeOk {
 				maxLatency = await r.u53();
 				startGroup = await r.u53();
 				endGroup = await r.u53();
-				compression = compressionFromCode(await r.u53());
+				// Order matches draft-lcurley-moq-lite-05 SUBSCRIBE_OK: Timescale, Cache, Compression.
+				timescale = await r.u53();
 				cache = await r.u53();
+				compression = compressionFromCode(await r.u53());
 				break;
 		}
 
@@ -280,6 +296,7 @@ export class SubscribeOk {
 			startGroup: startGroup !== undefined && startGroup > 0 ? startGroup - 1 : undefined,
 			endGroup: endGroup !== undefined && endGroup > 0 ? endGroup - 1 : undefined,
 			compression,
+			timescale,
 			cache,
 		});
 	}

--- a/js/net/src/lite/subscribe.ts
+++ b/js/net/src/lite/subscribe.ts
@@ -1,6 +1,7 @@
 import { Compression, compressionFromCode } from "../compression.ts";
 import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
+import { DEFAULT_CACHE_MS } from "../track.ts";
 import * as Message from "./message.ts";
 import { Version } from "./version.ts";
 
@@ -177,6 +178,11 @@ export class SubscribeOk {
 	 * {@link Compression.None}.
 	 */
 	compression: Compression;
+	/**
+	 * How long (milliseconds) the publisher keeps old groups available before
+	 * evicting them. Draft-05+ only; older drafts assume {@link DEFAULT_CACHE_MS}.
+	 */
+	cache: number;
 
 	constructor({
 		priority = 0,
@@ -185,6 +191,7 @@ export class SubscribeOk {
 		startGroup = undefined,
 		endGroup = undefined,
 		compression = Compression.None,
+		cache = DEFAULT_CACHE_MS,
 	}: {
 		priority?: number;
 		ordered?: boolean;
@@ -192,6 +199,7 @@ export class SubscribeOk {
 		startGroup?: number;
 		endGroup?: number;
 		compression?: Compression;
+		cache?: number;
 	}) {
 		this.priority = priority;
 		this.ordered = ordered;
@@ -199,6 +207,7 @@ export class SubscribeOk {
 		this.startGroup = startGroup;
 		this.endGroup = endGroup;
 		this.compression = compression;
+		this.cache = cache;
 	}
 
 	async #encode(w: Writer, version: Version) {
@@ -224,6 +233,7 @@ export class SubscribeOk {
 				await w.u53(this.startGroup !== undefined ? this.startGroup + 1 : 0);
 				await w.u53(this.endGroup !== undefined ? this.endGroup + 1 : 0);
 				await w.u53(this.compression);
+				await w.u53(this.cache);
 				break;
 		}
 	}
@@ -235,6 +245,7 @@ export class SubscribeOk {
 		let startGroup: number | undefined;
 		let endGroup: number | undefined;
 		let compression: Compression = Compression.None;
+		let cache: number = DEFAULT_CACHE_MS;
 
 		switch (version) {
 			case Version.DRAFT_02:
@@ -258,6 +269,7 @@ export class SubscribeOk {
 				startGroup = await r.u53();
 				endGroup = await r.u53();
 				compression = compressionFromCode(await r.u53());
+				cache = await r.u53();
 				break;
 		}
 
@@ -268,6 +280,7 @@ export class SubscribeOk {
 			startGroup: startGroup !== undefined && startGroup > 0 ? startGroup - 1 : undefined,
 			endGroup: endGroup !== undefined && endGroup > 0 ? endGroup - 1 : undefined,
 			compression,
+			cache,
 		});
 	}
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -225,6 +225,8 @@ export class Subscriber {
 			stream = ok.stream;
 			// Unblock any group streams waiting to learn how to decode frames.
 			compression.set(ok.compression);
+			// Learn the publisher's cache window so a re-serving relay matches it.
+			request.track.cache = ok.cache;
 			console.debug(`subscribe ok: id=${id} broadcast=${broadcast} track=${request.track.name}`);
 		} catch (err) {
 			const e = error(err);
@@ -280,7 +282,7 @@ export class Subscriber {
 	async #openSubscribe(
 		state: { stream?: Stream },
 		msg: Subscribe,
-	): Promise<{ stream: Stream; compression: Compression }> {
+	): Promise<{ stream: Stream; compression: Compression; cache: number }> {
 		state.stream = await Stream.open(this.#quic);
 		await state.stream.writer.u53(StreamId.Subscribe);
 		await msg.encode(state.stream.writer, this.version);
@@ -290,7 +292,7 @@ export class Subscriber {
 		if (!("ok" in resp)) {
 			throw new Error("first subscribe response must be SUBSCRIBE_OK");
 		}
-		return { stream: state.stream, compression: resp.ok.compression };
+		return { stream: state.stream, compression: resp.ok.compression, cache: resp.ok.cache };
 	}
 
 	/**

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -41,6 +41,10 @@ interface SubscribeEntry {
 	track: Track;
 	// undefined until SUBSCRIBE_OK arrives and tells us the negotiated codec.
 	compression: Signal<Compression | undefined>;
+	// Per-frame timestamp scale (0 = none). undefined until SUBSCRIBE_OK arrives.
+	// A non-zero value means each frame on the group stream is prefixed with a
+	// zigzag-delta timestamp varint that runGroup must consume to stay in sync.
+	timescale: Signal<number | undefined>;
 }
 
 /**
@@ -203,7 +207,8 @@ export class Subscriber {
 		// Save the writer so we can append groups to it. `compression` stays
 		// undefined until SUBSCRIBE_OK resolves it; runGroup blocks on it.
 		const compression = new Signal<Compression | undefined>(undefined);
-		this.#subscribes.set(id, { track: request.track, compression });
+		const timescale = new Signal<number | undefined>(undefined);
+		this.#subscribes.set(id, { track: request.track, compression, timescale });
 
 		console.debug(`subscribe start: id=${id} broadcast=${broadcast} track=${request.track.name}`);
 
@@ -225,6 +230,7 @@ export class Subscriber {
 			stream = ok.stream;
 			// Unblock any group streams waiting to learn how to decode frames.
 			compression.set(ok.compression);
+			timescale.set(ok.timescale);
 			// Learn the publisher's cache window so a re-serving relay matches it.
 			request.track.cache = ok.cache;
 			console.debug(`subscribe ok: id=${id} broadcast=${broadcast} track=${request.track.name}`);
@@ -282,7 +288,7 @@ export class Subscriber {
 	async #openSubscribe(
 		state: { stream?: Stream },
 		msg: Subscribe,
-	): Promise<{ stream: Stream; compression: Compression; cache: number }> {
+	): Promise<{ stream: Stream; compression: Compression; cache: number; timescale: number }> {
 		state.stream = await Stream.open(this.#quic);
 		await state.stream.writer.u53(StreamId.Subscribe);
 		await msg.encode(state.stream.writer, this.version);
@@ -292,7 +298,12 @@ export class Subscriber {
 		if (!("ok" in resp)) {
 			throw new Error("first subscribe response must be SUBSCRIBE_OK");
 		}
-		return { stream: state.stream, compression: resp.ok.compression, cache: resp.ok.cache };
+		return {
+			stream: state.stream,
+			compression: resp.ok.compression,
+			cache: resp.ok.cache,
+			timescale: resp.ok.timescale,
+		};
 	}
 
 	/**
@@ -357,7 +368,7 @@ export class Subscriber {
 			return;
 		}
 
-		const { track, compression } = entry;
+		const { track, compression, timescale } = entry;
 		const producer = new Group(group.sequence);
 		track.writeGroup(producer);
 
@@ -376,9 +387,21 @@ export class Subscriber {
 				codec = compression.peek();
 			}
 
+			// timescale resolves together with compression at SUBSCRIBE_OK. A
+			// non-zero scale means every frame is prefixed with a zigzag-delta
+			// timestamp varint (see the lite-05 FRAME format). We don't surface
+			// per-frame timestamps to the application yet, but we must still read
+			// the varint to keep the frame framing in sync with the publisher.
+			const scale = timescale.peek() ?? 0;
+
 			for (;;) {
 				const done = await Promise.race([stream.done(), track.closed, producer.closed]);
 				if (done !== false) break;
+
+				if (scale !== 0) {
+					// Consume (and discard) the per-frame timestamp delta.
+					await stream.u62();
+				}
 
 				const size = await stream.u53();
 				const payload = await stream.read(size);

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1,6 +1,9 @@
 import { Signal } from "@moq/signals";
 import { Group } from "./group.ts";
 
+/** Default {@link Track.cache} window (milliseconds) when the publisher doesn't set one. */
+export const DEFAULT_CACHE_MS = 5000;
+
 export class TrackState {
 	groups = new Signal<Group[]>([]);
 	closed = new Signal<boolean | Error>(false);
@@ -17,6 +20,13 @@ export class Track {
 	 * track is served so the negotiated codec is known when SUBSCRIBE_OK is sent.
 	 */
 	compress = false;
+
+	/**
+	 * How long (milliseconds) the publisher keeps old groups available before
+	 * evicting them. Announced in SUBSCRIBE_OK so relays re-serve with the same
+	 * window. Lite05+ only; older drafts assume {@link DEFAULT_CACHE_MS}.
+	 */
+	cache = DEFAULT_CACHE_MS;
 
 	state = new TrackState();
 	#next?: number;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -485,6 +485,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			end_group: None,
 			compression,
 			timescale,
+			// Announce the publisher's cache window so the subscriber (a relay)
+			// re-serves with the same eviction window. Pre-lite-05 peers ignore it.
+			cache: track.cache,
 		};
 
 		stream.writer.encode(&lite::SubscribeResponse::Ok(info)).await?;
@@ -579,7 +582,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 
 				// next_group respects the cap set via track.end_at and parks
 				// while the next sequence is above the cap. Groups beyond the
-				// cap stay in the producer's cache (bounded by its 5s eviction).
+				// cap stay in the producer's cache (bounded by its cache window).
 				res = track.next_group() => {
 					match res? {
 						Some(group) => self.spawn_serve(group, &mut tasks),

--- a/rs/moq-net/src/lite/subscribe.rs
+++ b/rs/moq-net/src/lite/subscribe.rs
@@ -89,6 +89,11 @@ pub struct SubscribeOk {
 	/// headers omit them). Lite05+ only; older drafts always decode as `None`.
 	/// On the wire `None` is `0` and `Some(n)` is `n`.
 	pub timescale: Option<Timescale>,
+	/// How long the publisher keeps old groups available before evicting them.
+	/// A relay re-serves with the same window and clamps each subscriber's stale
+	/// preference to it. Lite05+ only; older drafts always get
+	/// [`crate::DEFAULT_CACHE`].
+	pub cache: std::time::Duration,
 }
 
 impl Message for SubscribeOk {
@@ -113,6 +118,7 @@ impl Message for SubscribeOk {
 				self.end_group.encode(w, version)?;
 				self.compression.to_code().encode(w, version)?;
 				self.timescale.map(u64::from).unwrap_or(0).encode(w, version)?;
+				self.cache.encode(w, version)?;
 			}
 		}
 
@@ -129,6 +135,7 @@ impl Message for SubscribeOk {
 				end_group: None,
 				compression: Compression::None,
 				timescale: None,
+				cache: crate::DEFAULT_CACHE,
 			}),
 			Version::Lite02 => Ok(Self {
 				priority: 0,
@@ -138,6 +145,7 @@ impl Message for SubscribeOk {
 				end_group: None,
 				compression: Compression::None,
 				timescale: None,
+				cache: crate::DEFAULT_CACHE,
 			}),
 			Version::Lite03 | Version::Lite04 => {
 				let priority = u8::decode(r, version)?;
@@ -154,6 +162,7 @@ impl Message for SubscribeOk {
 					end_group,
 					compression: Compression::None,
 					timescale: None,
+					cache: crate::DEFAULT_CACHE,
 				})
 			}
 			_ => {
@@ -165,6 +174,7 @@ impl Message for SubscribeOk {
 				let compression =
 					Compression::from_code(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)?;
 				let timescale = Timescale::new(u64::decode(r, version)?).ok();
+				let cache = std::time::Duration::decode(r, version)?;
 
 				Ok(Self {
 					priority,
@@ -174,6 +184,7 @@ impl Message for SubscribeOk {
 					end_group,
 					compression,
 					timescale,
+					cache,
 				})
 			}
 		}
@@ -387,6 +398,7 @@ mod test {
 			end_group: None,
 			compression: Compression::Deflate,
 			timescale: Some(Timescale::MICRO),
+			cache: Duration::from_secs(10),
 		}
 	}
 
@@ -442,5 +454,16 @@ mod test {
 		let mut ok = sample();
 		ok.timescale = None;
 		assert_eq!(roundtrip(Version::Lite05Wip, &ok).timescale, None);
+	}
+
+	#[test]
+	fn cache_roundtrips_on_lite05() {
+		assert_eq!(roundtrip(Version::Lite05Wip, &sample()).cache, Duration::from_secs(10));
+	}
+
+	#[test]
+	fn cache_absent_before_lite05() {
+		// Lite04 doesn't carry the cache varint, so it always decodes as the default.
+		assert_eq!(roundtrip(Version::Lite04, &sample()).cache, crate::DEFAULT_CACHE);
 	}
 }

--- a/rs/moq-net/src/lite/subscribe.rs
+++ b/rs/moq-net/src/lite/subscribe.rs
@@ -116,9 +116,10 @@ impl Message for SubscribeOk {
 				self.max_latency.encode(w, version)?;
 				self.start_group.encode(w, version)?;
 				self.end_group.encode(w, version)?;
-				self.compression.to_code().encode(w, version)?;
+				// Order matches draft-lcurley-moq-lite-05 SUBSCRIBE_OK: Timescale, Cache, Compression.
 				self.timescale.map(u64::from).unwrap_or(0).encode(w, version)?;
 				self.cache.encode(w, version)?;
+				self.compression.to_code().encode(w, version)?;
 			}
 		}
 
@@ -171,10 +172,11 @@ impl Message for SubscribeOk {
 				let max_latency = std::time::Duration::decode(r, version)?;
 				let start_group = Option::<u64>::decode(r, version)?;
 				let end_group = Option::<u64>::decode(r, version)?;
-				let compression =
-					Compression::from_code(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)?;
+				// Order matches draft-lcurley-moq-lite-05 SUBSCRIBE_OK: Timescale, Cache, Compression.
 				let timescale = Timescale::new(u64::decode(r, version)?).ok();
 				let cache = std::time::Duration::decode(r, version)?;
+				let compression =
+					Compression::from_code(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)?;
 
 				Ok(Self {
 					priority,

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -602,6 +602,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// path) can validate per-frame timestamps at the model layer.
 		let mut local_info = Track::new(name);
 		local_info.timescale = info.timescale;
+		// Carry the publisher's cache window so the local producer evicts (and
+		// clamps downstream stale windows) with the same bound when re-served.
+		local_info.cache = info.cache;
 		let mut track = match request.accept(local_info) {
 			Ok(track) => track,
 			Err(err) => {

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -23,9 +23,8 @@ use std::{
 	time::Duration,
 };
 
-/// Groups older than this are evicted from the track cache (unless they are the max_sequence group).
-// TODO: Replace with a configurable cache size.
-const MAX_GROUP_AGE: Duration = Duration::from_secs(5);
+/// Default [`Track::cache`] age when the publisher doesn't set one.
+pub const DEFAULT_CACHE: Duration = Duration::from_secs(5);
 
 /// Publisher-side properties of a track.
 ///
@@ -33,7 +32,7 @@ const MAX_GROUP_AGE: Duration = Duration::from_secs(5);
 /// while the track is alive. A subscriber learns them via
 /// [`BroadcastConsumer::consume_track`](crate::BroadcastConsumer::consume_track),
 /// which returns the publisher's [`Track`] once the subscription is accepted.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Track {
 	/// Identifier within a broadcast. Unique per [`crate::Broadcast`].
@@ -52,6 +51,52 @@ pub struct Track {
 	/// the wrong scale prevents silent corruption.
 	#[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
 	pub timescale: Option<Timescale>,
+	/// How long the publisher keeps old groups available before evicting them
+	/// (the newest group is always retained). A subscriber's
+	/// [`Subscription::stale`] window is clamped to this, since a group can't be
+	/// waited for longer than it's kept around. Announced in SUBSCRIBE_OK so
+	/// relays re-serve with the same window. Defaults to [`DEFAULT_CACHE`].
+	#[cfg_attr(
+		feature = "serde",
+		serde(
+			default = "default_cache",
+			skip_serializing_if = "is_default_cache",
+			with = "cache_millis"
+		)
+	)]
+	pub cache: Duration,
+}
+
+impl Default for Track {
+	fn default() -> Self {
+		Self::new(String::new())
+	}
+}
+
+#[cfg(feature = "serde")]
+fn default_cache() -> Duration {
+	DEFAULT_CACHE
+}
+
+#[cfg(feature = "serde")]
+fn is_default_cache(cache: &Duration) -> bool {
+	*cache == DEFAULT_CACHE
+}
+
+/// Serialize [`Track::cache`] as a bare integer of milliseconds, matching the
+/// catalog's other durations (and the wire), rather than serde's `{secs, nanos}`.
+#[cfg(feature = "serde")]
+mod cache_millis {
+	use std::time::Duration;
+
+	pub fn serialize<S: serde::Serializer>(cache: &Duration, s: S) -> Result<S::Ok, S::Error> {
+		s.serialize_u64(cache.as_millis() as u64)
+	}
+
+	pub fn deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+		let ms = <u64 as serde::Deserialize>::deserialize(d)?;
+		Ok(Duration::from_millis(ms))
+	}
 }
 
 impl Track {
@@ -61,6 +106,7 @@ impl Track {
 			name: name.into(),
 			compress: false,
 			timescale: None,
+			cache: DEFAULT_CACHE,
 		}
 	}
 
@@ -76,6 +122,19 @@ impl Track {
 	pub fn with_timescale(mut self, timescale: Timescale) -> Self {
 		self.timescale = Some(timescale);
 		self
+	}
+
+	/// Set how long old groups stay available before eviction, returning `self` for chaining.
+	pub fn with_cache(mut self, cache: Duration) -> Self {
+		self.cache = cache;
+		self
+	}
+
+	/// Clamp a subscriber's stale window to this track's [`Self::cache`]: a
+	/// subscriber can't wait for a late group longer than the publisher keeps it.
+	/// `Duration::ZERO` (skip immediately) is left untouched by the `min`.
+	fn clamp_stale(&self, stale: Duration) -> Duration {
+		stale.min(self.cache)
 	}
 
 	/// Consume this [`Track`] to create a producer that owns its metadata.
@@ -333,13 +392,13 @@ impl State {
 		}
 	}
 
-	/// Evict groups older than MAX_GROUP_AGE, never evicting the max_sequence group.
+	/// Evict groups older than `max_age`, never evicting the max_sequence group.
 	///
 	/// Groups are in arrival order, so we can stop early when we hit a non-expired,
 	/// non-max_sequence group (everything after it arrived even later).
 	/// When max_sequence is at the front, we skip past it and tombstone expired groups
 	/// behind it.
-	fn evict_expired(&mut self, now: tokio::time::Instant) {
+	fn evict_expired(&mut self, now: tokio::time::Instant, max_age: Duration) {
 		for slot in self.groups.iter_mut() {
 			let Some((group, created_at)) = slot else { continue };
 
@@ -347,7 +406,7 @@ impl State {
 				continue;
 			}
 
-			if now.duration_since(*created_at) <= MAX_GROUP_AGE {
+			if now.duration_since(*created_at) <= max_age {
 				break;
 			}
 
@@ -469,7 +528,7 @@ impl TrackProducer {
 		let now = tokio::time::Instant::now();
 		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(group.sequence));
 		state.groups.push_back(Some((group.clone(), now)));
-		state.evict_expired(now);
+		state.evict_expired(now, self.info.cache);
 
 		Ok(group)
 	}
@@ -493,7 +552,7 @@ impl TrackProducer {
 		state.duplicates.insert(sequence);
 		state.max_sequence = Some(sequence);
 		state.groups.push_back(Some((group.clone(), now)));
-		state.evict_expired(now);
+		state.evict_expired(now, self.info.cache);
 
 		Ok(group)
 	}
@@ -555,7 +614,8 @@ impl TrackProducer {
 	///
 	/// The preferences feed the producer's [`Self::subscription`] aggregate and
 	/// can be changed later via [`TrackSubscriber::update`].
-	pub fn subscribe(&self, subscription: Subscription) -> TrackSubscriber {
+	pub fn subscribe(&self, mut subscription: Subscription) -> TrackSubscriber {
+		subscription.stale = self.info.clamp_stale(subscription.stale);
 		let subscription = Arc::new(Mutex::new(subscription));
 		if let Ok(mut state) = self.state.write() {
 			state.subscriptions.push(Arc::downgrade(&subscription));
@@ -664,7 +724,8 @@ impl TrackWeak {
 		self.state.is_closed()
 	}
 
-	pub fn subscribe(&self, subscription: Subscription) -> TrackSubscriber {
+	pub fn subscribe(&self, mut subscription: Subscription) -> TrackSubscriber {
+		subscription.stale = self.info.clamp_stale(subscription.stale);
 		let subscription = Arc::new(Mutex::new(subscription));
 		// Register the preference if the producer is still alive so it shows up
 		// in the aggregate; otherwise the consumer will just observe close.
@@ -886,7 +947,8 @@ impl TrackSubscriber {
 	}
 
 	/// Replace this subscriber's preferences, updating the producer's aggregate.
-	pub fn update(&self, subscription: Subscription) {
+	pub fn update(&self, mut subscription: Subscription) {
+		subscription.stale = self.info.clamp_stale(subscription.stale);
 		*self.subscription.lock().unwrap() = subscription;
 	}
 
@@ -981,7 +1043,7 @@ mod test {
 		}
 
 		// Advance time past the eviction threshold.
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 
 		// Append a new group to trigger eviction.
 		producer.append_group().unwrap(); // seq 3
@@ -1008,7 +1070,7 @@ mod test {
 		producer.append_group().unwrap(); // seq 0
 
 		// Advance time past threshold.
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 
 		// Append another group; seq 0 is expired and evicted.
 		producer.append_group().unwrap(); // seq 1
@@ -1046,12 +1108,47 @@ mod test {
 
 		let mut consumer = producer.subscribe_default();
 
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 		producer.append_group().unwrap(); // seq 1
 
 		// Group 0 was evicted. Consumer should get group 1.
 		let group = consumer.assert_group();
 		assert_eq!(group.sequence, 1);
+	}
+
+	#[tokio::test]
+	async fn cache_age_controls_eviction() {
+		tokio::time::pause();
+
+		// A shorter cache evicts sooner than the default.
+		let mut producer = Track::new("test").with_cache(Duration::from_secs(1)).produce();
+		producer.append_group().unwrap(); // seq 0
+
+		// Past the custom cache but well within DEFAULT_CACHE.
+		tokio::time::advance(Duration::from_secs(2)).await;
+		producer.append_group().unwrap(); // seq 1
+
+		// Seq 0 is gone because the publisher only keeps groups for 1s.
+		let state = producer.state.read();
+		assert_eq!(live_groups(&state), 1);
+		assert_eq!(first_live_sequence(&state), 1);
+	}
+
+	#[test]
+	fn stale_clamped_to_cache() {
+		let producer = Track::new("test").with_cache(Duration::from_secs(2)).produce();
+
+		// A stale window beyond the cache is capped to the cache; a group can't be
+		// waited for longer than the publisher keeps it.
+		let subscriber = producer.subscribe(Subscription::default().with_stale(Duration::from_secs(10)));
+		assert_eq!(subscriber.subscription().stale, Duration::from_secs(2));
+
+		// A window within the cache is left alone, and ZERO (skip immediately) stays ZERO.
+		subscriber.update(Subscription::default().with_stale(Duration::from_millis(500)));
+		assert_eq!(subscriber.subscription().stale, Duration::from_millis(500));
+
+		subscriber.update(Subscription::default().with_stale(Duration::ZERO));
+		assert_eq!(subscriber.subscription().stale, Duration::ZERO);
 	}
 
 	#[tokio::test]
@@ -1072,7 +1169,7 @@ mod test {
 		}
 
 		// Expire all three groups.
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 
 		// Append seq 6 (becomes new max_sequence).
 		producer.append_group().unwrap(); // seq 6
@@ -1099,7 +1196,7 @@ mod test {
 		// Arrive: seq 5, then seq 3.
 		producer.create_group(Group { sequence: 5 }).unwrap();
 
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 
 		// Seq 3 arrives late; max_sequence is still 5 (at front).
 		producer.create_group(Group { sequence: 3 }).unwrap();
@@ -1113,7 +1210,7 @@ mod test {
 		}
 
 		// Expire seq 3 as well.
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 
 		// Seq 2 arrives late, triggering eviction.
 		producer.create_group(Group { sequence: 2 }).unwrap();


### PR DESCRIPTION
## Summary

Adds a publisher-controlled **cache age** to `Track` (replacing the hard-coded 5s group-eviction window), announced in lite-05 `SUBSCRIBE_OK` so relays re-serve with the same window; each subscriber's `stale` window is clamped to it. Also reconciles the `SUBSCRIBE_OK` field order with the draft and ports timescale negotiation to js/net so JS↔Rust lite-05 is wire-compatible again.

Implements `Publisher Cache` from the moq-lite-05 draft ([moq-dev/drafts#23](https://github.com/moq-dev/drafts/pull/23)): "max age, in ms, of the oldest group the publisher will retain," analogous to HTTP `Cache-Control: max-age`.

### Cache age
- **`rs/moq-net` model**: `MAX_GROUP_AGE` → `pub const DEFAULT_CACHE` (5s). New `Track.cache: Duration` (default 5s, `with_cache`, manual `Default`, serde as integer-ms skipping default). `evict_expired` uses `Track.cache`. `stale` clamped to `cache` in `TrackProducer::subscribe`, `TrackWeak::subscribe`, `TrackSubscriber::update`.
- **publisher/subscriber**: publisher announces `track.cache`; subscriber stamps `info.cache` onto the reconstructed local `Track`.
- **`js/net`**: mirrored `Track.cache` + `SUBSCRIBE_OK` wire field.

### SUBSCRIBE_OK field order (reconciled with the draft)
The draft orders the trailing fields `Timescale, Cache, Compression`, but the merged timescale impl (#1439) emitted `Compression, Timescale`. Per the draft, both Rust and JS now encode/decode **`Timescale, Cache, Compression`**. lite-05 is WIP/unreleased, so this additive + reorder needs no version bump.

### Timescale port to js/net
PR #1439 added per-frame timestamps to the Rust moq-net wire but never touched js/net, leaving JS↔Rust lite-05 wire-incompatible. This PR:
- adds `timescale` to the JS `SUBSCRIBE_OK`, and
- has the JS group-stream reader consume the per-frame zigzag-delta timestamp varint when the negotiated timescale is non-zero, keeping frame framing in sync with a timestamped (Rust) publisher.

js/net doesn't yet **surface or produce** per-frame moq-net timestamps (it reads media timestamps from the container payload), so JS publishers advertise `timescale = 0` and the decoded delta is read only to stay in sync. Fully surfacing/producing per-frame timestamps in JS (the js/hang container migration that Rust did across moq-mux) is a separate follow-up.

## Open items for the draft author
- **`Duration Delta`**: draft PR #23 adds both `Timestamp Delta` and `Duration Delta` to FRAME, but the merged Rust impl (#1439) only implements `Timestamp Delta`. This PR matches the shipped Rust wire (timestamp-delta only). The draft should either drop `Duration Delta` or it should be implemented in Rust first.

## Test plan
- [x] `cargo test -p moq-net` (350 pass) incl. `cache_age_controls_eviction`, `stale_clamped_to_cache`, `cache_roundtrips_on_lite05`, `cache_absent_before_lite05`
- [x] `cargo test -p hang` (catalog round-trips unaffected; `cache` skipped at default)
- [x] `just rs check` (clippy `-D warnings` + rustfmt)
- [x] `just js check` + biome; `bun test` in js/net (149 pass) incl. updated SUBSCRIBE_OK round-trip (timescale + cache + compression) and integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)