### PR TITLE
libmoq: expose moq_error(), stop logging FFI errors

### DIFF
--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -54,6 +54,21 @@ The matching `*_close` function only *requests* shutdown: it returns immediately
 
 Because the terminal callback runs on libmoq's thread, bindings that own thread-affine objects (e.g. a Qt `QObject`) should hop to the owning thread to perform the actual destruction; the `user_data` lifetime contract holds regardless of which thread tears the object down.
 
+## Error handling
+
+Functions return a negative code on failure (`0` or a positive handle on success). The code identifies the kind of failure, but the human-readable reason is available separately via `moq_error()`:
+
+```c
+int rc = moq_consume_catalog_close(catalog);
+if (rc < 0) {
+    fprintf(stderr, "close failed: %s\n", moq_error());
+}
+```
+
+`moq_error()` returns the reason for the most recent failed call **on the calling thread**, including detail the numeric code can't carry (which URL failed to parse, why a decode failed, etc.). The returned pointer is valid until the next libmoq call on that thread, so copy it if you need to keep it. It is only meaningful after a call returned a negative code; check the code first. Errors delivered through status callbacks carry their code directly, so read `moq_error()` from inside the callback if you want the matching reason.
+
+Failed calls are reported only through the return code and `moq_error()`, not logged. To surface libmoq's internal logs (moq-net / QUIC activity), call `moq_log_level("debug")` (or `"trace"`, `"info"`, etc.) to install a tracing subscriber.
+
 ## Use cases
 
 - **C/C++ applications** integrating MoQ without a Rust toolchain

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -104,6 +104,22 @@ pub unsafe extern "C" fn moq_log_level(level: *const c_char, level_len: usize) -
 	})
 }
 
+/// Human-readable reason for the most recent failed call on the calling thread.
+///
+/// libmoq functions return only a negative code; this exposes the matching message
+/// (including detail the code can't carry, e.g. which URL failed to parse or why a
+/// decode failed). The string is only meaningful after a call returned a negative
+/// code; check the code first.
+///
+/// Returns a NUL-terminated, UTF-8 pointer valid until the next libmoq call **on the
+/// same thread**, or NULL if no error has been recorded on this thread. Copy it if you
+/// need it to outlive the next call. Errors delivered through status callbacks carry
+/// their code directly; read this from inside the callback to get their reason.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_error() -> *const c_char {
+	ffi::last_error_ptr()
+}
+
 /// Start establishing a connection to a MoQ server.
 ///
 /// Takes origin handles, which are used for publishing and consuming broadcasts respectively.

--- a/rs/libmoq/src/error.rs
+++ b/rs/libmoq/src/error.rs
@@ -155,8 +155,11 @@ impl From<moq_mux::Error> for Error {
 }
 
 impl ffi::ReturnCode for Error {
+	fn error(&self) -> Option<&Error> {
+		Some(self)
+	}
+
 	fn code(&self) -> i32 {
-		tracing::error!("{}", self);
 		match self {
 			Error::Moq(_) => -2,
 			Error::Url(_) => -3,

--- a/rs/libmoq/src/ffi.rs
+++ b/rs/libmoq/src/ffi.rs
@@ -1,5 +1,6 @@
 use std::{
-	ffi::{c_char, c_void},
+	cell::RefCell,
+	ffi::{CString, c_char, c_void},
 	sync::{LazyLock, Mutex},
 };
 
@@ -36,8 +37,14 @@ pub fn enter<C: ReturnCode, F: FnOnce() -> C>(f: F) -> i32 {
 	let _guard = handle.enter();
 
 	match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
-		Ok(ret) => ret.code(),
-		Err(_) => Error::Panic.code(),
+		Ok(ret) => {
+			record_error(&ret);
+			ret.code()
+		}
+		Err(_) => {
+			record_error(&Error::Panic);
+			Error::Panic.code()
+		}
 	}
 }
 
@@ -65,9 +72,14 @@ impl OnStatus {
 	}
 
 	/// Invoke the callback with a result code.
+	///
+	/// We record the reason before invoking the callback (on the same thread)
+	/// so a callback receiving a negative code can read `moq_error()` for it.
 	pub fn call<C: ReturnCode>(&self, ret: C) {
+		record_error(&ret);
+		let code = ret.code();
 		if let Some(on_status) = &self.on_status {
-			on_status(self.user_data, ret.code());
+			on_status(self.user_data, code);
 		}
 	}
 }
@@ -78,6 +90,12 @@ unsafe impl Send for OnStatus {}
 pub trait ReturnCode {
 	/// Convert to an i32 status code.
 	fn code(&self) -> i32;
+
+	/// The error this carries, if any, so the boundary can record its reason
+	/// for `moq_error`. Defaults to none for non-fallible return types.
+	fn error(&self) -> Option<&Error> {
+		None
+	}
 }
 
 impl ReturnCode for () {
@@ -100,6 +118,10 @@ impl ReturnCode for Result<i32, Error> {
 			Err(e) => e.code(),
 		}
 	}
+
+	fn error(&self) -> Option<&Error> {
+		self.as_ref().err()
+	}
 }
 
 impl ReturnCode for Result<usize, Error> {
@@ -108,6 +130,10 @@ impl ReturnCode for Result<usize, Error> {
 			Ok(code) => i32::try_from(*code).unwrap_or_else(|_| Error::InvalidCode.code()),
 			Err(e) => e.code(),
 		}
+	}
+
+	fn error(&self) -> Option<&Error> {
+		self.as_ref().err()
 	}
 }
 
@@ -118,6 +144,10 @@ impl ReturnCode for Result<Id, Error> {
 			Err(e) => e.code(),
 		}
 	}
+
+	fn error(&self) -> Option<&Error> {
+		self.as_ref().err()
+	}
 }
 
 impl ReturnCode for Result<(), Error> {
@@ -126,6 +156,10 @@ impl ReturnCode for Result<(), Error> {
 			Ok(()) => 0,
 			Err(e) => e.code(),
 		}
+	}
+
+	fn error(&self) -> Option<&Error> {
+		self.as_ref().err()
 	}
 }
 
@@ -139,6 +173,33 @@ impl ReturnCode for Id {
 	fn code(&self) -> i32 {
 		i32::from(*self)
 	}
+}
+
+thread_local! {
+	/// Reason for the most recent error returned on this thread. FFI functions
+	/// hand back only a numeric code, so we stash the human-readable message
+	/// here for `moq_error` to retrieve.
+	static LAST_ERROR: RefCell<Option<CString>> = const { RefCell::new(None) };
+}
+
+/// Record the reason for an error return into this thread's `moq_error` slot.
+///
+/// Called at the FFI boundary (sync return and callback dispatch) right before
+/// the numeric code is produced, so the conversion in `code()` stays pure.
+fn record_error<C: ReturnCode>(ret: &C) {
+	let Some(err) = ret.error() else { return };
+	// CString::new fails only on an interior NUL, which our messages never
+	// contain; skip storing rather than truncating if it ever happens.
+	if let Ok(msg) = CString::new(err.to_string()) {
+		LAST_ERROR.with(|cell| *cell.borrow_mut() = Some(msg));
+	}
+}
+
+/// Pointer to this thread's last error message, or null if none was recorded.
+///
+/// The pointer is valid until the next libmoq call on the same thread.
+pub fn last_error_ptr() -> *const c_char {
+	LAST_ERROR.with(|cell| cell.borrow().as_ref().map_or(std::ptr::null(), |msg| msg.as_ptr()))
 }
 
 /// Parse an i32 handle into an Id.

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -95,6 +95,37 @@ fn origin_lifecycle() {
 }
 
 #[test]
+fn last_error_reports_reason() {
+	// A failed call records a retrievable reason string for moq_error().
+	assert!(moq_origin_close(9999) < 0);
+	let ptr = moq_error();
+	assert!(!ptr.is_null(), "expected a recorded error message");
+	let msg = unsafe { std::ffi::CStr::from_ptr(ptr) }.to_str().unwrap();
+	assert_eq!(msg, "origin not found");
+}
+
+#[test]
+fn last_error_set_before_callback() {
+	use crate::Error;
+	use crate::ffi::OnStatus;
+
+	// A binding reads moq_error() from inside the callback; the reason for a
+	// negative status must already be recorded by the time the callback runs.
+	extern "C" fn capture(user_data: *mut c_void, code: i32) {
+		assert!(code < 0, "expected a negative status, got {code}");
+		let slot = unsafe { &mut *(user_data as *mut Option<String>) };
+		let ptr = moq_error();
+		*slot = (!ptr.is_null()).then(|| unsafe { std::ffi::CStr::from_ptr(ptr) }.to_str().unwrap().to_owned());
+	}
+
+	let mut captured: Option<String> = None;
+	let cb = unsafe { OnStatus::new(&mut captured as *mut _ as *mut c_void, Some(capture)) };
+	cb.call(Err::<(), Error>(Error::OriginNotFound));
+
+	assert_eq!(captured.as_deref(), Some("origin not found"));
+}
+
+#[test]
 fn publish_media_lifecycle() {
 	let broadcast = id(moq_publish_create());
 	let _guard = Guard(Some(|| {


### PR DESCRIPTION
## Summary

libmoq's FFI returns only a numeric code, so the human-readable reason for a failure was reachable only through `Error::code()`'s unconditional `tracing::error!`. Two problems with that:

- **Noise.** Routine lookup misses logged at error level. The motivating case: closing a track/catalog right as the session drops, where libmoq's background task removed its slab entry a hair before the `*_close` call, so the close returns a benign `*NotFound` that got logged as an error.
- **Reason invisible by default.** The string was only emitted if the caller had installed a tracing subscriber via `moq_log_level`. With no subscriber (the default), a caller saw just the `i32` and lost the detail the code can't carry (which URL failed to parse, why a decode failed, etc.).

This adds a proper retrieval path and removes the logging:

- New **`moq_error() -> *const c_char`**, errno/strerror style. Returns the reason for the most recent failed call **on the calling thread**, recorded into a thread-local. The pointer is valid until the next libmoq call on that thread and is only meaningful after a negative return (check the code first).
- **Works for callbacks.** The reason is recorded at the FFI boundary right before the code is handed back, so a callback receiving a negative status can read `moq_error()` for the reason. Read it from inside the callback if you marshal to another thread afterward.
- **Recording is an explicit boundary step, not a `code()` side effect.** `ReturnCode` gains an `error()` accessor; `enter` and `OnStatus::call` call a `record_error()` helper before producing the numeric code, so `code()` stays a pure `Error -> i32` conversion. The unconditional logging is gone; `moq_log_level` still governs the moq-net / QUIC internal logs.

The `*_close` race itself is unchanged: a close landing after the task self-terminated still returns its truthful negative code. That's correct (there was nothing left to close); it just no longer spams the log, and the reason is now retrievable on demand. (This supersedes earlier explorations of idempotent close and typed handles, which were dropped as over-engineering for what is fundamentally a logging/observability gap.)

## Changes

- `rs/libmoq/src/ffi.rs` — thread-local `LAST_ERROR` + `record_error()` (boundary helper) + `last_error_ptr()`; `ReturnCode::error()` accessor; `enter` and `OnStatus::call` record before converting to a code.
- `rs/libmoq/src/error.rs` — `Error::code()` is a pure conversion again (no logging); `error()` returns `Some(self)`.
- `rs/libmoq/src/api.rs` — `moq_error()` (regenerates `const char *moq_error(void);` in `moq.h` via cbindgen).
- `rs/libmoq/src/test.rs` — `last_error_reports_reason` (sync path) and `last_error_set_before_callback` (drives `OnStatus::call` directly to assert the reason is visible inside a negative-status callback).
- `doc/lib/c/index.md` — new "Error handling" section.

## Test plan

- [x] `cargo build -p libmoq` (regenerates `moq.h` with `moq_error`)
- [x] `cargo test -p libmoq` — 23 passed
- [x] `cargo clippy -p libmoq --all-targets` — clean
- [x] `cargo fmt -p libmoq`

(all via `nix develop` to match CI's pinned toolchain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)