### PR TITLE
moq-boy: exit non-zero on reconnect give-up instead of hanging

### DIFF
--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -449,7 +449,7 @@ async fn main() -> Result<()> {
 	let result = tokio::select! {
 		res = run(&config) => res,
 		Err(err) = jemalloc => Err(err).context("jemalloc profiler failed"),
-		_ = tokio::signal::ctrl_c() => Ok(()),
+		res = tokio::signal::ctrl_c() => res.context("failed to listen for ctrl-c"),
 	};
 
 	// run() owns a spawn_blocking emulator thread that loops forever. Returning from main

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -446,9 +446,21 @@ async fn main() -> Result<()> {
 	#[cfg(not(feature = "jemalloc"))]
 	let jemalloc = std::future::pending::<anyhow::Result<()>>();
 
-	tokio::select! {
+	let result = tokio::select! {
 		res = run(&config) => res,
 		Err(err) = jemalloc => Err(err).context("jemalloc profiler failed"),
-		_ = tokio::signal::ctrl_c() => std::process::exit(0),
+		_ = tokio::signal::ctrl_c() => Ok(()),
+	};
+
+	// run() owns a spawn_blocking emulator thread that loops forever. Returning from main
+	// drops the tokio runtime, whose drop blocks indefinitely joining that thread, so the
+	// process would hang instead of exiting (defeating systemd Restart=always when the
+	// reconnect loop gives up). Exit explicitly so a real exit code reaches the supervisor.
+	match result {
+		Ok(()) => std::process::exit(0),
+		Err(err) => {
+			tracing::error!(err = %format!("{err:#}"), "exiting");
+			std::process::exit(1);
+		}
 	}
 }


### PR DESCRIPTION
## Problem

moq-boy gives up reconnecting to the relay after the mandatory 5m backoff timeout (added in #1443), but the process **doesn't exit** — it hangs as a zombie. This defeats systemd's `Restart=always`, so a relay outage (or any future deploy/relay rebuild) longer than the reconnect window silently kills the games and they never come back.

### Root cause

The emulator runs on a `spawn_blocking` thread that loops forever (`rs/moq-boy/src/main.rs:274`). When the reconnect loop gives up, `run()` returns `Err`, `main` returns it, and the tokio runtime is dropped. Dropping the runtime **blocks indefinitely joining that never-ending blocking thread**, so the process hangs instead of exiting. The `ctrl_c` branch already side-stepped this with an explicit `std::process::exit(0)`; the give-up path did not.

## Fix

Capture the `select!` result and exit explicitly via `std::process::exit` (0 on clean shutdown, 1 on error) instead of returning from `main`. `process::exit` terminates immediately without dropping the runtime, so it can't hang on the blocking thread, and a real non-zero exit code reaches systemd. The give-up error is logged on the way out.

The 5m timeout is kept as-is (a permanent relay outage still surfaces as a non-zero exit rather than silently spinning forever), so `Restart=always` now correctly restarts the service.

## moq-cli

No change needed. moq-cli has no `spawn_blocking` task, so returning `Err` from `main` already exits non-zero cleanly. It shares the same 5m give-up shape but never happened to hit the window.

## Test plan

- [x] `cargo check -p moq-boy`
- [x] `cargo clippy -p moq-boy` (via nix toolchain)

(Written by Claude)