### PR TITLE
moq-mux: support out-of-band avc1/hvc1 in MPEG-TS export

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -142,9 +142,10 @@ ffmpeg -i input.mp4 -c copy -f mpegts - | \
 moq-cli subscribe --url https://relay.example.com --broadcast my-stream --format ts | ffplay -
 ```
 
-TS export carries H.264 / H.265 as Annex-B and AAC as ADTS. It needs in-band
-video (avc3 / hev1), which is what the moq-cli importers produce; out-of-band
-avc1 / hvc1 sources are rejected.
+TS export carries H.264 / H.265 as Annex-B and AAC as ADTS. Both in-band
+(avc3 / hev1) and out-of-band (avc1 / hvc1, e.g. from an fMP4 import) video
+sources work: the parameter sets are read from the bitstream or the catalog
+`description` and re-injected as Annex-B on each keyframe.
 
 ## Authentication
 

--- a/rs/moq-mux/src/codec/annexb.rs
+++ b/rs/moq-mux/src/codec/annexb.rs
@@ -54,6 +54,31 @@ impl<'a, T: Buf + AsRef<[u8]> + 'a> Iterator for NalIterator<'a, T> {
 	}
 }
 
+/// Rewrite a length-prefixed NALU buffer (avc1/hvc1 sample, each NAL preceded
+/// by a `length_size`-byte big-endian length) into Annex-B by replacing every
+/// length prefix with a 4-byte start code. This is the inverse of the
+/// length-prefixing done by [`crate::codec::h264::Avc1`] / [`crate::codec::h265::Hvc1`].
+pub fn length_prefixed_to_annexb(mut data: &[u8], length_size: usize, out: &mut Vec<u8>) -> anyhow::Result<()> {
+	anyhow::ensure!((1..=4).contains(&length_size), "invalid NALU length size {length_size}");
+	while !data.is_empty() {
+		anyhow::ensure!(data.len() >= length_size, "truncated NALU length prefix");
+		let mut len = 0usize;
+		for &b in &data[..length_size] {
+			len = (len << 8) | b as usize;
+		}
+		data = &data[length_size..];
+		anyhow::ensure!(
+			data.len() >= len,
+			"NALU length {len} exceeds {} remaining bytes",
+			data.len()
+		);
+		out.extend_from_slice(&START_CODE);
+		out.extend_from_slice(&data[..len]);
+		data = &data[len..];
+	}
+	Ok(())
+}
+
 // Return the size of the start code at the start of the buffer.
 pub fn after_start_code(b: &[u8]) -> anyhow::Result<Option<usize>> {
 	if b.len() < 3 {
@@ -139,6 +164,23 @@ pub fn find_start_code(mut b: &[u8]) -> Option<(usize, usize)> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn length_prefixed_to_annexb_rewrites_prefixes() {
+		// Two 4-byte-length-prefixed NALs -> two start-code-delimited NALs.
+		let input = [0, 0, 0, 2, 0x67, 0x42, 0, 0, 0, 3, 0x68, 0xce, 0x3c];
+		let mut out = Vec::new();
+		length_prefixed_to_annexb(&input, 4, &mut out).unwrap();
+		assert_eq!(out, vec![0, 0, 0, 1, 0x67, 0x42, 0, 0, 0, 1, 0x68, 0xce, 0x3c]);
+	}
+
+	#[test]
+	fn length_prefixed_to_annexb_rejects_truncated() {
+		// Declared length (5) overruns the buffer.
+		let input = [0, 0, 0, 5, 0x67];
+		let mut out = Vec::new();
+		assert!(length_prefixed_to_annexb(&input, 4, &mut out).is_err());
+	}
 
 	// Tests for after_start_code - validates and measures start code at buffer beginning
 

--- a/rs/moq-mux/src/codec/h264/mod.rs
+++ b/rs/moq-mux/src/codec/h264/mod.rs
@@ -145,6 +145,39 @@ pub(crate) fn build_avcc(sps_nal: &[u8], pps_nal: &[u8]) -> anyhow::Result<Bytes
 	Ok(out.freeze())
 }
 
+/// Extract the parameter-set NALs (SPS then PPS) and the NALU length size from
+/// an AVCDecoderConfigurationRecord. The inverse of [`build_avcc`]; used to
+/// re-emit out-of-band avc1 parameter sets as inline Annex-B (e.g. for MPEG-TS).
+pub(crate) fn avcc_params(avcc: &[u8]) -> anyhow::Result<(usize, Vec<Bytes>)> {
+	anyhow::ensure!(avcc.len() >= 6, "AVCDecoderConfigurationRecord too short");
+	let length_size = (avcc[4] & 0x03) as usize + 1;
+
+	let mut params = Vec::new();
+	let num_sps = avcc[5] & 0x1f;
+	let mut pos = read_param_set_array(avcc, 6, num_sps as usize, &mut params)?;
+
+	anyhow::ensure!(avcc.len() > pos, "avcC missing PPS count");
+	let num_pps = avcc[pos];
+	pos += 1;
+	read_param_set_array(avcc, pos, num_pps as usize, &mut params)?;
+
+	Ok((length_size, params))
+}
+
+/// Read `count` u16-length-prefixed NALs starting at `pos`, appending each to
+/// `params`. Returns the offset just past the last NAL read.
+fn read_param_set_array(buf: &[u8], mut pos: usize, count: usize, params: &mut Vec<Bytes>) -> anyhow::Result<usize> {
+	for _ in 0..count {
+		anyhow::ensure!(buf.len() >= pos + 2, "truncated parameter-set length");
+		let len = u16::from_be_bytes([buf[pos], buf[pos + 1]]) as usize;
+		pos += 2;
+		anyhow::ensure!(buf.len() >= pos + len, "parameter-set NAL exceeds buffer");
+		params.push(Bytes::copy_from_slice(&buf[pos..pos + len]));
+		pos += len;
+	}
+	Ok(pos)
+}
+
 /// Transform H.264 frames from Annex-B (inline SPS/PPS, "avc3") to
 /// length-prefixed NALU (out-of-band AVCDecoderConfigurationRecord, "avc1").
 ///
@@ -304,6 +337,20 @@ mod tests {
 		expected.extend_from_slice(&(idr.len() as u32).to_be_bytes());
 		expected.extend_from_slice(idr);
 		assert_eq!(out.as_ref(), expected.as_ref());
+	}
+
+	#[test]
+	fn avcc_params_roundtrips_build_avcc() {
+		let sps = &[0x67, 0x42, 0xc0, 0x1f, 0xde][..];
+		let pps = &[0x68, 0xce, 0x3c, 0x80][..];
+
+		let avcc = build_avcc(sps, pps).unwrap();
+		let (length_size, params) = avcc_params(&avcc).unwrap();
+
+		assert_eq!(length_size, 4);
+		assert_eq!(params.len(), 2);
+		assert_eq!(params[0].as_ref(), sps);
+		assert_eq!(params[1].as_ref(), pps);
 	}
 
 	#[test]

--- a/rs/moq-mux/src/codec/h265/mod.rs
+++ b/rs/moq-mux/src/codec/h265/mod.rs
@@ -185,6 +185,36 @@ pub(crate) fn build_hvcc(vps_nal: &[u8], sps_nal: &[u8], pps_nal: &[u8]) -> anyh
 	Ok(out.freeze())
 }
 
+/// Extract the parameter-set NALs (VPS, SPS, PPS in array order) and the NALU
+/// length size from an HEVCDecoderConfigurationRecord. The inverse of
+/// [`build_hvcc`]; used to re-emit out-of-band hvc1 parameter sets as inline
+/// Annex-B (e.g. for MPEG-TS).
+pub(crate) fn hvcc_params(hvcc: &[u8]) -> anyhow::Result<(usize, Vec<Bytes>)> {
+	anyhow::ensure!(hvcc.len() >= 23, "HEVCDecoderConfigurationRecord too short");
+	let length_size = (hvcc[21] & 0x03) as usize + 1;
+	let num_arrays = hvcc[22];
+
+	let mut params = Vec::new();
+	let mut pos = 23;
+	for _ in 0..num_arrays {
+		// Skip the array_completeness | NAL_unit_type byte.
+		anyhow::ensure!(hvcc.len() >= pos + 3, "truncated hvcC NAL array header");
+		pos += 1;
+		let num_nalus = u16::from_be_bytes([hvcc[pos], hvcc[pos + 1]]);
+		pos += 2;
+		for _ in 0..num_nalus {
+			anyhow::ensure!(hvcc.len() >= pos + 2, "truncated hvcC NAL length");
+			let len = u16::from_be_bytes([hvcc[pos], hvcc[pos + 1]]) as usize;
+			pos += 2;
+			anyhow::ensure!(hvcc.len() >= pos + len, "hvcC NAL exceeds buffer");
+			params.push(Bytes::copy_from_slice(&hvcc[pos..pos + len]));
+			pos += len;
+		}
+	}
+
+	Ok((length_size, params))
+}
+
 /// Pack the constraint flags from ITU H.265 V10 §7.3.3 Profile, tier and level syntax.
 pub(crate) fn pack_constraint_flags(profile: &scuffle_h265::Profile) -> [u8; 6] {
 	let mut flags = [0u8; 6];
@@ -193,4 +223,41 @@ pub(crate) fn pack_constraint_flags(profile: &scuffle_h265::Profile) -> [u8; 6] 
 		| ((profile.non_packed_constraint_flag as u8) << 5)
 		| ((profile.frame_only_constraint_flag as u8) << 4);
 	flags
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Hand-build an hvcC (the layout `build_hvcc` emits) and assert the
+	/// parameter sets and length size are recovered. Built by hand rather than
+	/// via `build_hvcc` so it doesn't need a real, parseable HEVC SPS.
+	#[test]
+	fn hvcc_params_parses_vps_sps_pps() {
+		let vps = &[0x40, 0x01, 0x0c][..]; // NAL type 32
+		let sps = &[0x42, 0x01, 0x01, 0x60][..]; // NAL type 33
+		let pps = &[0x44, 0x01, 0xc0][..]; // NAL type 34
+
+		let mut hvcc = BytesMut::new();
+		hvcc.extend_from_slice(&[0u8; 21]); // fixed fields up to (but not including) byte 21
+		hvcc.put_u8(0xfc | 0x03); // byte 21: ...| lengthSizeMinusOne = 3 -> length_size 4
+		hvcc.put_u8(3); // numOfArrays
+		for (nal_type, nal) in [
+			(u8::from(NALUnitType::VpsNut), vps),
+			(u8::from(NALUnitType::SpsNut), sps),
+			(u8::from(NALUnitType::PpsNut), pps),
+		] {
+			hvcc.put_u8(0x80 | (nal_type & 0x3f));
+			hvcc.put_u16(1); // numNalus
+			hvcc.put_u16(nal.len() as u16);
+			hvcc.put_slice(nal);
+		}
+
+		let (length_size, params) = hvcc_params(&hvcc).unwrap();
+		assert_eq!(length_size, 4);
+		assert_eq!(params.len(), 3);
+		assert_eq!(params[0].as_ref(), vps);
+		assert_eq!(params[1].as_ref(), sps);
+		assert_eq!(params[2].as_ref(), pps);
+	}
 }

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -5,10 +5,12 @@
 //! packetized into 188-byte TS packets. Video is carried as Annex-B, audio as
 //! ADTS AAC.
 //!
-//! Only in-band sources are supported: H.264 (`inline: true`), H.265
-//! (`in_band: true`), and AAC, all in the Legacy/LOC container (raw codec
-//! payloads). Out-of-band avc1/hvc1 (length-prefixed, `description` = avcC/hvcC)
-//! and CMAF tracks are rejected with a clear error.
+//! Video flows through [`ExportSource`], which normalizes every H.264/H.265
+//! source to length-prefixed NALU plus a resolved avcC/hvcC (parsing in-band
+//! avc3/hev1 parameter sets out of the bitstream, or taking the catalog
+//! `description` for out-of-band avc1/hvc1). The muxer then does one
+//! length-prefixed -> Annex-B conversion, re-injecting the parameter sets as
+//! inline NALs on every keyframe. CMAF tracks are rejected with a clear error.
 
 use std::collections::HashMap;
 use std::task::Poll;
@@ -27,8 +29,8 @@ use mpeg2ts::ts::{
 };
 
 use crate::catalog::CatalogFormat;
-use crate::catalog::hang::Container as HangContainer;
-use crate::container::{CatalogSource, Consumer, Frame};
+use crate::codec::annexb;
+use crate::container::{CatalogSource, ExportSource, Frame};
 
 use super::adts;
 
@@ -60,7 +62,7 @@ pub struct Export {
 }
 
 struct Track {
-	consumer: Consumer<HangContainer>,
+	source: ExportSource,
 	pending: Option<Frame>,
 	finished: bool,
 	pid: u16,
@@ -141,7 +143,38 @@ impl Export {
 			}
 		}
 
-		// 2. Emit the program tables once the layout is resolved.
+		// 2. Pull a frame into every idle track. ExportSource has already
+		// transformed Annex-B avc3/hev1 into length-prefixed form and resolved
+		// the avcC/hvcC. Before the program tables are written, drop slices that
+		// arrive before their codec config resolves: a receiver joining mid-GOP
+		// can't use them, and parking them would stop us polling for the keyframe
+		// that carries the parameter sets.
+		let waiting_for_header = self.psi.is_none();
+		for track in self.tracks.values_mut() {
+			if track.pending.is_some() || track.finished {
+				continue;
+			}
+			loop {
+				match track.source.poll_read(waiter) {
+					Poll::Ready(Ok(Some(frame))) => {
+						if waiting_for_header && !track.source.header_ready() {
+							continue;
+						}
+						track.pending = Some(frame);
+						break;
+					}
+					Poll::Ready(Ok(None)) => {
+						track.finished = true;
+						break;
+					}
+					Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+					Poll::Pending => break,
+				}
+			}
+		}
+
+		// 3. Emit the program tables once the layout is resolved and every
+		// track's codec config is ready.
 		if self.psi.is_none() {
 			if self.tracks.is_empty() {
 				// No tracks yet. If the catalog is also done, the broadcast is empty.
@@ -150,22 +183,17 @@ impl Export {
 				}
 				return Poll::Pending;
 			}
+			if !self.header_ready() {
+				// Still waiting on codec configs. If every track finished without
+				// producing one, the broadcast can't be muxed.
+				if self.catalog.is_none() && self.tracks.values().all(|t| t.finished) {
+					return Poll::Ready(Ok(None));
+				}
+				return Poll::Pending;
+			}
 			self.build_psi()?;
 			let header = self.write_psi()?;
 			return Poll::Ready(Ok(Some(header)));
-		}
-
-		// 3. Pull a frame into every idle track.
-		for track in self.tracks.values_mut() {
-			if track.pending.is_some() || track.finished {
-				continue;
-			}
-			match track.consumer.poll_read(waiter) {
-				Poll::Ready(Ok(Some(frame))) => track.pending = Some(frame),
-				Poll::Ready(Ok(None)) => track.finished = true,
-				Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
-				Poll::Pending => {}
-			}
 		}
 
 		// 4. Emit the smallest-timestamp pending frame as a PES packet.
@@ -225,11 +253,11 @@ impl Export {
 				continue;
 			}
 			let kind = video_kind(config, name)?;
-			let consumer = self.subscribe(name, &config.container)?;
+			let source = ExportSource::for_video(&self.broadcast, name, config, self.latency)?;
 			self.tracks.insert(
 				name.clone(),
 				Track {
-					consumer,
+					source,
 					pending: None,
 					finished: false,
 					pid: next_pid,
@@ -244,11 +272,11 @@ impl Export {
 				continue;
 			}
 			let kind = audio_kind(config, name)?;
-			let consumer = self.subscribe(name, &config.container)?;
+			let source = ExportSource::for_audio(&self.broadcast, name, config, self.latency)?;
 			self.tracks.insert(
 				name.clone(),
 				Track {
-					consumer,
+					source,
 					pending: None,
 					finished: false,
 					pid: next_pid,
@@ -262,10 +290,10 @@ impl Export {
 		Ok(())
 	}
 
-	fn subscribe(&self, name: &str, container: &Container) -> anyhow::Result<Consumer<HangContainer>> {
-		let media: HangContainer = container.try_into()?;
-		let track = self.broadcast.subscribe_track(&moq_net::Track::new(name.to_string()))?;
-		Ok(Consumer::new(track, media).with_latency(self.latency))
+	/// Header is ready when every track's [`ExportSource`] has resolved its
+	/// codec config (from the catalog `description`, or built by the transform).
+	fn header_ready(&self) -> bool {
+		self.tracks.values().all(|t| t.source.header_ready())
 	}
 
 	/// Build the PAT/PMT once every track's PID and codec is known.
@@ -344,6 +372,23 @@ impl Export {
 		let is_pcr = self.psi.as_ref().is_some_and(|p| p.pcr_pid == pid);
 		let is_video = matches!(kind, Kind::Video(_));
 
+		// Build the elementary-stream payload for this frame. Video needs the
+		// resolved avcC/hvcC to rewrite length-prefixed NALs as Annex-B.
+		let es_payload = match &kind {
+			Kind::Video(stream_type) => video_es_payload(*stream_type, track.source.description(), &frame)?,
+			Kind::Aac {
+				object_type,
+				sample_rate,
+				channel_count,
+			} => {
+				let header = adts::write_header(*object_type, *sample_rate, *channel_count, frame.payload.len())?;
+				let mut framed = Vec::with_capacity(7 + frame.payload.len());
+				framed.extend_from_slice(&header);
+				framed.extend_from_slice(&frame.payload);
+				framed
+			}
+		};
+
 		let mut out = Vec::with_capacity(TsPacket::SIZE);
 
 		// Refresh PSI at keyframes or after the interval lapses.
@@ -360,22 +405,6 @@ impl Export {
 			self.last_psi = Some(frame.timestamp);
 		}
 
-		// Build the elementary-stream payload for this frame.
-		let payload = match &kind {
-			Kind::Video(_) => frame.payload.to_vec(),
-			Kind::Aac {
-				object_type,
-				sample_rate,
-				channel_count,
-			} => {
-				let header = adts::write_header(*object_type, *sample_rate, *channel_count, frame.payload.len())?;
-				let mut framed = Vec::with_capacity(7 + frame.payload.len());
-				framed.extend_from_slice(&header);
-				framed.extend_from_slice(&frame.payload);
-				framed
-			}
-		};
-
 		let unit = PesUnit {
 			pid,
 			is_pcr,
@@ -383,7 +412,7 @@ impl Export {
 			keyframe: frame.keyframe,
 			timestamp: frame.timestamp,
 		};
-		self.write_pes(&mut out, &unit, &payload)?;
+		self.write_pes(&mut out, &unit, &es_payload)?;
 		Ok(Bytes::from(out))
 	}
 
@@ -514,23 +543,37 @@ fn to_ts_timestamp(timestamp: crate::container::Timestamp) -> anyhow::Result<TsT
 
 fn video_kind(config: &VideoConfig, name: &str) -> anyhow::Result<Kind> {
 	ensure_raw(&config.container, "video", name)?;
+	// Both in-band (avc3/hev1) and out-of-band (avc1/hvc1) are accepted:
+	// ExportSource normalizes both to length-prefixed NALU + avcC/hvcC, and the
+	// muxer rewrites them to Annex-B.
 	match &config.codec {
-		VideoCodec::H264(h264) => {
-			anyhow::ensure!(
-				h264.inline,
-				"TS export needs in-band H.264 (avc3); track '{name}' is out-of-band (avc1)"
-			);
-			Ok(Kind::Video(StreamType::H264))
-		}
-		VideoCodec::H265(h265) => {
-			anyhow::ensure!(
-				h265.in_band,
-				"TS export needs in-band H.265 (hev1); track '{name}' is out-of-band (hvc1)"
-			);
-			Ok(Kind::Video(StreamType::H265))
-		}
+		VideoCodec::H264(_) => Ok(Kind::Video(StreamType::H264)),
+		VideoCodec::H265(_) => Ok(Kind::Video(StreamType::H265)),
 		other => anyhow::bail!("TS export does not support video codec {other:?} (track '{name}')"),
 	}
+}
+
+/// Build the Annex-B elementary-stream payload for one video frame: rewrite the
+/// length-prefixed NALs to start-code-delimited NALs, prepending the parameter
+/// sets (SPS/PPS, plus VPS for H.265) from the avcC/hvcC on keyframes so a
+/// receiver can tune in mid-stream.
+fn video_es_payload(stream_type: StreamType, description: Option<&Bytes>, frame: &Frame) -> anyhow::Result<Vec<u8>> {
+	let description = description.context("video codec config (avcC/hvcC) not resolved")?;
+	let (length_size, params) = match stream_type {
+		StreamType::H264 => crate::codec::h264::avcc_params(description)?,
+		StreamType::H265 => crate::codec::h265::hvcc_params(description)?,
+		other => anyhow::bail!("unsupported TS video stream type {other:?}"),
+	};
+
+	let mut out = Vec::with_capacity(frame.payload.len() + 64);
+	if frame.keyframe {
+		for nal in &params {
+			out.extend_from_slice(&annexb::START_CODE);
+			out.extend_from_slice(nal);
+		}
+	}
+	annexb::length_prefixed_to_annexb(&frame.payload, length_size, &mut out)?;
+	Ok(out)
 }
 
 fn audio_kind(config: &AudioConfig, name: &str) -> anyhow::Result<Kind> {

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1,8 +1,9 @@
 //! Tests for the MPEG-TS exporter.
 //!
-//! The muxer treats codec payloads as opaque (Annex-B passthrough for video,
-//! ADTS framing for audio), so these build a synthetic broadcast of raw bytes,
-//! export to TS, and re-parse with the `mpeg2ts` reader.
+//! Audio is framed as ADTS; video is normalized to length-prefixed NALU by
+//! `ExportSource` and rewritten to Annex-B by the muxer (re-injecting the
+//! parameter sets on keyframes). These build a synthetic broadcast, export to
+//! TS, and re-parse with the `mpeg2ts` reader.
 
 use std::io::Cursor;
 
@@ -14,6 +15,32 @@ use mpeg2ts::ts::{ReadTsPacket, TsPacketReader, TsPayload};
 
 use crate::catalog::hang::Container as HangContainer;
 use crate::container::{Frame, Producer, Timestamp};
+
+const SC: &[u8] = &[0, 0, 0, 1];
+// Reusable H.264 parameter-set and slice NALs (NAL type = first byte & 0x1f).
+const SPS: &[u8] = &[0x67, 0x42, 0xc0, 0x1f, 0xde];
+const PPS: &[u8] = &[0x68, 0xce, 0x3c, 0x80];
+
+/// Concatenate NALs into an Annex-B buffer (4-byte start code before each).
+fn annexb(nals: &[&[u8]]) -> Bytes {
+	let mut buf = BytesMut::new();
+	for nal in nals {
+		buf.extend_from_slice(SC);
+		buf.extend_from_slice(nal);
+	}
+	buf.freeze()
+}
+
+/// Concatenate NALs into a length-prefixed (avc1/hvc1) buffer (4-byte big-endian
+/// length before each), the wire shape of an out-of-band source.
+fn length_prefixed(nals: &[&[u8]]) -> Bytes {
+	let mut buf = BytesMut::new();
+	for nal in nals {
+		buf.extend_from_slice(&(nal.len() as u32).to_be_bytes());
+		buf.extend_from_slice(nal);
+	}
+	buf.freeze()
+}
 
 /// Drive an exporter until it stops producing output, concatenating every chunk.
 ///
@@ -117,42 +144,11 @@ async fn export_aac_roundtrip() {
 	}
 }
 
-#[tokio::test(start_paused = true)]
-async fn export_video_carries_pcr_and_reassembles() {
-	let mut broadcast = moq_net::Broadcast::new().produce();
-	let consumer = broadcast.consume();
-	let mut catalog = crate::catalog::hang::Producer::new(&mut broadcast).unwrap();
-
-	let track = broadcast.unique_track(".avc3").unwrap();
-	let name = track.name.clone();
-	{
-		let mut cfg = VideoConfig::new(H264 {
-			profile: 0x64,
-			constraints: 0,
-			level: 0x1f,
-			inline: true,
-		});
-		cfg.container = Container::Legacy;
-		catalog.lock().video.renditions.insert(name.clone(), cfg);
-	}
-	let mut producer = Producer::new(track, HangContainer::Legacy);
-
-	// 300 bytes spans multiple TS packets.
-	let payload = Bytes::from(vec![0xABu8; 300]);
-	producer
-		.write(Frame {
-			timestamp: Timestamp::from_millis(0).unwrap(),
-			payload: payload.clone(),
-			keyframe: true,
-		})
-		.unwrap();
-	producer.finish().unwrap();
-
-	// Keep the producers alive (see `export_aac_roundtrip`).
-	let ts = drain(consumer).await;
-	assert_packet_aligned(&ts);
-
-	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+/// Re-parse a TS byte stream: assert the single video stream type, that the
+/// keyframe carries random-access + PCR in an unbounded PES, and return the
+/// reassembled Annex-B elementary stream.
+fn reassemble_video(ts: &[u8], expected_stream_type: StreamType) -> Vec<u8> {
+	let mut reader = TsPacketReader::new(Cursor::new(ts));
 	let mut video_pid = None;
 	let mut saw_random_access = false;
 	let mut saw_pcr = false;
@@ -163,7 +159,7 @@ async fn export_video_carries_pcr_and_reassembles() {
 		match packet.payload {
 			Some(TsPayload::Pmt(pmt)) => {
 				assert_eq!(pmt.es_info.len(), 1);
-				assert_eq!(pmt.es_info[0].stream_type, StreamType::H264);
+				assert_eq!(pmt.es_info[0].stream_type, expected_stream_type);
 				video_pid = Some(pmt.es_info[0].elementary_pid);
 			}
 			Some(TsPayload::PesStart(pes)) => {
@@ -184,5 +180,98 @@ async fn export_video_carries_pcr_and_reassembles() {
 	assert!(saw_random_access, "keyframe should set random_access_indicator");
 	assert!(saw_pcr, "PCR pid should carry a PCR on the keyframe");
 	assert!(unbounded, "video PES should be unbounded");
-	assert_eq!(reassembled.as_slice(), payload.as_ref(), "Annex-B payload mismatch");
+	reassembled
+}
+
+/// In-band avc3: SPS/PPS are inline in the bitstream. ExportSource strips them
+/// into a synthesized avcC, and the muxer re-injects them on the keyframe.
+#[tokio::test(start_paused = true)]
+async fn export_avc3_in_band_reassembles() {
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::hang::Producer::new(&mut broadcast).unwrap();
+
+	let track = broadcast.unique_track(".avc3").unwrap();
+	let name = track.name.clone();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0,
+			level: 0x1f,
+			inline: true,
+		});
+		cfg.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(name.clone(), cfg);
+	}
+	let mut producer = Producer::new(track, HangContainer::Legacy);
+
+	// IDR slice (NAL type 5), padded past 184 bytes to span multiple TS packets.
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xAB, 300));
+	// Annex-B keyframe: inline SPS + PPS + IDR.
+	producer
+		.write(Frame {
+			timestamp: Timestamp::from_millis(0).unwrap(),
+			payload: annexb(&[SPS, PPS, &idr]),
+			keyframe: true,
+		})
+		.unwrap();
+	producer.finish().unwrap();
+
+	// Keep the producers alive (see `export_aac_roundtrip`).
+	let ts = drain(consumer).await;
+	assert_packet_aligned(&ts);
+
+	let reassembled = reassemble_video(&ts, StreamType::H264);
+	// The parameter sets the muxer re-injected, followed by the slice, all Annex-B.
+	assert_eq!(reassembled.as_slice(), annexb(&[SPS, PPS, &idr]).as_ref());
+}
+
+/// Out-of-band avc1 (e.g. from fmp4 import): length-prefixed NALs with the
+/// SPS/PPS only in the catalog `description` (avcC). The muxer must parse the
+/// avcC, prepend the parameter sets as Annex-B on the keyframe, and rewrite the
+/// length prefixes to start codes.
+#[tokio::test(start_paused = true)]
+async fn export_avc1_out_of_band_reassembles() {
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::hang::Producer::new(&mut broadcast).unwrap();
+
+	let avcc = crate::codec::h264::build_avcc(SPS, PPS).unwrap();
+
+	let track = broadcast.unique_track(".avc1").unwrap();
+	let name = track.name.clone();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0,
+			level: 0x1f,
+			inline: false,
+		});
+		cfg.container = Container::Legacy;
+		cfg.description = Some(avcc);
+		catalog.lock().video.renditions.insert(name.clone(), cfg);
+	}
+	let mut producer = Producer::new(track, HangContainer::Legacy);
+
+	// IDR slice (NAL type 5), padded past 184 bytes to span multiple TS packets.
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xAB, 300));
+	// Length-prefixed keyframe: just the slice, no inline parameter sets.
+	producer
+		.write(Frame {
+			timestamp: Timestamp::from_millis(0).unwrap(),
+			payload: length_prefixed(&[&idr]),
+			keyframe: true,
+		})
+		.unwrap();
+	producer.finish().unwrap();
+
+	// Keep the producers alive (see `export_aac_roundtrip`).
+	let ts = drain(consumer).await;
+	assert_packet_aligned(&ts);
+
+	let reassembled = reassemble_video(&ts, StreamType::H264);
+	// SPS/PPS from the avcC must precede the slice, all converted to Annex-B.
+	assert_eq!(reassembled.as_slice(), annexb(&[SPS, PPS, &idr]).as_ref());
 }


### PR DESCRIPTION
Stacked on #1587 (MPEG-TS import/export). Targets that branch as its base; rebase onto `main` once #1587 merges.

## Problem

TS export only accepted in-band video (`H264 { inline: true }` / `H265 { in_band: true }`) and rejected out-of-band avc1/hvc1 (catalog `description` = avcC/hvcC, length-prefixed NALs) in `video_kind()` with an error. A broadcast sourced from an fMP4 import (which produces avc1) therefore couldn't be exported to MPEG-TS.

## Approach

Route TS video through `ExportSource` (as the fmp4/mkv exporters already do). `ExportSource` normalizes both wire shapes to length-prefixed NALU + a resolved avcC/hvcC: for in-band sources it strips the inline SPS/PPS and synthesizes the config record; for out-of-band sources it takes the catalog `description` directly. The muxer then does a single length-prefixed → Annex-B conversion, re-injecting the parameter sets (SPS/PPS, plus VPS for H.265) parsed back out of the avcC/hvcC as inline Annex-B on every keyframe. This removes the in-band/out-of-band fork entirely.

New codec helpers (the inverse of the existing `Avc1`/`Hvc1` transforms):
- `annexb::length_prefixed_to_annexb` — rewrite length prefixes to start codes
- `h264::avcc_params` / `h265::hvcc_params` — extract parameter-set NALs and the NALU length size from the config record

Because an in-band source's avcC only resolves once frames start flowing, the exporter now gates PAT/PMT emission on every track's codec config being ready and drops pre-header slices (a receiver joining mid-GOP can't use them) — mirroring the MKV exporter's `header_ready` handling.

## Tests

- `export_avc1_out_of_band_reassembles` (new): out-of-band avc1 with the avcC only in the catalog `description`; asserts the SPS/PPS are re-injected ahead of the slice as Annex-B.
- `export_avc3_in_band_reassembles`: rewrote the old `export_video_carries_pcr_and_reassembles` to feed real Annex-B (it previously fed non-Annex-B bytes that only worked under the old opaque passthrough) and assert the full round-trip.
- Unit tests for `avcc_params`, `hvcc_params`, and `length_prefixed_to_annexb`.

`cargo test -p moq-mux` (157 pass), `cargo clippy -p moq-mux --all-targets` (clean), and `cargo build -p moq-cli` all green via the pinned Nix toolchain.

## Cross-package sync

- `doc/bin/cli.md`: updated the MPEG-TS section, which previously documented the out-of-band rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)