### PR TITLE
moq-mux: synthesize AAC esds in fMP4 export; guard MKV header race

### DIFF
--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -104,6 +104,93 @@ async fn avc3_source_to_cmaf_export_roundtrip() {
 	assert_eq!(mvex.trex[0].track_id, trak.tkhd.track_id);
 }
 
+/// Legacy AAC source (catalog `Container::Legacy`, codec `mp4a.40.2`, with a
+/// `description` carrying the AudioSpecificConfig — the shape an MPEG-TS import
+/// produces) → fMP4 export must synthesize an mp4a sample entry whose esds
+/// carries that AudioSpecificConfig, instead of bailing with UnsupportedSynthesis.
+#[tokio::test(start_paused = true)]
+async fn legacy_aac_source_to_cmaf_export_synthesizes_esds() {
+	use crate::container::Timestamp;
+	use bytes::Bytes;
+	use hang::catalog::{AAC, AudioConfig, Container};
+
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	let mut catalog = crate::catalog::hang::Producer::new(&mut producer).unwrap();
+	let track = producer.unique_track(".aac").unwrap();
+
+	// AAC-LC (profile 2), 44100 Hz, stereo. The TS importer sets `description`
+	// via aac::Config::encode; mirror that here.
+	let description = crate::codec::aac::Config {
+		profile: 2,
+		sample_rate: 44100,
+		channel_count: 2,
+	}
+	.encode();
+	let mut config = AudioConfig::new(AAC { profile: 2 }, 44100, 2);
+	config.description = Some(description.clone());
+	config.container = Container::Legacy;
+	catalog.lock().audio.renditions.insert(track.name.clone(), config);
+
+	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
+	track_producer
+		.write(crate::container::Frame {
+			timestamp: Timestamp::from_micros(0).unwrap(),
+			payload: Bytes::from_static(&[0x01, 0x02, 0x03, 0x04]),
+			keyframe: true,
+		})
+		.unwrap();
+	track_producer.finish().unwrap();
+
+	let mut exporter = crate::container::fmp4::Export::new(consumer).expect("new Fmp4");
+
+	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
+		.await
+		.expect("exporter timed out")
+		.expect("exporter result")
+		.expect("expected init bytes");
+
+	drop(track_producer);
+	drop(catalog);
+	drop(producer);
+
+	let mut cursor = Cursor::new(init.as_ref());
+	let mut moov: Option<mp4_atom::Moov> = None;
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).expect("decode init") {
+		if let mp4_atom::Any::Moov(m) = atom {
+			moov = Some(m);
+		}
+	}
+	let moov = moov.expect("init segment missing moov");
+	assert_eq!(moov.trak.len(), 1, "expected single track in moov");
+
+	let trak = &moov.trak[0];
+	let stsd = &trak.mdia.minf.stbl.stsd;
+	assert_eq!(stsd.codecs.len(), 1, "expected single sample entry");
+	let mp4a = match &stsd.codecs[0] {
+		mp4_atom::Codec::Mp4a(mp4a) => mp4a,
+		other => panic!("expected Mp4a sample entry, got {:?}", other),
+	};
+
+	assert_eq!(mp4a.audio.channel_count, 2);
+	assert_eq!(mp4a.audio.sample_rate.integer(), 44100);
+
+	let dec_config = &mp4a.esds.es_desc.dec_config;
+	assert_eq!(dec_config.object_type_indication, 0x40, "MPEG-4 AAC");
+	assert_eq!(dec_config.stream_type, 0x05, "audio stream");
+
+	let dec_specific = &dec_config.dec_specific;
+	assert_eq!(dec_specific.profile, 2, "AAC-LC");
+	assert_eq!(dec_specific.freq_index, 4, "44100 Hz");
+	assert_eq!(dec_specific.chan_conf, 2, "stereo");
+
+	// The synthesized init must round-trip through encode (esds included).
+	let mut buf = Vec::new();
+	moov.encode(&mut buf).expect("encode synthesized moov");
+}
+
 /// CMAF source (catalog `Container::Cmaf`) → fMP4 export should keep using
 /// the passthrough init path: existing init bytes are merged into the moov.
 ///

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -342,6 +342,8 @@ pub(crate) fn synthesize_audio_trak(
 	timescale: u64,
 	config: &AudioConfig,
 ) -> Result<mp4_atom::Trak, Error> {
+	use mp4_atom::Decode;
+
 	let audio = mp4_atom::Audio {
 		data_reference_index: 1,
 		channel_count: config.channel_count as u16,
@@ -361,8 +363,6 @@ pub(crate) fn synthesize_audio_trak(
 			btrt: None,
 		}),
 		AudioCodec::AAC(_) => {
-			use mp4_atom::Decode;
-
 			// The catalog `description` is the AudioSpecificConfig (set by the TS
 			// importer via aac::Config::encode, or carried over from a CMAF source).
 			// mp4_atom models the esds DecoderSpecific as the parsed

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -63,6 +63,9 @@ pub enum Error {
 
 	#[error("can't synthesize CMAF init for {0}")]
 	UnsupportedSynthesis(String),
+
+	#[error("audio codec {0} needs a description (AudioSpecificConfig) to synthesize a CMAF init")]
+	MissingAudioDescription(String),
 }
 
 /// CMAF container: encodes/decodes a single track's moof+mdat fragments.
@@ -357,6 +360,43 @@ pub(crate) fn synthesize_audio_trak(
 			},
 			btrt: None,
 		}),
+		AudioCodec::AAC(_) => {
+			use mp4_atom::Decode;
+
+			// The catalog `description` is the AudioSpecificConfig (set by the TS
+			// importer via aac::Config::encode, or carried over from a CMAF source).
+			// mp4_atom models the esds DecoderSpecific as the parsed
+			// AudioSpecificConfig, so decode the blob back into that shape.
+			let description = config
+				.description
+				.as_ref()
+				.ok_or_else(|| Error::MissingAudioDescription(config.codec.to_string()))?;
+			let mut cursor = std::io::Cursor::new(description.as_ref());
+			let dec_specific = mp4_atom::esds::DecoderSpecific::decode(&mut cursor)?;
+
+			let bitrate = config.bitrate.unwrap_or(0) as u32;
+			mp4_atom::Codec::from(mp4_atom::Mp4a {
+				audio,
+				esds: mp4_atom::Esds {
+					es_desc: mp4_atom::esds::EsDescriptor {
+						// ISO/IEC 14496-14 §5.6: ES_ID is 0 in an MP4 file (the track id carries identity).
+						es_id: 0,
+						dec_config: mp4_atom::esds::DecoderConfig {
+							object_type_indication: 0x40, // MPEG-4 AAC
+							stream_type: 0x05,            // audio
+							up_stream: 0,
+							buffer_size_db: Default::default(),
+							max_bitrate: bitrate,
+							avg_bitrate: bitrate,
+							dec_specific,
+						},
+						sl_config: Default::default(),
+					},
+				},
+				btrt: None,
+				taic: None,
+			})
+		}
 		other => return Err(Error::UnsupportedSynthesis(format!("audio codec {:?}", other))),
 	};
 

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -381,10 +381,17 @@ impl Export {
 		Ok(())
 	}
 
-	/// Header is ready when every track's [`ExportSource`] has resolved its
-	/// codec config — from the catalog `description` or built by the transform.
+	/// Header is ready when the catalog snapshot has arrived, at least one track
+	/// is subscribed, and every track's [`ExportSource`] has resolved its codec
+	/// config (from the catalog `description` or built by the transform).
+	///
+	/// The non-empty guard matters for a mid-stream subscriber: before the
+	/// catalog arrives `tracks` is empty, and `all()` would otherwise be
+	/// vacuously true and send us into `build_header` with no snapshot.
 	fn header_ready(&self) -> bool {
-		self.tracks.values().all(|t| t.source.header_ready())
+		self.catalog_snapshot.is_some()
+			&& !self.tracks.is_empty()
+			&& self.tracks.values().all(|t| t.source.header_ready())
 	}
 
 	fn build_header(&self) -> anyhow::Result<Bytes> {

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -136,6 +136,33 @@ async fn export_header_roundtrip_vp9_opus() {
 	assert_eq!(a.sample_rate, 48000);
 }
 
+/// A mid-stream subscriber may poll the exporter before the catalog track has
+/// arrived. With `tracks` empty, `header_ready()` must not be vacuously true and
+/// drive `build_header` into a "no catalog snapshot" error; it should stay
+/// pending until the catalog lands.
+#[tokio::test(start_paused = true)]
+async fn export_waits_for_catalog_before_header() {
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	// The catalog track exists (so the subscriber can attach) but no renditions
+	// have been published yet: `tracks` stays empty on the first polls.
+	let _catalog = crate::catalog::hang::Producer::new(&mut producer).unwrap();
+
+	let mut exporter = crate::container::mkv::Export::new(consumer).unwrap();
+
+	// next() must remain pending (timing out), not surface a "no catalog
+	// snapshot" error from a vacuously-ready empty track set.
+	let result = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next()).await;
+	assert!(
+		result.is_err(),
+		"exporter should stay pending before any rendition arrives, got {result:?}"
+	);
+
+	drop(producer);
+}
+
 #[tokio::test(start_paused = true)]
 async fn export_emits_blocks_for_each_frame() {
 	// Import a WebM that contains 3 video frames + 2 audio frames, export it,


### PR DESCRIPTION
## Summary

- **fMP4 export now supports AAC.** `synthesize_audio_trak` in `rs/moq-mux/src/container/fmp4/mod.rs` only handled `AudioCodec::Opus`, so exporting any Legacy/LOC-container AAC track failed with `can't synthesize CMAF init for audio codec AAC`. A broadcast imported from MPEG-TS (`moq publish ts`) or raw AAC therefore couldn't be re-exported via `moq subscribe --format fmp4`. It now builds an `mp4_atom::Mp4a` sample entry with a full `esds`:
  - Reads the catalog `AudioConfig.description` (the AudioSpecificConfig the TS importer sets via `aac::Config::encode`).
  - `mp4_atom` models the esds `DecoderSpecific` *as* the parsed AudioSpecificConfig, so the blob is decoded back into that shape (the inverse of the fMP4 importer at `import.rs:340`) and wrapped in a `DecoderConfig` (`object_type_indication: 0x40` MPEG-4 AAC, `stream_type: 0x05` audio) + `EsDescriptor` (`es_id: 0`, per ISO/IEC 14496-14 §5.6).
  - A missing description now returns a clear `Error::MissingAudioDescription` instead of the generic `UnsupportedSynthesis`.
  - This mirrors how the MKV exporter consumes `config.description` for AAC.

- **MKV exporter header race fix.** `header_ready()` returned vacuously `true` when `tracks` was still empty (before the catalog arrived), sending a mid-stream subscriber straight into `build_header` → `no catalog snapshot`. It now also requires a catalog snapshot and a non-empty track set, mirroring fMP4's `init_ready()`.

## Why

Re-exporting an MPEG-TS-sourced AAC broadcast as fMP4 is a common path that was previously broken. The MKV race is a related latent bug affecting subscribers that attach before the catalog frame is delivered.

## Testing

- `cargo test -p moq-mux --lib` — all 146 pass.
- New `legacy_aac_source_to_cmaf_export_synthesizes_esds` asserts the synthesized moov carries an `Mp4a` entry with the right `audio` box and esds fields (profile 2, freq_index 4 = 44100 Hz, chan_conf 2) and re-encodes cleanly.
- New `export_waits_for_catalog_before_header` is a regression test for the MKV race; confirmed it fails without the fix (`Ok(Err(no catalog snapshot))`) and passes with it.
- End-to-end: dumped a synthesized fMP4 from a Legacy AAC source (real AAC frame from ffmpeg) and ran `ffprobe`, which reported `codec_name=aac`, `sample_rate=44100`, `channels=2`.
- `cargo fmt` + `cargo clippy --all-targets` (via Nix to match CI) clean.

No Cross-Package Sync rows apply: this is internal to `moq-mux` with no wire/catalog/public-API change, and `doc/` has no references to the prior AAC limitation.

(Written by Claude)