### PR TITLE
build(deps): bump the cargo group (with code fixes for rand/rubato/rcgen)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,7 +408,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -638,15 +675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
-]
-
-[[package]]
-name = "buffer-pool"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a735dacb3d6e895d2537d263a01a09c3e48838e03818a8beed7a41249dffe09f"
-dependencies = [
- "crossbeam",
 ]
 
 [[package]]
@@ -1134,8 +1162,6 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-queue",
  "crossbeam-utils",
 ]
 
@@ -1153,15 +1179,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1361,11 +1378,11 @@ dependencies = [
 
 [[package]]
 name = "datagram-socket"
-version = "0.5.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2dc498ae9ce30da432498ea95297c7ed80d09a88ea4dce4ba6db2126eef60b"
+checksum = "e352260f0c4539a6380c32001b3ca4912aa7a038030478d70d74bcffe3b0fc95"
 dependencies = [
- "buffer-pool",
+ "bytes",
  "futures-util",
  "libc",
  "smallvec",
@@ -1389,6 +1406,12 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "debug_panic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9377eb110cece2e9431deb8d7d2ec8c116510b896741f9f2bf02b352147aa2a6"
 
 [[package]]
 name = "der"
@@ -1773,10 +1796,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "ff"
@@ -1843,13 +1881,13 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
+ "fastrand",
  "futures-core",
  "futures-sink",
- "nanorand",
  "spin 0.9.8",
 ]
 
@@ -2686,7 +2724,7 @@ dependencies = [
  "http-cache",
  "http-cache-semantics",
  "reqwest 0.12.28",
- "reqwest-middleware",
+ "reqwest-middleware 0.4.2",
  "serde",
  "url",
 ]
@@ -3114,9 +3152,9 @@ dependencies = [
  "n0-future",
  "n0-watcher",
  "netwatch",
- "noq 1.0.0-rc.0",
- "noq-proto 1.0.0-rc.0",
- "noq-udp 1.0.0-rc.0",
+ "noq",
+ "noq-proto",
+ "noq-udp",
  "papaya",
  "pin-project",
  "portable-atomic",
@@ -3236,8 +3274,8 @@ dependencies = [
  "lru",
  "n0-error",
  "n0-future",
- "noq 1.0.0-rc.0",
- "noq-proto 1.0.0-rc.0",
+ "noq",
+ "noq-proto",
  "num_enum",
  "pin-project",
  "postcard",
@@ -3837,8 +3875,8 @@ dependencies = [
  "parking_lot",
  "qmux",
  "quinn",
- "rand 0.9.4",
- "rcgen 0.14.8",
+ "rand 0.10.1",
+ "rcgen",
  "reqwest 0.12.28",
  "rustls",
  "rustls-native-certs",
@@ -3849,7 +3887,7 @@ dependencies = [
  "tikv-jemallocator",
  "time",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-android",
  "tracing-subscriber",
@@ -3870,7 +3908,7 @@ dependencies = [
  "futures",
  "kio",
  "num_enum",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3898,9 +3936,9 @@ dependencies = [
  "moq-token",
  "notify",
  "qmux",
- "rcgen 0.13.2",
+ "rcgen",
  "reqwest 0.12.28",
- "reqwest-middleware",
+ "reqwest-middleware 0.5.2",
  "rustls",
  "sd-notify",
  "serde",
@@ -3910,7 +3948,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tower-http",
  "tower-service",
  "tracing",
@@ -4031,15 +4069,6 @@ dependencies = [
  "derive_more",
  "n0-error",
  "n0-future",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4181,7 +4210,7 @@ dependencies = [
  "netlink-packet-route 0.30.0",
  "netlink-proto",
  "netlink-sys",
- "noq-udp 1.0.0-rc.0",
+ "noq-udp",
  "objc2-core-foundation",
  "objc2-system-configuration",
  "pin-project-lite",
@@ -4228,27 +4257,6 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "noq"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df966fb44ac763bc86da97fa6c811c54ae82ef656575949f93c6dae0c9f09bf"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "noq-proto 0.16.0",
- "noq-udp 0.9.0",
- "pin-project-lite",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "noq"
 version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22739e0831e40f5ab7d6ac5317ed80bfe5fb3f44be57d23fa2eea8bff83fb303"
@@ -4256,8 +4264,8 @@ dependencies = [
  "bytes",
  "cfg_aliases",
  "derive_more",
- "noq-proto 1.0.0-rc.0",
- "noq-udp 1.0.0-rc.0",
+ "noq-proto",
+ "noq-udp",
  "pin-project-lite",
  "rustc-hash",
  "rustls",
@@ -4265,34 +4273,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "noq-proto"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c61b72abd670eebc05b5cf720e077b04a3ef3354bc7bc19f1c3524cb424db7b"
-dependencies = [
- "aes-gcm",
- "bytes",
- "derive_more",
- "enum-assoc",
- "fastbloom",
- "getrandom 0.3.4",
- "identity-hash",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
- "slab",
- "sorted-index-buffer",
- "thiserror 2.0.18",
- "tinyvec",
  "tracing",
  "web-time",
 ]
@@ -4308,6 +4288,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "enum-assoc",
+ "fastbloom 0.17.0",
  "getrandom 0.4.2",
  "identity-hash",
  "lru-slab",
@@ -4316,25 +4297,13 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier 0.7.0",
  "slab",
  "sorted-index-buffer",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
-]
-
-[[package]]
-name = "noq-udp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9be4fedd6b98f3ba82ccd3506f4d0219fb723c3f97c67e12fe1494aa020e44"
-dependencies = [
- "cfg_aliases",
- "libc",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5259,21 +5228,24 @@ dependencies = [
 
 [[package]]
 name = "qlog"
-version = "0.15.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f15b83c59e6b945f2261c95a1dd9faf239187f32ff0a96af1d1d28c4557f919"
+checksum = "c65c0ae39cba4538fd935d376ba17f858046b386dc4597e3fa5c1aedb919ef30"
 dependencies = [
+ "flate2",
+ "foundations",
+ "humantime",
  "serde",
  "serde_json",
  "serde_with",
- "smallvec",
+ "zstd",
 ]
 
 [[package]]
 name = "qmux"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a625edac9a3021654a955444ca602b7b66b6764c7372196df08af53779ffbe7"
+checksum = "d3a761722f4499404d45c4971e332b8d0d1fe4a1882d404c2c5f96f3e49933e9"
 dependencies = [
  "bytes",
  "futures",
@@ -5281,7 +5253,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tracing",
  "web-transport-proto",
  "web-transport-trait",
@@ -5304,12 +5276,13 @@ dependencies = [
 
 [[package]]
 name = "quiche"
-version = "0.24.9"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba053386c3a3b16441cb8a34574f91a9178fd3d813c0639514fcd8e4f274a44b"
+checksum = "c1f7537688130c9bb919e2afdc4f89fae5e71c11001573f175fd79b4dc3ffae9"
 dependencies = [
  "boring",
- "cmake",
+ "bytes",
+ "debug_panic",
  "either",
  "enum_dispatch",
  "foreign-types-shared",
@@ -5319,6 +5292,9 @@ dependencies = [
  "log",
  "octets",
  "qlog",
+ "serde",
+ "serde_json",
+ "serde_with",
  "slab",
  "smallvec",
  "windows-sys 0.59.0",
@@ -5361,7 +5337,7 @@ checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "fastbloom",
+ "fastbloom 0.14.1",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
@@ -5516,29 +5492,17 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "yasna 0.5.2",
-]
-
-[[package]]
-name = "rcgen"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "aws-lc-rs",
+ "pem",
  "ring",
  "rustls-pki-types",
  "time",
  "x509-parser",
- "yasna 0.6.0",
+ "yasna",
 ]
 
 [[package]]
@@ -5699,6 +5663,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5750,14 +5728,18 @@ dependencies = [
 
 [[package]]
 name = "rubato"
-version = "0.16.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5258099699851cfd0082aeb645feb9c084d9a5e1f1b8d5372086b989fc5e56a1"
+checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
 dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
  "num-complex",
  "num-integer",
  "num-traits",
  "realfft",
+ "visibility",
+ "windowfunctions",
 ]
 
 [[package]]
@@ -6519,9 +6501,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "smawk"
@@ -6967,13 +6946,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-quiche"
-version = "0.12.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3152843e8aafb0dae1f31cb0e1223ffff010de71efca2ec2a6b5405a57001a5"
+checksum = "1ccfade367886d928786ca70071787ae5afa1b9267be923f8a53b2440e8c54da"
 dependencies = [
  "anyhow",
  "boring",
- "buffer-pool",
+ "bytes",
  "crossbeam",
  "datagram-socket",
  "foundations",
@@ -6985,6 +6964,7 @@ dependencies = [
  "nix",
  "octets",
  "pin-project",
+ "qlog",
  "quiche",
  "serde",
  "serde_with",
@@ -6996,7 +6976,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "triomphe",
  "url",
 ]
 
@@ -7024,9 +7003,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -7035,19 +7014,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -7428,39 +7395,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "triomphe"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
-dependencies = [
- "serde",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "rustls",
- "rustls-pki-types",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
 
 [[package]]
 name = "tungstenite"
@@ -7474,6 +7412,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
 ]
@@ -7700,12 +7640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7788,6 +7722,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "walkdir"
@@ -7985,14 +7930,14 @@ dependencies = [
 
 [[package]]
 name = "web-transport-noq"
-version = "0.0.3"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42caba209a9583813c1d802197fc568e9a78f45e42ff40fba54e4d16d2e3af2"
+checksum = "16b64412e8441cb849677140caf92be00a417f9e2fa64a97d305f85278926615"
 dependencies = [
  "bytes",
  "futures",
  "http",
- "noq 0.17.0",
+ "noq",
  "rustls",
  "rustls-native-certs",
  "thiserror 2.0.18",
@@ -8019,9 +7964,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quiche"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b165e13c505ce9541d0a1f762020fed6e63d3ee88e6f685e4f60007cfa555282"
+checksum = "155128d482189e2ea32704fa09ac2b7f3df41370bccddc600c6e5f84738e0a63"
 dependencies = [
  "boring",
  "bytes",
@@ -8033,7 +7978,6 @@ dependencies = [
  "tokio",
  "tokio-quiche",
  "tracing",
- "url",
  "web-transport-proto",
  "web-transport-trait",
 ]
@@ -8139,6 +8083,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "windows"
@@ -8724,15 +8677,6 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-dependencies = [
- "time",
-]
-
-[[package]]
-name = "yasna"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
@@ -8863,3 +8807,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1373,7 +1373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1759,7 +1759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2724,7 +2724,7 @@ dependencies = [
  "http-cache",
  "http-cache-semantics",
  "reqwest 0.12.28",
- "reqwest-middleware 0.4.2",
+ "reqwest-middleware",
  "serde",
  "url",
 ]
@@ -3305,7 +3305,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3938,7 +3938,7 @@ dependencies = [
  "qmux",
  "rcgen",
  "reqwest 0.12.28",
- "reqwest-middleware 0.5.2",
+ "reqwest-middleware",
  "rustls",
  "sd-notify",
  "serde",
@@ -4352,7 +4352,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5632,7 +5632,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier 0.6.2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -5659,20 +5659,6 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "thiserror 1.0.69",
- "tower-service",
-]
-
-[[package]]
-name = "reqwest-middleware"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
-dependencies = [
- "anyhow",
- "async-trait",
- "http",
- "reqwest 0.13.4",
- "thiserror 2.0.18",
  "tower-service",
 ]
 
@@ -5809,7 +5795,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5868,7 +5854,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5889,7 +5875,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6104,7 +6090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6515,7 +6501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6745,7 +6731,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6754,7 +6740,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8075,7 +8061,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5048,15 +5048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primal-check"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
-dependencies = [
- "num-integer",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5506,15 +5497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "realfft"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
-dependencies = [
- "rustfft",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5720,10 +5702,8 @@ checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
 dependencies = [
  "audioadapter",
  "audioadapter-buffers",
- "num-complex",
  "num-integer",
  "num-traits",
- "realfft",
  "visibility",
  "windowfunctions",
 ]
@@ -5747,20 +5727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustfft"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-traits",
- "primal-check",
- "strength_reduce",
- "transpose",
 ]
 
 [[package]]
@@ -6578,12 +6544,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7368,16 +7328,6 @@ checksum = "ebeb235c5847e2f82cfe0f07eb971d1e5f6804b18dac2ae16349cc604380f82f"
 dependencies = [
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,15 +52,15 @@ moq-mux = { version = "0.5", path = "rs/moq-mux" }
 moq-native = { version = "0.16", path = "rs/moq-native", default-features = false }
 moq-net = { version = "0.1", path = "rs/moq-net" }
 moq-token = { version = "0.6", path = "rs/moq-token" }
-qmux = { version = "0.0.7", default-features = false }
+qmux = { version = "0.0.8", default-features = false }
 
 serde = { version = "1", features = ["derive"] }
 tokio = "1.48"
 web-async = { version = "0.1.3", features = ["tracing"] }
 web-transport-iroh = "0.5"
-web-transport-noq = "0.0.3"
+web-transport-noq = "0.1.1"
 web-transport-proto = "0.6"
-web-transport-quiche = "0.2"
+web-transport-quiche = "0.4"
 web-transport-quinn = "0.11"
 web-transport-trait = "0.3.4"
 

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -20,7 +20,7 @@ bytes = "1"
 hang = { workspace = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
-rubato = "0.16"
+rubato = "3.0"
 thiserror = "2"
 # Pure-Rust transpilation of libopus 1.3.1. No CMake toolchain, no C
 # linker hackery, and crucially still maintained, unlike the

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -20,7 +20,9 @@ bytes = "1"
 hang = { workspace = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
-rubato = "3.0"
+# We only use the sinc resampler (Async::new_sinc), so skip the default
+# fft_resampler feature and its RustFFT/realfft dependencies.
+rubato = { version = "3.0", default-features = false }
 thiserror = "2"
 # Pure-Rust transpilation of libopus 1.3.1. No CMake toolchain, no C
 # linker hackery, and crucially still maintained, unlike the

--- a/rs/moq-audio/src/resample.rs
+++ b/rs/moq-audio/src/resample.rs
@@ -4,19 +4,21 @@
 //! producer/consumer doesn't have to convert to planar on every call.
 //! Currently sample-rate only; channel up/downmix is rejected upstream.
 
+use rubato::audioadapter_buffers::direct::SequentialSliceOfVecs;
 use rubato::{
-	Resampler as RubatoTrait, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
+	Async, FixedAsync, Resampler as RubatoTrait, SincInterpolationParameters, SincInterpolationType, WindowFunction,
 };
 
 use crate::AudioError;
 
 /// Sample-rate converter over interleaved `f32` PCM.
 pub struct Resampler {
-	resampler: SincFixedIn<f32>,
+	resampler: Async<f32>,
 	chunk_frames: usize,
 	channels: usize,
 	input_planar: Vec<Vec<f32>>,
 	output_planar: Vec<Vec<f32>>,
+	output_frames_max: usize,
 	pending: Vec<f32>,
 }
 
@@ -39,16 +41,18 @@ impl Resampler {
 			oversampling_factor: 128,
 			window: WindowFunction::BlackmanHarris2,
 		};
-		let resampler = SincFixedIn::<f32>::new(
+		let resampler = Async::<f32>::new_sinc(
 			output_rate as f64 / input_rate as f64,
 			1.0,
-			params,
+			&params,
 			chunk_frames,
 			channels as usize,
+			FixedAsync::Input,
 		)?;
 
 		let input_planar = (0..channels as usize).map(|_| vec![0.0f32; chunk_frames]).collect();
-		let output_planar = resampler.output_buffer_allocate(true);
+		let output_frames_max = resampler.output_frames_max();
+		let output_planar = vec![vec![0.0f32; output_frames_max]; channels as usize];
 
 		Ok(Self {
 			resampler,
@@ -56,6 +60,7 @@ impl Resampler {
 			channels: channels as usize,
 			input_planar,
 			output_planar,
+			output_frames_max,
 			pending: Vec::new(),
 		})
 	}
@@ -83,9 +88,12 @@ impl Resampler {
 				}
 			}
 
-			let (_, produced) =
-				self.resampler
-					.process_into_buffer(&self.input_planar, &mut self.output_planar, None)?;
+			let input = SequentialSliceOfVecs::new(&self.input_planar, self.channels, self.chunk_frames)
+				.expect("resampler input buffer dimensions");
+			let mut output =
+				SequentialSliceOfVecs::new_mut(&mut self.output_planar, self.channels, self.output_frames_max)
+					.expect("resampler output buffer dimensions");
+			let (_, produced) = self.resampler.process_into_buffer(&input, &mut output, None)?;
 
 			let prev_len = out.len();
 			out.resize(prev_len + produced * self.channels, 0.0);

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -41,7 +41,7 @@ moq-net = { workspace = true, features = ["serde"] }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 qmux = { workspace = true, features = ["wss", "tls"], optional = true }
 quinn = { version = "0.11", default-features = false, features = ["platform-verifier", "runtime-tokio", "bloom"], optional = true }
-rand = "0.9.2"
+rand = "0.10.1"
 rcgen = { version = "0.14", default-features = false, optional = true }
 reqwest = { version = "0.12", default-features = false, optional = true }
 rustls = "0.23"
@@ -68,5 +68,5 @@ tracing-android = { version = "0.2", optional = true }
 [dev-dependencies]
 bytes = "1"
 chrono = "0.4"
-toml = "0.9"
+toml = "1.1"
 tracing-test = "0.2"

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -367,7 +367,7 @@ impl ServerIdGenerator {
 
 impl noq::ConnectionIdGenerator for ServerIdGenerator {
 	fn generate_cid(&mut self) -> noq::ConnectionId {
-		use rand::Rng;
+		use rand::RngExt;
 		let cid_len = self.cid_len();
 		let mut cid = Vec::with_capacity(cid_len);
 		// First byte has "self-encoded length" of server ID + nonce

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -209,7 +209,9 @@ impl NoqServer {
 				nonce_len,
 				"using QUIC-LB compatible connection ID generation"
 			);
-			endpoint_config.cid_generator(move || Box::new(ServerIdGenerator::new(server_id.clone(), nonce_len)));
+			endpoint_config.cid_generator(Arc::new(move || {
+				Box::new(ServerIdGenerator::new(server_id.clone(), nonce_len))
+			}));
 		}
 
 		let socket = std::net::UdpSocket::bind(listen).context("failed to bind UDP socket")?;
@@ -272,14 +274,17 @@ impl NoqRequest {
 		let alpn = String::from_utf8(alpn).context("failed to decode ALPN")?;
 		let host = handshake.server_name.unwrap_or_default();
 
-		tracing::debug!(%host, ip = %conn.remote_address(), %alpn, "accepting");
+		// The established Connection no longer exposes a single peer address (noq 1.0
+		// supports multipath), so capture it from the Connecting before awaiting.
+		let remote = conn.remote_address();
+		tracing::debug!(%host, ip = %remote, %alpn, "accepting");
 
 		// Wait for the QUIC connection to be established.
 		let conn = conn.await.context("failed to establish QUIC connection")?;
 
 		let span = tracing::Span::current();
 		span.record("id", conn.stable_id());
-		tracing::debug!(%host, ip = %conn.remote_address(), %alpn, "accepted");
+		tracing::debug!(%host, ip = %remote, %alpn, "accepted");
 
 		match alpn.as_str() {
 			web_transport_noq::ALPN => {

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -78,7 +78,10 @@ impl QuicheClient {
 				let conn = builder
 					.connect(&host, port)
 					.await
-					.context("failed to connect to quiche server")?;
+					.context("failed to connect to quiche server")?
+					.established()
+					.await
+					.context("failed to establish quiche connection")?;
 				let session = web_transport_quiche::Connection::connect(conn, request)
 					.await
 					.context("failed to connect to quiche server")?;
@@ -89,7 +92,10 @@ impl QuicheClient {
 				let conn = builder
 					.connect(&host, port)
 					.await
-					.context("failed to connect to quiche server")?;
+					.context("failed to connect to quiche server")?
+					.established()
+					.await
+					.context("failed to establish quiche connection")?;
 
 				let alpn = conn.alpn().context("missing ALPN")?;
 				let alpn = std::str::from_utf8(&alpn).context("failed to decode ALPN")?;

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -403,7 +403,7 @@ impl ServerIdGenerator {
 
 impl quinn::ConnectionIdGenerator for ServerIdGenerator {
 	fn generate_cid(&mut self) -> quinn::ConnectionId {
-		use rand::Rng;
+		use rand::RngExt;
 		let cid_len = self.cid_len();
 		let mut cid = Vec::with_capacity(cid_len);
 		// First byte has "self-encoded length" of server ID + nonce

--- a/rs/moq-net/Cargo.toml
+++ b/rs/moq-net/Cargo.toml
@@ -21,7 +21,7 @@ bytes = "1"
 futures = "0.3"
 kio = { workspace = true }
 num_enum = "0.7"
-rand = "0.9.2"
+rand = "0.10.1"
 serde = { workspace = true, features = ["rc"] }
 serde_json = "1"
 thiserror = "2"

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -5,7 +5,7 @@ use std::{
 	task::Poll,
 };
 
-use rand::Rng;
+use rand::RngExt;
 use web_async::Lock;
 
 use super::BroadcastConsumer;

--- a/rs/moq-net/src/model/time.rs
+++ b/rs/moq-net/src/model/time.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 
 use crate::Error;
 use crate::coding::{Decode, DecodeError, Encode, EncodeError, VarInt};

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -45,7 +45,7 @@ moq-token = { workspace = true, features = ["tokio"] }
 notify = "8"
 qmux = { workspace = true, features = ["ws"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-reqwest-middleware = "0.5"
+reqwest-middleware = "0.4"
 rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -45,7 +45,7 @@ moq-token = { workspace = true, features = ["tokio"] }
 notify = "8"
 qmux = { workspace = true, features = ["ws"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-reqwest-middleware = "0.4"
+reqwest-middleware = "0.5"
 rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -53,7 +53,7 @@ serde_with = { version = "3", features = ["json", "base64"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false }
-toml = "0.9"
+toml = "1.1"
 tower-http = { version = "0.6", features = ["cors"] }
 tower-service = "0.3"
 tracing = "0.1"
@@ -63,7 +63,7 @@ url = { version = "2", features = ["serde"] }
 sd-notify = "0.5"
 
 [dev-dependencies]
-rcgen = "0.13"
+rcgen = "0.14"
 tempfile = "3"
 web-transport-trait = { workspace = true }
 wiremock = "0.6"

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -2482,6 +2482,7 @@ api = "https://api.example.com/access"
 		ca_params.distinguished_name.push(rcgen::DnType::CommonName, "Test CA");
 		ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
 		let ca_cert = ca_params.self_signed(&ca_kp).unwrap();
+		let ca_issuer = rcgen::Issuer::from_params(&ca_params, &ca_kp);
 
 		// 2. Server cert (SAN: 127.0.0.1) signed by the CA.
 		let server_kp = KeyPair::generate().unwrap();
@@ -2489,7 +2490,7 @@ api = "https://api.example.com/access"
 		server_params
 			.distinguished_name
 			.push(rcgen::DnType::CommonName, "test-server");
-		let server_cert = server_params.signed_by(&server_kp, &ca_cert, &ca_kp).unwrap();
+		let server_cert = server_params.signed_by(&server_kp, &ca_issuer).unwrap();
 
 		// 3. Client cert signed by the CA.
 		let client_kp = KeyPair::generate().unwrap();
@@ -2497,7 +2498,7 @@ api = "https://api.example.com/access"
 		client_params
 			.distinguished_name
 			.push(rcgen::DnType::CommonName, "test-client");
-		let client_cert = client_params.signed_by(&client_kp, &ca_cert, &ca_kp).unwrap();
+		let client_cert = client_params.signed_by(&client_kp, &ca_issuer).unwrap();
 
 		// 4. Write CA + client cert/key to temp files.
 		let dir = TempDir::new().unwrap();

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -667,13 +667,14 @@ mod tests {
 		ca_params.distinguished_name.push(rcgen::DnType::CommonName, "Test CA");
 		ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
 		let ca_cert = ca_params.self_signed(&ca_kp).unwrap();
+		let ca_issuer = rcgen::Issuer::from_params(&ca_params, &ca_kp);
 
 		let server_kp = KeyPair::generate().unwrap();
 		let mut server_params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
 		server_params
 			.distinguished_name
 			.push(rcgen::DnType::CommonName, "test-server");
-		let server_cert = server_params.signed_by(&server_kp, &ca_cert, &ca_kp).unwrap();
+		let server_cert = server_params.signed_by(&server_kp, &ca_issuer).unwrap();
 
 		let ca_path = dir.path().join("ca.pem");
 		let cert_path = dir.path().join("server.cert.pem");


### PR DESCRIPTION
Supersedes #1600. Brings in the dependabot grouped cargo bump plus the source changes the major-version updates require so CI compiles. #1600 failed `Check` on a `moq-net` compile error (`rand 0.10` API change), with further breakage in `moq-audio` (`rubato 3.0`), `moq-relay` tests (`rcgen 0.14`), and the feature-gated `moq-native` `noq`/`quiche` backends.

## Dependency updates

| Package | From | To |
| --- | --- | --- |
| qmux | 0.0.7 | 0.0.8 |
| web-transport-noq | 0.0.3 | 0.1.1 |
| web-transport-quiche | 0.2.3 | 0.4.0 |
| rubato | 0.16.2 | 3.0.0 |
| rand | 0.9.4 | 0.10.1 |
| rcgen | 0.13.2 | 0.14.8 |
| toml | 0.9 | 1.1 |

## Code changes

- **rand 0.9 → 0.10**: `random_range` and `random_iter` moved to the new `RngExt` trait. Swapped `use rand::Rng` for `use rand::RngExt` in `moq-net` (`model/origin.rs`, `model/time.rs`) and `moq-native` (`quinn.rs`, `noq.rs`).
- **rubato 0.16 → 3.0**: `SincFixedIn` is now `Async` + `FixedAsync::Input`, and `process_into_buffer` takes `audioadapter` buffers instead of `&[Vec<f32>]`. Rewrote the `moq-audio` resampler wrapper to wrap the planar buffers in `SequentialSliceOfVecs` and allocate the output via `output_frames_max()`. Also dropped rubato's default `fft_resampler` feature since we only use the sinc resampler, which removes the unused `realfft`/RustFFT deps. The existing `upsample_44100_to_48000_preserves_energy_roughly` and `opus_round_trip_44100_s16_resampled` tests still pass, so behavior is preserved.
- **rcgen 0.13 → 0.14**: `CertificateParams::signed_by` now takes an `Issuer` that bundles the CA cert and signing key. Build an `Issuer::from_params` once and reuse it in the `moq-relay` mTLS test fixtures (`auth.rs`, `web.rs`).
- **web-transport-quiche 0.2 → 0.4** (`moq-native`, `quiche` feature): `ClientBuilder::connect` now returns a `Connecting` that must be `.established().await`ed into a `Connection`. Establish before `Connection::connect` / `Connection::raw` / `alpn()`.
- **web-transport-noq 0.0.3 → 0.1.1** (`moq-native`, `noq` feature; pulls noq 1.0.0-rc): `EndpointConfig::cid_generator` now takes an `Arc<dyn Fn() -> Box<...> + Send + Sync>`, so wrap the factory closure in `Arc`. The established `Connection` no longer exposes `remote_address` (noq 1.0 supports multipath), so capture the peer address from the `Connecting` before awaiting.

## reqwest-middleware kept at 0.4

The original #1600 also bumped `reqwest-middleware` 0.4 → 0.5, but that breaks the relay HTTP cache: `http-cache-reqwest`'s only stable release (0.16) still requires `reqwest-middleware 0.4` + `reqwest 0.12`. The only `http-cache-reqwest` releases on `reqwest-middleware 0.5` are `1.0.0-alpha.x` pre-releases (which also pull `reqwest 0.13`). Taking 0.5 would force a pre-release dependency and a `reqwest 0.12 → 0.13` migration across the relay, which is out of scope for a routine bump. Pinned it back to `0.4` so the rest of the group can land.

## Test plan

- [x] `cargo check -p moq-native --all-features` clean (covers the `noq`/`quiche` backends CI exercises)
- [x] `cargo clippy` clean for `moq-audio`, `moq-net`, `moq-native` (incl. `--all-features --all-targets`), `moq-relay`
- [x] `cargo test` passes for those crates (the `moq-native` `alpn` integration tests fail only in this sandbox because it has no IPv6 to bind `[::]:0`; they exercise networking, not the bumped deps)
- [x] rubato migration validated by the existing resample/opus round-trip tests; `realfft` confirmed dropped from `Cargo.lock`

(Written by Claude)