### PR TITLE
moq-net: accept `impl Into<Option<Subscription>>` for subscribe, drop subscribe_default

### DIFF
--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -407,10 +407,7 @@ impl Consume {
 		// `subscribe` blocks on SUBSCRIBE_OK, so run it inside the task.
 		tokio::spawn(async move {
 			let res = async move {
-				let track = broadcast
-					.consume_track(&name)
-					.subscribe(moq_net::Subscription::default())
-					.await?;
+				let track = broadcast.consume_track(&name).subscribe(None).await?;
 				Self::run_raw(on_frame, track, channel.1).await
 			}
 			.await;

--- a/rs/moq-audio/src/consumer.rs
+++ b/rs/moq-audio/src/consumer.rs
@@ -53,10 +53,7 @@ impl AudioConsumer {
 		};
 
 		let name = name.into();
-		let track = broadcast
-			.consume_track(&name)
-			.subscribe(moq_net::Subscription::default())
-			.await?;
+		let track = broadcast.consume_track(&name).subscribe(None).await?;
 		let mut track = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 		if let Some(latency) = output.latency_max {
 			track = track.with_latency(latency);

--- a/rs/moq-boy/src/input.rs
+++ b/rs/moq-boy/src/input.rs
@@ -99,10 +99,7 @@ async fn handle_viewer_commands(
 	broadcast: moq_net::BroadcastConsumer,
 	cmd_tx: &tokio::sync::mpsc::Sender<Command>,
 ) -> anyhow::Result<()> {
-	let mut track = broadcast
-		.consume_track("command")
-		.subscribe(moq_net::Subscription::default())
-		.await?;
+	let mut track = broadcast.consume_track("command").subscribe(None).await?;
 
 	while let Some(mut group) = track.recv_group().await? {
 		while let Some(frame) = group.read_frame().await? {

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -97,11 +97,7 @@ impl MoqBroadcastConsumer {
 	///
 	/// Frames are returned as plain byte payloads with no codec or container parsing.
 	pub async fn subscribe_track(&self, name: String) -> Result<Arc<MoqTrackConsumer>, MoqError> {
-		let track = self
-			.inner
-			.consume_track(&name)
-			.subscribe(moq_net::Subscription::default())
-			.await?;
+		let track = self.inner.consume_track(&name).subscribe(None).await?;
 		Ok(Arc::new(MoqTrackConsumer::new(track)))
 	}
 
@@ -121,11 +117,7 @@ impl MoqBroadcastConsumer {
 		let media: moq_mux::catalog::hang::Container = (&container)
 			.try_into()
 			.map_err(|e| MoqError::Codec(format!("invalid container: {e}")))?;
-		let track = self
-			.inner
-			.consume_track(&name)
-			.subscribe(moq_net::Subscription::default())
-			.await?;
+		let track = self.inner.consume_track(&name).subscribe(None).await?;
 		let latency = std::time::Duration::from_millis(max_latency_ms);
 		let consumer = moq_mux::container::Consumer::new(track, media).with_latency(latency);
 		Ok(Arc::new(MoqMediaConsumer {

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -203,7 +203,7 @@ impl MoqTrackProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.inner.lock().unwrap();
 		let track = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		Ok(Arc::new(MoqTrackConsumer::new(track.subscribe_default())))
+		Ok(Arc::new(MoqTrackConsumer::new(track.subscribe(None))))
 	}
 
 	/// Append a new group to the track, returning a producer for writing frames into it.

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -448,10 +448,7 @@ async fn run_session(
 		};
 		let caps = video_caps(&config)?;
 		let endpoint = request_pad(&control_tx, descriptor.clone(), caps).await?;
-		let track_consumer = broadcast
-			.consume_track(&track_name)
-			.subscribe(moq_net::Subscription::default())
-			.await?;
+		let track_consumer = broadcast.consume_track(&track_name).subscribe(None).await?;
 		let track = moq_mux::container::Consumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
 			.with_latency(Duration::from_secs(1));
 		tasks.push(spawn_track_pump(track, descriptor, endpoint, shutdown.clone()));
@@ -464,10 +461,7 @@ async fn run_session(
 		};
 		let caps = audio_caps(&config)?;
 		let endpoint = request_pad(&control_tx, descriptor.clone(), caps).await?;
-		let track_consumer = broadcast
-			.consume_track(&track_name)
-			.subscribe(moq_net::Subscription::default())
-			.await?;
+		let track_consumer = broadcast.consume_track(&track_name).subscribe(None).await?;
 		let track = moq_mux::container::Consumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
 			.with_latency(Duration::from_secs(1));
 		tasks.push(spawn_track_pump(track, descriptor, endpoint, shutdown.clone()));

--- a/rs/moq-mux/src/catalog/consumer.rs
+++ b/rs/moq-mux/src/catalog/consumer.rs
@@ -32,10 +32,7 @@ impl Consumer {
 				Self::Hang(super::hang::Consumer::new(track))
 			}
 			CatalogFormat::Msf => {
-				let track = broadcast
-					.consume_track(moq_msf::DEFAULT_NAME)
-					.subscribe(moq_net::Subscription::default())
-					.await?;
+				let track = broadcast.consume_track(moq_msf::DEFAULT_NAME).subscribe(None).await?;
 				Self::Msf(super::msf::Consumer::new(track))
 			}
 		})

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -94,7 +94,7 @@ mod test {
 	#[test]
 	fn waits_for_pending_catalog_group_payload() {
 		let mut track = Catalog::default_track().produce();
-		let mut consumer = Consumer::new(track.subscribe_default());
+		let mut consumer = Consumer::new(track.subscribe(None));
 		let mut group = track.append_group().expect("catalog group should append");
 
 		let waiter = kio::Waiter::noop();
@@ -110,7 +110,7 @@ mod test {
 	#[test]
 	fn waits_for_pending_catalog_group_payload_after_track_finish() {
 		let mut track = Catalog::default_track().produce();
-		let mut consumer = Consumer::new(track.subscribe_default());
+		let mut consumer = Consumer::new(track.subscribe(None));
 		let mut group = track.append_group().expect("catalog group should append");
 
 		track.finish().expect("catalog track should finish");
@@ -128,7 +128,7 @@ mod test {
 	#[test]
 	fn returns_latest_complete_catalog_group() {
 		let mut track = Catalog::default_track().produce();
-		let mut consumer = Consumer::new(track.subscribe_default());
+		let mut consumer = Consumer::new(track.subscribe(None));
 		let waiter = kio::Waiter::noop();
 
 		let (_old, old_payload) = catalog_payload("old");
@@ -154,7 +154,7 @@ mod test {
 	#[test]
 	fn waits_for_newer_pending_group_instead_of_returning_older_ready_group() {
 		let mut track = Catalog::default_track().produce();
-		let mut consumer = Consumer::new(track.subscribe_default());
+		let mut consumer = Consumer::new(track.subscribe(None));
 		let waiter = kio::Waiter::noop();
 
 		let (_old, old_payload) = catalog_payload("old");
@@ -181,7 +181,7 @@ mod test {
 	#[test]
 	fn retained_pending_group_is_superseded_by_newer_group() {
 		let mut track = Catalog::default_track().produce();
-		let mut consumer = Consumer::new(track.subscribe_default());
+		let mut consumer = Consumer::new(track.subscribe(None));
 		let waiter = kio::Waiter::noop();
 
 		let (_old, old_payload) = catalog_payload("old");
@@ -211,7 +211,7 @@ mod test {
 	#[test]
 	fn returns_none_when_empty_track_finishes() {
 		let mut track = Catalog::default_track().produce();
-		let mut consumer = Consumer::new(track.subscribe_default());
+		let mut consumer = Consumer::new(track.subscribe(None));
 		let waiter = kio::Waiter::noop();
 
 		track.finish().expect("catalog track should finish");

--- a/rs/moq-mux/src/catalog/hang/producer.rs
+++ b/rs/moq-mux/src/catalog/hang/producer.rs
@@ -54,7 +54,7 @@ impl Producer {
 
 	/// Create a consumer for this catalog, receiving updates as they're published.
 	pub fn consume(&self) -> Result<super::Consumer, moq_net::Error> {
-		let track = self.hang_track.subscribe_default();
+		let track = self.hang_track.subscribe(None);
 		let subscriber = track;
 		Ok(super::Consumer::new(subscriber))
 	}

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -411,11 +411,6 @@ mod tests {
 		Timestamp::from_micros(micros).unwrap()
 	}
 
-	/// Subscribe to a track with default preferences (test helper).
-	fn subscribe_default(track: &moq_net::TrackProducer) -> moq_net::TrackSubscriber {
-		track.subscribe_default()
-	}
-
 	/// Test-only container that round-trips a per-sample duration on the wire, so the
 	/// duration-based skip can be exercised without building a real CMAF init segment.
 	/// Each frame is `[timestamp_us: u64 LE][duration_us: u64 LE][payload]`.
@@ -510,7 +505,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -530,7 +525,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_000), ts(66_000)]);
@@ -550,7 +545,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		// 5 groups, 20ms spacing. Total span = 80ms, well within 500ms latency.
@@ -571,7 +566,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
@@ -615,7 +610,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::ZERO);
 
 		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
@@ -654,7 +649,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
@@ -699,7 +694,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
@@ -737,7 +732,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -757,7 +752,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(66_000), ts(33_000)]);
@@ -778,7 +773,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		track.finish().unwrap();
@@ -798,7 +793,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -822,7 +817,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		assert!(
@@ -847,7 +842,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		write_group(&mut track, 0, &[ts(0), ts(20_000)]);
@@ -867,7 +862,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(80));
 
 		write_group(&mut track, 5, &[ts(0), ts(20_000)]);
@@ -887,7 +882,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0), ts(33_333), ts(66_666)]);
@@ -909,7 +904,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
@@ -949,7 +944,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
 
 		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
@@ -997,7 +992,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(3700));
 
 		let one_hour = 3_600_000_000u64;
@@ -1015,7 +1010,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1035,7 +1030,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = track.subscribe_default();
+		let consumer_track = track.subscribe(None);
 		// latency must exceed (group1_max - group0_min) = 100ms - 0ms = 100ms
 		// to avoid the latency skip and test B-frame timestamp tracking.
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(110));
@@ -1089,7 +1084,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		write_group(&mut track, 3, &[ts(0)]);
@@ -1144,7 +1139,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		let _group5 = track.create_group(moq_net::Group { sequence: 5 }).unwrap();
@@ -1169,7 +1164,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 100, &[ts(3_000_000)]);
@@ -1185,7 +1180,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(50));
 
 		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
@@ -1223,7 +1218,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
@@ -1263,7 +1258,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: stalled at ts=0, NOT finished
@@ -1303,7 +1298,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: finished normally
@@ -1321,7 +1316,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
@@ -1340,7 +1335,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		write_group(&mut track, 0, &[ts(0)]);
@@ -1371,7 +1366,7 @@ mod tests {
 		let mut track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = subscribe_default(&track);
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
@@ -1393,7 +1388,7 @@ mod tests {
 		let mut track = moq_net::Track::new("video")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer_track = track.subscribe_default();
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		// Write frames using Container::Legacy encoding
@@ -1435,7 +1430,7 @@ mod tests {
 		// DurationWire is a test-only container that doesn't stamp moq_net frame
 		// timestamps; leave the track untimed so model-layer validation matches.
 		let mut track = moq_net::Track::new("test").produce();
-		let consumer_track = track.subscribe_default();
+		let consumer_track = track.subscribe(None);
 		// Latency dwarfs the gap, so only duration coverage can trigger the skip.
 		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
 
@@ -1476,7 +1471,7 @@ mod tests {
 		tokio::time::pause();
 		// DurationWire is untimed at the moq_net frame layer.
 		let mut track = moq_net::Track::new("test").produce();
-		let consumer_track = track.subscribe_default();
+		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
 
 		// Group 0: frame at ts=0 lasting only 10ms, far short of group 1 at 33ms.

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -184,7 +184,7 @@ async fn test_seek_sets_initial_sequence() {
 	let video_name = snap.video.renditions.keys().next().expect("video track").clone();
 	let mut video_track = broadcast_consumer
 		.consume_track(&video_name)
-		.subscribe(moq_net::Subscription::default())
+		.subscribe(None)
 		.await
 		.expect("video track should exist");
 
@@ -224,7 +224,7 @@ async fn test_msf_catalog_roundtrip() {
 
 	let track = consumer
 		.consume_track(moq_msf::DEFAULT_NAME)
-		.subscribe(moq_net::Subscription::default())
+		.subscribe(None)
 		.await
 		.expect("MSF catalog track should exist");
 	let mut msf = crate::catalog::msf::Consumer::new(track);

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -185,7 +185,7 @@ impl<C: Container> Producer<C> {
 
 	/// Create a consumer for this track.
 	pub fn consume(&self) -> moq_net::TrackSubscriber {
-		self.inner.subscribe_default()
+		self.inner.subscribe(None)
 	}
 }
 
@@ -233,7 +233,7 @@ mod tests {
 		let track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer = track.subscribe_default();
+		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		producer.write(frame(0, true)).unwrap(); // first frame must be a keyframe
@@ -251,7 +251,7 @@ mod tests {
 		let track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer = track.subscribe_default();
+		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		producer.write(frame(0, true)).unwrap();
@@ -290,7 +290,7 @@ mod tests {
 		let track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer = track.subscribe_default();
+		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		producer.write(frame(0, true)).unwrap(); // seq 0
@@ -307,7 +307,7 @@ mod tests {
 		let track = moq_net::Track::new("test")
 			.with_timescale(hang::container::TIMESCALE)
 			.produce();
-		let consumer = track.subscribe_default();
+		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		producer.seek(5).unwrap();

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -82,11 +82,7 @@ impl ExportSource {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
 		Ok(Self {
-			state: SourceState::Subscribing(
-				broadcast
-					.consume_track(name)
-					.subscribe(moq_net::Subscription::default()),
-			),
+			state: SourceState::Subscribing(broadcast.consume_track(name).subscribe(None)),
 			media: Some(media),
 			latency,
 			transform,
@@ -108,11 +104,7 @@ impl ExportSource {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
 		Ok(Self {
-			state: SourceState::Subscribing(
-				broadcast
-					.consume_track(name)
-					.subscribe(moq_net::Subscription::default()),
-			),
+			state: SourceState::Subscribing(broadcast.consume_track(name).subscribe(None)),
 			media: Some(media),
 			latency,
 			transform: None,
@@ -132,11 +124,7 @@ impl ExportSource {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
 		Ok(Self {
-			state: SourceState::Subscribing(
-				broadcast
-					.consume_track(name)
-					.subscribe(moq_net::Subscription::default()),
-			),
+			state: SourceState::Subscribing(broadcast.consume_track(name).subscribe(None)),
 			media: Some(media),
 			latency,
 			transform: None,

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -102,7 +102,7 @@ async fn main() -> anyhow::Result<()> {
 						Some(broadcast) => {
 							tracing::info!(broadcast = %path, "broadcast is online, subscribing to track");
 							let track = broadcast
-								.consume_track(&track).subscribe(moq_net::Subscription::default())
+								.consume_track(&track).subscribe(None)
 								.await?;
 							clock = Some(Subscriber::new(track));
 						}

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -71,7 +71,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 
 	let mut track_sub = bc
 		.consume_track("video")
-		.subscribe(moq_native::moq_net::Subscription::default())
+		.subscribe(None)
 		.await
 		.expect("consume_track failed");
 
@@ -225,7 +225,7 @@ async fn iroh_connect() {
 
 	let mut track_sub = bc
 		.consume_track("video")
-		.subscribe(moq_native::moq_net::Subscription::default())
+		.subscribe(None)
 		.await
 		.expect("consume_track failed");
 

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -89,7 +89,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	// Subscribe to the track.
 	let mut track_sub = bc
 		.consume_track("video")
-		.subscribe(moq_native::moq_net::Subscription::default())
+		.subscribe(None)
 		.await
 		.expect("consume_track failed");
 
@@ -120,7 +120,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 /// Lite05 publisher↔subscriber round-trip exercising the per-frame timestamp
 /// delta encoding, including negative deltas (B-frame ordering).
 async fn lite05_timestamp_roundtrip(scheme: &str) {
-	use moq_native::moq_net::{Subscription, Timescale, Timestamp};
+	use moq_native::moq_net::{Timescale, Timestamp};
 
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
@@ -189,7 +189,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 
 	let mut track_sub = bc
 		.consume_track("video")
-		.subscribe(Subscription::default())
+		.subscribe(None)
 		.await
 		.expect("consume_track failed");
 
@@ -233,8 +233,6 @@ async fn broadcast_moq_lite_05_timestamps_webtransport() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_moq_lite_05_without_timescale() {
-	use moq_native::moq_net::Subscription;
-
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
 	let mut track = broadcast.create_track(Track::new("video")).expect("create track");
@@ -282,7 +280,7 @@ async fn broadcast_moq_lite_05_without_timescale() {
 
 	let mut track_sub = bc
 		.consume_track("video")
-		.subscribe(Subscription::default())
+		.subscribe(None)
 		.await
 		.expect("consume_track failed");
 
@@ -696,7 +694,7 @@ async fn broadcast_websocket() {
 	// Subscribe to the track.
 	let mut track_sub = bc
 		.consume_track("video")
-		.subscribe(moq_native::moq_net::Subscription::default())
+		.subscribe(None)
 		.await
 		.expect("consume_track failed");
 
@@ -805,7 +803,7 @@ async fn broadcast_websocket_fallback() {
 	// Subscribe to the track.
 	let mut track_sub = bc
 		.consume_track("video")
-		.subscribe(moq_native::moq_net::Subscription::default())
+		.subscribe(None)
 		.await
 		.expect("consume_track failed");
 
@@ -1046,11 +1044,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	let bc = bc.broadcast().expect("expected announce");
 
 	// First subscription: receive group 0.
-	let mut sub1 = bc
-		.consume_track("video")
-		.subscribe(moq_native::moq_net::Subscription::default())
-		.await
-		.expect("subscribe1");
+	let mut sub1 = bc.consume_track("video").subscribe(None).await.expect("subscribe1");
 	let mut g = tokio::time::timeout(TIMEOUT, sub1.recv_group())
 		.await
 		.expect("recv group 0 timeout")
@@ -1074,11 +1068,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	tokio::time::sleep(Duration::from_millis(20)).await;
 
 	// Resubscribe well inside the 5s linger window.
-	let mut sub2 = bc
-		.consume_track("video")
-		.subscribe(moq_native::moq_net::Subscription::default())
-		.await
-		.expect("subscribe2");
+	let mut sub2 = bc.consume_track("video").subscribe(None).await.expect("subscribe2");
 
 	// A new group published after the resubscribe must reach the consumer
 	// regardless of which linger branch fired.

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -476,7 +476,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		drop(state);
 
 		let mut broadcast = self.start_announce(msg.track_namespace.to_owned())?;
-		broadcast.insert_track(track.subscribe_default())?;
+		broadcast.insert_track(track.subscribe(None))?;
 
 		Ok(())
 	}

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -239,7 +239,7 @@ impl BroadcastProducer {
 	}
 
 	pub fn assert_insert_track(&mut self, track: &TrackProducer) {
-		self.insert_track(track.subscribe_default())
+		self.insert_track(track.subscribe(None))
 			.expect("should not have errored")
 	}
 }
@@ -708,10 +708,12 @@ impl TrackConsumer {
 	/// groups; or drive it with [`TrackPending::poll_ok`] from a poll loop.
 	///
 	/// `subscription` is this subscriber's preferences and feeds the producer's
-	/// [`TrackProducer::subscription`] aggregate. Concurrent subscribers to the
-	/// same name coalesce onto one request.
-	pub fn subscribe(&self, subscription: Subscription) -> TrackPending {
-		self.broadcast.request_subscribe(&self.name, subscription)
+	/// [`TrackProducer::subscription`] aggregate; pass `None` for
+	/// [`Subscription::default`]. Concurrent subscribers to the same name coalesce
+	/// onto one request.
+	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> TrackPending {
+		self.broadcast
+			.request_subscribe(&self.name, subscription.into().unwrap_or_default())
 	}
 }
 
@@ -734,7 +736,7 @@ mod test {
 	/// a publisher accepts). Returns the [`TrackPending`] to resolve after accepting.
 	macro_rules! subscribe_pending {
 		($consumer:expr, $name:expr) => {{
-			let pending = $consumer.consume_track($name).subscribe(Subscription::default());
+			let pending = $consumer.consume_track($name).subscribe(None);
 			assert!(
 				pending.poll_ok(&kio::Waiter::noop()).is_pending(),
 				"consume_track should stay pending until the request is accepted"
@@ -755,22 +757,14 @@ mod test {
 		let consumer = producer.consume();
 
 		// The track already exists, so subscribe resolves immediately.
-		let mut track1_sub = consumer
-			.consume_track("track1")
-			.subscribe(Subscription::default())
-			.await
-			.unwrap();
+		let mut track1_sub = consumer.consume_track("track1").subscribe(None).await.unwrap();
 		track1_sub.assert_group();
 
 		let mut track2 = Track::new("track2").produce();
 		producer.assert_insert_track(&track2);
 
 		let consumer2 = producer.consume();
-		let mut track2_consumer = consumer2
-			.consume_track("track2")
-			.subscribe(Subscription::default())
-			.await
-			.unwrap();
+		let mut track2_consumer = consumer2.consume_track("track2").subscribe(None).await.unwrap();
 		track2_consumer.assert_no_group();
 
 		track2.append_group().unwrap();
@@ -788,11 +782,7 @@ mod test {
 
 		// Create a new track and insert it into the broadcast (resolves immediately).
 		let track1 = producer.assert_create_track(&Track::new("track1"));
-		let track1c = consumer
-			.consume_track("track1")
-			.subscribe(Subscription::default())
-			.await
-			.unwrap();
+		let track1c = consumer.consume_track("track1").subscribe(None).await.unwrap();
 
 		// A track nobody publishes stays pending until accepted.
 		let track2_fut = subscribe_pending!(consumer, "track2");
@@ -831,7 +821,7 @@ mod test {
 
 		track1.assert_not_closed();
 		track1.assert_is_clone(&track2);
-		track3.subscribe_default().assert_is_clone(&track1);
+		track3.subscribe(None).assert_is_clone(&track1);
 
 		// Append a group and make sure they all get it.
 		track3.append_group().unwrap();
@@ -844,10 +834,7 @@ mod test {
 		assert!(track4_fut.await.is_err());
 
 		// With no dynamic producer left, new subscribes fail outright.
-		let track5 = consumer2
-			.consume_track("track3")
-			.subscribe(Subscription::default())
-			.await;
+		let track5 = consumer2.consume_track("track3").subscribe(None).await;
 		assert!(track5.is_err(), "should have errored");
 	}
 
@@ -898,11 +885,7 @@ mod test {
 		);
 
 		// A second subscriber reuses the live producer (fast path / dedup).
-		let consumer2 = bc
-			.consume_track("unknown_track")
-			.subscribe(Subscription::default())
-			.await
-			.unwrap();
+		let consumer2 = bc.consume_track("unknown_track").subscribe(None).await.unwrap();
 		consumer2.assert_is_clone(&consumer1);
 
 		drop(consumer1);
@@ -920,12 +903,8 @@ mod test {
 		// While the producer is still alive, re-subscribing to the same name reuses
 		// it (no new request) — this is what lets the relay linger upstream
 		// subscriptions across transient consumer churn.
-		let consumer3 = bc
-			.consume_track("unknown_track")
-			.subscribe(Subscription::default())
-			.await
-			.unwrap();
-		consumer3.assert_is_clone(&producer1.subscribe_default());
+		let consumer3 = bc.consume_track("unknown_track").subscribe(None).await.unwrap();
+		consumer3.assert_is_clone(&producer1.subscribe(None));
 		broadcast.assert_no_request();
 		drop(consumer3);
 

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -612,9 +612,11 @@ impl TrackProducer {
 
 	/// Subscribe to the track in-process with the given subscriber preferences.
 	///
-	/// The preferences feed the producer's [`Self::subscription`] aggregate and
-	/// can be changed later via [`TrackSubscriber::update`].
-	pub fn subscribe(&self, mut subscription: Subscription) -> TrackSubscriber {
+	/// Pass `None` for [`Subscription::default`]. The preferences feed the
+	/// producer's [`Self::subscription`] aggregate and can be changed later via
+	/// [`TrackSubscriber::update`].
+	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> TrackSubscriber {
+		let mut subscription = subscription.into().unwrap_or_default();
 		subscription.stale = self.info.clamp_stale(subscription.stale);
 		let subscription = Arc::new(Mutex::new(subscription));
 		if let Ok(mut state) = self.state.write() {
@@ -629,11 +631,6 @@ impl TrackProducer {
 			next_sequence: 0,
 			end_sequence: None,
 		}
-	}
-
-	/// Subscribe to the track in-process with default ([`Subscription::default`]) preferences.
-	pub fn subscribe_default(&self) -> TrackSubscriber {
-		self.subscribe(Subscription::default())
 	}
 
 	/// The aggregate of every live subscriber's [`Subscription`] (most demanding
@@ -1106,7 +1103,7 @@ mod test {
 		let mut producer = Track::new("test").produce();
 		producer.append_group().unwrap(); // seq 0
 
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 		producer.append_group().unwrap(); // seq 1
@@ -1229,7 +1226,7 @@ mod test {
 		}
 
 		// Consumer should still be able to read through the hole.
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 		let group = consumer.assert_group();
 		// consume() starts at index 0, first non-tombstoned group is seq 5.
 		assert_eq!(group.sequence, 5);
@@ -1280,7 +1277,7 @@ mod test {
 		producer.create_group(Group { sequence: 1 }).unwrap();
 		producer.finish_at(1).unwrap();
 
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 		assert_eq!(consumer.assert_group().sequence, 1);
 
 		let done = consumer
@@ -1294,7 +1291,7 @@ mod test {
 	#[tokio::test]
 	async fn next_group_skips_late_arrivals() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		// Seq 5 arrives first.
 		producer.create_group(Group { sequence: 5 }).unwrap();
@@ -1331,7 +1328,7 @@ mod test {
 	#[tokio::test]
 	async fn next_group_returns_arrivals_in_order() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		// Seq 3 arrives first, then seq 5 — both should be returned in arrival order.
 		producer.create_group(Group { sequence: 3 }).unwrap();
@@ -1357,7 +1354,7 @@ mod test {
 	#[tokio::test]
 	async fn next_group_and_recv_group_use_independent_cursors() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		// Out-of-order arrivals: seq 5 first, then seq 3.
 		producer.create_group(Group { sequence: 5 }).unwrap();
@@ -1381,7 +1378,7 @@ mod test {
 	#[tokio::test]
 	async fn end_at_caps_next_group() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		for s in 0..6 {
 			producer.create_group(Group { sequence: s }).unwrap();
@@ -1413,7 +1410,7 @@ mod test {
 	#[tokio::test]
 	async fn end_at_release_drains_cached_groups() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		for s in 0..6 {
 			producer.create_group(Group { sequence: s }).unwrap();
@@ -1458,7 +1455,7 @@ mod test {
 	#[tokio::test]
 	async fn end_at_lower_than_cursor_parks_consumer() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		for s in 0..3 {
 			producer.create_group(Group { sequence: s }).unwrap();
@@ -1502,7 +1499,7 @@ mod test {
 	#[tokio::test]
 	async fn end_at_toggling_around_late_arrivals() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		consumer.end_at(5);
 
@@ -1545,7 +1542,7 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_returns_single_frame_per_group() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		producer.write_frame(b"hello".as_slice()).unwrap();
 		producer.write_frame(b"world".as_slice()).unwrap();
@@ -1570,7 +1567,7 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_skips_stalled_group_for_newer_ready_frame() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		// Seq 3: group open, no frame yet (stalled).
 		let _stalled = producer.create_group(Group { sequence: 3 }).unwrap();
@@ -1592,7 +1589,7 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_discards_rest_of_multi_frame_group() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		// Group 0 has two frames; only the first is returned.
 		let mut g0 = producer.create_group(Group { sequence: 0 }).unwrap();
@@ -1626,7 +1623,7 @@ mod test {
 		// finish() sets final_sequence, but groups already created with lower sequences
 		// can still produce frames. read_frame must not return None prematurely.
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		let mut g0 = producer.create_group(Group { sequence: 0 }).unwrap();
 		producer.finish().unwrap();
@@ -1653,7 +1650,7 @@ mod test {
 		// start_at sets min_sequence; read_frame must skip groups below it even though
 		// next_sequence is still 0.
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 		consumer.start_at(5);
 
 		// Seq 3 has a frame but is below min_sequence — must be skipped.
@@ -1677,7 +1674,7 @@ mod test {
 	#[tokio::test]
 	async fn read_frame_returns_none_when_finished() {
 		let mut producer = Track::new("test").produce();
-		let mut consumer = producer.subscribe_default();
+		let mut consumer = producer.subscribe(None);
 
 		producer.write_frame(b"only".as_slice()).unwrap();
 		producer.finish().unwrap();
@@ -1704,7 +1701,7 @@ mod test {
 		producer.create_group(Group { sequence: 1 }).unwrap();
 		producer.finish_at(1).unwrap();
 
-		let consumer = producer.subscribe_default();
+		let consumer = producer.subscribe(None);
 		// get_group(0) blocks because group 0 is below final_sequence and could still arrive.
 		assert!(
 			consumer.get_group(0).now_or_never().is_none(),

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -932,7 +932,7 @@ fn advertised_path(prefix: &Path, node: Option<&str>) -> PathOwned {
 mod tests {
 	use std::{collections::BTreeMap, sync::atomic::Ordering::Relaxed};
 
-	use crate::{Origin, Path, Subscription};
+	use crate::{Origin, Path};
 
 	use super::*;
 
@@ -1161,7 +1161,7 @@ mod tests {
 		let broadcast = event.broadcast().expect("active");
 		let track = broadcast
 			.consume_track("publisher.json")
-			.subscribe(Subscription::default())
+			.subscribe(None)
 			.await
 			.expect("subscribe");
 		let frame = read_frame(track).await;
@@ -1188,7 +1188,7 @@ mod tests {
 		let broadcast = event.broadcast().expect("active");
 		let track = broadcast
 			.consume_track("publisher.json")
-			.subscribe(Subscription::default())
+			.subscribe(None)
 			.await
 			.expect("subscribe");
 		let frame = read_frame(track).await;
@@ -1220,7 +1220,7 @@ mod tests {
 		let broadcast = event.broadcast().expect("active");
 		let track = broadcast
 			.consume_track("publisher.json")
-			.subscribe(Subscription::default())
+			.subscribe(None)
 			.await
 			.expect("subscribe");
 		let frame = read_frame(track).await;
@@ -1298,7 +1298,7 @@ mod tests {
 		// External publisher slot SHOULD include foo/bar.
 		let pub_track = broadcast
 			.consume_track("publisher.json")
-			.subscribe(Subscription::default())
+			.subscribe(None)
 			.await
 			.expect("subscribe");
 		assert!(
@@ -1309,11 +1309,7 @@ mod tests {
 		// The other three slots had zero activity. The first frame on
 		// each must be `{}`, not `{"foo/bar": {all zeros}}`.
 		for name in ["subscriber.json", "internal/publisher.json", "internal/subscriber.json"] {
-			let t = broadcast
-				.consume_track(name)
-				.subscribe(Subscription::default())
-				.await
-				.expect("subscribe");
+			let t = broadcast.consume_track(name).subscribe(None).await.expect("subscribe");
 			let frame = read_frame(t).await;
 			assert!(
 				frame.is_empty(),

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -521,7 +521,7 @@ async fn serve_fetch(
 			.ok_or(StatusCode::NOT_FOUND)?;
 		let mut track = broadcast
 			.consume_track(&track)
-			.subscribe(moq_net::Subscription::default())
+			.subscribe(None)
 			.await
 			.map_err(|err| match err {
 				moq_net::Error::NotFound => StatusCode::NOT_FOUND,

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -160,11 +160,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	assert_eq!(path.as_str(), "test");
 	let bc = bc.broadcast().expect("expected announce, got unannounce");
 
-	let mut track_sub = bc
-		.consume_track("video")
-		.subscribe(moq_native::moq_net::Subscription::default())
-		.await
-		.expect("consume_track");
+	let mut track_sub = bc.consume_track("video").subscribe(None).await.expect("consume_track");
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
 		.expect("recv_group timeout")

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -79,10 +79,7 @@ impl Track {
 	/// Audio track for an Opus rendition.
 	pub async fn opus(broadcast: &moq_net::BroadcastConsumer, name: &str) -> Result<Self> {
 		let container = moq_mux::catalog::hang::Container::Legacy;
-		let track = broadcast
-			.consume_track(name)
-			.subscribe(moq_net::Subscription::default())
-			.await?;
+		let track = broadcast.consume_track(name).subscribe(None).await?;
 		let consumer = moq_mux::container::Consumer::new(track, container);
 		Ok(Self {
 			consumer,
@@ -95,10 +92,7 @@ impl Track {
 	/// inferred from `config.description` (avc1 vs avc3).
 	pub async fn video(broadcast: &moq_net::BroadcastConsumer, name: &str, config: &VideoConfig) -> Result<Self> {
 		let container: moq_mux::catalog::hang::Container = (&config.container).try_into()?;
-		let track = broadcast
-			.consume_track(name)
-			.subscribe(moq_net::Subscription::default())
-			.await?;
+		let track = broadcast.consume_track(name).subscribe(None).await?;
 		let consumer = moq_mux::container::Consumer::new(track, container);
 
 		let (codec, convert) = match &config.codec {


### PR DESCRIPTION
## Summary

Makes subscribing ergonomic when you just want the defaults: pass `None` instead of `Subscription::default()`.

- `TrackProducer::subscribe` and `TrackConsumer::subscribe` now take `impl Into<Option<Subscription>>`, converting once at the public boundary via `.into().unwrap_or_default()`. This matches the existing `impl Into<Option<T>>` convention in the codebase (e.g. `with_group_start`, `end_at`). Internal helpers (`request_subscribe`, `TrackWeak::subscribe`) keep taking a concrete `Subscription`.
- Removed the now-redundant `subscribe_default()` method (and a same-named local test helper in moq-mux) in favor of `subscribe(None)`.
- Updated every call site across the workspace: `.subscribe(Subscription::default())` and `.subscribe_default()` → `.subscribe(None)`.

Call sites that build a customized subscription (`Subscription { .. }` or `Subscription::default().with_priority(1)`) are untouched and still work, since `Subscription` itself satisfies `Into<Option<Subscription>>`.

## Why `dev`

Removing `subscribe_default` is a breaking change to the public `rs/moq-net` API, so this targets `dev` per the branch-targeting rules.

## Cross-package sync

No JS/doc changes needed: the `js/net` API is `subscribe(name, priority)` with no `Subscription` struct equivalent, and this is a Rust-only ergonomic change, not a wire or semantic change.

## Test plan

- [x] `cargo check --workspace --tests` clean (no warnings)
- [x] `cargo test -p moq-net -p moq-mux` pass
- [x] `cargo fmt --check` clean (via nix)

(Written by Claude)