### PR TITLE
chore(moq-relay): bump to 0.12.7

### DIFF
--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.12.6"
+version = "0.12.7"
 edition = "2024"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary

Manual patch bump of `moq-relay` from `0.12.6` to `0.12.7`.

A separate branch adds a `health` field to the public `WebState` struct, which trips cargo-semver-checks (`constructible_struct_adds_field`: an externally-constructible struct gains a field). `moq-relay` has no external consumers yet, so per our patch-only semver policy we ship this as a patch bump and ignore the semver-checks finding rather than forcing a new minor version just for an internal field.

## Notes for reviewers

- This branch contains **only** the version bump. The `WebState.health` field itself lands on its own branch.
- We considered `#[non_exhaustive]` on `WebState` (and demoting it to `pub(crate)` since it's really internal plumbing), but opted to keep it simple for now.

(Written by Claude)