### PR TITLE
fix(infra): serve the apt keyring dearmored, rename to moq-keyring.gpg

### DIFF
--- a/doc/setup/linux.md
+++ b/doc/setup/linux.md
@@ -18,11 +18,11 @@ on Debian 12+ / Ubuntu 24.04+; the other packages install on Ubuntu 22.04 too.
 
 ```bash
 # Trust the project's signing key.
-curl -fsSL https://apt.moq.dev/moq-archive-keyring.gpg \
-  | sudo tee /usr/share/keyrings/moq-archive-keyring.gpg > /dev/null
+curl -fsSL https://apt.moq.dev/moq-keyring.gpg \
+  | sudo tee /usr/share/keyrings/moq-keyring.gpg > /dev/null
 
 # Add the repository.
-echo "deb [signed-by=/usr/share/keyrings/moq-archive-keyring.gpg] https://apt.moq.dev stable main" \
+echo "deb [signed-by=/usr/share/keyrings/moq-keyring.gpg] https://apt.moq.dev stable main" \
   | sudo tee /etc/apt/sources.list.d/moq.list
 
 sudo apt update
@@ -100,12 +100,12 @@ If your distro doesn't have a native package on offer:
 The apt and rpm repositories are signed with the same project GPG key. The
 public key is served at:
 
-- <https://apt.moq.dev/moq-archive-keyring.gpg>
-- <https://rpm.moq.dev/moq-archive-keyring.gpg>
+- <https://apt.moq.dev/moq-keyring.gpg>
+- <https://rpm.moq.dev/moq-keyring.gpg>
 
 Verify the apt repository metadata signature manually:
 
 ```bash
-gpg --import moq-archive-keyring.gpg
+gpg --import moq-keyring.gpg
 gpg --verify Release.gpg Release
 ```

--- a/infra/README.md
+++ b/infra/README.md
@@ -52,14 +52,28 @@ domain, and signing key already exist. To stand them up the first time:
    id, so no separate `KEY_ID` secret is needed.
 
 4. **Upload the public key** to both buckets so users can verify the
-   repository signature:
+   repository signature. The two ecosystems need different encodings of the
+   *same* key, so export it twice:
+
+   - **apt** verifies repos with `gpgv`, which reads **binary** keyrings only
+     and rejects ASCII armor (`gpgv: invalid packet (ctb=2d)` -> `NO_PUBKEY`).
+     Export without `--armor` (or `gpg --dearmor` an armored copy).
+   - **rpm**/dnf imports the key via `gpgkey=` and wants the conventional
+     **ASCII-armored** form.
+
+   The install docs do a plain `curl | tee` with no client-side dearmor, so the
+   bytes we serve have to be usable as-is.
 
    ```bash
-   gpg --export --armor admin@moq.dev > moq-archive-keyring.gpg
-   bun wrangler r2 object put apt-moq-dev/moq-archive-keyring.gpg \
-     --file moq-archive-keyring.gpg --remote
-   bun wrangler r2 object put rpm-moq-dev/moq-archive-keyring.gpg \
-     --file moq-archive-keyring.gpg --remote
+   # apt: binary / dearmored
+   gpg --export admin@moq.dev > moq-keyring.gpg
+   bun wrangler r2 object put apt-moq-dev/moq-keyring.gpg \
+     --file moq-keyring.gpg --remote
+
+   # rpm: ASCII-armored
+   gpg --export --armor admin@moq.dev > moq-keyring.asc
+   bun wrangler r2 object put rpm-moq-dev/moq-keyring.gpg \
+     --file moq-keyring.asc --remote
    ```
 
 5. **Configure GitHub Actions secrets** (Settings -> Secrets and variables
@@ -78,12 +92,12 @@ regenerates the repository metadata, signs it, and uploads the diff.
 
 ## Rotating the signing key
 
-If the key needs to be rotated, repeat steps 3 through 5 with a new key.
-Upload the new `moq-archive-keyring.gpg` alongside the old one (use a
-versioned filename, e.g. `moq-archive-keyring-2026.gpg`) and update the
-install docs at `doc/setup/linux.md` to point users at the new URL.
-Existing installations keep validating against the old key until they
-re-import.
+If the key needs to be rotated, repeat steps 3 through 5 with a new key
+(keeping the apt-binary / rpm-armored split). Upload the new keyring under a
+versioned filename, e.g. `moq-keyring-2026.gpg`, alongside the existing
+`moq-keyring.gpg`, and update the install docs at `doc/setup/linux.md` to point
+users at the new URL. Existing installations keep validating against the old
+key until they re-import.
 
 ## Manual regeneration
 

--- a/infra/apt/src/worker.ts
+++ b/infra/apt/src/worker.ts
@@ -1,7 +1,7 @@
 // Cloudflare Worker for apt.moq.dev. Serves a flat-ish apt repository out of
 // the apt-moq-dev R2 bucket. Layout written by infra/apt/publish.sh:
 //
-//   /moq-archive-keyring.gpg                          public signing key
+//   /moq-keyring.gpg                                  public signing key (binary/dearmored)
 //   /dists/stable/InRelease                           signed metadata
 //   /dists/stable/Release                             metadata
 //   /dists/stable/Release.gpg                         detached signature
@@ -30,12 +30,19 @@ const CONTENT_TYPE_BY_NAME: Record<string, string> = {
 	Sources: "text/plain; charset=utf-8",
 };
 
-// Cache long for the content-addressed package blobs and the static archive
-// keyring (versioned filename or pinned, immutable). Cache short for repo
-// metadata signatures like Release.gpg, which get rewritten every release.
+// Cache long for the content-addressed package blobs: a given .deb under a
+// given pool path never changes. Cache short for repo metadata signatures like
+// Release.gpg, which get rewritten every release. The keyring sits in between:
+// it's a fixed filename whose *contents* change if the signing key is ever
+// rotated, so it must NOT be immutable -- a stale immutable copy would keep
+// breaking `apt-get update` (NO_PUBKEY) for the whole cache lifetime. It's tiny
+// and only fetched at first-time setup, so a modest TTL is plenty.
 function cacheControl(key: string): string {
-	if (key.endsWith(".deb") || key.includes("/pool/") || key === "moq-archive-keyring.gpg") {
+	if (key.endsWith(".deb") || key.includes("/pool/")) {
 		return "public, max-age=2592000, immutable";
+	}
+	if (key === "moq-keyring.gpg") {
+		return "public, max-age=3600";
 	}
 	return "public, max-age=300";
 }

--- a/infra/rpm/publish.sh
+++ b/infra/rpm/publish.sh
@@ -109,7 +109,7 @@ baseurl=https://rpm.moq.dev/${DIST}/\$basearch
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=https://rpm.moq.dev/moq-archive-keyring.gpg
+gpgkey=https://rpm.moq.dev/moq-keyring.gpg
 EOF
 
 # GNUPGHOME is removed by the EXIT trap; no need for an explicit `rm -rf`.

--- a/infra/rpm/src/worker.ts
+++ b/infra/rpm/src/worker.ts
@@ -1,7 +1,7 @@
 // Cloudflare Worker for rpm.moq.dev. Serves a yum/dnf repository out of the
 // rpm-moq-dev R2 bucket. Layout written by infra/rpm/publish.sh:
 //
-//   /moq-archive-keyring.gpg                        public signing key
+//   /moq-keyring.gpg                                public signing key (ASCII-armored)
 //   /moq.repo                                       .repo file users drop into /etc/yum.repos.d/
 //   /el9/x86_64/repodata/repomd.xml{,.asc}          signed metadata
 //   /el9/x86_64/repodata/<hash>-primary.xml.gz      indices
@@ -27,9 +27,15 @@ const CONTENT_TYPE_BY_NAME: Record<string, string> = {
 };
 
 // Repo metadata changes per release; .rpm blobs are versioned and immutable.
+// The keyring is a fixed-name trust anchor whose contents change on key
+// rotation, so it gets a bounded TTL rather than immutable -- otherwise a
+// rotated key can't propagate until the long cache expires.
 function cacheControl(key: string): string {
-	if (key.endsWith(".rpm") || key.endsWith(".gpg")) {
+	if (key.endsWith(".rpm")) {
 		return "public, max-age=2592000, immutable";
+	}
+	if (key === "moq-keyring.gpg") {
+		return "public, max-age=3600";
 	}
 	return "public, max-age=300";
 }

--- a/rs/moq-gst/README.md
+++ b/rs/moq-gst/README.md
@@ -17,9 +17,9 @@ This crate is not published to crates.io. Pre-built binaries are attached to Git
 ### Debian / Ubuntu (recommended on Linux)
 
 ```bash
-curl -fsSL https://apt.moq.dev/moq-archive-keyring.gpg \
-  | sudo tee /usr/share/keyrings/moq-archive-keyring.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/moq-archive-keyring.gpg] https://apt.moq.dev stable main" \
+curl -fsSL https://apt.moq.dev/moq-keyring.gpg \
+  | sudo tee /usr/share/keyrings/moq-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/moq-keyring.gpg] https://apt.moq.dev stable main" \
   | sudo tee /etc/apt/sources.list.d/moq.list
 sudo apt update && sudo apt install gstreamer1.0-moq
 ```

--- a/rs/moq-relay/README.md
+++ b/rs/moq-relay/README.md
@@ -11,9 +11,9 @@ See [localhost.toml](https://github.com/moq-dev/moq/blob/main/demo/relay/localho
 ### Debian / Ubuntu
 
 ```bash
-curl -fsSL https://apt.moq.dev/moq-archive-keyring.gpg \
-  | sudo tee /usr/share/keyrings/moq-archive-keyring.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/moq-archive-keyring.gpg] https://apt.moq.dev stable main" \
+curl -fsSL https://apt.moq.dev/moq-keyring.gpg \
+  | sudo tee /usr/share/keyrings/moq-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/moq-keyring.gpg] https://apt.moq.dev stable main" \
   | sudo tee /etc/apt/sources.list.d/moq.list
 sudo apt update && sudo apt install moq-relay
 ```


### PR DESCRIPTION
## Problem

The nightly cross-language smoke run fails on the apt channel, deterministically:

```
Err: https://apt.moq.dev stable InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 8FBE8982FDD3FCA2
E: The repository 'https://apt.moq.dev stable InRelease' is not signed.
```

The signing key is correct and `InRelease` is properly signed by it — `gpg --verify` reports a good signature. The bug is **encoding**: `apt` verifies repositories with **`gpgv`**, which only reads *binary* keyrings and rejects ASCII armor. We published `moq-archive-keyring.gpg` in armored form, so gpgv dies on the first byte:

```
gpgv: [don't know]: invalid packet (ctb=2d)   # 0x2d = the '-' of "-----BEGIN"
gpgv: keydb_search failed: Invalid packet
```

→ no usable key → `NO_PUBKEY`. Dearmoring the exact same key to binary makes gpgv report "Good signature".

Root cause: [`infra/README.md`](infra/README.md) step 4 exported the key with `gpg --export --armor` and pushed that *same* armored file to **both** the apt and rpm buckets. Armored is correct for rpm/dnf, but wrong for apt.

## Changes

- **infra/README.md** — export the key **binary** for apt (`gpg --export`, no `--armor`) and **armored** for rpm, instead of one armored file for both. This is the actual fix.
- **apt + rpm workers** — stop serving the keyring `immutable, max-age=2592000`. It's a fixed-name trust anchor whose bytes change on key rotation; `immutable` would pin a stale/rotated/broken copy for the whole 30-day window and block recovery. Now a bounded 1h TTL (content-addressed `.deb`/`.rpm` blobs stay immutable).
- **Rename** `moq-archive-keyring.gpg` → `moq-keyring.gpg` across docs and workers (old name dropped).

The keyring stays **manually managed** — `publish.sh` deliberately never touches the trust anchor, so a key swap can't silently re-publish itself, and a rotation can keep old+new keys side by side (the key is shared with Maven, whose old artifacts stay signed by the old key).

## ⚠️ Required manual step before/with merge

The renamed URL won't exist until the binary key is uploaded to R2 (see infra/README.md step 4):

```bash
gpg --export admin@moq.dev > moq-keyring.gpg            # binary, NO --armor
bun wrangler r2 object put apt-moq-dev/moq-keyring.gpg --file moq-keyring.gpg --remote
gpg --export --armor admin@moq.dev > moq-keyring.asc
bun wrangler r2 object put rpm-moq-dev/moq-keyring.gpg --file moq-keyring.asc --remote
```

Then `just infra apt deploy` / `just infra rpm deploy` for the cache-header change. Existing installs that already fetched the broken armored file locally will need to re-run the install command.

## Verification

Reproduced both the failure (armored → `gpgv: invalid packet`) and the fix (dearmored → `gpgv: Good signature`) locally against the live `apt.moq.dev` endpoint. Biome + remark lint pass on changed files.

Note: the same nightly run also has an unrelated macOS failure (the C subscriber hitting the anonymous GitHub API rate limit) — tracked/fixed separately in the smoke repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
