### PR TITLE
fix(publish): honor requested audio channel count on macOS

### DIFF
--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -23,6 +23,7 @@ export type EncoderProps = {
 	muted?: boolean | Signal<boolean>;
 	volume?: number | Signal<number>;
 	sampleRate?: number | Signal<number | undefined>;
+	channelCount?: number | Signal<number | undefined>;
 
 	container?: Catalog.Container;
 };
@@ -36,6 +37,7 @@ export class Encoder {
 	muted: Signal<boolean>;
 	volume: Signal<number>;
 	sampleRate: Signal<number | undefined>;
+	channelCount: Signal<number | undefined>;
 
 	source: Signal<Source | undefined>;
 
@@ -60,6 +62,7 @@ export class Encoder {
 		this.muted = Signal.from(props?.muted ?? false);
 		this.volume = Signal.from(props?.volume ?? 1);
 		this.sampleRate = Signal.from<number | undefined>(props?.sampleRate);
+		this.channelCount = Signal.from<number | undefined>(props?.channelCount);
 
 		this.#signals.run(this.#runSource.bind(this));
 		this.#signals.run(this.#runGain.bind(this));
@@ -75,6 +78,12 @@ export class Encoder {
 		const settings = source.track.getSettings();
 		const overrideSampleRate = effect.get(this.sampleRate);
 		const sampleRate = overrideSampleRate ?? settings.sampleRate;
+
+		// macOS misreports a mono mic as stereo: getSettings().channelCount is undefined and
+		// MediaStreamAudioSourceNode.channelCount defaults to 2, so the graph carries (and Opus
+		// encodes) duplicated mono as stereo. Prefer an explicitly requested channel count, from
+		// the prop or the track's applied getUserMedia constraint, and force the worklet to mix to it.
+		const requestedChannels = effect.get(this.channelCount) ?? requestedChannelCount(source.track);
 
 		const context = new AudioContext({
 			latencyHint: "interactive",
@@ -98,11 +107,15 @@ export class Encoder {
 			await context.audioWorklet.addModule(CaptureWorklet);
 			if (context.state === "closed") return;
 
-			const channelCount = settings.channelCount ?? root.channelCount;
+			const channelCount = requestedChannels ?? settings.channelCount ?? root.channelCount;
 			const worklet = new AudioWorkletNode(context, "capture", {
 				numberOfInputs: 1,
 				numberOfOutputs: 0,
 				channelCount,
+				// "explicit" forces Web Audio to (down)mix the input to channelCount before the
+				// worklet sees it. The default "max" just follows the input, which is the unreliable
+				// path on macOS. Only force it when we actually have a requested count to honor.
+				channelCountMode: requestedChannels !== undefined ? "explicit" : "max",
 			});
 
 			effect.set(this.#worklet, worklet);
@@ -258,6 +271,15 @@ export class Encoder {
 	close() {
 		this.#signals.close();
 	}
+}
+
+// getConstraints() echoes the constraints applied via getUserMedia, which (unlike getSettings)
+// survives the macOS mono->stereo misreport. Returns the requested channel count, if any.
+function requestedChannelCount(track: MediaStreamTrack): number | undefined {
+	const constraint = track.getConstraints().channelCount;
+	if (constraint === undefined) return undefined;
+	if (typeof constraint === "number") return constraint;
+	return constraint.exact ?? constraint.ideal ?? constraint.max ?? constraint.min;
 }
 
 // `application` and `signal` are in the WebCodecs spec but missing from lib.dom.d.ts.


### PR DESCRIPTION
## Summary

The audio encoder produced stereo Opus from a mono microphone on macOS, wasting bitrate. This forces the WebAudio capture graph to honor the requested channel count instead of trusting the platform's (unreliable) reporting.

## Root cause

`Source.Microphone` already forwards `constraints.channelCount` to `getUserMedia`, so the constraint itself wasn't being dropped. The problem is downstream in the encoder:

- On macOS, `track.getSettings().channelCount` is `undefined` and `MediaStreamAudioSourceNode.channelCount` defaults to `2`, so [`encoder.ts`](js/publish/src/audio/encoder.ts) fell back to `2` channels.
- The `AudioWorkletNode` used the default `channelCountMode: "max"`, which just follows the input graph rather than the `channelCount` passed to it. So even a correctly-requested mono mic was carried (and encoded) as duplicated stereo.

Because the platform misreports the track *after* `getUserMedia`, the `{ channelCount: 1 }` constraint alone can't fix it at the source.

## Changes

- Add a `channelCount` override prop on `Audio.Encoder` (mirrors the existing `sampleRate` prop). Reachable through `Broadcast` via `audio: { channelCount: 1 }`.
- Recover the requested count from the track's applied constraint via `getConstraints().channelCount`, which echoes what was requested and survives the macOS misreport (unlike `getSettings()`).
- Force `channelCountMode: "explicit"` when a channel count is requested, so WebAudio deterministically downmixes before the capture worklet sees the frames. The worklet then reports the correct count, so the Opus config and `AudioData` frames both come out mono automatically.
- Non-mic sources and callers that don't request a count keep the existing `"max"` behavior, so there's no regression and no default change.

With this, `new Source.Microphone({ constraints: { channelCount: 1 } })` produces correct mono end-to-end. Consuming apps can drop both the JS `getUserMedia` bypass and any server-side downmix workaround.

## Cross-package sync

No paired updates needed. This is browser-only WebAudio capture (the Rust `moq-audio` path handles PCM channels natively and separately), and `demo/web` doesn't set a channel count, so the additive prop needs no demo change.

## Test plan

- [x] `tsc --noEmit` passes for `js/publish`
- [x] Biome clean on the changed file
- [ ] Manual: mono mic on macOS now encodes as mono (1 channel in the catalog config) instead of stereo

> No unit test added: js/publish has no test harness and Web Audio / `getUserMedia` aren't mockable in this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)