### PR TITLE
ci(release): publish moq-gst so release-plz tags it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "moq-gst"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/rs/moq-gst/Cargo.toml
+++ b/rs/moq-gst/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version.workspace = true
-publish = false
+publish = true
 
 [lib]
 name = "gstmoq"


### PR DESCRIPTION
## Summary

`moq-gst` was never getting released. It had `publish = false` in its `Cargo.toml` (added when the plugin moved into the monorepo). cargo reports a `publish = false` crate as unpublishable, so **release-plz drops it from its member set entirely** - no version bump, no changelog, and crucially no `moq-gst-v*` tag. The `moq-gst.yml` workflow only triggers `on: push: tags: moq-gst-v*`, so the whole binary-release chain (tarball / `.deb` / `.rpm` + apt/rpm repo publish) never fired and the install matrix had nothing to install. moq-gst was the only crate in the workspace with `publish = false`.

A release-plz config override (`release = true`) is **not** enough - I confirmed empirically that release-plz still excludes the crate, because the exclusion happens at the cargo-metadata level before per-package config applies.

## Change

- `rs/moq-gst/Cargo.toml`: `publish = false` → `publish = true`, and bump the patch version `0.2.2` → `0.2.3`.
- `Cargo.lock`: matching version bump.

moq-gst was already on crates.io at `0.1.7` before the flag was flipped, so this restores its prior behavior rather than introducing a new publish target. With `publish = true` it's a normal workspace member again: release-plz publishes it to crates.io and cuts the `moq-gst-v*` tag that triggers the release workflow.

## Why publish = true (vs. keeping it off crates.io)

`release-plz release` is the only publish pathway in the repo (no bare `cargo publish` anywhere), so letting it manage moq-gst like every other crate is the simplest correct fix. The alternative - keeping the crate off crates.io while still tagging - requires moving `publish = false` into `.release-plz.toml`, which works but adds special-casing for no real benefit here.

## Validation

- In a clean clone, release-plz now processes moq-gst (`determining next version for moq-gst 0.2.3`); before the change it was absent from the member set.
- Read release-plz's `release_package_if_needed`: tag creation is gated on `repo.tag_exists()` first, so re-runs are idempotent (no duplicate tagging).
- `taplo` format check and `cargo sort` pass.

## Reviewer notes

- On the next merge to `main`, `release-rs.yml` will publish `moq-gst 0.2.3` (not yet on crates.io) and cut `moq-gst-v0.2.3`, firing `moq-gst.yml` and populating apt/brew/rpm/tarball.
- `cargo publish` runs a verify build, which for moq-gst needs GStreamer dev libs. `release-rs.yml` runs inside `nix develop`, whose shell includes GStreamer, so that build resolves.

(Written by Claude)