### PR TITLE
ci(moq-gst): fix zigbuild glib link + release v0.2.4

### DIFF
--- a/.github/workflows/moq-gst.yml
+++ b/.github/workflows/moq-gst.yml
@@ -138,6 +138,15 @@ jobs:
         shell: bash
         # Pin glibc to 2.34 so one .so covers Debian 12+/Ubuntu 22.04+
         # (.deb) and AlmaLinux/RHEL/Rocky 9+ (.rpm).
+        #
+        # PKG_CONFIG_ALLOW_SYSTEM_LIBS keeps the `-L /usr/lib/<multiarch>` for
+        # glib in pkg-config's output. pkg-config strips system lib paths by
+        # default (the native linker searches them anyway), but zig's linker
+        # does not, and rustc fails the dylib lookup (strategy 'no_fallback')
+        # before linking. The explicit -L lets it resolve libglib-2.0.so /
+        # libgobject-2.0.so.
+        env:
+          PKG_CONFIG_ALLOW_SYSTEM_LIBS: "1"
         run: cargo zigbuild --release --target ${{ matrix.target }}.2.34 -p moq-gst
 
       - name: Package .deb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "moq-gst"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "bytes",

--- a/rs/moq-gst/Cargo.toml
+++ b/rs/moq-gst/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version.workspace = true
 publish = true


### PR DESCRIPTION
## Summary

The `moq-gst-v0.2.3` tag triggered the first real run of the `.deb/.rpm` packaging job, which failed in both `Package .deb/.rpm` matrix legs ([run #26927524306](https://github.com/moq-dev/moq/actions/runs/26927524306)):

```
error: unable to find dynamic system library 'glib-2.0' using strategy 'no_fallback'
error: unable to find dynamic system library 'gobject-2.0' using strategy 'no_fallback'
error: could not compile `moq-gst` (lib) due to 1 previous error
```

(The Nix-cache `HTTP 418` / rate-limit lines earlier in the log are unrelated noise from `magic-nix-cache` shutting down.)

This PR does two things:

1. **Fixes the build** by setting `PKG_CONFIG_ALLOW_SYSTEM_LIBS=1` on the zigbuild step.
2. **Bumps moq-gst to v0.2.4** so release-plz tags `moq-gst-v0.2.4` on merge and re-runs the now-fixed release workflow (v0.2.3's packaging job failed before the fix landed).

## Root cause

`moq-gst` links glib/gobject (via `gstreamer 0.23`) through pkg-config. pkg-config strips `-L /usr/lib/<multiarch>` from its output by default, since the native GNU linker searches those dirs anyway. The package job links with **`cargo zigbuild`**, and zig's linker does **not** search the host multiarch dirs. Recent rustc verifies each dylib exists in the `-L` search paths (`strategy 'no_fallback'`) and aborts before linking when the path is missing.

The Nix tarball job is unaffected because Nix's glib lives in `/nix/store/...`, a non-system path that pkg-config keeps in its `-L` output.

## Fix

Set `PKG_CONFIG_ALLOW_SYSTEM_LIBS=1` on the `Build (release, glibc 2.34)` step so pkg-config emits the explicit `-L /usr/lib/<multiarch>`, letting zig/rustc resolve `libglib-2.0.so` / `libgobject-2.0.so`.

## Notes for reviewers

- Only `moq-gst` is affected. The other three zigbuild workflows (`moq-cli`, `moq-relay`, `moq-token-cli`) build pure-Rust binaries with no pkg-config-linked host shared library, so they don't need this and their Linux zigbuild jobs are green.
- The workflow trigger is tag-only (`moq-gst-v*`), so this PR's own CI can't exercise the packaging job. The v0.2.4 bump is what re-runs it end-to-end once release-plz tags the new version on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)