### PR TITLE
ci: cross-compile all x86_64-darwin release artifacts on Apple Silicon

### DIFF
--- a/.github/workflows/libmoq.yml
+++ b/.github/workflows/libmoq.yml
@@ -28,8 +28,12 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             use_nix: true
+          # Both Apple targets build on the Apple Silicon runner: the
+          # Determinate Nix installer dropped Intel macOS, so x86_64 is
+          # cross-compiled (Apple clang is multi-arch). libmoq.a needs no
+          # execution, so no Rosetta. See rs/libmoq/build.sh.
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-latest
             use_nix: true
           - target: aarch64-apple-darwin
             os: macos-latest

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -147,8 +147,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Both Apple targets build on the Apple Silicon runner. The
+          # Determinate Nix installer dropped Intel macOS, so x86_64 is
+          # cross-compiled (Apple clang is multi-arch) and its smoke test
+          # runs under Rosetta. See rs/scripts/package-binary.sh.
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -162,6 +166,13 @@ jobs:
         with:
           determinate: false
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
+
+      # The cross build links system libs only, but its dyld smoke test must
+      # actually run the x86_64 binary on this arm host. Idempotent no-op when
+      # Rosetta is already present.
+      - name: Install Rosetta (x86_64 smoke test)
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: softwareupdate --install-rosetta --agree-to-license
 
       - name: Parse version
         id: parse

--- a/.github/workflows/moq-gst.yml
+++ b/.github/workflows/moq-gst.yml
@@ -21,8 +21,13 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+          # Both Apple targets build on the Apple Silicon runner. The
+          # Determinate Nix installer dropped Intel macOS, so x86_64 is
+          # cross-compiled against an x86_64 GStreamer (see nix/overlay.nix);
+          # its gst-inspect smoke test is skipped (an arm gst-inspect can't
+          # load an x86_64 plugin).
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -58,7 +63,11 @@ jobs:
       # This is the customer-facing scenario: `nix build .#moq-gst` then
       # `gst-inspect-1.0 moq`. If dyld/ld.so can't resolve the plugin's deps
       # against the system GStreamer, this step fails.
+      # Skipped for the x86_64-darwin cross build: the arm runner's
+      # gst-inspect can't load an x86_64 plugin. Native builds (incl. the
+      # arm mac) still exercise the full load test.
       - name: Install system GStreamer
+        if: matrix.target != 'x86_64-apple-darwin'
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
@@ -72,6 +81,7 @@ jobs:
           fi
 
       - name: Smoke test (gst-inspect against system GStreamer)
+        if: matrix.target != 'x86_64-apple-darwin'
         shell: bash
         env:
           TARGET: ${{ matrix.target }}

--- a/.github/workflows/moq-relay.yml
+++ b/.github/workflows/moq-relay.yml
@@ -136,8 +136,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Both Apple targets build on the Apple Silicon runner. The
+          # Determinate Nix installer dropped Intel macOS, so x86_64 is
+          # cross-compiled (Apple clang is multi-arch) and its smoke test
+          # runs under Rosetta. See rs/scripts/package-binary.sh.
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -151,6 +155,13 @@ jobs:
         with:
           determinate: false
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
+
+      # The cross build links system libs only, but its dyld smoke test must
+      # actually run the x86_64 binary on this arm host. Idempotent no-op when
+      # Rosetta is already present.
+      - name: Install Rosetta (x86_64 smoke test)
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: softwareupdate --install-rosetta --agree-to-license
 
       - name: Parse version
         id: parse

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -133,8 +133,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Both Apple targets build on the Apple Silicon runner. The
+          # Determinate Nix installer dropped Intel macOS, so x86_64 is
+          # cross-compiled (Apple clang is multi-arch) and its smoke test
+          # runs under Rosetta. See rs/scripts/package-binary.sh.
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -148,6 +152,13 @@ jobs:
         with:
           determinate: false
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
+
+      # The cross build links system libs only, but its dyld smoke test must
+      # actually run the x86_64 binary on this arm host. Idempotent no-op when
+      # Rosetta is already present.
+      - name: Install Rosetta (x86_64 smoke test)
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: softwareupdate --install-rosetta --agree-to-license
 
       - name: Parse version
         id: parse

--- a/.github/workflows/release-py-ffi.yml
+++ b/.github/workflows/release-py-ffi.yml
@@ -82,8 +82,12 @@ jobs:
             manylinux: 2_28
             # The cross image sets TARGET_CC/CXX which leaks into host builds.
             before-script-linux: "unset TARGET_CC TARGET_CXX"
+          # Both Apple targets build on the Apple Silicon runner. maturin
+          # cross-compiles x86_64 natively via Apple's multi-arch clang (no
+          # external C libs in moq-ffi's tree), and uniffi 0.31 reads binding
+          # metadata from the cdylib statically, so no Rosetta is needed.
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/flake.nix
+++ b/flake.nix
@@ -195,6 +195,7 @@
             moq-cli-x86_64-apple-darwin
             moq-token-cli-x86_64-apple-darwin
             libmoq-x86_64-apple-darwin
+            moq-gst-plugin-x86_64-apple-darwin
             ;
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -157,7 +157,7 @@
         overlayPkgs = pkgs.extend self.overlays.default;
       in
       {
-        packages = rec {
+        packages = (rec {
           default = pkgs.symlinkJoin {
             name = "moq-all";
             paths = [
@@ -184,6 +184,18 @@
             name = "moq-packaging-tools";
             paths = packagingDeps ++ publishDeps;
           };
+        })
+        # x86_64-darwin release artifacts are cross-compiled from the
+        # aarch64-darwin runner (see nix/overlay.nix). The cross outputs only
+        # evaluate on an aarch64-darwin host, so gate them on the system to
+        # keep `nix flake check` working on Linux and Intel macs.
+        // pkgs.lib.optionalAttrs (system == "aarch64-darwin") {
+          inherit (overlayPkgs)
+            moq-relay-x86_64-apple-darwin
+            moq-cli-x86_64-apple-darwin
+            moq-token-cli-x86_64-apple-darwin
+            libmoq-x86_64-apple-darwin
+            ;
         };
 
         # Re-export gst_all_1 so users can pair the plugin with a matching

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -113,6 +113,86 @@ let
       runHook postInstall
     '';
   };
+
+  # Native x86_64-darwin package set (matches cache.nixos.org's prebuilt
+  # binaries), used to link the cross moq-gst plugin against an x86_64
+  # GStreamer. pkgsCross would rebuild GStreamer from source under a cross
+  # stdenv; this fetches it. Lazy, so it's only instantiated when the cross
+  # plugin is actually built (aarch64-darwin only, see flake.nix).
+  pkgsX86Darwin = import final.path { system = "x86_64-darwin"; };
+
+  moqGstPluginArgs = crateInfo ../rs/moq-gst/Cargo.toml // {
+    src = craneLib.cleanCargoSource ../.;
+    cargoExtraArgs = "-p moq-gst";
+    doCheck = false;
+
+    nativeBuildInputs = with final; [ pkg-config ];
+    buildInputs = with final; [
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+    ];
+
+    # moq-gst is a cdylib GStreamer plugin. Install into lib/gstreamer-1.0
+    # so gst_all_1.gstreamer's nixpkgs setup-hook (which scans every input
+    # for that subdir) appends us to GST_PLUGIN_SYSTEM_PATH_1_0. Then
+    #   nix shell .#moq-gst .#gst_all_1.gstreamer --command gst-inspect-1.0 moq
+    # discovers moqsink/moqsrc without any env-var fiddling. Crane's
+    # default install phase only handles binaries, so we copy by hand.
+    installPhase = ''
+      runHook preInstall
+
+      # A cross --target build puts the cdylib under target/<triple>/.
+      tdir="target''${CARGO_BUILD_TARGET:+/$CARGO_BUILD_TARGET}"
+      mkdir -p $out/lib/gstreamer-1.0
+      if [ -f "$tdir/release/libgstmoq.dylib" ]; then
+        cp "$tdir/release/libgstmoq.dylib" $out/lib/gstreamer-1.0/
+      else
+        cp "$tdir/release/libgstmoq.so" $out/lib/gstreamer-1.0/
+      fi
+
+      runHook postInstall
+    '';
+
+    # The flake output is meant to load against nix's GStreamer (in a
+    # `nix shell .#moq-gst` / cachix-pulled context). `/nix/store` refs
+    # are correct there. The only thing we fix is the rustc-emitted
+    # self-reference to /nix/var/nix/builds/.../libgstmoq.dylib (the
+    # cargo build dir, gone post-build) which would break loading even
+    # inside nix. rs/moq-gst/scrub.sh handles tarball / homebrew
+    # portability separately. The `[ -f ]` guard skips crane's
+    # deps-only stage, whose $out has no plugin.
+    postFixup = final.lib.optionalString final.stdenv.isDarwin ''
+      dylib="$out/lib/gstreamer-1.0/libgstmoq.dylib"
+      if [ -f "$dylib" ]; then
+        install_name_tool -id "@rpath/libgstmoq.dylib" "$dylib"
+
+        # The rustc self-ref is the only LC_LOAD_DYLIB whose basename
+        # matches our own and isn't already @rpath-prefixed. Rewriting
+        # it to @rpath/libgstmoq.dylib matches LC_ID_DYLIB, so dyld
+        # dedupes the load against the already-mapped image.
+        otool -L "$dylib" \
+          | tail -n +2 \
+          | awk '{print $1}' \
+          | { grep -E '/libgstmoq\.dylib$' || true; } \
+          | { grep -v '^@' || true; } \
+          | while read -r self_ref; do
+              install_name_tool -change "$self_ref" "@rpath/libgstmoq.dylib" "$dylib"
+            done
+
+        # Assert no build-sandbox paths leaked. /nix/store refs are
+        # fine here, see top comment.
+        bad="$(otool -L "$dylib" \
+          | tail -n +2 \
+          | awk '{print $1}' \
+          | { grep '^/nix/var/' || true; })"
+        if [ -n "$bad" ]; then
+          echo "ERROR: $dylib has /nix/var build-sandbox LC_LOAD_DYLIB entries:" >&2
+          echo "$bad" >&2
+          exit 1
+        fi
+      fi
+    '';
+  };
 in
 {
   moq-relay = craneLib.buildPackage moqRelayArgs;
@@ -146,78 +226,23 @@ in
   libmoq = craneLib.buildPackage libmoqArgs;
   libmoq-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin libmoqArgs);
 
-  moq-gst-plugin = craneLib.buildPackage (
-    crateInfo ../rs/moq-gst/Cargo.toml
-    // {
-      src = craneLib.cleanCargoSource ../.;
-      cargoExtraArgs = "-p moq-gst";
-      doCheck = false;
+  moq-gst-plugin = craneLib.buildPackage moqGstPluginArgs;
 
-      nativeBuildInputs = with final; [ pkg-config ];
-      buildInputs = with final; [
-        gst_all_1.gstreamer
-        gst_all_1.gst-plugins-base
-      ];
-
-      # moq-gst is a cdylib GStreamer plugin. Install into lib/gstreamer-1.0
-      # so gst_all_1.gstreamer's nixpkgs setup-hook (which scans every input
-      # for that subdir) appends us to GST_PLUGIN_SYSTEM_PATH_1_0. Then
-      #   nix shell .#moq-gst .#gst_all_1.gstreamer --command gst-inspect-1.0 moq
-      # discovers moqsink/moqsrc without any env-var fiddling. Crane's
-      # default install phase only handles binaries, so we copy by hand.
-      installPhase = ''
-        runHook preInstall
-
-        mkdir -p $out/lib/gstreamer-1.0
-        if [ -f target/release/libgstmoq.dylib ]; then
-          cp target/release/libgstmoq.dylib $out/lib/gstreamer-1.0/
-        else
-          cp target/release/libgstmoq.so $out/lib/gstreamer-1.0/
-        fi
-
-        runHook postInstall
-      '';
-
-      # The flake output is meant to load against nix's GStreamer (in a
-      # `nix shell .#moq-gst` / cachix-pulled context). `/nix/store` refs
-      # are correct there. The only thing we fix is the rustc-emitted
-      # self-reference to /nix/var/nix/builds/.../libgstmoq.dylib (the
-      # cargo build dir, gone post-build) which would break loading even
-      # inside nix. rs/moq-gst/scrub.sh handles tarball / homebrew
-      # portability separately. The `[ -f ]` guard skips crane's
-      # deps-only stage, whose $out has no plugin.
-      postFixup = final.lib.optionalString final.stdenv.isDarwin ''
-        dylib="$out/lib/gstreamer-1.0/libgstmoq.dylib"
-        if [ -f "$dylib" ]; then
-          install_name_tool -id "@rpath/libgstmoq.dylib" "$dylib"
-
-          # The rustc self-ref is the only LC_LOAD_DYLIB whose basename
-          # matches our own and isn't already @rpath-prefixed. Rewriting
-          # it to @rpath/libgstmoq.dylib matches LC_ID_DYLIB, so dyld
-          # dedupes the load against the already-mapped image.
-          otool -L "$dylib" \
-            | tail -n +2 \
-            | awk '{print $1}' \
-            | { grep -E '/libgstmoq\.dylib$' || true; } \
-            | { grep -v '^@' || true; } \
-            | while read -r self_ref; do
-                install_name_tool -change "$self_ref" "@rpath/libgstmoq.dylib" "$dylib"
-              done
-
-          # Assert no build-sandbox paths leaked. /nix/store refs are
-          # fine here, see top comment.
-          bad="$(otool -L "$dylib" \
-            | tail -n +2 \
-            | awk '{print $1}' \
-            | { grep '^/nix/var/' || true; })"
-          if [ -n "$bad" ]; then
-            echo "ERROR: $dylib has /nix/var build-sandbox LC_LOAD_DYLIB entries:" >&2
-            echo "$bad" >&2
-            exit 1
-          fi
-        fi
-      '';
-    }
+  # Cross plugin links the x86_64 GStreamer so the cdylib's LC_LOAD_DYLIB
+  # entries point at x86_64 libs. The release build (rs/moq-gst/build.sh)
+  # scrubs those nix paths to the user's system GStreamer and skips the
+  # gst-inspect smoke test, which can't load an x86_64 plugin under the
+  # arm runner's arm gst-inspect.
+  moq-gst-plugin-x86_64-apple-darwin = craneLib.buildPackage (
+    crossX86Darwin (
+      moqGstPluginArgs
+      // {
+        buildInputs = [
+          pkgsX86Darwin.gst_all_1.gstreamer
+          pkgsX86Darwin.gst_all_1.gst-plugins-base
+        ];
+      }
+    )
   );
 
   # User-facing flake output. Bundles the plugin with wrapped gstreamer

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -6,42 +6,123 @@ let
   # toolchain as `nix develop`. Without this, crane falls back to
   # `final.rustc`/`final.cargo`, which nixpkgs resolves to its default Rust
   # (currently 1.94) while the devShell pulls 1.95 from rust-overlay.
-  craneLib = (crane.mkLib final).overrideToolchain final.rust-bin.stable.latest.default;
+  #
+  # Add both Apple targets so an aarch64-darwin host can cross-compile the
+  # x86_64-darwin release artifacts (Apple's clang is multi-arch, so no
+  # emulated x86_64 toolchain is needed). The default profile only ships
+  # std for the host triple, which is why the target list is explicit.
+  rustToolchain = final.rust-bin.stable.latest.default.override {
+    targets = final.lib.optionals final.stdenv.isDarwin [
+      "x86_64-apple-darwin"
+      "aarch64-apple-darwin"
+    ];
+  };
+  craneLib = (crane.mkLib final).overrideToolchain rustToolchain;
 
   # Helper function to get crate info from Cargo.toml
   crateInfo = cargoTomlPath: craneLib.crateNameFromCargoToml { cargoToml = cargoTomlPath; };
+
+  # Cross-compile a crate's release artifact to x86_64-darwin from an
+  # aarch64-darwin host. The Determinate Nix installer dropped Intel macOS
+  # runners, but Apple's clang is multi-arch, so pointing cargo at the
+  # target produces a native (non-emulated) x86_64 build. doCheck is off
+  # because the x86_64 test binaries can't run in the aarch64 build sandbox.
+  # Only valid for pure-Rust artifacts with no cross buildInputs; moq-gst's
+  # GStreamer link would need pkgsCross instead.
+  crossX86Darwin =
+    args:
+    args
+    // {
+      CARGO_BUILD_TARGET = "x86_64-apple-darwin";
+      doCheck = false;
+    };
+
+  moqRelayArgs = crateInfo ../rs/moq-relay/Cargo.toml // {
+    src = craneLib.cleanCargoSource ../.;
+    cargoExtraArgs = "-p moq-relay --features jemalloc";
+    # Enable frame pointers for profiling support (negligible overhead on x86_64).
+    # This also ensures the CDN build matches what Cachix caches.
+    RUSTFLAGS = "-C force-frame-pointers=yes";
+    # jemalloc's configure uses -O0 test builds, which conflict with
+    # Nix's _FORTIFY_SOURCE hardening (requires -O).
+    hardeningDisable = [ "fortify" ];
+  };
+
+  moqCliArgs = crateInfo ../rs/moq-cli/Cargo.toml // {
+    src = craneLib.cleanCargoSource ../.;
+    cargoExtraArgs = "-p moq-cli";
+  };
+
+  moqTokenCliArgs = crateInfo ../rs/moq-token-cli/Cargo.toml // {
+    src = craneLib.cleanCargoSource ../.;
+    cargoExtraArgs = "-p moq-token-cli";
+    meta.mainProgram = "moq-token-cli";
+  };
+
+  libmoqInfo = crateInfo ../rs/libmoq/Cargo.toml;
+  libmoqArgs = libmoqInfo // {
+    # libmoq's build.rs reads moq.pc.in at compile time to generate the
+    # pkgconfig file. craneLib.cleanCargoSource's default filter drops
+    # .pc.in files, which makes build.rs silently skip pkgconfig
+    # generation (see the `if let Ok(template)` in rs/libmoq/build.rs)
+    # and the installPhase's `cp .../moq.pc` then fails.
+    src = final.lib.cleanSourceWith {
+      src = ../.;
+      name = "source";
+      filter = path: type: (final.lib.hasSuffix ".pc.in" path) || (craneLib.filterCargoSources path type);
+    };
+    cargoExtraArgs = "-p libmoq";
+    doCheck = false;
+    nativeBuildInputs = with final; [ pkg-config ];
+
+    # libmoq.a carries moq-ffi's whole dep tree, so an unstripped build is
+    # ~75 MB+. Thin LTO with a single codegen unit dead-strips the unused
+    # monomorphizations Rust bakes into a staticlib, halving the artifact
+    # with no source or ABI change, which keeps the release tarball and
+    # brew download small. Mirrors rs/libmoq/build.sh's Windows cargo path.
+    CARGO_PROFILE_RELEASE_LTO = "thin";
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+
+    # libmoq is a staticlib; crane's default install phase only handles
+    # binaries. Lay out the artifact tree the way release tarballs and
+    # downstream `find_package(moq)` consumers already expect.
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib/pkgconfig $out/include $out/lib/cmake/moq
+
+      # build.rs derives its output dir from OUT_DIR, so a cross --target
+      # build puts the staticlib, header and pkgconfig under target/<triple>/.
+      # Keep the prefix target-aware so the native and cross outputs share
+      # one installPhase.
+      tdir="target''${CARGO_BUILD_TARGET:+/$CARGO_BUILD_TARGET}"
+      cp "$tdir/release/libmoq.a" $out/lib/
+      cp "$tdir/include/moq.h" $out/include/
+      cp "$tdir/pkgconfig/moq.pc" $out/lib/pkgconfig/
+
+      major_version="$(echo "${libmoqInfo.version}" | cut -d. -f1)"
+      substitute ${../rs/libmoq/cmake/moq-config.cmake.in} \
+        $out/lib/cmake/moq/moq-config.cmake \
+        --subst-var-by LIB_FILE libmoq.a \
+        --subst-var-by VERSION "${libmoqInfo.version}"
+      substitute ${../rs/libmoq/cmake/moq-config-version.cmake.in} \
+        $out/lib/cmake/moq/moq-config-version.cmake \
+        --subst-var-by VERSION "${libmoqInfo.version}" \
+        --subst-var-by MAJOR_VERSION "$major_version"
+
+      runHook postInstall
+    '';
+  };
 in
 {
-  moq-relay = craneLib.buildPackage (
-    crateInfo ../rs/moq-relay/Cargo.toml
-    // {
-      src = craneLib.cleanCargoSource ../.;
-      cargoExtraArgs = "-p moq-relay --features jemalloc";
-      # Enable frame pointers for profiling support (negligible overhead on x86_64).
-      # This also ensures the CDN build matches what Cachix caches.
-      RUSTFLAGS = "-C force-frame-pointers=yes";
-      # jemalloc's configure uses -O0 test builds, which conflict with
-      # Nix's _FORTIFY_SOURCE hardening (requires -O).
-      hardeningDisable = [ "fortify" ];
-    }
-  );
+  moq-relay = craneLib.buildPackage moqRelayArgs;
+  moq-relay-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqRelayArgs);
 
-  moq-cli = craneLib.buildPackage (
-    crateInfo ../rs/moq-cli/Cargo.toml
-    // {
-      src = craneLib.cleanCargoSource ../.;
-      cargoExtraArgs = "-p moq-cli";
-    }
-  );
+  moq-cli = craneLib.buildPackage moqCliArgs;
+  moq-cli-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqCliArgs);
 
-  moq-token-cli = craneLib.buildPackage (
-    crateInfo ../rs/moq-token-cli/Cargo.toml
-    // {
-      src = craneLib.cleanCargoSource ../.;
-      cargoExtraArgs = "-p moq-token-cli";
-      meta.mainProgram = "moq-token-cli";
-    }
-  );
+  moq-token-cli = craneLib.buildPackage moqTokenCliArgs;
+  moq-token-cli-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqTokenCliArgs);
 
   moq-boy = craneLib.buildPackage (
     crateInfo ../rs/moq-boy/Cargo.toml
@@ -62,60 +143,8 @@ in
     }
   );
 
-  libmoq =
-    let
-      info = crateInfo ../rs/libmoq/Cargo.toml;
-    in
-    craneLib.buildPackage (
-      info
-      // {
-        # libmoq's build.rs reads moq.pc.in at compile time to generate the
-        # pkgconfig file. craneLib.cleanCargoSource's default filter drops
-        # .pc.in files, which makes build.rs silently skip pkgconfig
-        # generation (see the `if let Ok(template)` in rs/libmoq/build.rs)
-        # and the installPhase's `cp target/pkgconfig/moq.pc` then fails.
-        src = final.lib.cleanSourceWith {
-          src = ../.;
-          name = "source";
-          filter = path: type: (final.lib.hasSuffix ".pc.in" path) || (craneLib.filterCargoSources path type);
-        };
-        cargoExtraArgs = "-p libmoq";
-        doCheck = false;
-        nativeBuildInputs = with final; [ pkg-config ];
-
-        # libmoq.a carries moq-ffi's whole dep tree, so an unstripped build is
-        # ~75 MB+. Thin LTO with a single codegen unit dead-strips the unused
-        # monomorphizations Rust bakes into a staticlib, halving the artifact
-        # with no source or ABI change, which keeps the release tarball and
-        # brew download small. Mirrors rs/libmoq/build.sh's Windows cargo path.
-        CARGO_PROFILE_RELEASE_LTO = "thin";
-        CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
-
-        # libmoq is a staticlib; crane's default install phase only handles
-        # binaries. Lay out the artifact tree the way release tarballs and
-        # downstream `find_package(moq)` consumers already expect.
-        installPhase = ''
-          runHook preInstall
-
-          mkdir -p $out/lib/pkgconfig $out/include $out/lib/cmake/moq
-          cp target/release/libmoq.a $out/lib/
-          cp target/include/moq.h $out/include/
-          cp target/pkgconfig/moq.pc $out/lib/pkgconfig/
-
-          major_version="$(echo "${info.version}" | cut -d. -f1)"
-          substitute ${../rs/libmoq/cmake/moq-config.cmake.in} \
-            $out/lib/cmake/moq/moq-config.cmake \
-            --subst-var-by LIB_FILE libmoq.a \
-            --subst-var-by VERSION "${info.version}"
-          substitute ${../rs/libmoq/cmake/moq-config-version.cmake.in} \
-            $out/lib/cmake/moq/moq-config-version.cmake \
-            --subst-var-by VERSION "${info.version}" \
-            --subst-var-by MAJOR_VERSION "$major_version"
-
-          runHook postInstall
-        '';
-      }
-    );
+  libmoq = craneLib.buildPackage libmoqArgs;
+  libmoq-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin libmoqArgs);
 
   moq-gst-plugin = craneLib.buildPackage (
     crateInfo ../rs/moq-gst/Cargo.toml

--- a/rs/libmoq/build.sh
+++ b/rs/libmoq/build.sh
@@ -92,11 +92,28 @@ if [[ "$TARGET" == *"-windows-"* ]]; then
         -e "s|@MAJOR_VERSION@|${MAJOR_VERSION}|g" \
         "$SCRIPT_DIR/cmake/moq-config-version.cmake.in" >"$PACKAGE_DIR/lib/cmake/moq/moq-config-version.cmake"
 else
-    echo "Building libmoq for $TARGET via nix..."
+    # Native builds use the bare flake output; the one supported cross is the
+    # Intel mac release built on an Apple Silicon runner (the Determinate Nix
+    # installer dropped Intel macOS). The flake exposes a per-target output for
+    # it; Apple's clang cross-compiles natively. libmoq.a needs no execution,
+    # so unlike the binary tarballs there's no Rosetta smoke test.
+    HOST_TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
+    NIX_ATTR="libmoq"
+    if [[ "$TARGET" != "$HOST_TARGET" ]]; then
+        if [[ "$HOST_TARGET" == "aarch64-apple-darwin" && "$TARGET" == "x86_64-apple-darwin" ]]; then
+            NIX_ATTR="libmoq-$TARGET"
+        else
+            echo "Error: unsupported cross ($HOST_TARGET -> $TARGET)." >&2
+            echo "Only aarch64-apple-darwin -> x86_64-apple-darwin is wired up." >&2
+            exit 1
+        fi
+    fi
+
+    echo "Building libmoq for $TARGET via nix (output: $NIX_ATTR)..."
     BUILD_TMP="$(mktemp -d)"
     trap 'rm -rf "$BUILD_TMP"' EXIT
     RESULT_LINK="$BUILD_TMP/result"
-    nix build "$WORKSPACE_DIR#libmoq" --out-link "$RESULT_LINK"
+    nix build "$WORKSPACE_DIR#$NIX_ATTR" --out-link "$RESULT_LINK"
 
     # The derivation lays out everything under $out/{lib,include}; copy it
     # verbatim so the release tarball matches what nix produced.

--- a/rs/moq-gst/build.sh
+++ b/rs/moq-gst/build.sh
@@ -52,12 +52,32 @@ if [[ -z "$TARGET" ]]; then
     echo "Detected target: $TARGET"
 fi
 
-echo "Building moq-gst for $TARGET via nix..."
+# Native builds use the bare flake output. The one supported cross is the
+# Intel mac release built on an Apple Silicon runner (the Determinate Nix
+# installer dropped Intel macOS): a dedicated plugin output links the x86_64
+# GStreamer, and Apple's clang cross-compiles natively. The smoke test is
+# skipped for the cross plugin (an arm gst-inspect can't load an x86_64
+# plugin); scrub.sh and its no-/nix assertion still run.
+HOST_TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
+NIX_ATTR="moq-gst"
+CROSS=false
+if [[ "$TARGET" != "$HOST_TARGET" ]]; then
+    if [[ "$HOST_TARGET" == "aarch64-apple-darwin" && "$TARGET" == "x86_64-apple-darwin" ]]; then
+        NIX_ATTR="moq-gst-plugin-$TARGET"
+        CROSS=true
+    else
+        echo "Error: unsupported cross ($HOST_TARGET -> $TARGET)." >&2
+        echo "Only aarch64-apple-darwin -> x86_64-apple-darwin is wired up." >&2
+        exit 1
+    fi
+fi
+
+echo "Building moq-gst for $TARGET via nix (output: $NIX_ATTR)..."
 
 BUILD_TMP="$(mktemp -d)"
 trap 'rm -rf "$BUILD_TMP"' EXIT
 RESULT_LINK="$BUILD_TMP/result"
-nix build "$WORKSPACE_DIR#moq-gst" --out-link "$RESULT_LINK"
+nix build "$WORKSPACE_DIR#$NIX_ATTR" --out-link "$RESULT_LINK"
 
 # Locate the produced shared library (extension differs by platform).
 # The flake places it in lib/gstreamer-1.0/ so gst_all_1.gstreamer's
@@ -94,7 +114,11 @@ cp "$WORKSPACE_DIR/LICENSE-MIT" "$PACKAGE_DIR/"
 cp "$WORKSPACE_DIR/LICENSE-APACHE" "$PACKAGE_DIR/"
 
 "$SCRIPT_DIR/scrub.sh" "$PACKAGE_DIR/lib/gstreamer-1.0/$LIB_FILE"
-"$SCRIPT_DIR/smoke.sh" "$PACKAGE_DIR/lib/gstreamer-1.0"
+if [[ "$CROSS" == true ]]; then
+    echo "Skipping smoke test for cross build ($TARGET): host gst-inspect can't load it."
+else
+    "$SCRIPT_DIR/smoke.sh" "$PACKAGE_DIR/lib/gstreamer-1.0"
+fi
 
 cd "$OUTPUT_DIR"
 ARCHIVE="$NAME.tar.gz"

--- a/rs/scripts/package-binary.sh
+++ b/rs/scripts/package-binary.sh
@@ -65,23 +65,30 @@ if [[ -z "$TARGET" ]]; then
     echo "Detected target: $TARGET"
 fi
 
-# This script builds the native nix output for the host. Cross-compilation
-# isn't wired up, so an explicit --target that disagrees with the host
-# would silently mislabel the archive. CI keeps target == host by matching
-# each matrix entry to a runner of the right arch.
+# Native builds use the bare flake output. The one supported cross is the
+# Intel mac release built on an Apple Silicon runner (the Determinate Nix
+# installer dropped Intel macOS): the flake exposes a per-target output for
+# it (nix/overlay.nix) and Apple's clang cross-compiles natively, so the only
+# emulation is the Rosetta smoke test below. Any other host/target mismatch
+# would silently mislabel the archive, so it's rejected.
 HOST_TARGET=$(rustc -vV | awk '/^host:/ {print $2}')
+NIX_ATTR="$CRATE"
 if [[ "$TARGET" != "$HOST_TARGET" ]]; then
-    echo "Error: --target ($TARGET) does not match host target ($HOST_TARGET)." >&2
-    echo "This script builds native nix outputs; refusing to mislabel the archive." >&2
-    exit 1
+    if [[ "$HOST_TARGET" == "aarch64-apple-darwin" && "$TARGET" == "x86_64-apple-darwin" ]]; then
+        NIX_ATTR="$CRATE-$TARGET"
+    else
+        echo "Error: unsupported cross ($HOST_TARGET -> $TARGET)." >&2
+        echo "Only aarch64-apple-darwin -> x86_64-apple-darwin is wired up; refusing to mislabel the archive." >&2
+        exit 1
+    fi
 fi
 
-echo "Building $CRATE for $TARGET via nix..."
+echo "Building $CRATE for $TARGET via nix (output: $NIX_ATTR)..."
 
 BUILD_TMP="$(mktemp -d)"
 trap 'rm -rf "$BUILD_TMP"' EXIT
 RESULT_LINK="$BUILD_TMP/result"
-nix build "$WORKSPACE_DIR#$CRATE" --out-link "$RESULT_LINK"
+nix build "$WORKSPACE_DIR#$NIX_ATTR" --out-link "$RESULT_LINK"
 
 # Locate the built binary. Crane installs to result/bin/<binary>.
 # By convention each of our binaries shares its crate name.
@@ -115,11 +122,12 @@ if [[ "$(uname)" == "Darwin" ]]; then
     bin="$PACKAGE_DIR/bin/$CRATE"
     "$SCRIPT_DIR/scrub-macho.sh" "$bin"
 
-    # Prove dyld actually loads the scrubbed binary. host==target is enforced
-    # above, so it runs natively; --help triggers dyld's dependency load (the
-    # exact step that aborted on a clean Mac) before clap exits 0.
+    # Prove dyld actually loads the scrubbed binary. --help triggers dyld's
+    # dependency load (the exact step that aborted on a clean Mac) before clap
+    # exits 0. Native for the host arch; the x86_64 cross build runs under
+    # Rosetta 2, which the workflow installs before invoking this script.
     if ! "$bin" --help >/dev/null 2>&1; then
-        echo "Error: scrubbed $bin failed to launch (dyld load failure?)." >&2
+        echo "Error: scrubbed $bin failed to launch (dyld load failure, or missing Rosetta for a cross build?)." >&2
         otool -L "$bin" >&2
         exit 1
     fi


### PR DESCRIPTION
## Summary

The Determinate Nix installer dropped Intel macOS support, leaving every `x86_64-apple-darwin` release job on a deprecated path (Nix jobs pinned to installer v3.12.2 as a fallback, with a standing warning each run). This builds all of them on the Apple Silicon runner via a **native cross-compile** instead.

Apple's clang is multi-arch, so cross-compiling `x86_64-apple-darwin` from an `aarch64-darwin` host is a full-speed, non-emulated build. The alternative — emulating an x86_64 Nix toolchain under Rosetta — would roughly double build time (the arm build is ~18 min; emulated ~35–50 min) and add a fragile x86 nix-daemon setup. We keep the Nix/Crane reproducible-build model.

Covers all six x86_64-darwin release artifacts: **moq-relay, moq-cli, moq-token-cli, libmoq, moq-gst, and the py-ffi wheel.**

## How each artifact crosses

- **moq-relay / moq-cli / moq-token-cli / libmoq** — pure-Rust links (no external dylib `buildInputs`), so `CARGO_BUILD_TARGET` alone cross-compiles them. The binary tarballs run their dyld smoke test under Rosetta (installed in CI); libmoq is a staticlib, no smoke test. libmoq's custom `installPhase` is now target-aware because `build.rs` derives its output dir from `OUT_DIR` (`target/<triple>/` when cross-building).
- **moq-gst** — the cdylib links external GStreamer, so the overlay links the **cached native x86_64-darwin package set** (`import nixpkgs { system = "x86_64-darwin"; }`) rather than `pkgsCross`, which would rebuild GStreamer from source. The release build scrubs the nix paths to the user's system GStreamer as before; its `gst-inspect` smoke test is **skipped for the cross plugin** (an arm `gst-inspect` can't load an x86_64 plugin), while native builds (incl. the arm mac) keep the full load test. `scrub-macho.sh` (otool/install_name_tool only, no execution) and its no-`/nix` assertion still run, so the cross path needs no Rosetta.
- **py-ffi** — uses maturin, not Nix (so it never depended on the installer; it was on Intel just to build the wheel natively). moq-ffi's tree has no external C libs and uniffi 0.31 reads binding metadata from the cdylib statically, so simply moving the x86_64 wheel to `macos-latest` with `target: x86_64-apple-darwin` cross-compiles cleanly.

## Changes

- **`nix/overlay.nix`**: dual-target toolchain; a `crossX86Darwin` helper (`CARGO_BUILD_TARGET` + `doCheck = false`, since x86_64 tests can't run in the aarch64 sandbox); extracted per-crate args; per-target outputs for moq-relay, moq-cli, moq-token-cli, libmoq, and moq-gst (the last linking x86_64 GStreamer).
- **`flake.nix`**: expose the `*-x86_64-apple-darwin` outputs, gated to `system == "aarch64-darwin"` so `nix flake check` stays green on Linux and Intel macs.
- **`rs/scripts/package-binary.sh`** / **`rs/libmoq/build.sh`** / **`rs/moq-gst/build.sh`**: accept the `aarch64-apple-darwin -> x86_64-apple-darwin` cross, select the per-target Nix output, reject any other mismatch. moq-gst skips the smoke test when cross.
- **Workflows** (moq-token-cli, moq-relay, moq-cli, libmoq, moq-gst, release-py-ffi): `x86_64-apple-darwin` now runs on `macos-latest`. Binary-tarball jobs add an idempotent `softwareupdate --install-rosetta` for the dyld smoke test; moq-gst skips its system-GStreamer install + smoke for x86_64; libmoq and py-ffi need no Rosetta.

## Test plan

All validated locally on an Apple Silicon Mac:

- [x] `nix build` of all five cross outputs (moq-relay/cli/token-cli/libmoq/moq-gst-plugin) → genuine x86_64 artifacts
- [x] moq-relay (jemalloc C build) and moq-token-cli run under Rosetta; link only system libs
- [x] libmoq → x86_64 `.a` + correct headers/pkgconfig/cmake; `moq.pc` shows Apple frameworks
- [x] moq-gst cross → x86_64 cdylib linking x86_64 GStreamer; after scrub, **no `/nix` paths**, rpaths point at `/opt/homebrew`, `/usr/local`, GStreamer.framework, `/usr/lib`
- [x] `package-binary.sh` (cross + native regression), `libmoq/build.sh` cross, `moq-gst/build.sh` cross (scrub runs, smoke skipped) all produce correct tarballs
- [x] maturin cross-compiled the full moq-ffi tree for x86_64 (the local maturin packaging step is exercised by this PR's own `release-py-ffi` dry-run, which triggers on the workflow path change)
- [x] cross outputs present only on `aarch64-darwin`; `nixfmt`/`shfmt`/`shellcheck`/`actionlint` all pass

## Notes on the nixpkgs x86_64-darwin sunset

nixpkgs warns that 26.05 (~May 2026) will be its last release to support the x86_64-darwin platform. This affects **only moq-gst**, which instantiates `nixpkgs { system = "x86_64-darwin"; }` to link x86_64 GStreamer (confirmed: the eval warning fires for the moq-gst cross output and for none of the others). The binary/staticlib crosses (moq-relay, moq-cli, moq-token-cli, libmoq) don't touch that platform at all — they cross-compile via rust-overlay's `x86_64-apple-darwin` rustup target (a Rust tier-1 platform) plus the multi-arch macOS SDK, linking only `/usr/lib/libSystem`. So the Homebrew-distributed binaries keep shipping x86_64 well past the sunset; only moq-gst's x86_64 has a finite, isolated shelf life (revisit when unstable drops x86_64-darwin: pin moq-gst's gstreamer to an older nixpkgs, drop x86_64 moq-gst, or source x86_64 GStreamer another way). Not a blocker now — flake.lock pins a working set.

`cachix.yml` is unaffected (it builds the single native output named by the tag). The release artifacts themselves are unchanged from a user's perspective; only how/where they're built changed, so no doc/API updates.

(Written by Claude)