### PR TITLE
feat(moq-mux): add VP8 and VP9 codec modules (import + fMP4 export)

### DIFF
--- a/rs/moq-mux/src/codec/mod.rs
+++ b/rs/moq-mux/src/codec/mod.rs
@@ -13,3 +13,4 @@ pub mod h264;
 pub mod h265;
 pub mod opus;
 pub mod vp8;
+pub mod vp9;

--- a/rs/moq-mux/src/codec/mod.rs
+++ b/rs/moq-mux/src/codec/mod.rs
@@ -12,3 +12,4 @@ pub mod av1;
 pub mod h264;
 pub mod h265;
 pub mod opus;
+pub mod vp8;

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -1,0 +1,226 @@
+use anyhow::Context;
+use bytes::Buf;
+
+use crate::container::jitter::MinFrameDuration;
+
+use super::FrameHeader;
+
+/// A frame-based importer for raw VP8.
+///
+/// A VP8 elementary stream isn't self-delimiting, so the caller must pass whole
+/// frames, one per [`decode_frame`](Self::decode_frame). The first key frame's
+/// header supplies the catalog dimensions; the track is created lazily so the
+/// importer can be constructed before any media arrives.
+pub struct Import {
+	// The broadcast being produced.
+	broadcast: moq_net::BroadcastProducer,
+
+	// The catalog being produced.
+	catalog: crate::catalog::hang::Producer,
+
+	// The track being produced, created on the first key frame.
+	track: Option<crate::container::Producer<crate::catalog::hang::Container>>,
+
+	// The resolved config, used to detect resolution changes.
+	config: Option<hang::catalog::VideoConfig>,
+
+	// Used to compute wall clock timestamps when the caller has none.
+	zero: Option<tokio::time::Instant>,
+
+	// Tracks the minimum frame duration and updates the catalog `jitter` field.
+	jitter: MinFrameDuration,
+}
+
+impl Import {
+	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::hang::Producer) -> Self {
+		Self {
+			broadcast,
+			catalog,
+			track: None,
+			config: None,
+			zero: None,
+			jitter: MinFrameDuration::new(),
+		}
+	}
+
+	/// Initialize the importer.
+	///
+	/// VP8 has no out-of-band configuration record, so this is normally called
+	/// with an empty buffer (gstreamer / ffi pass `Bytes::new()`) and the track
+	/// is created lazily from the first key frame. If the caller does pass the
+	/// first frame here, it's decoded so nothing is dropped.
+	pub fn initialize<T: Buf + AsRef<[u8]>>(&mut self, buf: &mut T) -> anyhow::Result<()> {
+		if buf.has_remaining() {
+			self.decode_frame(buf, None)?;
+		}
+		Ok(())
+	}
+
+	fn init(&mut self, width: u16, height: u16) -> anyhow::Result<()> {
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		config.coded_width = Some(width as u32);
+		config.coded_height = Some(height as u32);
+		config.container = hang::catalog::Container::Legacy;
+
+		if self.config.as_ref() == Some(&config) {
+			return Ok(());
+		}
+
+		if let Some(track) = self.track.take() {
+			tracing::debug!(name = ?track.name, "reinitializing track");
+			self.catalog.lock().video.renditions.remove(&track.name);
+		}
+
+		let track = self.broadcast.unique_track(".vp8")?;
+		tracing::debug!(name = ?track.name, ?config, "starting track");
+		self.catalog
+			.lock()
+			.video
+			.renditions
+			.insert(track.name.clone(), config.clone());
+
+		self.config = Some(config);
+		self.track = Some(crate::container::Producer::new(
+			track,
+			crate::catalog::hang::Container::Legacy,
+		));
+
+		Ok(())
+	}
+
+	/// Decode a single VP8 frame.
+	pub fn decode_frame<T: Buf + AsRef<[u8]>>(
+		&mut self,
+		buf: &mut T,
+		pts: Option<crate::container::Timestamp>,
+	) -> anyhow::Result<()> {
+		let payload = buf.copy_to_bytes(buf.remaining());
+		anyhow::ensure!(!payload.is_empty(), "empty VP8 frame");
+
+		let header = FrameHeader::parse(&payload)?;
+		if let Some((width, height)) = header.dimensions {
+			self.init(width, height)?;
+		}
+
+		// Resolve the timestamp before borrowing `track` so `pts` doesn't hold a
+		// `&mut self` across the track write.
+		let pts = self.pts(pts)?;
+		let track = self
+			.track
+			.as_mut()
+			.context("expected a VP8 key frame before any interframe")?;
+
+		track.write(crate::container::Frame {
+			timestamp: pts,
+			payload,
+			keyframe: header.keyframe,
+		})?;
+
+		if let Some(jitter) = self.jitter.observe(pts)
+			&& let Some(c) = self.catalog.lock().video.renditions.get_mut(&track.name)
+		{
+			c.jitter = Some(jitter);
+		}
+
+		Ok(())
+	}
+
+	/// Returns a reference to the underlying track producer.
+	pub fn track(&self) -> anyhow::Result<&moq_net::TrackProducer> {
+		Ok(self.track.as_ref().context("not initialized")?.track())
+	}
+
+	/// Finish the track, flushing the current group.
+	pub fn finish(&mut self) -> anyhow::Result<()> {
+		let track = self.track.as_mut().context("not initialized")?;
+		track.finish()?;
+		Ok(())
+	}
+
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		let track = self.track.as_mut().context("not initialized")?;
+		track.seek(sequence)?;
+		Ok(())
+	}
+
+	pub fn is_initialized(&self) -> bool {
+		self.track.is_some()
+	}
+
+	fn pts(&mut self, hint: Option<crate::container::Timestamp>) -> anyhow::Result<crate::container::Timestamp> {
+		if let Some(pts) = hint {
+			return Ok(pts);
+		}
+
+		let zero = self.zero.get_or_insert_with(tokio::time::Instant::now);
+		Ok(crate::container::Timestamp::from_micros(
+			zero.elapsed().as_micros() as u64
+		)?)
+	}
+}
+
+impl Drop for Import {
+	fn drop(&mut self) {
+		if let Some(track) = self.track.take() {
+			tracing::debug!(name = ?track.name, "ending track");
+			self.catalog.lock().video.renditions.remove(&track.name);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use bytes::Bytes;
+
+	use crate::container::Timestamp;
+
+	/// A 320x240 key frame followed by an interframe should create a single VP8
+	/// rendition with the right dimensions and emit both frames.
+	#[tokio::test(start_paused = true)]
+	async fn imports_keyframe_then_interframe() {
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let mut catalog = crate::catalog::hang::Producer::new(&mut broadcast).unwrap();
+		let mut import = super::Import::new(broadcast.clone(), catalog.clone());
+
+		// Empty init buffer: the track is created lazily on the first key frame.
+		import.initialize(&mut Bytes::new()).unwrap();
+		assert!(!import.is_initialized());
+
+		let keyframe = Bytes::from_static(&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x40, 0x01, 0xf0, 0x00]);
+		import
+			.decode_frame(&mut keyframe.clone(), Some(Timestamp::from_micros(0).unwrap()))
+			.unwrap();
+
+		assert!(import.is_initialized());
+		let name = import.track().unwrap().name.clone();
+		let config = catalog.lock().video.renditions.get(&name).cloned().unwrap();
+		assert_eq!(config.codec, hang::catalog::VideoCodec::VP8);
+		assert_eq!(config.coded_width, Some(320));
+		assert_eq!(config.coded_height, Some(240));
+
+		// Interframe: no start code or dimensions, but still a valid frame.
+		let interframe = Bytes::from_static(&[0x31, 0x00, 0x00, 0xaa, 0xbb]);
+		import
+			.decode_frame(&mut interframe.clone(), Some(Timestamp::from_micros(33_000).unwrap()))
+			.unwrap();
+
+		import.finish().unwrap();
+	}
+
+	/// An interframe before any key frame has no dimensions, so the track can't
+	/// be created and the Producer rejects a non-keyframe first frame.
+	#[tokio::test(start_paused = true)]
+	async fn rejects_interframe_first() {
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let catalog = crate::catalog::hang::Producer::new(&mut broadcast).unwrap();
+		let mut import = super::Import::new(broadcast.clone(), catalog);
+
+		let mut interframe = Bytes::from_static(&[0x31, 0x00, 0x00, 0xaa, 0xbb]);
+		assert!(
+			import
+				.decode_frame(&mut interframe, Some(Timestamp::from_micros(0).unwrap()))
+				.is_err()
+		);
+	}
+}

--- a/rs/moq-mux/src/codec/vp8/mod.rs
+++ b/rs/moq-mux/src/codec/vp8/mod.rs
@@ -4,7 +4,7 @@
 //! key frames and read the encoded dimensions, and provides an [`Import`] that
 //! publishes a raw VP8 bitstream (one frame per buffer) to a moq broadcast.
 //!
-//! VP8 carries no out-of-band configuration record, so [`vpcc`] synthesizes the
+//! VP8 carries no out-of-band configuration record, so `vpcc` synthesizes the
 //! informational `vpcC` box the fMP4 exporter needs.
 
 mod import;

--- a/rs/moq-mux/src/codec/vp8/mod.rs
+++ b/rs/moq-mux/src/codec/vp8/mod.rs
@@ -1,0 +1,107 @@
+//! VP8.
+//!
+//! Parses the VP8 uncompressed frame header (RFC 6386 §9.1, §19.1) to detect
+//! key frames and read the encoded dimensions, and provides an [`Import`] that
+//! publishes a raw VP8 bitstream (one frame per buffer) to a moq broadcast.
+//!
+//! VP8 carries no out-of-band configuration record, so [`vpcc`] synthesizes the
+//! informational `vpcC` box the fMP4 exporter needs.
+
+mod import;
+
+pub use import::*;
+
+/// Fields parsed from a VP8 frame tag (RFC 6386 §9.1) plus, for key frames, the
+/// key-frame header (§19.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FrameHeader {
+	/// True for a key frame (frame_type bit clear), false for an interframe.
+	pub keyframe: bool,
+	/// Encoded `(width, height)`, present only on key frames.
+	pub dimensions: Option<(u16, u16)>,
+}
+
+impl FrameHeader {
+	/// Parse the leading bytes of a VP8 frame.
+	///
+	/// Reads the 3-byte frame tag, and on a key frame the 7-byte header that
+	/// follows (start code + dimensions). Interframes carry neither a start code
+	/// nor dimensions.
+	pub fn parse(data: &[u8]) -> anyhow::Result<Self> {
+		anyhow::ensure!(data.len() >= 3, "VP8 frame too short for tag");
+
+		// 24-bit little-endian frame tag. Bit 0 is frame_type: 0 = key frame.
+		let tag = u32::from(data[0]) | (u32::from(data[1]) << 8) | (u32::from(data[2]) << 16);
+		let keyframe = tag & 0x1 == 0;
+
+		if !keyframe {
+			return Ok(Self {
+				keyframe: false,
+				dimensions: None,
+			});
+		}
+
+		anyhow::ensure!(data.len() >= 10, "VP8 key frame too short for header");
+		anyhow::ensure!(
+			data[3] == 0x9d && data[4] == 0x01 && data[5] == 0x2a,
+			"VP8 key frame start code mismatch"
+		);
+
+		// 14-bit dimensions; the top 2 bits of each field are the scaling factor.
+		let width = (u16::from(data[6]) | (u16::from(data[7]) << 8)) & 0x3fff;
+		let height = (u16::from(data[8]) | (u16::from(data[9]) << 8)) & 0x3fff;
+
+		Ok(Self {
+			keyframe: true,
+			dimensions: Some((width, height)),
+		})
+	}
+}
+
+/// Build the informational `vpcC` configuration record for VP8.
+///
+/// VP8 is always 8-bit 4:2:0 with no out-of-band parameters, so the box carries
+/// fixed placeholders. Profile 0 / level 0 are the standard "unspecified"
+/// values. See https://www.webmproject.org/vp9/mp4/.
+pub(crate) fn vpcc() -> mp4_atom::VpcC {
+	mp4_atom::VpcC {
+		profile: 0,
+		level: 0,
+		bit_depth: 8,
+		..Default::default()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parses_keyframe_dimensions() {
+		// Key frame tag (bit 0 = 0) + start code + 320x240.
+		let frame = [0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x40, 0x01, 0xf0, 0x00];
+		let header = FrameHeader::parse(&frame).expect("parse key frame");
+		assert!(header.keyframe);
+		assert_eq!(header.dimensions, Some((320, 240)));
+	}
+
+	#[test]
+	fn parses_interframe() {
+		// Interframe tag (bit 0 = 1); no start code or dimensions follow.
+		let frame = [0x31, 0x00, 0x00];
+		let header = FrameHeader::parse(&frame).expect("parse interframe");
+		assert!(!header.keyframe);
+		assert_eq!(header.dimensions, None);
+	}
+
+	#[test]
+	fn rejects_bad_start_code() {
+		let frame = [0x10, 0x00, 0x00, 0xde, 0xad, 0xbe, 0x40, 0x01, 0xf0, 0x00];
+		assert!(FrameHeader::parse(&frame).is_err());
+	}
+
+	#[test]
+	fn rejects_short_frame() {
+		assert!(FrameHeader::parse(&[0x10, 0x00]).is_err());
+	}
+}

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -1,0 +1,228 @@
+use anyhow::Context;
+use bytes::Buf;
+
+use crate::container::jitter::MinFrameDuration;
+
+use super::FrameHeader;
+
+/// A frame-based importer for raw VP9.
+///
+/// Like VP8, a VP9 elementary stream isn't self-delimiting, so the caller must
+/// pass whole frames (or superframes), one per
+/// [`decode_frame`](Self::decode_frame). The first key frame's header supplies
+/// the catalog config; the track is created lazily.
+pub struct Import {
+	// The broadcast being produced.
+	broadcast: moq_net::BroadcastProducer,
+
+	// The catalog being produced.
+	catalog: crate::catalog::hang::Producer,
+
+	// The track being produced, created on the first key frame.
+	track: Option<crate::container::Producer<crate::catalog::hang::Container>>,
+
+	// The resolved config, used to detect resolution / format changes.
+	config: Option<hang::catalog::VideoConfig>,
+
+	// Used to compute wall clock timestamps when the caller has none.
+	zero: Option<tokio::time::Instant>,
+
+	// Tracks the minimum frame duration and updates the catalog `jitter` field.
+	jitter: MinFrameDuration,
+}
+
+impl Import {
+	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::hang::Producer) -> Self {
+		Self {
+			broadcast,
+			catalog,
+			track: None,
+			config: None,
+			zero: None,
+			jitter: MinFrameDuration::new(),
+		}
+	}
+
+	/// Initialize the importer.
+	///
+	/// VP9 has no out-of-band configuration record, so this is normally called
+	/// with an empty buffer (gstreamer / ffi pass `Bytes::new()`) and the track
+	/// is created lazily from the first key frame. If the caller does pass the
+	/// first frame here, it's decoded so nothing is dropped.
+	pub fn initialize<T: Buf + AsRef<[u8]>>(&mut self, buf: &mut T) -> anyhow::Result<()> {
+		if buf.has_remaining() {
+			self.decode_frame(buf, None)?;
+		}
+		Ok(())
+	}
+
+	fn init(&mut self, vp9: hang::catalog::VP9, width: u16, height: u16) -> anyhow::Result<()> {
+		let mut config = hang::catalog::VideoConfig::new(vp9);
+		config.coded_width = Some(width as u32);
+		config.coded_height = Some(height as u32);
+		config.container = hang::catalog::Container::Legacy;
+
+		if self.config.as_ref() == Some(&config) {
+			return Ok(());
+		}
+
+		if let Some(track) = self.track.take() {
+			tracing::debug!(name = ?track.name, "reinitializing track");
+			self.catalog.lock().video.renditions.remove(&track.name);
+		}
+
+		let track = self.broadcast.unique_track(".vp09")?;
+		tracing::debug!(name = ?track.name, ?config, "starting track");
+		self.catalog
+			.lock()
+			.video
+			.renditions
+			.insert(track.name.clone(), config.clone());
+
+		self.config = Some(config);
+		self.track = Some(crate::container::Producer::new(
+			track,
+			crate::catalog::hang::Container::Legacy,
+		));
+
+		Ok(())
+	}
+
+	/// Decode a single VP9 frame (or superframe).
+	pub fn decode_frame<T: Buf + AsRef<[u8]>>(
+		&mut self,
+		buf: &mut T,
+		pts: Option<crate::container::Timestamp>,
+	) -> anyhow::Result<()> {
+		let payload = buf.copy_to_bytes(buf.remaining());
+		anyhow::ensure!(!payload.is_empty(), "empty VP9 frame");
+
+		let header = FrameHeader::parse(&payload)?;
+		if let Some(key) = header.key {
+			self.init(key.to_catalog(), key.width, key.height)?;
+		}
+
+		// Resolve the timestamp before borrowing `track` so `pts` doesn't hold a
+		// `&mut self` across the track write.
+		let pts = self.pts(pts)?;
+		let track = self
+			.track
+			.as_mut()
+			.context("expected a VP9 key frame before any interframe")?;
+
+		track.write(crate::container::Frame {
+			timestamp: pts,
+			payload,
+			keyframe: header.keyframe,
+		})?;
+
+		if let Some(jitter) = self.jitter.observe(pts)
+			&& let Some(c) = self.catalog.lock().video.renditions.get_mut(&track.name)
+		{
+			c.jitter = Some(jitter);
+		}
+
+		Ok(())
+	}
+
+	/// Returns a reference to the underlying track producer.
+	pub fn track(&self) -> anyhow::Result<&moq_net::TrackProducer> {
+		Ok(self.track.as_ref().context("not initialized")?.track())
+	}
+
+	/// Finish the track, flushing the current group.
+	pub fn finish(&mut self) -> anyhow::Result<()> {
+		let track = self.track.as_mut().context("not initialized")?;
+		track.finish()?;
+		Ok(())
+	}
+
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		let track = self.track.as_mut().context("not initialized")?;
+		track.seek(sequence)?;
+		Ok(())
+	}
+
+	pub fn is_initialized(&self) -> bool {
+		self.track.is_some()
+	}
+
+	fn pts(&mut self, hint: Option<crate::container::Timestamp>) -> anyhow::Result<crate::container::Timestamp> {
+		if let Some(pts) = hint {
+			return Ok(pts);
+		}
+
+		let zero = self.zero.get_or_insert_with(tokio::time::Instant::now);
+		Ok(crate::container::Timestamp::from_micros(
+			zero.elapsed().as_micros() as u64
+		)?)
+	}
+}
+
+impl Drop for Import {
+	fn drop(&mut self) {
+		if let Some(track) = self.track.take() {
+			tracing::debug!(name = ?track.name, "ending track");
+			self.catalog.lock().video.renditions.remove(&track.name);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use bytes::Bytes;
+
+	use crate::container::Timestamp;
+
+	// profile 0, 8-bit, CS_BT_601, studio range, 4:2:0, 320x240.
+	const KEYFRAME: &[u8] = &[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00];
+
+	#[tokio::test(start_paused = true)]
+	async fn imports_keyframe_then_interframe() {
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let mut catalog = crate::catalog::hang::Producer::new(&mut broadcast).unwrap();
+		let mut import = super::Import::new(broadcast.clone(), catalog.clone());
+
+		import.initialize(&mut Bytes::new()).unwrap();
+		assert!(!import.is_initialized());
+
+		import
+			.decode_frame(
+				&mut Bytes::from_static(KEYFRAME),
+				Some(Timestamp::from_micros(0).unwrap()),
+			)
+			.unwrap();
+
+		assert!(import.is_initialized());
+		let name = import.track().unwrap().name.clone();
+		let config = catalog.lock().video.renditions.get(&name).cloned().unwrap();
+		assert!(matches!(config.codec, hang::catalog::VideoCodec::VP9(_)));
+		assert_eq!(config.coded_width, Some(320));
+		assert_eq!(config.coded_height, Some(240));
+
+		// Interframe: marker(10) profile(00) show_existing(0) frame_type(1) = 0x84.
+		import
+			.decode_frame(
+				&mut Bytes::from_static(&[0x84, 0x00, 0x00]),
+				Some(Timestamp::from_micros(33_000).unwrap()),
+			)
+			.unwrap();
+
+		import.finish().unwrap();
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn rejects_interframe_first() {
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let catalog = crate::catalog::hang::Producer::new(&mut broadcast).unwrap();
+		let mut import = super::Import::new(broadcast.clone(), catalog);
+
+		let mut interframe = Bytes::from_static(&[0x84, 0x00, 0x00]);
+		assert!(
+			import
+				.decode_frame(&mut interframe, Some(Timestamp::from_micros(0).unwrap()))
+				.is_err()
+		);
+	}
+}

--- a/rs/moq-mux/src/codec/vp9/mod.rs
+++ b/rs/moq-mux/src/codec/vp9/mod.rs
@@ -1,0 +1,320 @@
+//! VP9.
+//!
+//! Parses the VP9 uncompressed frame header (VP9 bitstream spec §6.2, §7.2) to
+//! detect key frames and read the dimensions, profile, bit depth, and color
+//! config, and provides an [`Import`] that publishes a raw VP9 bitstream (one
+//! frame per buffer) to a moq broadcast.
+//!
+//! VP9 stores its codec config in a `vpcC` box, so [`vpcc`] builds that record
+//! for the fMP4 exporter. It's the exact inverse of the `Vp09` import mapping.
+
+mod import;
+
+pub use import::*;
+
+use hang::catalog::VP9;
+
+/// VP9 key-frame sync code (VP9 spec §6.2, `frame_sync_code`).
+const SYNC_CODE: u32 = 0x49_8342;
+
+/// Fields parsed from a VP9 uncompressed frame header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FrameHeader {
+	/// True for a key frame (`frame_type == 0`).
+	pub keyframe: bool,
+	/// Encoded `(width, height)` and color config, present only on key frames.
+	pub key: Option<KeyFrame>,
+}
+
+/// The parts of a VP9 key-frame header we surface to the catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct KeyFrame {
+	pub width: u16,
+	pub height: u16,
+	pub profile: u8,
+	pub bit_depth: u8,
+	/// `vpcC` chroma subsampling enum (0 = 4:2:0 vertical, 1 = 4:2:0 colocated,
+	/// 2 = 4:2:2, 3 = 4:4:4).
+	pub chroma_subsampling: u8,
+	/// CICP matrix coefficients derived from the VP9 `color_space`.
+	pub matrix_coefficients: u8,
+	pub full_range: bool,
+}
+
+impl FrameHeader {
+	/// Parse the VP9 uncompressed header.
+	///
+	/// Reads only as far as the frame size (the last field we care about);
+	/// everything after it is left untouched.
+	pub fn parse(data: &[u8]) -> anyhow::Result<Self> {
+		let mut r = BitReader::new(data);
+
+		anyhow::ensure!(r.read(2)? == 0b10, "invalid VP9 frame marker");
+
+		let profile_low = r.read(1)?;
+		let profile_high = r.read(1)?;
+		let profile = ((profile_high << 1) | profile_low) as u8;
+		if profile == 3 {
+			r.skip(1)?; // reserved_zero
+		}
+
+		// show_existing_frame: displays a previously decoded frame, no header follows.
+		if r.read(1)? == 1 {
+			r.skip(3)?; // frame_to_show_map_idx
+			return Ok(Self {
+				keyframe: false,
+				key: None,
+			});
+		}
+
+		let keyframe = r.read(1)? == 0; // frame_type: 0 = KEY_FRAME
+		r.skip(2)?; // show_frame, error_resilient_mode
+
+		if !keyframe {
+			return Ok(Self {
+				keyframe: false,
+				key: None,
+			});
+		}
+
+		anyhow::ensure!(r.read(24)? == SYNC_CODE, "invalid VP9 sync code");
+
+		// color_config (VP9 spec §6.2.2).
+		let bit_depth = if profile >= 2 {
+			if r.read(1)? == 1 { 12 } else { 10 }
+		} else {
+			8
+		};
+		let color_space = r.read(3)? as u8;
+
+		const CS_RGB: u8 = 7;
+		let (subsampling_x, subsampling_y, full_range);
+		if color_space != CS_RGB {
+			full_range = r.read(1)? == 1;
+			if profile == 1 || profile == 3 {
+				subsampling_x = r.read(1)? == 1;
+				subsampling_y = r.read(1)? == 1;
+				r.skip(1)?; // reserved_zero
+			} else {
+				// Profiles 0 and 2 are 4:2:0 only.
+				(subsampling_x, subsampling_y) = (true, true);
+			}
+		} else {
+			// CS_RGB is full-range 4:4:4, allowed only with profile 1 or 3.
+			full_range = true;
+			(subsampling_x, subsampling_y) = (false, false);
+			if profile == 1 || profile == 3 {
+				r.skip(1)?; // reserved_zero
+			}
+		}
+
+		// frame_size (VP9 spec §6.2.3): each field is `value - 1`.
+		let width = (r.read(16)? + 1) as u16;
+		let height = (r.read(16)? + 1) as u16;
+
+		Ok(Self {
+			keyframe: true,
+			key: Some(KeyFrame {
+				width,
+				height,
+				profile,
+				bit_depth,
+				chroma_subsampling: chroma_subsampling(subsampling_x, subsampling_y),
+				matrix_coefficients: matrix_coefficients(color_space),
+				full_range,
+			}),
+		})
+	}
+}
+
+impl KeyFrame {
+	/// Build the catalog VP9 config from a parsed key frame.
+	///
+	/// Color primaries and transfer characteristics aren't recoverable from the
+	/// VP9 `color_space` alone, so they're left unspecified (2), matching what
+	/// remuxers like ffmpeg do. `level` is the minimum that fits the picture
+	/// size (see [`level_for`]).
+	pub fn to_catalog(self) -> VP9 {
+		VP9 {
+			profile: self.profile,
+			level: level_for(self.width, self.height),
+			bit_depth: self.bit_depth,
+			chroma_subsampling: self.chroma_subsampling,
+			color_primaries: 2,
+			transfer_characteristics: 2,
+			matrix_coefficients: self.matrix_coefficients,
+			full_range: self.full_range,
+		}
+	}
+}
+
+/// `vpcC` chroma subsampling enum from the VP9 `subsampling_x`/`subsampling_y`
+/// flags. VP9 doesn't signal chroma siting, so 4:2:0 maps to "colocated" (1),
+/// the value encoders conventionally write.
+fn chroma_subsampling(x: bool, y: bool) -> u8 {
+	match (x, y) {
+		(true, true) => 1,   // 4:2:0
+		(true, false) => 2,  // 4:2:2
+		(false, false) => 3, // 4:4:4
+		(false, true) => 0,  // 4:4:0 (rare)
+	}
+}
+
+/// CICP matrix coefficients for a VP9 `color_space` (VP9 spec Table in §7.2.2),
+/// matching ffmpeg's `vp9_colorspaces`. Unknown/reserved map to unspecified (2).
+fn matrix_coefficients(color_space: u8) -> u8 {
+	match color_space {
+		1 => 5, // CS_BT_601  -> BT.470BG
+		2 => 1, // CS_BT_709  -> BT.709
+		3 => 6, // CS_SMPTE_170 -> SMPTE 170M
+		4 => 7, // CS_SMPTE_240 -> SMPTE 240M
+		5 => 9, // CS_BT_2020 -> BT.2020 non-constant luminance
+		7 => 0, // CS_RGB     -> identity
+		_ => 2, // CS_UNKNOWN / CS_RESERVED -> unspecified
+	}
+}
+
+/// The lowest VP9 level whose `MaxLumaPictureSize` fits `width * height` (VP9
+/// spec Annex A). Framerate and bitrate aren't known from the header, so this
+/// is a picture-size lower bound rather than the exact encoded level.
+fn level_for(width: u16, height: u16) -> u8 {
+	let area = width as u64 * height as u64;
+	// (level, MaxLumaPictureSize), ascending.
+	const LEVELS: &[(u8, u64)] = &[
+		(10, 36_864),
+		(11, 73_728),
+		(20, 122_880),
+		(21, 245_760),
+		(30, 552_960),
+		(31, 983_040),
+		(40, 2_228_224),
+		(50, 8_912_896),
+		(60, 35_651_584),
+		(62, 70_254_592),
+	];
+	LEVELS
+		.iter()
+		.find(|(_, max)| area <= *max)
+		.map(|(level, _)| *level)
+		.unwrap_or(62)
+}
+
+/// Build the `vpcC` configuration record for VP9.
+///
+/// The exact inverse of the `Vp09` -> catalog mapping in the fMP4 importer.
+pub(crate) fn vpcc(vp9: &VP9) -> mp4_atom::VpcC {
+	mp4_atom::VpcC {
+		profile: vp9.profile,
+		level: vp9.level,
+		bit_depth: vp9.bit_depth,
+		chroma_subsampling: vp9.chroma_subsampling,
+		video_full_range_flag: vp9.full_range,
+		color_primaries: vp9.color_primaries,
+		transfer_characteristics: vp9.transfer_characteristics,
+		matrix_coefficients: vp9.matrix_coefficients,
+		codec_initialization_data: Vec::new(),
+	}
+}
+
+/// Minimal MSB-first bit reader over a byte slice.
+struct BitReader<'a> {
+	data: &'a [u8],
+	bit: usize,
+}
+
+impl<'a> BitReader<'a> {
+	fn new(data: &'a [u8]) -> Self {
+		Self { data, bit: 0 }
+	}
+
+	fn read(&mut self, n: u32) -> anyhow::Result<u32> {
+		let mut value = 0;
+		for _ in 0..n {
+			let byte = self.bit / 8;
+			anyhow::ensure!(byte < self.data.len(), "VP9 header truncated");
+			let shift = 7 - (self.bit % 8);
+			value = (value << 1) | u32::from((self.data[byte] >> shift) & 1);
+			self.bit += 1;
+		}
+		Ok(value)
+	}
+
+	fn skip(&mut self, n: u32) -> anyhow::Result<()> {
+		self.read(n).map(|_| ())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// A real-shape VP9 key frame: profile 0, show_frame, 8-bit, CS_BT_601,
+	// studio range, 4:2:0, 320x240. Bytes after the frame size are irrelevant.
+	const KEYFRAME_320X240: &[u8] = &[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00];
+
+	#[test]
+	fn parses_keyframe() {
+		let header = FrameHeader::parse(KEYFRAME_320X240).expect("parse key frame");
+		assert!(header.keyframe);
+		let key = header.key.expect("key frame fields");
+		assert_eq!((key.width, key.height), (320, 240));
+		assert_eq!(key.profile, 0);
+		assert_eq!(key.bit_depth, 8);
+		assert_eq!(key.chroma_subsampling, 1); // 4:2:0
+		assert_eq!(key.matrix_coefficients, 5); // CS_BT_601 -> BT.470BG
+		assert!(!key.full_range);
+	}
+
+	#[test]
+	fn keyframe_to_catalog() {
+		let key = FrameHeader::parse(KEYFRAME_320X240).unwrap().key.unwrap();
+		let vp9 = key.to_catalog();
+		assert_eq!(vp9.profile, 0);
+		assert_eq!(vp9.bit_depth, 8);
+		assert_eq!(vp9.level, 20); // 320x240 = 76800, above level 1.1's 73728
+		assert_eq!(vp9.color_primaries, 2); // unspecified
+	}
+
+	#[test]
+	fn parses_interframe() {
+		// Non-key frame: marker(10) profile(00) show_existing(0) frame_type(1) ...
+		// 0b10_00_0_1_00 = 0x84.
+		let header = FrameHeader::parse(&[0x84, 0x00, 0x00]).expect("parse interframe");
+		assert!(!header.keyframe);
+		assert!(header.key.is_none());
+	}
+
+	#[test]
+	fn parses_show_existing() {
+		// marker(10) profile(00) show_existing(1) idx(000) = 0b10_00_1_000 = 0x88.
+		let header = FrameHeader::parse(&[0x88]).expect("parse show_existing");
+		assert!(!header.keyframe);
+		assert!(header.key.is_none());
+	}
+
+	#[test]
+	fn rejects_bad_sync() {
+		let mut frame = KEYFRAME_320X240.to_vec();
+		frame[1] = 0x00; // corrupt the sync code
+		assert!(FrameHeader::parse(&frame).is_err());
+	}
+
+	#[test]
+	fn vpcc_round_trips_catalog() {
+		let vp9 = VP9 {
+			profile: 2,
+			level: 31,
+			bit_depth: 10,
+			chroma_subsampling: 1,
+			color_primaries: 9,
+			transfer_characteristics: 16,
+			matrix_coefficients: 9,
+			full_range: true,
+		};
+		let vpcc = vpcc(&vp9);
+		assert_eq!(vpcc.profile, 2);
+		assert_eq!(vpcc.bit_depth, 10);
+		assert_eq!(vpcc.matrix_coefficients, 9);
+		assert!(vpcc.video_full_range_flag);
+	}
+}

--- a/rs/moq-mux/src/codec/vp9/mod.rs
+++ b/rs/moq-mux/src/codec/vp9/mod.rs
@@ -5,7 +5,7 @@
 //! config, and provides an [`Import`] that publishes a raw VP9 bitstream (one
 //! frame per buffer) to a moq broadcast.
 //!
-//! VP9 stores its codec config in a `vpcC` box, so [`vpcc`] builds that record
+//! VP9 stores its codec config in a `vpcC` box, so `vpcc` builds that record
 //! for the fMP4 exporter. It's the exact inverse of the `Vp09` import mapping.
 
 mod import;

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -342,15 +342,13 @@ impl Export {
 					extract_init(init, &mut ftyp_data, &mut traks, &mut trexs)?;
 				}
 				Container::Legacy | Container::Loc => {
-					let description = track
-						.source
-						.description()
-						.context("video track missing codec config for synthesized init")?;
+					// H.264/H.265 need a synthesized config record here; VP8 has none.
+					let description = track.source.description();
 					let trak = crate::container::fmp4::synthesize_video_trak(
 						track.track_id,
 						track.timescale,
 						config,
-						description.as_ref(),
+						description.map(|d| d.as_ref()),
 					)?;
 					trexs.push(mp4_atom::Trex {
 						track_id: trak.tkhd.track_id,

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -260,6 +260,83 @@ async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
 	moov.encode(&mut buf).expect("encode synthesized moov");
 }
 
+/// VP9 source (catalog `Container::Legacy`, codec `vp09`, no `description`) →
+/// fMP4 export must synthesize a `vp09` sample entry whose `vpcC` round-trips
+/// the catalog's VP9 parameters.
+#[tokio::test(start_paused = true)]
+async fn vp9_source_to_cmaf_export_synthesizes_vp09() {
+	use crate::container::Timestamp;
+	use bytes::Bytes;
+	use hang::catalog::{Container, VP9, VideoConfig};
+
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	let mut catalog = crate::catalog::hang::Producer::new(&mut producer).unwrap();
+	let track = producer.unique_track(".vp9").unwrap();
+	let mut config = VideoConfig::new(VP9 {
+		profile: 0,
+		level: 20,
+		bit_depth: 8,
+		chroma_subsampling: 1,
+		color_primaries: 2,
+		transfer_characteristics: 2,
+		matrix_coefficients: 5,
+		full_range: false,
+	});
+	config.coded_width = Some(320);
+	config.coded_height = Some(240);
+	config.container = Container::Legacy;
+	catalog.lock().video.renditions.insert(track.name.clone(), config);
+
+	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
+	track_producer
+		.write(crate::container::Frame {
+			timestamp: Timestamp::from_micros(0).unwrap(),
+			payload: Bytes::from_static(&[0x82, 0x49, 0x83, 0x42]),
+			keyframe: true,
+		})
+		.unwrap();
+	track_producer.finish().unwrap();
+
+	let mut exporter = crate::container::fmp4::Export::new(consumer).expect("new Fmp4");
+
+	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
+		.await
+		.expect("exporter timed out")
+		.expect("exporter result")
+		.expect("expected init bytes");
+
+	drop(track_producer);
+	drop(catalog);
+	drop(producer);
+
+	let mut cursor = Cursor::new(init.as_ref());
+	let mut moov: Option<mp4_atom::Moov> = None;
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).expect("decode init") {
+		if let mp4_atom::Any::Moov(m) = atom {
+			moov = Some(m);
+		}
+	}
+	let moov = moov.expect("init segment missing moov");
+	let trak = &moov.trak[0];
+	let stsd = &trak.mdia.minf.stbl.stsd;
+	let vp09 = match &stsd.codecs[0] {
+		mp4_atom::Codec::Vp09(vp09) => vp09,
+		other => panic!("expected Vp09 sample entry, got {:?}", other),
+	};
+	assert_eq!(vp09.visual.width, 320);
+	assert_eq!(vp09.visual.height, 240);
+	assert_eq!(vp09.vpcc.profile, 0);
+	assert_eq!(vp09.vpcc.bit_depth, 8);
+	assert_eq!(vp09.vpcc.matrix_coefficients, 5);
+
+	// The synthesized init (vpcC included) must round-trip through encode.
+	let mut buf = Vec::new();
+	moov.encode(&mut buf).expect("encode synthesized moov");
+}
+
 /// CMAF source (catalog `Container::Cmaf`) → fMP4 export should keep using
 /// the passthrough init path: existing init bytes are merged into the moov.
 ///

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -320,6 +320,8 @@ async fn vp9_source_to_cmaf_export_synthesizes_vp09() {
 		}
 	}
 	let moov = moov.expect("init segment missing moov");
+	assert_eq!(moov.trak.len(), 1, "expected single track in moov");
+
 	let trak = &moov.trak[0];
 	let stsd = &trak.mdia.minf.stbl.stsd;
 	let vp09 = match &stsd.codecs[0] {

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -191,6 +191,75 @@ async fn legacy_aac_source_to_cmaf_export_synthesizes_esds() {
 	moov.encode(&mut buf).expect("encode synthesized moov");
 }
 
+/// VP8 source (catalog `Container::Legacy`, codec `vp8`, no `description`) →
+/// fMP4 export must synthesize a `vp08` sample entry. VP8 carries no out-of-band
+/// config, so this exercises the description-less synthesis path.
+#[tokio::test(start_paused = true)]
+async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
+	use crate::container::Timestamp;
+	use bytes::Bytes;
+	use hang::catalog::{Container, VideoCodec, VideoConfig};
+
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	let mut catalog = crate::catalog::hang::Producer::new(&mut producer).unwrap();
+	let track = producer.unique_track(".vp8").unwrap();
+	let mut config = VideoConfig::new(VideoCodec::VP8);
+	config.coded_width = Some(320);
+	config.coded_height = Some(240);
+	config.container = Container::Legacy;
+	catalog.lock().video.renditions.insert(track.name.clone(), config);
+
+	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
+	track_producer
+		.write(crate::container::Frame {
+			timestamp: Timestamp::from_micros(0).unwrap(),
+			payload: Bytes::from_static(&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a]),
+			keyframe: true,
+		})
+		.unwrap();
+	track_producer.finish().unwrap();
+
+	let mut exporter = crate::container::fmp4::Export::new(consumer).expect("new Fmp4");
+
+	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
+		.await
+		.expect("exporter timed out")
+		.expect("exporter result")
+		.expect("expected init bytes");
+
+	drop(track_producer);
+	drop(catalog);
+	drop(producer);
+
+	let mut cursor = Cursor::new(init.as_ref());
+	let mut moov: Option<mp4_atom::Moov> = None;
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).expect("decode init") {
+		if let mp4_atom::Any::Moov(m) = atom {
+			moov = Some(m);
+		}
+	}
+	let moov = moov.expect("init segment missing moov");
+	assert_eq!(moov.trak.len(), 1, "expected single track in moov");
+
+	let trak = &moov.trak[0];
+	let stsd = &trak.mdia.minf.stbl.stsd;
+	assert_eq!(stsd.codecs.len(), 1, "expected single sample entry");
+	let vp08 = match &stsd.codecs[0] {
+		mp4_atom::Codec::Vp08(vp08) => vp08,
+		other => panic!("expected Vp08 sample entry, got {:?}", other),
+	};
+	assert_eq!(vp08.visual.width, 320);
+	assert_eq!(vp08.visual.height, 240);
+	assert_eq!(vp08.vpcc.bit_depth, 8);
+
+	// The synthesized init (vpcC included) must round-trip through encode.
+	let mut buf = Vec::new();
+	moov.encode(&mut buf).expect("encode synthesized moov");
+}
+
 /// CMAF source (catalog `Container::Cmaf`) → fMP4 export should keep using
 /// the passthrough init path: existing init bytes are merged into the moov.
 ///

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -341,6 +341,11 @@ pub(crate) fn synthesize_video_trak(
 			vpcc: crate::codec::vp8::vpcc(),
 			..Default::default()
 		}),
+		VideoCodec::VP9(vp9) => mp4_atom::Codec::from(mp4_atom::Vp09 {
+			visual,
+			vpcc: crate::codec::vp9::vpcc(vp9),
+			..Default::default()
+		}),
 		other => return Err(Error::UnsupportedSynthesis(format!("video codec {:?}", other))),
 	};
 

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -64,6 +64,9 @@ pub enum Error {
 	#[error("can't synthesize CMAF init for {0}")]
 	UnsupportedSynthesis(String),
 
+	#[error("video codec {0} needs a description (codec config record) to synthesize a CMAF init")]
+	MissingVideoDescription(String),
+
 	#[error("audio codec {0} needs a description (AudioSpecificConfig) to synthesize a CMAF init")]
 	MissingAudioDescription(String),
 }
@@ -283,15 +286,15 @@ pub(crate) fn encode_fragment(
 /// Synthesize a CMAF `Trak` for a video rendition that has no init segment.
 ///
 /// Used by the fMP4 exporter when its source is a `Container::Legacy` track
-/// (Avc3/Hev1/etc. importers that publish raw codec bitstreams). The codec's
-/// out-of-band configuration record (`description`) must be available, e.g.
-/// because the Avc1 / Hvc1 transform has finished building it from inline
-/// parameter sets.
+/// (Avc3/Hev1/etc. importers that publish raw codec bitstreams). H.264/H.265
+/// need their out-of-band configuration record (`description`), e.g. because the
+/// Avc1 / Hvc1 transform has finished building it from inline parameter sets.
+/// VP8 carries no out-of-band config, so `description` is `None` for it.
 pub(crate) fn synthesize_video_trak(
 	track_id: u32,
 	timescale: u64,
 	config: &VideoConfig,
-	description: &[u8],
+	description: Option<&[u8]>,
 ) -> Result<mp4_atom::Trak, Error> {
 	let width = config.coded_width.unwrap_or(0) as u16;
 	let height = config.coded_height.unwrap_or(0) as u16;
@@ -302,9 +305,12 @@ pub(crate) fn synthesize_video_trak(
 		..Default::default()
 	};
 
+	// Codecs that carry an out-of-band config record require `description`.
+	let require_description = || description.ok_or_else(|| Error::MissingVideoDescription(config.codec.to_string()));
+
 	let sample_entry = match &config.codec {
 		VideoCodec::H264(_) => {
-			let mut cursor = std::io::Cursor::new(description);
+			let mut cursor = std::io::Cursor::new(require_description()?);
 			let avcc = mp4_atom::Avcc::decode_body(&mut cursor).map_err(Error::Mp4)?;
 			mp4_atom::Codec::from(mp4_atom::Avc1 {
 				visual,
@@ -313,7 +319,7 @@ pub(crate) fn synthesize_video_trak(
 			})
 		}
 		VideoCodec::H265(h265) => {
-			let mut cursor = std::io::Cursor::new(description);
+			let mut cursor = std::io::Cursor::new(require_description()?);
 			let hvcc = mp4_atom::Hvcc::decode_body(&mut cursor).map_err(Error::Mp4)?;
 			// `in_band` (catalog) ↔ hev1 sample entry; otherwise hvc1.
 			if h265.in_band {
@@ -329,6 +335,21 @@ pub(crate) fn synthesize_video_trak(
 					..Default::default()
 				})
 			}
+		}
+		VideoCodec::VP8 => {
+			// VP8 is always 8-bit 4:2:0; the catalog carries no parameters, so the
+			// vpcC is purely informational. Profile 0 / level 0 are the standard
+			// "unspecified" placeholders. See https://www.webmproject.org/vp9/mp4/.
+			mp4_atom::Codec::from(mp4_atom::Vp08 {
+				visual,
+				vpcc: mp4_atom::VpcC {
+					profile: 0,
+					level: 0,
+					bit_depth: 8,
+					..Default::default()
+				},
+				..Default::default()
+			})
 		}
 		other => return Err(Error::UnsupportedSynthesis(format!("video codec {:?}", other))),
 	};

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -336,21 +336,11 @@ pub(crate) fn synthesize_video_trak(
 				})
 			}
 		}
-		VideoCodec::VP8 => {
-			// VP8 is always 8-bit 4:2:0; the catalog carries no parameters, so the
-			// vpcC is purely informational. Profile 0 / level 0 are the standard
-			// "unspecified" placeholders. See https://www.webmproject.org/vp9/mp4/.
-			mp4_atom::Codec::from(mp4_atom::Vp08 {
-				visual,
-				vpcc: mp4_atom::VpcC {
-					profile: 0,
-					level: 0,
-					bit_depth: 8,
-					..Default::default()
-				},
-				..Default::default()
-			})
-		}
+		VideoCodec::VP8 => mp4_atom::Codec::from(mp4_atom::Vp08 {
+			visual,
+			vpcc: crate::codec::vp8::vpcc(),
+			..Default::default()
+		}),
 		other => return Err(Error::UnsupportedSynthesis(format!("video codec {:?}", other))),
 	};
 

--- a/rs/moq-mux/src/import.rs
+++ b/rs/moq-mux/src/import.rs
@@ -28,6 +28,8 @@ pub enum FramedFormat {
 	Hev1,
 	/// AV1 with inline sequence headers
 	Av01,
+	/// VP8 (one frame per buffer; not self-delimiting).
+	Vp8,
 	/// Raw AAC frames (not ADTS).
 	Aac,
 	/// Raw Opus frames (not Ogg).
@@ -48,6 +50,7 @@ impl FromStr for FramedFormat {
 			"hev1" => Ok(FramedFormat::Hev1),
 			"fmp4" | "cmaf" => Ok(FramedFormat::Fmp4),
 			"av01" | "av1" | "av1c" | "av1C" => Ok(FramedFormat::Av01),
+			"vp8" | "vp08" => Ok(FramedFormat::Vp8),
 			"aac" => Ok(FramedFormat::Aac),
 			"opus" => Ok(FramedFormat::Opus),
 			"mkv" | "webm" | "matroska" => Ok(FramedFormat::Mkv),
@@ -65,6 +68,7 @@ impl fmt::Display for FramedFormat {
 			FramedFormat::Fmp4 => write!(f, "fmp4"),
 			FramedFormat::Hev1 => write!(f, "hev1"),
 			FramedFormat::Av01 => write!(f, "av01"),
+			FramedFormat::Vp8 => write!(f, "vp8"),
 			FramedFormat::Aac => write!(f, "aac"),
 			FramedFormat::Opus => write!(f, "opus"),
 			FramedFormat::Mkv => write!(f, "mkv"),
@@ -94,6 +98,7 @@ enum FramedKind {
 	Fmp4(Box<crate::container::fmp4::Import>),
 	Hev1(crate::codec::h265::Import),
 	Av01(crate::codec::av1::Import),
+	Vp8(crate::codec::vp8::Import),
 	Aac(crate::codec::aac::Import),
 	Opus(crate::codec::opus::Import),
 	// Boxed for the same reason as Fmp4.
@@ -146,6 +151,11 @@ impl Framed {
 				decoder.initialize(buf)?;
 				FramedKind::Av01(decoder)
 			}
+			FramedFormat::Vp8 => {
+				let mut decoder = crate::codec::vp8::Import::new(broadcast, catalog);
+				decoder.initialize(buf)?;
+				FramedKind::Vp8(decoder)
+			}
 			FramedFormat::Aac => {
 				let config = crate::codec::aac::Config::parse(buf)?;
 				FramedKind::Aac(crate::codec::aac::Import::new(broadcast, catalog, config)?)
@@ -178,6 +188,7 @@ impl Framed {
 			FramedKind::Fmp4(ref mut decoder) => decoder.finish(),
 			FramedKind::Hev1(ref mut decoder) => decoder.finish(),
 			FramedKind::Av01(ref mut decoder) => decoder.finish(),
+			FramedKind::Vp8(ref mut decoder) => decoder.finish(),
 			FramedKind::Aac(ref mut decoder) => decoder.finish(),
 			FramedKind::Opus(ref mut decoder) => decoder.finish(),
 			FramedKind::Mkv(ref mut decoder) => decoder.finish(),
@@ -192,6 +203,7 @@ impl Framed {
 			FramedKind::Fmp4(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Hev1(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Av01(ref mut decoder) => decoder.seek(sequence),
+			FramedKind::Vp8(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Aac(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Opus(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Mkv(ref mut decoder) => decoder.seek(sequence),
@@ -206,6 +218,7 @@ impl Framed {
 			FramedKind::Fmp4(_) => anyhow::bail!("fmp4 can contain multiple tracks"),
 			FramedKind::Hev1(ref decoder) => decoder.track(),
 			FramedKind::Av01(ref decoder) => decoder.track(),
+			FramedKind::Vp8(ref decoder) => decoder.track(),
 			FramedKind::Aac(ref decoder) => Ok(decoder.track()),
 			FramedKind::Opus(ref decoder) => Ok(decoder.track()),
 			FramedKind::Mkv(_) => anyhow::bail!("mkv can contain multiple tracks"),
@@ -224,6 +237,7 @@ impl Framed {
 			FramedKind::Fmp4(ref mut decoder) => decoder.decode(buf)?,
 			FramedKind::Hev1(ref mut decoder) => decoder.decode_frame(buf, pts)?,
 			FramedKind::Av01(ref mut decoder) => decoder.decode_frame(buf, pts)?,
+			FramedKind::Vp8(ref mut decoder) => decoder.decode_frame(buf, pts)?,
 			FramedKind::Aac(ref mut decoder) => decoder.decode(buf, pts)?,
 			FramedKind::Opus(ref mut decoder) => decoder.decode(buf, pts)?,
 			FramedKind::Mkv(ref mut decoder) => {

--- a/rs/moq-mux/src/import.rs
+++ b/rs/moq-mux/src/import.rs
@@ -30,6 +30,8 @@ pub enum FramedFormat {
 	Av01,
 	/// VP8 (one frame per buffer; not self-delimiting).
 	Vp8,
+	/// VP9 (one frame per buffer; not self-delimiting).
+	Vp9,
 	/// Raw AAC frames (not ADTS).
 	Aac,
 	/// Raw Opus frames (not Ogg).
@@ -51,6 +53,7 @@ impl FromStr for FramedFormat {
 			"fmp4" | "cmaf" => Ok(FramedFormat::Fmp4),
 			"av01" | "av1" | "av1c" | "av1C" => Ok(FramedFormat::Av01),
 			"vp8" | "vp08" => Ok(FramedFormat::Vp8),
+			"vp9" | "vp09" => Ok(FramedFormat::Vp9),
 			"aac" => Ok(FramedFormat::Aac),
 			"opus" => Ok(FramedFormat::Opus),
 			"mkv" | "webm" | "matroska" => Ok(FramedFormat::Mkv),
@@ -69,6 +72,7 @@ impl fmt::Display for FramedFormat {
 			FramedFormat::Hev1 => write!(f, "hev1"),
 			FramedFormat::Av01 => write!(f, "av01"),
 			FramedFormat::Vp8 => write!(f, "vp8"),
+			FramedFormat::Vp9 => write!(f, "vp9"),
 			FramedFormat::Aac => write!(f, "aac"),
 			FramedFormat::Opus => write!(f, "opus"),
 			FramedFormat::Mkv => write!(f, "mkv"),
@@ -99,6 +103,7 @@ enum FramedKind {
 	Hev1(crate::codec::h265::Import),
 	Av01(crate::codec::av1::Import),
 	Vp8(crate::codec::vp8::Import),
+	Vp9(crate::codec::vp9::Import),
 	Aac(crate::codec::aac::Import),
 	Opus(crate::codec::opus::Import),
 	// Boxed for the same reason as Fmp4.
@@ -156,6 +161,11 @@ impl Framed {
 				decoder.initialize(buf)?;
 				FramedKind::Vp8(decoder)
 			}
+			FramedFormat::Vp9 => {
+				let mut decoder = crate::codec::vp9::Import::new(broadcast, catalog);
+				decoder.initialize(buf)?;
+				FramedKind::Vp9(decoder)
+			}
 			FramedFormat::Aac => {
 				let config = crate::codec::aac::Config::parse(buf)?;
 				FramedKind::Aac(crate::codec::aac::Import::new(broadcast, catalog, config)?)
@@ -189,6 +199,7 @@ impl Framed {
 			FramedKind::Hev1(ref mut decoder) => decoder.finish(),
 			FramedKind::Av01(ref mut decoder) => decoder.finish(),
 			FramedKind::Vp8(ref mut decoder) => decoder.finish(),
+			FramedKind::Vp9(ref mut decoder) => decoder.finish(),
 			FramedKind::Aac(ref mut decoder) => decoder.finish(),
 			FramedKind::Opus(ref mut decoder) => decoder.finish(),
 			FramedKind::Mkv(ref mut decoder) => decoder.finish(),
@@ -204,6 +215,7 @@ impl Framed {
 			FramedKind::Hev1(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Av01(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Vp8(ref mut decoder) => decoder.seek(sequence),
+			FramedKind::Vp9(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Aac(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Opus(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Mkv(ref mut decoder) => decoder.seek(sequence),
@@ -219,6 +231,7 @@ impl Framed {
 			FramedKind::Hev1(ref decoder) => decoder.track(),
 			FramedKind::Av01(ref decoder) => decoder.track(),
 			FramedKind::Vp8(ref decoder) => decoder.track(),
+			FramedKind::Vp9(ref decoder) => decoder.track(),
 			FramedKind::Aac(ref decoder) => Ok(decoder.track()),
 			FramedKind::Opus(ref decoder) => Ok(decoder.track()),
 			FramedKind::Mkv(_) => anyhow::bail!("mkv can contain multiple tracks"),
@@ -238,6 +251,7 @@ impl Framed {
 			FramedKind::Hev1(ref mut decoder) => decoder.decode_frame(buf, pts)?,
 			FramedKind::Av01(ref mut decoder) => decoder.decode_frame(buf, pts)?,
 			FramedKind::Vp8(ref mut decoder) => decoder.decode_frame(buf, pts)?,
+			FramedKind::Vp9(ref mut decoder) => decoder.decode_frame(buf, pts)?,
 			FramedKind::Aac(ref mut decoder) => decoder.decode(buf, pts)?,
 			FramedKind::Opus(ref mut decoder) => decoder.decode(buf, pts)?,
 			FramedKind::Mkv(ref mut decoder) => {


### PR DESCRIPTION
## Summary

Gives VP8 and VP9 proper homes in `moq-mux`, matching the per-codec module layout used by `av1`/`h264`/`h265`, and fills in their missing fMP4 export support.

### New `codec/vp8` and `codec/vp9` modules

Each mirrors `codec/av1`:

- **Frame-header parsers** — VP8 reads the uncompressed frame tag (RFC 6386 §9.1/§19.1); VP9 parses the uncompressed header (VP9 spec §6.2/§7.2) via a small MSB-first bit reader, for key-frame detection, dimensions, profile, bit depth, and color config.
- **`Import` types** — publish a raw bitstream (one frame/superframe per buffer) to a moq broadcast, creating the track lazily from the first key frame. Neither codec's elementary stream is self-delimiting, so both are frame-based only (no `Stream` variant).
- **`vpcc()` builders** for the export side. VP9's is the exact inverse of the `Vp09` → catalog mapping in the fMP4 importer.
- Wired into the `FramedFormat` dispatcher (`"vp8"`/`"vp08"`, `"vp9"`/`"vp09"`), so `moq-ffi` and `libmoq` accept them via `FromStr`.

### fMP4 export

Previously a VP8 or VP9 stream (e.g. imported from WebM as `Container::Legacy`) couldn't be exported back to fMP4:

1. `build_init` unconditionally required a codec `description` for every Legacy/Loc video track. VP8/VP9 have no out-of-band config record, so they errored before synthesis.
2. `synthesize_video_trak` had no VP8/VP9 arm and returned `UnsupportedSynthesis`.

Now the description is optional: H.264/H.265 still require it (new `Error::MissingVideoDescription`); VP8 synthesizes a `vp08` entry via `codec::vp8::vpcc()`, and VP9 a `vp09` entry via `codec::vp9::vpcc()` from the catalog's VP9 params.

## Why

Completes VP8/VP9 import ↔ export symmetry and gives each codec a dedicated module instead of scattering logic across the container paths.

## Reviewer notes

- **VP8 `vpcC`** uses fixed placeholders (`profile 0`, `level 0`, `bit_depth 8`) — VP8 is always 8-bit 4:2:0 with no out-of-band params, so the box is purely informational.
- **VP9 catalog mapping**: `color_space` → CICP matrix coefficients follows ffmpeg's `vp9_colorspaces` table; color primaries/transfer stay unspecified (2) since they aren't recoverable from the bitstream. `level` is the minimum that fits the picture size (framerate/bitrate aren't in the header). chroma 4:2:0 maps to the "colocated" enum value (1), matching what encoders write (confirmed against the repo's `vp9.mp4` fixture).
- The `vp9.mp4` test fixture is truncated (no `mdat`), so the VP9 parser test vector is a hand-built, bit-verified 320x240 key-frame header rather than an extracted real frame.
- The `Import`s are wired into `FramedFormat` only. The `moq-gst` sink matches caps explicitly, so it won't pick up `video/x-vp8` / `video/x-vp9` until caps arms are added there — happy to do that as a follow-up.
- Cross-Package Sync: internal to `moq-mux` (no `moq-net` wire, `hang` catalog/container, or breaking public-API change), so no paired package/doc updates triggered.

## Test plan

- [x] `cargo test -p moq-mux` (175 tests; new: VP8/VP9 frame-header parsing, both `Import`s end-to-end, VP8 + VP9 fMP4 export round-trips)
- [x] `cargo check -p moq-cli -p libmoq -p moq-ffi` (dependents build with the new `FramedFormat` variants)
- [x] `cargo fmt` + `cargo clippy --all-targets` via `nix develop` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)