### PR TITLE
gstreamer: add VP8 and VP9 codec support

### DIFF
--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -194,6 +194,8 @@ gst-launch-1.0 -v -e \
 | Video | H.264 | `video/x-h264`        |
 | Video | H.265 | `video/x-h265`        |
 | Video | AV1   | `video/x-av1`         |
+| Video | VP8   | `video/x-vp8`         |
+| Video | VP9   | `video/x-vp9`         |
 | Audio | AAC   | `audio/mpeg` (v4)     |
 | Audio | Opus  | `audio/x-opus`        |
 

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -205,6 +205,8 @@ impl ElementImpl for MoqSink {
 					.build(),
 			);
 			caps.merge(gst::Caps::builder("video/x-av1").build());
+			caps.merge(gst::Caps::builder("video/x-vp8").build());
+			caps.merge(gst::Caps::builder("video/x-vp9").build());
 			caps.merge(
 				gst::Caps::builder("audio/mpeg")
 					.field("mpegversion", 4i32)
@@ -457,6 +459,14 @@ fn handle_caps(runtime: &mut RuntimeState, pad_name: String, caps: gst::Caps) ->
 		"video/x-av1" => {
 			let mut bytes = Bytes::new();
 			new_decoder(runtime, moq_mux::import::FramedFormat::Av01, &mut bytes)?
+		}
+		"video/x-vp8" => {
+			let mut bytes = Bytes::new();
+			new_decoder(runtime, moq_mux::import::FramedFormat::Vp8, &mut bytes)?
+		}
+		"video/x-vp9" => {
+			let mut bytes = Bytes::new();
+			new_decoder(runtime, moq_mux::import::FramedFormat::Vp9, &mut bytes)?
 		}
 		"audio/mpeg" => {
 			let codec_data = structure

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -609,6 +609,10 @@ fn video_caps(config: &hang::catalog::VideoConfig) -> Result<gst::Caps> {
 			}
 			builder.build()
 		}
+		// VP8/VP9 are raw frame streams: gstreamer carries each frame as one buffer
+		// and the decoders read configuration inline, so no codec_data is attached.
+		VideoCodec::VP8 => gst::Caps::builder("video/x-vp8").build(),
+		VideoCodec::VP9(_) => gst::Caps::builder("video/x-vp9").build(),
 		other => bail!("unsupported video codec: {other:?}"),
 	};
 	Ok(caps)


### PR DESCRIPTION
## Summary

Adds VP8 and VP9 support to the GStreamer plugin (`moqsink` / `moqsrc`). H.264, H.265, AV1, AAC, and Opus were already wired up, and the VP8/VP9 importers already exist in `moq-mux`, so this is purely plumbing the GStreamer caps through to them.

## Changes

- **moqsink (publish)** — accept `video/x-vp8` and `video/x-vp9` sink pads and map them to `FramedFormat::Vp8` / `Vp9`. Like AV1, they initialize with an empty buffer since VP8/VP9 carry no out-of-band config; the track is created lazily from the first keyframe's inline dimensions.
- **moqsrc (subscribe)** — emit `video/x-vp8` / `video/x-vp9` caps for VP8/VP9 catalog entries. No `codec_data` is attached since the decoders parse profile/bit-depth from the bitstream itself.
- **docs** — added VP8/VP9 rows to the supported-codecs table in `doc/bin/gstreamer.md` (per the Cross-Package Sync rule).

## Reviewer notes

- VP8 and VP9 were the only video codecs missing; all audio codecs (AAC, Opus) were already present.
- On the source side I attach no `codec_data` for VP9, so the catalog's `vpcC` config record isn't propagated into the GStreamer caps. `vp9dec` / `decodebin3` parse the needed config from the bitstream, so this works in practice. If strict caps negotiation is later desired, we could translate `vpcC` → the `profile` / `bit-depth` caps fields.

## Test plan

- [x] `cargo build -p moq-gst` — clean
- [x] `cargo clippy -p moq-gst` (via nix to match CI toolchain) — clean, no warnings
- [ ] End-to-end VP8/VP9 publish → subscribe round-trip with a real GStreamer pipeline

(Written by Claude)