### PR TITLE
refactor(moq-gst): pump moqsrc pads directly instead of bridging to glib

### DIFF
--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -205,7 +205,15 @@ impl ElementImpl for MoqSrc {
 					gst::error!(CAT, obj = self.obj(), "failed to start session: {err:?}");
 					return Err(gst::StateChangeError);
 				}
-				let success = self.parent_change_state(transition)?;
+				// Roll back the session we just started if the parent transition fails,
+				// otherwise it would keep running while the element stays in READY.
+				let success = match self.parent_change_state(transition) {
+					Ok(success) => success,
+					Err(err) => {
+						self.stop_session();
+						return Err(err);
+					}
+				};
 				// A live source never prerolls.
 				Ok(match success {
 					gst::StateChangeSuccess::Async => gst::StateChangeSuccess::Async,
@@ -296,11 +304,19 @@ async fn run_session(
 		}
 
 		tokio::select! {
-			// Full session shutdown: cancel every pump and wait for it to drop its pad.
+			// Full session shutdown: cancel every pump, then wait for them all to drop
+			// their pads. Cancel all up front (pumps only exit on their own `cancel`), or
+			// awaiting one at a time would let the not-yet-cancelled pumps keep streaming.
 			_ = shutdown.changed() => {
-				for (_, track) in active.drain() {
-					let _ = track.cancel.send(true);
-					let _ = track.handle.await;
+				let handles: Vec<_> = active
+					.drain()
+					.map(|(_, track)| {
+						let _ = track.cancel.send(true);
+						track.handle
+					})
+					.collect();
+				for handle in handles {
+					let _ = handle.await;
 				}
 				break;
 			}

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, Context, Result};
 use gst::glib;
 use gst::prelude::*;
 use gst::subclass::prelude::*;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::watch;
 
 use hang::moq_net;
 
@@ -207,12 +207,9 @@ impl ElementImpl for MoqSrc {
 				}
 				// Roll back the session we just started if the parent transition fails,
 				// otherwise it would keep running while the element stays in READY.
-				let success = match self.parent_change_state(transition) {
-					Ok(success) => success,
-					Err(err) => {
-						self.stop_session();
-						return Err(err);
-					}
+				let Ok(success) = self.parent_change_state(transition) else {
+					self.stop_session();
+					return Err(gst::StateChangeError);
 				};
 				// A live source never prerolls.
 				Ok(match success {
@@ -253,9 +250,10 @@ struct ActiveTrack {
 	/// Tells the pump to drop its pad and exit (set on shutdown or when reconcile
 	/// removes/replaces the rendition).
 	cancel: watch::Sender<bool>,
-	/// The pump task. `is_finished()` lets the session reap pumps that ended on
-	/// their own so a re-announced rendition can be resubscribed.
-	handle: tokio::task::JoinHandle<()>,
+	/// Handle to the pump task in the session's `JoinSet`. We only read
+	/// `is_finished()` to prune this entry once the pump ends (the `JoinSet` owns
+	/// the task and reaps it); teardown goes through `cancel`, never `abort()`.
+	task: tokio::task::AbortHandle,
 }
 
 async fn run_session(
@@ -290,43 +288,38 @@ async fn run_session(
 	// configures, then add renditions a beat later, as well as renditions appearing,
 	// disappearing, or changing codec/resolution mid-stream.
 	let mut active: HashMap<String, ActiveTrack> = HashMap::new();
-	let (done_tx, mut done_rx) = mpsc::unbounded_channel::<()>();
+	let mut pumps: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
 	let mut next_pad_id: u64 = 0;
 	let mut catalog_closed = false;
 
 	loop {
-		// Reap pumps that ended on their own (track finished or errored). Once the catalog
-		// is closed and every pump has drained, we're done: each already emitted EOS (or a
-		// pad drop on error) downstream via its own end path.
-		active.retain(|_, track| !track.handle.is_finished());
-		if catalog_closed && active.is_empty() {
+		// Prune metadata for pumps that have ended (the JoinSet has already reaped the
+		// tasks). Once the catalog is closed and the last pump drains we're done: each
+		// emitted EOS (or a pad drop on error) downstream via its own end path.
+		active.retain(|_, track| !track.task.is_finished());
+		if catalog_closed && pumps.is_empty() {
 			break;
 		}
 
 		tokio::select! {
 			// Full session shutdown: cancel every pump, then wait for them all to drop
 			// their pads. Cancel all up front (pumps only exit on their own `cancel`), or
-			// awaiting one at a time would let the not-yet-cancelled pumps keep streaming.
+			// the not-yet-cancelled ones would keep streaming while we await the rest.
 			_ = shutdown.changed() => {
-				let handles: Vec<_> = active
-					.drain()
-					.map(|(_, track)| {
-						let _ = track.cancel.send(true);
-						track.handle
-					})
-					.collect();
-				for handle in handles {
-					let _ = handle.await;
+				for (_, track) in active.drain() {
+					let _ = track.cancel.send(true);
 				}
+				while pumps.join_next().await.is_some() {}
 				break;
 			}
-			// A pump exited; loop back so the `retain` above reaps it.
-			_ = done_rx.recv() => {}
+			// A pump finished; loop back so the `retain` above prunes its entry and the
+			// break condition sees the drained set.
+			_ = pumps.join_next(), if !pumps.is_empty() => {}
 			// The guard stops us polling a closed catalog track (which would spin the loop
 			// returning None) while we wait for the remaining pumps to drain.
 			next = catalog_consumer.next(), if !catalog_closed => {
 				match next? {
-					Some(catalog) => reconcile(&catalog, &mut active, &mut next_pad_id, &broadcast, &element, &done_tx)?,
+					Some(catalog) => reconcile(&catalog, &mut active, &mut pumps, &mut next_pad_id, &broadcast, &element)?,
 					// Catalog track closed. Don't cancel the pumps: let each reach its
 					// natural Ok(None) -> EOS end so downstream sees a clean EOS rather than a
 					// bare pad drop. We just stop reconciling and wait for them to drain.
@@ -344,10 +337,10 @@ async fn run_session(
 fn reconcile(
 	catalog: &hang::catalog::Catalog,
 	active: &mut HashMap<String, ActiveTrack>,
+	pumps: &mut tokio::task::JoinSet<()>,
 	next_pad_id: &mut u64,
 	broadcast: &moq_net::BroadcastConsumer,
 	element: &glib::WeakRef<super::MoqSrc>,
-	done_tx: &mpsc::UnboundedSender<()>,
 ) -> Result<()> {
 	struct Desired {
 		kind: TrackKind,
@@ -416,14 +409,10 @@ fn reconcile(
 			id,
 		};
 		let (cancel_tx, cancel_rx) = watch::channel(false);
-		let handle = RUNTIME.spawn(run_pump(
-			element.clone(),
-			descriptor,
-			d.caps.clone(),
-			track,
-			cancel_rx,
-			done_tx.clone(),
-		));
+		let task = pumps.spawn_on(
+			run_pump(element.clone(), descriptor, d.caps.clone(), track, cancel_rx),
+			RUNTIME.handle(),
+		);
 
 		active.insert(
 			name,
@@ -431,7 +420,7 @@ fn reconcile(
 				caps: d.caps,
 				container: d.container_hint,
 				cancel: cancel_tx,
-				handle,
+				task,
 			},
 		);
 	}
@@ -467,10 +456,8 @@ async fn run_pump(
 	caps: gst::Caps,
 	mut track: moq_mux::container::Consumer<moq_mux::catalog::hang::Container>,
 	mut cancel: watch::Receiver<bool>,
-	done: mpsc::UnboundedSender<()>,
 ) {
 	let Some(pad) = create_pad(&element, &descriptor, &caps) else {
-		let _ = done.send(());
 		return;
 	};
 
@@ -502,10 +489,6 @@ async fn run_pump(
 	if let Some(obj) = element.upgrade() {
 		let _ = obj.remove_pad(&pad);
 	}
-
-	// Wake the session so it reaps us (and can resubscribe if the rendition reappears).
-	// Best-effort: the receiver is gone once the session itself is shutting down.
-	let _ = done.send(());
 }
 
 /// Create, activate, and add a src pad for the track, seeding it with the sticky

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, Context, Result};
 use gst::glib;
 use gst::prelude::*;
 use gst::subclass::prelude::*;
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{mpsc, watch};
 
 use hang::moq_net;
 
@@ -65,73 +65,24 @@ impl TrackKind {
 	}
 }
 
-#[derive(Debug, Clone)]
-struct TrackDescriptor {
-	kind: TrackKind,
-	/// The moq track name to subscribe to / the GStreamer stream id.
-	name: String,
-	/// A process-unique pad index. Pads are named `video_<id>` / `audio_<id>`
-	/// (matching the `%u` templates) rather than after the track name, so a
-	/// rendition can be torn down and recreated (when its codec/resolution
-	/// changes mid-stream) without two pads ever sharing a name.
-	id: u64,
-}
-
-impl TrackDescriptor {
-	fn pad_name(&self) -> String {
-		match self.kind {
-			TrackKind::Video => format!("video_{}", self.id),
-			TrackKind::Audio => format!("audio_{}", self.id),
-		}
-	}
-}
-
-#[derive(Debug)]
-enum ControlMessage {
-	CreatePad {
-		descriptor: TrackDescriptor,
-		caps: gst::Caps,
-		reply: oneshot::Sender<PadEndpoint>,
-	},
-	ReportError(anyhow::Error),
-}
-
-#[derive(Debug)]
-enum PadMessage {
-	Buffer(gst::Buffer),
-	Eos,
-	Drop,
-}
-
-#[derive(Debug, Clone)]
-struct PadEndpoint {
-	sender: mpsc::UnboundedSender<PadMessage>,
-}
-
-impl PadEndpoint {
-	fn send(&self, msg: PadMessage) -> bool {
-		self.sender.send(msg).is_ok()
-	}
-}
-
-struct PadHandle {
-	sender: mpsc::UnboundedSender<PadMessage>,
-	task: glib::JoinHandle<()>,
-}
-
+/// The session task drives everything: it connects, follows the catalog, and
+/// runs one [pump](run_pump) per active rendition. The element just starts and
+/// stops it. No control-plane channel is needed because pumps push to their pads
+/// directly from their own task (a source pad's push *is* its streaming thread),
+/// so there's nothing to marshal back onto the element.
 struct SessionController {
 	shutdown: watch::Sender<bool>,
 	join: tokio::task::JoinHandle<()>,
 }
 
 impl SessionController {
-	fn start(settings: ResolvedSettings, control_tx: mpsc::UnboundedSender<ControlMessage>) -> Self {
+	fn start(settings: ResolvedSettings, element: glib::WeakRef<super::MoqSrc>) -> Self {
 		let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
-		let control_for_error = control_tx.clone();
 		let join = RUNTIME.spawn(async move {
-			let result = run_session(settings, control_tx, &mut shutdown_rx).await;
-			if let Err(err) = result {
-				let _ = control_for_error.send(ControlMessage::ReportError(err));
+			if let Err(err) = run_session(settings, element.clone(), &mut shutdown_rx).await {
+				if let Some(obj) = element.upgrade() {
+					gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
+				}
 			}
 		});
 
@@ -154,9 +105,6 @@ impl SessionController {
 #[derive(Default)]
 pub struct MoqSrc {
 	settings: Mutex<Settings>,
-	pads: Mutex<HashMap<String, PadHandle>>,
-	control_task: Mutex<Option<glib::JoinHandle<()>>>,
-	control_sender: Mutex<Option<mpsc::UnboundedSender<ControlMessage>>>,
 	session: Mutex<Option<SessionController>>,
 }
 
@@ -258,11 +206,11 @@ impl ElementImpl for MoqSrc {
 					return Err(gst::StateChangeError);
 				}
 				let success = self.parent_change_state(transition)?;
-				let result = match success {
+				// A live source never prerolls.
+				Ok(match success {
 					gst::StateChangeSuccess::Async => gst::StateChangeSuccess::Async,
 					_ => gst::StateChangeSuccess::NoPreroll,
-				};
-				Ok(result)
+				})
 			}
 			gst::StateChange::PausedToReady => {
 				self.stop_session();
@@ -275,28 +223,8 @@ impl ElementImpl for MoqSrc {
 
 impl MoqSrc {
 	fn start_session(&self) -> Result<()> {
-		let settings = {
-			let settings = self.settings.lock().unwrap().clone();
-			ResolvedSettings::try_from(settings)?
-		};
-
-		let (control_tx, control_rx) = mpsc::unbounded_channel();
-		let obj = self.obj();
-		let weak = obj.downgrade();
-		let context = glib::MainContext::default();
-		let control_task = spawn_main_context_forwarder(&context, control_rx, move |msg| {
-			if let Some(obj) = weak.upgrade() {
-				obj.imp().handle_control_message(msg);
-				true
-			} else {
-				false
-			}
-		});
-
-		*self.control_task.lock().unwrap() = Some(control_task);
-		*self.control_sender.lock().unwrap() = Some(control_tx.clone());
-
-		let session = SessionController::start(settings, control_tx);
+		let settings = ResolvedSettings::try_from(self.settings.lock().unwrap().clone())?;
+		let session = SessionController::start(settings, self.obj().downgrade());
 		*self.session.lock().unwrap() = Some(session);
 		Ok(())
 	}
@@ -305,118 +233,26 @@ impl MoqSrc {
 		if let Some(session) = self.session.lock().unwrap().take() {
 			session.stop();
 		}
-
-		if let Some(control_task) = self.control_task.lock().unwrap().take() {
-			control_task.abort();
-		}
-
-		let handles = self.pads.lock().unwrap().drain().collect::<Vec<_>>();
-		for (name, handle) in handles {
-			gst::debug!(CAT, "dropping pad {name}");
-			let _ = handle.sender.send(PadMessage::Drop);
-			handle.task.abort();
-		}
-
-		*self.control_sender.lock().unwrap() = None;
 	}
+}
 
-	fn handle_control_message(&self, msg: ControlMessage) {
-		match msg {
-			ControlMessage::CreatePad {
-				descriptor,
-				caps,
-				reply,
-			} => {
-				if let Err(err) = self.create_pad(descriptor, caps, reply) {
-					gst::error!(CAT, obj = self.obj(), "failed to create pad: {err:?}");
-				}
-			}
-			ControlMessage::ReportError(err) => {
-				gst::element_error!(self.obj(), gst::CoreError::Failed, ("session error"), ["{err:?}"]);
-			}
-		}
-	}
-
-	fn create_pad(
-		&self,
-		descriptor: TrackDescriptor,
-		caps: gst::Caps,
-		reply: oneshot::Sender<PadEndpoint>,
-	) -> Result<()> {
-		let obj = self.obj();
-		let templ = obj
-			.element_class()
-			.pad_template(descriptor.kind.template_name())
-			.context("missing pad template")?;
-
-		let pad = gst::Pad::builder_from_template(&templ)
-			.name(descriptor.pad_name())
-			.build();
-
-		pad.set_active(true)?;
-
-		let stream_start = gst::event::StreamStart::builder(&descriptor.name)
-			.group_id(gst::GroupId::next())
-			.build();
-		pad.push_event(stream_start);
-		pad.push_event(gst::event::Caps::new(&caps));
-		pad.push_event(gst::event::Segment::new(&gst::FormattedSegment::<gst::ClockTime>::new()));
-
-		obj.add_pad(&pad)?;
-
-		let (pad_tx, pad_rx) = mpsc::unbounded_channel();
-		let pad_clone = pad.clone();
-		let weak = obj.downgrade();
-		let context = glib::MainContext::default();
-		let task = spawn_main_context_forwarder(&context, pad_rx, move |msg| {
-			if let Some(obj) = weak.upgrade() {
-				let imp = obj.imp();
-				imp.dispatch_pad_message(&pad_clone, msg)
-			} else {
-				false
-			}
-		});
-
-		self.pads.lock().unwrap().insert(
-			descriptor.pad_name(),
-			PadHandle {
-				sender: pad_tx.clone(),
-				task,
-			},
-		);
-
-		let _ = reply.send(PadEndpoint { sender: pad_tx });
-		Ok(())
-	}
-
-	fn dispatch_pad_message(&self, pad: &gst::Pad, msg: PadMessage) -> bool {
-		match msg {
-			PadMessage::Buffer(buffer) => {
-				if let Err(err) = pad.push(buffer) {
-					gst::warning!(CAT, "failed to push buffer: {err:?}");
-					return false;
-				}
-				true
-			}
-			PadMessage::Eos => {
-				pad.push_event(gst::event::Eos::builder().build());
-				true
-			}
-			PadMessage::Drop => {
-				let _ = pad.set_active(false);
-				let _ = self.obj().remove_pad(pad);
-				// Evict the handle so a long-lived session that keeps swapping
-				// renditions doesn't accumulate dead entries.
-				self.pads.lock().unwrap().remove(pad.name().as_str());
-				false
-			}
-		}
-	}
+/// A rendition we're currently serving, keyed in the session by moq track name.
+struct ActiveTrack {
+	/// The negotiated caps; a catalog update that changes them recreates the pad.
+	caps: gst::Caps,
+	/// The wire container; a change (e.g. legacy -> cmaf) also recreates the pad.
+	container: hang::catalog::Container,
+	/// Tells the pump to drop its pad and exit (set on shutdown or when reconcile
+	/// removes/replaces the rendition).
+	cancel: watch::Sender<bool>,
+	/// The pump task. `is_finished()` lets the session reap pumps that ended on
+	/// their own so a re-announced rendition can be resubscribed.
+	handle: tokio::task::JoinHandle<()>,
 }
 
 async fn run_session(
 	settings: ResolvedSettings,
-	control_tx: mpsc::UnboundedSender<ControlMessage>,
+	element: glib::WeakRef<super::MoqSrc>,
 	shutdown: &mut watch::Receiver<bool>,
 ) -> Result<()> {
 	let mut config = moq_native::ClientConfig::default();
@@ -440,72 +276,44 @@ async fn run_session(
 	let catalog_track = broadcast.subscribe_track(&hang::catalog::Catalog::default_track())?;
 	let mut catalog_consumer = moq_mux::catalog::hang::Consumer::new(catalog_track);
 
-	// Follow the catalog for the whole session and reconcile our pads against every
-	// update, rather than building them once from the first frame. This covers:
-	//   - reactive publishers (the browser via @moq/hang) that announce an empty
-	//     catalog before their encoder configures, then add renditions a beat later;
-	//   - renditions appearing, disappearing, or changing codec/resolution mid-stream.
-	// `Consumer::next` already coalesces to the newest catalog, so we only ever
-	// reconcile against the latest published state.
+	// Follow the catalog for the whole session and reconcile our pumps against every update,
+	// rather than building them once from the first frame. This covers reactive publishers
+	// (the browser via @moq/hang) that announce an empty catalog before their encoder
+	// configures, then add renditions a beat later, as well as renditions appearing,
+	// disappearing, or changing codec/resolution mid-stream.
 	let mut active: HashMap<String, ActiveTrack> = HashMap::new();
-	let (done_tx, mut done_rx) = mpsc::unbounded_channel::<TrackDone>();
+	let (done_tx, mut done_rx) = mpsc::unbounded_channel::<()>();
 	let mut next_pad_id: u64 = 0;
-	// A detached clone for the pumps, kept separate so the `shutdown.changed()`
-	// branch below can borrow `shutdown` mutably without conflicting with reconcile.
-	let pump_shutdown = shutdown.clone();
-
 	let mut catalog_closed = false;
 
 	loop {
-		// Done once the catalog is closed and every pump has drained on its own.
-		// Those pumps already emitted EOS downstream via their natural end path.
+		// Reap pumps that ended on their own (track finished or errored). Once the catalog
+		// is closed and every pump has drained, we're done: each already emitted EOS (or a
+		// pad drop on error) downstream via its own end path.
+		active.retain(|_, track| !track.handle.is_finished());
 		if catalog_closed && active.is_empty() {
 			break;
 		}
 
 		tokio::select! {
-			// Full session shutdown: cancel any pumps still running. (They watch this
-			// same signal too, so this is belt-and-suspenders for a prompt teardown.)
+			// Full session shutdown: cancel every pump and wait for it to drop its pad.
 			_ = shutdown.changed() => {
 				for (_, track) in active.drain() {
 					let _ = track.cancel.send(true);
+					let _ = track.handle.await;
 				}
 				break;
 			}
-			// A pump ended on its own (track finished or errored). Forget it so a
-			// later catalog update can resubscribe if the rendition reappears -- but
-			// only if it's still the pump we have on file, since a replaced rendition
-			// reuses the name under a fresh id.
-			Some(done) = done_rx.recv() => {
-				if active.get(&done.name).is_some_and(|track| track.id == done.id) {
-					active.remove(&done.name);
-				}
-			}
-			// The guard stops us polling a closed catalog track (which would spin the
-			// loop returning None) while we wait for the pumps to drain.
+			// A pump exited; loop back so the `retain` above reaps it.
+			_ = done_rx.recv() => {}
+			// The guard stops us polling a closed catalog track (which would spin the loop
+			// returning None) while we wait for the remaining pumps to drain.
 			next = catalog_consumer.next(), if !catalog_closed => {
 				match next? {
-					Some(catalog) => {
-						reconcile(
-							&catalog,
-							&mut active,
-							&mut next_pad_id,
-							&broadcast,
-							&control_tx,
-							&done_tx,
-							&pump_shutdown,
-						)
-						.await?;
-						// We deliberately never emit `no_more_pads`: a later catalog can
-						// add renditions at any time, so we can't promise the pad set is
-						// complete. The `Sometimes` pads link on pad-added, and the one
-						// moment we'd truly know there are no more pads -- the catalog
-						// closing -- coincides with the streams ending (EOS) anyway.
-					}
-					// Catalog track closed. Don't cancel the pumps -- let each reach
-					// its natural Ok(None) -> EOS end so downstream sees a clean EOS
-					// rather than a bare pad drop. We just stop reconciling and wait
-					// for the pumps to drain (or for a global shutdown).
+					Some(catalog) => reconcile(&catalog, &mut active, &mut next_pad_id, &broadcast, &element, &done_tx)?,
+					// Catalog track closed. Don't cancel the pumps: let each reach its
+					// natural Ok(None) -> EOS end so downstream sees a clean EOS rather than a
+					// bare pad drop. We just stop reconciling and wait for them to drain.
 					None => catalog_closed = true,
 				}
 			}
@@ -515,37 +323,15 @@ async fn run_session(
 	Ok(())
 }
 
-/// A track whose pump is currently running, keyed in the session by moq track name.
-struct ActiveTrack {
-	/// Identifies this particular pump, so a stale completion from a replaced
-	/// rendition (same name, older id) doesn't evict its successor.
-	id: u64,
-	/// The negotiated caps; a catalog update that changes them recreates the pad.
-	caps: gst::Caps,
-	/// The wire container; a change (e.g. legacy -> cmaf) also recreates the pad.
-	container: hang::catalog::Container,
-	/// Signals the pump to drop its pad and exit.
-	cancel: watch::Sender<bool>,
-}
-
-/// Posted by a pump when it exits on its own (end of track or error).
-struct TrackDone {
-	name: String,
-	id: u64,
-}
-
-/// Bring the live set of pads in line with `catalog`: spawn pumps for newly
-/// announced renditions, tear down ones that vanished, and recreate any whose
-/// caps or container changed.
-#[allow(clippy::too_many_arguments)]
-async fn reconcile(
+/// Bring the live set of pumps in line with `catalog`: spawn pumps for newly announced
+/// renditions, tear down ones that vanished, and recreate any whose caps or container changed.
+fn reconcile(
 	catalog: &hang::catalog::Catalog,
 	active: &mut HashMap<String, ActiveTrack>,
 	next_pad_id: &mut u64,
 	broadcast: &moq_net::BroadcastConsumer,
-	control_tx: &mpsc::UnboundedSender<ControlMessage>,
-	done_tx: &mpsc::UnboundedSender<TrackDone>,
-	shutdown: &watch::Receiver<bool>,
+	element: &glib::WeakRef<super::MoqSrc>,
+	done_tx: &mpsc::UnboundedSender<()>,
 ) -> Result<()> {
 	struct Desired {
 		kind: TrackKind,
@@ -586,8 +372,8 @@ async fn reconcile(
 		}
 	}
 
-	// Drop anything that disappeared or changed shape; survivors stay put, and the
-	// changed ones get re-added below under a fresh pad id.
+	// Drop anything that disappeared or changed shape; survivors stay put, and the changed
+	// ones get respawned below under a fresh pad id. Each cancelled pump drops its own pad.
 	active.retain(|name, track| match desired.get(name) {
 		Some(d) if d.caps == track.caps && d.container_hint == track.container => true,
 		_ => {
@@ -596,7 +382,7 @@ async fn reconcile(
 		}
 	});
 
-	// Add the renditions we aren't already serving.
+	// Spawn pumps for the renditions we aren't already serving.
 	for (name, d) in desired {
 		if active.contains_key(&name) {
 			continue;
@@ -605,33 +391,31 @@ async fn reconcile(
 		let id = *next_pad_id;
 		*next_pad_id += 1;
 
+		let track_consumer = broadcast.subscribe_track(&moq_net::Track::new(&name))?;
+		let track = moq_mux::container::Consumer::new(track_consumer, d.container).with_latency(Duration::from_secs(1));
+
 		let descriptor = TrackDescriptor {
 			kind: d.kind,
 			name: name.clone(),
 			id,
 		};
-		let endpoint = request_pad(control_tx, descriptor.clone(), d.caps.clone()).await?;
-
-		let track_consumer = broadcast.subscribe_track(&moq_net::Track::new(&name))?;
-		let track = moq_mux::container::Consumer::new(track_consumer, d.container).with_latency(Duration::from_secs(1));
-
 		let (cancel_tx, cancel_rx) = watch::channel(false);
-		spawn_track_pump(
-			track,
+		let handle = RUNTIME.spawn(run_pump(
+			element.clone(),
 			descriptor,
-			endpoint,
-			shutdown.clone(),
+			d.caps.clone(),
+			track,
 			cancel_rx,
 			done_tx.clone(),
-		);
+		));
 
 		active.insert(
 			name,
 			ActiveTrack {
-				id,
 				caps: d.caps,
 				container: d.container_hint,
 				cancel: cancel_tx,
+				handle,
 			},
 		);
 	}
@@ -639,117 +423,133 @@ async fn reconcile(
 	Ok(())
 }
 
-async fn request_pad(
-	control_tx: &mpsc::UnboundedSender<ControlMessage>,
+/// Identifies a pump's pad. Pads are named `video_<id>` / `audio_<id>` from a
+/// process-unique counter (matching the `%u` templates) rather than after the
+/// track name, so a rendition can be torn down and recreated (when its
+/// codec/resolution changes mid-stream) without two pads ever sharing a name.
+struct TrackDescriptor {
+	kind: TrackKind,
+	name: String,
+	id: u64,
+}
+
+impl TrackDescriptor {
+	fn pad_name(&self) -> String {
+		match self.kind {
+			TrackKind::Video => format!("video_{}", self.id),
+			TrackKind::Audio => format!("audio_{}", self.id),
+		}
+	}
+}
+
+/// Reads frames from one track and pushes them to a pad it owns for its whole lifetime:
+/// it creates the pad, streams buffers, and removes the pad on exit. Runs until the track
+/// ends (EOS), errors, or `cancel` fires.
+async fn run_pump(
+	element: glib::WeakRef<super::MoqSrc>,
 	descriptor: TrackDescriptor,
 	caps: gst::Caps,
-) -> Result<PadEndpoint> {
-	let (reply_tx, reply_rx) = oneshot::channel();
-	control_tx
-		.send(ControlMessage::CreatePad {
-			descriptor,
-			caps,
-			reply: reply_tx,
-		})
-		.map_err(|_| anyhow::anyhow!("control plane shut down"))?;
-
-	let endpoint = reply_rx.await.context("pad creation cancelled")?;
-	Ok(endpoint)
-}
-
-fn spawn_track_pump(
-	track: moq_mux::container::Consumer<moq_mux::catalog::hang::Container>,
-	descriptor: TrackDescriptor,
-	pad_endpoint: PadEndpoint,
-	shutdown: watch::Receiver<bool>,
-	cancel: watch::Receiver<bool>,
-	done: mpsc::UnboundedSender<TrackDone>,
-) -> tokio::task::JoinHandle<()> {
-	RUNTIME.spawn(run_track_pump(track, descriptor, pad_endpoint, shutdown, cancel, done))
-}
-
-async fn run_track_pump(
 	mut track: moq_mux::container::Consumer<moq_mux::catalog::hang::Container>,
-	descriptor: TrackDescriptor,
-	pad_endpoint: PadEndpoint,
-	mut shutdown: watch::Receiver<bool>,
 	mut cancel: watch::Receiver<bool>,
-	done: mpsc::UnboundedSender<TrackDone>,
+	done: mpsc::UnboundedSender<()>,
 ) {
+	let Some(pad) = create_pad(&element, &descriptor, &caps) else {
+		let _ = done.send(());
+		return;
+	};
+
 	let mut reference_ts = None;
 	loop {
 		tokio::select! {
-			// Whole session going away.
-			_ = shutdown.changed() => {
-				pad_endpoint.send(PadMessage::Drop);
-				break;
-			}
-			// Just this rendition being torn down (dropped or replaced by a catalog update).
-			_ = cancel.changed() => {
-				pad_endpoint.send(PadMessage::Drop);
-				break;
-			}
-			frame = track.read() => {
-				match frame {
-					Ok(Some(frame)) => {
-						let timestamp = frame.timestamp;
-						let is_keyframe = frame.keyframe;
-						let payload = frame.payload;
-						let mut buffer = gst::Buffer::from_slice(payload.to_vec());
-						let buffer_mut = buffer.get_mut().unwrap();
-
-						let pts = match reference_ts {
-							Some(reference) => {
-								let delta: Duration = (timestamp - reference).into();
-								gst::ClockTime::from_nseconds(delta.as_nanos() as u64)
-							}
-							None => {
-								reference_ts = Some(timestamp);
-								gst::ClockTime::ZERO
-							}
-						};
-						buffer_mut.set_pts(Some(pts));
-
-						let mut flags = buffer_mut.flags();
-						match descriptor.kind {
-							TrackKind::Video => {
-								if is_keyframe {
-									flags.remove(gst::BufferFlags::DELTA_UNIT);
-								} else {
-									flags.insert(gst::BufferFlags::DELTA_UNIT);
-								}
-							}
-							TrackKind::Audio => {
-								flags.remove(gst::BufferFlags::DELTA_UNIT);
-							}
-						}
-						buffer_mut.set_flags(flags);
-
-						if !pad_endpoint.send(PadMessage::Buffer(buffer)) {
-							break;
-						}
-					}
-					Ok(None) => {
-						pad_endpoint.send(PadMessage::Eos);
-						pad_endpoint.send(PadMessage::Drop);
+			// This rendition is being torn down (shutdown, or replaced by a catalog update).
+			_ = cancel.changed() => break,
+			frame = track.read() => match frame {
+				Ok(Some(frame)) => {
+					let buffer = build_buffer(frame, &mut reference_ts, descriptor.kind);
+					if pad.push(buffer).is_err() {
 						break;
 					}
-					Err(err) => {
-						gst::warning!(CAT, "track {} failed: {err:?}", descriptor.name);
-						pad_endpoint.send(PadMessage::Drop);
-						break;
-					}
+				}
+				Ok(None) => {
+					let _ = pad.push_event(gst::event::Eos::builder().build());
+					break;
+				}
+				Err(err) => {
+					gst::warning!(CAT, "track {} failed: {err:?}", descriptor.name);
+					break;
 				}
 			}
 		}
 	}
 
-	// Let the session know this pump is gone so it can resubscribe if the rendition
-	// reappears in a later catalog. Best-effort: the receiver is gone during shutdown.
-	let _ = done.send(TrackDone {
-		name: descriptor.name.clone(),
-		id: descriptor.id,
-	});
+	let _ = pad.set_active(false);
+	if let Some(obj) = element.upgrade() {
+		let _ = obj.remove_pad(&pad);
+	}
+
+	// Wake the session so it reaps us (and can resubscribe if the rendition reappears).
+	// Best-effort: the receiver is gone once the session itself is shutting down.
+	let _ = done.send(());
+}
+
+/// Create, activate, and add a src pad for the track, seeding it with the sticky
+/// stream-start/caps/segment events. Returns `None` if the element is already gone.
+fn create_pad(
+	element: &glib::WeakRef<super::MoqSrc>,
+	descriptor: &TrackDescriptor,
+	caps: &gst::Caps,
+) -> Option<gst::Pad> {
+	let obj = element.upgrade()?;
+	let templ = obj.element_class().pad_template(descriptor.kind.template_name())?;
+
+	let pad = gst::Pad::builder_from_template(&templ)
+		.name(descriptor.pad_name())
+		.build();
+
+	pad.set_active(true).ok()?;
+	pad.push_event(
+		gst::event::StreamStart::builder(&descriptor.name)
+			.group_id(gst::GroupId::next())
+			.build(),
+	);
+	pad.push_event(gst::event::Caps::new(caps));
+	pad.push_event(gst::event::Segment::new(&gst::FormattedSegment::<gst::ClockTime>::new()));
+
+	obj.add_pad(&pad).ok()?;
+	Some(pad)
+}
+
+/// Wrap a decoded frame in a gst buffer, assigning a pts relative to the track's first frame.
+fn build_buffer(
+	frame: moq_mux::container::Frame,
+	reference_ts: &mut Option<moq_mux::container::Timestamp>,
+	kind: TrackKind,
+) -> gst::Buffer {
+	let mut buffer = gst::Buffer::from_slice(frame.payload);
+	let buffer_mut = buffer.get_mut().unwrap();
+
+	let pts = match *reference_ts {
+		Some(reference) => {
+			let delta: Duration = (frame.timestamp - reference).into();
+			gst::ClockTime::from_nseconds(delta.as_nanos() as u64)
+		}
+		None => {
+			*reference_ts = Some(frame.timestamp);
+			gst::ClockTime::ZERO
+		}
+	};
+	buffer_mut.set_pts(Some(pts));
+
+	let mut flags = buffer_mut.flags();
+	match kind {
+		// Video carries the keyframe bit per frame; audio frames are all keyframes.
+		TrackKind::Video if frame.keyframe => flags.remove(gst::BufferFlags::DELTA_UNIT),
+		TrackKind::Video => flags.insert(gst::BufferFlags::DELTA_UNIT),
+		TrackKind::Audio => flags.remove(gst::BufferFlags::DELTA_UNIT),
+	}
+	buffer_mut.set_flags(flags);
+
+	buffer
 }
 
 fn video_caps(config: &hang::catalog::VideoConfig) -> Result<gst::Caps> {
@@ -829,23 +629,4 @@ fn audio_caps(config: &hang::catalog::AudioConfig) -> Result<gst::Caps> {
 		other => bail!("unsupported audio codec: {other:?}"),
 	};
 	Ok(caps)
-}
-
-fn spawn_main_context_forwarder<T, F>(
-	context: &glib::MainContext,
-	mut rx: mpsc::UnboundedReceiver<T>,
-	mut handler: F,
-) -> glib::JoinHandle<()>
-where
-	T: Send + 'static,
-	F: FnMut(T) -> bool + 'static,
-{
-	let ctx = context.clone();
-	ctx.spawn_local(async move {
-		while let Some(msg) = rx.recv().await {
-			if !handler(msg) {
-				break;
-			}
-		}
-	})
 }


### PR DESCRIPTION
> **Stacked on #1627** (base = `fix/moqsrc-catalog-wait-for-renditions`). Review/merge #1627 first; this diff is just the refactor. Once #1627 lands, GitHub retargets this to `main`.

## Motivation

`moqsrc`'s "async spaghetti": every buffer crossed **two** channels and a glib bridge.

The session task (tokio) couldn't touch GStreamer pads, so it marshalled everything onto the element's GLib main context:

- a `ControlMessage` channel to ask the element to create a pad,
- a per-pad `PadMessage` channel to forward each buffer / EOS / drop,
- `spawn_main_context_forwarder` tasks draining both onto `MainContext::default()`.

That bridge also carried a hidden requirement: **the application had to run a GLib main loop** or the forwarders never ran and no buffers flowed. Fine under `gst-launch`; a trap for an embedded host.

## Change

A source pad's `push` *is* its streaming thread, so there's nothing to marshal back. Each rendition now runs one **pump task that owns its pad end to end**: it creates the pad, pushes buffers/events directly, and removes the pad on exit (the sink already calls `add_pad`/`remove_pad` from a tokio task via a `WeakRef`, so this is an established pattern in the crate).

Deleted: `ControlMessage`, `PadMessage`, `PadEndpoint`, `PadHandle`, `request_pad`, `create_pad`/`dispatch_pad_message`/`handle_control_message`, `spawn_main_context_forwarder`, and the three `Mutex` fields behind them.

The session loop simplified to match:

- pumps are reaped via `JoinHandle::is_finished()` (woken by a unit `done` channel) instead of a name+id-correlated completion channel,
- a single per-pump `cancel` watch replaces the old shutdown+cancel pair.

**Net -219 lines** (`imp.rs` 848 → 628). No consumer-facing behavior change.

## Test

Built the plugin and exercised it at runtime (system GStreamer 1.26 via Nix + a local relay + a synthetic publisher):

- **Regression** — real H264 from `cdn.moq.dev/demo` decodes: 40 NV12 720p frames, exit 0.
- **Empty-first catalog race + unsupported skip + EOS** — publisher announces an empty catalog, then `video/hd` (H264) + `video/vp8` (unsupported): VP8 is skipped with a warning, exactly 120 buffers flow on `video/hd` (4s × 30fps), clean EOS on publisher finish.
- **Abrupt teardown** — SIGTERM mid-stream (`PausedToReady`): prompt clean shutdown, no hang/panic (the case the new pump-owns-its-pad model most needed to prove).
- `cargo clippy -p moq-gst` clean, `cargo fmt --check` clean.

Sizable rewrite of `moqsrc`'s internals, so a careful read on the threading is welcome even though all runtime tests pass.

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)