### PR TITLE
feat(moq-net): tag broadcasts with a per-connection origin hop when the wire carries none

### DIFF
--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -58,6 +58,12 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts the
 	/// distinct upstream sessions feeding each broadcast.
 	broadcasts: crate::SessionBroadcasts,
+	// A random per-connection origin stamped into the hop chain of every
+	// broadcast. moq-transport never carries hop ids on the wire, so each
+	// upstream session needs a stable, unique identity in the hop list for two
+	// sessions publishing the same path to resolve as distinct routes instead
+	// of colliding on an empty chain.
+	session_origin: crate::Origin,
 	state: Lock<State>,
 	version: Version,
 }
@@ -77,6 +83,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			control,
 			stats,
 			broadcasts,
+			session_origin: crate::Origin::random(),
 			state: Default::default(),
 			version,
 		}
@@ -447,7 +454,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				return Ok(entry.get().producer.clone());
 			}
 			Entry::Vacant(entry) => {
-				let broadcast = Broadcast::new().produce();
+				// Stamp this connection's origin as the sole hop so the route is
+				// attributable to the upstream session (moq-transport carries no
+				// hops on the wire, so the chain is otherwise empty).
+				let mut hops = crate::OriginList::new();
+				hops.push(self.session_origin)
+					.expect("an empty hop chain has room for one entry");
+				let broadcast = Broadcast { hops }.produce();
 				origin.publish_broadcast(path.clone(), broadcast.consume());
 				entry.insert(BroadcastState {
 					producer: broadcast.clone(),

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -46,6 +46,12 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	// to skip broadcasts whose hop chain already passed through us, and we
 	// double-check incoming announces against it as defense in depth.
 	self_origin: crate::Origin,
+	// A random per-connection origin prepended to the hop chain of broadcasts
+	// from versions that don't carry one on the wire (Lite01/02/03). It gives
+	// each upstream session a stable, unique identity in the hop list so two
+	// sessions publishing the same path resolve as distinct routes instead of
+	// colliding on an empty/placeholder chain.
+	session_origin: crate::Origin,
 	subscribes: Lock<HashMap<u64, TrackEntry>>,
 	next_id: Arc<atomic::AtomicU64>,
 	version: Version,
@@ -73,6 +79,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			broadcasts,
 			recv_bandwidth: config.recv_bandwidth,
 			self_origin,
+			session_origin: crate::Origin::random(),
 			subscribes: Default::default(),
 			next_id: Default::default(),
 			version: config.version,
@@ -269,15 +276,27 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	fn start_announce(
 		&mut self,
 		path: PathOwned,
-		hops: crate::OriginList,
+		mut hops: crate::OriginList,
 		producers: &mut HashMap<PathOwned, BroadcastProducer>,
 	) -> Result<bool, Error> {
-		// Drop announces that already passed through us — this connection is
+		// Drop announces that already passed through us. This connection is
 		// a reflection, not a new path. Peers should be filtering via
 		// AnnounceInterest.exclude_hop, but Lite03 peers can't, so this is
 		// the authoritative cluster-loop check on the receiver.
 		if hops.contains(&self.self_origin) {
 			tracing::debug!(broadcast = %self.log_path(&path), "dropping reflected announce");
+			return Ok(false);
+		}
+
+		// Versions before Lite04 don't carry a real hop list (Lite01/02 send
+		// none, Lite03 sends a count with placeholder ids), so every broadcast
+		// arrives with an empty or anonymous chain. Prepend this connection's
+		// origin so the route is attributable to the upstream session.
+		if self.version_lacks_hops() && hops.push_front(self.session_origin).is_err() {
+			tracing::warn!(
+				broadcast = %self.log_path(&path),
+				"dropping announce; hop chain at MAX_HOPS (possible loop)",
+			);
 			return Ok(false);
 		}
 
@@ -512,5 +531,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	fn log_path(&self, path: impl AsPath) -> Path<'_> {
 		self.origin.as_ref().unwrap().root().join(path)
+	}
+
+	/// True for versions that don't carry a real hop list on the wire, so the
+	/// received chain is empty (Lite01/02) or anonymous placeholders (Lite03).
+	fn version_lacks_hops(&self) -> bool {
+		matches!(self.version, Version::Lite01 | Version::Lite02 | Version::Lite03)
 	}
 }

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -288,14 +288,22 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Ok(false);
 		}
 
-		// Versions before Lite04 don't carry real hop ids: Lite01/02 send an
-		// empty chain, Lite03 sends a count materialized as UNKNOWN
-		// placeholders. Stamp this connection's origin into the chain so the
-		// route is attributable to the upstream session. Rewrite a Lite03
-		// placeholder in place (preserving its hop count, so shortest-path
-		// selection and the MAX_HOPS limit are unaffected); for an empty chain
-		// add a single entry, which can never overflow.
-		if self.version_lacks_hops() && !hops.replace_first(crate::Origin::UNKNOWN, self.session_origin) {
+		// Lite03 carries its hop count as UNKNOWN placeholders rather than real
+		// ids. Rewrite the first placeholder with this connection's origin so
+		// the route is attributable to the upstream session, without changing
+		// the hop count (shortest-path selection and the MAX_HOPS limit stay
+		// accurate). Lite01/02 send no placeholders; they're covered below.
+		if self.version_lacks_hops() {
+			hops.replace_first(crate::Origin::UNKNOWN, self.session_origin);
+		}
+
+		// Guarantee at least one hop we control. A peer is meant to stamp its
+		// own origin (Lite04+) or have one filled in above, but we don't trust
+		// an empty chain: a peer that sends zero hops would otherwise be
+		// indistinguishable from any other, so two empty-chain routes to the
+		// same path would collide. Insert our session origin so every broadcast
+		// stays attributable. The list is empty here, so this can't overflow.
+		if hops.is_empty() {
 			hops.push(self.session_origin)
 				.expect("an empty hop chain always has room for one entry");
 		}

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -46,11 +46,11 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	// to skip broadcasts whose hop chain already passed through us, and we
 	// double-check incoming announces against it as defense in depth.
 	self_origin: crate::Origin,
-	// A random per-connection origin prepended to the hop chain of broadcasts
-	// from versions that don't carry one on the wire (Lite01/02/03). It gives
-	// each upstream session a stable, unique identity in the hop list so two
-	// sessions publishing the same path resolve as distinct routes instead of
-	// colliding on an empty/placeholder chain.
+	// A random per-connection origin stamped into the hop chain of broadcasts
+	// from versions that don't carry real hop ids on the wire (Lite01/02/03).
+	// It gives each upstream session a stable, unique identity in the hop list
+	// so two sessions publishing the same path resolve as distinct routes
+	// instead of colliding on an empty/placeholder chain.
 	session_origin: crate::Origin,
 	subscribes: Lock<HashMap<u64, TrackEntry>>,
 	next_id: Arc<atomic::AtomicU64>,
@@ -288,16 +288,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Ok(false);
 		}
 
-		// Versions before Lite04 don't carry a real hop list (Lite01/02 send
-		// none, Lite03 sends a count with placeholder ids), so every broadcast
-		// arrives with an empty or anonymous chain. Prepend this connection's
-		// origin so the route is attributable to the upstream session.
-		if self.version_lacks_hops() && hops.push_front(self.session_origin).is_err() {
-			tracing::warn!(
-				broadcast = %self.log_path(&path),
-				"dropping announce; hop chain at MAX_HOPS (possible loop)",
-			);
-			return Ok(false);
+		// Versions before Lite04 don't carry real hop ids: Lite01/02 send an
+		// empty chain, Lite03 sends a count materialized as UNKNOWN
+		// placeholders. Stamp this connection's origin into the chain so the
+		// route is attributable to the upstream session. Rewrite a Lite03
+		// placeholder in place (preserving its hop count, so shortest-path
+		// selection and the MAX_HOPS limit are unaffected); for an empty chain
+		// add a single entry, which can never overflow.
+		if self.version_lacks_hops() && !hops.replace_first(crate::Origin::UNKNOWN, self.session_origin) {
+			hops.push(self.session_origin)
+				.expect("an empty hop chain always has room for one entry");
 		}
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "announce");

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -135,6 +135,16 @@ impl OriginList {
 		Ok(())
 	}
 
+	/// Insert an [`Origin`] at the front (oldest position). Returns
+	/// [`TooManyOrigins`] if the list is full.
+	pub fn push_front(&mut self, origin: Origin) -> Result<(), TooManyOrigins> {
+		if self.0.len() >= MAX_HOPS {
+			return Err(TooManyOrigins);
+		}
+		self.0.insert(0, origin);
+		Ok(())
+	}
+
 	/// Returns true if any entry matches `origin`.
 	pub fn contains(&self, origin: &Origin) -> bool {
 		self.0.contains(origin)
@@ -1052,6 +1062,20 @@ mod tests {
 		}
 		assert_eq!(list.len(), MAX_HOPS);
 		assert_eq!(list.push(Origin::random()), Err(TooManyOrigins));
+	}
+
+	#[test]
+	fn origin_list_push_front_orders_and_limits() {
+		let mut list = OriginList::new();
+		list.push(Origin::from(2)).unwrap();
+		list.push(Origin::from(3)).unwrap();
+		list.push_front(Origin::from(1)).unwrap();
+		assert_eq!(list.as_slice(), &[Origin::from(1), Origin::from(2), Origin::from(3)]);
+
+		while list.len() < MAX_HOPS {
+			list.push(Origin::random()).unwrap();
+		}
+		assert_eq!(list.push_front(Origin::random()), Err(TooManyOrigins));
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -135,14 +135,16 @@ impl OriginList {
 		Ok(())
 	}
 
-	/// Insert an [`Origin`] at the front (oldest position). Returns
-	/// [`TooManyOrigins`] if the list is full.
-	pub fn push_front(&mut self, origin: Origin) -> Result<(), TooManyOrigins> {
-		if self.0.len() >= MAX_HOPS {
-			return Err(TooManyOrigins);
+	/// Replace the first entry equal to `target` with `replacement`, returning
+	/// true if a match was found. The length is unchanged.
+	pub fn replace_first(&mut self, target: Origin, replacement: Origin) -> bool {
+		for entry in &mut self.0 {
+			if *entry == target {
+				*entry = replacement;
+				return true;
+			}
 		}
-		self.0.insert(0, origin);
-		Ok(())
+		false
 	}
 
 	/// Returns true if any entry matches `origin`.
@@ -1065,17 +1067,19 @@ mod tests {
 	}
 
 	#[test]
-	fn origin_list_push_front_orders_and_limits() {
+	fn origin_list_replace_first() {
 		let mut list = OriginList::new();
-		list.push(Origin::from(2)).unwrap();
-		list.push(Origin::from(3)).unwrap();
-		list.push_front(Origin::from(1)).unwrap();
-		assert_eq!(list.as_slice(), &[Origin::from(1), Origin::from(2), Origin::from(3)]);
-
-		while list.len() < MAX_HOPS {
-			list.push(Origin::random()).unwrap();
+		for _ in 0..3 {
+			list.push(Origin::UNKNOWN).unwrap();
 		}
-		assert_eq!(list.push_front(Origin::random()), Err(TooManyOrigins));
+
+		// Rewrites only the first placeholder, keeping the length the same.
+		assert!(list.replace_first(Origin::UNKNOWN, Origin::from(7)));
+		assert_eq!(list.as_slice(), &[Origin::from(7), Origin::UNKNOWN, Origin::UNKNOWN]);
+
+		// No match leaves the list untouched.
+		assert!(!list.replace_first(Origin::from(99), Origin::from(8)));
+		assert_eq!(list.len(), 3);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

When a relay consumes the same broadcast path from two different upstream sessions, it needs to tell the routes apart for shortest-path / route selection (`route_key`). That key is `(hop_count, hash(name + hops))`, so two sessions whose broadcasts arrive with **identical** hop chains collide and can't be distinguished.

That collision happens for every wire version that doesn't carry real hop ids:

- **moq-lite Lite01/02**: empty hop chain.
- **moq-lite Lite03**: a hop *count* materialized as anonymous `UNKNOWN` placeholders.
- **moq-transport (all drafts)**: no hop list on the wire at all.

This PR gives each subscriber connection a random `session_origin` and stamps it into the hop chain so each upstream session is attributable and resolves as a distinct route.

## How it's stamped

| Case | Behavior |
|---|---|
| moq-lite Lite01/02 (empty) | add the session origin as the sole hop |
| moq-lite Lite03 (`UNKNOWN` placeholders) | rewrite the **first placeholder in place** via `OriginList::replace_first`, so the hop **count is preserved** (shortest-path selection and the `MAX_HOPS` limit are unaffected) |
| moq-lite Lite04+ | untouched; real hop ids already on the wire |
| moq-transport | add the session origin as the sole hop (no hops on the wire) |

## What is *not* changed

`self_origin` (the moq-lite subscriber's relay identity, used for `AnnounceInterest.exclude_hop` and the reflected-announce loop check) is unchanged. It stays the stable shared relay origin, as required for cross-session loop detection. The new `session_origin` is a separate per-connection value used only to populate the hop chain.

The moq-transport publisher does no hop manipulation (the wire format has no hop list), so only the subscriber needed the change.

## Files

- `rs/moq-net/src/model/origin.rs` — new `OriginList::replace_first`.
- `rs/moq-net/src/lite/subscriber.rs` — stamp `session_origin` for Lite01/02/03 (rewrite placeholder for Lite03).
- `rs/moq-net/src/ietf/subscriber.rs` — stamp `session_origin` as the sole hop for moq-transport.

## Test plan

- [x] `cargo test -p moq-net` (333 passed), incl. new `origin_list_replace_first`
- [x] `cargo clippy -p moq-net --all-targets`
- [x] `cargo fmt -p moq-net`

(Written by Claude)