### PR TITLE
moq-net: make Group/Frame producers track-only constructible

### DIFF
--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -38,8 +38,12 @@ pub struct Frame {
 }
 
 impl Frame {
-	/// Create a new producer for the frame.
-	pub fn produce(self) -> FrameProducer {
+	/// Create a producer for the frame.
+	///
+	/// Crate-private: frames are only constructed via
+	/// [`crate::GroupProducer::create_frame`], which validates the timestamp
+	/// against the parent track's timescale.
+	pub(crate) fn produce(self) -> FrameProducer {
 		FrameProducer::new(self)
 	}
 }
@@ -188,7 +192,7 @@ impl std::ops::Deref for FrameProducer {
 
 impl FrameProducer {
 	/// Create a new frame producer for the given frame header.
-	pub fn new(info: Frame) -> Self {
+	pub(crate) fn new(info: Frame) -> Self {
 		let buf = FrameBuf::new(info.size as usize);
 		Self {
 			info,
@@ -316,12 +320,6 @@ impl Clone for FrameProducer {
 			state: self.state.clone(),
 			buf: self.buf.clone(),
 		}
-	}
-}
-
-impl From<Frame> for FrameProducer {
-	fn from(info: Frame) -> Self {
-		FrameProducer::new(info)
 	}
 }
 

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -34,9 +34,14 @@ pub struct Group {
 }
 
 impl Group {
-	/// Consume this [`Group`] to create a producer that owns its sequence number.
-	pub fn produce(self) -> GroupProducer {
-		GroupProducer::new(self)
+	/// Create an untimed producer for this group.
+	///
+	/// Test-only: real groups are created via [`crate::TrackProducer`], which
+	/// supplies the track's negotiated timescale. This helper exists for in-crate
+	/// tests that don't exercise timestamps.
+	#[cfg(test)]
+	pub(crate) fn produce(self) -> GroupProducer {
+		GroupProducer::new(self, None)
 	}
 }
 
@@ -159,22 +164,13 @@ impl std::ops::Deref for GroupProducer {
 }
 
 impl GroupProducer {
-	/// Create a new group producer with no parent-track timescale. Frames added
-	/// to this group must have `timestamp = None`; use
-	/// [`Self::new_with_timescale`] to bind a timescale at construction.
-	pub fn new(info: Group) -> Self {
-		Self {
-			info,
-			state: kio::Producer::default(),
-			timescale: None,
-		}
-	}
-
-	/// Create a new group producer tied to a parent track's timescale. Frames
-	/// added to this group must have `timestamp = Some(ts)` with
-	/// `ts.scale() == timescale`. `None` means the parent track is untimed and
-	/// added frames must have `timestamp = None`.
-	pub fn new_with_timescale(info: Group, timescale: Option<Timescale>) -> Self {
+	/// Create a group producer bound to its parent track's timescale.
+	///
+	/// Crate-private: groups are only constructed via [`crate::TrackProducer`],
+	/// which supplies the negotiated timescale. `None` means the parent track is
+	/// untimed and added frames must have `timestamp = None`; `Some(scale)`
+	/// requires every frame's `timestamp` to be `Some(ts)` with `ts.scale() == scale`.
+	pub(crate) fn new(info: Group, timescale: Option<Timescale>) -> Self {
 		Self {
 			info,
 			state: kio::Producer::default(),
@@ -288,12 +284,6 @@ impl Clone for GroupProducer {
 			state: self.state.clone(),
 			timescale: self.timescale,
 		}
-	}
-}
-
-impl From<Group> for GroupProducer {
-	fn from(info: Group) -> Self {
-		GroupProducer::new(info)
 	}
 }
 
@@ -633,7 +623,7 @@ mod test {
 	fn append_frame_rejects_timestamp_on_untimed_group() {
 		use crate::Timestamp;
 
-		let mut producer = GroupProducer::new_with_timescale(Group { sequence: 0 }, None);
+		let mut producer = GroupProducer::new(Group { sequence: 0 }, None);
 		let frame = Frame {
 			size: 3,
 			timestamp: Some(Timestamp::from_micros(42).unwrap()),
@@ -646,7 +636,7 @@ mod test {
 	fn append_frame_rejects_missing_timestamp_on_timed_group() {
 		use crate::Timescale;
 
-		let mut producer = GroupProducer::new_with_timescale(Group { sequence: 0 }, Some(Timescale::MICRO));
+		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
 		let frame = Frame {
 			size: 3,
 			timestamp: None,
@@ -659,7 +649,7 @@ mod test {
 	fn append_frame_rejects_scale_mismatch() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new_with_timescale(Group { sequence: 0 }, Some(Timescale::MICRO));
+		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
 		let frame = Frame {
 			size: 3,
 			timestamp: Some(Timestamp::from_millis(1).unwrap()), // millis, not micros
@@ -672,7 +662,7 @@ mod test {
 	fn append_frame_accepts_matching_scale() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new_with_timescale(Group { sequence: 0 }, Some(Timescale::MICRO));
+		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
 		let frame = Frame {
 			size: 1,
 			timestamp: Some(Timestamp::from_micros(7).unwrap()),

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -425,7 +425,7 @@ impl TrackState {
 		// Adopt the supplied info only if the track hasn't been accepted yet.
 		let info = self.info.get_or_insert_with(|| info.unwrap_or_default());
 
-		let group = GroupProducer::new_with_timescale(Group { sequence }, info.timescale);
+		let group = GroupProducer::new(Group { sequence }, info.timescale);
 		let cache = info.cache;
 		let now = tokio::time::Instant::now();
 		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
@@ -473,7 +473,7 @@ impl TrackProducer {
 		let timescale = info.timescale;
 		let cache = info.cache;
 
-		let group = GroupProducer::new_with_timescale(group, timescale);
+		let group = GroupProducer::new(group, timescale);
 		if !state.duplicates.insert(group.sequence) {
 			return Err(Error::Duplicate);
 		}
@@ -503,7 +503,7 @@ impl TrackProducer {
 		let timescale = info.timescale;
 		let cache = info.cache;
 
-		let group = GroupProducer::new_with_timescale(Group { sequence }, timescale);
+		let group = GroupProducer::new(Group { sequence }, timescale);
 
 		let now = tokio::time::Instant::now();
 		state.duplicates.insert(sequence);


### PR DESCRIPTION
## Summary

`GroupProducer::new_with_timescale` leaked into the public API. It only existed because `GroupProducer`/`FrameProducer` were publicly constructible and a group needs its parent track's timescale to validate frame timestamps. Rather than un-leak that one method, this closes every public construction door so groups/frames can only be built through a track.

- Collapse `GroupProducer::new` + `new_with_timescale` into a single `pub(crate) fn new(info, timescale)`.
- Make `FrameProducer::new` and `Frame::produce` `pub(crate)`; gate the test-only `Group::produce` behind `#[cfg(test)]`.
- Remove the unused `From<Group> for GroupProducer` and `From<Frame> for FrameProducer` impls.
- Update the three internal `TrackProducer` call sites.

Groups now only come from a `TrackProducer` and frames only from `GroupProducer::create_frame`, so the timescale is always the track's negotiated value. The `append_frame` timestamp/timescale check stays a **hard error** (`Error::TimestampMismatch`): with construction gated, a scale mismatch (or a missing/extra timestamp) is a genuine producer bug, not a recoverable condition.

## Why this shape

- **Kept `Timestamp` (no `u64` in `Frame`).** The self-describing scale is load-bearing: `Timestamp::convert()`, the zigzag delta encode in the lite publisher's `serve_frame`, and hang's `convert(TIMESCALE)` all depend on it. A bare `u64` wouldn't remove the wrong-timescale footgun, it would make it silent and uncatchable.
- **No warn/convert in `publisher.rs`.** Once construction is track-gated the group always knows the negotiated timescale, so the per-byte hot path doesn't need to second-guess it. `serve_frame`'s `frame.timestamp.expect(...)` still rests on the model-layer invariant.
- **Construction-dependence only.** This restricts how Group/Frame are *constructed*, not how they *close*. They remain independently closeable and shareable, so the no-cascade-abort contract is untouched.

## Compatibility

This is a breaking change to `rs/moq-net`'s public Rust API (hence targeting `dev`), but there is **zero external churn**: every caller in the workspace already builds via `create_group` / `create_frame`, including the lite subscriber receive path. No JS/wire/catalog changes, so no Cross-Package Sync rows apply.

## Test plan

- [x] `cargo test -p moq-net --lib` (365 passed)
- [x] `cargo build --workspace`
- [x] `cargo clippy -p moq-net --all-targets` (clean)
- [x] `cargo fmt -p moq-net`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)