### PR TITLE
feat(moq-json): JSON Merge Patch snapshot/delta helper; route hang catalog through it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3519,6 +3519,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3898,6 +3920,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "moq-json"
+version = "0.0.1"
+dependencies = [
+ "bytes",
+ "json-patch",
+ "kio",
+ "moq-net",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "moq-loc"
 version = "0.1.0"
 dependencies = [
@@ -3927,6 +3962,7 @@ dependencies = [
  "hang",
  "kio",
  "m3u8-rs",
+ "moq-json",
  "moq-loc",
  "moq-msf",
  "moq-net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "rs/moq-cli",
     "rs/moq-ffi",
     "rs/moq-gst",
+    "rs/moq-json",
     "rs/moq-loc",
     "rs/moq-msf",
     "rs/moq-mux",
@@ -28,6 +29,7 @@ default-members = [
     "rs/moq-cli",
     # "rs/moq-ffi",   # requires Python/maturin
     # "rs/moq-gst",   # requires GStreamer
+    "rs/moq-json",
     "rs/moq-loc",
     "rs/moq-msf",
     "rs/moq-net",
@@ -49,6 +51,7 @@ flate2 = "1.1"
 hang = { version = "0.18", path = "rs/hang" }
 kio = { version = "0.3", path = "rs/kio" }
 moq-audio = { version = "0.0.1", path = "rs/moq-audio" }
+moq-json = { version = "0.0.1", path = "rs/moq-json" }
 moq-loc = { version = "0.1", path = "rs/moq-loc" }
 moq-msf = { version = "0.2", path = "rs/moq-msf" }
 moq-mux = { version = "0.5", path = "rs/moq-mux" }

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "moq",
@@ -97,6 +98,22 @@
         "typescript": "^6.0.3",
       },
     },
+    "js/json": {
+      "name": "@moq/json",
+      "version": "0.0.1",
+      "dependencies": {
+        "@moq/net": "workspace:^",
+        "@moq/signals": "workspace:^",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.14",
+        "rimraf": "^6.1.3",
+        "typescript": "^6.0.3",
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0",
+      },
+    },
     "js/loc": {
       "name": "@moq/loc",
       "version": "0.1.0",
@@ -165,6 +182,7 @@
       "version": "0.2.10",
       "dependencies": {
         "@moq/hang": "workspace:^",
+        "@moq/json": "workspace:^",
         "@moq/net": "workspace:^",
         "@moq/signals": "workspace:^",
       },
@@ -221,6 +239,7 @@
       "version": "0.2.14",
       "dependencies": {
         "@moq/hang": "workspace:^",
+        "@moq/json": "workspace:^",
         "@moq/msf": "workspace:^",
         "@moq/net": "workspace:^",
         "@moq/signals": "workspace:^",
@@ -501,6 +520,8 @@
     "@moq/demo-boy": ["@moq/demo-boy@workspace:demo/boy"],
 
     "@moq/hang": ["@moq/hang@workspace:js/hang"],
+
+    "@moq/json": ["@moq/json@workspace:js/json"],
 
     "@moq/loc": ["@moq/loc@workspace:js/loc"],
 

--- a/js/json/README.md
+++ b/js/json/README.md
@@ -33,4 +33,4 @@ for await (const value of consumer) {
 }
 ```
 
-Pass `{ maxDeltaRatio: x }` to `Producer` to emit merge-patch deltas while a group stays within `x` times the size of a fresh snapshot. Arrays are replaced wholesale within a delta; a value set to `null` falls back to a snapshot, since merge patch reads `null` as a key deletion.
+Pass `{ deltaRatio: x }` to `Producer` to emit merge-patch deltas while a group stays within `x` times the size of a fresh snapshot. Arrays are replaced wholesale within a delta; a value set to `null` falls back to a snapshot, since merge patch reads `null` as a key deletion.

--- a/js/json/README.md
+++ b/js/json/README.md
@@ -1,0 +1,36 @@
+<p align="center">
+	<img height="128px" src="https://github.com/moq-dev/moq/blob/main/.github/logo.svg" alt="Media over QUIC">
+</p>
+
+# @moq/json
+
+[![npm version](https://img.shields.io/npm/v/@moq/json)](https://www.npmjs.com/package/@moq/json)
+[![TypeScript](https://img.shields.io/badge/TypeScript-ready-blue.svg)](https://www.typescriptlang.org/)
+
+Snapshot/delta JSON publishing over [Media over QUIC](https://moq.dev/) tracks using [RFC 7396 JSON Merge Patch](https://www.rfc-editor.org/rfc/rfc7396.html).
+
+A JSON value is published over a [`@moq/net`](../net) track as a series of groups. Each group is self-contained: its first frame is a full snapshot and any following frames are JSON Merge Patch deltas applied in order. A consumer jumps to the newest group, reads the snapshot, and applies the deltas, so a late joiner never needs older groups.
+
+Deltas are opt-in via `maxDeltaRatio` (omit it to publish a full snapshot per group).
+
+## Quick Start
+
+```bash
+npm add @moq/json
+```
+
+```ts
+import { Producer, Consumer } from "@moq/json";
+
+// Publish: deltas off by default (one snapshot per group).
+const producer = new Producer(track);
+producer.update({ hello: "world" });
+
+// Consume: yields the reconstructed value after each update.
+const consumer = new Consumer(track);
+for await (const value of consumer) {
+	console.log(value);
+}
+```
+
+Pass `{ maxDeltaRatio: x }` to `Producer` to emit merge-patch deltas while a group stays within `x` times the size of a fresh snapshot. Arrays are replaced wholesale within a delta; a value set to `null` falls back to a snapshot, since merge patch reads `null` as a key deletion.

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@moq/json",
+	"type": "module",
+	"version": "0.0.1",
+	"description": "Snapshot/delta JSON publishing over MoQ tracks using RFC 7396 JSON Merge Patch.",
+	"license": "(MIT OR Apache-2.0)",
+	"repository": "github:moq-dev/moq",
+	"sideEffects": false,
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"check": "tsc --noEmit",
+		"test": "bun test --only-failures",
+		"release": "bun ../common/release.ts"
+	},
+	"dependencies": {
+		"@moq/net": "workspace:^",
+		"@moq/signals": "workspace:^"
+	},
+	"peerDependencies": {
+		"zod": "^4.0.0"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.3.14",
+		"rimraf": "^6.1.3",
+		"typescript": "^6.0.3"
+	}
+}

--- a/js/json/src/consumer.ts
+++ b/js/json/src/consumer.ts
@@ -1,0 +1,91 @@
+import type * as Moq from "@moq/net";
+import { Signal } from "@moq/signals";
+import type * as z from "zod/mini";
+
+import { merge } from "./diff.ts";
+
+/**
+ * Consumes a JSON value from a track, reconstructing it from snapshots and deltas.
+ *
+ * Always jumps to the newest group, reads its snapshot, and applies deltas in order, yielding
+ * the reconstructed value after each frame. A late joiner never needs older groups.
+ */
+export class Consumer<T> {
+	#track: Moq.Track;
+	#schema?: z.ZodMiniType<T>;
+
+	#group?: Moq.Group;
+	#current?: unknown;
+	#framesRead = 0;
+
+	constructor(track: Moq.Track, schema?: z.ZodMiniType<T>) {
+		this.#track = track;
+		this.#schema = schema;
+	}
+
+	/** Get the next reconstructed value, or `undefined` once the track ends. */
+	async next(): Promise<T | undefined> {
+		for (;;) {
+			// Jump to the newest group, discarding any older ones, and reset reconstruction.
+			const groups = this.#track.state.groups.peek();
+			if (groups.length > 0 && groups.at(-1) !== this.#group) {
+				while (groups.length > 1) groups.shift()?.close();
+				this.#group = groups[0];
+				this.#current = undefined;
+				this.#framesRead = 0;
+			}
+
+			const group = this.#group;
+			if (!group) {
+				const closed = this.#track.state.closed.peek();
+				if (closed instanceof Error) throw closed;
+				if (closed) return undefined;
+
+				await Signal.race(this.#track.state.groups, this.#track.state.closed);
+				continue;
+			}
+
+			// Frame 0 of a group is a snapshot, the rest are merge patches.
+			const frame = group.state.frames.peek().shift();
+			if (frame) return this.#apply(frame);
+
+			// The current group has no pending frame.
+			const groupClosed = group.state.closed.peek();
+			if (groupClosed) {
+				if (groupClosed instanceof Error) throw groupClosed;
+
+				// The group is exhausted; wait for a newer one.
+				if (this.#group === group) this.#group = undefined;
+				const closed = this.#track.state.closed.peek();
+				if (closed instanceof Error) throw closed;
+				if (closed) return undefined;
+
+				await Signal.race(this.#track.state.groups, this.#track.state.closed);
+				continue;
+			}
+
+			// Group open but no frame yet: wait for a frame, a newer group, or track close.
+			await Signal.race(group.state.frames, this.#track.state.groups, this.#track.state.closed);
+		}
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<T> {
+		for (;;) {
+			const value = await this.next();
+			if (value === undefined) return;
+			yield value;
+		}
+	}
+
+	#apply(frame: Uint8Array): T {
+		const parsed = JSON.parse(new TextDecoder().decode(frame));
+		if (this.#framesRead === 0) {
+			this.#current = parsed;
+		} else {
+			this.#current = merge(this.#current, parsed);
+		}
+		this.#framesRead += 1;
+
+		return this.#schema ? this.#schema.parse(this.#current) : (this.#current as T);
+	}
+}

--- a/js/json/src/consumer.ts
+++ b/js/json/src/consumer.ts
@@ -1,14 +1,13 @@
 import type * as Moq from "@moq/net";
-import { Signal } from "@moq/signals";
 import type * as z from "zod/mini";
-
 import { merge } from "./diff.ts";
+import type { Config } from "./producer.ts";
 
 /**
  * Consumes a JSON value from a track, reconstructing it from snapshots and deltas.
  *
- * Always jumps to the newest group, reads its snapshot, and applies deltas in order, yielding
- * the reconstructed value after each frame. A late joiner never needs older groups.
+ * Reads each group's snapshot (frame 0) and applies the following frames as merge patches,
+ * yielding the reconstructed value after each one.
  */
 export class Consumer<T> {
 	#track: Moq.Track;
@@ -18,54 +17,30 @@ export class Consumer<T> {
 	#current?: unknown;
 	#framesRead = 0;
 
-	constructor(track: Moq.Track, schema?: z.ZodMiniType<T>) {
+	constructor(track: Moq.Track, config: Config<T> = {}) {
 		this.#track = track;
-		this.#schema = schema;
+		this.#schema = config.schema;
 	}
 
 	/** Get the next reconstructed value, or `undefined` once the track ends. */
 	async next(): Promise<T | undefined> {
 		for (;;) {
-			// Jump to the newest group, discarding any older ones, and reset reconstruction.
-			const groups = this.#track.state.groups.peek();
-			if (groups.length > 0 && groups.at(-1) !== this.#group) {
-				while (groups.length > 1) groups.shift()?.close();
-				this.#group = groups[0];
+			if (!this.#group) {
+				// Advance to the next group with a higher sequence number (skipping late arrivals).
+				this.#group = await this.#track.nextGroupOrdered();
+				if (!this.#group) return undefined;
 				this.#current = undefined;
 				this.#framesRead = 0;
 			}
 
-			const group = this.#group;
-			if (!group) {
-				const closed = this.#track.state.closed.peek();
-				if (closed instanceof Error) throw closed;
-				if (closed) return undefined;
-
-				await Signal.race(this.#track.state.groups, this.#track.state.closed);
+			const frame = await this.#group.readFrame();
+			if (frame === undefined) {
+				// The group is exhausted; advance to the next one.
+				this.#group = undefined;
 				continue;
 			}
 
-			// Frame 0 of a group is a snapshot, the rest are merge patches.
-			const frame = group.state.frames.peek().shift();
-			if (frame) return this.#apply(frame);
-
-			// The current group has no pending frame.
-			const groupClosed = group.state.closed.peek();
-			if (groupClosed) {
-				if (groupClosed instanceof Error) throw groupClosed;
-
-				// The group is exhausted; wait for a newer one.
-				if (this.#group === group) this.#group = undefined;
-				const closed = this.#track.state.closed.peek();
-				if (closed instanceof Error) throw closed;
-				if (closed) return undefined;
-
-				await Signal.race(this.#track.state.groups, this.#track.state.closed);
-				continue;
-			}
-
-			// Group open but no frame yet: wait for a frame, a newer group, or track close.
-			await Signal.race(group.state.frames, this.#track.state.groups, this.#track.state.closed);
+			return this.#apply(frame);
 		}
 	}
 
@@ -77,6 +52,7 @@ export class Consumer<T> {
 		}
 	}
 
+	// Frame 0 of a group is a snapshot, the rest are merge patches.
 	#apply(frame: Uint8Array): T {
 		const parsed = JSON.parse(new TextDecoder().decode(frame));
 		if (this.#framesRead === 0) {

--- a/js/json/src/consumer.ts
+++ b/js/json/src/consumer.ts
@@ -27,7 +27,7 @@ export class Consumer<T> {
 		for (;;) {
 			if (!this.#group) {
 				// Advance to the next group with a higher sequence number (skipping late arrivals).
-				this.#group = await this.#track.nextGroupOrdered();
+				this.#group = await this.#track.nextGroup();
 				if (!this.#group) return undefined;
 				this.#current = undefined;
 				this.#framesRead = 0;

--- a/js/json/src/diff.test.ts
+++ b/js/json/src/diff.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { deepEqual, diff, merge } from "./diff.ts";
+
+// Applying the patch to old should reproduce new (RFC 7396 semantics).
+function assertRoundtrip(oldVal: unknown, newVal: unknown) {
+	const result = diff(oldVal, newVal);
+	expect(result.forcedSnapshot).toBe(false);
+	expect(merge(oldVal, result.patch)).toEqual(newVal as object);
+}
+
+test("changed scalar", () => {
+	assertRoundtrip({ a: 1, b: 2 }, { a: 1, b: 3 });
+});
+
+test("added key", () => {
+	const result = diff({ a: 1 }, { a: 1, b: 2 });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ b: 2 });
+});
+
+test("removed key is null", () => {
+	const result = diff({ a: 1, b: 2 }, { a: 1 });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ b: null });
+	assertRoundtrip({ a: 1, b: 2 }, { a: 1 });
+});
+
+test("nested object only includes changed keys", () => {
+	const result = diff({ o: { x: 1, y: 2 } }, { o: { x: 1, y: 9 } });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ o: { y: 9 } });
+});
+
+test("changed array is a wholesale delta", () => {
+	const result = diff({ a: [1, 2] }, { a: [1, 2, 3] });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ a: [1, 2, 3] });
+	assertRoundtrip({ a: [1, 2] }, { a: [1, 2, 3] });
+});
+
+test("added array is a delta", () => {
+	const result = diff({ a: 1 }, { a: 1, b: [1] });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ b: [1] });
+});
+
+test("nested array is a delta", () => {
+	const result = diff({ o: { x: 1 } }, { o: { x: 1, list: [1] } });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ o: { list: [1] } });
+	assertRoundtrip({ o: { x: 1 } }, { o: { x: 1, list: [1] } });
+});
+
+test("set to null forces snapshot", () => {
+	expect(diff({ a: 1 }, { a: null }).forcedSnapshot).toBe(true);
+});
+
+test("replacing object with scalar", () => {
+	assertRoundtrip({ a: { x: 1 } }, { a: 5 });
+});
+
+test("non-object root forces snapshot", () => {
+	expect(diff(1, 2).forcedSnapshot).toBe(true);
+});
+
+test("deepEqual", () => {
+	expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
+	expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+	expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+});

--- a/js/json/src/diff.ts
+++ b/js/json/src/diff.ts
@@ -1,0 +1,100 @@
+// RFC 7396 JSON Merge Patch: generate a patch between two values, and apply one.
+
+export interface Diff {
+	// A merge patch transforming the old value into the new one.
+	patch: unknown;
+
+	// Set when the change can't be faithfully expressed as a merge patch, so the caller should
+	// publish a full snapshot instead. This happens when a value is set to null, which merge
+	// patch reads as a key deletion. Arrays are fine: merge patch replaces them wholesale, which
+	// is still typically smaller than a full snapshot.
+	forcedSnapshot: boolean;
+}
+
+type Obj = Record<string, unknown>;
+
+function isObject(value: unknown): value is Obj {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Generate an RFC 7396 merge patch transforming `oldVal` into `newVal`.
+ *
+ * Only object roots produce a recursive patch; any other root forces a snapshot.
+ */
+export function diff(oldVal: unknown, newVal: unknown): Diff {
+	if (isObject(oldVal) && isObject(newVal)) {
+		const patch: Obj = {};
+		const forced = { value: false };
+		diffObjects(oldVal, newVal, patch, forced);
+		return { patch, forcedSnapshot: forced.value };
+	}
+	return { patch: newVal, forcedSnapshot: true };
+}
+
+function diffObjects(oldObj: Obj, newObj: Obj, patch: Obj, forced: { value: boolean }): void {
+	// Keys present in old but missing from new become explicit null deletions.
+	for (const key of Object.keys(oldObj)) {
+		if (!(key in newObj)) patch[key] = null;
+	}
+
+	for (const key of Object.keys(newObj)) {
+		const newV = newObj[key];
+		const oldV = oldObj[key];
+		const inOld = key in oldObj;
+
+		if (inOld && deepEqual(oldV, newV)) continue;
+
+		// Recurse into nested objects so unchanged sibling keys stay out of the patch.
+		if (isObject(oldV) && isObject(newV)) {
+			const sub: Obj = {};
+			diffObjects(oldV, newV, sub, forced);
+			if (Object.keys(sub).length > 0) patch[key] = sub;
+			continue;
+		}
+
+		// Added or replaced with a non-object value. A literal null can't be stored: merge patch
+		// would delete the key. Arrays are kept in the patch and replace the target wholesale.
+		if (newV === null) {
+			forced.value = true;
+		}
+		patch[key] = newV;
+	}
+}
+
+/**
+ * Apply an RFC 7396 merge patch to a target value, returning the result.
+ *
+ * Objects merge recursively; a null patch value deletes that key; any other patch value
+ * (scalar or array) replaces the target wholesale.
+ */
+export function merge(target: unknown, patch: unknown): unknown {
+	if (!isObject(patch)) return patch;
+
+	const base: Obj = isObject(target) ? { ...target } : {};
+	for (const [key, value] of Object.entries(patch)) {
+		if (value === null) {
+			delete base[key];
+		} else {
+			base[key] = merge(base[key], value);
+		}
+	}
+	return base;
+}
+
+/** Structural equality for JSON values. */
+export function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+
+	if (Array.isArray(a) && Array.isArray(b)) {
+		return a.length === b.length && a.every((item, i) => deepEqual(item, b[i]));
+	}
+
+	if (isObject(a) && isObject(b)) {
+		const keys = Object.keys(a);
+		if (keys.length !== Object.keys(b).length) return false;
+		return keys.every((key) => key in b && deepEqual(a[key], b[key]));
+	}
+
+	return false;
+}

--- a/js/json/src/index.ts
+++ b/js/json/src/index.ts
@@ -1,0 +1,3 @@
+export { Consumer } from "./consumer.ts";
+export { type Diff, deepEqual, diff, merge } from "./diff.ts";
+export { type Config, Producer } from "./producer.ts";

--- a/js/json/src/json.test.ts
+++ b/js/json/src/json.test.ts
@@ -5,28 +5,37 @@ import { Producer } from "./producer.ts";
 
 type Value = Record<string, unknown>;
 
-function groups(track: Track) {
-	return track.state.groups.peek();
-}
-
-async function drain(consumer: Consumer<Value>): Promise<Value[]> {
+// Reconstruct every value a consumer yields, in order.
+async function drain(track: Track): Promise<Value[]> {
 	const out: Value[] = [];
-	for await (const value of consumer) out.push(value);
+	for await (const value of new Consumer<Value>(track)) out.push(value);
 	return out;
 }
 
-test("deltas off: snapshot per group, latest only", async () => {
+// Inspect the published layout via the public API: the frame count of each group, in order.
+// The track must be finished first so group/frame reads terminate.
+async function structure(track: Track): Promise<number[]> {
+	const counts: number[] = [];
+	for (;;) {
+		const group = await track.nextGroupOrdered();
+		if (!group) break;
+
+		let frames = 0;
+		while ((await group.readFrame()) !== undefined) frames++;
+		counts.push(frames);
+	}
+	return counts;
+}
+
+test("deltas off: a snapshot group per change", async () => {
 	const track = new Track("test");
 	const producer = new Producer<Value>(track);
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
-
-	// Two updates => two groups, each a full snapshot.
-	expect(groups(track).length).toBe(2);
-
 	producer.finish();
-	// A consumer that joins after both exist only sees the latest.
-	expect(await drain(new Consumer<Value>(track))).toEqual([{ a: 2 }]);
+
+	// Two changes => two single-frame snapshot groups, reconstructed in order.
+	expect(await drain(track)).toEqual([{ a: 1 }, { a: 2 }]);
 });
 
 test("live consumer sees each update", async () => {
@@ -45,70 +54,65 @@ test("unchanged value writes nothing", async () => {
 	const producer = new Producer<Value>(track);
 	producer.update({ a: 1 });
 	producer.update({ a: 1 });
+	producer.finish();
 
-	expect(groups(track).length).toBe(1);
+	expect(await structure(track)).toEqual([1]);
 });
 
 test("deltas share one group", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { maxDeltaRatio: 100 });
+	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
 	producer.update({ a: 1, b: 3 });
-
-	// All updates fit in a single group as snapshot + deltas.
-	expect(groups(track).length).toBe(1);
-	expect(groups(track)[0].state.frames.peek().length).toBe(3);
-
 	producer.finish();
-	expect((await drain(new Consumer<Value>(track))).at(-1)).toEqual({ a: 1, b: 3 });
+
+	// All updates fit in a single group as snapshot + two deltas.
+	expect(await structure(track)).toEqual([3]);
 });
 
-test("tight ratio rolls snapshots", async () => {
+test("deltas reconstruct to the final value", async () => {
 	const track = new Track("test");
-	// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
-	const producer = new Producer<Value>(track, { maxDeltaRatio: 1.0 });
-	producer.update({ a: 1 });
-	producer.update({ a: 2 });
-	producer.update({ a: 3 });
-
-	expect(groups(track).length).toBe(3);
-});
-
-test("array change is a wholesale delta", async () => {
-	const track = new Track("test");
-	const producer = new Producer<Value>(track, { maxDeltaRatio: 100 });
-	producer.update({ list: [1, 2] });
-	producer.update({ list: [1, 2, 3] });
-
-	// The array is replaced wholesale in a delta, so it stays in the same group.
-	expect(groups(track).length).toBe(1);
-
-	producer.finish();
-	expect((await drain(new Consumer<Value>(track))).at(-1)).toEqual({ list: [1, 2, 3] });
-});
-
-test("frame cap rolls snapshot", async () => {
-	const track = new Track("test");
-	const producer = new Producer<Value>(track, { maxDeltaRatio: 1_000_000 });
-	// First update is the snapshot; then deltas fill the group until the frame cap forces a roll.
-	for (let i = 0; i <= 256; i++) {
-		producer.update({ n: i });
-	}
-
-	expect(groups(track).length).toBe(2);
-
-	producer.finish();
-	expect((await drain(new Consumer<Value>(track))).at(-1)).toEqual({ n: 256 });
-});
-
-test("late joiner reconstructs from deltas", async () => {
-	const track = new Track("test");
-	const producer = new Producer<Value>(track, { maxDeltaRatio: 100 });
+	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
 	producer.update({ a: 5, b: 2 });
 	producer.finish();
 
-	expect((await drain(new Consumer<Value>(track))).at(-1)).toEqual({ a: 5, b: 2 });
+	expect((await drain(track)).at(-1)).toEqual({ a: 5, b: 2 });
+});
+
+test("tight ratio rolls snapshots", async () => {
+	const track = new Track("test");
+	// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
+	const producer = new Producer<Value>(track, { deltaRatio: 1.0 });
+	producer.update({ a: 1 });
+	producer.update({ a: 2 });
+	producer.update({ a: 3 });
+	producer.finish();
+
+	expect(await structure(track)).toEqual([1, 1, 1]);
+});
+
+test("array change is a wholesale delta", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { deltaRatio: 100 });
+	producer.update({ list: [1, 2] });
+	producer.update({ list: [1, 2, 3] });
+	producer.finish();
+
+	// The array is replaced wholesale in a delta, so it stays in the same group.
+	expect(await structure(track)).toEqual([2]);
+});
+
+test("frame cap rolls snapshot", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { deltaRatio: 1_000_000 });
+	// First update is the snapshot; deltas fill the group until the frame cap forces a roll.
+	for (let i = 0; i <= 256; i++) {
+		producer.update({ n: i });
+	}
+	producer.finish();
+
+	expect(await structure(track)).toEqual([256, 1]);
 });

--- a/js/json/src/json.test.ts
+++ b/js/json/src/json.test.ts
@@ -17,7 +17,7 @@ async function drain(track: Track): Promise<Value[]> {
 async function structure(track: Track): Promise<number[]> {
 	const counts: number[] = [];
 	for (;;) {
-		const group = await track.nextGroupOrdered();
+		const group = await track.nextGroup();
 		if (!group) break;
 
 		let frames = 0;

--- a/js/json/src/json.test.ts
+++ b/js/json/src/json.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "bun:test";
+import { Track } from "@moq/net";
+import { Consumer } from "./consumer.ts";
+import { Producer } from "./producer.ts";
+
+type Value = Record<string, unknown>;
+
+function groups(track: Track) {
+	return track.state.groups.peek();
+}
+
+async function drain(consumer: Consumer<Value>): Promise<Value[]> {
+	const out: Value[] = [];
+	for await (const value of consumer) out.push(value);
+	return out;
+}
+
+test("deltas off: snapshot per group, latest only", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track);
+	producer.update({ a: 1 });
+	producer.update({ a: 2 });
+
+	// Two updates => two groups, each a full snapshot.
+	expect(groups(track).length).toBe(2);
+
+	producer.finish();
+	// A consumer that joins after both exist only sees the latest.
+	expect(await drain(new Consumer<Value>(track))).toEqual([{ a: 2 }]);
+});
+
+test("live consumer sees each update", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track);
+	const consumer = new Consumer<Value>(track);
+
+	for (let n = 1; n <= 3; n++) {
+		producer.update({ a: n });
+		expect(await consumer.next()).toEqual({ a: n });
+	}
+});
+
+test("unchanged value writes nothing", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track);
+	producer.update({ a: 1 });
+	producer.update({ a: 1 });
+
+	expect(groups(track).length).toBe(1);
+});
+
+test("deltas share one group", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { maxDeltaRatio: 100 });
+	producer.update({ a: 1, b: 1 });
+	producer.update({ a: 1, b: 2 });
+	producer.update({ a: 1, b: 3 });
+
+	// All updates fit in a single group as snapshot + deltas.
+	expect(groups(track).length).toBe(1);
+	expect(groups(track)[0].state.frames.peek().length).toBe(3);
+
+	producer.finish();
+	expect((await drain(new Consumer<Value>(track))).at(-1)).toEqual({ a: 1, b: 3 });
+});
+
+test("tight ratio rolls snapshots", async () => {
+	const track = new Track("test");
+	// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
+	const producer = new Producer<Value>(track, { maxDeltaRatio: 1.0 });
+	producer.update({ a: 1 });
+	producer.update({ a: 2 });
+	producer.update({ a: 3 });
+
+	expect(groups(track).length).toBe(3);
+});
+
+test("array change is a wholesale delta", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { maxDeltaRatio: 100 });
+	producer.update({ list: [1, 2] });
+	producer.update({ list: [1, 2, 3] });
+
+	// The array is replaced wholesale in a delta, so it stays in the same group.
+	expect(groups(track).length).toBe(1);
+
+	producer.finish();
+	expect((await drain(new Consumer<Value>(track))).at(-1)).toEqual({ list: [1, 2, 3] });
+});
+
+test("frame cap rolls snapshot", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { maxDeltaRatio: 1_000_000 });
+	// First update is the snapshot; then deltas fill the group until the frame cap forces a roll.
+	for (let i = 0; i <= 256; i++) {
+		producer.update({ n: i });
+	}
+
+	expect(groups(track).length).toBe(2);
+
+	producer.finish();
+	expect((await drain(new Consumer<Value>(track))).at(-1)).toEqual({ n: 256 });
+});
+
+test("late joiner reconstructs from deltas", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { maxDeltaRatio: 100 });
+	producer.update({ a: 1, b: 1 });
+	producer.update({ a: 1, b: 2 });
+	producer.update({ a: 5, b: 2 });
+	producer.finish();
+
+	expect((await drain(new Consumer<Value>(track))).at(-1)).toEqual({ a: 5, b: 2 });
+});

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -7,37 +7,38 @@ import { deepEqual, diff } from "./diff.ts";
 // well below the per-group frame cap so a late joiner can always read the snapshot at frame 0.
 const MAX_DELTA_FRAMES = 256;
 
-export interface Config {
+export interface Config<T> {
 	// Controls whether the producer emits deltas (merge patches) instead of full snapshots.
 	//
 	// `undefined` disables deltas: every change is published as a new snapshot group.
 	//
 	// A number enables deltas: a delta is appended to the current group as long as the group's
-	// total size stays within `maxDeltaRatio` times the size of a fresh snapshot; otherwise a
-	// new snapshot group is started.
-	maxDeltaRatio?: number;
+	// total size stays within `deltaRatio` times the size of a fresh snapshot; otherwise a new
+	// snapshot group is started.
+	deltaRatio?: number;
+
+	// Optional zod schema used to validate each value before publishing.
+	schema?: z.ZodMiniType<T>;
 }
 
 /** Publishes a JSON value over a track, choosing snapshots and deltas automatically. */
 export class Producer<T> {
 	#track: Moq.Track;
-	#config: Config;
-	#schema?: z.ZodMiniType<T>;
+	#config: Config<T>;
 
 	#group?: Moq.Group;
 	#last?: unknown;
 	#groupBytes = 0;
 	#groupFrames = 0;
 
-	constructor(track: Moq.Track, config: Config = {}, schema?: z.ZodMiniType<T>) {
+	constructor(track: Moq.Track, config: Config<T> = {}) {
 		this.#track = track;
 		this.#config = config;
-		this.#schema = schema;
 	}
 
 	/** Publish a new value, emitting a snapshot or delta automatically. No-op if unchanged. */
 	update(value: T): void {
-		const valid = this.#schema ? this.#schema.parse(value) : value;
+		const valid = this.#config.schema ? this.#config.schema.parse(value) : value;
 
 		// Serialize once; parse it back to a normalized JSON value for diffing and comparison
 		// (dropping `undefined` fields, matching what lands on the wire).
@@ -47,10 +48,8 @@ export class Producer<T> {
 
 		const snapshot = new TextEncoder().encode(text);
 		const delta = this.#delta(json, snapshot.length);
-		if (delta) {
-			// biome-ignore lint/style/noNonNullAssertion: a delta is only produced with an open group.
-			const group = this.#group!;
-			group.writeFrame(delta);
+		if (delta && this.#group) {
+			this.#group.writeFrame(delta);
 			this.#groupBytes += delta.length;
 			this.#groupFrames += 1;
 		} else {
@@ -68,7 +67,7 @@ export class Producer<T> {
 	}
 
 	#delta(json: unknown, snapshotLen: number): Uint8Array | undefined {
-		const ratio = this.#config.maxDeltaRatio;
+		const ratio = this.#config.deltaRatio;
 		if (ratio === undefined) return undefined;
 		if (this.#last === undefined) return undefined;
 		if (!this.#group || this.#groupFrames >= MAX_DELTA_FRAMES) return undefined;
@@ -93,7 +92,7 @@ export class Producer<T> {
 		this.#groupBytes = snapshot.length;
 		this.#groupFrames = 1;
 
-		if (this.#config.maxDeltaRatio !== undefined) {
+		if (this.#config.deltaRatio !== undefined) {
 			// Keep the group open so future deltas can be appended.
 			this.#group = group;
 		} else {

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -1,0 +1,105 @@
+import type * as Moq from "@moq/net";
+import type * as z from "zod/mini";
+
+import { deepEqual, diff } from "./diff.ts";
+
+// Maximum frames (snapshot + deltas) in a single group before a new snapshot is forced. Kept
+// well below the per-group frame cap so a late joiner can always read the snapshot at frame 0.
+const MAX_DELTA_FRAMES = 256;
+
+export interface Config {
+	// Controls whether the producer emits deltas (merge patches) instead of full snapshots.
+	//
+	// `undefined` disables deltas: every change is published as a new snapshot group.
+	//
+	// A number enables deltas: a delta is appended to the current group as long as the group's
+	// total size stays within `maxDeltaRatio` times the size of a fresh snapshot; otherwise a
+	// new snapshot group is started.
+	maxDeltaRatio?: number;
+}
+
+/** Publishes a JSON value over a track, choosing snapshots and deltas automatically. */
+export class Producer<T> {
+	#track: Moq.Track;
+	#config: Config;
+	#schema?: z.ZodMiniType<T>;
+
+	#group?: Moq.Group;
+	#last?: unknown;
+	#groupBytes = 0;
+	#groupFrames = 0;
+
+	constructor(track: Moq.Track, config: Config = {}, schema?: z.ZodMiniType<T>) {
+		this.#track = track;
+		this.#config = config;
+		this.#schema = schema;
+	}
+
+	/** Publish a new value, emitting a snapshot or delta automatically. No-op if unchanged. */
+	update(value: T): void {
+		const valid = this.#schema ? this.#schema.parse(value) : value;
+
+		// Serialize once; parse it back to a normalized JSON value for diffing and comparison
+		// (dropping `undefined` fields, matching what lands on the wire).
+		const text = JSON.stringify(valid);
+		const json = JSON.parse(text);
+		if (this.#last !== undefined && deepEqual(this.#last, json)) return;
+
+		const snapshot = new TextEncoder().encode(text);
+		const delta = this.#delta(json, snapshot.length);
+		if (delta) {
+			// biome-ignore lint/style/noNonNullAssertion: a delta is only produced with an open group.
+			const group = this.#group!;
+			group.writeFrame(delta);
+			this.#groupBytes += delta.length;
+			this.#groupFrames += 1;
+		} else {
+			this.#snapshot(snapshot);
+		}
+
+		this.#last = json;
+	}
+
+	/** Finish the track, closing any open group. */
+	finish(): void {
+		this.#group?.close();
+		this.#group = undefined;
+		this.#track.close();
+	}
+
+	#delta(json: unknown, snapshotLen: number): Uint8Array | undefined {
+		const ratio = this.#config.maxDeltaRatio;
+		if (ratio === undefined) return undefined;
+		if (this.#last === undefined) return undefined;
+		if (!this.#group || this.#groupFrames >= MAX_DELTA_FRAMES) return undefined;
+
+		const result = diff(this.#last, json);
+		if (result.forcedSnapshot) return undefined;
+
+		const delta = new TextEncoder().encode(JSON.stringify(result.patch));
+
+		// Roll a snapshot if appending the delta would bloat the group past the budget.
+		if (this.#groupBytes + delta.length > ratio * snapshotLen) return undefined;
+
+		return delta;
+	}
+
+	#snapshot(snapshot: Uint8Array): void {
+		// The previous group is complete; no more frames will be appended to it.
+		this.#group?.close();
+
+		const group = this.#track.appendGroup();
+		group.writeFrame(snapshot);
+		this.#groupBytes = snapshot.length;
+		this.#groupFrames = 1;
+
+		if (this.#config.maxDeltaRatio !== undefined) {
+			// Keep the group open so future deltas can be appended.
+			this.#group = group;
+		} else {
+			// Deltas disabled: one frame per group, identical to a plain JSON track.
+			group.close();
+			this.#group = undefined;
+		}
+	}
+}

--- a/js/json/src/vectors.test.ts
+++ b/js/json/src/vectors.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { diff, merge } from "./diff.ts";
+
+// Shared cross-impl fixture, owned by the reference Rust crate. Both suites assert the same
+// vectors so the two implementations agree on every snapshot/delta decision and patch shape.
+const url = new URL("../../../rs/moq-json/tests/vectors.json", import.meta.url);
+const vectors = (await Bun.file(url).json()) as Array<{
+	name: string;
+	old: unknown;
+	new: unknown;
+	forced: boolean;
+	patch?: unknown;
+}>;
+
+for (const vector of vectors) {
+	test(`vector: ${vector.name}`, () => {
+		const result = diff(vector.old, vector.new);
+		expect(result.forcedSnapshot).toBe(vector.forced);
+
+		if (!vector.forced) {
+			expect(result.patch).toEqual(vector.patch as object);
+			expect(merge(vector.old, result.patch)).toEqual(vector.new as object);
+		}
+	});
+}

--- a/js/json/tsconfig.json
+++ b/js/json/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "./src",
+		"types": ["bun"]
+	},
+	"include": ["src"]
+}

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -2,12 +2,12 @@ import { expect, test } from "bun:test";
 import { Group } from "./group.ts";
 import { Track } from "./track.ts";
 
-test("nextGroupOrdered skips late arrivals", async () => {
+test("nextGroup skips late arrivals", async () => {
 	const track = new Track("test");
 
 	track.writeGroup(new Group(5));
 
-	const first = await track.nextGroupOrdered();
+	const first = await track.nextGroup();
 	expect(first?.sequence).toBe(5);
 
 	// Late arrivals with sequence <= last returned are skipped.
@@ -15,27 +15,27 @@ test("nextGroupOrdered skips late arrivals", async () => {
 	track.writeGroup(new Group(4));
 	track.writeGroup(new Group(7));
 
-	const next = await track.nextGroupOrdered();
+	const next = await track.nextGroup();
 	expect(next?.sequence).toBe(7);
 });
 
-test("nextGroupOrdered returns buffered groups in sequence", async () => {
+test("nextGroup returns buffered groups in sequence", async () => {
 	const track = new Track("test");
 
 	track.writeGroup(new Group(3));
 	track.writeGroup(new Group(5));
 
-	expect((await track.nextGroupOrdered())?.sequence).toBe(3);
-	expect((await track.nextGroupOrdered())?.sequence).toBe(5);
+	expect((await track.nextGroup())?.sequence).toBe(3);
+	expect((await track.nextGroup())?.sequence).toBe(5);
 });
 
-test("recvGroup after nextGroupOrdered still returns late arrivals", async () => {
+test("recvGroup after nextGroup still returns late arrivals", async () => {
 	const track = new Track("test");
 
 	track.writeGroup(new Group(5));
 
 	// Ordered returns seq 5, advancing its cursor.
-	const ordered = await track.nextGroupOrdered();
+	const ordered = await track.nextGroup();
 	expect(ordered?.sequence).toBe(5);
 
 	// recvGroup is independent of the ordered cursor: a late seq 3 still surfaces.
@@ -44,8 +44,8 @@ test("recvGroup after nextGroupOrdered still returns late arrivals", async () =>
 	expect(recv?.sequence).toBe(3);
 });
 
-test("nextGroupOrdered returns undefined when track closes", async () => {
+test("nextGroup returns undefined when track closes", async () => {
 	const track = new Track("test");
 	track.close();
-	expect(await track.nextGroupOrdered()).toBeUndefined();
+	expect(await track.nextGroup()).toBeUndefined();
 });

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -115,7 +115,7 @@ export class Track {
 	 * Receive the next group available on this track, in arrival order.
 	 *
 	 * Groups may arrive out of order or with gaps due to network conditions.
-	 * Use {@link nextGroupOrdered} if you need groups in sequence order,
+	 * Use {@link nextGroup} if you need groups in sequence order,
 	 * skipping those that arrive too late.
 	 */
 	async recvGroup(): Promise<Group | undefined> {
@@ -134,20 +134,12 @@ export class Track {
 	}
 
 	/**
-	 * @deprecated Use {@link recvGroup} for arrival order, or {@link nextGroupOrdered} for sequence order.
-	 */
-	async nextGroup(): Promise<Group | undefined> {
-		return this.recvGroup();
-	}
-
-	/**
 	 * Return the next group with a strictly-greater sequence number than the last returned.
 	 *
 	 * Late arrivals (with a sequence number at or below the last one returned) are silently skipped.
-	 *
-	 * NOTE: This will be renamed to `nextGroup` in the next major version.
+	 * Use {@link recvGroup} to see every group in arrival order instead.
 	 */
-	async nextGroupOrdered(): Promise<Group | undefined> {
+	async nextGroup(): Promise<Group | undefined> {
 		for (;;) {
 			const group = await this.recvGroup();
 			if (!group) return undefined;

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -24,6 +24,7 @@
 	},
 	"dependencies": {
 		"@moq/hang": "workspace:^",
+		"@moq/json": "workspace:^",
 		"@moq/net": "workspace:^",
 		"@moq/signals": "workspace:^"
 	},

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -1,4 +1,5 @@
 import * as Catalog from "@moq/hang/catalog";
+import * as Json from "@moq/json";
 import * as Moq from "@moq/net";
 import { Effect, Signal } from "@moq/signals";
 import * as Audio from "./audio";
@@ -79,12 +80,20 @@ export class Broadcast {
 
 			effect.cleanup(() => request.track.close());
 
+			// Persistent JSON producer for the catalog track, so it survives reactive re-runs
+			// (and can emit deltas in the future). Deltas are disabled for now.
+			const catalogProducer =
+				request.track.name === Broadcast.CATALOG_TRACK
+					? new Json.Producer<Catalog.Root>(request.track)
+					: undefined;
+
 			effect.run((effect) => {
 				if (effect.get(request.track.state.closed)) return;
 
 				switch (request.track.name) {
 					case Broadcast.CATALOG_TRACK:
-						this.#serveCatalog(request.track, effect);
+						// biome-ignore lint/style/noNonNullAssertion: created above for this track name.
+						this.#serveCatalog(catalogProducer!, effect);
 						break;
 					case Location.Window.TRACK:
 						this.location.window.serve(request.track, effect);
@@ -119,10 +128,10 @@ export class Broadcast {
 		}
 	}
 
-	#serveCatalog(track: Moq.Track, effect: Effect): void {
+	#serveCatalog(producer: Json.Producer<Catalog.Root>, effect: Effect): void {
 		if (!effect.get(this.enabled)) {
 			// Clear the catalog.
-			track.writeFrame(Catalog.encode({}));
+			producer.update({});
 			return;
 		}
 
@@ -136,8 +145,7 @@ export class Broadcast {
 			preview: effect.get(this.preview.catalog),
 		};
 
-		const encoded = Catalog.encode(catalog);
-		track.writeFrame(encoded);
+		producer.update(catalog);
 	}
 
 	close() {

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -80,20 +80,12 @@ export class Broadcast {
 
 			effect.cleanup(() => request.track.close());
 
-			// Persistent JSON producer for the catalog track, so it survives reactive re-runs
-			// (and can emit deltas in the future). Deltas are disabled for now.
-			const catalogProducer =
-				request.track.name === Broadcast.CATALOG_TRACK
-					? new Json.Producer<Catalog.Root>(request.track)
-					: undefined;
-
 			effect.run((effect) => {
 				if (effect.get(request.track.state.closed)) return;
 
 				switch (request.track.name) {
 					case Broadcast.CATALOG_TRACK:
-						// biome-ignore lint/style/noNonNullAssertion: created above for this track name.
-						this.#serveCatalog(catalogProducer!, effect);
+						this.#serveCatalog(new Json.Producer<Catalog.Root>(request.track), effect);
 						break;
 					case Location.Window.TRACK:
 						this.location.window.serve(request.track, effect);

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -25,6 +25,7 @@
 	},
 	"dependencies": {
 		"@moq/hang": "workspace:^",
+		"@moq/json": "workspace:^",
 		"@moq/net": "workspace:^",
 		"@moq/msf": "workspace:^",
 		"@moq/signals": "workspace:^"

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -160,17 +160,16 @@ export class Broadcast {
 
 		// The hang catalog is reconstructed from snapshots (and future deltas) via @moq/json;
 		// MSF stays on its own one-blob-per-group fetch.
-		const catalogConsumer =
-			format === "hang" ? new Json.Consumer<Catalog.Root>(track, Catalog.RootSchema) : undefined;
-
-		const fetchNext =
-			format === "hang"
-				? // biome-ignore lint/style/noNonNullAssertion: defined whenever format is "hang".
-					async () => catalogConsumer!.next()
-				: async () => {
-						const update = await Msf.fetch(track);
-						return update ? toHang(update) : undefined;
-					};
+		let fetchNext: () => Promise<Catalog.Root | undefined>;
+		if (format === "hang") {
+			const consumer = new Json.Consumer<Catalog.Root>(track, { schema: Catalog.RootSchema });
+			fetchNext = () => consumer.next();
+		} else {
+			fetchNext = async () => {
+				const update = await Msf.fetch(track);
+				return update ? toHang(update) : undefined;
+			};
+		}
 
 		effect.spawn(async () => {
 			try {

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -1,4 +1,5 @@
 import * as Catalog from "@moq/hang/catalog";
+import * as Json from "@moq/json";
 import * as Msf from "@moq/msf";
 import type * as Moq from "@moq/net";
 import { Path } from "@moq/net";
@@ -157,9 +158,15 @@ export class Broadcast {
 		const track = broadcast.subscribe(trackName, Catalog.PRIORITY.catalog);
 		effect.cleanup(() => track.close());
 
+		// The hang catalog is reconstructed from snapshots (and future deltas) via @moq/json;
+		// MSF stays on its own one-blob-per-group fetch.
+		const catalogConsumer =
+			format === "hang" ? new Json.Consumer<Catalog.Root>(track, Catalog.RootSchema) : undefined;
+
 		const fetchNext =
 			format === "hang"
-				? async () => Catalog.fetch(track)
+				? // biome-ignore lint/style/noNonNullAssertion: defined whenever format is "hang".
+					async () => catalogConsumer!.next()
 				: async () => {
 						const update = await Msf.fetch(track);
 						return update ? toHang(update) : undefined;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"js/net",
 		"js/clock",
 		"js/token",
+		"js/json",
 		"js/hang",
 		"js/loc",
 		"js/msf",

--- a/rs/moq-json/Cargo.toml
+++ b/rs/moq-json/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "moq-json"
+description = "Snapshot/delta JSON publishing over MoQ tracks using RFC 7396 JSON Merge Patch."
+authors = ["Luke Curley <kixelated@gmail.com>"]
+repository = "https://github.com/moq-dev/moq"
+license = "MIT OR Apache-2.0"
+
+version = "0.0.1"
+edition = "2024"
+rust-version.workspace = true
+
+keywords = ["quic", "http3", "webtransport", "json", "live"]
+categories = ["multimedia", "network-programming", "web-programming"]
+
+[lib]
+doctest = false
+
+[dependencies]
+bytes = "1"
+json-patch = "4"
+kio = { workspace = true }
+moq-net = { workspace = true }
+serde = { workspace = true }
+serde_json = "1"
+thiserror = "2"

--- a/rs/moq-json/src/diff.rs
+++ b/rs/moq-json/src/diff.rs
@@ -1,0 +1,176 @@
+use serde_json::{Map, Value};
+
+/// The result of diffing two JSON values into an RFC 7396 merge patch.
+pub struct Diff {
+	/// A merge patch that transforms the old value into the new one.
+	pub patch: Value,
+
+	/// Set when the change can't be faithfully expressed as a merge patch, so the caller
+	/// should publish a full snapshot instead. This happens when a value is set to JSON null,
+	/// which merge patch reads as a key deletion. Arrays are fine: merge patch replaces them
+	/// wholesale, which is still typically smaller than a full snapshot.
+	pub forced_snapshot: bool,
+}
+
+/// Generate an RFC 7396 merge patch transforming `old` into `new`.
+///
+/// Only object roots produce a recursive patch; any other root forces a snapshot.
+pub fn diff(old: &Value, new: &Value) -> Diff {
+	if let (Value::Object(old), Value::Object(new)) = (old, new) {
+		let mut patch = Map::new();
+		let mut forced = false;
+		diff_objects(old, new, &mut patch, &mut forced);
+		Diff {
+			patch: Value::Object(patch),
+			forced_snapshot: forced,
+		}
+	} else {
+		Diff {
+			patch: new.clone(),
+			forced_snapshot: true,
+		}
+	}
+}
+
+fn diff_objects(old: &Map<String, Value>, new: &Map<String, Value>, patch: &mut Map<String, Value>, forced: &mut bool) {
+	// Keys present in old but missing from new become explicit null deletions.
+	for key in old.keys() {
+		if !new.contains_key(key) {
+			patch.insert(key.clone(), Value::Null);
+		}
+	}
+
+	for (key, new_val) in new {
+		let old_val = old.get(key);
+		if old_val == Some(new_val) {
+			continue;
+		}
+
+		// Recurse into nested objects so unchanged sibling keys stay out of the patch.
+		if let (Some(Value::Object(old_obj)), Value::Object(new_obj)) = (old_val, new_val) {
+			let mut sub = Map::new();
+			diff_objects(old_obj, new_obj, &mut sub, forced);
+			if !sub.is_empty() {
+				patch.insert(key.clone(), Value::Object(sub));
+			}
+			continue;
+		}
+
+		// Added or replaced with a non-object value. A literal null can't be stored: merge patch
+		// would delete the key. Arrays are kept in the patch and replace the target wholesale.
+		if new_val.is_null() {
+			*forced = true;
+		}
+		patch.insert(key.clone(), new_val.clone());
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use serde_json::json;
+
+	/// Applying the patch to old should reproduce new (RFC 7396 semantics).
+	fn assert_roundtrip(old: Value, new: Value) {
+		let result = diff(&old, &new);
+		assert!(!result.forced_snapshot, "expected a delta, got a forced snapshot");
+		let mut applied = old;
+		json_patch::merge(&mut applied, &result.patch);
+		assert_eq!(applied, new);
+	}
+
+	#[test]
+	fn changed_scalar() {
+		assert_roundtrip(json!({ "a": 1, "b": 2 }), json!({ "a": 1, "b": 3 }));
+	}
+
+	#[test]
+	fn added_key() {
+		let result = diff(&json!({ "a": 1 }), &json!({ "a": 1, "b": 2 }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "b": 2 }));
+	}
+
+	#[test]
+	fn removed_key_is_null() {
+		let result = diff(&json!({ "a": 1, "b": 2 }), &json!({ "a": 1 }));
+		assert!(!result.forced_snapshot, "removing a key is a clean delete");
+		assert_eq!(result.patch, json!({ "b": null }));
+		assert_roundtrip(json!({ "a": 1, "b": 2 }), json!({ "a": 1 }));
+	}
+
+	#[test]
+	fn nested_object_only_includes_changed_keys() {
+		let result = diff(&json!({ "o": { "x": 1, "y": 2 } }), &json!({ "o": { "x": 1, "y": 9 } }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "o": { "y": 9 } }));
+	}
+
+	#[test]
+	fn changed_array_is_wholesale_delta() {
+		let result = diff(&json!({ "a": [1, 2] }), &json!({ "a": [1, 2, 3] }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "a": [1, 2, 3] }));
+		assert_roundtrip(json!({ "a": [1, 2] }), json!({ "a": [1, 2, 3] }));
+	}
+
+	#[test]
+	fn added_array_is_delta() {
+		let result = diff(&json!({ "a": 1 }), &json!({ "a": 1, "b": [1] }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "b": [1] }));
+	}
+
+	#[test]
+	fn nested_array_is_delta() {
+		let result = diff(&json!({ "o": { "x": 1 } }), &json!({ "o": { "x": 1, "list": [1] } }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "o": { "list": [1] } }));
+		assert_roundtrip(json!({ "o": { "x": 1 } }), json!({ "o": { "x": 1, "list": [1] } }));
+	}
+
+	#[test]
+	fn set_to_null_forces_snapshot() {
+		// A genuine null value can't be represented: merge patch would delete the key.
+		let result = diff(&json!({ "a": 1 }), &json!({ "a": null }));
+		assert!(result.forced_snapshot);
+	}
+
+	#[test]
+	fn replacing_object_with_scalar() {
+		assert_roundtrip(json!({ "a": { "x": 1 } }), json!({ "a": 5 }));
+	}
+
+	#[test]
+	fn non_object_root_forces_snapshot() {
+		let result = diff(&json!(1), &json!(2));
+		assert!(result.forced_snapshot);
+	}
+
+	#[derive(serde::Deserialize)]
+	struct Vector {
+		name: String,
+		old: Value,
+		new: Value,
+		forced: bool,
+		patch: Option<Value>,
+	}
+
+	/// Shared cross-impl fixture: the TS suite (js/json) asserts the same vectors so both
+	/// implementations agree on every snapshot/delta decision and patch shape.
+	#[test]
+	fn golden_vectors() {
+		let vectors: Vec<Vector> = serde_json::from_str(include_str!("../tests/vectors.json")).unwrap();
+		for case in vectors {
+			let result = diff(&case.old, &case.new);
+			assert_eq!(result.forced_snapshot, case.forced, "{}: forced_snapshot", case.name);
+
+			if let Some(expected) = case.patch {
+				assert_eq!(result.patch, expected, "{}: patch", case.name);
+				let mut applied = case.old.clone();
+				json_patch::merge(&mut applied, &result.patch);
+				assert_eq!(applied, case.new, "{}: roundtrip", case.name);
+			}
+		}
+	}
+}

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -1,0 +1,440 @@
+//! Snapshot/delta JSON publishing over [`moq-net`](moq_net) tracks.
+//!
+//! A JSON value is published over a track as a series of groups, where each group is
+//! self-contained: its first frame is a full snapshot and any following frames are
+//! [RFC 7396](https://www.rfc-editor.org/rfc/rfc7396.html) JSON Merge Patch deltas applied in
+//! order. A consumer jumps to the newest group, reads the snapshot, and applies the deltas, so
+//! a late joiner never needs older groups.
+//!
+//! Deltas are opt-in via [`JsonConfig::max_delta_ratio`]. With deltas disabled (the default)
+//! every change is a fresh snapshot group, matching a plain "one JSON blob per group" track.
+
+mod diff;
+
+use std::marker::PhantomData;
+use std::task::Poll;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::diff::diff;
+
+/// Maximum frames (snapshot + deltas) in a single group before a new snapshot is forced.
+///
+/// Kept well below moq-net's per-group frame cap so a late joiner can always read the snapshot
+/// at frame 0 before the group is evicted.
+const MAX_DELTA_FRAMES: usize = 256;
+
+/// Errors produced while publishing or consuming JSON.
+#[derive(thiserror::Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum Error {
+	/// An error from the underlying track.
+	#[error(transparent)]
+	Net(#[from] moq_net::Error),
+
+	/// A value failed to serialize, deserialize, or apply as a merge patch.
+	///
+	/// Stored as a string since [`serde_json::Error`] is not [`Clone`].
+	#[error("json: {0}")]
+	Json(String),
+}
+
+impl From<serde_json::Error> for Error {
+	fn from(err: serde_json::Error) -> Self {
+		Error::Json(err.to_string())
+	}
+}
+
+/// A [`Result`](std::result::Result) using this crate's [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Configuration for a [`JsonProducer`].
+#[derive(Debug, Clone, Default)]
+pub struct JsonConfig {
+	/// Controls whether the producer emits deltas (merge patches) instead of full snapshots.
+	///
+	/// `None` disables deltas: every change is published as a new snapshot group.
+	///
+	/// `Some(ratio)` enables deltas. A delta is appended to the current group as long as the
+	/// group's total size stays within `ratio` times the size of a fresh snapshot; otherwise a
+	/// new snapshot group is started. A larger ratio tolerates bigger groups before snapshotting.
+	pub max_delta_ratio: Option<f64>,
+}
+
+/// Publishes a JSON value over a track, choosing snapshots and deltas automatically.
+pub struct JsonProducer<T> {
+	track: moq_net::TrackProducer,
+	group: Option<moq_net::GroupProducer>,
+	last: Option<Value>,
+	group_bytes: u64,
+	group_frames: usize,
+	config: JsonConfig,
+	_marker: PhantomData<fn(T)>,
+}
+
+impl<T> JsonProducer<T> {
+	/// Create a subscriber for the underlying track.
+	pub fn consume(&self) -> moq_net::TrackSubscriber {
+		self.track.subscribe(None)
+	}
+}
+
+impl<T: Serialize> JsonProducer<T> {
+	/// Create a producer that publishes to the given track.
+	pub fn new(track: moq_net::TrackProducer, config: JsonConfig) -> Self {
+		Self {
+			track,
+			group: None,
+			last: None,
+			group_bytes: 0,
+			group_frames: 0,
+			config,
+			_marker: PhantomData,
+		}
+	}
+
+	/// Publish a new value, emitting a snapshot or a delta automatically.
+	///
+	/// Does nothing if the value is unchanged from the previous publish.
+	pub fn update(&mut self, value: &T) -> Result<()> {
+		let json = serde_json::to_value(value)?;
+		if self.last.as_ref() == Some(&json) {
+			return Ok(());
+		}
+
+		// Serialize the value directly (not via `json`) so a snapshot preserves the type's own
+		// field order, keeping the wire bytes identical to serializing `T` straight to a frame.
+		let snapshot = serde_json::to_vec(value)?;
+
+		match self.delta(&json, snapshot.len())? {
+			Some(delta) => {
+				let group = self.group.as_mut().expect("delta requires an open group");
+				let len = delta.len() as u64;
+				group.write_frame(delta)?;
+				self.group_bytes += len;
+				self.group_frames += 1;
+			}
+			None => self.snapshot(snapshot)?,
+		}
+
+		self.last = Some(json);
+		Ok(())
+	}
+
+	/// Finish the track, closing any open group.
+	pub fn finish(&mut self) -> Result<()> {
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+		self.track.finish()?;
+		Ok(())
+	}
+
+	/// Serialize a delta if deltas are enabled and appending one keeps the group within budget;
+	/// otherwise `None`, signalling that a fresh snapshot should be published instead.
+	fn delta(&self, value: &Value, snapshot_len: usize) -> Result<Option<Vec<u8>>> {
+		let Some(ratio) = self.config.max_delta_ratio else {
+			return Ok(None);
+		};
+		let Some(last) = &self.last else {
+			return Ok(None);
+		};
+		if self.group.is_none() || self.group_frames >= MAX_DELTA_FRAMES {
+			return Ok(None);
+		}
+
+		let diff = diff(last, value);
+		if diff.forced_snapshot {
+			return Ok(None);
+		}
+
+		let delta = serde_json::to_vec(&diff.patch)?;
+
+		// Roll a snapshot if appending the delta would bloat the group past the budget.
+		let projected = (self.group_bytes + delta.len() as u64) as f64;
+		if projected > ratio * snapshot_len as f64 {
+			return Ok(None);
+		}
+
+		Ok(Some(delta))
+	}
+
+	/// Start a new group with a full snapshot as its first frame.
+	fn snapshot(&mut self, snapshot: Vec<u8>) -> Result<()> {
+		// The previous group is complete; no more frames will be appended to it.
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+
+		let len = snapshot.len() as u64;
+		let mut group = self.track.append_group()?;
+		group.write_frame(snapshot)?;
+		self.group_bytes = len;
+		self.group_frames = 1;
+
+		if self.config.max_delta_ratio.is_some() {
+			// Keep the group open so future deltas can be appended.
+			self.group = Some(group);
+		} else {
+			// Deltas disabled: one frame per group, identical to a plain JSON track.
+			group.finish()?;
+		}
+
+		Ok(())
+	}
+}
+
+/// Consumes a JSON value from a track, reconstructing it from snapshots and deltas.
+pub struct JsonConsumer<T> {
+	track: moq_net::TrackSubscriber,
+	group: Option<moq_net::GroupConsumer>,
+	current: Option<Value>,
+	frames_read: usize,
+	_marker: PhantomData<fn() -> T>,
+}
+
+impl<T: DeserializeOwned> JsonConsumer<T> {
+	/// Create a consumer reading from the given track subscriber.
+	pub fn new(track: moq_net::TrackSubscriber) -> Self {
+		Self {
+			track,
+			group: None,
+			current: None,
+			frames_read: 0,
+			_marker: PhantomData,
+		}
+	}
+
+	/// Get the next reconstructed value, or `None` once the track ends.
+	pub async fn next(&mut self) -> Result<Option<T>>
+	where
+		T: Unpin,
+	{
+		kio::wait(|waiter| self.poll_next(waiter)).await
+	}
+
+	/// Poll for the next reconstructed value, without blocking.
+	///
+	/// Jumps to the newest group, reads its snapshot, and applies deltas in order, yielding the
+	/// reconstructed value after each frame. Switching to a newer group discards the older one.
+	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<T>>> {
+		// Drain to the newest group, resetting reconstruction state whenever we switch.
+		let track_finished = loop {
+			match self.track.poll_next_group(waiter)? {
+				Poll::Ready(Some(group)) => {
+					self.group = Some(group);
+					self.current = None;
+					self.frames_read = 0;
+				}
+				Poll::Ready(None) => break true,
+				Poll::Pending => break false,
+			}
+		};
+
+		if let Some(group) = &mut self.group {
+			match group.poll_read_frame(waiter)? {
+				Poll::Ready(Some(frame)) => return Poll::Ready(Ok(Some(self.apply(frame)?))),
+				// The current group is exhausted; wait for a newer one.
+				Poll::Ready(None) => self.group = None,
+				Poll::Pending => return Poll::Pending,
+			}
+		}
+
+		if track_finished {
+			Poll::Ready(Ok(None))
+		} else {
+			Poll::Pending
+		}
+	}
+
+	/// Apply one frame: frame 0 of a group is a snapshot, the rest are merge patches.
+	fn apply(&mut self, frame: bytes::Bytes) -> Result<T> {
+		if self.frames_read == 0 {
+			self.current = Some(serde_json::from_slice(&frame)?);
+		} else {
+			let patch: Value = serde_json::from_slice(&frame)?;
+			let current = self.current.as_mut().expect("a snapshot precedes any delta");
+			json_patch::merge(current, &patch);
+		}
+		self.frames_read += 1;
+
+		let current = self
+			.current
+			.as_ref()
+			.expect("a value is present after applying a frame");
+		Ok(serde_json::from_value(current.clone())?)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use serde_json::json;
+
+	fn producer(config: JsonConfig) -> (JsonProducer<Value>, moq_net::TrackSubscriber) {
+		let track = moq_net::TrackProducer::new("test", None);
+		let consumer = track.subscribe(None);
+		(JsonProducer::new(track, config), consumer)
+	}
+
+	/// Drain every value currently available from a consumer without blocking.
+	fn drain(track: moq_net::TrackSubscriber) -> Vec<Value> {
+		let mut consumer = JsonConsumer::<Value>::new(track);
+		let waiter = kio::Waiter::noop();
+		let mut out = Vec::new();
+		while let Poll::Ready(Ok(Some(value))) = consumer.poll_next(&waiter) {
+			out.push(value);
+		}
+		out
+	}
+
+	#[test]
+	fn deltas_off_snapshot_per_group() {
+		let (mut producer, track) = producer(JsonConfig::default());
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.update(&json!({ "a": 2 })).unwrap();
+		producer.finish().unwrap();
+
+		// Two updates => two groups, each a full snapshot. A consumer that joins after both
+		// exist only sees the latest, like the existing catalog consumer.
+		assert_eq!(track.latest(), Some(1));
+		assert_eq!(drain(track), vec![json!({ "a": 2 })]);
+	}
+
+	#[test]
+	fn live_consumer_sees_each_update() {
+		let (mut producer, track) = producer(JsonConfig::default());
+		let mut consumer = JsonConsumer::<Value>::new(track);
+		let waiter = kio::Waiter::noop();
+
+		for n in 1..=3 {
+			producer.update(&json!({ "a": n })).unwrap();
+			match consumer.poll_next(&waiter) {
+				Poll::Ready(Ok(Some(value))) => assert_eq!(value, json!({ "a": n })),
+				other => panic!("expected value, got {other:?}"),
+			}
+		}
+	}
+
+	#[test]
+	fn unchanged_value_writes_nothing() {
+		let (mut producer, track) = producer(JsonConfig::default());
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(track.latest(), Some(0));
+		assert_eq!(drain(track), vec![json!({ "a": 1 })]);
+	}
+
+	#[test]
+	fn deltas_share_one_group() {
+		let config = JsonConfig {
+			max_delta_ratio: Some(100.0),
+		};
+		let (mut producer, track) = producer(config);
+		producer.update(&json!({ "a": 1, "b": 1 })).unwrap();
+		producer.update(&json!({ "a": 1, "b": 2 })).unwrap();
+		producer.update(&json!({ "a": 1, "b": 3 })).unwrap();
+		producer.finish().unwrap();
+
+		// All updates fit in a single group as snapshot + deltas.
+		assert_eq!(track.latest(), Some(0));
+		let values = drain(track);
+		assert_eq!(values.last().unwrap(), &json!({ "a": 1, "b": 3 }));
+	}
+
+	#[test]
+	fn tight_ratio_rolls_snapshots() {
+		// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
+		let config = JsonConfig {
+			max_delta_ratio: Some(1.0),
+		};
+		let (mut producer, track) = producer(config);
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.update(&json!({ "a": 2 })).unwrap();
+		producer.update(&json!({ "a": 3 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(track.latest(), Some(2));
+	}
+
+	#[test]
+	fn array_change_is_delta() {
+		let config = JsonConfig {
+			max_delta_ratio: Some(100.0),
+		};
+		let (mut producer, track) = producer(config);
+		producer.update(&json!({ "list": [1, 2] })).unwrap();
+		producer.update(&json!({ "list": [1, 2, 3] })).unwrap();
+		producer.finish().unwrap();
+
+		// The array is replaced wholesale in a delta, so it stays in the same group.
+		assert_eq!(track.latest(), Some(0));
+		assert_eq!(drain(track).last().unwrap(), &json!({ "list": [1, 2, 3] }));
+	}
+
+	#[test]
+	fn frame_cap_rolls_snapshot() {
+		let config = JsonConfig {
+			max_delta_ratio: Some(1_000_000.0),
+		};
+		let (mut producer, track) = producer(config);
+		// First update is the snapshot (frame 0); then MAX_DELTA_FRAMES - 1 deltas fill the group.
+		for i in 0..=MAX_DELTA_FRAMES {
+			producer.update(&json!({ "n": i })).unwrap();
+		}
+		producer.finish().unwrap();
+
+		// The frame cap forced exactly one extra snapshot group despite the huge ratio.
+		assert_eq!(track.latest(), Some(1));
+		assert_eq!(drain(track).last().unwrap(), &json!({ "n": MAX_DELTA_FRAMES }));
+	}
+
+	#[test]
+	fn late_joiner_reconstructs_from_deltas() {
+		let config = JsonConfig {
+			max_delta_ratio: Some(100.0),
+		};
+		let (mut producer, track) = producer(config);
+		producer.update(&json!({ "a": 1, "b": 1 })).unwrap();
+		producer.update(&json!({ "a": 1, "b": 2 })).unwrap();
+		producer.update(&json!({ "a": 5, "b": 2 })).unwrap();
+		producer.finish().unwrap();
+
+		// A consumer created only now still rebuilds the final value from snapshot + deltas.
+		assert_eq!(drain(track).last().unwrap(), &json!({ "a": 5, "b": 2 }));
+	}
+
+	#[test]
+	fn newer_group_supersedes_in_progress_reconstruction() {
+		// A tight ratio lets one delta fit, then forces the next update into a new snapshot group.
+		let config = JsonConfig {
+			max_delta_ratio: Some(2.0),
+		};
+		let (mut producer, track) = producer(config);
+		let observer = producer.consume();
+		let mut consumer = JsonConsumer::<Value>::new(track);
+		let waiter = kio::Waiter::noop();
+
+		producer.update(&json!({ "a": 1 })).unwrap(); // snapshot, group 0
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(value))) => assert_eq!(value, json!({ "a": 1 })),
+			other => panic!("expected first value, got {other:?}"),
+		}
+
+		producer.update(&json!({ "a": 2 })).unwrap(); // delta in group 0
+		producer.update(&json!({ "a": 3 })).unwrap(); // exceeds budget, rolls group 1
+		producer.finish().unwrap();
+		assert_eq!(observer.latest(), Some(1));
+
+		// The consumer jumps to the newest group and never yields a stale value.
+		let mut last = None;
+		while let Poll::Ready(Ok(Some(value))) = consumer.poll_next(&waiter) {
+			last = Some(value);
+		}
+		assert_eq!(last.unwrap(), json!({ "a": 3 }));
+	}
+}

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -6,12 +6,13 @@
 //! order. A consumer jumps to the newest group, reads the snapshot, and applies the deltas, so
 //! a late joiner never needs older groups.
 //!
-//! Deltas are opt-in via [`JsonConfig::max_delta_ratio`]. With deltas disabled (the default)
+//! Deltas are opt-in via [`Config::delta_ratio`]. With deltas disabled (the default)
 //! every change is a fresh snapshot group, matching a plain "one JSON blob per group" track.
 
 mod diff;
 
 use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
 use std::task::Poll;
 
 use serde::Serialize;
@@ -50,9 +51,9 @@ impl From<serde_json::Error> for Error {
 /// A [`Result`](std::result::Result) using this crate's [`Error`].
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Configuration for a [`JsonProducer`].
+/// Configuration for a [`Producer`].
 #[derive(Debug, Clone, Default)]
-pub struct JsonConfig {
+pub struct Config {
 	/// Controls whether the producer emits deltas (merge patches) instead of full snapshots.
 	///
 	/// `None` disables deltas: every change is published as a new snapshot group.
@@ -60,37 +61,46 @@ pub struct JsonConfig {
 	/// `Some(ratio)` enables deltas. A delta is appended to the current group as long as the
 	/// group's total size stays within `ratio` times the size of a fresh snapshot; otherwise a
 	/// new snapshot group is started. A larger ratio tolerates bigger groups before snapshotting.
-	pub max_delta_ratio: Option<f64>,
+	pub delta_ratio: Option<f64>,
 }
 
 /// Publishes a JSON value over a track, choosing snapshots and deltas automatically.
-pub struct JsonProducer<T> {
-	track: moq_net::TrackProducer,
-	group: Option<moq_net::GroupProducer>,
-	last: Option<Value>,
-	group_bytes: u64,
-	group_frames: usize,
-	config: JsonConfig,
+///
+/// Cheaply clonable: clones share one underlying track and publishing state, like other MoQ
+/// producers.
+pub struct Producer<T> {
+	inner: Arc<Mutex<Inner>>,
 	_marker: PhantomData<fn(T)>,
 }
 
-impl<T> JsonProducer<T> {
-	/// Create a subscriber for the underlying track.
-	pub fn consume(&self) -> moq_net::TrackSubscriber {
-		self.track.subscribe(None)
+impl<T> Clone for Producer<T> {
+	fn clone(&self) -> Self {
+		Self {
+			inner: self.inner.clone(),
+			_marker: PhantomData,
+		}
 	}
 }
 
-impl<T: Serialize> JsonProducer<T> {
+impl<T> Producer<T> {
+	/// Create a subscriber for the underlying track.
+	pub fn consume(&self) -> moq_net::TrackSubscriber {
+		self.inner.lock().unwrap().track.subscribe(None)
+	}
+}
+
+impl<T: Serialize> Producer<T> {
 	/// Create a producer that publishes to the given track.
-	pub fn new(track: moq_net::TrackProducer, config: JsonConfig) -> Self {
+	pub fn new(track: moq_net::TrackProducer, config: Config) -> Self {
 		Self {
-			track,
-			group: None,
-			last: None,
-			group_bytes: 0,
-			group_frames: 0,
-			config,
+			inner: Arc::new(Mutex::new(Inner {
+				track,
+				group: None,
+				last: None,
+				group_bytes: 0,
+				group_frames: 0,
+				config,
+			})),
 			_marker: PhantomData,
 		}
 	}
@@ -100,13 +110,33 @@ impl<T: Serialize> JsonProducer<T> {
 	/// Does nothing if the value is unchanged from the previous publish.
 	pub fn update(&mut self, value: &T) -> Result<()> {
 		let json = serde_json::to_value(value)?;
-		if self.last.as_ref() == Some(&json) {
-			return Ok(());
-		}
-
 		// Serialize the value directly (not via `json`) so a snapshot preserves the type's own
 		// field order, keeping the wire bytes identical to serializing `T` straight to a frame.
 		let snapshot = serde_json::to_vec(value)?;
+		self.inner.lock().unwrap().update(json, snapshot)
+	}
+
+	/// Finish the track, closing any open group.
+	pub fn finish(&mut self) -> Result<()> {
+		self.inner.lock().unwrap().finish()
+	}
+}
+
+/// Shared publishing state behind [`Producer`]'s `Arc<Mutex>`.
+struct Inner {
+	track: moq_net::TrackProducer,
+	group: Option<moq_net::GroupProducer>,
+	last: Option<Value>,
+	group_bytes: u64,
+	group_frames: usize,
+	config: Config,
+}
+
+impl Inner {
+	fn update(&mut self, json: Value, snapshot: Vec<u8>) -> Result<()> {
+		if self.last.as_ref() == Some(&json) {
+			return Ok(());
+		}
 
 		match self.delta(&json, snapshot.len())? {
 			Some(delta) => {
@@ -123,19 +153,10 @@ impl<T: Serialize> JsonProducer<T> {
 		Ok(())
 	}
 
-	/// Finish the track, closing any open group.
-	pub fn finish(&mut self) -> Result<()> {
-		if let Some(mut group) = self.group.take() {
-			group.finish()?;
-		}
-		self.track.finish()?;
-		Ok(())
-	}
-
 	/// Serialize a delta if deltas are enabled and appending one keeps the group within budget;
 	/// otherwise `None`, signalling that a fresh snapshot should be published instead.
 	fn delta(&self, value: &Value, snapshot_len: usize) -> Result<Option<Vec<u8>>> {
-		let Some(ratio) = self.config.max_delta_ratio else {
+		let Some(ratio) = self.config.delta_ratio else {
 			return Ok(None);
 		};
 		let Some(last) = &self.last else {
@@ -174,7 +195,7 @@ impl<T: Serialize> JsonProducer<T> {
 		self.group_bytes = len;
 		self.group_frames = 1;
 
-		if self.config.max_delta_ratio.is_some() {
+		if self.config.delta_ratio.is_some() {
 			// Keep the group open so future deltas can be appended.
 			self.group = Some(group);
 		} else {
@@ -184,10 +205,18 @@ impl<T: Serialize> JsonProducer<T> {
 
 		Ok(())
 	}
+
+	fn finish(&mut self) -> Result<()> {
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+		self.track.finish()?;
+		Ok(())
+	}
 }
 
 /// Consumes a JSON value from a track, reconstructing it from snapshots and deltas.
-pub struct JsonConsumer<T> {
+pub struct Consumer<T> {
 	track: moq_net::TrackSubscriber,
 	group: Option<moq_net::GroupConsumer>,
 	current: Option<Value>,
@@ -195,7 +224,7 @@ pub struct JsonConsumer<T> {
 	_marker: PhantomData<fn() -> T>,
 }
 
-impl<T: DeserializeOwned> JsonConsumer<T> {
+impl<T: DeserializeOwned> Consumer<T> {
 	/// Create a consumer reading from the given track subscriber.
 	pub fn new(track: moq_net::TrackSubscriber) -> Self {
 		Self {
@@ -273,15 +302,15 @@ mod test {
 	use super::*;
 	use serde_json::json;
 
-	fn producer(config: JsonConfig) -> (JsonProducer<Value>, moq_net::TrackSubscriber) {
+	fn producer(config: Config) -> (Producer<Value>, moq_net::TrackSubscriber) {
 		let track = moq_net::TrackProducer::new("test", None);
 		let consumer = track.subscribe(None);
-		(JsonProducer::new(track, config), consumer)
+		(Producer::new(track, config), consumer)
 	}
 
 	/// Drain every value currently available from a consumer without blocking.
 	fn drain(track: moq_net::TrackSubscriber) -> Vec<Value> {
-		let mut consumer = JsonConsumer::<Value>::new(track);
+		let mut consumer = Consumer::<Value>::new(track);
 		let waiter = kio::Waiter::noop();
 		let mut out = Vec::new();
 		while let Poll::Ready(Ok(Some(value))) = consumer.poll_next(&waiter) {
@@ -292,7 +321,7 @@ mod test {
 
 	#[test]
 	fn deltas_off_snapshot_per_group() {
-		let (mut producer, track) = producer(JsonConfig::default());
+		let (mut producer, track) = producer(Config::default());
 		producer.update(&json!({ "a": 1 })).unwrap();
 		producer.update(&json!({ "a": 2 })).unwrap();
 		producer.finish().unwrap();
@@ -305,8 +334,8 @@ mod test {
 
 	#[test]
 	fn live_consumer_sees_each_update() {
-		let (mut producer, track) = producer(JsonConfig::default());
-		let mut consumer = JsonConsumer::<Value>::new(track);
+		let (mut producer, track) = producer(Config::default());
+		let mut consumer = Consumer::<Value>::new(track);
 		let waiter = kio::Waiter::noop();
 
 		for n in 1..=3 {
@@ -320,7 +349,7 @@ mod test {
 
 	#[test]
 	fn unchanged_value_writes_nothing() {
-		let (mut producer, track) = producer(JsonConfig::default());
+		let (mut producer, track) = producer(Config::default());
 		producer.update(&json!({ "a": 1 })).unwrap();
 		producer.update(&json!({ "a": 1 })).unwrap();
 		producer.finish().unwrap();
@@ -331,8 +360,8 @@ mod test {
 
 	#[test]
 	fn deltas_share_one_group() {
-		let config = JsonConfig {
-			max_delta_ratio: Some(100.0),
+		let config = Config {
+			delta_ratio: Some(100.0),
 		};
 		let (mut producer, track) = producer(config);
 		producer.update(&json!({ "a": 1, "b": 1 })).unwrap();
@@ -349,9 +378,7 @@ mod test {
 	#[test]
 	fn tight_ratio_rolls_snapshots() {
 		// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
-		let config = JsonConfig {
-			max_delta_ratio: Some(1.0),
-		};
+		let config = Config { delta_ratio: Some(1.0) };
 		let (mut producer, track) = producer(config);
 		producer.update(&json!({ "a": 1 })).unwrap();
 		producer.update(&json!({ "a": 2 })).unwrap();
@@ -363,8 +390,8 @@ mod test {
 
 	#[test]
 	fn array_change_is_delta() {
-		let config = JsonConfig {
-			max_delta_ratio: Some(100.0),
+		let config = Config {
+			delta_ratio: Some(100.0),
 		};
 		let (mut producer, track) = producer(config);
 		producer.update(&json!({ "list": [1, 2] })).unwrap();
@@ -378,8 +405,8 @@ mod test {
 
 	#[test]
 	fn frame_cap_rolls_snapshot() {
-		let config = JsonConfig {
-			max_delta_ratio: Some(1_000_000.0),
+		let config = Config {
+			delta_ratio: Some(1_000_000.0),
 		};
 		let (mut producer, track) = producer(config);
 		// First update is the snapshot (frame 0); then MAX_DELTA_FRAMES - 1 deltas fill the group.
@@ -395,8 +422,8 @@ mod test {
 
 	#[test]
 	fn late_joiner_reconstructs_from_deltas() {
-		let config = JsonConfig {
-			max_delta_ratio: Some(100.0),
+		let config = Config {
+			delta_ratio: Some(100.0),
 		};
 		let (mut producer, track) = producer(config);
 		producer.update(&json!({ "a": 1, "b": 1 })).unwrap();
@@ -411,12 +438,10 @@ mod test {
 	#[test]
 	fn newer_group_supersedes_in_progress_reconstruction() {
 		// A tight ratio lets one delta fit, then forces the next update into a new snapshot group.
-		let config = JsonConfig {
-			max_delta_ratio: Some(2.0),
-		};
+		let config = Config { delta_ratio: Some(2.0) };
 		let (mut producer, track) = producer(config);
 		let observer = producer.consume();
-		let mut consumer = JsonConsumer::<Value>::new(track);
+		let mut consumer = Consumer::<Value>::new(track);
 		let waiter = kio::Waiter::noop();
 
 		producer.update(&json!({ "a": 1 })).unwrap(); // snapshot, group 0

--- a/rs/moq-json/tests/vectors.json
+++ b/rs/moq-json/tests/vectors.json
@@ -1,0 +1,64 @@
+[
+	{
+		"name": "changed_scalar",
+		"old": { "a": 1, "b": 2 },
+		"new": { "a": 1, "b": 3 },
+		"forced": false,
+		"patch": { "b": 3 }
+	},
+	{
+		"name": "added_key",
+		"old": { "a": 1 },
+		"new": { "a": 1, "b": 2 },
+		"forced": false,
+		"patch": { "b": 2 }
+	},
+	{
+		"name": "removed_key_is_null",
+		"old": { "a": 1, "b": 2 },
+		"new": { "a": 1 },
+		"forced": false,
+		"patch": { "b": null }
+	},
+	{
+		"name": "nested_object",
+		"old": { "o": { "x": 1, "y": 2 } },
+		"new": { "o": { "x": 1, "y": 9 } },
+		"forced": false,
+		"patch": { "o": { "y": 9 } }
+	},
+	{
+		"name": "replace_object_with_scalar",
+		"old": { "a": { "x": 1 } },
+		"new": { "a": 5 },
+		"forced": false,
+		"patch": { "a": 5 }
+	},
+	{
+		"name": "catalog_like_add_user",
+		"old": { "video": { "renditions": {} }, "audio": { "renditions": {} } },
+		"new": { "video": { "renditions": {} }, "audio": { "renditions": {} }, "user": { "name": "alice" } },
+		"forced": false,
+		"patch": { "user": { "name": "alice" } }
+	},
+	{
+		"name": "changed_array_is_wholesale_delta",
+		"old": { "a": [1, 2] },
+		"new": { "a": [1, 2, 3] },
+		"forced": false,
+		"patch": { "a": [1, 2, 3] }
+	},
+	{
+		"name": "added_array_is_delta",
+		"old": { "a": 1 },
+		"new": { "a": 1, "b": [1] },
+		"forced": false,
+		"patch": { "b": [1] }
+	},
+	{
+		"name": "set_to_null_forces_snapshot",
+		"old": { "a": 1 },
+		"new": { "a": null },
+		"forced": true
+	}
+]

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -24,6 +24,7 @@ h264-parser = { version = "0.4.0" }
 hang = { workspace = true }
 kio = { workspace = true }
 m3u8-rs = { version = "6" }
+moq-json = { workspace = true }
 moq-loc = { workspace = true }
 moq-msf = { workspace = true }
 moq-net = { workspace = true, features = ["serde"] }

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -6,47 +6,25 @@ use crate::Result;
 
 /// A catalog consumer, used to receive catalog updates and discover tracks.
 ///
-/// This wraps a `moq_net::TrackSubscriber` and automatically deserializes JSON
-/// catalog data to discover available audio and video tracks in a broadcast.
+/// This wraps a [`moq_json::JsonConsumer`], reconstructing the JSON catalog from the latest
+/// group's snapshot (plus any future deltas) to discover available audio and video tracks.
 pub struct Consumer {
-	/// Access to the underlying track consumer.
-	pub track: moq_net::TrackSubscriber,
-	group: Option<moq_net::GroupConsumer>,
+	inner: moq_json::JsonConsumer<Catalog>,
 }
 
 impl Consumer {
-	/// Create a new catalog consumer from a MoQ track consumer.
+	/// Create a new catalog consumer from a MoQ track subscriber.
 	pub fn new(track: moq_net::TrackSubscriber) -> Self {
-		Self { track, group: None }
+		Self {
+			inner: moq_json::JsonConsumer::new(track),
+		}
 	}
 
 	/// Poll for the next catalog update.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Catalog>>> {
-		// Drain pending groups, keeping only the newest. Remember whether the track is done
-		// so we can distinguish "more groups may arrive" from "no more groups, ever".
-		let track_finished = loop {
-			match self.track.poll_next_group(waiter)? {
-				Poll::Ready(Some(group)) => self.group = Some(group),
-				Poll::Ready(None) => break true,
-				Poll::Pending => break false,
-			}
-		};
-
-		if let Some(group) = &mut self.group {
-			match group.poll_read_frame(waiter)? {
-				Poll::Ready(Some(frame)) => {
-					self.group = None;
-					return Poll::Ready(Ok(Some(Catalog::from_slice(&frame)?)));
-				}
-				Poll::Ready(None) => self.group = None,
-				Poll::Pending => return Poll::Pending,
-			}
-		}
-
-		if track_finished {
-			Poll::Ready(Ok(None))
-		} else {
-			Poll::Pending
+		match self.inner.poll_next(waiter) {
+			Poll::Ready(result) => Poll::Ready(result.map_err(Into::into)),
+			Poll::Pending => Poll::Pending,
 		}
 	}
 
@@ -55,7 +33,7 @@ impl Consumer {
 	/// This method waits for the next catalog publication and returns the
 	/// catalog data. If there are no more updates, `None` is returned.
 	pub async fn next(&mut self) -> Result<Option<Catalog>> {
-		kio::wait(|waiter| self.poll_next(waiter)).await
+		Ok(self.inner.next().await?)
 	}
 }
 

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -1,4 +1,4 @@
-use std::task::Poll;
+use std::task::{Poll, ready};
 
 use hang::Catalog;
 
@@ -6,26 +6,24 @@ use crate::Result;
 
 /// A catalog consumer, used to receive catalog updates and discover tracks.
 ///
-/// This wraps a [`moq_json::JsonConsumer`], reconstructing the JSON catalog from the latest
+/// This wraps a [`moq_json::Consumer`], reconstructing the JSON catalog from the latest
 /// group's snapshot (plus any future deltas) to discover available audio and video tracks.
 pub struct Consumer {
-	inner: moq_json::JsonConsumer<Catalog>,
+	inner: moq_json::Consumer<Catalog>,
 }
 
 impl Consumer {
 	/// Create a new catalog consumer from a MoQ track subscriber.
 	pub fn new(track: moq_net::TrackSubscriber) -> Self {
 		Self {
-			inner: moq_json::JsonConsumer::new(track),
+			inner: moq_json::Consumer::new(track),
 		}
 	}
 
 	/// Poll for the next catalog update.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Catalog>>> {
-		match self.inner.poll_next(waiter) {
-			Poll::Ready(result) => Poll::Ready(result.map_err(Into::into)),
-			Poll::Pending => Poll::Pending,
-		}
+		let result = ready!(self.inner.poll_next(waiter));
+		Poll::Ready(result.map_err(Into::into))
 	}
 
 	/// Get the next catalog update.

--- a/rs/moq-mux/src/catalog/hang/producer.rs
+++ b/rs/moq-mux/src/catalog/hang/producer.rs
@@ -14,7 +14,7 @@ use base64::Engine;
 /// so deltas can be enabled later without changing the wire format used today.
 #[derive(Clone)]
 pub struct Producer {
-	hang: Arc<Mutex<moq_json::JsonProducer<hang::Catalog>>>,
+	hang: moq_json::Producer<hang::Catalog>,
 	msf_track: moq_net::TrackProducer,
 
 	current: Arc<Mutex<hang::Catalog>>,
@@ -34,10 +34,10 @@ impl Producer {
 		let hang_track = broadcast.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())?;
 		let msf_track = broadcast.create_track(moq_msf::DEFAULT_NAME, None)?;
 
-		let hang = moq_json::JsonProducer::new(hang_track, moq_json::JsonConfig::default());
+		let hang = moq_json::Producer::new(hang_track, moq_json::Config::default());
 
 		Ok(Self {
-			hang: Arc::new(Mutex::new(hang)),
+			hang,
 			msf_track,
 			current: Arc::new(Mutex::new(catalog)),
 		})
@@ -47,7 +47,7 @@ impl Producer {
 	pub fn lock(&mut self) -> Guard<'_> {
 		Guard {
 			catalog: self.current.lock().unwrap(),
-			hang: &self.hang,
+			hang: &mut self.hang,
 			msf_track: &mut self.msf_track,
 			updated: false,
 		}
@@ -60,13 +60,12 @@ impl Producer {
 
 	/// Create a consumer for this catalog, receiving updates as they're published.
 	pub fn consume(&self) -> Result<super::Consumer, moq_net::Error> {
-		let track = self.hang.lock().unwrap().consume();
-		Ok(super::Consumer::new(track))
+		Ok(super::Consumer::new(self.hang.consume()))
 	}
 
 	/// Finish publishing to this catalog.
 	pub fn finish(&mut self) -> crate::Result<()> {
-		self.hang.lock().unwrap().finish()?;
+		self.hang.finish()?;
 		self.msf_track.finish()?;
 		Ok(())
 	}
@@ -79,7 +78,7 @@ impl Producer {
 /// On drop, both the hang and MSF catalog tracks are updated if the catalog was mutated.
 pub struct Guard<'a> {
 	catalog: MutexGuard<'a, hang::Catalog>,
-	hang: &'a Arc<Mutex<moq_json::JsonProducer<hang::Catalog>>>,
+	hang: &'a mut moq_json::Producer<hang::Catalog>,
 	msf_track: &'a mut moq_net::TrackProducer,
 	updated: bool,
 }
@@ -106,10 +105,8 @@ impl Drop for Guard<'_> {
 		}
 
 		// Publish the hang catalog (one snapshot per group while deltas are disabled).
-		if let Ok(mut hang) = self.hang.lock() {
-			let catalog: &hang::Catalog = &self.catalog;
-			let _ = hang.update(catalog);
-		}
+		let catalog: &hang::Catalog = &self.catalog;
+		let _ = self.hang.update(catalog);
 
 		// Publish MSF catalog
 		let msf = to_msf(&self.catalog);

--- a/rs/moq-mux/src/catalog/hang/producer.rs
+++ b/rs/moq-mux/src/catalog/hang/producer.rs
@@ -8,9 +8,13 @@ use base64::Engine;
 /// The JSON catalog is updated when tracks are added/removed but is *not* automatically published.
 /// You'll have to call [`lock`](Self::lock) to update and publish the catalog.
 /// Both the hang (`catalog.json`) and MSF (`catalog`) tracks are published on drop of the guard.
+///
+/// The hang track is published through [`moq_json`], which currently emits one snapshot per
+/// group (deltas disabled). This routes catalog publishing through the JSON merge-patch helper
+/// so deltas can be enabled later without changing the wire format used today.
 #[derive(Clone)]
 pub struct Producer {
-	hang_track: moq_net::TrackProducer,
+	hang: Arc<Mutex<moq_json::JsonProducer<hang::Catalog>>>,
 	msf_track: moq_net::TrackProducer,
 
 	current: Arc<Mutex<hang::Catalog>>,
@@ -30,8 +34,10 @@ impl Producer {
 		let hang_track = broadcast.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())?;
 		let msf_track = broadcast.create_track(moq_msf::DEFAULT_NAME, None)?;
 
+		let hang = moq_json::JsonProducer::new(hang_track, moq_json::JsonConfig::default());
+
 		Ok(Self {
-			hang_track,
+			hang: Arc::new(Mutex::new(hang)),
 			msf_track,
 			current: Arc::new(Mutex::new(catalog)),
 		})
@@ -41,7 +47,7 @@ impl Producer {
 	pub fn lock(&mut self) -> Guard<'_> {
 		Guard {
 			catalog: self.current.lock().unwrap(),
-			hang_track: &mut self.hang_track,
+			hang: &self.hang,
 			msf_track: &mut self.msf_track,
 			updated: false,
 		}
@@ -54,14 +60,13 @@ impl Producer {
 
 	/// Create a consumer for this catalog, receiving updates as they're published.
 	pub fn consume(&self) -> Result<super::Consumer, moq_net::Error> {
-		let track = self.hang_track.subscribe(None);
-		let subscriber = track;
-		Ok(super::Consumer::new(subscriber))
+		let track = self.hang.lock().unwrap().consume();
+		Ok(super::Consumer::new(track))
 	}
 
 	/// Finish publishing to this catalog.
-	pub fn finish(&mut self) -> Result<(), moq_net::Error> {
-		self.hang_track.finish()?;
+	pub fn finish(&mut self) -> crate::Result<()> {
+		self.hang.lock().unwrap().finish()?;
 		self.msf_track.finish()?;
 		Ok(())
 	}
@@ -74,7 +79,7 @@ impl Producer {
 /// On drop, both the hang and MSF catalog tracks are updated if the catalog was mutated.
 pub struct Guard<'a> {
 	catalog: MutexGuard<'a, hang::Catalog>,
-	hang_track: &'a mut moq_net::TrackProducer,
+	hang: &'a Arc<Mutex<moq_json::JsonProducer<hang::Catalog>>>,
 	msf_track: &'a mut moq_net::TrackProducer,
 	updated: bool,
 }
@@ -100,11 +105,10 @@ impl Drop for Guard<'_> {
 			return;
 		}
 
-		// Publish hang catalog
-		if let Ok(mut group) = self.hang_track.append_group() {
-			let frame = self.catalog.to_string().expect("invalid catalog");
-			let _ = group.write_frame(frame);
-			let _ = group.finish();
+		// Publish the hang catalog (one snapshot per group while deltas are disabled).
+		if let Ok(mut hang) = self.hang.lock() {
+			let catalog: &hang::Catalog = &self.catalog;
+			let _ = hang.update(catalog);
 		}
 
 		// Publish MSF catalog

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -15,6 +15,10 @@ pub enum Error {
 	#[error("hang: {0}")]
 	Hang(#[from] hang::Error),
 
+	/// Error publishing or consuming JSON over a track.
+	#[error("json: {0}")]
+	Json(#[from] moq_json::Error),
+
 	/// Error parsing or building CMAF moof+mdat fragments.
 	#[error("cmaf: {0}")]
 	Cmaf(#[from] crate::container::fmp4::Error),


### PR DESCRIPTION
## Summary

Adds a generic JSON snapshot/delta helper (RFC 7396 JSON Merge Patch) in both Rust (`moq-json`) and TypeScript (`@moq/json`), and routes the hang catalog through it with **deltas disabled** so today's wire format is byte-identical. The goal is to land the infrastructure and get consumers onto the new reader now, so JSON Merge Patch deltas can be enabled later without touching every consumer.

A track carries a JSON value as a series of groups; each group is self-contained (frame 0 = full snapshot, frames 1.. = merge patches applied in order). A consumer jumps to the newest group, reads the snapshot, and applies deltas, so a late joiner never needs older groups. Deltas are opt-in via `max_delta_ratio` (`None`/`undefined` = off).

## What's here

**New `rs/moq-json` crate**
- `diff.rs`: hand-rolled RFC 7396 diff returning `{ patch, forced_snapshot }`. Arrays are replaced wholesale in a delta (still typically smaller than a full snapshot); only a literal-null value forces a snapshot, since merge patch reads null as a key deletion. Apply uses the `json-patch` crate's `merge`.
- `lib.rs`: `JsonProducer<T>` / `JsonConsumer<T>` owning a `TrackProducer` / `TrackSubscriber`. The producer picks snapshot vs delta from `max_delta_ratio`, with a 256-frame-per-group cap so late joiners can always read frame 0 before eviction. The consumer jumps to the newest group and reconstructs, modeled on the existing catalog consumer.

**New `js/json` (`@moq/json`) package** — a faithful TS port mirroring the Rust semantics.

**Catalog migration (deltas off, behavior-preserving)**
- Rust: `catalog/hang/producer.rs` holds the stateful `JsonProducer` behind an `Arc<Mutex>` so `Producer` stays `Clone`; `consumer.rs` wraps `JsonConsumer<Catalog>`, keeping `Consumer::next()` / `From<TrackSubscriber>`. Snapshots serialize `&T` directly, so bytes match `Catalog::to_string()` exactly.
- JS: `publish/broadcast.ts` (`#serveCatalog` → a per-request `Json.Producer`) and `watch/broadcast.ts` (hang fetch → `Json.Consumer`).

## Why dev

Targets `dev` because it makes breaking public-API changes in `moq-mux`: the catalog `Consumer` loses its (unused) `pub track` field and `Producer::finish()` now returns `crate::Result`. The new `moq-json` crate is also adapted to dev's `TrackSubscriber` / `.subscribe()` moq-net API.

## Test plan

- [x] Rust: `moq-json` unit + golden-vector tests; `moq-mux` catalog tests (the behavior-preservation gate) all pass.
- [x] JS: `@moq/json` 28 tests; `js/json`, `js/publish`, `js/watch` typecheck.
- [x] Cross-impl parity locked by a shared fixture (`rs/moq-json/tests/vectors.json`) asserted by both the Rust and TS suites.
- [x] `cargo check --workspace`, clippy, `cargo fmt --check`, `cargo sort` clean; biome clean.

## Cross-package sync

- `rs/moq-net` wire/API: unchanged (no wire change; deltas off ⇒ byte-identical).
- `rs/hang` / `js/hang` catalog format: unchanged.
- `doc/concept`: no change needed now (wire format preserved); worth a docs pass when deltas actually ship.
- No `moq-ffi`/wrapper changes (internal helper; `moq-ffi` only calls `catalog.finish()`, which converts the new `moq_mux::Error` transparently).

## Follow-ups

- Enable deltas by setting `max_delta_ratio` where the catalog producers are constructed — no consumer changes needed.
- A moq-net-free "pure transform" core (`Group(Bytes)`/`Frame(Bytes)` instructions) was deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
