### PR TITLE
doc(lib): fill empty env pages and flesh out install examples

### DIFF
--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -26,7 +26,52 @@ A C-callable shared and static library exposing the MoQ pub/sub API. Header file
 
 ## Installation
 
+### From prebuilt releases
+
+Each [`libmoq-v*` release](https://github.com/moq-dev/moq/releases) ships a
+`moq-<version>-<target>.tar.gz` bundle with the static library, the dynamic
+library, and the generated header. Supported targets:
+
+- `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`
+- `x86_64-apple-darwin`, `aarch64-apple-darwin`
+
+Download and extract a bundle (here `0.2.0` on Linux x86_64):
+
+```bash
+ver=0.2.0
+target=x86_64-unknown-linux-gnu
+curl -fsSL "https://github.com/moq-dev/moq/releases/download/libmoq-v$ver/moq-$ver-$target.tar.gz" \
+  | tar xz
+```
+
+That gives you a `moq-$ver-$target/` directory containing `include/moq.h`
+and `lib/` (`libmoq.a` plus the dynamic library).
+
+### Compile against it
+
+Point your compiler at the extracted `include/` and `lib/` directories and link
+`-lmoq`, plus the platform system libraries `libmoq` needs:
+
+```bash
+root=moq-$ver-$target
+
+# Linux
+cc subscribe.c -I"$root/include" -L"$root/lib" -lmoq -lpthread -ldl -lm -o subscribe
+
+# macOS
+cc subscribe.c -I"$root/include" -L"$root/lib" -lmoq \
+  -framework CoreFoundation -framework Security -o subscribe
+```
+
+The static library (`libmoq.a`) links the whole Rust runtime in, so the result
+has no libmoq runtime dependency. To link the dynamic library instead, keep
+`lib/` on your loader path (`LD_LIBRARY_PATH` on Linux, `DYLD_LIBRARY_PATH` on
+macOS) at runtime.
+
 ### From source
+
+If there's no prebuilt bundle for your target, build it yourself. You'll need a
+[Rust toolchain](https://rustup.rs/):
 
 ```bash
 git clone https://github.com/moq-dev/moq
@@ -34,11 +79,9 @@ cd moq/rs/libmoq
 cargo build --release
 ```
 
-The library will be in `target/release/libmoq.a` (static) and `target/release/libmoq.{so,dylib,dll}` (dynamic). The C header is emitted as `target/release/moq.h`.
-
-### From prebuilt releases
-
-Prebuilt binaries are attached to each [`libmoq-v*` release](https://github.com/moq-dev/moq/releases) for the major Tier 1 targets.
+The library lands in `target/release/libmoq.a` (static) and
+`target/release/libmoq.{so,dylib,dll}` (dynamic), with the generated header at
+`target/release/moq.h`.
 
 ## Callback lifetime
 

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -79,9 +79,10 @@ cd moq/rs/libmoq
 cargo build --release
 ```
 
-The library lands in `target/release/libmoq.a` (static) and
-`target/release/libmoq.{so,dylib,dll}` (dynamic), with the generated header at
-`target/release/moq.h`.
+`libmoq` is part of the Cargo workspace, so the build emits to the workspace
+root `target/` (two levels up from `rs/libmoq/`): `../../target/release/libmoq.a`
+(static) and `../../target/release/libmoq.{so,dylib,dll}` (dynamic), with the
+generated header at `../../target/release/moq.h`.
 
 ## Callback lifetime
 

--- a/doc/lib/js/env/native.md
+++ b/doc/lib/js/env/native.md
@@ -1,0 +1,92 @@
+---
+title: Server-side JS
+description: Running @moq/net in Node, Bun, and Deno outside the browser
+---
+
+# Server-side JS
+
+`@moq/net` runs outside the browser too, in Node, Bun, and Deno. This is handy
+for bots, recorders, transcoders, test harnesses, and anything that needs to
+publish or subscribe without a tab open.
+
+`@moq/hang` is browser-only. It leans on WebCodecs, WebAudio, and the DOM, so
+keep server-side work at the `@moq/net` layer (raw broadcasts, tracks, groups,
+and frames) and do any media encode/decode yourself.
+
+## Install
+
+```bash
+bun add @moq/net
+# or
+npm add @moq/net
+```
+
+## Transport
+
+The browser gives `@moq/net` a native `WebTransport`. Server runtimes don't have
+one yet, so `@moq/net` falls back to **WebSocket** and talks to the relay over
+its WebSocket endpoint instead. No code change required, the relay accepts both.
+
+- **Bun** and **Node 21+** ship `WebSocket` globally, so nothing else is needed.
+- **Older Node** has no global `WebSocket`. Add the [`ws`](https://www.npmjs.com/package/ws)
+  polyfill before importing `@moq/net`:
+
+  ```javascript
+  import WebSocket from "ws";
+  globalThis.WebSocket = WebSocket;
+
+  import * as Moq from "@moq/net";
+  ```
+
+### Optional: native WebTransport
+
+WebSocket is the path of least resistance and works everywhere. If you'd rather
+keep the QUIC/HTTP3 transport on the server (lower overhead, datagram support),
+install the [`@moq/web-transport`](https://www.npmjs.com/package/@moq/web-transport)
+polyfill, which provides a native WebTransport via NAPI, and register it before
+importing `@moq/net`:
+
+```bash
+bun add @moq/web-transport
+```
+
+```javascript
+import { install } from "@moq/web-transport";
+install(); // sets globalThis.WebTransport
+
+import * as Moq from "@moq/net";
+```
+
+::: tip Runtime support
+Bun and Deno are the smoothest server-side targets today. Node works over
+WebSocket; the native WebTransport polyfill is the newer path and is still
+settling, so reach for it only if you specifically need QUIC server-side.
+:::
+
+## Connect
+
+Once a transport is in place, the API is identical to the browser:
+
+```javascript
+import * as Moq from "@moq/net";
+
+const url = new URL("https://relay.moq.dev/anon");
+const connection = await Moq.Connection.connect(url);
+
+// publish or subscribe exactly as you would in the browser...
+
+await connection.close();
+```
+
+See the [`js/net/examples/`](https://github.com/moq-dev/moq/tree/main/js/net/examples)
+directory for runnable [connection](https://github.com/moq-dev/moq/blob/main/js/net/examples/connection.ts),
+[publish](https://github.com/moq-dev/moq/blob/main/js/net/examples/publish.ts),
+[subscribe](https://github.com/moq-dev/moq/blob/main/js/net/examples/subscribe.ts),
+and [discovery](https://github.com/moq-dev/moq/blob/main/js/net/examples/discovery.ts)
+scripts. Run them with `bun` or `tsx`.
+
+## Next steps
+
+- [@moq/net](/lib/js/@moq/net) - Core protocol API
+- [Web Components](/lib/js/env/web) - The browser story
+- [moq-relay](/bin/relay/) - The relay these clients connect to

--- a/doc/lib/js/index.md
+++ b/doc/lib/js/index.md
@@ -81,10 +81,10 @@ bun add @moq/net
 bun add @moq/watch
 bun add @moq/publish
 
-# or with other package managers
-npm add @moq/net
-npm add @moq/watch
-npm add @moq/publish
+# or with npm
+npm install @moq/net
+npm install @moq/watch
+npm install @moq/publish
 ```
 
 Pick the channel that matches where your code runs:

--- a/doc/lib/js/index.md
+++ b/doc/lib/js/index.md
@@ -87,6 +87,24 @@ npm add @moq/watch
 npm add @moq/publish
 ```
 
+Pick the channel that matches where your code runs:
+
+- **Browser with a bundler** (Vite, esbuild, webpack) - install the packages
+  above and import them. This is the standard path. See [Web Components](/lib/js/env/web).
+- **Browser, no build step** - load straight from a CDN, no install required:
+
+  ```html
+  <script type="module">
+      import "https://cdn.jsdelivr.net/npm/@moq/watch/element/+esm";
+      import "https://cdn.jsdelivr.net/npm/@moq/publish/element/+esm";
+  </script>
+  ```
+
+  [esm.sh](https://esm.sh) works the same way. Great for demos and embeds. See
+  [Loading from a CDN](/lib/js/env/web#loading-from-a-cdn-no-bundler).
+- **Server-side** (Node, Bun, Deno) - install `@moq/net` and set up a transport.
+  `@moq/hang` is browser-only. See [Server-side JS](/lib/js/env/native).
+
 ## Quick Start
 
 ### Using Web Components

--- a/doc/lib/py/index.md
+++ b/doc/lib/py/index.md
@@ -29,6 +29,10 @@ The raw UniFFI bindings (the `Moq`-prefixed classes), tracking the [`moq-ffi`](h
 
 ```bash
 pip install moq-rs
+
+# or with uv
+uv add moq-rs        # into a project
+uv pip install moq-rs # into the active environment
 ```
 
 This pulls in `moq-ffi`, for which prebuilt wheels are published for:

--- a/doc/lib/rs/env/index.md
+++ b/doc/lib/rs/env/index.md
@@ -1,0 +1,29 @@
+---
+title: Rust Environments
+description: Where Rust MoQ clients run, native and WebAssembly
+---
+
+# Rust Environments
+
+The same Rust crates ([`moq-net`](/lib/rs/crate/moq-net), [`hang`](/lib/rs/crate/hang))
+target two very different environments. `moq-net` is transport-agnostic: it runs
+over anything that implements [`web_transport_trait::Session`](https://docs.rs/web-transport-trait),
+so the only thing that changes between environments is which transport you hand it.
+
+## [Native](/lib/rs/env/native) <Badge type="tip" text="server, desktop, mobile" />
+
+Servers, CLIs, desktop apps, and mobile (via the [FFI bindings](/lib/)). Uses
+[`moq-native`](/lib/rs/crate/moq-native) to stand up a QUIC endpoint with
+[quinn](https://crates.io/crates/quinn) and [rustls](https://crates.io/crates/rustls),
+with automatic WebSocket fallback. This is the common case.
+
+[Native guide](/lib/rs/env/native)
+
+## [WebAssembly](/lib/rs/env/wasm) <Badge type="tip" text="browser" />
+
+Compile a Rust client to `wasm32-unknown-unknown` and run it inside a browser
+tab, reusing the browser's own `WebTransport`. Useful when you want to share
+Rust logic between native and web instead of maintaining a separate
+[TypeScript](/lib/js/) client.
+
+[WASM guide](/lib/rs/env/wasm)

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -1,0 +1,93 @@
+---
+title: WebAssembly
+description: Compiling a Rust MoQ client to wasm32 and running it in the browser
+---
+
+# WebAssembly
+
+[`moq-net`](/lib/rs/crate/moq-net) compiles to `wasm32-unknown-unknown` and runs
+inside a browser tab. There it reuses the browser's native `WebTransport` instead
+of bringing its own QUIC stack, so the wasm bundle stays small. Reach for this
+when you want to share Rust networking and media logic between a native app and
+the web, rather than maintaining a separate [TypeScript](/lib/js/) client.
+
+If you just want MoQ in a web page and aren't already invested in Rust, the
+[TypeScript libraries](/lib/js/) are the easier path. They're the reference
+browser implementation.
+
+## How it fits together
+
+`moq-net` talks to anything that implements [`web_transport_trait::Session`](https://docs.rs/web-transport-trait).
+The [`web-transport`](https://crates.io/crates/web-transport) meta-crate picks
+the backend by target automatically:
+
+- **native** &rarr; [`web-transport-quinn`](https://crates.io/crates/web-transport-quinn) (a real QUIC stack)
+- **wasm** &rarr; [`web-transport-wasm`](https://crates.io/crates/web-transport-wasm) (a thin wrapper over the browser's `WebTransport`)
+
+So the same `moq-net` code works in both places. On wasm you skip
+[`moq-native`](/lib/rs/crate/moq-native) entirely (it's quinn-only) and get the
+`Session` from `web-transport` instead.
+
+::: warning No `Send` on wasm
+Browser wasm is single-threaded and its `WebTransport` handles aren't `Send`,
+so the futures driving the transport can't be `Send` either. Spawn them on a
+local task (`wasm_bindgen_futures::spawn_local`) rather than a multi-threaded
+executor like a default `tokio` runtime.
+:::
+
+## Setup
+
+```toml
+# Cargo.toml
+[dependencies]
+moq-net = "0.1"
+web-transport = "0.10"
+url = "2"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+```
+
+Build with [`wasm-pack`](https://rustwasm.github.io/wasm-pack/) or
+[`trunk`](https://trunkrs.dev/):
+
+```bash
+wasm-pack build --target web
+# or, for a full app
+trunk serve
+```
+
+## Connecting
+
+Build a transport `Session` with `web-transport`, then hand it to
+[`moq_net::Client`](https://docs.rs/moq-net/latest/moq_net/struct.Client.html).
+From there the pub/sub API is identical to [native](/lib/rs/env/native):
+
+```rust
+let url = url::Url::parse("https://relay.moq.dev/anon")?;
+
+// On wasm this wraps the browser's native WebTransport.
+let transport = web_transport::ClientBuilder::new()
+    .with_system_roots()
+    .connect(url)
+    .await?;
+
+// Hand the transport to moq-net and run the MoQ handshake.
+let origin = moq_net::Origin::new().produce();
+let mut consumer = origin.consume();
+let session = moq_net::Client::new()
+    .with_consume(origin)
+    .connect(transport)
+    .await?;
+
+// Read announcements off `consumer` exactly as on native...
+```
+
+Only the transport setup differs from [native](/lib/rs/env/native); the
+[`Origin`](https://docs.rs/moq-net/latest/moq_net/struct.Origin.html),
+broadcast, track, group, and frame APIs are the same.
+
+## Next steps
+
+- [Native environment](/lib/rs/env/native) - The same API over a real QUIC stack
+- [moq-net](/lib/rs/crate/moq-net) - Core networking crate
+- [TypeScript libraries](/lib/js/) - The reference browser client

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -172,9 +172,9 @@ C bindings for `moq-net` via FFI.
 
 ## Installation
 
-### From crates.io
+### Libraries (crates.io)
 
-Add to your `Cargo.toml`:
+Add the crates you need to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -182,7 +182,36 @@ moq-net = "0.1"
 hang = "0.1"
 ```
 
-### From Source
+All crates are published to [crates.io](https://crates.io/search?q=moq) with API
+docs on [docs.rs](https://docs.rs).
+
+### Binaries
+
+The relay and CLI ship through several channels. Pick whichever fits:
+
+```bash
+# crates.io (any platform with a Rust toolchain)
+cargo install moq-relay moq-cli moq-token-cli
+
+# Homebrew (macOS / Linux)
+brew install moq-dev/tap/moq-relay moq-dev/tap/moq-cli
+
+# Debian / Ubuntu / Fedora (see the Linux packages guide for repo setup)
+sudo apt install moq-relay moq-cli
+
+# Nix
+nix build github:moq-dev/moq#moq-relay
+nix build github:moq-dev/moq#moq-cli
+
+# Docker
+docker run moqdev/moq-relay
+docker run moqdev/moq-cli
+```
+
+See [Linux packages](/setup/linux) for apt/dnf repository setup and the
+[Applications](/bin/) docs for usage.
+
+### From source
 
 ```bash
 git clone https://github.com/moq-dev/moq
@@ -190,74 +219,37 @@ cd moq/rs
 cargo build --release
 ```
 
-### Using Nix
-
-```bash
-# Build moq-relay
-nix build github:moq-dev/moq#moq-relay
-
-# Build moq-cli
-nix build github:moq-dev/moq#moq-cli
-```
-
 ## Quick Start
 
-### Publishing (Rust)
+[`moq-native`](/lib/rs/crate/moq-native) configures the QUIC endpoint and TLS for
+you, then [`moq-net`](/lib/rs/crate/moq-net) handles the MoQ handshake. Connect to
+a relay with a few lines:
 
 ```rust
-use moq_net::*;
-use tokio;
+let client = moq_native::ClientConfig::default().init()?;
+let url = url::Url::parse("https://relay.moq.dev/anon")?;
+let session = client.connect(url).await?;
+```
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Connect to relay
-    let connection = Connection::connect("https://relay.example.com/demo").await?;
+To publish or consume, wire an [`Origin`](https://docs.rs/moq-net/latest/moq_net/struct.Origin.html)
+into the session before connecting:
 
-    // Create a broadcast
-    let mut broadcast = BroadcastProducer::new("my-broadcast");
+```rust
+// Subscribe: wait for broadcasts to be announced.
+let origin = moq_net::Origin::new().produce();
+let mut consumer = origin.consume();
+let session = client.with_consume(origin).connect(url).await?;
 
-    // Create a track
-    let mut track = broadcast.create_track("chat");
-
-    // Publish a group with a frame
-    let mut group = track.append_group();
-    group.write(b"Hello, MoQ!")?;
-    group.close()?;
-
-    // Publish to connection
-    connection.publish(&mut broadcast).await?;
-
-    Ok(())
+while let Some((path, broadcast)) = consumer.announced().await {
+    // ... subscribe to tracks on each broadcast ...
 }
 ```
 
-### Subscribing (Rust)
-
-```rust
-use moq_net::*;
-use tokio;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Connect to relay
-    let connection = Connection::connect("https://relay.example.com/demo").await?;
-
-    // Subscribe to a broadcast
-    let broadcast = connection.consume("my-broadcast").await?;
-
-    // Subscribe to a track
-    let mut track = broadcast.subscribe("chat").await?;
-
-    // Read groups and frames
-    while let Some(group) = track.recv_group().await? {
-        while let Some(frame) = group.read().await? {
-            println!("Received: {:?}", frame);
-        }
-    }
-
-    Ok(())
-}
-```
+The [Native guide](/lib/rs/env/native) walks through publishing, subscribing,
+reading the catalog, and decoding frames end to end. For runnable code see the
+[`hang/examples`](https://github.com/moq-dev/moq/tree/main/rs/hang/examples)
+directory: [video.rs](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/video.rs)
+(publish) and [subscribe.rs](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/subscribe.rs).
 
 ## API Documentation
 

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -196,8 +196,11 @@ cargo install moq-relay moq-cli moq-token-cli
 # Homebrew (macOS / Linux)
 brew install moq-dev/tap/moq-relay moq-dev/tap/moq-cli
 
-# Debian / Ubuntu / Fedora (see the Linux packages guide for repo setup)
+# Debian / Ubuntu (see the Linux packages guide for repo setup)
 sudo apt install moq-relay moq-cli
+
+# Fedora / RHEL (see the Linux packages guide for repo setup)
+sudo dnf install moq-relay moq-cli
 
 # Nix
 nix build github:moq-dev/moq#moq-relay


### PR DESCRIPTION
## Summary

Improves the `/lib` docs so every language has a concrete, **verified** path to installing and running MoQ. The install channels mirror the [moq-dev/smoke](https://github.com/moq-dev/smoke) interop matrix, which installs each client straight from its public registry, so the commands here match what's actually published and tested.

Three pages under `/lib` were empty stubs that were already wired into the sidebar (so they rendered as blank pages). This fills them and tightens the install sections everywhere else.

### Changes

- **`js/env/native.md`** (was empty) - Running `@moq/net` server-side in Node/Bun/Deno: the WebSocket fallback transport, the `ws` polyfill for older Node, and the optional native `@moq/web-transport` path. Notes that `@moq/hang` is browser-only.
- **`rs/env/index.md`** (was empty) - Landing page contrasting the native and WASM environments, with the key point that `moq-net` is transport-agnostic (rides on `web_transport_trait::Session`).
- **`rs/env/wasm.md`** (was empty) - Compiling `moq-net` to `wasm32-unknown-unknown` over the browser's WebTransport via the `web-transport` meta-crate (which auto-selects the quinn vs wasm backend by target). Includes the `Send`-on-wasm caveat. Snippet verified against the real `moq_net::Client` + `web_transport::ClientBuilder` APIs.
- **`c/index.md`** - Replaced the vague "prebuilt binaries are attached" note with the actual release-tarball download (`moq-<ver>-<target>.tar.gz`) plus `cc` compile/link commands for Linux and macOS, including the platform system libs (`-lpthread -ldl -lm` / `CoreFoundation` + `Security`).
- **`rs/index.md`** - Split installation into **libraries** (crates.io) vs **binaries** (cargo / brew tap / apt / nix / docker). Replaced the stale Quick Start, which used a non-existent `Connection::connect(...)` API, with the real `moq-native` + `Origin` flow used in the native guide.
- **`js/index.md`** - Documented the three browser/server channels (bundler, jsDelivr CDN no-build, server-side), each linking the relevant environment page.
- **`py/index.md`** - Added the `uv` install path alongside `pip`.

### Test plan

- [x] `cd doc && bun run build` succeeds (VitePress fails the build on broken internal links; all new cross-links resolve).
- [x] Rust/WASM snippets checked against the current `moq_net::Client`, `moq_native::ClientConfig`, and `web_transport::ClientBuilder` signatures rather than copied from the old (incorrect) Quick Start.
- [x] Install commands cross-checked against the smoke interop matrix and the package READMEs.

Note: GStreamer and the Docker images are apps, documented under `/bin` and `/setup`, so they're out of scope for these `/lib` pages (the relay/CLI binary channels are still summarized on the Rust page with a pointer to `/setup/linux`).

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2eJb35iSfrbKdTcDQ6HM7)_