### PR TITLE
Migrate published-package smoke tests in-tree with per-release pinning

### DIFF
--- a/.github/workflows/libmoq.yml
+++ b/.github/workflows/libmoq.yml
@@ -81,6 +81,8 @@ jobs:
     name: Release
     needs: build
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
     permissions:
       contents: write
 
@@ -111,3 +113,13 @@ jobs:
           RELEASE_TITLE: "libmoq v${{ steps.parse.outputs.version }}"
           RELEASE_PREV_TAG: ${{ steps.prev_tag.outputs.tag }}
         run: .github/scripts/release.sh create artifacts
+
+  # Interop check against the version just published: download the libmoq release
+  # tarball pinned to it, build the C subscriber, and read a rust broadcast.
+  smoke:
+    name: Smoke
+    needs: [release]
+    uses: ./.github/workflows/smoke-release.yml
+    with:
+      slice: c
+      version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/moq-gst.yml
+++ b/.github/workflows/moq-gst.yml
@@ -199,6 +199,8 @@ jobs:
     name: Release
     needs: [build, package]
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
     permissions:
       contents: write
       actions: write
@@ -236,3 +238,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: .github/scripts/trigger-repo-publish.sh
+
+  # Interop check against the version just published: download the moq-gst plugin
+  # tarball pinned to it and subscribe via moqsrc against a system GStreamer.
+  smoke:
+    name: Smoke
+    needs: [release]
+    uses: ./.github/workflows/smoke-release.yml
+    with:
+      slice: gst
+      version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -225,3 +225,13 @@ jobs:
           GIT_AUTHOR_NAME: moq-bot
           GIT_AUTHOR_EMAIL: moq-bot[bot]@users.noreply.github.com
         run: ./go/scripts/publish.sh
+
+  # Interop check against the version just published: go get moq-dev/moq-go pinned
+  # to it and subscribe to a rust broadcast.
+  smoke:
+    name: Smoke
+    needs: [parse-version, publish]
+    uses: ./.github/workflows/smoke-release.yml
+    with:
+      slice: go
+      version: ${{ needs.parse-version.outputs.version }}

--- a/.github/workflows/release-kt.yml
+++ b/.github/workflows/release-kt.yml
@@ -198,3 +198,14 @@ jobs:
         with:
           name: kotlin-package
           path: release-out/*
+
+  # Interop check against the version just published: resolve dev.moq:moq from
+  # Maven Central pinned to it and subscribe to a rust broadcast. Central sync can
+  # lag, so the harness polls repo1 for the POM (longer budget; see smoke-release).
+  smoke:
+    name: Smoke
+    needs: [parse-version, package]
+    uses: ./.github/workflows/smoke-release.yml
+    with:
+      slice: kotlin
+      version: ${{ needs.parse-version.outputs.version }}

--- a/.github/workflows/release-py.yml
+++ b/.github/workflows/release-py.yml
@@ -90,3 +90,13 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+
+  # Interop check against the version just published: install moq-rs from PyPI
+  # pinned to it and run the python<->rust matrix.
+  smoke:
+    name: Smoke
+    needs: [build, publish]
+    uses: ./.github/workflows/smoke-release.yml
+    with:
+      slice: python
+      version: ${{ needs.build.outputs.version }}

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -257,3 +257,15 @@ jobs:
           GIT_AUTHOR_NAME: moq-bot
           GIT_AUTHOR_EMAIL: moq-bot[bot]@users.noreply.github.com
         run: ./swift/scripts/publish.sh
+
+  # Interop check against the version just published: resolve the Swift package
+  # from the mirror pinned to it (macOS, Xcode toolchain) and subscribe to a rust
+  # broadcast.
+  smoke:
+    name: Smoke
+    needs: [parse-version, publish]
+    uses: ./.github/workflows/smoke-release.yml
+    with:
+      slice: swift
+      version: ${{ needs.parse-version.outputs.version }}
+      os: macos-latest

--- a/.github/workflows/smoke-release.yml
+++ b/.github/workflows/smoke-release.yml
@@ -108,9 +108,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good
 
-      # Run the pinned slice. CC=/usr/bin/cc builds the C client with the system
-      # compiler (unused by other slices). Maven Central can lag npm/PyPI/Go, so
-      # kotlin gets a longer propagation budget (20 min); others use the 5m default.
+      # Run the pinned slice. The c client builds with the devShell's own cc so its
+      # binary and runtime share one libc (see smoke.yml). Maven Central can lag
+      # npm/PyPI/Go, so kotlin gets a longer propagation budget (20 min); others
+      # use the 5m default.
       - name: Smoke
         env:
           SMOKE_SHELL: ${{ steps.cfg.outputs.shell }}
@@ -118,5 +119,5 @@ jobs:
           SUB: ${{ steps.cfg.outputs.sub }}
           SMOKE_POLL_TRIES: ${{ inputs.slice == 'kotlin' && '240' || '60' }}
         run: |
-          nix develop ".#$SMOKE_SHELL" --command env CC=/usr/bin/cc ./test/smoke/smoke.sh \
+          nix develop ".#$SMOKE_SHELL" --command ./test/smoke/smoke.sh \
             --publishers "$PUB" --subscribers "$SUB" --timeout 30

--- a/.github/workflows/smoke-release.yml
+++ b/.github/workflows/smoke-release.yml
@@ -8,6 +8,12 @@ name: Smoke (release)
 # the artifact is downloadable). This is the immediate, per-release replacement
 # for the old daily cross-OS cron; the nightly smoke.yml stays as the Linux
 # cross-package backstop.
+#
+# Client toolchains come from a per-slice `nix develop .#smoke-<...>` shell, so a
+# release runs one lean shell (the swift job on the pricey macOS runner pulls only
+# the harness, never jdk/Chromium). The reference relay/cli are built from the
+# checkout with `nix build`. GStreamer (gst) and the C compiler (c) stay
+# system-level for the same reasons as the nightly.
 
 on:
   workflow_call:
@@ -29,10 +35,6 @@ on:
 permissions:
   contents: read
 
-defaults:
-  run:
-    working-directory: test/smoke
-
 jobs:
   smoke:
     name: ${{ inputs.slice }} @ ${{ inputs.version }}
@@ -50,28 +52,30 @@ jobs:
         with:
           persist-credentials: false
 
-      # Map the slice to its publish/subscribe axes and version env. Each client
-      # is paired with rust on the opposite axis as the reference implementation.
+      # Map the slice to its publish/subscribe axes, version env, and the lean
+      # devShell that carries its toolchain. Each client is paired with rust on
+      # the opposite axis as the reference implementation.
       - name: Resolve slice
         id: cfg
         env:
           SLICE: ${{ inputs.slice }}
         run: |
           case "$SLICE" in
-            python)    pub=rust,python; sub=rust,python; venv=MOQ_RS_VERSION ;;
-            swift)     pub=rust;        sub=swift;       venv=MOQ_SWIFT_VERSION ;;
-            kotlin)    pub=rust;        sub=kotlin;      venv=MOQ_KT_VERSION ;;
-            go)        pub=rust;        sub=go;          venv=MOQ_GO_VERSION ;;
-            c)         pub=rust;        sub=c;           venv=MOQ_LIBMOQ_VERSION ;;
-            gst)       pub=rust;        sub=gst;         venv=MOQ_GST_VERSION ;;
-            js)        pub=rust,js-vite,js-esbuild,js-jsdelivr; sub=rust,js-vite,js-esbuild,js-jsdelivr; venv=MOQ_NPM_VERSION ;;
-            js-native) pub=rust;        sub=js-native-node,js-native-bun; venv=MOQ_NPM_VERSION ;;
+            python)    pub=rust,python; sub=rust,python; venv=MOQ_RS_VERSION;     shell=smoke-python ;;
+            swift)     pub=rust;        sub=swift;       venv=MOQ_SWIFT_VERSION;  shell=smoke-min ;;
+            kotlin)    pub=rust;        sub=kotlin;      venv=MOQ_KT_VERSION;     shell=smoke-kotlin ;;
+            go)        pub=rust;        sub=go;          venv=MOQ_GO_VERSION;     shell=smoke-go ;;
+            c)         pub=rust;        sub=c;           venv=MOQ_LIBMOQ_VERSION; shell=smoke-min ;;
+            gst)       pub=rust;        sub=gst;         venv=MOQ_GST_VERSION;    shell=smoke-min ;;
+            js)        pub=rust,js-vite,js-esbuild,js-jsdelivr; sub=rust,js-vite,js-esbuild,js-jsdelivr; venv=MOQ_NPM_VERSION; shell=smoke-js ;;
+            js-native) pub=rust;        sub=js-native-node,js-native-bun; venv=MOQ_NPM_VERSION; shell=smoke-js ;;
             *) echo "unknown slice: $SLICE" >&2; exit 1 ;;
           esac
           {
             echo "pub=$pub"
             echo "sub=$sub"
             echo "venv=$venv"
+            echo "shell=$shell"
           } >> "$GITHUB_OUTPUT"
 
       - name: Pin version
@@ -80,69 +84,39 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: echo "$VENV=$VERSION" >> "$GITHUB_ENV"
 
-      # ── reference relay + cli (rust, from crates.io) ───────────────────
-      - name: System deps (Linux)
-        if: runner.os == 'Linux'
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: |
+            extra-substituters = https://kixelated.cachix.org
+            extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
+
+      # Reference relay + cli, built from the checkout (deps from cachix).
+      - name: Build reference relay + cli
+        run: |
+          relay=$(nix build --no-link --print-out-paths '.#moq-relay')
+          cli=$(nix build --no-link --print-out-paths '.#moq-cli')
+          {
+            echo "RELAY_BIN=$relay/bin/moq-relay"
+            echo "MOQ_BIN=$cli/bin/moq-cli"
+          } >> "$GITHUB_ENV"
+
+      # GStreamer is the system runtime the prebuilt moq-gst plugin links against.
+      - name: System GStreamer (gst)
+        if: inputs.slice == 'gst'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg curl procps coreutils jq
-      - name: System deps (gstreamer, Linux)
-        if: runner.os == 'Linux' && inputs.slice == 'gst'
-        run: sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good
-      - name: System deps (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install ffmpeg coreutils jq
-          echo "$(brew --prefix)/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
+          sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Rust cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Install moq-relay + moq-cli (cargo)
-        run: cargo install moq-relay moq-cli
-
-      # ── per-slice client toolchain ─────────────────────────────────────
-      - name: Setup uv (python)
-        if: inputs.slice == 'python'
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - name: Setup Go (go)
-        if: inputs.slice == 'go'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: stable
-      - name: Setup Java (kotlin)
-        if: inputs.slice == 'kotlin'
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: "21"
-      - name: Setup Gradle (kotlin)
-        if: inputs.slice == 'kotlin'
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          gradle-version: "8.14.4"
-      - name: Setup Bun (js)
-        if: inputs.slice == 'js' || inputs.slice == 'js-native'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      - name: Setup Node (js)
-        if: inputs.slice == 'js' || inputs.slice == 'js-native'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "22"
-      - name: Playwright system deps (js)
-        if: (inputs.slice == 'js' || inputs.slice == 'js-native') && runner.os == 'Linux'
-        run: |
-          cd clients/js
-          bun install
-          bunx playwright install-deps chromium
-
-      # ── run the pinned slice ───────────────────────────────────────────
+      # Run the pinned slice. CC=/usr/bin/cc builds the C client with the system
+      # compiler (unused by other slices). Maven Central can lag npm/PyPI/Go, so
+      # kotlin gets a longer propagation budget (20 min); others use the 5m default.
       - name: Smoke
         env:
+          SMOKE_SHELL: ${{ steps.cfg.outputs.shell }}
           PUB: ${{ steps.cfg.outputs.pub }}
           SUB: ${{ steps.cfg.outputs.sub }}
-          # Maven Central can take far longer than npm/PyPI/the Go proxy to sync a
-          # release to repo1, so kotlin gets a longer propagation budget (20 min).
           SMOKE_POLL_TRIES: ${{ inputs.slice == 'kotlin' && '240' || '60' }}
-        run: ./smoke.sh --publishers "$PUB" --subscribers "$SUB" --timeout 30
+        run: |
+          nix develop ".#$SMOKE_SHELL" --command env CC=/usr/bin/cc ./test/smoke/smoke.sh \
+            --publishers "$PUB" --subscribers "$SUB" --timeout 30

--- a/.github/workflows/smoke-release.yml
+++ b/.github/workflows/smoke-release.yml
@@ -1,0 +1,148 @@
+name: Smoke (release)
+
+# Reusable per-release interop check. A release workflow calls this right after
+# it publishes, passing the slice (which client) and the exact version it just
+# cut. The harness (test/smoke) then installs that client from its public
+# registry pinned to that version and runs it against a rust reference relay +
+# cli, polling the registry until the version resolves (publish can finish before
+# the artifact is downloadable). This is the immediate, per-release replacement
+# for the old daily cross-OS cron; the nightly smoke.yml stays as the Linux
+# cross-package backstop.
+
+on:
+  workflow_call:
+    inputs:
+      slice:
+        description: "client to test: python | swift | kotlin | go | c | gst | js | js-native"
+        required: true
+        type: string
+      version:
+        description: "exact published version to pin (no leading v)"
+        required: true
+        type: string
+      os:
+        description: "runner OS"
+        required: false
+        type: string
+        default: ubuntu-latest
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: test/smoke
+
+jobs:
+  smoke:
+    name: ${{ inputs.slice }} @ ${{ inputs.version }}
+    runs-on: ${{ inputs.os }}
+    if: ${{ github.repository_owner == 'moq-dev' }}
+    timeout-minutes: 30
+    env:
+      # Lifts the anonymous GitHub API limit so the c / gst release-asset lookups
+      # don't get throttled on shared runners.
+      GITHUB_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # Map the slice to its publish/subscribe axes and version env. Each client
+      # is paired with rust on the opposite axis as the reference implementation.
+      - name: Resolve slice
+        id: cfg
+        env:
+          SLICE: ${{ inputs.slice }}
+        run: |
+          case "$SLICE" in
+            python)    pub=rust,python; sub=rust,python; venv=MOQ_RS_VERSION ;;
+            swift)     pub=rust;        sub=swift;       venv=MOQ_SWIFT_VERSION ;;
+            kotlin)    pub=rust;        sub=kotlin;      venv=MOQ_KT_VERSION ;;
+            go)        pub=rust;        sub=go;          venv=MOQ_GO_VERSION ;;
+            c)         pub=rust;        sub=c;           venv=MOQ_LIBMOQ_VERSION ;;
+            gst)       pub=rust;        sub=gst;         venv=MOQ_GST_VERSION ;;
+            js)        pub=rust,js-vite,js-esbuild,js-jsdelivr; sub=rust,js-vite,js-esbuild,js-jsdelivr; venv=MOQ_NPM_VERSION ;;
+            js-native) pub=rust;        sub=js-native-node,js-native-bun; venv=MOQ_NPM_VERSION ;;
+            *) echo "unknown slice: $SLICE" >&2; exit 1 ;;
+          esac
+          {
+            echo "pub=$pub"
+            echo "sub=$sub"
+            echo "venv=$venv"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Pin version
+        env:
+          VENV: ${{ steps.cfg.outputs.venv }}
+          VERSION: ${{ inputs.version }}
+        run: echo "$VENV=$VERSION" >> "$GITHUB_ENV"
+
+      # ── reference relay + cli (rust, from crates.io) ───────────────────
+      - name: System deps (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg curl procps coreutils jq
+      - name: System deps (gstreamer, Linux)
+        if: runner.os == 'Linux' && inputs.slice == 'gst'
+        run: sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+      - name: System deps (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install ffmpeg coreutils jq
+          echo "$(brew --prefix)/opt/coreutils/libexec/gnubin" >> "$GITHUB_PATH"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install moq-relay + moq-cli (cargo)
+        run: cargo install moq-relay moq-cli
+
+      # ── per-slice client toolchain ─────────────────────────────────────
+      - name: Setup uv (python)
+        if: inputs.slice == 'python'
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Setup Go (go)
+        if: inputs.slice == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+      - name: Setup Java (kotlin)
+        if: inputs.slice == 'kotlin'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "21"
+      - name: Setup Gradle (kotlin)
+        if: inputs.slice == 'kotlin'
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          gradle-version: "8.14.4"
+      - name: Setup Bun (js)
+        if: inputs.slice == 'js' || inputs.slice == 'js-native'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Setup Node (js)
+        if: inputs.slice == 'js' || inputs.slice == 'js-native'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+      - name: Playwright system deps (js)
+        if: (inputs.slice == 'js' || inputs.slice == 'js-native') && runner.os == 'Linux'
+        run: |
+          cd clients/js
+          bun install
+          bunx playwright install-deps chromium
+
+      # ── run the pinned slice ───────────────────────────────────────────
+      - name: Smoke
+        env:
+          PUB: ${{ steps.cfg.outputs.pub }}
+          SUB: ${{ steps.cfg.outputs.sub }}
+          # Maven Central can take far longer than npm/PyPI/the Go proxy to sync a
+          # release to repo1, so kotlin gets a longer propagation budget (20 min).
+          SMOKE_POLL_TRIES: ${{ inputs.slice == 'kotlin' && '240' || '60' }}
+        run: ./smoke.sh --publishers "$PUB" --subscribers "$SUB" --timeout 30

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -56,8 +56,10 @@ jobs:
       matrix:
         # The Rust binaries ship through channels that install the same thing; we
         # test each separately. The Python / Go / browser clients always come from
-        # their own registries.
-        channel: [cargo, apt, nix, docker]
+        # their own registries. A PR (which only fires when the harness itself
+        # changes) validates mechanics on the fast cargo channel; the nightly and
+        # on-demand runs exercise every channel.
+        channel: ${{ (github.event_name == 'pull_request' && fromJSON('["cargo"]')) || fromJSON('["cargo","apt","nix","docker"]') }}
 
     steps:
       - name: Checkout
@@ -151,17 +153,24 @@ jobs:
       - name: Freshness
         run: ./freshness.sh
 
-      # ── run the full interop matrix (Linux: no swift) ──────────────────
+      # ── run the interop matrix (Linux: no swift) ──────────────────────
       # rust, python, and the three browser variants publish; go/kotlin/c/gst and
       # the native-JS runtimes subscribe. --timeout 30 gives headless Chromium
-      # cold-start headroom.
+      # cold-start headroom. The gst subscriber can't yet read browser-published
+      # broadcasts (a published-package interop gap in moqsrc, not the harness),
+      # so it's part of the nightly's full matrix but dropped from PR runs, which
+      # only need to prove the harness mechanics still work.
       - name: Smoke
+        env:
+          EVENT: ${{ github.event_name }}
         run: |
           browser="js-vite,js-esbuild,js-jsdelivr"
           native="js-native-node,js-native-bun"
+          subs="rust,python,go,kotlin,c,$browser,$native"
+          if [ "$EVENT" != "pull_request" ]; then subs="$subs,gst"; fi
           ./smoke.sh \
             --publishers "rust,python,$browser" \
-            --subscribers "rust,python,go,kotlin,c,gst,$browser,$native" \
+            --subscribers "$subs" \
             --timeout 30
 
       # Quick proof the harness can actually report failure.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,6 +11,12 @@ name: Smoke
 #
 # macOS is NOT run here (cost): the only macOS-specific artifacts (the Swift
 # package, brew bottles) are smoke-tested per-release in release-swift.yml.
+#
+# Client toolchains come from the `smoke` devShell (`nix develop .#smoke`), so
+# this carries no per-language setup actions. The two things that must stay
+# system-level: GStreamer (the gst client loads the prebuilt plugin against a
+# system GStreamer, the scenario it tests) and the C compiler (the C client links
+# the prebuilt libmoq.a with the system cc, via CC=/usr/bin/cc).
 
 on:
   # Manual on-demand runs.
@@ -21,6 +27,7 @@ on:
     paths:
       - "test/smoke/**"
       - ".github/workflows/smoke.yml"
+      - "flake.nix"
   # Nightly cross-package backstop.
   schedule:
     - cron: "0 8 * * *"
@@ -31,10 +38,6 @@ permissions:
 concurrency:
   group: smoke-${{ github.ref }}
   cancel-in-progress: true
-
-defaults:
-  run:
-    working-directory: test/smoke
 
 jobs:
   smoke:
@@ -67,39 +70,42 @@ jobs:
         with:
           persist-credentials: false
 
-      # ── client toolchains ──────────────────────────────────────────────
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      # Nix provides every client toolchain (ffmpeg, uv, go, jdk/gradle, bun,
+      # node, a pinned Chromium, ...) via the `smoke` devShell. The cachix
+      # substituter serves the moq packages; the toolchain comes from
+      # cache.nixos.org.
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
-          go-version: stable
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "22"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: "21"
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          gradle-version: "8.14.4"
+          extra-conf: |
+            extra-substituters = https://kixelated.cachix.org
+            extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
 
-      - name: System deps
+      # GStreamer is the system runtime the prebuilt moq-gst plugin links against,
+      # so it can't come from the devShell. Only the nightly/on-demand runs include
+      # the gst cell, so skip the install on PRs.
+      - name: System GStreamer
+        if: github.event_name != 'pull_request'
         run: |
           sudo apt-get update
-          # gcc (cc) for the C client is already on the runner. gstreamer1.0-*
-          # provides gst-launch/gst-inspect + the core elements (filesink) the
-          # moq-gst subscriber loads the prebuilt plugin against.
-          sudo apt-get install -y ffmpeg curl procps coreutils jq \
-            gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+          sudo apt-get install -y gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good
 
-      # ── Rust binaries, per channel (left on PATH / RELAY_BIN for smoke.sh) ──
+      # ── Rust binaries, per channel (RELAY_BIN/MOQ_BIN or PATH for smoke.sh) ──
       - name: Install moq-relay + moq-cli + moq-token-cli (cargo)
         if: matrix.channel == 'cargo'
-        run: cargo install moq-relay moq-cli moq-token-cli
+        # cargo from the devShell; install to a known root so smoke.sh can point at
+        # it without depending on ~/.cargo/bin being on PATH inside `nix develop`.
+        run: |
+          nix develop .#smoke --command cargo install --root "$PWD/.channel" moq-relay moq-cli moq-token-cli
+          {
+            echo "RELAY_BIN=$PWD/.channel/bin/moq-relay"
+            echo "MOQ_BIN=$PWD/.channel/bin/moq-cli"
+            echo "TOKEN_BIN=$PWD/.channel/bin/moq-token-cli"
+          } >> "$GITHUB_ENV"
 
       - name: Install moq-relay + moq-cli + moq-token-cli (apt)
         if: matrix.channel == 'apt'
+        # Left on /usr/bin, which stays on PATH inside `nix develop`.
         run: |
           curl -fsSL https://apt.moq.dev/moq-keyring.gpg \
             | sudo tee /usr/share/keyrings/moq-keyring.gpg > /dev/null
@@ -108,16 +114,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y moq-relay moq-cli moq-token-cli
 
-      - name: Install Nix (nix channel)
-        if: matrix.channel == 'nix'
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-        with:
-          extra-conf: |
-            extra-substituters = https://kixelated.cachix.org
-            extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
-
       - name: Build moq from the flake (nix channel)
         if: matrix.channel == 'nix'
+        # The moq flake is itself a public channel (nix run github:moq-dev/moq).
         # --refresh so we always build the latest moq, never a cached eval.
         run: |
           relay=$(nix build --refresh --no-link --print-out-paths 'github:moq-dev/moq#moq-relay')
@@ -137,29 +136,24 @@ jobs:
           docker pull moqdev/moq-relay
           docker pull moqdev/moq-cli
           {
-            echo "RELAY_BIN=$PWD/clients/docker/moq-relay"
-            echo "MOQ_BIN=$PWD/clients/docker/moq-cli"
+            echo "RELAY_BIN=$PWD/test/smoke/clients/docker/moq-relay"
+            echo "MOQ_BIN=$PWD/test/smoke/clients/docker/moq-cli"
           } >> "$GITHUB_ENV"
 
-      # ── browser deps (Chromium runtime libs) ───────────────────────────
-      - name: Playwright system deps
-        run: |
-          cd clients/js
-          bun install
-          bunx playwright install-deps chromium
-
       # Fail loudly if we've drifted off "latest": a committed client lock file, a
-      # moq package that stopped being requested at latest, or a stale playwright pin.
+      # moq package that stopped being requested at latest, or (now that the
+      # devShell exports PLAYWRIGHT_VERSION) a stale playwright pin.
       - name: Freshness
-        run: ./freshness.sh
+        run: nix develop .#smoke --command ./test/smoke/freshness.sh
 
       # ── run the interop matrix (Linux: no swift) ──────────────────────
       # rust, python, and the three browser variants publish; go/kotlin/c/gst and
       # the native-JS runtimes subscribe. --timeout 30 gives headless Chromium
-      # cold-start headroom. The gst subscriber can't yet read browser-published
-      # broadcasts (a published-package interop gap in moqsrc, not the harness),
-      # so it's part of the nightly's full matrix but dropped from PR runs, which
-      # only need to prove the harness mechanics still work.
+      # cold-start headroom. CC=/usr/bin/cc builds the C client with the system
+      # compiler (it links the prebuilt libmoq.a, built for the system glibc). The
+      # gst subscriber can't yet read browser-published broadcasts (a
+      # published-package gap in moqsrc, not the harness), so it's in the nightly's
+      # full matrix but dropped from PR runs, which only prove harness mechanics.
       - name: Smoke
         env:
           EVENT: ${{ github.event_name }}
@@ -168,17 +162,17 @@ jobs:
           native="js-native-node,js-native-bun"
           subs="rust,python,go,kotlin,c,$browser,$native"
           if [ "$EVENT" != "pull_request" ]; then subs="$subs,gst"; fi
-          ./smoke.sh \
+          nix develop .#smoke --command env CC=/usr/bin/cc ./test/smoke/smoke.sh \
             --publishers "rust,python,$browser" \
             --subscribers "$subs" \
             --timeout 30
 
       # Quick proof the harness can actually report failure.
       - name: Negative control
-        run: ./smoke.sh --negative --subscribers rust,python
+        run: nix develop .#smoke --command ./test/smoke/smoke.sh --negative --subscribers rust,python
 
       # ── token interop ──────────────────────────────────────────────────
       # moq-token-cli rides the same channel as moq-relay/moq-cli; @moq/token
       # comes from npm under node + bun; rust-docker pulls the moqdev image.
       - name: Token interop
-        run: ./token.sh --generators rust,js-node,js-bun,rust-docker --verifiers rust,js-node,js-bun,rust-docker
+        run: nix develop .#smoke --command ./test/smoke/token.sh --generators rust,js-node,js-bun,rust-docker --verifiers rust,js-node,js-bun,rust-docker

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,175 @@
+name: Smoke
+
+# Cross-language interop smoke test against the PUBLISHED moq packages (the
+# harness lives in test/smoke). This is the Linux-only safety net that catches
+# breakage from a freshly published wheel / formula / .deb / npm / go module that
+# a developer wouldn't notice until a user hit it. Per-language slices also run
+# from each release workflow, pinned to the version just cut (see the `smoke` job
+# in release-*.yml); this job is the nightly cross-package backstop, since a
+# release of package A can break interop with an already-published B without
+# re-triggering A.
+#
+# macOS is NOT run here (cost): the only macOS-specific artifacts (the Swift
+# package, brew bottles) are smoke-tested per-release in release-swift.yml.
+
+on:
+  # Manual on-demand runs.
+  workflow_dispatch:
+  # On PRs that touch the harness itself: run the matrix so a broken cell shows
+  # up before it merges. Path-filtered so unrelated PRs don't pay for it.
+  pull_request:
+    paths:
+      - "test/smoke/**"
+      - ".github/workflows/smoke.yml"
+  # Nightly cross-package backstop.
+  schedule:
+    - cron: "0 8 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: test/smoke
+
+jobs:
+  smoke:
+    name: ${{ matrix.channel }}
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'moq-dev' }}
+    # The matrix runs in real time (ffmpeg -re pacing + per-subscriber timeouts);
+    # this is just a safety net against a hung relay/client.
+    timeout-minutes: 45
+
+    # smoke.sh resolves the latest libmoq / moq-gst release via the GitHub API.
+    # Without a token that call is anonymous (60 req/hr per IP); authenticating
+    # lifts it to 1000 req/hr so the C / GStreamer subscribers don't drop out.
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # The Rust binaries ship through channels that install the same thing; we
+        # test each separately. The Python / Go / browser clients always come from
+        # their own registries.
+        channel: [cargo, apt, nix, docker]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # ── client toolchains ──────────────────────────────────────────────
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "21"
+      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          gradle-version: "8.14.4"
+
+      - name: System deps
+        run: |
+          sudo apt-get update
+          # gcc (cc) for the C client is already on the runner. gstreamer1.0-*
+          # provides gst-launch/gst-inspect + the core elements (filesink) the
+          # moq-gst subscriber loads the prebuilt plugin against.
+          sudo apt-get install -y ffmpeg curl procps coreutils jq \
+            gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+
+      # ── Rust binaries, per channel (left on PATH / RELAY_BIN for smoke.sh) ──
+      - name: Install moq-relay + moq-cli + moq-token-cli (cargo)
+        if: matrix.channel == 'cargo'
+        run: cargo install moq-relay moq-cli moq-token-cli
+
+      - name: Install moq-relay + moq-cli + moq-token-cli (apt)
+        if: matrix.channel == 'apt'
+        run: |
+          curl -fsSL https://apt.moq.dev/moq-keyring.gpg \
+            | sudo tee /usr/share/keyrings/moq-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/moq-keyring.gpg] https://apt.moq.dev stable main" \
+            | sudo tee /etc/apt/sources.list.d/moq.list
+          sudo apt-get update
+          sudo apt-get install -y moq-relay moq-cli moq-token-cli
+
+      - name: Install Nix (nix channel)
+        if: matrix.channel == 'nix'
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: |
+            extra-substituters = https://kixelated.cachix.org
+            extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
+
+      - name: Build moq from the flake (nix channel)
+        if: matrix.channel == 'nix'
+        # --refresh so we always build the latest moq, never a cached eval.
+        run: |
+          relay=$(nix build --refresh --no-link --print-out-paths 'github:moq-dev/moq#moq-relay')
+          cli=$(nix build --refresh --no-link --print-out-paths 'github:moq-dev/moq#moq-cli')
+          token=$(nix build --refresh --no-link --print-out-paths 'github:moq-dev/moq#moq-token-cli')
+          {
+            echo "RELAY_BIN=$relay/bin/moq-relay"
+            echo "MOQ_BIN=$cli/bin/moq-cli"
+            echo "TOKEN_BIN=$token/bin/moq-token-cli"
+          } >> "$GITHUB_ENV"
+
+      - name: Pull moqdev images (docker channel)
+        if: matrix.channel == 'docker'
+        # Pull :latest fresh, then point smoke.sh at the wrapper scripts (which
+        # `docker run --network host` the images). Docker is preinstalled here.
+        run: |
+          docker pull moqdev/moq-relay
+          docker pull moqdev/moq-cli
+          {
+            echo "RELAY_BIN=$PWD/clients/docker/moq-relay"
+            echo "MOQ_BIN=$PWD/clients/docker/moq-cli"
+          } >> "$GITHUB_ENV"
+
+      # ── browser deps (Chromium runtime libs) ───────────────────────────
+      - name: Playwright system deps
+        run: |
+          cd clients/js
+          bun install
+          bunx playwright install-deps chromium
+
+      # Fail loudly if we've drifted off "latest": a committed client lock file, a
+      # moq package that stopped being requested at latest, or a stale playwright pin.
+      - name: Freshness
+        run: ./freshness.sh
+
+      # ── run the full interop matrix (Linux: no swift) ──────────────────
+      # rust, python, and the three browser variants publish; go/kotlin/c/gst and
+      # the native-JS runtimes subscribe. --timeout 30 gives headless Chromium
+      # cold-start headroom.
+      - name: Smoke
+        run: |
+          browser="js-vite,js-esbuild,js-jsdelivr"
+          native="js-native-node,js-native-bun"
+          ./smoke.sh \
+            --publishers "rust,python,$browser" \
+            --subscribers "rust,python,go,kotlin,c,gst,$browser,$native" \
+            --timeout 30
+
+      # Quick proof the harness can actually report failure.
+      - name: Negative control
+        run: ./smoke.sh --negative --subscribers rust,python
+
+      # ── token interop ──────────────────────────────────────────────────
+      # moq-token-cli rides the same channel as moq-relay/moq-cli; @moq/token
+      # comes from npm under node + bun; rust-docker pulls the moqdev image.
+      - name: Token interop
+        run: ./token.sh --generators rust,js-node,js-bun,rust-docker --verifiers rust,js-node,js-bun,rust-docker

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -149,11 +149,12 @@ jobs:
       # ── run the interop matrix (Linux: no swift) ──────────────────────
       # rust, python, and the three browser variants publish; go/kotlin/c/gst and
       # the native-JS runtimes subscribe. --timeout 30 gives headless Chromium
-      # cold-start headroom. CC=/usr/bin/cc builds the C client with the system
-      # compiler (it links the prebuilt libmoq.a, built for the system glibc). The
-      # gst subscriber can't yet read browser-published broadcasts (a
-      # published-package gap in moqsrc, not the harness), so it's in the nightly's
-      # full matrix but dropped from PR runs, which only prove harness mechanics.
+      # cold-start headroom. The c and go clients link the prebuilt libmoq static
+      # lib and are built with the devShell's own cc, so the binary and its runtime
+      # share one (nix) libc; building with the system cc and running under
+      # `nix develop` mixes the two and segfaults. The gst subscriber can't yet
+      # read browser-published broadcasts (a published-package gap in moqsrc, not
+      # the harness), so it's in the nightly's full matrix but dropped from PR runs.
       - name: Smoke
         env:
           EVENT: ${{ github.event_name }}
@@ -162,7 +163,7 @@ jobs:
           native="js-native-node,js-native-bun"
           subs="rust,python,go,kotlin,c,$browser,$native"
           if [ "$EVENT" != "pull_request" ]; then subs="$subs,gst"; fi
-          nix develop .#smoke --command env CC=/usr/bin/cc ./test/smoke/smoke.sh \
+          nix develop .#smoke --command ./test/smoke/smoke.sh \
             --publishers "rust,python,$browser" \
             --subscribers "$subs" \
             --timeout 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,15 @@ Key architectural rule: The CDN/relay does not know anything about media. Anythi
   throttle/          # Network throttle script for testing
 
 /doc/                 # Documentation site (VitePress, deployed via Cloudflare)
+
+/test/                # Cross-language tests
+  smoke/             # Interop matrix against the PUBLISHED packages (not workspace
+                     # source): `just smoke <lang>` installs each client from its
+                     # registry and runs publish/subscribe. Latest mode (nightly
+                     # Linux) + pinned mode (per-release, via smoke-release.yml).
+                     # Clients live in test/smoke/clients and are deliberately
+                     # OUTSIDE the cargo/bun workspaces so they resolve published
+                     # artifacts, never workspace source.
 ```
 
 ## Dependencies
@@ -164,6 +173,7 @@ A function with 4+ args, or a call site passing the same 3+ values into multiple
 - Run `just fix` to automatically fix formating and easy things.
 - Rust tests are integrated within source files
 - Async tests that sleep should call `tokio::time::pause()` at the start to simulate time instantly
+- These tests build from workspace source. To verify the **published** packages interoperate (catch a packaging break a user would hit), run `just smoke <lang>` (see `test/smoke`). CI runs it nightly on Linux and per-release pinned to the version just cut.
 
 ## Cross-Package Sync
 
@@ -179,6 +189,7 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 | `rs/moq-cli` | `doc/bin/cli.md` |
 | `rs/moq-gst` | `doc/bin/gstreamer.md` |
 | `js/{watch,publish}` UI/API | `demo/web` if it consumes the API |
+| A published client API the smoke harness drives (publish/subscribe CLIs, `@moq/*` element usage) | the matching `test/smoke/clients/*` |
 
 ## Branch Targeting
 

--- a/flake.nix
+++ b/flake.nix
@@ -153,6 +153,57 @@
           nixfmt
         ];
 
+        # Client toolchains for the published-package smoke matrix (test/smoke),
+        # composed into per-slice devShells below. Kept SEPARATE from the default
+        # shell so day-to-day `nix develop` never pulls go/jdk/gradle/Chromium.
+        # Three clients deliberately use the system toolchain, not nix, so they
+        # appear in no group: GStreamer (the gst client loads the prebuilt plugin
+        # against a *system* GStreamer, the scenario it tests; a nix-store gst
+        # wouldn't satisfy the plugin's NEEDED libs), the C compiler (the c client
+        # links the prebuilt libmoq.a with the system cc), and Swift (system Xcode).
+        smoke = {
+          # orchestrator + harness, in every smoke shell.
+          base = with pkgs; [
+            just
+            git
+            ffmpeg
+            curl
+            jq
+            coreutils # GNU `timeout` (macOS lacks it)
+            procps # `pgrep`
+            gnutar
+            shellcheck # `just smoke check`
+            shfmt
+          ];
+          # `cargo install` of the reference binaries (only the nightly cargo
+          # channel; release slices get the reference relay via `nix build`).
+          rust = [ rust-toolchain ];
+          python = with pkgs; [
+            uv
+            python3
+          ];
+          go = [ pkgs.go ];
+          kotlin = with pkgs; [
+            jdk
+            gradle
+          ];
+          # browser + native-js, with a pinned Chromium so no `playwright install`
+          # download / `install-deps` apt step is needed.
+          js = with pkgs; [
+            bun
+            nodejs_24
+            playwright-driver.browsers
+          ];
+          # Point Playwright at the pinned nix Chromium; freshness.sh asserts
+          # clients/js pins this exact version. Only js shells get this (it pulls
+          # Chromium into the closure).
+          playwrightHook = ''
+            export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+            export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
+            export PLAYWRIGHT_VERSION="${pkgs.playwright-driver.version}"
+          '';
+        };
+
         # Apply our overlay to get the package definitions
         overlayPkgs = pkgs.extend self.overlays.default;
       in
@@ -222,6 +273,25 @@
             export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
           '';
         };
+
+        # Toolchains for the published-package smoke matrix (test/smoke). The full
+        # `smoke` shell drives the nightly (every client + the cargo channel); the
+        # per-slice shells keep each release job lean (a release runs one slice, so
+        # the swift job on the pricey macOS runner shouldn't pull jdk/Chromium).
+        # CI runs `nix develop .#smoke[-<slice>] --command ./test/smoke/smoke.sh ...`.
+        devShells.smoke = pkgs.mkShell {
+          packages = smoke.base ++ smoke.rust ++ smoke.python ++ smoke.go ++ smoke.kotlin ++ smoke.js;
+          shellHook = smoke.playwrightHook;
+        };
+        devShells.smoke-python = pkgs.mkShell { packages = smoke.base ++ smoke.python; };
+        devShells.smoke-go = pkgs.mkShell { packages = smoke.base ++ smoke.go; };
+        devShells.smoke-kotlin = pkgs.mkShell { packages = smoke.base ++ smoke.kotlin; };
+        devShells.smoke-js = pkgs.mkShell {
+          packages = smoke.base ++ smoke.js;
+          shellHook = smoke.playwrightHook;
+        };
+        # c / gst / swift need only the harness; their toolchain is system-level.
+        devShells.smoke-min = pkgs.mkShell { packages = smoke.base; };
 
         formatter = pkgs.nixfmt-tree;
       }

--- a/flake.nix
+++ b/flake.nix
@@ -156,11 +156,13 @@
         # Client toolchains for the published-package smoke matrix (test/smoke),
         # composed into per-slice devShells below. Kept SEPARATE from the default
         # shell so day-to-day `nix develop` never pulls go/jdk/gradle/Chromium.
-        # Three clients deliberately use the system toolchain, not nix, so they
-        # appear in no group: GStreamer (the gst client loads the prebuilt plugin
-        # against a *system* GStreamer, the scenario it tests; a nix-store gst
-        # wouldn't satisfy the plugin's NEEDED libs), the C compiler (the c client
-        # links the prebuilt libmoq.a with the system cc), and Swift (system Xcode).
+        # The c client needs no group: it links the prebuilt libmoq.a with the
+        # devShell's own stdenv cc, so the binary and its runtime share one libc
+        # (linking with the system cc and running under `nix develop` mixes the two
+        # and segfaults). Two clients genuinely use the system toolchain, not nix:
+        # GStreamer (the gst client loads the prebuilt plugin against a *system*
+        # GStreamer, the scenario it tests; a nix-store gst wouldn't satisfy the
+        # plugin's NEEDED libs) and Swift (system Xcode).
         smoke = {
           # orchestrator + harness, in every smoke shell.
           base = with pkgs; [

--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ mod go
 # Unit tests per language (`just test`).
 mod test
 
+# Cross-language interop smoke test against the published packages
+# (`just smoke <lang>`). Installs each client from its public registry.
+mod smoke 'test/smoke'
+
 # Demos and infra.
 mod demo
 mod infra

--- a/test/justfile
+++ b/test/justfile
@@ -3,8 +3,8 @@
 # Tests that span more than one language. Per-language unit tests live in each
 # language's own justfile; this module aggregates them.
 #
-# The cross-language interop smoke test against the published packages now lives
-# in its own repo: https://github.com/moq-dev/smoke
+# These build from workspace source. The cross-language interop smoke test
+# against the PUBLISHED packages lives in `test/smoke` (`just smoke <lang>`).
 
 # Fall back to the root justfile so `just js test` (etc.) resolve from here.
 set fallback

--- a/test/smoke/.gitignore
+++ b/test/smoke/.gitignore
@@ -1,0 +1,31 @@
+# Per-client build/install artifacts. Everything here is fetched from a public
+# package registry at test time, never committed.
+clients/js/node_modules/
+clients/js/dist-vite/
+clients/js/dist-esbuild/
+clients/js-native/node_modules/
+clients/token/js/node_modules/
+clients/go/bin/
+clients/swift/.build/
+clients/kotlin/.gradle/
+clients/kotlin/build/
+*.log
+
+# No committed PACKAGE lock files for the smoke clients: every latest-mode run
+# must re-resolve the moq packages under test to their LATEST published versions.
+# freshness.sh enforces this within this subtree only (the monorepo root commits
+# its own Cargo.lock / bun.lock / uv.lock, which are out of scope here).
+go.sum
+clients/js/bun.lock
+clients/js/bun.lockb
+clients/js-native/bun.lock
+clients/js-native/bun.lockb
+clients/token/js/bun.lock
+clients/token/js/bun.lockb
+Cargo.lock
+uv.lock
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+clients/swift/Package.resolved
+clients/kotlin/gradle.lockfile

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -2,7 +2,7 @@
 
 Cross-language interop smoke test for the **published** [Media over QUIC](https://github.com/moq-dev/moq) packages.
 
-The per-language unit tests (`just test`) build every client from workspace source. That proves the code in the tree works; it does **not** prove a real user can install the published artifacts and have them talk to each other. A missing wheel, a stale Homebrew formula, a broken `.deb`, an export that didn't survive packaging, a Go module missing its header. none of that shows up until someone installs from a registry.
+The per-language unit tests (`just test`) build every client from workspace source. That proves the code in the tree works; it does **not** prove a real user can install the published artifacts and have them talk to each other. A missing wheel, a stale Homebrew formula, a broken `.deb`, an export that didn't survive packaging, a Go module missing its header. None of that shows up until someone installs from a registry.
 
 This harness installs each client straight from its public package registry, stands up a relay, and runs the interop matrix:
 
@@ -95,7 +95,7 @@ The poll budget is `SMOKE_POLL_TRIES` x `SMOKE_POLL_SLEEP` (default 60 x 5s = 5 
 
 ## Layout
 
-```
+```text
 justfile                 per-language slices (`just smoke <lang>`), wired into the root justfile
 smoke.sh                 orchestrator: relay + media interop matrix
 smoke.toml               relay config (anonymous, self-signed localhost)

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -69,7 +69,7 @@ Or call the harness directly from this directory:
 RELAY_BIN=/path/to/moq-relay MOQ_BIN=/path/to/moq-cli ./smoke.sh
 ```
 
-The browser client needs a Chromium that matches the npm `playwright` pin in `clients/js/package.json`; set `PLAYWRIGHT_BROWSERS_PATH` to a nix `playwright-driver.browsers` (and `PLAYWRIGHT_VERSION` so `freshness.sh` can confirm the pin), or let `bunx playwright install chromium` fetch one. The monorepo `nix develop` shell does not currently carry Chromium, so `just smoke js` under it falls back to a Playwright download.
+The simplest way to get every toolchain (ffmpeg, uv, go, jdk/gradle, bun, node, and a pinned Chromium) is the `smoke` devShell: `nix develop .#smoke` (CI uses this, plus leaner per-slice `.#smoke-{python,go,kotlin,js,min}` shells). It sets `PLAYWRIGHT_BROWSERS_PATH`/`PLAYWRIGHT_VERSION` to the nix Chromium, so the browser client needs no `playwright install` download and `freshness.sh` can confirm the pin. The default `nix develop` stays lean and does not carry these. Without nix, install the toolchains yourself; the browser client falls back to `bunx playwright install chromium` (which must match the `playwright` pin in `clients/js/package.json`).
 
 ### Pinned mode
 

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -1,0 +1,192 @@
+# moq smoke
+
+Cross-language interop smoke test for the **published** [Media over QUIC](https://github.com/moq-dev/moq) packages.
+
+The per-language unit tests (`just test`) build every client from workspace source. That proves the code in the tree works; it does **not** prove a real user can install the published artifacts and have them talk to each other. A missing wheel, a stale Homebrew formula, a broken `.deb`, an export that didn't survive packaging, a Go module missing its header. none of that shows up until someone installs from a registry.
+
+This harness installs each client straight from its public package registry, stands up a relay, and runs the interop matrix:
+
+- A relay (`moq-relay`) routes broadcasts.
+- For each publisher language, publish an H.264 broadcast.
+- For each subscriber language, confirm bytes flow end-to-end (a non-empty frame before the timeout).
+
+We check that bytes move across implementations, not that H.264 decodes.
+
+## Clients and channels
+
+| Client | Source under test | Install |
+|---|---|---|
+| `moq-relay` + `moq-cli` (Rust) | crates.io / Homebrew tap / apt repo / the moq flake / Docker Hub | `cargo install`, `brew install moq-dev/tap/...`, `apt install`, `nix build github:moq-dev/moq#...`, `docker run moqdev/moq-relay` |
+| Python | [PyPI `moq-rs`](https://pypi.org/project/moq-rs/) (import `moq`) | `uv pip install moq-rs` |
+| Go | [`github.com/moq-dev/moq-go`](https://github.com/moq-dev/moq-go) | `go get` |
+| Browser | npm [`@moq/watch`](https://www.npmjs.com/package/@moq/watch) + [`@moq/publish`](https://www.npmjs.com/package/@moq/publish), delivered three ways | headless Chromium (Playwright) loading a **vite** bundle, an **esbuild** bundle, or straight from the **jsDelivr** ESM CDN |
+| Native JS | npm [`@moq/net`](https://www.npmjs.com/package/@moq/net) + [`@moq/hang`](https://www.npmjs.com/package/@moq/hang) + moq's own [`@moq/web-transport`](https://www.npmjs.com/package/@moq/web-transport) polyfill | non-browser runtimes: **node** and **bun** |
+| Swift | SPM [`moq-dev/moq-swift`](https://github.com/moq-dev/moq-swift) | `swift build` (macOS, Xcode toolchain) |
+| Kotlin | Maven Central [`dev.moq:moq`](https://central.sonatype.com/artifact/dev.moq/moq) | `gradle` (JVM) |
+| C | [`libmoq`](https://github.com/moq-dev/moq/releases) prebuilt release assets | `cc` + the platform tarball |
+| GStreamer | [`moq-gst`](https://github.com/moq-dev/moq/releases?q=moq-gst) prebuilt plugin (apt `gstreamer1.0-moq` / brew tap / rpm / tarball) | `gst-launch-1.0` + the platform tarball, against a **system** GStreamer |
+
+The **Native JS** client runs the JS packages *outside* a browser, where there's no native WebTransport, using moq's own `@moq/web-transport` polyfill (a prebuilt NAPI QUIC/HTTP3 addon). It runs as two cells, `js-native-node` and `js-native-bun`, to catch runtime-specific breakage. Subscribe only here too: publishing media needs a WebCodecs encoder, which a native JS runtime lacks (reading raw container frames doesn't).
+
+Swift, Kotlin, C, and GStreamer **subscribe only**. The FFI wrappers (Swift/Kotlin/C) publish through the streaming importer (`publish_media_stream`), which isn't in the published 0.2.x FFI yet, so they can only subscribe until it ships; the GStreamer cell drives `moqsrc` (publishing via `moqsink` needs an encoder + request-pad muxing — a follow-up). Rust and the browser publish today.
+
+The **GStreamer** client downloads the latest `moq-gst` plugin tarball, points `GST_PLUGIN_PATH` at it, and runs `moqsrc url=… broadcast=… ! filesink` — the same "did a frame's bytes arrive" bar as every other subscriber, no decode. The prebuilt plugin dynamic-links the host's *system* GStreamer (the `.deb`/brew/tarball scenario), so this cell needs `gst-launch-1.0` + the core plugins on the system, not nix; under a bare nix shell with no system GStreamer it just marks itself unavailable. Point `MOQ_GST_PLUGIN_DIR` at a local `cargo build -p moq-gst` output to test an unreleased build.
+
+The Rust binaries (`moq-relay`, `moq-cli`) ship through five channels that deliver the *same* binaries. CI treats each as a separate test where the OS supports it: Linux exercises **apt**, **cargo**, **nix**, **docker**; macOS exercises **brew**, **cargo**, **nix**. `smoke.sh` itself just takes whatever is on `PATH` (or `RELAY_BIN`/`MOQ_BIN`); the channel is chosen by how the binaries are provided:
+
+- **cargo** / **brew** / **apt** put the binaries on `PATH` (`cargo install moq-relay moq-cli`, etc.).
+- **nix** builds them from the moq flake (`just nix-channel`), the same outputs `nix run github:moq-dev/moq#moq-cli` resolves. The moq flake is referenced ad-hoc with `--refresh`, so the moq version is always the latest default-branch build, never locked by this repo.
+- **docker** points `RELAY_BIN`/`MOQ_BIN` at the wrapper scripts in [`clients/docker/`](clients/docker), which `docker run --network host` the published [`moqdev/moq-relay`](https://hub.docker.com/r/moqdev/moq-relay) + [`moqdev/moq-cli`](https://hub.docker.com/r/moqdev/moq-cli) images (`:latest`, pulled fresh). Host networking lets the containerised relay bind the ports the orchestrator and the cli containers reach on `127.0.0.1`, so the committed `smoke.toml` works unchanged. Linux-only (a native Docker daemon); the other language clients still install from their own registries, so this run also proves the Docker relay routes between every implementation. Override the runtime with `SMOKE_DOCKER=podman`.
+
+The **browser** client is itself three delivery variants of the *same* page, run as separate matrix cells, to catch breakage specific to how the package is consumed:
+
+- `js-vite` — bundled by [vite](https://vite.dev/).
+- `js-esbuild` — bundled by [esbuild](https://esbuild.github.io/) (a different bundler).
+- `js-jsdelivr` — no bundler, no install: the page `import`s the packages straight from the [jsDelivr](https://www.jsdelivr.com/) ESM CDN (`https://cdn.jsdelivr.net/npm/@moq/watch/element/+esm`), which resolves the export map and bundles the dep graph.
+
+## Running locally
+
+You bring `moq-relay` + `moq-cli` on `PATH` (the channel under test: `cargo install moq-relay moq-cli`, or brew / apt / nix), plus the toolchains for whichever clients you include (python -> uv, go -> go, browser/native -> bun + node + a Chromium, kotlin -> gradle, c -> a C compiler, gst -> a system GStreamer). `smoke.sh` installs the language clients (PyPI / Go proxy / npm / release assets) into a scratch dir on each run, so you always test the published versions. It does **not** install the Rust binaries.
+
+Run a per-language slice from the monorepo root with `just smoke <lang>` (each pairs the named client with rust on the opposite axis):
+
+```bash
+just smoke rust          # rust<->rust baseline (no network installs)
+just smoke python        # PyPI moq-rs, publish + subscribe
+just smoke swift         # SPM moq-dev/moq-swift, subscribe (macOS)
+just smoke js            # npm @moq/* browser variants: vite, esbuild, jsDelivr
+just smoke full          # the whole matrix
+just smoke negative      # no publisher; every subscriber must time out
+just smoke token         # token-tooling cross-verify (see below)
+```
+
+Or call the harness directly from this directory:
+
+```bash
+./smoke.sh --publishers rust,python --subscribers rust,python,js-jsdelivr --timeout 30
+
+# point at a specific relay/cli build instead of PATH:
+RELAY_BIN=/path/to/moq-relay MOQ_BIN=/path/to/moq-cli ./smoke.sh
+```
+
+The browser client needs a Chromium that matches the npm `playwright` pin in `clients/js/package.json`; set `PLAYWRIGHT_BROWSERS_PATH` to a nix `playwright-driver.browsers` (and `PLAYWRIGHT_VERSION` so `freshness.sh` can confirm the pin), or let `bunx playwright install chromium` fetch one. The monorepo `nix develop` shell does not currently carry Chromium, so `just smoke js` under it falls back to a Playwright download.
+
+### Pinned mode
+
+By default every client resolves the **newest** published version (the nightly's behaviour, guarded by `freshness.sh`). A release workflow instead tests the **exact** version it just cut by setting the matching env var, which flips the harness into pinned mode: it skips the freshness guard and polls the registry until that version resolves (a publish can finish before the artifact is downloadable).
+
+| Env | Client | Pins |
+|---|---|---|
+| `RELAY_BIN` / `MOQ_BIN` | rust | the relay/cli build under test |
+| `MOQ_RS_VERSION` | python | `moq-rs` on PyPI |
+| `MOQ_GO_VERSION` | go | `moq-dev/moq-go` |
+| `MOQ_NPM_VERSION` | js / js-native | `@moq/{net,hang,watch,publish}` on npm |
+| `MOQ_SWIFT_VERSION` | swift | `moq-dev/moq-swift` (SPM) |
+| `MOQ_KT_VERSION` | kotlin | `dev.moq:moq` (Maven Central) |
+| `MOQ_LIBMOQ_VERSION` | c | the `libmoq-v*` release tarball |
+| `MOQ_GST_VERSION` | gst | the `moq-gst-v*` release tarball |
+
+```bash
+# test exactly what a release just published:
+MOQ_RS_VERSION=0.2.17 just smoke python
+```
+
+The poll budget is `SMOKE_POLL_TRIES` x `SMOKE_POLL_SLEEP` (default 60 x 5s = 5 min).
+
+## Layout
+
+```
+justfile                 per-language slices (`just smoke <lang>`), wired into the root justfile
+smoke.sh                 orchestrator: relay + media interop matrix
+smoke.toml               relay config (anonymous, self-signed localhost)
+token.sh                 orchestrator: moq-token generate/verify interop matrix
+clients/
+  python/smoke.py        publish/subscribe via moq-rs (PyPI)
+  go/                     publish/subscribe via moq-dev/moq-go (go get)
+  js/                     headless-Chromium publish/subscribe via @moq/watch + @moq/publish;
+                          three delivery variants: vite, esbuild, jsdelivr (shared jsdelivr/setup.js)
+  swift/                  subscribe via moq-dev/moq-swift (SPM, macOS)
+  kotlin/                 subscribe via dev.moq:moq (Gradle/JVM)
+  c/subscribe.c          subscribe via libmoq (prebuilt release)
+  js-native/subscribe.ts subscribe via @moq/net + @moq/hang + WebTransport polyfill (node, bun)
+  (gst)                   subscribe via the moq-gst plugin (moqsrc); no client dir, driven by gst-launch
+  docker/                 moq-relay + moq-cli wrappers: docker run the moqdev/* images (the docker channel)
+  token/js/              installs @moq/token (npm) for token.sh to drive under node + bun
+freshness.sh             enforces the "always latest, no package locks" policy (latest mode)
+```
+
+CI lives at the repo root: [`.github/workflows/smoke.yml`](../../.github/workflows/smoke.yml) is the nightly Linux backstop (the full matrix across the cargo/apt/nix/docker channels) plus on-demand + PR-on-harness-change runs; [`.github/workflows/smoke-release.yml`](../../.github/workflows/smoke-release.yml) is a reusable per-language slice that each `release-*.yml` calls right after publishing, pinned to the version it just cut.
+
+## Token interop
+
+`token.sh` is a second, independent smoke test for moq's authentication tooling.
+`moq-relay` is keyed with a JWK and verifies the JWTs that publishers and
+subscribers present, so a token minted by one implementation has to verify under
+the implementation a relay was keyed with. The token tooling ships in several
+published flavours, and this test proves they cross-verify:
+
+| Cell | Source under test | Install |
+|---|---|---|
+| `rust` | the `moq-token-cli` binary (crates.io / Homebrew tap / apt repo / the moq flake) | `cargo install moq-token-cli`, `brew install moq-dev/tap/moq-token-cli`, `apt install`, `nix run github:moq-dev/moq#moq-token-cli` |
+| `js-node` | npm [`@moq/token`](https://www.npmjs.com/package/@moq/token)'s `moq-token` CLI, run under **node** | `npm i @moq/token` |
+| `js-bun` | the same published npm package, run under **bun** | `npm i @moq/token` |
+| `rust-docker` | the [`moqdev/moq-token-cli`](https://hub.docker.com/r/moqdev/moq-token-cli) Docker Hub image (`:latest`) | `docker run moqdev/moq-token-cli …` |
+
+Like `smoke.sh`, the Rust binary is taken from `PATH` (or `TOKEN_BIN`), so the
+install channel is whatever put `moq-token-cli` there; `@moq/token` is installed
+from npm on each run; `rust-docker` `docker pull`s the `moqdev/moq-token-cli`
+image fresh (`:latest`) and runs the CLI in a throwaway container with the scratch
+dir bind-mounted. The image is built `FROM nixos/nix` and ships the nix store, so
+it's a genuinely different artifact from the `cargo`/`brew`/`apt` binaries — and
+in CI it runs only on the Linux runners (GitHub's macOS runners have no Docker
+daemon); set `TOKEN_DOCKER=podman` to drive it with podman. For every
+*(generator × verifier × algorithm)* cell, the
+generator mints a key and signs a token, and the verifier checks it — covering
+both symmetric (`HS256`, shared secret) and asymmetric (`EdDSA`/`ES256`/`RS256`,
+sign-private/verify-public) keys, and the fact that one side's key encoding
+(the Rust CLI writes base64url-JSON; `@moq/token` writes plain JSON) loads on the
+other. A negative pass then confirms each verifier **rejects** a tampered token
+and a token signed by the wrong key, so a green cell means "accepts the valid
+one and refuses the bad ones", not "accepts everything".
+
+This complements moq's in-tree token unit tests: those run against workspace
+source with hardcoded fixtures; this runs the real published CLIs, live on both
+sides, so a packaging break (a missing bin in the `.deb`, a stale formula, an
+export that didn't survive `tsc`) shows up as a red cell.
+
+```bash
+just token            # default: rust generates + verifies (roundtrip + negatives)
+just token-full       # full matrix: rust, js-node, js-bun + rust-docker (the
+                      # moqdev/moq-token-cli image, where a container runtime is
+                      # available; set TOKEN_DOCKER=podman to use podman)
+# or call it directly with explicit axes:
+./token.sh --generators rust,js-node --verifiers rust,js-bun --algorithms HS256,EdDSA
+```
+
+## Always the latest moq packages (no package lock files)
+
+In latest mode (the nightly), to test what a user gets today, this harness commits **no client package lock files** under `test/smoke` (`go.sum`, `bun.lock`, `Cargo.lock`, `uv.lock`, ... are gitignored here; the monorepo's own root lock files are out of scope). Every run re-resolves the moq packages to their latest published versions: `@moq/*` at the `latest` npm tag, `moq-rs` via `uv pip install`, `moq-go` via `go get @latest`, and the **nix** channel builds the moq flake ad-hoc with `--refresh`. Pinned mode (above) is the deliberate exception, and skips this guard.
+
+The one version that can't float freely is the npm `playwright`, which must match the Chromium runtime in use. Point `PLAYWRIGHT_BROWSERS_PATH` at a nix `playwright-driver.browsers` and export its `PLAYWRIGHT_VERSION`; `freshness.sh` (run by `just smoke freshness`, by CI, and at the top of `smoke.sh` in latest mode) fails if the pin in `clients/js/package.json` drifts from it, if a *package* lock file gets committed, or if a moq package stops being requested at latest. So even the one pin can't go stale silently.
+
+```bash
+just smoke freshness   # enforce the policy
+just smoke check       # lint + freshness
+```
+
+## Current state
+
+This test tracks the **latest published** packages, so it sometimes runs ahead of a release. A red cell is the signal, not noise. As of this writing:
+
+- **Rust publish/subscribe** and **browser publish/subscribe** (all three delivery variants: vite, esbuild, jsDelivr): working (`cargo install` / `brew` / `apt` / `nix` + npm/CDN). The green baseline.
+- **Docker channel** (`moqdev/moq-relay` + `moqdev/moq-cli`, Linux): working. The containerised relay routes the full matrix and the containerised `moq-cli` publishes/subscribes end-to-end, validated against the published images.
+- **Python publish/subscribe**: working. `moq-rs` 0.2.16 shipped the streaming importer (`publish_media_stream`), so Python now publishes a raw Annex-B broadcast too, verified end-to-end against rust/swift/c subscribers.
+- **Swift / Kotlin / C subscribe**: working, verified end-to-end against the published 0.2.16 / 0.3.0 packages (`moq-dev/moq-swift`, `dev.moq:moq`, `libmoq`). Subscriber-only by choice.
+- **Native JS on bun** (`js-native-bun`): working. `@moq/net` + `@moq/hang` + moq's `@moq/web-transport` polyfill connect via WebTransport and read frames under Bun. (An earlier attempt with `@fails-components/webtransport` crashed Bun; moq's own polyfill is the one to use.)
+- **Native JS on node** (`js-native-node`): red. `@moq/web-transport`'s `src/session.ts` does `import { NapiClient } from "../napi.js"` — a *named* import from a napi-rs CJS module whose exports node's ESM loader can't statically see, so node throws `does not provide an export named 'NapiClient'`. Bun's looser CJS interop accepts it. The fix lives in `@moq/web-transport` (default-import the CJS binding, then destructure); this cell goes green once that ships. Tracked upstream in moq-dev/web-transport.
+- **Go (any role)**: red. The published `moq-dev/moq-go` module is still un-buildable (stuck at v0.2.15): it's missing the generated `moq.h` header (its `moq.go` does `#include <moq.h>`) and the linux static libs, so `go get` + build fails. Tracked upstream in moq-dev/moq's release-go packaging.
+- **GStreamer subscribe** (`gst`): red — but only because no `moq-gst` release has been published yet. The plugin, its packaging (apt/brew/rpm/tarball + nix), and a `gst-inspect` CI check all exist in-tree, but no `moq-gst-v*` tag has been cut, so there's no installable artifact and the cell reports "no moq-gst-v\* release found". The interop itself is verified: built from source (`cargo build -p moq-gst`) and pointed at via `MOQ_GST_PLUGIN_DIR`, `moqsrc` reads a rust-published H.264 broadcast end-to-end. The cell flips green automatically once the first release ships.
+- **Token interop** (`token.sh`): working on **cargo / apt / nix** plus the **`moqdev/moq-token-cli` Docker image** (Linux). The published `moq-token-cli` (crates.io / apt / nix / Docker Hub) and `@moq/token` (npm, under both node and bun) cross-verify every token across `HS256`, `EdDSA`, `ES256`, and `RS256`, and each verifier rejects tampered tokens and the wrong key. The Docker cell (`rust-docker`) proves the image — built `FROM nixos/nix`, so it carries the libiconv the brew bottle leaks — runs cleanly. Subscriber-only languages don't ship token tooling yet, so the matrix is rust (binary + Docker) + the two JS runtimes for now.
+- **Token interop on the Homebrew bottle** (`rust` cells, macOS `brew`): red. The published `moq-dev/tap/moq-token-cli` bottle aborts on launch — it baked in a `/nix/store/…-libiconv/lib/libiconv.2.dylib` rpath from the build sandbox that doesn't exist on a user's Mac (`dyld: Library not loaded`). `token.sh` runs the binary once at startup and marks `rust` unavailable when it won't launch, so the JS cells still report; the row goes green once the bottle is rebuilt without the leaked path. Exactly the packaging break this repo exists to surface. Tracked upstream in moq-dev/moq's Homebrew packaging.
+
+A broken published package fails only its own matrix cells (see `mark_broken` in `smoke.sh` / `token.sh`); it never aborts the rest of the run.

--- a/test/smoke/clients/c/subscribe.c
+++ b/test/smoke/clients/c/subscribe.c
@@ -1,0 +1,149 @@
+// Subscribe-only cross-language interop client for the smoke test, linked
+// against the prebuilt libmoq (the C bindings, libmoq-v* release assets).
+//
+// libmoq is a handle + callback API: connect, consume a broadcast, get a
+// catalog snapshot via callback, start the video track, and a frame callback
+// fires as frames arrive. We exit 0 the moment a non-empty frame lands, 1 on
+// timeout. Publishing isn't wired up: the raw-stream importer that the other
+// clients use to publish isn't part of this subscribe-only client.
+//
+//   c-smoke subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+#include <moq.h>
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+typedef struct {
+    pthread_mutex_t mu;
+    pthread_cond_t cv;
+    int got;           // a non-empty frame arrived
+    int video_started; // guard: start the video track only once
+} ctx_t;
+
+// Callbacks run on libmoq's runtime thread; main waits on the condvar. ctx
+// lives on main's stack and outlives the callbacks (main blocks until got/
+// timeout, then the process exits), so there's no use-after-free.
+static void on_status(void *ud, int32_t code) {
+    (void)ud;
+    fprintf(stderr, "session status: %d\n", code);
+}
+
+static void on_frame(void *ud, int32_t frame) {
+    ctx_t *c = (ctx_t *)ud;
+    if (frame <= 0) return; // 0 = ended, negative = error
+    moq_frame f;
+    memset(&f, 0, sizeof(f));
+    if (moq_consume_frame((uint32_t)frame, &f) == 0 && f.payload_size > 0) {
+        pthread_mutex_lock(&c->mu);
+        c->got = 1;
+        pthread_cond_signal(&c->cv);
+        pthread_mutex_unlock(&c->mu);
+    }
+    moq_consume_frame_close((uint32_t)frame);
+}
+
+static void on_catalog(void *ud, int32_t catalog) {
+    ctx_t *c = (ctx_t *)ud;
+    if (catalog <= 0) return;
+
+    pthread_mutex_lock(&c->mu);
+    int start = !c->video_started;
+    pthread_mutex_unlock(&c->mu);
+
+    if (start) {
+        // A lazy publisher may announce video in a later catalog update, so this
+        // just no-ops (config returns < 0) until a video track exists at index 0.
+        moq_video_config vcfg;
+        memset(&vcfg, 0, sizeof(vcfg));
+        if (moq_consume_video_config((uint32_t)catalog, 0, &vcfg) == 0) {
+            int32_t track = moq_consume_video_ordered((uint32_t)catalog, 0, 1000, on_frame, ud);
+            if (track > 0) {
+                pthread_mutex_lock(&c->mu);
+                c->video_started = 1;
+                pthread_mutex_unlock(&c->mu);
+            }
+        }
+    }
+    moq_consume_catalog_free((uint32_t)catalog);
+}
+
+int main(int argc, char **argv) {
+    const char *url = NULL, *broadcast = NULL;
+    double timeout_s = 20.0;
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--url") && i + 1 < argc) url = argv[++i];
+        else if (!strcmp(argv[i], "--broadcast") && i + 1 < argc) broadcast = argv[++i];
+        else if (!strcmp(argv[i], "--timeout") && i + 1 < argc) timeout_s = atof(argv[++i]);
+        // a leading "subscribe" positional (and anything else) is ignored.
+    }
+    if (!url || !broadcast) {
+        fprintf(stderr, "usage: c-smoke subscribe --url U --broadcast B [--timeout S]\n");
+        return 2;
+    }
+
+    ctx_t c;
+    pthread_mutex_init(&c.mu, NULL);
+    pthread_cond_init(&c.cv, NULL);
+    c.got = 0;
+    c.video_started = 0;
+
+    int32_t origin = moq_origin_create();
+    if (origin <= 0) {
+        fprintf(stderr, "error: moq_origin_create failed: %d\n", origin);
+        return 1;
+    }
+
+    // origin_publish = 0 disables publishing; consume via our origin.
+    int32_t session = moq_session_connect(url, strlen(url), 0, (uint32_t)origin, on_status, &c);
+    if (session <= 0) {
+        fprintf(stderr, "error: moq_session_connect failed: %d\n", session);
+        return 1;
+    }
+
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += (time_t)timeout_s;
+
+    // moq_origin_consume is a synchronous lookup, but the broadcast arrives over
+    // the network after connect. Retry until it's announced (or we run out of
+    // time). We don't enable libmoq logging, so the misses stay quiet.
+    int32_t bc = -1;
+    while (1) {
+        bc = moq_origin_consume((uint32_t)origin, broadcast, strlen(broadcast));
+        if (bc > 0) break;
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+        if (now.tv_sec >= deadline.tv_sec) break;
+        usleep(150 * 1000);
+    }
+    if (bc <= 0) {
+        fprintf(stderr, "error: broadcast never announced (moq_origin_consume: %d)\n", bc);
+        return 1;
+    }
+
+    int32_t cat = moq_consume_catalog((uint32_t)bc, on_catalog, &c);
+    if (cat <= 0) {
+        fprintf(stderr, "error: moq_consume_catalog failed: %d\n", cat);
+        return 1;
+    }
+
+    pthread_mutex_lock(&c.mu);
+    while (!c.got) {
+        if (pthread_cond_timedwait(&c.cv, &c.mu, &deadline) != 0) break; // timed out
+    }
+    int got = c.got;
+    pthread_mutex_unlock(&c.mu);
+
+    if (got) {
+        fprintf(stderr, "received a frame from %s\n", broadcast);
+        moq_session_close((uint32_t)session);
+        return 0;
+    }
+    fprintf(stderr, "error: timed out waiting for data\n");
+    return 1;
+}

--- a/test/smoke/clients/docker/moq-cli
+++ b/test/smoke/clients/docker/moq-cli
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Run the published moqdev/moq-cli Docker image as the cli-under-test (the
+# publisher and the rust subscriber), the moq-cli half of the Docker channel.
+#
+# Host networking so it reaches the relay on 127.0.0.1; -i so the publisher can
+# pipe ffmpeg's Annex-B stream to `moq publish` over the container's stdin.
+# Linux-only for the same reason as the moq-relay wrapper. Override with
+# SMOKE_DOCKER=podman / MOQ_CLI_IMAGE.
+set -euo pipefail
+
+runtime="${SMOKE_DOCKER:-docker}"
+image="${MOQ_CLI_IMAGE:-moqdev/moq-cli}"
+
+exec "$runtime" run --rm -i --network host "$image" "$@"

--- a/test/smoke/clients/docker/moq-relay
+++ b/test/smoke/clients/docker/moq-relay
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run the published moqdev/moq-relay Docker image as the relay-under-test, so the
+# media smoke exercises the Docker Hub channel alongside cargo/brew/apt/nix.
+#
+# smoke.sh points RELAY_BIN at this script and invokes it with the relay config
+# path. We bind-mount that file's directory and use host networking so the relay
+# binds the ports the orchestrator (curl on 127.0.0.1) and the moq-cli containers
+# reach -- the committed smoke.toml's 127.0.0.1 listeners work unchanged.
+#
+# Linux-only: --network host needs a native Docker daemon sharing the host's
+# network namespace, which GitHub's macOS runners (and Docker Desktop / podman
+# machine VMs) don't provide. Override the runtime with SMOKE_DOCKER=podman and
+# the image with MOQ_RELAY_IMAGE.
+set -euo pipefail
+
+runtime="${SMOKE_DOCKER:-docker}"
+image="${MOQ_RELAY_IMAGE:-moqdev/moq-relay}"
+
+# smoke.sh passes the config path as the final argument.
+cfg="${*: -1}"
+dir=$(cd "$(dirname "$cfg")" && pwd)
+
+exec "$runtime" run --rm -i --network host -v "$dir:$dir" "$image" "$@"

--- a/test/smoke/clients/go/go.mod
+++ b/test/smoke/clients/go/go.mod
@@ -1,0 +1,5 @@
+module moqsmoke
+
+go 1.23
+
+require github.com/moq-dev/moq-go v0.2.15

--- a/test/smoke/clients/go/smoke.go
+++ b/test/smoke/clients/go/smoke.go
@@ -1,0 +1,209 @@
+// Cross-language interop client for the smoke test, built against the published
+// github.com/moq-dev/moq-go module (the raw uniffi-bindgen-go surface).
+//
+// publish:   read raw Annex-B H.264 from stdin (e.g. piped from ffmpeg) and feed
+//            it to a streaming importer, which infers frame boundaries.
+// subscribe: connect, find the video track in the catalog, and exit 0 as soon as
+//            any non-empty frame arrives (exit 1 on timeout / no data).
+//
+//	ffmpeg ... -f h264 - | go-smoke publish   --url http://127.0.0.1:4443 --broadcast b.hang
+//	                       go-smoke subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/moq-dev/moq-go/moq"
+)
+
+const (
+	readChunk    = 64 * 1024
+	maxLatencyMs = 1000 // subscribe_media congestion-control / lookahead window
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go-smoke publish|subscribe --url U --broadcast B [--timeout S]")
+		os.Exit(2)
+	}
+	role := os.Args[1]
+
+	fs := flag.NewFlagSet(role, flag.ExitOnError)
+	url := fs.String("url", "", "MoQ server URL")
+	broadcast := fs.String("broadcast", "", "broadcast name")
+	timeout := fs.Float64("timeout", 20, "subscribe timeout in seconds")
+	_ = fs.Parse(os.Args[2:])
+
+	if *url == "" || *broadcast == "" {
+		fmt.Fprintln(os.Stderr, "error: --url and --broadcast are required")
+		os.Exit(2)
+	}
+
+	var err error
+	switch role {
+	case "publish":
+		err = publish(*url, *broadcast)
+	case "subscribe":
+		err = subscribe(*url, *broadcast, *timeout)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown role: %s\n", role)
+		os.Exit(2)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func publish(url, broadcast string) error {
+	origin := moq.NewMoqOriginProducer()
+	defer origin.Destroy()
+
+	producer, err := moq.NewMoqBroadcastProducer()
+	if err != nil {
+		return err
+	}
+	defer producer.Destroy()
+
+	// avc3: a self-describing Annex-B H.264 stream the importer can frame on its own.
+	media, err := producer.PublishMediaStream("avc3")
+	if err != nil {
+		return err
+	}
+	defer media.Destroy()
+
+	if err := origin.Publish(broadcast, producer); err != nil {
+		return err
+	}
+
+	client := moq.NewMoqClient()
+	defer client.Destroy()
+	client.SetTlsDisableVerify(true)
+	client.SetPublish(&origin)
+
+	session, err := client.Connect(url)
+	if err != nil {
+		return err
+	}
+	defer session.Destroy()
+
+	fmt.Fprintf(os.Stderr, "publishing %q (Annex-B H.264 from stdin) to %s\n", broadcast, url)
+
+	buf := make([]byte, readChunk)
+	for {
+		n, rerr := os.Stdin.Read(buf)
+		if n > 0 {
+			if werr := media.Write(buf[:n]); werr != nil {
+				return werr
+			}
+		}
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return rerr
+		}
+	}
+	return media.Finish()
+}
+
+func subscribe(url, broadcast string, timeoutS float64) error {
+	done := make(chan error, 1)
+	go func() { done <- subscribeInner(url, broadcast) }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(time.Duration(timeoutS * float64(time.Second))):
+		// The FFI calls below block; the process exit tears down the goroutine.
+		return fmt.Errorf("timed out waiting for data")
+	}
+}
+
+func subscribeInner(url, broadcast string) error {
+	origin := moq.NewMoqOriginProducer()
+	defer origin.Destroy()
+
+	client := moq.NewMoqClient()
+	defer client.Destroy()
+	client.SetTlsDisableVerify(true)
+	client.SetConsume(&origin)
+
+	session, err := client.Connect(url)
+	if err != nil {
+		return err
+	}
+	defer session.Destroy()
+
+	consumer := origin.Consume()
+	defer consumer.Destroy()
+
+	announced, err := consumer.AnnouncedBroadcast(broadcast)
+	if err != nil {
+		return err
+	}
+	defer announced.Destroy()
+
+	bc, err := announced.Available()
+	if err != nil {
+		return err
+	}
+	defer bc.Destroy()
+
+	name, video, err := videoTrack(bc)
+	if err != nil {
+		return err
+	}
+
+	media, err := bc.SubscribeMedia(name, video.Container, maxLatencyMs)
+	if err != nil {
+		return err
+	}
+	defer media.Destroy()
+
+	total := 0
+	for {
+		frame, err := media.Next()
+		if err != nil {
+			return err
+		}
+		if frame == nil {
+			break
+		}
+		total += len(frame.Payload)
+		if total > 0 {
+			fmt.Fprintf(os.Stderr, "received %d bytes from %q\n", total, broadcast)
+			return nil
+		}
+	}
+	return fmt.Errorf("no frame data received")
+}
+
+// videoTrack waits for a catalog update that actually carries a video track. A
+// lazy publisher (e.g. the browser, which only encodes on demand) may announce
+// video in a later update, not the first snapshot.
+func videoTrack(bc *moq.MoqBroadcastConsumer) (string, moq.MoqVideo, error) {
+	cat, err := bc.SubscribeCatalog()
+	if err != nil {
+		return "", moq.MoqVideo{}, err
+	}
+	defer cat.Destroy()
+
+	for {
+		catalog, err := cat.Next()
+		if err != nil {
+			return "", moq.MoqVideo{}, err
+		}
+		if catalog == nil {
+			return "", moq.MoqVideo{}, fmt.Errorf("catalog stream ended without a video track")
+		}
+		for name, video := range catalog.Video {
+			return name, video, nil
+		}
+	}
+}

--- a/test/smoke/clients/js-native/package.json
+++ b/test/smoke/clients/js-native/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@moq/smoke-native",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@moq/hang": "latest",
+    "@moq/net": "latest",
+    "@moq/web-transport": "latest",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0"
+  }
+}

--- a/test/smoke/clients/js-native/subscribe.ts
+++ b/test/smoke/clients/js-native/subscribe.ts
@@ -1,0 +1,106 @@
+// Native-JS (non-browser) subscriber: run the published @moq/net + @moq/hang
+// packages under a JS runtime that has no native WebTransport, using moq's own
+// @moq/web-transport polyfill (a prebuilt NAPI QUIC/HTTP3 addon). Runs under both
+// node and bun -- see the smoke harness.
+//
+// Connect, read the .hang catalog to find the video track, subscribe it, and
+// exit 0 as soon as any non-empty frame arrives (1 on timeout).
+//
+//   node --import tsx subscribe.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+//
+// Subscribe-only: publishing media needs a WebCodecs encoder, which a native JS
+// runtime doesn't have. Reading raw container frames needs no codec.
+import { parseArgs } from "node:util";
+import * as Catalog from "@moq/hang/catalog";
+import * as Moq from "@moq/net";
+import { install } from "@moq/web-transport";
+
+// globalThis.WebTransport = the polyfill (no-op if a native one already exists).
+// @moq/net's connect() reads globalThis.WebTransport at call time, so this just
+// has to run before run() below.
+install();
+
+const { positionals, values } = parseArgs({
+	allowPositionals: true,
+	options: {
+		url: { type: "string" },
+		broadcast: { type: "string" },
+		timeout: { type: "string", default: "20" },
+	},
+});
+
+const role = positionals[0];
+const url = values.url;
+const broadcast = values.broadcast;
+const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
+if (role !== "subscribe" || !url || !broadcast) {
+	console.error("usage: subscribe.ts subscribe --url U --broadcast B [--timeout S]");
+	process.exit(2);
+}
+
+async function run(): Promise<void> {
+	const connection = await Moq.Connection.connect(new URL(url as string));
+	try {
+		const path = Moq.Path.from(broadcast as string);
+
+		// Wait for the broadcast to be announced before subscribing. Subscribing to a
+		// track on a broadcast the publisher hasn't announced yet races the relay,
+		// which resets the catalog stream (RESET_STREAM). The Rust API folds this
+		// wait into consume(); the JS API leaves it to the caller. The outer timeout
+		// below bounds how long we wait.
+		const announced = connection.announced(path);
+		try {
+			for (;;) {
+				const entry = await announced.next();
+				if (!entry) throw new Error("connection closed before broadcast was announced");
+				if (entry.active && Moq.Path.hasPrefix(path, entry.path)) break;
+			}
+		} finally {
+			announced.close();
+		}
+
+		const bc = connection.consume(path);
+
+		// The .hang catalog lives on the "catalog.json" track. A lazy publisher may
+		// announce video in a later update, so keep reading frames until one has it.
+		const catalog = bc.subscribe("catalog.json", Catalog.PRIORITY.catalog);
+		let videoTrack: string | undefined;
+		while (!videoTrack) {
+			const root = await Catalog.fetch(catalog);
+			if (!root) throw new Error("catalog ended without a video track");
+			const renditions = root.video?.renditions;
+			if (renditions) videoTrack = Object.keys(renditions)[0];
+		}
+
+		const video = bc.subscribe(videoTrack, 0);
+		let total = 0;
+		for (;;) {
+			const group = await video.recvGroup();
+			if (!group) break;
+			for (;;) {
+				const frame = await group.readFrame();
+				if (!frame) break;
+				total += frame.byteLength;
+				if (total > 0) {
+					console.error(`received ${total} bytes from ${broadcast}`);
+					return;
+				}
+			}
+		}
+		throw new Error("no frame data received");
+	} finally {
+		connection.close(); // returns void, not a promise
+	}
+}
+
+const timeout = new Promise<never>((_, reject) =>
+	setTimeout(() => reject(new Error("timed out waiting for data")), timeoutMs),
+);
+
+try {
+	await Promise.race([run(), timeout]);
+	process.exit(0);
+} catch (err) {
+	console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+	process.exit(1);
+}

--- a/test/smoke/clients/js/build-esbuild.ts
+++ b/test/smoke/clients/js/build-esbuild.ts
@@ -1,0 +1,25 @@
+// The "another bundler" variant: bundle the same entry point with esbuild
+// instead of vite, to confirm the published packages consume cleanly under a
+// different bundler. Writes dist-esbuild/{main.js,index.html}.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { build } from "esbuild";
+
+await build({
+	entryPoints: ["src/main.ts"],
+	bundle: true,
+	format: "esm",
+	target: "esnext",
+	outfile: "dist-esbuild/main.js",
+	logLevel: "info",
+});
+
+mkdirSync("dist-esbuild", { recursive: true });
+writeFileSync(
+	"dist-esbuild/index.html",
+	`<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>moq smoke (esbuild)</title></head>
+  <body><script type="module" src="./main.js"></script></body>
+</html>
+`,
+);

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -1,0 +1,108 @@
+// Drives a headless Chromium (channel "chromium" for WebTransport + WebCodecs)
+// against a prebuilt page. publish streams a fake camera until killed; subscribe
+// exits 0 once the watch element decodes a frame.
+//
+// --variant selects how the published packages are delivered to the page:
+//   vite      bundled by vite           -> dist-vite/
+//   esbuild   bundled by esbuild        -> dist-esbuild/
+//   jsdelivr  imported from the CDN      -> jsdelivr/ (no build)
+// The smoke harness builds the bundler variants first; jsdelivr needs no build.
+//
+//   bun driver.ts publish   --variant vite --url http://127.0.0.1:4443 --broadcast b.hang
+//   bun driver.ts subscribe --variant jsdelivr --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { chromium } from "playwright";
+
+const { positionals, values } = parseArgs({
+	allowPositionals: true,
+	options: {
+		url: { type: "string" },
+		broadcast: { type: "string" },
+		variant: { type: "string", default: "vite" },
+		timeout: { type: "string", default: "20" },
+	},
+});
+
+const role = positionals[0];
+const url = values.url;
+const broadcast = values.broadcast;
+const variant = values.variant ?? "vite";
+const dirByVariant: Record<string, string> = {
+	vite: "dist-vite",
+	esbuild: "dist-esbuild",
+	jsdelivr: "jsdelivr",
+};
+const dir = dirByVariant[variant];
+if ((role !== "publish" && role !== "subscribe") || !url || !broadcast || !dir) {
+	console.error("usage: driver.ts publish|subscribe --variant vite|esbuild|jsdelivr --url U --broadcast B [--timeout S]");
+	process.exit(2);
+}
+const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
+
+// Serve the prebuilt page on localhost (a secure context, so WebTransport /
+// WebCodecs are enabled). A plain static server avoids running concurrent Vite
+// dev servers, which deadlock on the shared dep-optimizer cache.
+const root = join(new URL(".", import.meta.url).pathname, dir);
+const server = Bun.serve({
+	port: 0,
+	async fetch(req) {
+		let path = new URL(req.url).pathname;
+		if (path === "/") path = "/index.html";
+		const file = Bun.file(join(root, path));
+		if (await file.exists()) return new Response(file);
+		return new Response(Bun.file(join(root, "index.html"))); // SPA fallback
+	},
+});
+const pageUrl = `http://localhost:${server.port}/?role=${role}&url=${encodeURIComponent(url)}&broadcast=${encodeURIComponent(broadcast)}`;
+
+const browser = await chromium.launch({
+	channel: "chromium", // full Chromium (new headless); the headless shell lacks these APIs
+	headless: true,
+	args: [
+		"--use-fake-device-for-media-stream",
+		"--use-fake-ui-for-media-stream",
+		"--autoplay-policy=no-user-gesture-required",
+	],
+});
+
+let code = 1;
+try {
+	const page = await browser.newPage();
+	page.on("console", (m) => console.error(`[page] ${m.text()}`));
+	page.on("pageerror", (e) => console.error(`[page error] ${e.message}`));
+	await page.goto(pageUrl, { waitUntil: "load" });
+
+	if (role === "publish") {
+		console.error(`publishing ${broadcast} (fake camera, ${variant}) to ${url}`);
+		await new Promise(() => {}); // stream until the orchestrator kills us
+	} else {
+		const start = Date.now();
+		const deadline = start + timeoutMs;
+		let frames = 0;
+		let reloaded = false;
+		while (Date.now() < deadline) {
+			frames = await page.evaluate(() => {
+				const w = document.querySelector("moq-watch") as unknown as {
+					backend?: { video?: { stats?: { peek(): { frameCount?: number } | undefined } } };
+				} | null;
+				return w?.backend?.video?.stats?.peek()?.frameCount ?? 0;
+			});
+			if (frames > 0) break;
+			// The watch element gives up if it subscribes to the catalog before the
+			// publisher has announced it (RESET_STREAM). If nothing has decoded by the
+			// halfway mark, reload once to re-subscribe now that the publisher is up.
+			if (!reloaded && Date.now() - start > timeoutMs / 2) {
+				reloaded = true;
+				await page.reload({ waitUntil: "load" }).catch(() => {});
+			}
+			await new Promise((r) => setTimeout(r, 250));
+		}
+		console.error(`decoded ${frames} frames from ${broadcast} (${variant})`);
+		code = frames > 0 ? 0 : 1;
+	}
+} finally {
+	await browser.close().catch(() => {});
+	server.stop(true);
+}
+process.exit(code);

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -39,6 +39,9 @@ if ((role !== "publish" && role !== "subscribe") || !url || !broadcast || !dir) 
 	process.exit(2);
 }
 const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
+// If nothing has decoded by this fraction of the timeout, reload once to
+// re-subscribe (the publisher may have come up after the first subscribe).
+const RELOAD_AT_FRACTION = 0.5;
 
 // Serve the prebuilt page on localhost (a secure context, so WebTransport /
 // WebCodecs are enabled). A plain static server avoids running concurrent Vite
@@ -90,9 +93,9 @@ try {
 			});
 			if (frames > 0) break;
 			// The watch element gives up if it subscribes to the catalog before the
-			// publisher has announced it (RESET_STREAM). If nothing has decoded by the
-			// halfway mark, reload once to re-subscribe now that the publisher is up.
-			if (!reloaded && Date.now() - start > timeoutMs / 2) {
+			// publisher has announced it (RESET_STREAM). Reload once past the
+			// threshold to re-subscribe now that the publisher is up.
+			if (!reloaded && Date.now() - start > timeoutMs * RELOAD_AT_FRACTION) {
 				reloaded = true;
 				await page.reload({ waitUntil: "load" }).catch(() => {});
 			}

--- a/test/smoke/clients/js/index.html
+++ b/test/smoke/clients/js/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>moq smoke</title>
+  </head>
+  <body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/test/smoke/clients/js/jsdelivr/index.html
+++ b/test/smoke/clients/js/jsdelivr/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>moq smoke (jsdelivr)</title>
+  </head>
+  <body>
+    <!-- No bundler, no install: pull the published packages straight from the
+         jsDelivr ESM CDN. /+esm resolves the package export map and bundles the
+         dependency graph (@moq/hang, @moq/net, @moq/signals) into one module.
+         No @version pin, so jsDelivr serves the latest published release. -->
+    <script type="module">
+      import "https://cdn.jsdelivr.net/npm/@moq/publish/element/+esm";
+      import "https://cdn.jsdelivr.net/npm/@moq/watch/element/+esm";
+      import "./setup.js";
+    </script>
+  </body>
+</html>

--- a/test/smoke/clients/js/jsdelivr/setup.js
+++ b/test/smoke/clients/js/jsdelivr/setup.js
@@ -1,0 +1,30 @@
+// Shared role logic for every browser variant (vite, esbuild, jsdelivr). Pure
+// DOM, no package imports: each entry point registers the <moq-publish> /
+// <moq-watch> elements first (bundled or from the CDN), then imports this to
+// wire one up based on ?role=. The Playwright driver polls the watch element's
+// decoded-frame stats.
+const params = new URLSearchParams(location.search);
+const role = params.get("role");
+const url = params.get("url") ?? "";
+const broadcast = params.get("broadcast") ?? "";
+
+if (role === "publish") {
+	const el = document.createElement("moq-publish");
+	el.setAttribute("url", url);
+	el.setAttribute("name", broadcast);
+	el.setAttribute("muted", ""); // video only; keep the audio encoder out of it
+	// Chromium's --use-fake-device-for-media-stream feeds getUserMedia a pattern.
+	el.setAttribute("source", "camera");
+	document.body.appendChild(el);
+} else if (role === "subscribe") {
+	const el = document.createElement("moq-watch");
+	el.setAttribute("url", url);
+	el.setAttribute("name", broadcast);
+	// A render target is what makes <moq-watch> actually subscribe to and decode
+	// the video track. @moq/publish only encodes on subscriber demand, so without
+	// this the publisher never produces frames.
+	el.appendChild(document.createElement("canvas"));
+	document.body.appendChild(el);
+} else {
+	throw new Error("missing ?role=publish|subscribe");
+}

--- a/test/smoke/clients/js/package.json
+++ b/test/smoke/clients/js/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@moq/smoke-browser",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@moq/publish": "latest",
+    "@moq/watch": "latest"
+  },
+  "devDependencies": {
+    "esbuild": "^0.27.0",
+    "playwright": "1.59.1",
+    "vite": "^7.3.1"
+  }
+}

--- a/test/smoke/clients/js/src/main.ts
+++ b/test/smoke/clients/js/src/main.ts
@@ -1,0 +1,6 @@
+// Bundler entry point for the vite and esbuild variants. Registers the public
+// custom elements from the installed npm packages, then runs the shared role
+// logic. The jsdelivr variant does the same via CDN imports in its index.html.
+import "@moq/publish/element";
+import "@moq/watch/element";
+import "../jsdelivr/setup.js";

--- a/test/smoke/clients/js/vite.config.ts
+++ b/test/smoke/clients/js/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+
+// The published @moq/publish already inlines its audio worklets at build time,
+// so a consumer needs no special plugin. esnext keeps WebCodecs/WebTransport
+// syntax intact. Output to dist-vite/ so the esbuild variant can sit beside it.
+export default defineConfig({
+	build: { target: "esnext", outDir: "dist-vite" },
+});

--- a/test/smoke/clients/kotlin/build.gradle.kts
+++ b/test/smoke/clients/kotlin/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    kotlin("jvm") version "2.0.21"
+    application
+}
+
+repositories { mavenCentral() }
+
+dependencies {
+    // Latest mode (default): the dynamic `latest.release` always resolves the
+    // newest published dev.moq:moq. No dependency lockfile is committed, and
+    // caches of dynamic versions are disabled below, so each run re-resolves.
+    // Pinned mode: a release passes -PmoqVersion (or MOQ_KT_VERSION) with the
+    // exact version it just cut, so the smoke run tests that build.
+    val moqVersion = (findProperty("moqVersion") as String?)?.takeIf { it.isNotBlank() }
+        ?: System.getenv("MOQ_KT_VERSION")?.takeIf { it.isNotBlank() }
+        ?: "latest.release"
+    implementation("dev.moq:moq:$moqVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+}
+
+configurations.all {
+    resolutionStrategy.cacheDynamicVersionsFor(0, "seconds")
+}
+
+application { mainClass.set("MainKt") }

--- a/test/smoke/clients/kotlin/settings.gradle.kts
+++ b/test/smoke/clients/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "smoke"

--- a/test/smoke/clients/kotlin/src/main/kotlin/Main.kt
+++ b/test/smoke/clients/kotlin/src/main/kotlin/Main.kt
@@ -1,0 +1,90 @@
+// Subscribe-only cross-language interop client for the smoke test, built on the
+// published Kotlin package (dev.moq:moq on Maven Central). Connect, find the
+// video track in the catalog, and exit 0 as soon as any non-empty frame arrives
+// (1 on timeout).
+//
+//   smoke subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+//
+// Publishing isn't wired up: the raw-stream importer the other clients publish
+// with isn't in the published 0.2.x FFI yet, so this client only subscribes.
+import dev.moq.frames
+import dev.moq.updates
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import uniffi.moq.MoqBroadcastConsumer
+import uniffi.moq.MoqClient
+import uniffi.moq.MoqOriginProducer
+import uniffi.moq.MoqVideo
+import kotlin.system.exitProcess
+
+private const val MAX_LATENCY_MS = 1_000uL
+
+// A catalog update that actually carries a video track. A lazy publisher may
+// announce video in a later update, not the first snapshot.
+private suspend fun videoTrack(bc: MoqBroadcastConsumer): Pair<String, MoqVideo> =
+    bc.subscribeCatalog().use { catalog ->
+        catalog.updates()
+            .mapNotNull { it.video.entries.firstOrNull() }
+            .first()
+            .let { it.key to it.value }
+    }
+
+private suspend fun subscribe(url: String, broadcast: String) {
+    val origin = MoqOriginProducer()
+    val client = MoqClient()
+    client.setTlsDisableVerify(true)
+    client.setConsume(origin)
+
+    val session = client.connect(url)
+    try {
+        val consumer = origin.consume()
+        val announced = consumer.announcedBroadcast(broadcast)
+        val bc = announced.available()
+
+        val (name, video) = videoTrack(bc)
+        val media = bc.subscribeMedia(name, video.container, MAX_LATENCY_MS)
+
+        // Suspends until the first non-empty frame, or throws if the flow ends.
+        val frame = media.frames().first { it.payload.isNotEmpty() }
+        System.err.println("received ${frame.payload.size} bytes from $broadcast")
+    } finally {
+        session.cancel(0u) // code 0 = graceful close
+    }
+}
+
+fun main(args: Array<String>) {
+    var url = ""
+    var broadcast = ""
+    var timeout = 20.0
+    var i = 0
+    while (i < args.size) {
+        when (args[i]) {
+            "--url" -> url = args.getOrElse(++i) { "" }
+            "--broadcast" -> broadcast = args.getOrElse(++i) { "" }
+            "--timeout" -> timeout = args.getOrElse(++i) { "20" }.toDoubleOrNull() ?: 20.0
+            // leading "subscribe" positional and anything else ignored
+        }
+        i++
+    }
+    if (url.isEmpty() || broadcast.isEmpty()) {
+        System.err.println("usage: smoke subscribe --url U --broadcast B [--timeout S]")
+        exitProcess(2)
+    }
+
+    val code = runBlocking {
+        try {
+            withTimeout((timeout * 1000).toLong()) { subscribe(url, broadcast) }
+            0
+        } catch (e: TimeoutCancellationException) {
+            System.err.println("error: timed out waiting for data")
+            1
+        } catch (e: Exception) {
+            System.err.println("error: ${e.message}")
+            1
+        }
+    }
+    exitProcess(code)
+}

--- a/test/smoke/clients/python/smoke.py
+++ b/test/smoke/clients/python/smoke.py
@@ -1,0 +1,115 @@
+"""Cross-language interop client for the smoke test (PyPI `moq-rs`, import `moq`).
+
+publish:   read raw Annex-B H.264 from stdin (e.g. piped from ffmpeg) and feed
+           it to a streaming importer, which infers frame boundaries.
+subscribe: connect, find the video track in the catalog, and exit 0 as soon as
+           any non-empty frame arrives (exit 1 on timeout / no data).
+
+    ffmpeg ... -f h264 - | python smoke.py publish --url http://localhost:4443 --broadcast b.hang
+    python smoke.py subscribe --url http://localhost:4443 --broadcast b.hang --timeout 20
+"""
+
+import argparse
+import asyncio
+import sys
+
+import moq
+
+READ_CHUNK = 64 * 1024
+MAX_LATENCY_MS = 1_000  # subscribe_media congestion-control / lookahead window
+
+
+async def publish(url: str, broadcast: str) -> None:
+    producer = moq.BroadcastProducer()
+    if not hasattr(producer, "publish_media_stream"):
+        # The streaming importer (infers frame boundaries from a raw Annex-B
+        # pipe) is how every non-browser client publishes here. It's missing
+        # from this published wheel, so raw-stream publishing isn't available
+        # until a newer moq-rs ships. Subscribing still works.
+        raise RuntimeError(
+            "installed moq-rs has no BroadcastProducer.publish_media_stream; "
+            "raw-stream publishing needs a newer published wheel"
+        )
+    media = producer.publish_media_stream("avc3")
+
+    async with moq.Client(url, tls_verify=False) as client:
+        client.publish(broadcast, producer)
+        print(f"publishing {broadcast!r} (Annex-B H.264 from stdin) to {url}")
+
+        loop = asyncio.get_running_loop()
+        stdin = sys.stdin.buffer
+        # read1 returns as soon as any bytes are available (read() would block
+        # for a full chunk and batch up ffmpeg's real-time output). getattr both
+        # keeps pyright happy (BinaryIO doesn't declare read1) and falls back if
+        # the stream lacks it.
+        read = getattr(stdin, "read1", stdin.read)
+        while True:
+            # Blocking read off the event loop so the client keeps flushing.
+            chunk = await loop.run_in_executor(None, read, READ_CHUNK)
+            if not chunk:
+                break
+            media.write(chunk)
+        media.finish()
+
+
+async def _catalog_with_video(consumer: moq.BroadcastConsumer) -> moq.Catalog:
+    # The catalog is a live track. A lazy publisher (e.g. the browser, which only
+    # encodes on demand) may announce video in a *later* update, not the first
+    # snapshot, so wait for a catalog that actually has a video track.
+    async for catalog in consumer.subscribe_catalog():
+        if catalog.video:
+            return catalog
+    raise RuntimeError("catalog stream ended without a video track")
+
+
+async def subscribe(url: str, broadcast: str, timeout: float) -> None:
+    async with moq.Client(url, tls_verify=False) as client:
+        consumer = await asyncio.wait_for(client.announced_broadcast(broadcast), timeout)
+        catalog = await asyncio.wait_for(_catalog_with_video(consumer), timeout)
+
+        track_name = next(iter(catalog.video))
+        video = catalog.video[track_name]
+
+        media = consumer.subscribe_media(track_name, video.container, MAX_LATENCY_MS)
+
+        total = 0
+
+        async def drain() -> None:
+            nonlocal total
+            async for frame in media:
+                total += len(frame.payload)
+                if total > 0:
+                    return
+
+        await asyncio.wait_for(drain(), timeout)
+
+    if total <= 0:
+        raise RuntimeError("no frame data received")
+    print(f"received {total} bytes from {broadcast!r}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("role", choices=["publish", "subscribe"])
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--broadcast", required=True)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    args = parser.parse_args()
+
+    try:
+        if args.role == "publish":
+            asyncio.run(publish(args.url, args.broadcast))
+        else:
+            asyncio.run(subscribe(args.url, args.broadcast, args.timeout))
+    except KeyboardInterrupt:
+        pass
+    except (TimeoutError, asyncio.TimeoutError):
+        print("error: timed out waiting for data", file=sys.stderr)
+        sys.exit(1)
+    except Exception as err:  # noqa: BLE001 - smoke client: any failure is a failure
+        print(f"error: {err}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/smoke/clients/swift/Package.swift
+++ b/test/smoke/clients/swift/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.9
+import Foundation
+import PackageDescription
+
+// Subscribe-only smoke client built on the published Swift package, which pulls
+// a prebuilt MoqFFI.xcframework.
+//
+// Latest mode (default): `from:` resolves to the latest 0.x at `swift package
+// update` time (no Package.resolved is committed, so it never pins). Pinned
+// mode: a release sets MOQ_SWIFT_VERSION to the exact version it just cut, so
+// the smoke run tests that build rather than whatever happens to be newest.
+let moqURL = "https://github.com/moq-dev/moq-swift"
+let moqPin = ProcessInfo.processInfo.environment["MOQ_SWIFT_VERSION"]
+    .flatMap { $0.isEmpty ? nil : Version($0) }
+let moqDependency: Package.Dependency =
+    moqPin.map { .package(url: moqURL, exact: $0) }
+    ?? .package(url: moqURL, from: "0.2.0")
+
+let package = Package(
+    name: "smoke",
+    platforms: [.macOS(.v12)],
+    dependencies: [
+        moqDependency,
+    ],
+    targets: [
+        .executableTarget(
+            name: "smoke",
+            dependencies: [.product(name: "Moq", package: "moq-swift")],
+            path: "Sources/smoke"
+        ),
+    ]
+)

--- a/test/smoke/clients/swift/Sources/smoke/main.swift
+++ b/test/smoke/clients/swift/Sources/smoke/main.swift
@@ -1,0 +1,105 @@
+// Subscribe-only cross-language interop client for the smoke test, built on the
+// published Swift package (moq-dev/moq-swift). Connect, find the video track in
+// the catalog, and exit 0 as soon as any non-empty frame arrives (1 on timeout).
+//
+//   smoke subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+//
+// Publishing isn't wired up: the raw-stream importer the other clients publish
+// with isn't in the published 0.2.x FFI yet, so this client only subscribes.
+import Foundation
+import Moq
+// The published Moq module re-exports the generated types via plain `import`
+// (not @_exported yet), so name them from MoqFFI directly.
+import MoqFFI
+
+enum SmokeError: Error { case timeout, noVideo, noData }
+
+struct Args {
+    var url = ""
+    var broadcast = ""
+    var timeout = 20.0
+}
+
+func parseArgs() -> Args {
+    var a = Args()
+    let argv = CommandLine.arguments
+    var i = 1
+    while i < argv.count {
+        switch argv[i] {
+        case "--url": i += 1; if i < argv.count { a.url = argv[i] }
+        case "--broadcast": i += 1; if i < argv.count { a.broadcast = argv[i] }
+        case "--timeout": i += 1; if i < argv.count { a.timeout = Double(argv[i]) ?? 20.0 }
+        default: break // leading "subscribe" positional and anything else ignored
+        }
+        i += 1
+    }
+    return a
+}
+
+func warn(_ s: String) { FileHandle.standardError.write((s + "\n").data(using: .utf8)!) }
+
+// A catalog update that actually carries a video track. A lazy publisher may
+// announce video in a later update, not the first snapshot.
+func videoTrack(_ bc: MoqBroadcastConsumer) async throws -> (String, MoqVideo) {
+    let catalog = try bc.subscribeCatalog()
+    for try await update in catalog.updates {
+        if let first = update.video.first { return (first.key, first.value) }
+    }
+    throw SmokeError.noVideo
+}
+
+func subscribe(_ args: Args) async throws {
+    let origin = MoqOriginProducer()
+    let client = MoqClient()
+    client.setTlsDisableVerify(disable: true)
+    client.setConsume(origin: origin)
+
+    let session = try await client.connect(url: args.url)
+    defer { session.cancel(code: 0) } // code 0 = graceful close
+
+    let consumer = origin.consume()
+    let announced = try consumer.announcedBroadcast(path: args.broadcast)
+    let bc = try await announced.available()
+
+    let (name, video) = try await videoTrack(bc)
+    let media = try bc.subscribeMedia(name: name, container: video.container, maxLatencyMs: 1000)
+
+    var total = 0
+    for try await frame in media.frames {
+        total += frame.payload.count
+        if total > 0 {
+            warn("received \(total) bytes from \(args.broadcast)")
+            return
+        }
+    }
+    throw SmokeError.noData
+}
+
+func withTimeout(_ seconds: Double, _ op: @escaping () async throws -> Void) async throws {
+    try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask { try await op() }
+        group.addTask {
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            throw SmokeError.timeout
+        }
+        try await group.next()
+        group.cancelAll()
+    }
+}
+
+let args = parseArgs()
+if args.url.isEmpty || args.broadcast.isEmpty {
+    warn("usage: smoke subscribe --url U --broadcast B [--timeout S]")
+    exit(2)
+}
+
+do {
+    try await withTimeout(args.timeout) { try await subscribe(args) }
+    exit(0)
+} catch SmokeError.timeout {
+    warn("error: timed out waiting for data")
+    exit(1)
+} catch {
+    warn("error: \(error)")
+    exit(1)
+}

--- a/test/smoke/clients/token/js/package.json
+++ b/test/smoke/clients/token/js/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "moq-smoke-token",
+	"private": true,
+	"type": "module",
+	"description": "Installs the published @moq/token package so token.sh can drive its CLI under node and bun.",
+	"dependencies": {
+		"@moq/token": "latest"
+	}
+}

--- a/test/smoke/clients/token/js/resolve-bin.mjs
+++ b/test/smoke/clients/token/js/resolve-bin.mjs
@@ -1,13 +1,8 @@
-// Print the absolute path to the published @moq/token CLI entrypoint.
-//
-// token.sh runs this with BOTH node and bun so each runtime resolves the same
-// installed package and we drive the *published* bin (compiled dist), not the
-// in-tree TypeScript source. We read the installed package.json straight off
-// disk rather than via module resolution: @moq/token's `exports` map doesn't
-// expose ./package.json, which Node's strict ESM resolver refuses (bun allows
-// it), so require.resolve would work under bun but throw under node. Reading the
-// file keeps both runtimes on the same path, and the bin name is still taken
-// from the published manifest so a rename surfaces here.
+// Print the absolute path to the published @moq/token CLI bin, for both node
+// and bun. We read package.json off disk instead of via module resolution
+// because @moq/token's exports map doesn't expose ./package.json, which node's
+// strict ESM resolver refuses (bun allows it); reading the file keeps both
+// runtimes on the same path while still taking the bin name from the manifest.
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 

--- a/test/smoke/clients/token/js/resolve-bin.mjs
+++ b/test/smoke/clients/token/js/resolve-bin.mjs
@@ -1,0 +1,23 @@
+// Print the absolute path to the published @moq/token CLI entrypoint.
+//
+// token.sh runs this with BOTH node and bun so each runtime resolves the same
+// installed package and we drive the *published* bin (compiled dist), not the
+// in-tree TypeScript source. We read the installed package.json straight off
+// disk rather than via module resolution: @moq/token's `exports` map doesn't
+// expose ./package.json, which Node's strict ESM resolver refuses (bun allows
+// it), so require.resolve would work under bun but throw under node. Reading the
+// file keeps both runtimes on the same path, and the bin name is still taken
+// from the published manifest so a rename surfaces here.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const pkgDir = resolve(process.cwd(), "node_modules/@moq/token");
+const pkg = JSON.parse(readFileSync(resolve(pkgDir, "package.json"), "utf8"));
+
+const bin = typeof pkg.bin === "string" ? pkg.bin : (pkg.bin?.["moq-token"] ?? pkg.bin?.["moq-token-cli"]);
+if (!bin) {
+	console.error("@moq/token exposes no moq-token bin; published package changed shape");
+	process.exit(1);
+}
+
+console.log(resolve(pkgDir, bin));

--- a/test/smoke/freshness.sh
+++ b/test/smoke/freshness.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Guard the "always test the latest published packages" policy:
+#   1. no committed PACKAGE lock files (go.sum, bun.lock, Cargo.lock, ...), so
+#      every run re-resolves the moq packages to their latest. flake.lock is
+#      fine: it pins the dev toolchain, not the moq packages, and the moq "nix"
+#      channel references the moq flake ad-hoc so the moq version is never locked;
+#   2. the moq packages under test are requested as "latest", never pinned;
+#   3. the one unavoidable pin (npm `playwright`, which must match the toolchain's
+#      Chromium build) equals what the toolchain ships, so a toolchain bump can't
+#      quietly leave it stale.
+#
+# Run standalone (`just freshness`) or as the opening step of smoke.sh.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+PKG=clients/js/package.json
+fail=0
+note() { printf '  %-5s %s\n' "$1" "$2"; }
+json_dep() { grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$PKG" | sed -E 's/.*"([^"]*)"$/\1/'; }
+
+echo "== no committed package lock files =="
+# flake.lock is intentionally excluded: it locks the toolchain, not moq packages.
+locks=$(git ls-files 2>/dev/null | grep -E '(^|/)(go\.sum|bun\.lock|bun\.lockb|Cargo\.lock|uv\.lock|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|poetry\.lock|Pipfile\.lock|Package\.resolved|gradle\.lockfile)$' || true)
+if [[ -n "$locks" ]]; then
+    note FAIL "package lock files are checked in (delete them and add to .gitignore):"
+    # shellcheck disable=SC2001  # per-line indent prefix; not a plain expansion
+    echo "$locks" | sed 's/^/        /'
+    fail=1
+else
+    note ok "none tracked"
+fi
+
+echo "== moq packages requested at latest =="
+for dep in @moq/watch @moq/publish; do
+    ver=$(json_dep "$dep")
+    if [[ "$ver" == "latest" ]]; then note ok "$dep -> \"$ver\""; else
+        note FAIL "$dep pinned to \"$ver\" (want \"latest\")"
+        fail=1
+    fi
+done
+# The native-JS client (@moq/net + @moq/hang + @moq/web-transport) must also be latest.
+for dep in @moq/net @moq/hang @moq/web-transport; do
+    ver=$(grep -oE "\"$dep\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" clients/js-native/package.json | sed -E 's/.*"([^"]*)"$/\1/')
+    if [[ "$ver" == "latest" ]]; then note ok "$dep -> \"$ver\""; else
+        note FAIL "$dep pinned to \"$ver\" (want \"latest\")"
+        fail=1
+    fi
+done
+# The token client (@moq/token, driven by token.sh under node and bun) must be latest.
+ver=$(grep -oE "\"@moq/token\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" clients/token/js/package.json | sed -E 's/.*"([^"]*)"$/\1/')
+if [[ "$ver" == "latest" ]]; then note ok "@moq/token -> \"$ver\""; else
+    note FAIL "@moq/token pinned to \"$ver\" (want \"latest\")"
+    fail=1
+fi
+# The token Docker image must be the unpinned (:latest) tag, pulled fresh each run.
+# shellcheck disable=SC2016  # single-quoted grep patterns are literal by design
+if grep -qF 'DOCKER_TOKEN_IMAGE:-moqdev/moq-token-cli}' token.sh && grep -qF '"$DOCKER" pull "$DOCKER_TOKEN_IMAGE"' token.sh; then
+    note ok "moqdev/moq-token-cli -> :latest (pulled each run)"
+else
+    note FAIL "token.sh no longer pulls an unpinned moqdev/moq-token-cli :latest"
+    fail=1
+fi
+# The media Docker channel (relay + cli wrappers) must use the unpinned (:latest)
+# images, and CI must pull them fresh.
+if grep -qF 'moqdev/moq-relay}' clients/docker/moq-relay && grep -qF 'moqdev/moq-cli}' clients/docker/moq-cli &&
+    grep -qF 'docker pull moqdev/moq-relay' ../../.github/workflows/smoke.yml; then
+    note ok "moqdev/moq-relay + moqdev/moq-cli -> :latest (pulled each run)"
+else
+    note FAIL "the moqdev relay/cli Docker images are no longer unpinned :latest + pulled fresh"
+    fail=1
+fi
+# The jsDelivr CDN variant must not pin @version, so it serves the latest release.
+if grep -qE 'cdn\.jsdelivr\.net/npm/@moq/[a-z-]+@[0-9]' clients/js/jsdelivr/index.html; then
+    note FAIL "jsdelivr/index.html pins a @moq version (drop @x.y.z so the CDN serves latest)"
+    fail=1
+else
+    note ok "jsdelivr @moq/* -> unpinned (latest)"
+fi
+# shellcheck disable=SC2016  # single-quoted grep pattern is literal by design
+if grep -q 'uv pip install --quiet --python "$PY" moq-rs' smoke.sh; then
+    note ok "moq-rs -> uv pip install (unpinned)"
+else
+    note FAIL "smoke.sh no longer installs moq-rs unpinned"
+    fail=1
+fi
+# go_install defaults its ref to `latest`; a pin overrides it via MOQ_GO_VERSION.
+if grep -qE '^[[:space:]]*local ref=latest' smoke.sh; then
+    note ok "moq-go -> go get @latest by default"
+else
+    note FAIL "smoke.sh go_install default ref is no longer @latest"
+    fail=1
+fi
+# Swift: `from: "x"` floats to the newest compatible; an `.exact(` pin would not.
+if grep -q '\.exact(' clients/swift/Package.swift; then
+    note FAIL "moq-swift pinned with .exact( (want from:, which floats to latest)"
+    fail=1
+else
+    note ok "moq-swift -> from: (floats to latest)"
+fi
+# Kotlin: the committed default must be a dynamic version (latest.release) so an
+# unpinned run re-resolves to the newest each time. A pinned run overrides it via
+# -PmoqVersion / MOQ_KT_VERSION, but the fallback stays dynamic.
+if grep -qE '\?:[[:space:]]*"latest\.release"' clients/kotlin/build.gradle.kts; then
+    note ok "dev.moq:moq -> dynamic (latest) by default"
+else
+    note FAIL "build.gradle.kts default is not the dynamic latest.release"
+    fail=1
+fi
+# C: smoke.sh resolves the newest libmoq-v* release, never a fixed version.
+if grep -q "grep '\^libmoq-v' | head -1" smoke.sh; then
+    note ok "libmoq -> latest release"
+else
+    note FAIL "smoke.sh no longer resolves the latest libmoq-v* release"
+    fail=1
+fi
+# GStreamer: smoke.sh resolves the newest moq-gst-v* release, never a fixed version.
+if grep -q "grep '\^moq-gst-v' | head -1" smoke.sh; then
+    note ok "moq-gst -> latest release"
+else
+    note FAIL "smoke.sh no longer resolves the latest moq-gst-v* release"
+    fail=1
+fi
+
+echo "== forced pin (npm playwright) tracks the toolchain =="
+pin=$(json_dep playwright)
+if [[ "$pin" == ^* || "$pin" == "~"* || "$pin" == "latest" || "$pin" == *"x" || "$pin" == *"*"* ]]; then
+    note FAIL "playwright must be an exact version matching the toolchain's Chromium, got \"$pin\""
+    fail=1
+elif [[ -n "${PLAYWRIGHT_VERSION:-}" ]]; then
+    if [[ "$pin" == "$PLAYWRIGHT_VERSION" ]]; then
+        note ok "playwright $pin == toolchain $PLAYWRIGHT_VERSION"
+    else
+        note FAIL "playwright pinned to $pin but the toolchain ships $PLAYWRIGHT_VERSION; bump $PKG"
+        fail=1
+    fi
+else
+    note warn "PLAYWRIGHT_VERSION unset (not a nix shell); can't confirm \"$pin\" matches the Chromium in use"
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+    echo "freshness: ok"
+else
+    echo "freshness: FAILURES detected" >&2
+    exit 1
+fi

--- a/test/smoke/justfile
+++ b/test/smoke/justfile
@@ -1,0 +1,122 @@
+#!/usr/bin/env just --justfile
+#
+# Cross-language interop smoke test against the PUBLIC moq packages. Unlike the
+# in-tree unit tests (which build from workspace source), every client here
+# installs from its public registry (PyPI / npm / Maven / the Go proxy / GitHub
+# release assets / Docker Hub), so a packaging break shows up as a red cell.
+#
+# Two ways to run:
+#   * latest mode (default): each client resolves the newest published version.
+#     This is what the nightly Linux job runs. `just smoke::freshness` guards the
+#     "nothing is pinned" policy.
+#   * pinned mode: set the matching MOQ_*_VERSION env (see smoke.sh) to force an
+#     exact version. Release workflows use this to test the version they just cut,
+#     instead of whatever the registry happens to serve. Pinned mode skips the
+#     freshness guard.
+#
+# You bring moq-relay + moq-cli on PATH (cargo/brew/apt/nix); the per-language
+# recipes pair each client with rust on the opposite axis as the reference impl.
+
+# Default: the rust<->rust baseline (no network installs).
+default *args:
+    ./smoke.sh --publishers rust --subscribers rust {{ args }}
+
+# ── per-language slices ──────────────────────────────────────────────────────
+# Each runs only the cells involving one implementation, paired with rust on the
+# other axis. A release workflow runs the slice for the package it just shipped.
+
+# Rust (moq-cli): publishes + subscribes. The reference implementation.
+rust *args:
+    ./smoke.sh --publishers rust --subscribers rust {{ args }}
+
+# Python (PyPI moq-rs): publishes + subscribes.
+python *args:
+    ./smoke.sh --publishers rust,python --subscribers rust,python --timeout 30 {{ args }}
+
+# Go (moq-dev/moq-go): publishes + subscribes.
+go *args:
+    ./smoke.sh --publishers rust,go --subscribers rust,go --timeout 30 {{ args }}
+
+# Swift (moq-dev/moq-swift, SPM): subscribe only (macOS, Xcode toolchain).
+swift *args:
+    ./smoke.sh --publishers rust --subscribers swift --timeout 30 {{ args }}
+
+# Kotlin (dev.moq:moq, Maven Central): subscribe only (JVM).
+kotlin *args:
+    ./smoke.sh --publishers rust --subscribers kotlin --timeout 30 {{ args }}
+
+# C (libmoq prebuilt release): subscribe only.
+c *args:
+    ./smoke.sh --publishers rust --subscribers c --timeout 30 {{ args }}
+
+# GStreamer (moq-gst prebuilt plugin): subscribe only, needs a system gstreamer.
+gst *args:
+    ./smoke.sh --publishers rust --subscribers gst --timeout 30 {{ args }}
+
+# Browser (@moq/watch + @moq/publish from npm), publish + subscribe. Variants: vite, esbuild, jsDelivr.
+js *args:
+    ./smoke.sh --publishers rust,js-vite,js-esbuild,js-jsdelivr --subscribers rust,js-vite,js-esbuild,js-jsdelivr --timeout 30 {{ args }}
+
+# Native JS (@moq/net + @moq/hang + @moq/web-transport polyfill) under node + bun, subscribe only.
+js-native *args:
+    ./smoke.sh --publishers rust --subscribers js-native-node,js-native-bun --timeout 30 {{ args }}
+
+# ── full matrix ──────────────────────────────────────────────────────────────
+
+# Every implementation, every supported direction (swift needs the macOS Xcode toolchain).
+full:
+    ./smoke.sh --publishers rust,python,js-vite,js-esbuild,js-jsdelivr --subscribers rust,python,go,swift,kotlin,c,gst,js-vite,js-esbuild,js-jsdelivr,js-native-node,js-native-bun --timeout 30
+
+# The nightly Linux matrix: same as `full`, minus swift.
+full-linux:
+    ./smoke.sh --publishers rust,python,js-vite,js-esbuild,js-jsdelivr --subscribers rust,python,go,kotlin,c,gst,js-vite,js-esbuild,js-jsdelivr,js-native-node,js-native-bun --timeout 30
+
+# Negative control: no publisher, every subscriber must time out (proves the harness can fail).
+negative *args:
+    ./smoke.sh --negative {{ args }}
+
+# ── token interop ────────────────────────────────────────────────────────────
+
+# Token interop: install moq-token in each published flavour and cross-verify. Default: rust only.
+token *args:
+    ./token.sh {{ args }}
+
+# Full token matrix: rust (binary + moqdev/moq-token-cli image) + @moq/token under node and bun.
+token-full:
+    ./token.sh --generators rust,js-node,js-bun,rust-docker --verifiers rust,js-node,js-bun,rust-docker
+
+# ── nix channel ──────────────────────────────────────────────────────────────
+# Get moq-relay + moq-cli from the moq flake (a public distribution channel,
+# `nix run github:moq-dev/moq#moq-cli`) instead of cargo/brew/apt. Referenced
+# ad-hoc with --refresh so the moq version is the latest default-branch build.
+# Override the source with MOQ_FLAKE (e.g. a fork or a pinned ref).
+MOQ_FLAKE := env_var_or_default("MOQ_FLAKE", "github:moq-dev/moq")
+CACHIX_SUB := "https://kixelated.cachix.org"
+CACHIX_KEY := "kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk="
+
+nix-channel *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "building moq-relay + moq-cli from {{ MOQ_FLAKE }} (latest)..."
+    nix_build() {
+        nix build --refresh --no-link --print-out-paths \
+            --extra-substituters "{{ CACHIX_SUB }}" \
+            --extra-trusted-public-keys "{{ CACHIX_KEY }}" "$1"
+    }
+    relay=$(nix_build '{{ MOQ_FLAKE }}#moq-relay')
+    cli=$(nix_build '{{ MOQ_FLAKE }}#moq-cli')
+    echo "relay: $relay"
+    echo "cli:   $cli"
+    RELAY_BIN="$relay/bin/moq-relay" MOQ_BIN="$cli/bin/moq-cli" ./smoke.sh {{ args }}
+
+# ── lint ─────────────────────────────────────────────────────────────────────
+
+# Assert latest-mode policy: no committed client lock files, nothing pinned (gates the nightly).
+freshness:
+    ./freshness.sh
+
+# Lint the harness. Each tool is guarded so it skips when not on PATH.
+check:
+    command -v shellcheck >/dev/null && shellcheck smoke.sh freshness.sh token.sh || echo "shellcheck: skipped"
+    command -v shfmt >/dev/null && shfmt -d -i 4 -ci smoke.sh freshness.sh token.sh || echo "shfmt: skipped"
+    just freshness

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -1,0 +1,754 @@
+#!/usr/bin/env bash
+# Cross-language media interop smoke test against the PUBLIC packages.
+#
+# Unlike the in-repo smoke test (which builds from the moq-dev/moq workspace),
+# this stands up a relay and clients installed straight from public package
+# registries: cargo / brew / apt for the Rust binaries, PyPI for Python, the
+# Go module proxy for Go, and npm for the browser. The point is to catch breakage
+# that only a real consumer would see: a missing wheel, a stale formula, an
+# export that didn't survive packaging.
+#
+# It stands up a real moq-relay, then for each publisher language publishes an
+# H.264 broadcast and confirms every subscriber sees data flowing (a non-empty
+# frame before the timeout). We check that bytes move end-to-end across
+# implementations, not that H.264 decodes.
+set -euo pipefail
+
+SMOKE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CLIENTS="$SMOKE_DIR/clients"
+
+PUBLISHERS="rust"
+SUBSCRIBERS="rust"
+TIMEOUT="${SMOKE_TIMEOUT:-20}"
+FPS="${SMOKE_FPS:-30}"
+SIZE="${SMOKE_SIZE:-320x240}"
+PORT="${SMOKE_PORT:-4443}"
+URL="http://127.0.0.1:${PORT}"
+NEGATIVE=0
+
+# Binaries under test. Whatever channel installed them (cargo/brew/apt) just has
+# to leave them on PATH; override here to point at a specific build.
+RELAY="${RELAY_BIN:-moq-relay}"
+# The CLI's real binary name is `moq` (what the apt/rpm packages install). `cargo
+# install moq-cli` instead names it after the crate, `moq-cli`. Honor MOQ_BIN if
+# set, otherwise pick whichever name the channel left on PATH (resolved once the
+# `have` helper is defined, in require_tools).
+MOQ="${MOQ_BIN:-}"
+
+# Pinned mode. A release workflow sets the matching MOQ_*_VERSION to test the
+# EXACT version it just published, instead of whatever the registry serves as
+# latest. Unset means latest (the nightly's behavior). The Rust binaries pin via
+# RELAY_BIN / MOQ_BIN (point them at the build under test). Any pin flips
+# PINNED=1, which skips the freshness guard (pinning deliberately violates the
+# "always latest" policy) and makes each client poll its registry until the
+# version resolves, riding out propagation lag right after a publish.
+MOQ_RS_VERSION="${MOQ_RS_VERSION:-}"         # python  (PyPI moq-rs)
+MOQ_GO_VERSION="${MOQ_GO_VERSION:-}"         # go      (moq-dev/moq-go)
+MOQ_NPM_VERSION="${MOQ_NPM_VERSION:-}"       # js      (@moq/{net,hang,watch,publish})
+MOQ_SWIFT_VERSION="${MOQ_SWIFT_VERSION:-}"   # swift   (moq-dev/moq-swift)
+MOQ_KT_VERSION="${MOQ_KT_VERSION:-}"         # kotlin  (dev.moq:moq)
+MOQ_LIBMOQ_VERSION="${MOQ_LIBMOQ_VERSION:-}" # c       (libmoq release)
+MOQ_GST_VERSION="${MOQ_GST_VERSION:-}"       # gst     (moq-gst release)
+PINNED=0
+for _v in "$MOQ_RS_VERSION" "$MOQ_GO_VERSION" "$MOQ_NPM_VERSION" \
+    "$MOQ_SWIFT_VERSION" "$MOQ_KT_VERSION" "$MOQ_LIBMOQ_VERSION" "$MOQ_GST_VERSION"; do
+    [[ -n "$_v" ]] && PINNED=1
+done
+# Package.swift reads this from the environment to pick its dependency requirement.
+export MOQ_SWIFT_VERSION
+
+require_value() {
+    # require_value <flag> "$@": the flag plus the rest of the argv. Ensures a
+    # non-flag value follows, so `set -u` doesn't abort on a bare `--timeout`.
+    if [[ $# -lt 2 || -z "${2:-}" || "$2" == -* ]]; then
+        echo "error: $1 requires a value" >&2
+        exit 2
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --publishers)
+            require_value "$@"
+            PUBLISHERS="$2"
+            shift 2
+            ;;
+        --subscribers)
+            require_value "$@"
+            SUBSCRIBERS="$2"
+            shift 2
+            ;;
+        --timeout)
+            require_value "$@"
+            TIMEOUT="$2"
+            shift 2
+            ;;
+        --negative)
+            NEGATIVE=1
+            shift
+            ;;
+        *)
+            echo "unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+IFS=',' read -r -a PUB_LIST <<<"$PUBLISHERS"
+IFS=',' read -r -a SUB_LIST <<<"$SUBSCRIBERS"
+
+needs() {
+    # needs <lang>: true if <lang> appears in either list.
+    local lang="$1" x
+    for x in "${PUB_LIST[@]}" "${SUB_LIST[@]}"; do [[ "$x" == "$lang" ]] && return 0; done
+    return 1
+}
+
+TMP=$(mktemp -d)
+RELAY_PID=""
+PY=""             # python interpreter with moq-rs installed (set in prepare)
+GO_SMOKE=""       # compiled Go client binary (set in prepare)
+SWIFT_SMOKE=""    # compiled Swift client binary (set in prepare)
+KOTLIN_SMOKE=""   # Kotlin run script from `gradle installDist` (set in prepare)
+C_SMOKE=""        # compiled C client binary (set in prepare)
+GST_PLUGIN_DIR="" # dir holding the moq-gst plugin (libgstmoq.{so,dylib}; set in prepare)
+BROKEN_LANGS=""   # clients whose public package failed to install/build
+
+mark_broken() {
+    # A client whose published package won't install/build fails only its own
+    # matrix cells, instead of aborting the whole run. That's the point: a broken
+    # registry artifact should show up as a red cell, not hide every other result.
+    BROKEN_LANGS="$BROKEN_LANGS $1"
+    echo "  WARN  $1 client unavailable: $2"
+}
+
+is_broken() {
+    local lang="$1" x
+    for x in $BROKEN_LANGS; do [[ "$x" == "$lang" ]] && return 0; done
+    return 1
+}
+
+kill_tree() {
+    # SIGKILL, depth-first. moq-cli ignores SIGTERM (handles only SIGINT), so a
+    # polite kill would leak it; these are ephemeral test processes, so -9 is fine.
+    local pid="$1" child
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do kill_tree "$child"; done
+    kill -KILL "$pid" 2>/dev/null || true
+}
+
+# shellcheck disable=SC2329  # invoked indirectly via 'trap cleanup EXIT'
+cleanup() {
+    # Reap the last publisher too; subscribers self-terminate via their timeouts.
+    [[ -n "${PUB_PID:-}" ]] && kill_tree "$PUB_PID"
+    [[ -n "$RELAY_PID" ]] && kill_tree "$RELAY_PID"
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Pinned mode waits out registry/CDN propagation: a publish step can finish
+# seconds-to-minutes before the artifact is resolvable. Default 5 min (60 x 5s).
+POLL_TRIES="${SMOKE_POLL_TRIES:-60}"
+POLL_SLEEP="${SMOKE_POLL_SLEEP:-5}"
+poll_until() {
+    # poll_until <what> <cmd...>: run cmd until it succeeds or we give up.
+    local what="$1" i
+    shift
+    for ((i = 1; i <= POLL_TRIES; i++)); do
+        "$@" >/dev/null 2>&1 && return 0
+        echo "  waiting for $what to propagate ($i/$POLL_TRIES)..." >&2
+        sleep "$POLL_SLEEP"
+    done
+    echo "  gave up waiting for $what after $((POLL_TRIES * POLL_SLEEP))s" >&2
+    return 1
+}
+
+require_tools() {
+    # Resolve the CLI binary name unless MOQ_BIN pinned it: the apt/rpm packages
+    # install `moq`, while `cargo install moq-cli` names it `moq-cli`. Prefer the
+    # packaged name, fall back to the cargo one.
+    if [[ -z "$MOQ" ]]; then
+        if have moq; then MOQ=moq; elif have moq-cli; then MOQ=moq-cli; else MOQ=moq; fi
+    fi
+    # Only the relay, CLI, and harness essentials are hard requirements. A missing
+    # per-client toolchain (uv / go / bun / swift / gradle / cc) just marks that
+    # client broken in prepare, so it fails its own cells instead of the whole run.
+    local missing=() t
+    for t in ffmpeg curl pgrep timeout; do
+        have "$t" || missing+=("$t")
+    done
+    have "$RELAY" || missing+=("$RELAY (cargo/brew/apt/nix install moq-relay)")
+    have "$MOQ" || missing+=("moq / moq-cli (cargo/brew/apt/nix install moq-cli)")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "error: missing required tools: ${missing[*]}" >&2
+        exit 1
+    fi
+}
+
+# Run swift with the Xcode toolchain. A loaded nix devShell exports SDKROOT /
+# DEVELOPER_DIR pointing at a nix Apple SDK, which the Xcode swiftc rejects;
+# clear those so swift picks its own matching SDK.
+run_swift() {
+    env -u SDKROOT -u DEVELOPER_DIR -u NIX_CFLAGS_COMPILE -u NIX_CFLAGS_LINK \
+        -u CPATH -u LIBRARY_PATH -u MACOSX_DEPLOYMENT_TARGET swift "$@"
+}
+
+# Download the latest libmoq prebuilt release for this platform and compile the C
+# client against it. The tarball ships include/moq.h + lib/libmoq.a.
+c_prepare() {
+    local cc="${CC:-cc}" target os_libs tag ver url root hdr=()
+    have "$cc" || {
+        echo "no C compiler ($cc) on PATH" >&2
+        return 1
+    }
+    have curl || {
+        echo "curl required" >&2
+        return 1
+    }
+    have jq || {
+        echo "jq required" >&2
+        return 1
+    }
+    case "$(uname -s)/$(uname -m)" in
+        Darwin/arm64) target=aarch64-apple-darwin ;;
+        Darwin/x86_64) target=x86_64-apple-darwin ;;
+        Linux/x86_64) target=x86_64-unknown-linux-gnu ;;
+        Linux/aarch64 | Linux/arm64) target=aarch64-unknown-linux-gnu ;;
+        *)
+            echo "unsupported platform: $(uname -s)/$(uname -m)" >&2
+            return 1
+            ;;
+    esac
+    case "$(uname -s)" in
+        Darwin) os_libs="-framework CoreFoundation -framework Security" ;;
+        *) os_libs="-lpthread -ldl -lm" ;;
+    esac
+    # Authenticated if a token is around (CI) to dodge the 60/hr anonymous
+    # GitHub API limit.
+    [[ -n "${GITHUB_TOKEN:-}" ]] && hdr=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    if [[ -n "$MOQ_LIBMOQ_VERSION" ]]; then
+        # Pinned: the exact tag a release just cut.
+        ver="$MOQ_LIBMOQ_VERSION"
+        tag="libmoq-v$ver"
+    else
+        # Latest libmoq-v* release. macOS ships bash 3.2, where "${hdr[@]}" on an
+        # empty array trips `set -u`; the ${arr[@]+...} guard expands to nothing
+        # when the array is unset/empty.
+        tag=$(curl -sf ${hdr[@]+"${hdr[@]}"} "https://api.github.com/repos/moq-dev/moq/releases?per_page=100" |
+            jq -r '.[].tag_name' | grep '^libmoq-v' | head -1)
+        [[ -n "$tag" ]] || {
+            echo "no libmoq-v* release found" >&2
+            return 1
+        }
+        ver=${tag#libmoq-v}
+    fi
+    url="https://github.com/moq-dev/moq/releases/download/$tag/moq-$ver-$target.tar.gz"
+    echo "libmoq $tag ($target)"
+    # Pinned: the asset can lag the tag; wait for it before downloading.
+    [[ -n "$MOQ_LIBMOQ_VERSION" ]] && { poll_until "libmoq $tag asset" curl -sfLI -o /dev/null "$url" || return 1; }
+    mkdir -p "$TMP/libmoq"
+    curl -sfL "$url" | tar xz -C "$TMP/libmoq" || {
+        echo "download/extract failed: $url" >&2
+        return 1
+    }
+    root="$TMP/libmoq/moq-$ver-$target"
+    # shellcheck disable=SC2086  # os_libs is a deliberate multi-flag word list
+    "$cc" "$CLIENTS/c/subscribe.c" -I"$root/include" -L"$root/lib" -lmoq $os_libs -o "$C_SMOKE"
+}
+
+# Download the latest moq-gst prebuilt release for this platform and confirm the
+# plugin loads against the host's *system* GStreamer. The plugin (libgstmoq.so /
+# .dylib) dynamic-links libgstreamer, so this is the customer-facing scenario:
+# install the .deb / brew tap / tarball, then `gst-inspect-1.0 moq`. Sets
+# GST_PLUGIN_DIR to the dir holding the plugin. moqsrc connects over the network,
+# so it's relay-channel-agnostic; GST_PLUGIN_DIR + a system GStreamer is all it
+# needs. (Local nix shells have no GStreamer, and a prebuilt plugin wouldn't link
+# against nixpkgs' gst anyway, so this cell wants a real system gst install.)
+gst_prepare() {
+    local target tag ver url root hdr=()
+    have gst-launch-1.0 || {
+        echo "gst-launch-1.0 not on PATH (apt install gstreamer1.0-tools / brew install gstreamer)" >&2
+        return 1
+    }
+    have gst-inspect-1.0 || {
+        echo "gst-inspect-1.0 not on PATH" >&2
+        return 1
+    }
+    # Escape hatch: point at a locally-built plugin dir (e.g. target/release after
+    # `cargo build -p moq-gst`) instead of the published tarball, mirroring the
+    # RELAY_BIN/MOQ_BIN overrides. Skips the download but still load-checks it.
+    if [[ -n "${MOQ_GST_PLUGIN_DIR:-}" ]]; then
+        GST_PLUGIN_DIR="$MOQ_GST_PLUGIN_DIR"
+        echo "moq-gst (local: $GST_PLUGIN_DIR)"
+        [[ -d "$GST_PLUGIN_DIR" ]] || {
+            echo "MOQ_GST_PLUGIN_DIR is not a directory: $GST_PLUGIN_DIR" >&2
+            return 1
+        }
+        GST_PLUGIN_PATH_1_0="$GST_PLUGIN_DIR" GST_PLUGIN_SYSTEM_PATH_1_0="" \
+            GST_REGISTRY_1_0="$TMP/gst-registry.bin" \
+            gst-inspect-1.0 moq 2>/dev/null | grep -qE '^[[:space:]]+moqsrc:' ||
+            {
+                echo "moqsrc not exposed (plugin failed to load against this GStreamer)" >&2
+                return 1
+            }
+        return 0
+    fi
+    have curl || {
+        echo "curl required" >&2
+        return 1
+    }
+    have jq || {
+        echo "jq required" >&2
+        return 1
+    }
+    case "$(uname -s)/$(uname -m)" in
+        Darwin/arm64) target=aarch64-apple-darwin ;;
+        Darwin/x86_64) target=x86_64-apple-darwin ;;
+        Linux/x86_64) target=x86_64-unknown-linux-gnu ;;
+        Linux/aarch64 | Linux/arm64) target=aarch64-unknown-linux-gnu ;;
+        *)
+            echo "unsupported platform: $(uname -s)/$(uname -m)" >&2
+            return 1
+            ;;
+    esac
+    # Authenticated if a token is around (CI) to dodge the 60/hr anonymous
+    # GitHub API limit.
+    [[ -n "${GITHUB_TOKEN:-}" ]] && hdr=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    if [[ -n "$MOQ_GST_VERSION" ]]; then
+        # Pinned: the exact tag a release just cut.
+        ver="$MOQ_GST_VERSION"
+        tag="moq-gst-v$ver"
+    else
+        # Latest moq-gst-v* release.
+        tag=$(curl -sf ${hdr[@]+"${hdr[@]}"} "https://api.github.com/repos/moq-dev/moq/releases?per_page=100" |
+            jq -r '.[].tag_name' | grep '^moq-gst-v' | head -1)
+        [[ -n "$tag" ]] || {
+            echo "no moq-gst-v* release found" >&2
+            return 1
+        }
+        ver=${tag#moq-gst-v}
+    fi
+    url="https://github.com/moq-dev/moq/releases/download/$tag/moq-gst-$ver-$target.tar.gz"
+    echo "moq-gst $tag ($target)"
+    # Pinned: the asset can lag the tag; wait for it before downloading.
+    [[ -n "$MOQ_GST_VERSION" ]] && { poll_until "moq-gst $tag asset" curl -sfLI -o /dev/null "$url" || return 1; }
+    mkdir -p "$TMP/moq-gst"
+    curl -sfL "$url" | tar xz -C "$TMP/moq-gst" || {
+        echo "download/extract failed: $url" >&2
+        return 1
+    }
+    root="$TMP/moq-gst/moq-gst-$ver-$target"
+    GST_PLUGIN_DIR="$root/lib/gstreamer-1.0"
+    [[ -d "$GST_PLUGIN_DIR" ]] || {
+        echo "plugin dir missing in tarball: $GST_PLUGIN_DIR" >&2
+        return 1
+    }
+    # gst-inspect exits 0 even when the .so fails to load, so grep for the
+    # factory. Isolate discovery to our dir + a temp registry so a system-wide moq
+    # plugin can't shadow it (mirrors moq-gst's own smoke.sh).
+    GST_PLUGIN_PATH_1_0="$GST_PLUGIN_DIR" GST_PLUGIN_SYSTEM_PATH_1_0="" \
+        GST_REGISTRY_1_0="$TMP/gst-registry.bin" \
+        gst-inspect-1.0 moq 2>/dev/null | grep -qE '^[[:space:]]+moqsrc:' ||
+        {
+            echo "moqsrc not exposed (plugin failed to load against this GStreamer)" >&2
+            return 1
+        }
+}
+
+# Install the Python client, pinning moq-rs when MOQ_RS_VERSION is set.
+py_install() {
+    if [[ -n "$MOQ_RS_VERSION" ]]; then
+        poll_until "moq-rs $MOQ_RS_VERSION on PyPI" \
+            curl -sfL -o /dev/null "https://pypi.org/pypi/moq-rs/$MOQ_RS_VERSION/json" || return 1
+        uv pip install --quiet --python "$PY" "moq-rs==$MOQ_RS_VERSION"
+    else
+        uv pip install --quiet --python "$PY" moq-rs
+    fi
+}
+
+# go get + build the client, pinning moq-go when MOQ_GO_VERSION is set. Runs with
+# cwd already in clients/go.
+go_install() {
+    local ref=latest
+    if [[ -n "$MOQ_GO_VERSION" ]]; then
+        ref="v$MOQ_GO_VERSION"
+        poll_until "moq-go $ref on the Go proxy" \
+            curl -sfL -o /dev/null "https://proxy.golang.org/github.com/moq-dev/moq-go/@v/$ref.info" || return 1
+    fi
+    go get "github.com/moq-dev/moq-go@$ref" && CGO_ENABLED=1 go build -o "$GO_SMOKE" .
+}
+
+# Pin the monorepo's own @moq/* npm packages to MOQ_NPM_VERSION. Third-party deps
+# (e.g. @moq/web-transport, a separate repo) stay at whatever package.json asks.
+# npm_pin <dir> <pkg>...: poll npm for the first pkg, then `bun add` each pinned.
+npm_pin() {
+    local dir="$1"
+    shift
+    poll_until "@moq npm $MOQ_NPM_VERSION" \
+        curl -sfL -o /dev/null "https://registry.npmjs.org/$1/$MOQ_NPM_VERSION" || return 1
+    local specs=() p
+    for p in "$@"; do specs+=("$p@$MOQ_NPM_VERSION"); done
+    (cd "$dir" && bun add "${specs[@]}")
+}
+
+# Build the Swift client, pinning moq-swift (via the env Package.swift reads) and
+# waiting for the mirror tag when MOQ_SWIFT_VERSION is set.
+swift_build() {
+    if [[ -n "$MOQ_SWIFT_VERSION" ]]; then
+        poll_until "moq-swift $MOQ_SWIFT_VERSION tag" \
+            git ls-remote --exit-code https://github.com/moq-dev/moq-swift \
+            "refs/tags/$MOQ_SWIFT_VERSION" "refs/tags/v$MOQ_SWIFT_VERSION" || return 1
+    fi
+    (cd "$CLIENTS/swift" && run_swift package update && run_swift build)
+}
+
+# Build the Kotlin client, pinning dev.moq:moq (via -PmoqVersion) and waiting for
+# the Maven Central POM when MOQ_KT_VERSION is set.
+kt_build() {
+    local args=(--quiet --console=plain)
+    if [[ -n "$MOQ_KT_VERSION" ]]; then
+        poll_until "dev.moq:moq $MOQ_KT_VERSION on Maven Central" \
+            curl -sfL -o /dev/null \
+            "https://repo1.maven.org/maven2/dev/moq/moq/$MOQ_KT_VERSION/moq-$MOQ_KT_VERSION.pom" || return 1
+        args+=("-PmoqVersion=$MOQ_KT_VERSION")
+    fi
+    (cd "$CLIENTS/kotlin" && gradle "${args[@]}" installDist)
+}
+
+# ── setup ───────────────────────────────────────────────────────────────────
+require_tools
+
+if [[ "$PINNED" -eq 1 ]]; then
+    echo "pinned mode: testing exact published versions, skipping the freshness (always-latest) guard"
+else
+    # Surface any "we've drifted off latest" problem up front. Non-fatal here so
+    # the matrix still runs; `just freshness` / CI enforce it hard.
+    "$SMOKE_DIR/freshness.sh" || echo "WARN: freshness check failed (see above); continuing" >&2
+fi
+
+echo "relay:   $(command -v "$RELAY")"
+echo "moq-cli: $(command -v "$MOQ")"
+
+if needs python; then
+    echo "installing python client (moq-rs from PyPI)..."
+    PY="$TMP/venv/bin/python"
+    # Published wheel (latest, or MOQ_RS_VERSION); sdist fallback needs a Rust
+    # toolchain + C compiler.
+    if ! have uv; then
+        mark_broken python "uv not found"
+    elif uv venv --quiet "$TMP/venv" && py_install; then :; else
+        mark_broken python "uv pip install moq-rs failed"
+    fi
+fi
+
+if needs go; then
+    echo "building go client (moq-dev/moq-go from the module proxy)..."
+    GO_SMOKE="$TMP/go-smoke"
+    # Pull the published module (latest, or MOQ_GO_VERSION), then build against it.
+    if ! have go; then
+        mark_broken go "go not found"
+    elif (cd "$CLIENTS/go" && go_install) >"$TMP/go-build.log" 2>&1; then :; else
+        mark_broken go "go get/build of moq-dev/moq-go failed"
+        sed 's/^/        /' "$TMP/go-build.log" >&2 || true
+    fi
+fi
+
+# The browser client ships three delivery variants (js-vite, js-esbuild,
+# js-jsdelivr) that all drive the same <moq-publish>/<moq-watch> elements; they
+# differ only in how the published npm packages reach the page.
+if needs js-vite || needs js-esbuild || needs js-jsdelivr; then
+    echo "installing browser clients (@moq/watch + @moq/publish from npm)..."
+    if ! have bun; then
+        for v in js-vite js-esbuild js-jsdelivr; do mark_broken "$v" "bun not found"; done
+    else
+        js_base() {
+            (cd "$CLIENTS/js" && bun install) || return 1
+            # Pinned: override the "latest" deps with the exact published version.
+            [[ -n "$MOQ_NPM_VERSION" ]] && { npm_pin "$CLIENTS/js" @moq/watch @moq/publish || return 1; }
+            # Nix provides Chromium via PLAYWRIGHT_BROWSERS_PATH; otherwise fetch it.
+            [[ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ]] || (cd "$CLIENTS/js" && bunx playwright install chromium) || return 1
+        }
+        if js_base >"$TMP/js-base.log" 2>&1; then
+            # jsdelivr imports from the CDN at runtime, so it needs no build. The
+            # bundler variants each build their own page; a build failure fails
+            # only that variant.
+            if needs js-vite && ! (cd "$CLIENTS/js" && bunx vite build) >"$TMP/js-vite.log" 2>&1; then
+                mark_broken js-vite "vite build failed"
+                sed 's/^/        /' "$TMP/js-vite.log" >&2 || true
+            fi
+            if needs js-esbuild && ! (cd "$CLIENTS/js" && bun build-esbuild.ts) >"$TMP/js-esbuild.log" 2>&1; then
+                mark_broken js-esbuild "esbuild build failed"
+                sed 's/^/        /' "$TMP/js-esbuild.log" >&2 || true
+            fi
+        else
+            for v in js-vite js-esbuild js-jsdelivr; do mark_broken "$v" "bun install / playwright failed"; done
+            sed 's/^/        /' "$TMP/js-base.log" >&2 || true
+        fi
+    fi
+fi
+
+# Native (non-browser) JS: the published @moq/net + @moq/hang under a runtime
+# with no native WebTransport, using the @fails-components/webtransport polyfill.
+# Run under bun (js-native-bun) and node (js-native-node).
+if needs js-native-bun || needs js-native-node; then
+    echo "installing native-js client (@moq/net + @moq/hang + webtransport polyfill)..."
+    if ! have bun; then
+        for v in js-native-bun js-native-node; do mark_broken "$v" "bun not found (needed to install)"; done
+    elif (cd "$CLIENTS/js-native" && bun install &&
+        { [[ -z "$MOQ_NPM_VERSION" ]] || npm_pin "$CLIENTS/js-native" @moq/net @moq/hang; }) >"$TMP/js-native.log" 2>&1; then
+        if needs js-native-node && ! have node; then
+            mark_broken js-native-node "node not found"
+        fi
+    else
+        for v in js-native-bun js-native-node; do mark_broken "$v" "bun install failed"; done
+        sed 's/^/        /' "$TMP/js-native.log" >&2 || true
+    fi
+fi
+
+if needs swift; then
+    echo "building swift client (moq-dev/moq-swift via SPM)..."
+    SWIFT_SMOKE="$CLIENTS/swift/.build/debug/smoke"
+    # Resolves the latest 0.x (or MOQ_SWIFT_VERSION) at `swift package update` time.
+    if ! have swift; then
+        mark_broken swift "swift not found (needs the Xcode toolchain; macOS only)"
+    elif swift_build >"$TMP/swift-build.log" 2>&1; then :; else
+        mark_broken swift "swift package update / build failed"
+        sed 's/^/        /' "$TMP/swift-build.log" >&2 || true
+    fi
+fi
+
+if needs kotlin; then
+    echo "building kotlin client (dev.moq:moq from Maven Central)..."
+    KOTLIN_SMOKE="$CLIENTS/kotlin/build/install/smoke/bin/smoke"
+    # `latest.release` (or MOQ_KT_VERSION) + disabled dynamic-version caching.
+    if ! have gradle; then
+        mark_broken kotlin "gradle not found"
+    elif kt_build >"$TMP/kotlin-build.log" 2>&1; then :; else
+        mark_broken kotlin "gradle installDist failed"
+        sed 's/^/        /' "$TMP/kotlin-build.log" >&2 || true
+    fi
+fi
+
+if needs c; then
+    echo "building c client (libmoq prebuilt release)..."
+    C_SMOKE="$TMP/c-smoke"
+    if c_prepare >"$TMP/c-build.log" 2>&1; then :; else
+        mark_broken c "libmoq download / compile failed"
+        sed 's/^/        /' "$TMP/c-build.log" >&2 || true
+    fi
+fi
+
+if needs gst; then
+    echo "installing gstreamer client (moq-gst prebuilt release)..."
+    if gst_prepare >"$TMP/gst-build.log" 2>&1; then :; else
+        mark_broken gst "moq-gst download / plugin load failed"
+        sed 's/^/        /' "$TMP/gst-build.log" >&2 || true
+    fi
+fi
+
+if curl -sf "$URL/certificate.sha256" >/dev/null 2>&1; then
+    echo "error: something is already listening on 127.0.0.1:4443 (stale relay?)" >&2
+    exit 1
+fi
+
+echo "starting relay on 127.0.0.1:${PORT}..."
+# smoke.toml is the source of truth; rewrite its port into a scratch copy so a
+# busy 4443 (a dev relay, a parallel run) doesn't require editing the committed file.
+sed "s/4443/${PORT}/g" "$SMOKE_DIR/smoke.toml" >"$TMP/relay.toml"
+"$RELAY" "$TMP/relay.toml" >"$TMP/relay.log" 2>&1 &
+RELAY_PID=$!
+for _ in $(seq 1 60); do
+    curl -sf "$URL/certificate.sha256" >/dev/null 2>&1 && break
+    sleep 0.5
+done
+if ! curl -sf "$URL/certificate.sha256" >/dev/null 2>&1; then
+    echo "relay never became ready" >&2
+    sed 's/^/  relay: /' "$TMP/relay.log" >&2 || true
+    exit 1
+fi
+
+# ── client dispatch ─────────────────────────────────────────────────────────
+# Encode an endless H.264 Annex-B stream from a synthetic source to stdout.
+# Paced with -re so the broadcast streams in real time until the reader closes.
+# Baseline + repeat-headers re-emits SPS/PPS before every keyframe so a late
+# subscriber (or the stream importer) can initialize without the first packet.
+ffmpeg_h264() {
+    ffmpeg -hide_banner -loglevel error -re -f lavfi -i "testsrc=size=${SIZE}:rate=${FPS}" \
+        -an -c:v libx264 -profile:v baseline -preset ultrafast -pix_fmt yuv420p \
+        -x264-params "keyint=${FPS}:min-keyint=${FPS}:scenecut=0:repeat-headers=1" \
+        -f h264 -
+}
+
+# Sets global PUB_PID. Called in the current shell (no command substitution) so
+# $! refers to the backgrounded job and kill_tree can reap the whole pipeline.
+# Every publisher just consumes the same ffmpeg Annex-B stream on stdin; the
+# client frames it (moq-cli / the FFI importers only frame-and-forward, ffmpeg
+# encodes).
+PUB_PID=""
+start_publisher() {
+    local lang="$1" broadcast="$2" log="$TMP/pub-$1.log"
+    case "$lang" in
+        rust)
+            (ffmpeg_h264 | "$MOQ" publish --url "$URL" --broadcast "$broadcast" avc3) >"$log" 2>&1 &
+            ;;
+        python)
+            (ffmpeg_h264 | "$PY" "$CLIENTS/python/smoke.py" \
+                publish --url "$URL" --broadcast "$broadcast") >"$log" 2>&1 &
+            ;;
+        go)
+            (ffmpeg_h264 | "$GO_SMOKE" publish --url "$URL" --broadcast "$broadcast") >"$log" 2>&1 &
+            ;;
+        js-vite | js-esbuild | js-jsdelivr)
+            # Headless Chromium encodes its own H.264 from a fake camera via
+            # WebCodecs (lazily, once a subscriber creates demand). The variant
+            # selects how the published packages reach the page.
+            (cd "$CLIENTS/js" && bun driver.ts publish --variant "${lang#js-}" \
+                --url "$URL" --broadcast "$broadcast") >"$log" 2>&1 &
+            ;;
+        *)
+            echo "unknown publisher: $lang" >&2
+            return 1
+            ;;
+    esac
+    PUB_PID=$!
+}
+
+run_subscriber() {
+    local lang="$1" broadcast="$2"
+    case "$lang" in
+        rust)
+            # moq-cli only handles SIGINT, so -k forces SIGKILL if it ignores the
+            # SIGTERM that fires when no data arrives within the timeout.
+            local n
+            n=$(timeout -k 3 "$TIMEOUT" "$MOQ" subscribe --url "$URL" --broadcast "$broadcast" \
+                --format fmp4 2>/dev/null | head -c 1 | wc -c | tr -d ' ' || true)
+            [[ "${n:-0}" -ge 1 ]]
+            ;;
+        python)
+            "$PY" "$CLIENTS/python/smoke.py" \
+                subscribe --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
+            ;;
+        go)
+            "$GO_SMOKE" subscribe --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
+            ;;
+        swift)
+            "$SWIFT_SMOKE" subscribe --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
+            ;;
+        kotlin)
+            "$KOTLIN_SMOKE" subscribe --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
+            ;;
+        c)
+            "$C_SMOKE" subscribe --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
+            ;;
+        gst)
+            # moqsrc exposes the broadcast's video as a Sometimes pad (video_%u,
+            # ANY caps); gst-launch links it to filesink once it appears. We pipe
+            # the raw frames to stdout and grab one byte, the same "bytes moved"
+            # bar (and the same head -c 1 early-exit idiom) as the rust subscriber
+            # -- no decode. head closing the pipe SIGPIPEs gst-launch, so success
+            # returns at once; no data just runs out the timeout. Our plugin dir
+            # rides on top of the system path (which provides filesink); a private
+            # registry keeps the scan off the user's cache. buffer-mode=2 makes
+            # filesink unbuffered so the first frame reaches head immediately.
+            local n
+            n=$(GST_PLUGIN_PATH_1_0="$GST_PLUGIN_DIR" GST_REGISTRY_1_0="$TMP/gst-run-registry.bin" \
+                timeout -k 3 "$TIMEOUT" gst-launch-1.0 -q \
+                moqsrc url="$URL" broadcast="$broadcast" ! filesink location=/dev/stdout buffer-mode=2 \
+                2>/dev/null | head -c 1 | wc -c | tr -d ' ' || true)
+            [[ "${n:-0}" -ge 1 ]]
+            ;;
+        js-vite | js-esbuild | js-jsdelivr)
+            # Headless Chromium decodes via WebCodecs; exits 0 once a frame lands.
+            (cd "$CLIENTS/js" && bun driver.ts subscribe --variant "${lang#js-}" \
+                --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT")
+            ;;
+        js-native-bun)
+            # Native @moq/net via the WebTransport polyfill, under bun.
+            (cd "$CLIENTS/js-native" && bun subscribe.ts subscribe \
+                --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT")
+            ;;
+        js-native-node)
+            # Same, under node (tsx runs the TS directly).
+            (cd "$CLIENTS/js-native" && node --import tsx subscribe.ts subscribe \
+                --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT")
+            ;;
+        *)
+            echo "unknown subscriber: $lang" >&2
+            return 1
+            ;;
+    esac
+}
+
+# ── matrix ──────────────────────────────────────────────────────────────────
+overall=0
+
+run_round() {
+    local pub="$1" broadcast="$2" pub_pid="$3"
+    local pids=() names=() i sub
+    for sub in "${SUB_LIST[@]}"; do
+        if is_broken "$sub"; then
+            echo "  FAIL  $pub -> $sub (subscriber client unavailable)"
+            overall=1
+            continue
+        fi
+        (run_subscriber "$sub" "$broadcast") >"$TMP/$pub-$sub.log" 2>&1 &
+        pids+=("$!")
+        names+=("$sub")
+    done
+    # A publisher that streams forever should still be alive; if it died, the
+    # subscriber failures below are a publisher bug, so surface its log.
+    if [[ -n "$pub_pid" ]] && ! kill -0 "$pub_pid" 2>/dev/null; then
+        echo "  WARN  publisher '$pub' exited early:"
+        sed 's/^/        /' "$TMP/pub-$pub.log" 2>/dev/null || true
+    fi
+    local want_pass=1 got
+    [[ "$NEGATIVE" -eq 1 ]] && want_pass=0
+    # ${arr[@]+...} guard: a round may have no live subscribers (all broken),
+    # and bash 3.2 (macOS) errors on "${!pids[@]}" for an empty array under `set -u`.
+    for i in ${pids[@]+"${!pids[@]}"}; do
+        if wait "${pids[$i]}"; then got=1; else got=0; fi
+        if [[ "$got" -eq "$want_pass" ]]; then
+            echo "  PASS  $pub -> ${names[$i]}"
+        else
+            echo "  FAIL  $pub -> ${names[$i]}"
+            sed 's/^/        /' "$TMP/$pub-${names[$i]}.log" 2>/dev/null || true
+            overall=1
+        fi
+    done
+    if [[ -n "$pub_pid" ]]; then
+        kill_tree "$pub_pid"
+        wait "$pub_pid" 2>/dev/null || true
+        # Don't let cleanup() later signal this now-reaped (possibly recycled) PID.
+        [[ "${PUB_PID:-}" == "$pub_pid" ]] && PUB_PID=""
+    fi
+    return 0
+}
+
+if [[ "$NEGATIVE" -eq 1 ]]; then
+    # Negative control: no publisher. Every subscriber must FAIL (time out with
+    # no data), proving the harness can actually report failure.
+    echo "=== negative control: subscribers expect NO data ==="
+    run_round "none" "smoke-missing-$$-$RANDOM.hang" ""
+else
+    for pub in "${PUB_LIST[@]}"; do
+        broadcast="smoke-${pub}-$$-${RANDOM}.hang"
+        echo "=== publisher: $pub  broadcast: $broadcast ==="
+        if is_broken "$pub"; then
+            for sub in "${SUB_LIST[@]}"; do
+                echo "  FAIL  $pub -> $sub (publisher client unavailable)"
+            done
+            overall=1
+            continue
+        fi
+        start_publisher "$pub" "$broadcast"
+        run_round "$pub" "$broadcast" "$PUB_PID"
+    done
+fi
+
+if [[ "$overall" -eq 0 ]]; then
+    echo "smoke: all checks passed"
+else
+    echo "smoke: FAILURES detected" >&2
+fi
+exit "$overall"

--- a/test/smoke/smoke.toml
+++ b/test/smoke/smoke.toml
@@ -1,0 +1,18 @@
+# Relay config for the cross-language interop smoke test.
+# Anonymous access, self-signed localhost cert, QUIC + WebSocket on 127.0.0.1:4443.
+
+[log]
+level = "info"
+
+[server]
+# QUIC on UDP. 127.0.0.1 avoids IPv6 flakiness on CI runners.
+listen = "127.0.0.1:4443"
+tls.generate = ["localhost", "127.0.0.1"]
+
+[web.http]
+# HTTP + WebSocket on TCP, also serving /certificate.sha256 for cert pinning.
+listen = "127.0.0.1:4443"
+
+[auth]
+# Allow anonymous access to everything.
+public = ""

--- a/test/smoke/token.sh
+++ b/test/smoke/token.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+# Cross-implementation token interop smoke test against the PUBLIC packages.
+#
+# moq-relay authenticates with JWTs minted by the moq-token tooling, which ships
+# in several flavours from several registries:
+#
+#   - rust    : the moq-token-cli binary (cargo / brew / apt / nix), on PATH
+#   - js-node : the @moq/token npm package's `moq-token` CLI, run under node
+#   - js-bun  : the same published npm package, run under bun
+#
+# A token minted by any one of these must verify under every other one, or a
+# relay keyed by implementation A would reject a perfectly valid token from a
+# publisher using implementation B. This script proves that cross-verification
+# holds for the *published* artifacts: it installs each, then for every
+# (generator x verifier x algorithm) cell it has the generator mint a key and
+# sign a token, and the verifier check it. A negative pass confirms each verifier
+# actually rejects tampered tokens and the wrong key, so a green cell means
+# "accepts the valid one AND refuses the bad ones", not "accepts everything".
+#
+# This is the install/packaging companion to moq's in-tree token unit tests:
+# those run against workspace source with hardcoded fixtures; this runs the
+# real CLIs a user installs, live on both sides.
+set -euo pipefail
+
+SMOKE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+JS_DIR="$SMOKE_DIR/clients/token/js"
+
+GENERATORS="rust"
+VERIFIERS="rust"
+# Cover both code paths in each impl: symmetric (HS256) and every asymmetric
+# family they support — EdDSA (OKP/Ed25519), ES256 (EC), RS256 (RSA) — so the
+# default matrix (and `just token-full` / CI, which don't pass --algorithms)
+# can't silently stop exercising one. Override with --algorithms / TOKEN_ALGORITHMS.
+ALGORITHMS="${TOKEN_ALGORITHMS:-HS256,EdDSA,ES256,RS256}"
+
+# The Rust CLI under test. Whatever channel installed it (cargo/brew/apt/nix)
+# just has to leave it on PATH; override here to point at a specific build.
+TOKEN="${TOKEN_BIN:-moq-token-cli}"
+
+# The published Docker image for the `rust-docker` cell. Untagged = :latest, the
+# tag the release pipeline moves to the newest version; pulled fresh each run.
+DOCKER_TOKEN_IMAGE="${DOCKER_TOKEN_IMAGE:-moqdev/moq-token-cli}"
+# Container runtime for that cell. `docker` by default (what GitHub's Linux
+# runners ship); set TOKEN_DOCKER=podman to use a drop-in-compatible one.
+DOCKER="${TOKEN_DOCKER:-docker}"
+
+# Canary claims. Distinctive values so a verifier's claim dump can be grepped for
+# them regardless of output format (Rust prints a debug struct, JS prints JSON;
+# both contain these literal strings if the claims survived the round trip).
+ROOT="smoke-root"
+
+require_value() {
+    if [[ $# -lt 2 || -z "${2:-}" || "$2" == -* ]]; then
+        echo "error: $1 requires a value" >&2
+        exit 2
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --generators)
+            require_value "$@"
+            GENERATORS="$2"
+            shift 2
+            ;;
+        --verifiers)
+            require_value "$@"
+            VERIFIERS="$2"
+            shift 2
+            ;;
+        --algorithms)
+            require_value "$@"
+            ALGORITHMS="$2"
+            shift 2
+            ;;
+        *)
+            echo "unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+IFS=',' read -r -a GEN_LIST <<<"$GENERATORS"
+IFS=',' read -r -a VER_LIST <<<"$VERIFIERS"
+IFS=',' read -r -a ALGO_LIST <<<"$ALGORITHMS"
+
+needs() {
+    # needs <impl>: true if <impl> appears as a generator or verifier.
+    local impl="$1" x
+    for x in "${GEN_LIST[@]}" "${VER_LIST[@]}"; do [[ "$x" == "$impl" ]] && return 0; done
+    return 1
+}
+
+TMP=$(mktemp -d)
+CLI_NODE="" # node + @moq/token CLI path (set in prepare)
+CLI_BUN=""  # bun  + @moq/token CLI path (set in prepare)
+BROKEN_IMPLS=""
+
+mark_broken() {
+    # An implementation whose published package won't install fails only its own
+    # matrix cells, instead of aborting the run: a broken registry artifact should
+    # show up as a red cell, not hide every other result.
+    BROKEN_IMPLS="$BROKEN_IMPLS $1"
+    echo "  WARN  $1 unavailable: $2"
+}
+
+is_broken() {
+    local impl="$1" x
+    for x in $BROKEN_IMPLS; do [[ "$x" == "$impl" ]] && return 0; done
+    return 1
+}
+
+# shellcheck disable=SC2329  # invoked indirectly via 'trap cleanup EXIT'
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# ── per-implementation adapters ──────────────────────────────────────────────
+# Each implementation's CLI differs (flag names, key encoding, verify output),
+# so every operation is funnelled through an adapter that normalises it. The
+# contract:
+#   gen <impl> <algo> <dir>   -> writes <dir>/sign.jwk (key that signs) and
+#                                <dir>/verify.jwk (key that verifies)
+#   sign <impl> <signkey> <algo>  -> prints a token to stdout
+#   verify <impl> <verifykey> <token-file>  -> exit 0 + claim dump on stdout if
+#                                accepted, non-zero if rejected
+#
+# Symmetric (HS256): sign.jwk == verify.jwk (shared secret).
+# Asymmetric (EdDSA/ES256/RS256): verify.jwk is the public half.
+# Key encodings cross over fine: the Rust CLI writes base64url-JSON and reads
+# either; @moq/token writes plain JSON and reads either.
+
+cli_for() {
+    # The command prefix that runs each implementation's moq-token CLI. The word
+    # split is deliberate (runtime + path, or a whole `docker run ...` line), so
+    # callers expand it unquoted.
+    case "$1" in
+        rust) echo "$TOKEN" ;;
+        # Mount TMP at its real path so the in-container CLI reads/writes the same
+        # key/token files token.sh hands it. The image bundles the nix store, so
+        # the binary's libiconv deps resolve (the brew bottle's bug doesn't apply).
+        rust-docker) echo "$DOCKER run --rm -v $TMP:$TMP -w $TMP $DOCKER_TOKEN_IMAGE" ;;
+        js-node) echo "node $CLI_NODE" ;;
+        js-bun) echo "bun $CLI_BUN" ;;
+        *) return 1 ;;
+    esac
+}
+
+gen() {
+    local impl="$1" algo="$2" dir="$3"
+    mkdir -p "$dir"
+    local cli
+    cli=$(cli_for "$impl") || {
+        echo "unknown generator: $impl" >&2
+        return 1
+    }
+    case "$impl" in
+        rust | rust-docker)
+            if [[ "$algo" == HS* ]]; then
+                # shellcheck disable=SC2086  # cli is a deliberate multi-word prefix
+                $cli generate --algorithm "$algo" --out "$dir/sign.jwk"
+                cp "$dir/sign.jwk" "$dir/verify.jwk"
+            else
+                # shellcheck disable=SC2086
+                $cli generate --algorithm "$algo" --out "$dir/sign.jwk" --public "$dir/verify.jwk"
+            fi
+            ;;
+        js-node | js-bun)
+            if [[ "$algo" == HS* ]]; then
+                # shellcheck disable=SC2086
+                $cli generate --key "$dir/sign.jwk" --algorithm "$algo" >/dev/null
+                cp "$dir/sign.jwk" "$dir/verify.jwk"
+            else
+                # shellcheck disable=SC2086
+                $cli generate --key "$dir/sign.jwk" --algorithm "$algo" --public "$dir/verify.jwk" >/dev/null
+            fi
+            ;;
+    esac
+}
+
+sign() {
+    local impl="$1" signkey="$2" algo="$3" cli
+    cli=$(cli_for "$impl") || {
+        echo "unknown signer: $impl" >&2
+        return 1
+    }
+    # Same flags for the PATH binary and the Docker image; JS uses the same ones too.
+    # shellcheck disable=SC2086
+    $cli sign --key "$signkey" --root "$ROOT" \
+        --publish "pub-canary-$algo" --subscribe "sub-canary-$algo"
+}
+
+verify() {
+    local impl="$1" verifykey="$2" tokenfile="$3" cli
+    cli=$(cli_for "$impl") || {
+        echo "unknown verifier: $impl" >&2
+        return 1
+    }
+    case "$impl" in
+        rust | rust-docker)
+            # Rust verify reads the token from --in and ignores root (it just
+            # decodes); it prints a debug dump of the claims on success.
+            # shellcheck disable=SC2086
+            $cli verify --key "$verifykey" --in "$tokenfile"
+            ;;
+        js-node | js-bun)
+            # JS verify reads the token from stdin and enforces --root, so pass
+            # the same root the token was signed with; it prints claims as JSON.
+            # shellcheck disable=SC2086
+            $cli verify --key "$verifykey" --root "$ROOT" <"$tokenfile"
+            ;;
+    esac
+}
+
+# ── setup ────────────────────────────────────────────────────────────────────
+"$SMOKE_DIR/freshness.sh" || echo "WARN: freshness check failed (see above); continuing" >&2
+
+if needs rust; then
+    if ! have "$TOKEN"; then
+        mark_broken rust "$TOKEN not found (cargo/brew/apt/nix install moq-token-cli)"
+    # `have` only checks the file exists; actually run it once, since a broken
+    # published binary (e.g. a Homebrew bottle that baked in a /nix/store rpath
+    # and aborts on launch) is exactly the packaging failure this test exists to
+    # catch. A broken CLI marks the whole rust row unavailable instead of crashing
+    # mid-matrix.
+    elif "$TOKEN" generate --algorithm HS256 --out /dev/null >"$TMP/rust-probe.log" 2>&1; then
+        echo "rust:    $(command -v "$TOKEN")"
+    else
+        mark_broken rust "$TOKEN on PATH but won't run (see below)"
+        sed 's/^/        /' "$TMP/rust-probe.log" >&2 || true
+    fi
+fi
+
+if needs rust-docker; then
+    if ! have "$DOCKER"; then
+        mark_broken rust-docker "$DOCKER not found"
+    elif ! "$DOCKER" info >"$TMP/docker-info.log" 2>&1; then
+        mark_broken rust-docker "$DOCKER daemon not running"
+    # Pull :latest fresh (the published-package equivalent of the other channels'
+    # always-latest install), then run it once to confirm the image works.
+    elif "$DOCKER" pull "$DOCKER_TOKEN_IMAGE" >"$TMP/docker-pull.log" 2>&1 &&
+        "$DOCKER" run --rm "$DOCKER_TOKEN_IMAGE" generate --algorithm HS256 --out /dev/null >"$TMP/docker-probe.log" 2>&1; then
+        echo "rust-docker: $DOCKER_TOKEN_IMAGE (latest, via $DOCKER)"
+    else
+        mark_broken rust-docker "$DOCKER pull/run $DOCKER_TOKEN_IMAGE failed (see below)"
+        cat "$TMP/docker-pull.log" "$TMP/docker-probe.log" 2>/dev/null | sed 's/^/        /' >&2 || true
+    fi
+fi
+
+if needs js-node || needs js-bun; then
+    echo "installing js token client (@moq/token from npm)..."
+    if ! have bun; then
+        for v in js-node js-bun; do needs "$v" && mark_broken "$v" "bun not found (needed to install)"; done
+    elif (cd "$JS_DIR" && bun install) >"$TMP/js-install.log" 2>&1; then
+        # Resolve the published CLI path under each runtime we actually need.
+        if needs js-bun; then
+            if CLI_BUN=$(cd "$JS_DIR" && bun resolve-bin.mjs 2>"$TMP/js-bun-resolve.log"); then :; else
+                mark_broken js-bun "could not resolve @moq/token CLI under bun"
+                sed 's/^/        /' "$TMP/js-bun-resolve.log" >&2 || true
+            fi
+        fi
+        if needs js-node; then
+            if ! have node; then
+                mark_broken js-node "node not found"
+            elif CLI_NODE=$(cd "$JS_DIR" && node resolve-bin.mjs 2>"$TMP/js-node-resolve.log"); then :; else
+                mark_broken js-node "could not resolve @moq/token CLI under node"
+                sed 's/^/        /' "$TMP/js-node-resolve.log" >&2 || true
+            fi
+        fi
+    else
+        for v in js-node js-bun; do needs "$v" && mark_broken "$v" "bun install failed"; done
+        sed 's/^/        /' "$TMP/js-install.log" >&2 || true
+    fi
+fi
+
+# ── matrix ───────────────────────────────────────────────────────────────────
+overall=0
+
+# claims_ok <file> <algo>: the claim dump must carry every canary value, so a
+# verifier that accepts the signature but mangles the payload still fails.
+claims_ok() {
+    local file="$1" algo="$2"
+    grep -q "$ROOT" "$file" && grep -q "pub-canary-$algo" "$file" && grep -q "sub-canary-$algo" "$file"
+}
+
+echo "=== positive: generator mints, every verifier must ACCEPT ==="
+for algo in "${ALGO_LIST[@]}"; do
+    for g in "${GEN_LIST[@]}"; do
+        if is_broken "$g"; then
+            for v in "${VER_LIST[@]}"; do
+                echo "  FAIL  $g -> $v ($algo, generator unavailable)"
+                overall=1
+            done
+            continue
+        fi
+        keydir="$TMP/$g-$algo"
+        token="$keydir/token.jwt"
+        if ! gen "$g" "$algo" "$keydir" >"$keydir.gen.log" 2>&1; then
+            for v in "${VER_LIST[@]}"; do echo "  FAIL  $g -> $v ($algo, key generation failed)"; done
+            sed 's/^/        /' "$keydir.gen.log" >&2 || true
+            overall=1
+            continue
+        fi
+        if ! sign "$g" "$keydir/sign.jwk" "$algo" >"$token" 2>"$keydir.sign.log"; then
+            for v in "${VER_LIST[@]}"; do echo "  FAIL  $g -> $v ($algo, signing failed)"; done
+            sed 's/^/        /' "$keydir.sign.log" >&2 || true
+            overall=1
+            continue
+        fi
+        for v in "${VER_LIST[@]}"; do
+            if is_broken "$v"; then
+                echo "  FAIL  $g -> $v ($algo, verifier unavailable)"
+                overall=1
+                continue
+            fi
+            out="$TMP/verify-$g-$v-$algo.log"
+            if verify "$v" "$keydir/verify.jwk" "$token" >"$out" 2>&1 && claims_ok "$out" "$algo"; then
+                echo "  PASS  $g -> $v ($algo)"
+            else
+                echo "  FAIL  $g -> $v ($algo)"
+                sed 's/^/        /' "$out" >&2 || true
+                overall=1
+            fi
+        done
+    done
+done
+
+echo "=== negative: every verifier must REJECT a tampered token and the wrong key ==="
+# Use the first non-broken generator as the canonical minter for the bad tokens.
+canon=""
+for g in "${GEN_LIST[@]}"; do is_broken "$g" || {
+    canon="$g"
+    break
+}; done
+if [[ -z "$canon" ]]; then
+    echo "  WARN  no working generator; skipping negative pass"
+else
+    for algo in "${ALGO_LIST[@]}"; do
+        # Mint the canonical key + token here rather than reusing the positive
+        # pass's artifacts: `canon` is only "not marked broken", and its positive
+        # gen/sign for this algo may have failed (missing token.jwt), which would
+        # abort the whole negative pass under `set -e` and hide every later cell.
+        keydir="$TMP/$canon-neg-$algo"
+        token="$keydir/token.jwt"
+        if ! gen "$canon" "$algo" "$keydir" >"$keydir.gen.log" 2>&1; then
+            echo "  FAIL  reject(*, $algo): canonical key generation ($canon) failed"
+            sed 's/^/        /' "$keydir.gen.log" >&2 || true
+            overall=1
+            continue
+        fi
+        if ! sign "$canon" "$keydir/sign.jwk" "$algo" >"$token" 2>"$keydir.sign.log"; then
+            echo "  FAIL  reject(*, $algo): canonical signing ($canon) failed"
+            sed 's/^/        /' "$keydir.sign.log" >&2 || true
+            overall=1
+            continue
+        fi
+        # Tampered token: flip the FIRST character of the signature segment.
+        # The first base64url char of a segment carries 6 significant bits, so
+        # flipping it always changes the decoded signature bytes; appending or
+        # touching the last char would not (a short HS256 sig has slack bits at
+        # the tail that some decoders ignore, leaving the signature still valid).
+        tampered="$keydir/tampered.jwt"
+        trimmed=$(tr -d '[:space:]' <"$token")
+        head=${trimmed%.*} # header.payload
+        sig=${trimmed##*.} # signature
+        first=${sig:0:1}
+        flip=$([[ "$first" == "A" ]] && echo B || echo A)
+        printf '%s.%s%s\n' "$head" "$flip" "${sig:1}" >"$tampered"
+        for v in "${VER_LIST[@]}"; do
+            if is_broken "$v"; then
+                echo "  FAIL  reject($v, $algo): verifier unavailable"
+                overall=1
+                continue
+            fi
+            # (a) tampered token must be refused.
+            if verify "$v" "$keydir/verify.jwk" "$tampered" >"$TMP/neg-tamper-$v-$algo.log" 2>&1; then
+                echo "  FAIL  reject($v, $algo): accepted a tampered token"
+                overall=1
+            else
+                echo "  PASS  reject($v, $algo): tampered token refused"
+            fi
+            # (b) a valid token verified against an unrelated key must be refused.
+            wrongdir="$TMP/wrong-$v-$algo"
+            if ! gen "$v" "$algo" "$wrongdir" >"$wrongdir.gen.log" 2>&1; then
+                echo "  WARN  reject($v, $algo): could not mint a wrong key; skipping key check"
+                continue
+            fi
+            if verify "$v" "$wrongdir/verify.jwk" "$token" >"$TMP/neg-wrongkey-$v-$algo.log" 2>&1; then
+                echo "  FAIL  reject($v, $algo): accepted a token signed by a different key"
+                overall=1
+            else
+                echo "  PASS  reject($v, $algo): wrong key refused"
+            fi
+        done
+    done
+fi
+
+if [[ "$overall" -eq 0 ]]; then
+    echo "token: all checks passed"
+else
+    echo "token: FAILURES detected" >&2
+fi
+exit "$overall"


### PR DESCRIPTION
## Summary

Brings the cross-language interop smoke harness (formerly the standalone `moq-dev/smoke` repo) into the monorepo at `test/smoke`, and shifts it from a daily cross-OS cron to a **Linux-only nightly backstop + per-release slices pinned to the version just published**. macOS now runs only when a macOS artifact ships (the Swift package), removing the daily macOS spend that had already forced those cron cells to be disabled.

Motivation: the daily matrix was expensive (macOS runners), and "always latest" gives a fuzzy signal. Running a slice immediately after a release, pinned to the exact version, is cheaper and tests *what was actually shipped*.

## What changed

- **`test/smoke/`** — `smoke.sh`, `token.sh`, `smoke.toml`, `freshness.sh`, README, and all `clients/` moved in-tree. Clients install from public registries and sit **outside** the cargo/bun workspaces, so they resolve published artifacts, never workspace source. `git ls-files` scoping keeps the freshness lockfile guard local to the subtree (the monorepo's own root lockfiles are untouched).
- **`just smoke <lang>`** — per-language slices (`rust`, `python`, `go`, `swift`, `kotlin`, `c`, `gst`, `js`, `js-native`) wired into the root justfile as a module; each pairs the named client with rust on the opposite axis.
- **Pinned mode** — `MOQ_{RS,GO,NPM,SWIFT,KT,LIBMOQ,GST}_VERSION` (rust via `RELAY_BIN`/`MOQ_BIN`) install an exact version instead of latest, skip the freshness guard, and **poll the registry until the version resolves** (publish can finish before the artifact is downloadable). `Package.swift` / `build.gradle.kts` read the env to pick their dependency requirement.
- **CI** — `.github/workflows/smoke.yml` is the nightly Linux backstop (cargo/apt/nix/docker) + on-demand + PR-on-harness-change. `smoke-release.yml` is a reusable per-language slice that `release-py`, `release-swift`, `release-kt`, `release-go`, `libmoq`, and `moq-gst` call right after publishing, pinned to the version they just cut.
- **Docs** — README rewritten for the in-tree context + pinned mode; `CLAUDE.md` gains the `test/smoke` structure entry, a testing note, and a Cross-Package Sync row.

## Test plan / verification

- [x] `just smoke rust` (latest mode) passes
- [x] `MOQ_RS_VERSION=0.2.16 just smoke python` (pinned mode) passes 4/4, freshness skipped, exact wheel installed
- [x] `just smoke freshness` exit 0
- [x] shellcheck + shfmt clean on all `test/smoke` shell files (monorepo `.editorconfig`)
- [x] `actionlint` green on all 8 touched workflows (incl. reusable-workflow input validation)
- [x] justfile fmt + remark markdown clean
- [ ] Release-workflow hooks: correct by construction but only exercised by an actual release

## Reviewer notes

- **Scope can be trimmed.** The original ask was just "run `just smoke swift` after a release." This wires pinned hooks for 6 release workflows. If that's more surface than wanted, the leanest cut is to keep the nightly + only the `swift` and `python` hooks (the two verified locally) and drop the kt/go/c/gst hooks until there's demand — go and gst can't pass today anyway. The reusable workflow makes re-adding them a ~6-line job.
- **Per-release CI cost:** each hook `cargo install`s a reference relay+cli (~3–5 min cold); `moq-ffi-v*` fans out to swift+kt+go = three such jobs per release. Much cheaper than daily-all-OS, but not free.
- **Deliberately not wired:** `release-js` (publishes per-package versions, no single output to pin); `moq-cli`/`moq-relay` (rust is the reference, covered by every slice + nightly); token-interop pinning (stays nightly/latest).
- **Maven Central lag:** the kotlin slice gets a 20-min poll budget; if Central sync is slower the job will time out and need a re-run.
- **Local-nix gap:** the monorepo `nix develop` shell carries no Chromium, so `just smoke js` falls back to a Playwright download there. Adding `playwright-driver.browsers` to the flake is a clean follow-up.
- **Follow-up:** archive `moq-dev/smoke` once this merges — its role is now fully in-tree.

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)