### PR TITLE
feat(just): add `just clean` to wipe build artifacts and sweep worktrees

### DIFF
--- a/go/justfile
+++ b/go/justfile
@@ -19,6 +19,12 @@ check:
 package *args:
     bash scripts/package.sh {{ args }}
 
+# Remove the generated bindings, native libs, and vendoring that
+# scripts/check.sh produces in go/ (see go/.gitignore). The tmp staging
+# under the workspace dist/ is swept by `just js clean`.
+clean:
+    rm -rf moq/moq.go moq/lib go.sum vendor
+
 # Full Go CI: `check` builds moq-ffi, regenerates bindings, runs go
 # vet/build/test. Takes a newline-separated list of changed files;
 # skips if FILES is non-empty and none match the Go scope. Run

--- a/js/justfile
+++ b/js/justfile
@@ -41,6 +41,17 @@ test:
 build:
     bun run --filter='*' build
 
+# Remove node_modules and build output. The bun workspace spans the repo
+# (deps hoist to the root, not into js/), so sweep from the workspace root.
+clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd ..
+    find . -name .claude -prune -o \
+    	-type d \( -name node_modules -o -name dist -o -name out -o -name pkg \) \
+    	-prune -exec rm -rf {} +
+    find . -name .claude -prune -o -type f -name '*.tsbuildinfo' -exec rm -f {} +
+
 # Full JS CI: lint + tests + build. Takes a newline-separated list of
 # changed files; skips if FILES is non-empty and none match the JS
 # scope. Run `just js ci` (no FILES) to force-run everything.

--- a/justfile
+++ b/justfile
@@ -121,6 +121,40 @@ build:
     just rs build
     if command -v uv &> /dev/null; then just py build; fi
 
+# Delete build artifacts and caches across every language to reclaim disk
+# space, then recurse into any agent worktrees under .claude/worktrees/.
+# Each worktree now builds into its own target dir, so they're cleaned too.
+clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Rust workspace: wipes ./target.
+    cargo clean
+
+    # JS/TS dependency + build trees. Prune .claude (agent worktrees are
+    # handled by the recursion below) and stop find from descending into the
+    # node_modules trees it's about to delete.
+    find . -name .claude -prune -o \
+    	-type d \( -name node_modules -o -name dist -o -name out -o -name pkg \) \
+    	-prune -exec rm -rf {} +
+    find . -name .claude -prune -o -type f -name '*.tsbuildinfo' -exec rm -f {} +
+
+    # Python: virtualenv, bytecode caches, generated uniffi bindings.
+    rm -rf .venv py/moq-ffi/moq_ffi/_uniffi
+    find . -name .claude -prune -o -type d -name __pycache__ -prune -exec rm -rf {} +
+
+    # Misc: nix build result, direnv + wrangler caches.
+    rm -rf result .direnv .wrangler
+
+    # Agent worktrees each carry their own artifacts; clean them the same way.
+    # Worktrees don't nest, so this recurses exactly one level. Tolerate stale
+    # worktrees on branches that predate this recipe.
+    for wt in .claude/worktrees/*/; do
+    	[ -f "${wt}justfile" ] || continue
+    	echo "==> cleaning ${wt}"
+    	(cd "$wt" && just clean) || echo "    (skipped: no clean recipe in ${wt})"
+    done
+
 # Upgrade any tooling
 update:
     just js update

--- a/justfile
+++ b/justfile
@@ -121,34 +121,28 @@ build:
     just rs build
     if command -v uv &> /dev/null; then just py build; fi
 
-# Delete build artifacts and caches across every language to reclaim disk
-# space, then recurse into any agent worktrees under .claude/worktrees/.
-# Each worktree now builds into its own target dir, so they're cleaned too.
+# Delete build artifacts and caches to reclaim disk space. Each language
+# owns its own `clean` (see js/rs/py/kt/swift/go justfiles); this
+# orchestrates them, sweeps the caches no language owns, then recurses into
+# any agent worktrees under .claude/worktrees/.
 clean:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    # Rust workspace: wipes ./target.
-    cargo clean
+    just rs clean
+    just js clean
+    just py clean
+    just kt clean
+    just swift clean
+    just go clean
 
-    # JS/TS dependency + build trees. Prune .claude (agent worktrees are
-    # handled by the recursion below) and stop find from descending into the
-    # node_modules trees it's about to delete.
-    find . -name .claude -prune -o \
-    	-type d \( -name node_modules -o -name dist -o -name out -o -name pkg \) \
-    	-prune -exec rm -rf {} +
-    find . -name .claude -prune -o -type f -name '*.tsbuildinfo' -exec rm -f {} +
+    # Caches not owned by any one language: nix build result, direnv, wrangler.
+    rm -rf result .direnv
+    find . -name .claude -prune -o -type d -name .wrangler -prune -exec rm -rf {} +
 
-    # Python: virtualenv, bytecode caches, generated uniffi bindings.
-    rm -rf .venv py/moq-ffi/moq_ffi/_uniffi
-    find . -name .claude -prune -o -type d -name __pycache__ -prune -exec rm -rf {} +
-
-    # Misc: nix build result, direnv + wrangler caches.
-    rm -rf result .direnv .wrangler
-
-    # Agent worktrees each carry their own artifacts; clean them the same way.
-    # Worktrees don't nest, so this recurses exactly one level. Tolerate stale
-    # worktrees on branches that predate this recipe.
+    # Agent worktrees each carry their own artifacts now that the shared
+    # target dir is gone. Worktrees don't nest, so this recurses exactly one
+    # level. Tolerate stale worktrees on branches that predate this recipe.
     for wt in .claude/worktrees/*/; do
     	[ -f "${wt}justfile" ] || continue
     	echo "==> cleaning ${wt}"

--- a/justfile
+++ b/justfile
@@ -146,7 +146,7 @@ clean:
     for wt in .claude/worktrees/*/; do
     	[ -f "${wt}justfile" ] || continue
     	echo "==> cleaning ${wt}"
-    	(cd "$wt" && just clean) || echo "    (skipped: no clean recipe in ${wt})"
+    	(cd "$wt" && just clean) || echo "    (skipped: just clean failed in ${wt})"
     done
 
 # Upgrade any tooling

--- a/kt/justfile
+++ b/kt/justfile
@@ -25,7 +25,7 @@ package *args:
 clean:
     #!/usr/bin/env bash
     set -euo pipefail
-    find . -type d \( -name build -o -name .gradle -o -name .kotlin \) -prune -exec rm -rf {} +
+    find . -name .claude -prune -o -type d \( -name build -o -name .gradle -o -name .kotlin \) -prune -exec rm -rf {} +
     rm -rf local.properties \
     	moq/src/jvmAndAndroidMain/kotlin/uniffi \
     	moq/src/jvmMain/resources \

--- a/kt/justfile
+++ b/kt/justfile
@@ -20,6 +20,17 @@ check:
 package *args:
     bash scripts/package.sh {{ args }}
 
+# Remove gradle output plus the moq-ffi bindings and native libs that
+# scripts/check.sh generates into the source tree (see kt/.gitignore).
+clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    find . -type d \( -name build -o -name .gradle -o -name .kotlin \) -prune -exec rm -rf {} +
+    rm -rf local.properties \
+    	moq/src/jvmAndAndroidMain/kotlin/uniffi \
+    	moq/src/jvmMain/resources \
+    	moq/src/androidMain/jniLibs
+
 # Full Kotlin CI: `check` already builds moq-ffi and runs gradle tests.
 # Takes a newline-separated list of changed files; skips if FILES is
 # non-empty and none match the Kotlin scope. Run `just kt ci` (no

--- a/py/justfile
+++ b/py/justfile
@@ -54,8 +54,8 @@ clean:
     set -euo pipefail
     rm -rf dist moq-ffi/moq_ffi/_uniffi
     rm -rf ../.venv .venv
-    find . -type d -name __pycache__ -prune -exec rm -rf {} +
-    find . -type f -name '*.pyc' -delete
+    find . -name .claude -prune -o -type d -name __pycache__ -prune -exec rm -rf {} +
+    find . -name .claude -prune -o -type f -name '*.pyc' -exec rm -f {} +
 
 # Build the pure-python moq-rs wrapper sdist + wheel into py/dist (for release).
 # moq-ffi is built separately by maturin (see release-py.yml); the wrapper is

--- a/py/justfile
+++ b/py/justfile
@@ -46,6 +46,17 @@ build:
     uv sync --no-install-workspace
     just _develop
 
+# Remove the virtualenv, release dist, bytecode caches, and the uniffi
+# bindings maturin drops in during editable installs. The uv workspace venv
+# lives at the repo root, so reach up for it.
+clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rm -rf dist moq-ffi/moq_ffi/_uniffi
+    rm -rf ../.venv .venv
+    find . -type d -name __pycache__ -prune -exec rm -rf {} +
+    find . -type f -name '*.pyc' -delete
+
 # Build the pure-python moq-rs wrapper sdist + wheel into py/dist (for release).
 # moq-ffi is built separately by maturin (see release-py.yml); the wrapper is
 # pure python so it needs no compilation, just a metadata-correct wheel.

--- a/rs/justfile
+++ b/rs/justfile
@@ -56,6 +56,10 @@ test *args:
 build:
     cargo build
 
+# Remove the Rust target directory.
+clean:
+    cargo clean
+
 # Check semver compatibility against crates.io (default-members only).
 semver:
     cargo semver-checks check-release

--- a/swift/justfile
+++ b/swift/justfile
@@ -19,6 +19,11 @@ check:
 package *args:
     bash scripts/package.sh {{ args }}
 
+# Remove SwiftPM build output plus the XCFramework and generated bindings
+# that scripts/check.sh lays down (see swift/.gitignore).
+clean:
+    rm -rf .build .swiftpm Package.resolved Sources/MoqFFI/Generated.swift MoqFFI.xcframework
+
 # Full Swift CI: `check` already builds moq-ffi and runs swift test.
 # Takes a newline-separated list of changed files; skips if FILES is
 # non-empty and none match the Swift scope. Run `just swift ci` (no


### PR DESCRIPTION
## Summary

Adds a `just clean` recipe to reclaim disk space. Each language owns its own `clean`, matching the existing `check`/`fix`/`build` delegation pattern, and the root recipe orchestrates them:

- **rs**: `cargo clean`.
- **js**: `node_modules`, `dist`, `out`, `pkg`, `*.tsbuildinfo`. The bun workspace hoists deps to the repo root, so it sweeps from the workspace root.
- **py**: `.venv`, release `dist`, `__pycache__`/`*.pyc`, the generated `moq_ffi/_uniffi` bindings.
- **kt**: gradle `build`/`.gradle`/`.kotlin` plus the bindings and native libs `scripts/check.sh` drops into the source tree (per `kt/.gitignore`).
- **swift**: `.build`/`.swiftpm`, `MoqFFI.xcframework`, generated `Generated.swift`.
- **go**: generated `moq/moq.go`, `moq/lib`, `go.sum`, `vendor`.

The root `clean` then sweeps caches no language owns (nix `result`, `.direnv`, `.wrangler`) and recurses `just clean` into every `.claude/worktrees/*/`. Worktrees don't nest, so the recursion is exactly one level; stale worktrees on branches that predate the recipe are skipped with a note instead of aborting.

## Motivation

This replaces a machine-local shared-target hack: `.claude/worktrees/.cargo/config.toml` pointed every agent worktree at the main checkout's `target/`. It saved disk but kept causing intermediate build issues, since concurrent builds across worktrees serialized on a single target lock. That config was git-ignored (never committed); it's removed locally and nothing in the repo referenced it. Worktrees now build into their own `target/`, and `just clean` is the easy way to reclaim space when the disk fills up.

## Test plan

- [x] `just --fmt --check` passes on every modified justfile (root + rs/js/py/kt/swift/go).
- [x] Each delegated recipe (`just rs clean`, `just js clean`, ...) runs to exit 0.
- [x] Full `just clean` runs to exit 0 from a worktree and removes its artifacts; the worktree-recursion loop no-ops correctly since worktrees don't nest.
- [ ] Full root sweep across all sibling worktrees (not run here to avoid disrupting other active agent sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)