### PR TITLE
moq-lite-05: add TRACK stream, drop SUBSCRIBE_OK/FETCH_OK

### DIFF
--- a/js/clock/src/main.ts
+++ b/js/clock/src/main.ts
@@ -86,15 +86,17 @@ async function publish(config: Config) {
 		const request = await broadcast.requested();
 		if (!request) break;
 
-		if (request.track.name === config.track) {
-			publishTrack(request.track);
+		if (request.name === config.track) {
+			// Accept to commit the track's immutable properties (so a lite-05 TRACK
+			// request resolves) and obtain the Track to produce into.
+			publishTrack(request.accept());
 		} else {
-			request.track.close(new Error("not found"));
+			request.reject(new Error("not found"));
 		}
 	}
 }
 
-async function publishTrack(track: Moq.Track) {
+async function publishTrack(track: Moq.TrackProducer) {
 	// Send timestamps over the wire, matching the Rust implementation format
 	console.log("✅ Publishing clock data on track:", track.name);
 
@@ -141,7 +143,7 @@ async function subscribe(config: Config) {
 	console.log("✅ Connected to relay:", config.url);
 
 	const broadcast = connection.consume(Moq.Path.from(config.broadcast));
-	const track = broadcast.subscribe(config.track, 0);
+	const track = broadcast.track(config.track).subscribe({ priority: 0 });
 
 	console.log("✅ Subscribed to track:", config.track);
 

--- a/js/hang/src/catalog/root.ts
+++ b/js/hang/src/catalog/root.ts
@@ -38,7 +38,7 @@ export function decode(raw: Uint8Array): Root {
 	}
 }
 
-export async function fetch(track: Moq.Track): Promise<Root | undefined> {
+export async function fetch(track: Moq.TrackSubscriber): Promise<Root | undefined> {
 	const frame = await track.readFrame();
 	if (!frame) return undefined;
 	return decode(frame);

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { Group, type Time, Track, Varint } from "@moq/net";
+import { Group, type Time, TrackProducer, Varint } from "@moq/net";
 import type { InitSegment } from "./cmaf/decode.ts";
 import { encodeDataSegment } from "./cmaf/encode.ts";
 import { Format as CmafFormat } from "./cmaf/format.ts";
@@ -135,7 +135,7 @@ function encodeLegacy(timestamp: Time.Micro): Uint8Array {
 	return data;
 }
 
-function writeGroupWithLegacyFrames(track: Track, sequence: number, timestamps: Time.Micro[]) {
+function writeGroupWithLegacyFrames(track: TrackProducer, sequence: number, timestamps: Time.Micro[]) {
 	const group = new Group(sequence);
 	for (const ts of timestamps) {
 		group.writeFrame(encodeLegacy(ts));
@@ -163,8 +163,8 @@ async function drainFrames(
 }
 
 test("Consumer delivers frames from a single group", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
 	track.close();
@@ -177,8 +177,8 @@ test("Consumer delivers frames from a single group", async () => {
 });
 
 test("Consumer forces keyframe true at index 0", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
 	track.close();
@@ -201,8 +201,8 @@ test("Consumer index spans MoQ frames for keyframe detection", async () => {
 		},
 	};
 
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: multiFormat, latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: multiFormat, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
 	group.writeFrame(new Uint8Array([0x01])); // first MoQ frame → 3 samples
@@ -229,8 +229,8 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 		},
 	};
 
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: truncatingFormat, latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: truncatingFormat, latency: 500 as Time.Milli });
 
 	// Group 0: 2 valid frames then a tail-truncating error.
 	const g0 = new Group(0);
@@ -256,8 +256,8 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 });
 
 test("Consumer close returns undefined from next()", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	const promise = consumer.next();
 	consumer.close();
@@ -267,8 +267,8 @@ test("Consumer close returns undefined from next()", async () => {
 });
 
 test("Consumer throws on concurrent next() calls", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	// First call blocks waiting for data
 	consumer.next();
@@ -279,9 +279,9 @@ test("Consumer throws on concurrent next() calls", async () => {
 });
 
 test("Consumer skips groups via PTS-span when over latency", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	// Zero latency = skip everything that's not the latest
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 0 as Time.Milli });
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 0 as Time.Milli });
 
 	// Write groups with increasing timestamps. With 0 latency, any PTS span > 0 triggers skip.
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro]);
@@ -299,8 +299,8 @@ test("Consumer skips groups via PTS-span when over latency", async () => {
 // --- Ordering ---
 
 test("Consumer delivers groups in sequence order regardless of arrival order", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 2, [60_000 as Time.Micro]);
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro]);
@@ -318,8 +318,8 @@ test("Consumer delivers groups in sequence order regardless of arrival order", a
 });
 
 test("Consumer rejects stale groups", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	// Group 5 arrives first (sets active = 5)
 	writeGroupWithLegacyFrames(track, 5, [0 as Time.Micro]);
@@ -343,8 +343,8 @@ test("Consumer rejects stale groups", async () => {
 // --- Group boundary signals ---
 
 test("Consumer next() returns group-done signals", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
 	writeGroupWithLegacyFrames(track, 1, [66_000 as Time.Micro]);
@@ -374,8 +374,8 @@ test("Consumer next() returns group-done signals", async () => {
 // --- Buffered signal ---
 
 test("Consumer buffered signal updates as frames arrive", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	expect(consumer.buffered.peek()).toEqual([]);
 
@@ -396,8 +396,8 @@ test("Consumer buffered signal updates as frames arrive", async () => {
 // --- Gap recovery ---
 
 test("Consumer recovers from gap in group sequence numbers", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 100 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 100 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 20_000 as Time.Micro]);
 	writeGroupWithLegacyFrames(track, 1, [40_000 as Time.Micro, 60_000 as Time.Micro]);
@@ -426,8 +426,8 @@ test("Consumer handles empty decode result without deadlock", async () => {
 		},
 	};
 
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: emptyThenValid, latency: 500 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: emptyThenValid, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
 	group.writeFrame(new Uint8Array([0x01])); // empty decode
@@ -449,8 +449,8 @@ test("Consumer handles empty decode result without deadlock", async () => {
 // --- CMAF through Consumer ---
 
 test("Consumer with CmafFormat delivers correct timestamps", async () => {
-	const track = new Track("test");
-	const consumer = new Consumer(track, {
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), {
 		format: new CmafFormat(TEST_INIT),
 		latency: 500 as Time.Milli,
 	});
@@ -519,9 +519,9 @@ const durationFormat: ContainerFormat = {
 };
 
 test("Consumer duration-skips a stalled group once it is covered", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	// Latency dwarfs the gap, so only duration coverage can trigger the skip.
-	const consumer = new Consumer(track, { format: durationFormat, latency: 10_000 as Time.Milli });
+	const consumer = new Consumer(track.subscribe(), { format: durationFormat, latency: 10_000 as Time.Milli });
 
 	// Group 0: one frame at ts=0 lasting 33ms, never closed (stalled).
 	const g0 = new Group(0);
@@ -557,8 +557,8 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 		},
 	};
 
-	const track = new Track("test");
-	const consumer = new Consumer(track, { format: shortFormat, latency: 10_000 as Time.Milli });
+	const track = new TrackProducer("test");
+	const consumer = new Consumer(track.subscribe(), { format: shortFormat, latency: 10_000 as Time.Milli });
 
 	// Group 0 stays open and later receives a second frame; nothing covers the gap,
 	// so that late frame must survive rather than being skipped.

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -21,7 +21,7 @@ interface Group {
 }
 
 export class Consumer {
-	#track: Moq.Track;
+	#track: Moq.TrackSubscriber;
 	#format: Format;
 	#latency: Getter<Time.Milli>;
 	#groups: Group[] = [];
@@ -35,7 +35,7 @@ export class Consumer {
 
 	#signals = new Effect();
 
-	constructor(track: Moq.Track, props: ConsumerProps) {
+	constructor(track: Moq.TrackSubscriber, props: ConsumerProps) {
 		this.#track = track;
 		this.#format = props.format;
 		this.#latency = getter(props.latency ?? Moq.Time.Milli.zero);

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -35,10 +35,10 @@ export function encodeFrame(source: Uint8Array | Source, timestamp: Time.Micro):
 
 // A Helper class to encode frames into a track.
 export class Producer {
-	#track: Moq.Track;
+	#track: Moq.TrackProducer;
 	#group?: Moq.Group;
 
-	constructor(track: Moq.Track) {
+	constructor(track: Moq.TrackProducer) {
 		this.#track = track;
 	}
 

--- a/js/json/src/consumer.ts
+++ b/js/json/src/consumer.ts
@@ -10,14 +10,14 @@ import type { Config } from "./producer.ts";
  * yielding the reconstructed value after each one.
  */
 export class Consumer<T> {
-	#track: Moq.Track;
+	#track: Moq.TrackSubscriber;
 	#schema?: z.ZodMiniType<T>;
 
 	#group?: Moq.Group;
 	#current?: unknown;
 	#framesRead = 0;
 
-	constructor(track: Moq.Track, config: Config<T> = {}) {
+	constructor(track: Moq.TrackSubscriber, config: Config<T> = {}) {
 		this.#track = track;
 		this.#schema = config.schema;
 	}

--- a/js/json/src/json.test.ts
+++ b/js/json/src/json.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "bun:test";
-import { Track } from "@moq/net";
+import { TrackProducer, type TrackSubscriber } from "@moq/net";
 import { Consumer } from "./consumer.ts";
 import { Producer } from "./producer.ts";
 
 type Value = Record<string, unknown>;
 
 // Reconstruct every value a consumer yields, in order.
-async function drain(track: Track): Promise<Value[]> {
+async function drain(track: TrackSubscriber): Promise<Value[]> {
 	const out: Value[] = [];
 	for await (const value of new Consumer<Value>(track)) out.push(value);
 	return out;
@@ -14,7 +14,7 @@ async function drain(track: Track): Promise<Value[]> {
 
 // Inspect the published layout via the public API: the frame count of each group, in order.
 // The track must be finished first so group/frame reads terminate.
-async function structure(track: Track): Promise<number[]> {
+async function structure(track: TrackSubscriber): Promise<number[]> {
 	const counts: number[] = [];
 	for (;;) {
 		const group = await track.nextGroup();
@@ -28,20 +28,20 @@ async function structure(track: Track): Promise<number[]> {
 }
 
 test("deltas off: a snapshot group per change", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	const producer = new Producer<Value>(track);
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
 	producer.finish();
 
 	// Two changes => two single-frame snapshot groups, reconstructed in order.
-	expect(await drain(track)).toEqual([{ a: 1 }, { a: 2 }]);
+	expect(await drain(track.subscribe())).toEqual([{ a: 1 }, { a: 2 }]);
 });
 
 test("live consumer sees each update", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	const producer = new Producer<Value>(track);
-	const consumer = new Consumer<Value>(track);
+	const consumer = new Consumer<Value>(track.subscribe());
 
 	for (let n = 1; n <= 3; n++) {
 		producer.update({ a: n });
@@ -50,17 +50,17 @@ test("live consumer sees each update", async () => {
 });
 
 test("unchanged value writes nothing", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	const producer = new Producer<Value>(track);
 	producer.update({ a: 1 });
 	producer.update({ a: 1 });
 	producer.finish();
 
-	expect(await structure(track)).toEqual([1]);
+	expect(await structure(track.subscribe())).toEqual([1]);
 });
 
 test("deltas share one group", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
@@ -68,22 +68,22 @@ test("deltas share one group", async () => {
 	producer.finish();
 
 	// All updates fit in a single group as snapshot + two deltas.
-	expect(await structure(track)).toEqual([3]);
+	expect(await structure(track.subscribe())).toEqual([3]);
 });
 
 test("deltas reconstruct to the final value", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
 	producer.update({ a: 5, b: 2 });
 	producer.finish();
 
-	expect((await drain(track)).at(-1)).toEqual({ a: 5, b: 2 });
+	expect((await drain(track.subscribe())).at(-1)).toEqual({ a: 5, b: 2 });
 });
 
 test("tight ratio rolls snapshots", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
 	const producer = new Producer<Value>(track, { deltaRatio: 1.0 });
 	producer.update({ a: 1 });
@@ -91,22 +91,22 @@ test("tight ratio rolls snapshots", async () => {
 	producer.update({ a: 3 });
 	producer.finish();
 
-	expect(await structure(track)).toEqual([1, 1, 1]);
+	expect(await structure(track.subscribe())).toEqual([1, 1, 1]);
 });
 
 test("array change is a wholesale delta", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ list: [1, 2] });
 	producer.update({ list: [1, 2, 3] });
 	producer.finish();
 
 	// The array is replaced wholesale in a delta, so it stays in the same group.
-	expect(await structure(track)).toEqual([2]);
+	expect(await structure(track.subscribe())).toEqual([2]);
 });
 
 test("frame cap rolls snapshot", async () => {
-	const track = new Track("test");
+	const track = new TrackProducer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 1_000_000 });
 	// First update is the snapshot; deltas fill the group until the frame cap forces a roll.
 	for (let i = 0; i <= 256; i++) {
@@ -114,5 +114,5 @@ test("frame cap rolls snapshot", async () => {
 	}
 	producer.finish();
 
-	expect(await structure(track)).toEqual([256, 1]);
+	expect(await structure(track.subscribe())).toEqual([256, 1]);
 });

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -23,7 +23,7 @@ export interface Config<T> {
 
 /** Publishes a JSON value over a track, choosing snapshots and deltas automatically. */
 export class Producer<T> {
-	#track: Moq.Track;
+	#track: Moq.TrackProducer;
 	#config: Config<T>;
 
 	#group?: Moq.Group;
@@ -31,7 +31,7 @@ export class Producer<T> {
 	#groupBytes = 0;
 	#groupFrames = 0;
 
-	constructor(track: Moq.Track, config: Config<T> = {}) {
+	constructor(track: Moq.TrackProducer, config: Config<T> = {}) {
 		this.#track = track;
 		this.#config = config;
 	}

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -86,10 +86,10 @@ export interface Source {
  * bitstream payload.
  */
 export class Producer {
-	#track: Moq.Track;
+	#track: Moq.TrackProducer;
 	#group?: Moq.Group;
 
-	constructor(track: Moq.Track) {
+	constructor(track: Moq.TrackProducer) {
 		this.#track = track;
 	}
 

--- a/js/moq-boy/src/index.ts
+++ b/js/moq-boy/src/index.ts
@@ -288,14 +288,15 @@ export class Game {
 				const req = await Promise.race([effect.cancel, viewerBroadcast.requested()]);
 				if (!req) break;
 
-				if (req.track.name === "command") {
-					effect.run(this.#runCommandTrack.bind(this, req.track));
+				if (req.name === "command") {
+					// accept() commits the track's immutable properties and returns the Track.
+					effect.run(this.#runCommandTrack.bind(this, req.accept()));
 				}
 			}
 		});
 	}
 
-	#runCommandTrack(track: Moq.Track, effect: Moq.Signals.Effect) {
+	#runCommandTrack(track: Moq.TrackProducer, effect: Moq.Signals.Effect) {
 		if (effect.get(track.state.closed)) return;
 
 		const command = effect.get(this.#command);

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -63,7 +63,7 @@ export function decode(raw: Uint8Array): Catalog {
 	}
 }
 
-export async function fetch(track: Moq.Track): Promise<Catalog | undefined> {
+export async function fetch(track: Moq.TrackSubscriber): Promise<Catalog | undefined> {
 	const frame = await track.readFrame();
 	if (!frame) return undefined;
 	return decode(frame);

--- a/js/net/examples/publish.ts
+++ b/js/net/examples/publish.ts
@@ -17,16 +17,17 @@ async function main() {
 		if (!request) break;
 
 		// Accept the request for the "chat" track
-		if (request.track.name === "chat") {
-			publishTrack(request.track);
+		if (request.name === "chat") {
+			// accept() commits the track's immutable properties and returns the Track.
+			publishTrack(request.accept());
 		} else {
 			// Reject other tracks
-			request.track.close(new Error("track not found"));
+			request.reject(new Error("track not found"));
 		}
 	}
 }
 
-async function publishTrack(track: Moq.Track) {
+async function publishTrack(track: Moq.TrackProducer) {
 	console.log("Publishing to track:", track.name);
 
 	// Create a group (e.g., keyframe boundary)

--- a/js/net/examples/subscribe.ts
+++ b/js/net/examples/subscribe.ts
@@ -8,7 +8,7 @@ async function main() {
 	const broadcast = connection.consume(Moq.Path.from("my-broadcast"));
 
 	// Subscribe to a specific track (with priority 0)
-	const track = broadcast.subscribe("chat", 0);
+	const track = broadcast.track("chat").subscribe({ priority: 0 });
 
 	// Read data as it arrives
 	for (;;) {

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -1,9 +1,75 @@
 import { Signal } from "@moq/signals";
-import { Track } from "./track.ts";
+import { type TrackInfo, TrackProducer, TrackState, TrackSubscriber, trackInfoDefaults } from "./track.ts";
 
-export interface TrackRequest {
-	track: Track;
-	priority: number;
+/**
+ * A request for a track the peer wants, yielded by {@link Broadcast.requested}.
+ *
+ * The producer answers it with {@link accept}, declaring the track's immutable
+ * publisher properties and receiving a {@link TrackProducer} to write groups into,
+ * or {@link reject} to refuse it. The properties must be declared up front so the
+ * wire layer can answer a TRACK request (lite-05+) and pick the frame codec before
+ * any group is served. Mirrors the Rust `TrackRequest`.
+ */
+export class TrackRequest {
+	readonly name: string;
+	readonly priority: number;
+	// The shared state behind the matching TrackSubscriber handed to the caller of
+	// Broadcast.subscribe; accepting wraps it in a producer the two ends share.
+	#state: TrackState;
+
+	constructor(name: string, state: TrackState, priority: number) {
+		this.name = name;
+		this.#state = state;
+		this.priority = priority;
+	}
+
+	/**
+	 * Accept the request, committing the track's immutable {@link TrackInfo} and
+	 * returning a {@link TrackProducer} to write groups into. Any field left unset
+	 * keeps its default. Mirrors the Rust `TrackRequest::accept`.
+	 */
+	accept(info: Partial<TrackInfo> = {}): TrackProducer {
+		this.#state.info.set(trackInfoDefaults(info));
+		return new TrackProducer(this.name, this.#state);
+	}
+
+	/** Reject the request, closing the track (optionally with an error). */
+	reject(err?: Error): void {
+		this.#state.closed.set(err ?? true);
+	}
+}
+
+/**
+ * A lazy handle to a track on a consumed broadcast, mirroring the Rust
+ * `TrackConsumer`. Holding it sends nothing over the network; call {@link subscribe}
+ * to open a live subscription or {@link info} to fetch the immutable publisher
+ * properties (lite-05+).
+ */
+export class TrackConsumer {
+	readonly name: string;
+	#broadcast: Broadcast;
+
+	constructor(broadcast: Broadcast, name: string) {
+		this.#broadcast = broadcast;
+		this.name = name;
+	}
+
+	/**
+	 * Open a live subscription, returning a {@link TrackSubscriber} streaming the
+	 * track's groups. `priority` defaults to `0`.
+	 */
+	subscribe(options?: { priority?: number }): TrackSubscriber {
+		return this.#broadcast.subscribe(this.name, options?.priority ?? 0);
+	}
+
+	/**
+	 * Fetch the track's immutable publisher properties without subscribing, via a
+	 * TRACK stream. Lite-05+ only; rejects on older drafts (which carry no TRACK
+	 * stream) and if the track does not exist.
+	 */
+	info(): Promise<TrackInfo> {
+		return this.#broadcast.resolveTrackInfo(this.name);
+	}
 }
 
 export class BroadcastState {
@@ -20,6 +86,11 @@ export class Broadcast {
 	state = new BroadcastState();
 
 	readonly closed: Promise<Error | undefined>;
+
+	// Consume-side hook installed by the wire layer (Subscriber.consume) to resolve
+	// a track's immutable TRACK_INFO over a Track stream. Undefined on a published
+	// broadcast, where info comes from the producer's accept() instead.
+	#infoResolver?: (name: string) => Promise<TrackInfo>;
 
 	constructor() {
 		this.closed = new Promise((resolve) => {
@@ -49,21 +120,82 @@ export class Broadcast {
 	}
 
 	/**
-	 * Populates the provided track over the network.
+	 * Get a lazy {@link TrackConsumer} handle for a track on this broadcast.
+	 *
+	 * Sends nothing over the network until you call {@link TrackConsumer.subscribe}
+	 * or {@link TrackConsumer.info}. Mirrors the Rust `BroadcastConsumer::track`.
 	 */
-	subscribe(name: string, priority: number): Track {
-		const track = new Track(name);
+	track(name: string): TrackConsumer {
+		return new TrackConsumer(this, name);
+	}
 
+	/**
+	 * Open a live subscription to a track, returning the {@link TrackSubscriber} the
+	 * groups stream into. Called by the consuming application (usually via
+	 * {@link TrackConsumer.subscribe}) and by the publishing wire layer to ask the
+	 * application for a track to serve.
+	 */
+	subscribe(name: string, priority: number): TrackSubscriber {
 		if (this.state.closed.peek()) {
 			throw new Error(`broadcast is closed: ${this.state.closed.peek()}`);
 		}
+
+		// The subscriber (caller, reads) and the request's producer (other side,
+		// writes) share one state.
+		const state = new TrackState();
 		this.state.requested.mutate((requested) => {
-			requested.push({ track, priority });
+			requested.push(new TrackRequest(name, state, priority));
 			// Sort the tracks by priority in ascending order (we will pop)
 			requested.sort((a, b) => a.priority - b.priority);
 		});
 
-		return track;
+		return new TrackSubscriber(name, state);
+	}
+
+	/**
+	 * Install the consume-side TRACK_INFO resolver (used by {@link TrackConsumer.info}).
+	 * Called once by the wire layer when this broadcast is consumed. Internal.
+	 */
+	onTrackInfo(resolver: (name: string) => Promise<TrackInfo>): void {
+		this.#infoResolver = resolver;
+	}
+
+	/** Resolve a track's immutable info, used by {@link TrackConsumer.info}. Internal. */
+	resolveTrackInfo(name: string): Promise<TrackInfo> {
+		// Consume side: a TRACK stream (lite-05+) answers it.
+		if (this.#infoResolver) {
+			return this.#infoResolver(name);
+		}
+
+		// Publish side: ask the application by triggering a TrackRequest it answers
+		// with accept(TrackInfo); only the immutable properties are needed, so close
+		// the request once they're known rather than serving any groups.
+		if (this.state.closed.peek()) {
+			return Promise.reject(new Error(`broadcast is closed: ${this.state.closed.peek()}`));
+		}
+
+		const state = new TrackState();
+		this.state.requested.mutate((requested) => {
+			requested.push(new TrackRequest(name, state, 0));
+			requested.sort((a, b) => a.priority - b.priority);
+		});
+
+		return (async () => {
+			try {
+				for (;;) {
+					const info = state.info.peek();
+					if (info) return info;
+
+					const closed = state.closed.peek();
+					if (closed instanceof Error) throw closed;
+					if (closed) throw new Error(`track rejected: ${name}`);
+
+					await Signal.race(state.info, state.closed);
+				}
+			} finally {
+				state.closed.set(true);
+			}
+		})();
 	}
 
 	/**
@@ -73,8 +205,8 @@ export class Broadcast {
 	 */
 	close(abort?: Error) {
 		this.state.closed.set(abort ?? true);
-		for (const { track } of this.state.requested.peek()) {
-			track.close(abort);
+		for (const req of this.state.requested.peek()) {
+			req.reject(abort);
 		}
 		this.state.requested.mutate((requested) => {
 			requested.length = 0;

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -3,7 +3,7 @@ import { Broadcast, type TrackRequest } from "../broadcast.ts";
 import { Group } from "../group.ts";
 import * as Path from "../path.ts";
 import type { Reader, Stream } from "../stream.ts";
-import type { Track } from "../track.ts";
+import type { TrackProducer } from "../track.ts";
 import { error } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
@@ -45,7 +45,8 @@ export class Subscriber {
 	#session: Session;
 
 	// Our subscribed tracks — keyed by trackAlias for group routing
-	#subscribes = new Map<bigint, Track>();
+	// trackAlias -> the write side; incoming object streams are routed here.
+	#subscribes = new Map<bigint, TrackProducer>();
 
 	// Any currently active announcements.
 	#announced = new Set<Path.Valid>();
@@ -201,17 +202,24 @@ export class Subscriber {
 		const version = this.#session.version;
 		const requestId = await this.#session.nextRequestId();
 		if (requestId === undefined) {
-			request.track.close(new Error("session closed"));
+			request.reject(new Error("session closed"));
 			return;
 		}
 
-		console.debug(`subscribe start: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+		console.debug(`subscribe start: id=${requestId} broadcast=${broadcast} track=${request.name}`);
+
+		// IETF negotiates group order in SUBSCRIBE_OK; this implementation only
+		// supports descending (newest-first), so commit ordered: false. (There's no
+		// per-frame compression/timescale, so the rest stay at their defaults.) This
+		// resolves the consumer's track.info() and gives us the write side that
+		// incoming object streams are routed into.
+		const producer = request.accept({ ordered: false });
 
 		// Open the stream and wait for SUBSCRIBE_OK under a timeout. State
 		// flows back via `state` so the timeout path can clean up the stream
 		// and any registration if setup eventually finishes.
 		const state: SubscribeSetupState = {};
-		const setup = this.#openSubscribe(state, broadcast, request, requestId);
+		const setup = this.#openSubscribe(state, broadcast, request, producer, requestId);
 
 		let stream: Stream;
 		let trackAlias: bigint;
@@ -223,12 +231,12 @@ export class Subscriber {
 			);
 			stream = result.stream;
 			trackAlias = result.alias;
-			console.debug(`subscribe ok: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+			console.debug(`subscribe ok: id=${requestId} broadcast=${broadcast} track=${request.name}`);
 		} catch (err) {
 			const e = error(err);
-			request.track.close(e);
+			producer.close(e);
 			console.warn(
-				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
+				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.name} error=${e.message}`,
 			);
 			// If setup eventually settles after the timeout, abort the stream
 			// and drop any registration so we don't leak. Cover both branches:
@@ -244,7 +252,7 @@ export class Subscriber {
 
 		try {
 			// Wait for stream close (= PublishDone) or track close (= local unsubscribe)
-			await Promise.race([stream.reader.closed, request.track.closed]);
+			await Promise.race([stream.reader.closed, producer.closed]);
 
 			// For v14-v16: send Unsubscribe before closing (removed in v17+)
 			if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
@@ -257,15 +265,15 @@ export class Subscriber {
 				}
 			}
 
-			request.track.close();
+			producer.close();
 			stream.close();
-			console.debug(`subscribe close: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+			console.debug(`subscribe close: id=${requestId} broadcast=${broadcast} track=${request.name}`);
 		} catch (err) {
 			const e = error(err);
-			request.track.close(e);
+			producer.close(e);
 			stream.abort(e);
 			console.warn(
-				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
+				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.name} error=${e.message}`,
 			);
 		} finally {
 			this.#subscribes.delete(trackAlias);
@@ -280,6 +288,7 @@ export class Subscriber {
 		state: SubscribeSetupState,
 		broadcast: Path.Valid,
 		request: TrackRequest,
+		producer: TrackProducer,
 		requestId: bigint,
 	): Promise<{ stream: Stream; alias: bigint }> {
 		const version = this.#session.version;
@@ -290,15 +299,15 @@ export class Subscriber {
 		const msg = new Subscribe({
 			requestId,
 			trackNamespace: broadcast,
-			trackName: request.track.name,
+			trackName: request.name,
 			subscriberPriority: request.priority,
 		});
 		await msg.encode(state.stream.writer, version);
-		console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+		console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.name}`);
 
 		// Pre-register with requestId so early group uni streams aren't dropped.
 		// The publisher typically uses requestId as the trackAlias.
-		this.#subscribes.set(requestId, request.track);
+		this.#subscribes.set(requestId, producer);
 		state.registeredAlias = requestId;
 
 		const respTypeId = await state.stream.reader.u53();
@@ -321,7 +330,7 @@ export class Subscriber {
 		const ok = await SubscribeOk.decode(state.stream.reader, version);
 		if (ok.trackAlias !== requestId) {
 			this.#subscribes.delete(requestId);
-			this.#subscribes.set(ok.trackAlias, request.track);
+			this.#subscribes.set(ok.trackAlias, producer);
 			state.registeredAlias = ok.trackAlias;
 		}
 		return { stream: state.stream, alias: ok.trackAlias };

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -20,6 +20,23 @@ async function runPublishSubscribeFlow(protocol: string, version?: number) {
 	const broadcast = new Broadcast();
 	server.publish(Path.from("test"), broadcast);
 
+	// Serve every requested "video" track. On lite-05+ a subscribe is preceded by
+	// a TRACK info lookup, which the publisher answers by requesting the track too,
+	// so more than one request can arrive; the publisher must accept() each.
+	let served = 0;
+	const serving = (async () => {
+		for (;;) {
+			const req = await broadcast.requested();
+			if (!req) break;
+			if (req.name !== "video") {
+				req.reject(new Error(`unexpected track: ${req.name}`));
+				continue;
+			}
+			served++;
+			req.accept().writeString("hello");
+		}
+	})();
+
 	// Client discovers announced broadcast
 	const announced = client.announced();
 	const entry = await announced.next();
@@ -29,23 +46,16 @@ async function runPublishSubscribeFlow(protocol: string, version?: number) {
 
 	// Client consumes the broadcast and subscribes to a track
 	const remote = client.consume(Path.from("test"));
-	const track = remote.subscribe("video", 0);
-
-	// Server handles the subscription request
-	const req = await broadcast.requested();
-	if (!req) throw new Error("expected req");
-	expect(req.track.name).toBe("video");
-
-	// Server writes data
-	req.track.writeString("hello");
+	const track = remote.track("video").subscribe();
 
 	// Client reads data
 	const data = await track.readString();
 	expect(data).toBe("hello");
+	expect(served).toBeGreaterThan(0);
 
 	// Cleanup
-	req.track.close();
 	broadcast.close();
+	await serving;
 	announced.close();
 	remote.close();
 	client.close();

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -15,6 +15,7 @@ import { SessionInfo } from "./session.ts";
 import { StreamId } from "./stream.ts";
 import { Subscribe } from "./subscribe.ts";
 import { Subscriber } from "./subscriber.ts";
+import { Track as TrackMessage } from "./track.ts";
 import { Version, versionName } from "./version.ts";
 
 const SEND_BW_POLL_INTERVAL = 100; // ms
@@ -184,6 +185,9 @@ export class Connection implements Established {
 		} else if (typ === StreamId.Subscribe) {
 			const msg = await Subscribe.decode(stream.reader, this.#version);
 			await this.#publisher.runSubscribe(msg, stream);
+		} else if (typ === StreamId.Track) {
+			const msg = await TrackMessage.decode(stream.reader, this.#version);
+			await this.#publisher.runTrackInfo(msg, stream);
 		} else if (typ === StreamId.Probe) {
 			await this.#publisher.runProbe(stream);
 		} else if (typ === StreamId.Goaway) {

--- a/js/net/src/lite/index.ts
+++ b/js/net/src/lite/index.ts
@@ -7,4 +7,5 @@ export * from "./probe.ts";
 export * from "./session.ts";
 export * from "./stream.ts";
 export * from "./subscribe.ts";
+export * from "./track.ts";
 export * from "./version.ts";

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -4,21 +4,30 @@ import { Compression, compress } from "../compression.ts";
 import type { Group } from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
-import type { Track } from "../track.ts";
+import type { TrackSubscriber } from "../track.ts";
 import { error } from "../util/error.ts";
 import { Announce, AnnounceInit, type AnnounceInterest, AnnounceOk } from "./announce.ts";
 import { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
 import { Probe } from "./probe.ts";
-import { encodeSubscribeResponse, type Subscribe, SubscribeOk, SubscribeUpdate } from "./subscribe.ts";
+import {
+	encodeSubscribeResponse,
+	type Subscribe,
+	SubscribeEnd,
+	SubscribeOk,
+	SubscribeStart,
+	SubscribeUpdate,
+} from "./subscribe.ts";
+import { TrackInfo as TrackInfoMessage, type Track as TrackMessage } from "./track.ts";
 import { Version } from "./version.ts";
 
 const PROBE_INTERVAL = 100; // ms
 const PROBE_MAX_AGE = 10_000; // ms
 const PROBE_MAX_DELTA = 0.25;
 
-// SUBSCRIBE_OK only carries a compression codec on lite-05+.
-function supportsCompression(version: Version): boolean {
+// The TRACK stream, implicit SUBSCRIBE acceptance, and SUBSCRIBE_START/END are
+// all lite-05+.
+function supportsTrackStream(version: Version): boolean {
 	switch (version) {
 		case Version.DRAFT_01:
 		case Version.DRAFT_02:
@@ -50,6 +59,12 @@ export class Publisher {
 	// Our published broadcasts.
 	// It's a signal so we can live update any announce streams.
 	#broadcasts = new Signal<Map<Path.Valid, Broadcast> | undefined>(new Map());
+
+	// TRACK_INFO is immutable per track, so resolve it from the application once
+	// (via a throwaway subscribe whose info() resolves when the app calls accept)
+	// and reuse it for every later TRACK request of the same track. Keyed by
+	// `broadcast\0track`. A rejected lookup is evicted so a retry can re-probe.
+	#trackInfo = new Map<string, Promise<TrackInfoMessage>>();
 
 	/**
 	 * Creates a new Publisher instance.
@@ -197,16 +212,25 @@ export class Publisher {
 		const track = broadcast.subscribe(msg.track, msg.priority);
 
 		try {
-			// Compress only when the producer marked the track worth it and the
-			// negotiated draft understands the SUBSCRIBE_OK codec field. Older
-			// drafts get None and the frames stream verbatim.
-			const compression =
-				track.compress && supportsCompression(this.version) ? Compression.Deflate : Compression.None;
+			let compression: Compression = Compression.None;
 
-			// Announce the publisher's cache window so a relay re-serves with the
-			// same eviction bound. Pre-lite-05 peers ignore it.
-			const info = new SubscribeOk({ priority: msg.priority, compression, cache: track.cache });
-			await encodeSubscribeResponse(stream.writer, { ok: info }, this.version);
+			if (supportsTrackStream(this.version)) {
+				// Lite-05+ accepts implicitly: no SUBSCRIBE_OK (the immutable
+				// properties live in TRACK_INFO), and the resolved range arrives as
+				// SUBSCRIBE_START / SUBSCRIBE_END emitted from #runTrack.
+				//
+				// The frame codec is one of those immutable properties, so serving
+				// MUST use exactly what TRACK_INFO advertised. Both come from the
+				// producer's accept(), so they always agree. Awaiting info() also
+				// surfaces a rejected track (accept never called, track closed) as an
+				// error here, which resets the stream.
+				const info = await track.info();
+				compression = info.compress ? Compression.Deflate : Compression.None;
+			} else {
+				// Older drafts acknowledge with SUBSCRIBE_OK and stream frames verbatim.
+				const ok = new SubscribeOk({ priority: msg.priority });
+				await encodeSubscribeResponse(stream.writer, { ok }, this.version);
+			}
 
 			console.debug(`publish ok: broadcast=${msg.broadcast} track=${track.name}`);
 
@@ -246,7 +270,19 @@ export class Publisher {
 	 *
 	 * @internal
 	 */
-	async #runTrack(sub: bigint, broadcast: Path.Valid, track: Track, stream: Writer, compression: Compression) {
+	async #runTrack(
+		sub: bigint,
+		broadcast: Path.Valid,
+		track: TrackSubscriber,
+		stream: Writer,
+		compression: Compression,
+	) {
+		// Lite-05+ resolves the range on the subscribe stream: SUBSCRIBE_START once the
+		// first group is known, SUBSCRIBE_END when the track finishes.
+		const emitRange = supportsTrackStream(this.version);
+		let startSent = false;
+		let lastSequence = 0;
+
 		try {
 			for (;;) {
 				const next = track.recvGroup();
@@ -256,7 +292,17 @@ export class Publisher {
 					break;
 				}
 
+				if (emitRange && !startSent) {
+					startSent = true;
+					await encodeSubscribeResponse(stream, { start: new SubscribeStart(group.sequence) }, this.version);
+				}
+				lastSequence = group.sequence;
+
 				void this.#runGroup(sub, group, compression);
+			}
+
+			if (emitRange) {
+				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(lastSequence) }, this.version);
 			}
 
 			console.debug(`publish close: broadcast=${broadcast} track=${track.name}`);
@@ -268,6 +314,54 @@ export class Publisher {
 			track.close(e);
 			stream.reset(e);
 		}
+	}
+
+	/**
+	 * Answers a TRACK stream (0x6) with a single TRACK_INFO, then FINs.
+	 *
+	 * @internal
+	 */
+	async runTrackInfo(msg: TrackMessage, stream: Stream) {
+		try {
+			const info = await this.#resolveTrackInfo(msg.broadcast, msg.track);
+			await info.encode(stream.writer, this.version);
+			console.debug(`track info: broadcast=${msg.broadcast} track=${msg.track}`);
+			stream.close();
+		} catch (err) {
+			console.debug(`track unknown: broadcast=${msg.broadcast} track=${msg.track}`);
+			stream.writer.reset(error(err));
+		}
+	}
+
+	// Resolve (and cache) a track's immutable TRACK_INFO by asking the application.
+	// `broadcast.track(name).info()` triggers a TrackRequest the app answers with
+	// accept(TrackInfo); only the immutable properties are needed (not the groups).
+	// Cached because they're fixed for the track's lifetime. Rejects if the broadcast
+	// or track is unavailable.
+	#resolveTrackInfo(broadcast: Path.Valid, track: string): Promise<TrackInfoMessage> {
+		const key = `${broadcast}\0${track}`;
+		const cached = this.#trackInfo.get(key);
+		if (cached) return cached;
+
+		const pending = (async () => {
+			const published = this.#broadcasts.peek()?.get(broadcast);
+			if (!published) throw new Error("not found");
+
+			const info = await published.track(track).info();
+			return new TrackInfoMessage({
+				priority: info.priority,
+				ordered: info.ordered,
+				cache: info.cache,
+				// This implementation doesn't produce per-frame timestamps yet.
+				timescale: 0,
+				compression: info.compress ? Compression.Deflate : Compression.None,
+			});
+		})();
+
+		// Don't poison the cache on failure: a later request may succeed.
+		pending.catch(() => this.#trackInfo.delete(key));
+		this.#trackInfo.set(key, pending);
+		return pending;
 	}
 
 	/**

--- a/js/net/src/lite/stream.ts
+++ b/js/net/src/lite/stream.ts
@@ -3,8 +3,9 @@ import type { Goaway } from "./goaway.ts";
 import type { Group } from "./group.ts";
 import type { SessionClient } from "./session.ts";
 import type { Subscribe } from "./subscribe.ts";
+import type { Track } from "./track.ts";
 
-export type StreamBi = SessionClient | AnnounceInterest | Subscribe | Goaway;
+export type StreamBi = SessionClient | AnnounceInterest | Subscribe | Track | Goaway;
 export type StreamUni = Group;
 
 export const StreamId = {
@@ -14,6 +15,7 @@ export const StreamId = {
 	Fetch: 3,
 	Probe: 4,
 	Goaway: 5,
+	Track: 6,
 	ClientCompat: 0x20,
 	ServerCompat: 0x21,
 } as const;

--- a/js/net/src/lite/subscribe.test.ts
+++ b/js/net/src/lite/subscribe.test.ts
@@ -1,8 +1,14 @@
 import { expect, test } from "bun:test";
-import { Compression } from "../compression.ts";
 import { Reader, Writer } from "../stream.ts";
-import { DEFAULT_CACHE_MS } from "../track.ts";
-import { SubscribeOk } from "./subscribe.ts";
+import {
+	decodeSubscribeResponse,
+	encodeSubscribeResponse,
+	SubscribeDrop,
+	SubscribeEnd,
+	SubscribeOk,
+	type SubscribeResponse,
+	SubscribeStart,
+} from "./subscribe.ts";
 import { Version } from "./version.ts";
 
 function concat(chunks: Uint8Array[]): Uint8Array {
@@ -16,44 +22,62 @@ function concat(chunks: Uint8Array[]): Uint8Array {
 	return out;
 }
 
-async function roundtrip(version: Version, ok: SubscribeOk): Promise<SubscribeOk> {
+async function encode(version: Version, resp: SubscribeResponse): Promise<Uint8Array> {
 	const written: Uint8Array[] = [];
 	const writer = new Writer(
 		new WritableStream<Uint8Array>({ write: (chunk) => void written.push(new Uint8Array(chunk)) }),
 	);
-	await ok.encode(writer, version);
+	await encodeSubscribeResponse(writer, resp, version);
 	writer.close();
 	await writer.closed;
-
-	const reader = new Reader(undefined, concat(written));
-	return SubscribeOk.decode(reader, version);
+	return concat(written);
 }
 
-test("SubscribeOk: timescale, cache, and compression round-trip on draft-05", async () => {
-	const ok = new SubscribeOk({
-		priority: 7,
-		ordered: true,
-		maxLatency: 250,
-		startGroup: 3,
-		compression: Compression.Deflate,
-		cache: 10000,
-		timescale: 90000,
-	});
+async function responseRoundtrip(version: Version, resp: SubscribeResponse): Promise<SubscribeResponse> {
+	const reader = new Reader(undefined, await encode(version, resp));
+	return decodeSubscribeResponse(reader, version);
+}
 
-	const got = await roundtrip(Version.DRAFT_05_WIP, ok);
-	expect(got.compression).toBe(Compression.Deflate);
-	expect(got.cache).toBe(10000);
-	expect(got.timescale).toBe(90000);
-	expect(got.priority).toBe(7);
-	expect(got.ordered).toBe(true);
-	expect(got.startGroup).toBe(3);
+test("SubscribeOk round-trips priority/ordered/groups on draft-04", async () => {
+	const got = await responseRoundtrip(Version.DRAFT_04, {
+		ok: new SubscribeOk({ priority: 7, ordered: true, maxLatency: 250, startGroup: 3 }),
+	});
+	expect("ok" in got).toBe(true);
+	if (!("ok" in got)) throw new Error("expected ok");
+	expect(got.ok.priority).toBe(7);
+	expect(got.ok.ordered).toBe(true);
+	expect(got.ok.startGroup).toBe(3);
 });
 
-test("SubscribeOk: timescale, cache, and compression fields are absent before draft-05", async () => {
-	// draft-04 has no draft-05 trailing varints, so they decode to defaults.
-	const ok = new SubscribeOk({ priority: 7, compression: Compression.Deflate, cache: 10000, timescale: 90000 });
-	const got = await roundtrip(Version.DRAFT_04, ok);
-	expect(got.compression).toBe(Compression.None);
-	expect(got.cache).toBe(DEFAULT_CACHE_MS);
-	expect(got.timescale).toBe(0);
+test("SubscribeStart round-trips on draft-05", async () => {
+	const got = await responseRoundtrip(Version.DRAFT_05_WIP, { start: new SubscribeStart(42) });
+	expect("start" in got).toBe(true);
+	if (!("start" in got)) throw new Error("expected start");
+	expect(got.start.group).toBe(42);
+});
+
+test("SubscribeEnd round-trips on draft-05", async () => {
+	const got = await responseRoundtrip(Version.DRAFT_05_WIP, { end: new SubscribeEnd(7) });
+	expect("end" in got).toBe(true);
+	if (!("end" in got)) throw new Error("expected end");
+	expect(got.end.group).toBe(7);
+});
+
+test("SubscribeDrop is type 0x2 on draft-05 and 0x1 on draft-04", async () => {
+	const drop: SubscribeResponse = { drop: new SubscribeDrop({ start: 1, end: 3, error: 0 }) };
+
+	const wire05 = await encode(Version.DRAFT_05_WIP, drop);
+	expect(wire05[0]).toBe(2);
+
+	const wire04 = await encode(Version.DRAFT_04, drop);
+	expect(wire04[0]).toBe(1);
+
+	const got = await responseRoundtrip(Version.DRAFT_05_WIP, drop);
+	expect("drop" in got).toBe(true);
+	if (!("drop" in got)) throw new Error("expected drop");
+	expect([got.drop.start, got.drop.end]).toEqual([1, 3]);
+});
+
+test("SUBSCRIBE_OK is rejected on draft-05", async () => {
+	await expect(encode(Version.DRAFT_05_WIP, { ok: new SubscribeOk({ priority: 1 }) })).rejects.toThrow();
 });

--- a/js/net/src/lite/subscribe.ts
+++ b/js/net/src/lite/subscribe.ts
@@ -1,7 +1,5 @@
-import { Compression, compressionFromCode } from "../compression.ts";
 import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
-import { DEFAULT_CACHE_MS } from "../track.ts";
 import * as Message from "./message.ts";
 import { Version } from "./version.ts";
 
@@ -165,32 +163,18 @@ export class Subscribe {
 	}
 }
 
+/**
+ * Publisher's acknowledgement on the Subscribe Stream for drafts 01-04.
+ *
+ * Draft-05+ replaced this with implicit acceptance plus {@link SubscribeStart} /
+ * {@link SubscribeEnd}; the immutable codec/timescale/cache moved to TRACK_INFO.
+ */
 export class SubscribeOk {
 	priority: number;
 	ordered: boolean;
 	maxLatency: number;
 	startGroup?: number;
 	endGroup?: number;
-	/**
-	 * Codec the publisher will use for every frame on this track. Negotiated here
-	 * (not in SUBSCRIBE) so the subscriber blocks on this message before it can
-	 * decode any frame payload. Draft-05+ only; older drafts are always
-	 * {@link Compression.None}.
-	 */
-	compression: Compression;
-	/**
-	 * How long (milliseconds) the publisher keeps old groups available before
-	 * evicting them. Draft-05+ only; older drafts assume {@link DEFAULT_CACHE_MS}.
-	 */
-	cache: number;
-	/**
-	 * Per-frame timestamp scale (units per second) advertised by the publisher.
-	 * `0` means no per-frame timestamps on the wire (frame headers omit them).
-	 * Draft-05+ only; older drafts are always `0`. This implementation doesn't
-	 * yet produce per-frame timestamps, so publishers always send `0`; subscribers
-	 * read the delta to stay in sync with a timestamped (e.g. Rust) publisher.
-	 */
-	timescale: number;
 
 	constructor({
 		priority = 0,
@@ -198,27 +182,18 @@ export class SubscribeOk {
 		maxLatency = 0,
 		startGroup = undefined,
 		endGroup = undefined,
-		compression = Compression.None,
-		cache = DEFAULT_CACHE_MS,
-		timescale = 0,
 	}: {
 		priority?: number;
 		ordered?: boolean;
 		maxLatency?: number;
 		startGroup?: number;
 		endGroup?: number;
-		compression?: Compression;
-		cache?: number;
-		timescale?: number;
 	}) {
 		this.priority = priority;
 		this.ordered = ordered;
 		this.maxLatency = maxLatency;
 		this.startGroup = startGroup;
 		this.endGroup = endGroup;
-		this.compression = compression;
-		this.cache = cache;
-		this.timescale = timescale;
 	}
 
 	async #encode(w: Writer, version: Version) {
@@ -229,24 +204,14 @@ export class SubscribeOk {
 			case Version.DRAFT_01:
 				await w.u8(this.priority ?? 0);
 				break;
-			case Version.DRAFT_03:
-			case Version.DRAFT_04:
-				await w.u8(this.priority);
-				await w.bool(this.ordered);
-				await w.u53(this.maxLatency);
-				await w.u53(this.startGroup !== undefined ? this.startGroup + 1 : 0);
-				await w.u53(this.endGroup !== undefined ? this.endGroup + 1 : 0);
-				break;
+			// Draft-05+ never sends SUBSCRIBE_OK, but keep the field layout matching
+			// Draft-03/04 so a stray future use stays well-formed.
 			default:
 				await w.u8(this.priority);
 				await w.bool(this.ordered);
 				await w.u53(this.maxLatency);
 				await w.u53(this.startGroup !== undefined ? this.startGroup + 1 : 0);
 				await w.u53(this.endGroup !== undefined ? this.endGroup + 1 : 0);
-				// Order matches draft-lcurley-moq-lite-05 SUBSCRIBE_OK: Timescale, Cache, Compression.
-				await w.u53(this.timescale);
-				await w.u53(this.cache);
-				await w.u53(this.compression);
 				break;
 		}
 	}
@@ -257,9 +222,6 @@ export class SubscribeOk {
 		let maxLatency: number | undefined;
 		let startGroup: number | undefined;
 		let endGroup: number | undefined;
-		let compression: Compression = Compression.None;
-		let cache: number = DEFAULT_CACHE_MS;
-		let timescale = 0;
 
 		switch (version) {
 			case Version.DRAFT_02:
@@ -268,24 +230,12 @@ export class SubscribeOk {
 			case Version.DRAFT_01:
 				priority = await r.u8();
 				break;
-			case Version.DRAFT_03:
-			case Version.DRAFT_04:
-				priority = await r.u8();
-				ordered = await r.bool();
-				maxLatency = await r.u53();
-				startGroup = await r.u53();
-				endGroup = await r.u53();
-				break;
 			default:
 				priority = await r.u8();
 				ordered = await r.bool();
 				maxLatency = await r.u53();
 				startGroup = await r.u53();
 				endGroup = await r.u53();
-				// Order matches draft-lcurley-moq-lite-05 SUBSCRIBE_OK: Timescale, Cache, Compression.
-				timescale = await r.u53();
-				cache = await r.u53();
-				compression = compressionFromCode(await r.u53());
 				break;
 		}
 
@@ -295,9 +245,6 @@ export class SubscribeOk {
 			maxLatency,
 			startGroup: startGroup !== undefined && startGroup > 0 ? startGroup - 1 : undefined,
 			endGroup: endGroup !== undefined && endGroup > 0 ? endGroup - 1 : undefined,
-			compression,
-			timescale,
-			cache,
 		});
 	}
 
@@ -307,6 +254,51 @@ export class SubscribeOk {
 
 	static async decode(r: Reader, version: Version): Promise<SubscribeOk> {
 		return Message.decode(r, SubscribeOk.#decode.bind(SubscribeOk, version));
+	}
+}
+
+/**
+ * Resolves the absolute start group of a Draft-05+ subscription. The first message
+ * the publisher sends, once the start group is known. A value greater than the
+ * requested start implicitly drops the leading range.
+ */
+export class SubscribeStart {
+	group: number;
+
+	constructor(group: number) {
+		this.group = group;
+	}
+
+	async encode(w: Writer): Promise<void> {
+		return Message.encode(w, async (w) => {
+			await w.u53(this.group);
+		});
+	}
+
+	static async decode(r: Reader): Promise<SubscribeStart> {
+		return Message.decode(r, async (r) => new SubscribeStart(await r.u53()));
+	}
+}
+
+/**
+ * Signals that no group after `group` (inclusive upper bound) will be produced on
+ * a Draft-05+ subscription.
+ */
+export class SubscribeEnd {
+	group: number;
+
+	constructor(group: number) {
+		this.group = group;
+	}
+
+	async encode(w: Writer): Promise<void> {
+		return Message.encode(w, async (w) => {
+			await w.u53(this.group);
+		});
+	}
+
+	static async decode(r: Reader): Promise<SubscribeEnd> {
+		return Message.decode(r, async (r) => new SubscribeEnd(await r.u53()));
 	}
 }
 
@@ -344,15 +336,19 @@ export class SubscribeDrop {
 }
 
 /**
- * A response message on the subscribe stream.
+ * A response message on the subscribe stream, prefixed with a type discriminator
+ * on Draft-03+.
  *
- * In Draft03+, each response is prefixed with a type discriminator:
- * - 0x0 for SUBSCRIBE_OK
- * - 0x1 for SUBSCRIBE_DROP
- *
- * SUBSCRIBE_OK must be the first message on the response stream.
+ * The discriminator is version-dependent:
+ * - Draft-03/04: `0x0` SUBSCRIBE_OK, `0x1` SUBSCRIBE_DROP.
+ * - Draft-05+: `0x0` SUBSCRIBE_START, `0x1` SUBSCRIBE_END, `0x2` SUBSCRIBE_DROP
+ *   (SUBSCRIBE_OK was removed; acceptance is implicit).
  */
-export type SubscribeResponse = { ok: SubscribeOk } | { drop: SubscribeDrop };
+export type SubscribeResponse =
+	| { ok: SubscribeOk }
+	| { start: SubscribeStart }
+	| { end: SubscribeEnd }
+	| { drop: SubscribeDrop };
 
 export async function encodeSubscribeResponse(w: Writer, resp: SubscribeResponse, version: Version): Promise<void> {
 	switch (version) {
@@ -361,16 +357,34 @@ export async function encodeSubscribeResponse(w: Writer, resp: SubscribeResponse
 			if ("ok" in resp) {
 				await resp.ok.encode(w, version);
 			} else {
-				throw new Error("subscribe drop not supported for this version");
+				throw new Error("only SUBSCRIBE_OK is supported for this version");
 			}
 			break;
-		default:
+		case Version.DRAFT_03:
+		case Version.DRAFT_04:
 			if ("ok" in resp) {
 				await w.u53(0x0);
 				await resp.ok.encode(w, version);
-			} else {
+			} else if ("drop" in resp) {
 				await w.u53(0x1);
 				await resp.drop.encode(w);
+			} else {
+				throw new Error("SUBSCRIBE_START/END not supported for this version");
+			}
+			break;
+		default:
+			// Draft-05+: SUBSCRIBE_OK is gone; START/END/DROP carry the resolved range.
+			if ("start" in resp) {
+				await w.u53(0x0);
+				await resp.start.encode(w);
+			} else if ("end" in resp) {
+				await w.u53(0x1);
+				await resp.end.encode(w);
+			} else if ("drop" in resp) {
+				await w.u53(0x2);
+				await resp.drop.encode(w);
+			} else {
+				throw new Error("SUBSCRIBE_OK not supported for this version");
 			}
 			break;
 	}
@@ -381,7 +395,8 @@ export async function decodeSubscribeResponse(r: Reader, version: Version): Prom
 		case Version.DRAFT_01:
 		case Version.DRAFT_02:
 			return { ok: await SubscribeOk.decode(r, version) };
-		default: {
+		case Version.DRAFT_03:
+		case Version.DRAFT_04: {
 			const typ = await r.u53();
 			switch (typ) {
 				case 0x0:
@@ -392,5 +407,27 @@ export async function decodeSubscribeResponse(r: Reader, version: Version): Prom
 					throw new Error(`unknown subscribe response type: ${typ}`);
 			}
 		}
+		default: {
+			const typ = await r.u53();
+			switch (typ) {
+				case 0x0:
+					return { start: await SubscribeStart.decode(r) };
+				case 0x1:
+					return { end: await SubscribeEnd.decode(r) };
+				case 0x2:
+					return { drop: await SubscribeDrop.decode(r) };
+				default:
+					throw new Error(`unknown subscribe response type: ${typ}`);
+			}
+		}
 	}
+}
+
+/** Like {@link decodeSubscribeResponse} but resolves `undefined` on a clean FIN. */
+export async function decodeSubscribeResponseMaybe(
+	r: Reader,
+	version: Version,
+): Promise<SubscribeResponse | undefined> {
+	if (await r.done()) return undefined;
+	return decodeSubscribeResponse(r, version);
 }

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -7,7 +7,7 @@ import { Group } from "../group.ts";
 import * as Path from "../path.ts";
 import { type Reader, Stream } from "../stream.ts";
 import type * as Time from "../time.ts";
-import type { Track } from "../track.ts";
+import type { TrackProducer } from "../track.ts";
 import { error } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
 import { Announce, AnnounceInit, AnnounceInterest, AnnounceOk } from "./announce.ts";
@@ -15,13 +15,28 @@ import type { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
 import { Probe } from "./probe.ts";
 import { StreamId } from "./stream.ts";
-import { decodeSubscribeResponse, Subscribe, SubscribeUpdate } from "./subscribe.ts";
+import { decodeSubscribeResponse, decodeSubscribeResponseMaybe, Subscribe, SubscribeUpdate } from "./subscribe.ts";
+import { TrackInfo, Track as TrackMessage } from "./track.ts";
 import { Version } from "./version.ts";
 
-// Bound on how long stream-open plus SUBSCRIBE_OK may take. Browsers cap
-// concurrent QUIC streams (Chrome ~100); past the cap createBidirectionalStream
-// silently blocks. The timeout turns that into a clear error.
-const SUBSCRIBE_OK_TIMEOUT_MS = 10_000;
+// Bound on how long stream-open plus the first response (SUBSCRIBE_OK on older
+// drafts, or TRACK_INFO on lite-05+) may take. Browsers cap concurrent QUIC
+// streams (Chrome ~100); past the cap createBidirectionalStream silently blocks.
+// The timeout turns that into a clear error.
+const SUBSCRIBE_SETUP_TIMEOUT_MS = 10_000;
+
+// The TRACK stream and implicit SUBSCRIBE acceptance are lite-05+.
+function supportsTrackStream(version: Version): boolean {
+	switch (version) {
+		case Version.DRAFT_01:
+		case Version.DRAFT_02:
+		case Version.DRAFT_03:
+		case Version.DRAFT_04:
+			return false;
+		default:
+			return true;
+	}
+}
 
 /**
  * Options accepted by {@link Subscriber.announced}.
@@ -38,12 +53,15 @@ export interface AnnouncedOptions {
 }
 
 interface SubscribeEntry {
-	track: Track;
-	// undefined until SUBSCRIBE_OK arrives and tells us the negotiated codec.
+	// The write side: incoming GROUP streams are routed here. The application reads
+	// the matching TrackSubscriber it got from Broadcast.subscribe.
+	track: TrackProducer;
+	// undefined until the negotiated codec is known (from TRACK_INFO on lite-05+,
+	// or SUBSCRIBE_OK on older drafts).
 	compression: Signal<Compression | undefined>;
-	// Per-frame timestamp scale (0 = none). undefined until SUBSCRIBE_OK arrives.
-	// A non-zero value means each frame on the group stream is prefixed with a
-	// zigzag-delta timestamp varint that runGroup must consume to stay in sync.
+	// Per-frame timestamp scale (0 = none). undefined until it's known. A non-zero
+	// value means each frame on the group stream is prefixed with a zigzag-delta
+	// timestamp varint that runGroup must consume to stay in sync.
 	timescale: Signal<number | undefined>;
 }
 
@@ -62,9 +80,9 @@ export class Subscriber {
 	// own announcements on a per-call basis (see {@link AnnouncedOptions}).
 	readonly origin: Origin;
 
-	// Our subscribed tracks. `compression` resolves once SUBSCRIBE_OK arrives;
-	// group streams block on it before decoding any frame, since a group's QUIC
-	// stream can race ahead of SUBSCRIBE_OK on its own stream.
+	// Our subscribed tracks. `compression` resolves once the codec is known (from
+	// TRACK_INFO on lite-05+, or SUBSCRIBE_OK on older drafts); group streams block
+	// on it before decoding any frame, since a group's QUIC stream can race ahead.
 	#subscribes = new Map<bigint, SubscribeEntry>();
 	#subscribeNext = 0n;
 
@@ -190,6 +208,21 @@ export class Subscriber {
 	consume(path: Path.Valid): Broadcast {
 		const broadcast = new Broadcast();
 
+		// Resolve TrackConsumer.info() via a TRACK stream (lite-05+). On older drafts
+		// there's no TRACK stream, so info() rejects rather than fabricating defaults.
+		broadcast.onTrackInfo(async (name) => {
+			if (!supportsTrackStream(this.version)) {
+				throw new Error("track info requires moq-lite-05 or newer");
+			}
+			const info = await this.#trackInfo(path, name);
+			return {
+				compress: info.compression !== Compression.None,
+				cache: info.cache,
+				priority: info.priority,
+				ordered: info.ordered,
+			};
+		});
+
 		(async () => {
 			for (;;) {
 				const request = await broadcast.requested();
@@ -204,43 +237,33 @@ export class Subscriber {
 	async #runSubscribe(broadcast: Path.Valid, request: TrackRequest) {
 		const id = this.#subscribeNext++;
 
-		// Save the writer so we can append groups to it. `compression` stays
-		// undefined until SUBSCRIBE_OK resolves it; runGroup blocks on it.
+		// `compression` stays undefined until TRACK_INFO (or, on older drafts,
+		// implicit defaults) resolves it; runGroup blocks on it before decoding.
 		const compression = new Signal<Compression | undefined>(undefined);
 		const timescale = new Signal<number | undefined>(undefined);
-		this.#subscribes.set(id, { track: request.track, compression, timescale });
 
-		console.debug(`subscribe start: id=${id} broadcast=${broadcast} track=${request.track.name}`);
+		console.debug(`subscribe start: id=${id} broadcast=${broadcast} track=${request.name}`);
 
-		const msg = new Subscribe({ id, broadcast, track: request.track.name, priority: request.priority });
+		const msg = new Subscribe({ id, broadcast, track: request.name, priority: request.priority });
 
-		// Open the stream and wait for SUBSCRIBE_OK under a timeout. The stream
-		// handle flows back via `state` so the timeout path can abort it if it
-		// finishes opening after the deadline.
+		// Open the stream under a timeout. The stream handle flows back via `state`
+		// so the timeout path can abort it if it finishes opening after the deadline.
 		const state: { stream?: Stream } = {};
-		const setup = this.#openSubscribe(state, msg);
+		const setup = this.#openSubscribe(state, msg, request, id, compression, timescale);
 
-		let stream: Stream;
+		let opened: { stream: Stream; producer: TrackProducer };
 		try {
-			const ok = await withTimeout(
+			opened = await withTimeout(
 				setup,
-				SUBSCRIBE_OK_TIMEOUT_MS,
-				`subscribe timed out after ${SUBSCRIBE_OK_TIMEOUT_MS}ms waiting for SUBSCRIBE_OK (browser stream limit reached?)`,
+				SUBSCRIBE_SETUP_TIMEOUT_MS,
+				`subscribe timed out after ${SUBSCRIBE_SETUP_TIMEOUT_MS}ms waiting for the first response (browser stream limit reached?)`,
 			);
-			stream = ok.stream;
-			// Unblock any group streams waiting to learn how to decode frames.
-			compression.set(ok.compression);
-			timescale.set(ok.timescale);
-			// Learn the publisher's cache window so a re-serving relay matches it.
-			request.track.cache = ok.cache;
-			console.debug(`subscribe ok: id=${id} broadcast=${broadcast} track=${request.track.name}`);
+			console.debug(`subscribe ok: id=${id} broadcast=${broadcast} track=${request.name}`);
 		} catch (err) {
 			const e = error(err);
-			request.track.close(e);
+			request.reject(e);
 			this.#subscribes.delete(id);
-			console.warn(
-				`subscribe error: id=${id} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
-			);
+			console.warn(`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${e.message}`);
 			// If the stream eventually opens after the timeout, abort it so we
 			// don't leak it. Cover both branches: setup may resolve late, or it
 			// may reject (e.g. encode/decode failure) after the stream is open.
@@ -251,59 +274,127 @@ export class Subscriber {
 			return;
 		}
 
+		const { stream, producer } = opened;
 		try {
 			// Watch for priority changes and send SUBSCRIBE_UPDATE. Lite01/Lite02
 			// don't carry SUBSCRIBE_UPDATE on the wire, so skip the watcher there
 			// and just wait on the stream/track like before.
-			const waits: Promise<unknown>[] = [stream.reader.closed, request.track.closed];
+			//
+			// On lite-05+ the publisher sends SUBSCRIBE_START/END/DROP on this stream;
+			// drain them (we don't drive delivery off the resolved range) so the FIN is
+			// observed. Older drafts just wait for the stream to close.
+			const closed = supportsTrackStream(this.version) ? this.#drainResponses(stream) : stream.reader.closed;
+			const waits: Promise<unknown>[] = [closed, producer.closed];
 			switch (this.version) {
 				case Version.DRAFT_01:
 				case Version.DRAFT_02:
 					break;
 				default:
-					waits.push(this.#runPriorityUpdates(id, broadcast, request.track, msg, stream));
+					waits.push(this.#runPriorityUpdates(id, broadcast, producer, msg, stream));
 					break;
 			}
 
 			await Promise.race(waits);
 
-			request.track.close();
+			producer.close();
 			stream.close();
-			console.debug(`subscribe close: id=${id} broadcast=${broadcast} track=${request.track.name}`);
+			console.debug(`subscribe close: id=${id} broadcast=${broadcast} track=${request.name}`);
 		} catch (err) {
 			const e = error(err);
-			request.track.close(e);
-			console.warn(
-				`subscribe error: id=${id} broadcast=${broadcast} track=${request.track.name} error=${e.message}`,
-			);
+			producer.close(e);
+			console.warn(`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${e.message}`);
 			stream.abort(e);
 		} finally {
 			this.#subscribes.delete(id);
 		}
 	}
 
-	// Opens the subscribe stream, sends SUBSCRIBE, and reads SUBSCRIBE_OK.
-	// `state.stream` is populated as soon as the stream opens so the caller
-	// can clean it up on timeout even before this promise settles.
+	// Determine the track's immutable properties, accept the request (so the
+	// application's TrackSubscriber resolves and incoming groups have a producer to
+	// write into), register it, then open the subscribe stream. `state.stream` is
+	// populated as soon as the subscribe stream opens so the caller can clean it up
+	// on timeout even before this promise settles.
+	//
+	// On lite-05+ the properties come from a TRACK stream opened first, and the
+	// SUBSCRIBE is accepted implicitly (no SUBSCRIBE_OK). Older drafts carry no
+	// per-track properties, so they resolve to defaults and just drain SUBSCRIBE_OK.
 	async #openSubscribe(
 		state: { stream?: Stream },
 		msg: Subscribe,
-	): Promise<{ stream: Stream; compression: Compression; cache: number; timescale: number }> {
+		request: TrackRequest,
+		id: bigint,
+		compression: Signal<Compression | undefined>,
+		timescale: Signal<number | undefined>,
+	): Promise<{ stream: Stream; producer: TrackProducer }> {
+		let producer: TrackProducer;
+		let drainOk = false;
+
+		if (supportsTrackStream(this.version)) {
+			// Fetch the immutable properties once via the TRACK stream.
+			const info = await this.#trackInfo(msg.broadcast, msg.track);
+			producer = request.accept({
+				compress: info.compression !== Compression.None,
+				cache: info.cache,
+				priority: info.priority,
+				ordered: info.ordered,
+			});
+			compression.set(info.compression);
+			timescale.set(info.timescale);
+		} else {
+			// Older drafts negotiate nothing per-track: verbatim frames, no timescale.
+			producer = request.accept();
+			compression.set(Compression.None);
+			timescale.set(0);
+			drainOk = true;
+		}
+
+		// Register before opening SUBSCRIBE so a racing GROUP stream finds the entry.
+		this.#subscribes.set(id, { track: producer, compression, timescale });
+
 		state.stream = await Stream.open(this.#quic);
 		await state.stream.writer.u53(StreamId.Subscribe);
 		await msg.encode(state.stream.writer, this.version);
 
-		// The first response MUST be a SUBSCRIBE_OK.
-		const resp = await decodeSubscribeResponse(state.stream.reader, this.version);
-		if (!("ok" in resp)) {
-			throw new Error("first subscribe response must be SUBSCRIBE_OK");
+		if (drainOk) {
+			// The first response MUST be a SUBSCRIBE_OK (older drafts only).
+			const resp = await decodeSubscribeResponse(state.stream.reader, this.version);
+			if (!("ok" in resp)) {
+				throw new Error("first subscribe response must be SUBSCRIBE_OK");
+			}
 		}
-		return {
-			stream: state.stream,
-			compression: resp.ok.compression,
-			cache: resp.ok.cache,
-			timescale: resp.ok.timescale,
-		};
+
+		return { stream: state.stream, producer };
+	}
+
+	// Opens a TRACK stream, reads the single TRACK_INFO, and FINs. Lite-05+ only.
+	async #trackInfo(broadcast: Path.Valid, track: string): Promise<TrackInfo> {
+		const stream = await Stream.open(this.#quic);
+		try {
+			await stream.writer.u53(StreamId.Track);
+			await new TrackMessage(broadcast, track).encode(stream.writer, this.version);
+			const info = await TrackInfo.decode(stream.reader, this.version);
+			// The publisher FINs after TRACK_INFO; FIN our side too.
+			stream.close();
+			return info;
+		} catch (err) {
+			stream.abort(error(err));
+			throw err;
+		}
+	}
+
+	// Drains SUBSCRIBE_START/END/DROP on the subscribe stream until FIN (lite-05+).
+	// The resolved range is informational here; the producer already orders groups.
+	// Resolves (never rejects) on FIN or on the stream being reset out from under it,
+	// so it's safe to drop from a Promise.race without an unhandled rejection.
+	async #drainResponses(stream: Stream): Promise<void> {
+		try {
+			for (;;) {
+				const resp = await decodeSubscribeResponseMaybe(stream.reader, this.version);
+				if (!resp) return;
+			}
+		} catch {
+			// Stream closed or reset; nothing more to drain.
+		}
 	}
 
 	/**
@@ -320,7 +411,7 @@ export class Subscriber {
 	async #runPriorityUpdates(
 		id: bigint,
 		broadcast: Path.Valid,
-		track: Track,
+		track: TrackProducer,
 		msg: Subscribe,
 		stream: Stream,
 	): Promise<void> {
@@ -373,12 +464,12 @@ export class Subscriber {
 		track.writeGroup(producer);
 
 		try {
-			// Block until SUBSCRIBE_OK tells us the codec; the group's stream can
-			// arrive before SUBSCRIBE_OK lands on the subscribe stream.
+			// Block until the codec is known; the group's stream can arrive before
+			// TRACK_INFO (or SUBSCRIBE_OK) resolves it on the subscribe stream.
 			let codec = compression.peek();
 			while (codec === undefined) {
 				if (track.state.closed.peek()) {
-					// Subscription ended before SUBSCRIBE_OK; nothing to decode.
+					// Subscription ended before the codec resolved; nothing to decode.
 					producer.close();
 					stream.stop(new Error("cancel"));
 					return;
@@ -387,7 +478,7 @@ export class Subscriber {
 				codec = compression.peek();
 			}
 
-			// timescale resolves together with compression at SUBSCRIBE_OK. A
+			// timescale resolves together with compression (from TRACK_INFO). A
 			// non-zero scale means every frame is prefixed with a zigzag-delta
 			// timestamp varint (see the lite-05 FRAME format). We don't surface
 			// per-frame timestamps to the application yet, but we must still read

--- a/js/net/src/lite/track.test.ts
+++ b/js/net/src/lite/track.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import { Compression } from "../compression.ts";
+import * as Path from "../path.ts";
+import { Reader, Writer } from "../stream.ts";
+import { Track, TrackInfo } from "./track.ts";
+import { Version } from "./version.ts";
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+	const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const c of chunks) {
+		out.set(c, offset);
+		offset += c.byteLength;
+	}
+	return out;
+}
+
+async function bytes(f: (w: Writer) => Promise<void>): Promise<Uint8Array> {
+	const written: Uint8Array[] = [];
+	const writer = new Writer(
+		new WritableStream<Uint8Array>({ write: (chunk) => void written.push(new Uint8Array(chunk)) }),
+	);
+	await f(writer);
+	writer.close();
+	await writer.closed;
+	return concat(written);
+}
+
+test("TrackInfo round-trips on draft-05", async () => {
+	const info = new TrackInfo({
+		priority: 7,
+		ordered: false,
+		cache: 10000,
+		timescale: 90000,
+		compression: Compression.Deflate,
+	});
+	const reader = new Reader(undefined, await bytes((w) => info.encode(w, Version.DRAFT_05_WIP)));
+	const got = await TrackInfo.decode(reader, Version.DRAFT_05_WIP);
+	expect(got.priority).toBe(7);
+	expect(got.ordered).toBe(false);
+	expect(got.cache).toBe(10000);
+	expect(got.timescale).toBe(90000);
+	expect(got.compression).toBe(Compression.Deflate);
+});
+
+test("Track request round-trips on draft-05", async () => {
+	const msg = new Track(Path.from("room"), "video");
+	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05_WIP)));
+	const got = await Track.decode(reader, Version.DRAFT_05_WIP);
+	expect(got.broadcast).toBe(Path.from("room"));
+	expect(got.track).toBe("video");
+});
+
+test("TRACK_INFO is rejected before draft-05", async () => {
+	const info = new TrackInfo({ compression: Compression.None });
+	await expect(bytes((w) => info.encode(w, Version.DRAFT_04))).rejects.toThrow();
+});

--- a/js/net/src/lite/track.ts
+++ b/js/net/src/lite/track.ts
@@ -1,0 +1,120 @@
+import { Compression, compressionFromCode } from "../compression.ts";
+import * as Path from "../path.ts";
+import type { Reader, Writer } from "../stream.ts";
+import { DEFAULT_CACHE_MS } from "../track.ts";
+import * as Message from "./message.ts";
+import { Version } from "./version.ts";
+
+// The Track Stream (0x6) is draft-05+ only.
+function guardTrack(version: Version) {
+	switch (version) {
+		case Version.DRAFT_01:
+		case Version.DRAFT_02:
+		case Version.DRAFT_03:
+		case Version.DRAFT_04:
+			throw new Error("track stream not supported for this version");
+		default:
+			break;
+	}
+}
+
+/**
+ * TRACK request: the first (and only) subscriber message on a Track Stream (0x6).
+ * Asks for a track's immutable publisher properties without subscribing or fetching.
+ */
+export class Track {
+	broadcast: Path.Valid;
+	track: string;
+
+	constructor(broadcast: Path.Valid, track: string) {
+		this.broadcast = broadcast;
+		this.track = track;
+	}
+
+	async #encode(w: Writer) {
+		await w.string(this.broadcast);
+		await w.string(this.track);
+	}
+
+	static async #decode(r: Reader): Promise<Track> {
+		const broadcast = Path.from(await r.string());
+		const track = await r.string();
+		return new Track(broadcast, track);
+	}
+
+	async encode(w: Writer, version: Version): Promise<void> {
+		guardTrack(version);
+		return Message.encode(w, (w) => this.#encode(w));
+	}
+
+	static async decode(r: Reader, version: Version): Promise<Track> {
+		guardTrack(version);
+		return Message.decode(r, (r) => Track.#decode(r));
+	}
+}
+
+/**
+ * TRACK_INFO reply: the publisher's sole message on a Track Stream, carrying the
+ * track's immutable properties. Fetched once and reused across every SUBSCRIBE and
+ * FETCH for the track.
+ */
+export class TrackInfo {
+	priority: number;
+	ordered: boolean;
+	/** How long (milliseconds) the publisher keeps old groups available. */
+	cache: number;
+	/**
+	 * Per-frame timestamp scale (units per second). `0` means frames carry no
+	 * per-frame timestamps on the wire.
+	 */
+	timescale: number;
+	/** Codec applied to every frame payload on this track. */
+	compression: Compression;
+
+	constructor({
+		priority = 0,
+		ordered = true,
+		cache = DEFAULT_CACHE_MS,
+		timescale = 0,
+		compression = Compression.None,
+	}: {
+		priority?: number;
+		ordered?: boolean;
+		cache?: number;
+		timescale?: number;
+		compression?: Compression;
+	}) {
+		this.priority = priority;
+		this.ordered = ordered;
+		this.cache = cache;
+		this.timescale = timescale;
+		this.compression = compression;
+	}
+
+	async #encode(w: Writer) {
+		await w.u8(this.priority);
+		await w.bool(this.ordered);
+		await w.u53(this.cache);
+		await w.u53(this.timescale);
+		await w.u53(this.compression);
+	}
+
+	static async #decode(r: Reader): Promise<TrackInfo> {
+		const priority = await r.u8();
+		const ordered = await r.bool();
+		const cache = await r.u53();
+		const timescale = await r.u53();
+		const compression = compressionFromCode(await r.u53());
+		return new TrackInfo({ priority, ordered, cache, timescale, compression });
+	}
+
+	async encode(w: Writer, version: Version): Promise<void> {
+		guardTrack(version);
+		return Message.encode(w, (w) => this.#encode(w));
+	}
+
+	static async decode(r: Reader, version: Version): Promise<TrackInfo> {
+		guardTrack(version);
+		return Message.decode(r, (r) => TrackInfo.#decode(r));
+	}
+}

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -1,51 +1,55 @@
 import { expect, test } from "bun:test";
 import { Group } from "./group.ts";
-import { Track } from "./track.ts";
+import { TrackProducer } from "./track.ts";
 
 test("nextGroup skips late arrivals", async () => {
-	const track = new Track("test");
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
 
-	track.writeGroup(new Group(5));
+	producer.writeGroup(new Group(5));
 
 	const first = await track.nextGroup();
 	expect(first?.sequence).toBe(5);
 
 	// Late arrivals with sequence <= last returned are skipped.
-	track.writeGroup(new Group(3));
-	track.writeGroup(new Group(4));
-	track.writeGroup(new Group(7));
+	producer.writeGroup(new Group(3));
+	producer.writeGroup(new Group(4));
+	producer.writeGroup(new Group(7));
 
 	const next = await track.nextGroup();
 	expect(next?.sequence).toBe(7);
 });
 
 test("nextGroup returns buffered groups in sequence", async () => {
-	const track = new Track("test");
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
 
-	track.writeGroup(new Group(3));
-	track.writeGroup(new Group(5));
+	producer.writeGroup(new Group(3));
+	producer.writeGroup(new Group(5));
 
 	expect((await track.nextGroup())?.sequence).toBe(3);
 	expect((await track.nextGroup())?.sequence).toBe(5);
 });
 
 test("recvGroup after nextGroup still returns late arrivals", async () => {
-	const track = new Track("test");
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
 
-	track.writeGroup(new Group(5));
+	producer.writeGroup(new Group(5));
 
 	// Ordered returns seq 5, advancing its cursor.
 	const ordered = await track.nextGroup();
 	expect(ordered?.sequence).toBe(5);
 
 	// recvGroup is independent of the ordered cursor: a late seq 3 still surfaces.
-	track.writeGroup(new Group(3));
+	producer.writeGroup(new Group(3));
 	const recv = await track.recvGroup();
 	expect(recv?.sequence).toBe(3);
 });
 
 test("nextGroup returns undefined when track closes", async () => {
-	const track = new Track("test");
-	track.close();
+	const producer = new TrackProducer("test");
+	const track = producer.subscribe();
+	producer.close();
 	expect(await track.nextGroup()).toBeUndefined();
 });

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1,41 +1,55 @@
 import { Signal } from "@moq/signals";
 import { Group } from "./group.ts";
 
-/** Default {@link Track.cache} window (milliseconds) when the publisher doesn't set one. */
+/** Default {@link TrackInfo.cache} window (milliseconds) when the publisher doesn't set one. */
 export const DEFAULT_CACHE_MS = 5000;
 
+/**
+ * A track's immutable publisher properties, fixed for the lifetime of the track.
+ *
+ * A producer declares these once (via `TrackRequest.accept` or
+ * {@link TrackProducer.accept}); a consumer awaits them via {@link TrackSubscriber.info}
+ * (resolved from the wire TRACK_INFO on lite-05+). They map 1:1 onto TRACK_INFO.
+ */
+export interface TrackInfo {
+	/** Hint that frames are worth compressing (e.g. a JSON catalog). */
+	compress: boolean;
+	/** How long (milliseconds) old groups stay available before eviction. */
+	cache: number;
+	/** Tie-break priority between subscriptions of equal subscriber priority. */
+	priority: number;
+	/** Group ordering preference (newest-first when `false`). */
+	ordered: boolean;
+}
+
+/** Fill in any unset {@link TrackInfo} fields with their defaults. */
+export function trackInfoDefaults(info: Partial<TrackInfo> = {}): TrackInfo {
+	return {
+		compress: info.compress ?? false,
+		cache: info.cache ?? DEFAULT_CACHE_MS,
+		priority: info.priority ?? 0,
+		ordered: info.ordered ?? true,
+	};
+}
+
+/** The shared state behind a {@link TrackProducer} / {@link TrackSubscriber} pair. */
 export class TrackState {
 	groups = new Signal<Group[]>([]);
 	closed = new Signal<boolean | Error>(false);
 	priority = new Signal<number | undefined>(undefined);
+	/** Resolved once the producer commits the immutable properties. */
+	info = new Signal<TrackInfo | undefined>(undefined);
 }
 
-export class Track {
+/** Shared base for the two ends of a track: name, state, close, and info. */
+abstract class TrackHandle {
 	readonly name: string;
-
-	/**
-	 * Hint that this track's frames are worth compressing (e.g. a JSON catalog).
-	 * The publisher honors it by negotiating a codec in SUBSCRIBE_OK; codec-less
-	 * peers (older drafts) ignore it and send frames verbatim. Set it before the
-	 * track is served so the negotiated codec is known when SUBSCRIBE_OK is sent.
-	 */
-	compress = false;
-
-	/**
-	 * How long (milliseconds) the publisher keeps old groups available before
-	 * evicting them. Announced in SUBSCRIBE_OK so relays re-serve with the same
-	 * window. Lite05+ only; older drafts assume {@link DEFAULT_CACHE_MS}.
-	 */
-	cache = DEFAULT_CACHE_MS;
-
-	state = new TrackState();
-	#next?: number;
-	#nextSequence = 0;
-
+	readonly state: TrackState;
 	readonly closed: Promise<Error | undefined>;
 
-	constructor(name: string) {
+	constructor(name: string, state: TrackState) {
 		this.name = name;
+		this.state = state;
 
 		this.closed = new Promise((resolve) => {
 			const dispose = this.state.closed.subscribe((closed) => {
@@ -47,9 +61,61 @@ export class Track {
 	}
 
 	/**
-	 * Appends a new group to the track.
-	 * @returns A GroupProducer for the new group
+	 * Resolve this track's immutable publisher properties.
+	 *
+	 * On a producer this resolves once the info is committed (at accept time); on a
+	 * consumer once the wire layer commits the TRACK_INFO it received (lite-05+) or
+	 * defaults (older drafts), so awaiting it never yields a placeholder. Rejects if
+	 * the track is closed before the properties are known (e.g. a rejected subscription).
 	 */
+	async info(): Promise<TrackInfo> {
+		for (;;) {
+			const info = this.state.info.peek();
+			if (info) return info;
+
+			const closed = this.state.closed.peek();
+			if (closed instanceof Error) throw closed;
+			if (closed) throw new Error("track closed before info was known");
+
+			await Signal.race(this.state.info, this.state.closed);
+		}
+	}
+
+	/** Close the track (optionally with an error), closing any pending groups. */
+	close(abort?: Error) {
+		this.state.closed.set(abort ?? true);
+		for (const group of this.state.groups.peek()) {
+			group.close(abort);
+		}
+	}
+}
+
+/**
+ * The write side of a track, mirroring the Rust `TrackProducer`.
+ *
+ * Obtained from `TrackRequest.accept` (the wire asks the application for a track to
+ * serve) or constructed directly for an in-process track. Writes groups that a
+ * {@link TrackSubscriber} on the same {@link TrackState} reads.
+ */
+export class TrackProducer extends TrackHandle {
+	#next?: number;
+
+	constructor(name: string, state: TrackState = new TrackState()) {
+		super(name, state);
+	}
+
+	/** Commit the immutable publisher properties, resolving {@link info}. Returns `this`. */
+	accept(info: Partial<TrackInfo> = {}): this {
+		this.state.info.set(trackInfoDefaults(info));
+		return this;
+	}
+
+	/** A {@link TrackSubscriber} reading this in-process track's groups. */
+	subscribe(): TrackSubscriber {
+		return new TrackSubscriber(this.name, this.state);
+	}
+
+	/** Append a new group with the next sequence number. */
 	appendGroup(): Group {
 		if (this.state.closed.peek()) throw new Error("track is closed");
 
@@ -64,10 +130,7 @@ export class Track {
 		return group;
 	}
 
-	/**
-	 * Inserts an existing group into the track.
-	 * @param group - The group to insert
-	 */
+	/** Insert an existing group into the track. */
 	writeGroup(group: Group) {
 		if (this.state.closed.peek()) throw new Error("track is closed");
 
@@ -82,11 +145,7 @@ export class Track {
 		});
 	}
 
-	/**
-	 * Appends a frame to the track in its own group.
-	 *
-	 * @param frame - The frame to append
-	 */
+	/** Append a frame as its own single-frame group. */
 	writeFrame(frame: Uint8Array) {
 		const group = this.appendGroup();
 		group.writeFrame(frame);
@@ -110,13 +169,23 @@ export class Track {
 		group.writeBool(bool);
 		group.close();
 	}
+}
+
+/**
+ * The read side of a live track subscription, mirroring the Rust `TrackSubscriber`.
+ *
+ * Obtained from `Broadcast.subscribe` / `TrackConsumer.subscribe`, or from
+ * {@link TrackProducer.subscribe} for an in-process track. Reads the groups a
+ * {@link TrackProducer} on the same {@link TrackState} writes.
+ */
+export class TrackSubscriber extends TrackHandle {
+	#nextSequence = 0;
 
 	/**
 	 * Receive the next group available on this track, in arrival order.
 	 *
 	 * Groups may arrive out of order or with gaps due to network conditions.
-	 * Use {@link nextGroup} if you need groups in sequence order,
-	 * skipping those that arrive too late.
+	 * Use {@link nextGroup} for sequence order, skipping those that arrive too late.
 	 */
 	async recvGroup(): Promise<Group | undefined> {
 		for (;;) {
@@ -136,7 +205,7 @@ export class Track {
 	/**
 	 * Return the next group with a strictly-greater sequence number than the last returned.
 	 *
-	 * Late arrivals (with a sequence number at or below the last one returned) are silently skipped.
+	 * Late arrivals (sequence at or below the last returned) are silently skipped.
 	 * Use {@link recvGroup} to see every group in arrival order instead.
 	 */
 	async nextGroup(): Promise<Group | undefined> {
@@ -223,21 +292,9 @@ export class Track {
 	}
 
 	/**
-	 * Update the subscription priority. Triggers a SUBSCRIBE_UPDATE
-	 * to the publisher when used on a subscribed track.
+	 * Update this subscription's priority, triggering a SUBSCRIBE_UPDATE to the publisher.
 	 */
 	updatePriority(priority: number) {
 		this.state.priority.set(priority, true);
-	}
-
-	/**
-	 * Closes the publisher and all associated groups.
-	 */
-	close(abort?: Error) {
-		this.state.closed.set(abort ?? true);
-
-		for (const group of this.state.groups.peek()) {
-			group.close(abort);
-		}
 	}
 }

--- a/js/net/src/zod.ts
+++ b/js/net/src/zod.ts
@@ -2,15 +2,18 @@
 
 import type * as z from "zod/mini";
 import type { Group } from "./group.ts";
-import type { Track } from "./track.ts";
+import type { TrackProducer, TrackSubscriber } from "./track.ts";
 
-export async function read<T = unknown>(source: Track | Group, schema: z.ZodMiniType<T>): Promise<T | undefined> {
+export async function read<T = unknown>(
+	source: TrackSubscriber | Group,
+	schema: z.ZodMiniType<T>,
+): Promise<T | undefined> {
 	const next = await source.readJson();
 	if (next === undefined) return undefined; // only treat undefined as EOF, not other falsy values
 	return schema.parse(next);
 }
 
-export function write<T = unknown>(source: Track | Group, value: T, schema: z.ZodMiniType<T>) {
+export function write<T = unknown>(source: TrackProducer | Group, value: T, schema: z.ZodMiniType<T>) {
 	const valid = schema.parse(value);
 	source.writeJson(valid);
 }

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -175,7 +175,7 @@ export class Encoder {
 		}
 	}
 
-	serve(track: Moq.Track, effect: Effect): void {
+	serve(track: Moq.TrackProducer, effect: Effect): void {
 		const values = effect.getAll([this.enabled, this.#worklet]);
 		if (!values) return;
 		const [_, worklet] = values;

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -24,6 +24,19 @@ export type BroadcastProps = {
 export class Broadcast {
 	static readonly CATALOG_TRACK = "catalog.json";
 
+	// Track names this broadcast knows how to serve; any other request is rejected.
+	static readonly #TRACKS: ReadonlySet<string> = new Set([
+		Broadcast.CATALOG_TRACK,
+		Location.Window.TRACK,
+		Location.Peers.TRACK,
+		Preview.TRACK,
+		Chat.Typing.TRACK,
+		Chat.Message.TRACK,
+		Audio.Encoder.TRACK,
+		Video.Root.TRACK_HD,
+		Video.Root.TRACK_SD,
+	]);
+
 	connection: Signal<Moq.Connection.Established | undefined>;
 	enabled: Signal<boolean>;
 	name: Signal<Moq.Path.Valid>;
@@ -78,42 +91,49 @@ export class Broadcast {
 			const request = await broadcast.requested();
 			if (!request) break;
 
-			effect.cleanup(() => request.track.close());
+			// Accept the request to commit the track's immutable publisher properties up
+			// front (so the wire layer can answer a TRACK request on lite-05+ and pick the
+			// frame codec) and obtain the TrackProducer to serve. An unknown track is
+			// rejected instead, without accepting, so its TRACK / SUBSCRIBE resets.
+			if (!Broadcast.#TRACKS.has(request.name)) {
+				console.error("received subscription for unknown track", request.name);
+				request.reject(new Error(`Unknown track: ${request.name}`));
+				continue;
+			}
+
+			const track = request.accept();
+			effect.cleanup(() => track.close());
 
 			effect.run((effect) => {
-				if (effect.get(request.track.state.closed)) return;
+				if (effect.get(track.state.closed)) return;
 
-				switch (request.track.name) {
+				switch (request.name) {
 					case Broadcast.CATALOG_TRACK:
-						this.#serveCatalog(new Json.Producer<Catalog.Root>(request.track), effect);
+						this.#serveCatalog(new Json.Producer<Catalog.Root>(track), effect);
 						break;
 					case Location.Window.TRACK:
-						this.location.window.serve(request.track, effect);
+						this.location.window.serve(track, effect);
 						break;
 					case Location.Peers.TRACK:
-						this.location.peers.serve(request.track, effect);
+						this.location.peers.serve(track, effect);
 						break;
 					case Preview.TRACK:
-						this.preview.serve(request.track, effect);
+						this.preview.serve(track, effect);
 						break;
 					case Chat.Typing.TRACK:
-						this.chat.typing.serve(request.track, effect);
+						this.chat.typing.serve(track, effect);
 						break;
 					case Chat.Message.TRACK:
-						this.chat.message.serve(request.track, effect);
+						this.chat.message.serve(track, effect);
 						break;
 					case Audio.Encoder.TRACK:
-						this.audio.serve(request.track, effect);
+						this.audio.serve(track, effect);
 						break;
 					case Video.Root.TRACK_HD:
-						this.video.hd.serve(request.track, effect);
+						this.video.hd.serve(track, effect);
 						break;
 					case Video.Root.TRACK_SD:
-						this.video.sd.serve(request.track, effect);
-						break;
-					default:
-						console.error("received subscription for unknown track", request.track.name);
-						request.track.close(new Error(`Unknown track: ${request.track.name}`));
+						this.video.sd.serve(track, effect);
 						break;
 				}
 			});

--- a/js/publish/src/chat/message.ts
+++ b/js/publish/src/chat/message.ts
@@ -31,7 +31,7 @@ export class Message {
 		});
 	}
 
-	serve(track: Moq.Track, effect: Effect): void {
+	serve(track: Moq.TrackProducer, effect: Effect): void {
 		const enabled = effect.get(this.enabled);
 		if (!enabled) return;
 

--- a/js/publish/src/chat/typing.ts
+++ b/js/publish/src/chat/typing.ts
@@ -31,7 +31,7 @@ export class Typing {
 		});
 	}
 
-	serve(track: Moq.Track, effect: Effect): void {
+	serve(track: Moq.TrackProducer, effect: Effect): void {
 		const enabled = effect.get(this.enabled);
 		if (!enabled) return;
 

--- a/js/publish/src/location/peers.ts
+++ b/js/publish/src/location/peers.ts
@@ -30,7 +30,7 @@ export class Peers {
 		});
 	}
 
-	serve(track: Moq.Track, effect: Effect): void {
+	serve(track: Moq.TrackProducer, effect: Effect): void {
 		const values = effect.getAll([this.enabled, this.positions]);
 		if (!values) return;
 		const [_, positions] = values;

--- a/js/publish/src/location/window.ts
+++ b/js/publish/src/location/window.ts
@@ -43,7 +43,7 @@ export class Window {
 		});
 	}
 
-	serve(track: Moq.Track, effect: Effect): void {
+	serve(track: Moq.TrackProducer, effect: Effect): void {
 		const values = effect.getAll([this.enabled, this.position]);
 		if (!values) return;
 		const [_, position] = values;

--- a/js/publish/src/preview.ts
+++ b/js/publish/src/preview.ts
@@ -28,7 +28,7 @@ export class Preview {
 		});
 	}
 
-	serve(track: Moq.Track, effect: Effect): void {
+	serve(track: Moq.TrackProducer, effect: Effect): void {
 		const values = effect.getAll([this.enabled, this.info]);
 		if (!values) return;
 		const [_, info] = values;

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -77,7 +77,7 @@ export class Encoder {
 		this.#signals.run(this.#runDimensions.bind(this));
 	}
 
-	serve(track: Moq.Track, effect: Effect): void {
+	serve(track: Moq.TrackProducer, effect: Effect): void {
 		if (!effect.get(this.enabled)) return;
 
 		const producer = new Container.Legacy.Producer(track);

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -184,7 +184,7 @@ export class Decoder {
 		const active = effect.get(broadcast.output.active);
 		if (!active) return;
 
-		const sub = active.subscribe(track, Catalog.PRIORITY.audio);
+		const sub = active.track(track).subscribe({ priority: Catalog.PRIORITY.audio });
 		effect.cleanup(() => sub.close());
 
 		if (config.container.kind === "cmaf") {
@@ -194,7 +194,7 @@ export class Decoder {
 		}
 	}
 
-	#runLegacyDecoder(effect: Effect, sub: Moq.Track, config: Catalog.AudioConfig): void {
+	#runLegacyDecoder(effect: Effect, sub: Moq.TrackSubscriber, config: Catalog.AudioConfig): void {
 		const format = config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer with slightly less latency than the render worklet to avoid underflowing.
 		// TODO include JITTER_UNDERHEAD
@@ -271,7 +271,7 @@ export class Decoder {
 		});
 	}
 
-	#runCmafDecoder(effect: Effect, sub: Moq.Track, config: Catalog.AudioConfig): void {
+	#runCmafDecoder(effect: Effect, sub: Moq.TrackSubscriber, config: Catalog.AudioConfig): void {
 		if (config.container.kind !== "cmaf") return; // just to help typescript
 
 		const initSegment = base64ToBytes(config.container.init);

--- a/js/watch/src/audio/mse.ts
+++ b/js/watch/src/audio/mse.ts
@@ -87,7 +87,7 @@ export class Mse implements Backend {
 			this.#output.buffered.set(timeRangesToArray(sourceBuffer.buffered));
 		});
 
-		const sub = active.subscribe(track, Catalog.PRIORITY.audio);
+		const sub = active.track(track).subscribe({ priority: Catalog.PRIORITY.audio });
 		effect.cleanup(() => sub.close());
 
 		if (config.container.kind === "cmaf") {
@@ -109,7 +109,7 @@ export class Mse implements Backend {
 
 	#runCmafMedia(
 		effect: Effect,
-		sub: Moq.Track,
+		sub: Moq.TrackSubscriber,
 		config: Catalog.AudioConfig,
 		sourceBuffer: SourceBuffer,
 		element: HTMLMediaElement,
@@ -144,7 +144,7 @@ export class Mse implements Backend {
 
 	#runLegacyMedia(
 		effect: Effect,
-		sub: Moq.Track,
+		sub: Moq.TrackSubscriber,
 		config: Catalog.AudioConfig,
 		sourceBuffer: SourceBuffer,
 		element: HTMLMediaElement,

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -155,7 +155,7 @@ export class Broadcast {
 		this.#output.status.set("loading");
 
 		const trackName = format === "hang" ? "catalog.json" : "catalog";
-		const track = broadcast.subscribe(trackName, Catalog.PRIORITY.catalog);
+		const track = broadcast.track(trackName).subscribe({ priority: Catalog.PRIORITY.catalog });
 		effect.cleanup(() => track.close());
 
 		// The hang catalog is reconstructed from snapshots (and future deltas) via @moq/json;

--- a/js/watch/src/chat/message.ts
+++ b/js/watch/src/chat/message.ts
@@ -53,7 +53,7 @@ export class Message {
 		if (!values) return;
 		const [_, catalog, broadcast] = values;
 
-		const track = broadcast.subscribe(catalog.name, Catalog.PRIORITY.chat);
+		const track = broadcast.track(catalog.name).subscribe({ priority: Catalog.PRIORITY.chat });
 		effect.cleanup(() => track.close());
 
 		// Undefined is only when we're not subscribed to the track.

--- a/js/watch/src/chat/typing.ts
+++ b/js/watch/src/chat/typing.ts
@@ -52,7 +52,7 @@ export class Typing {
 		if (!values) return;
 		const [_, catalog, broadcast] = values;
 
-		const track = broadcast.subscribe(catalog.name, Catalog.PRIORITY.typing);
+		const track = broadcast.track(catalog.name).subscribe({ priority: Catalog.PRIORITY.typing });
 		effect.cleanup(() => track.close());
 
 		effect.spawn(async () => {

--- a/js/watch/src/location/peers.ts
+++ b/js/watch/src/location/peers.ts
@@ -44,13 +44,13 @@ export class Peers {
 		if (!values) return;
 		const [_, catalog, broadcast] = values;
 
-		const track = broadcast.subscribe(catalog.name, Catalog.PRIORITY.location);
+		const track = broadcast.track(catalog.name).subscribe({ priority: Catalog.PRIORITY.location });
 		effect.cleanup(() => track.close());
 
 		effect.spawn(this.#runTrack.bind(this, track));
 	}
 
-	async #runTrack(track: Moq.Track) {
+	async #runTrack(track: Moq.TrackSubscriber) {
 		try {
 			for (;;) {
 				const frame = await Zod.read(track, Catalog.PeersSchema);

--- a/js/watch/src/location/window.ts
+++ b/js/watch/src/location/window.ts
@@ -54,14 +54,14 @@ export class Window {
 			const updates = effect.get(this.#catalog)?.track;
 			if (!updates) return;
 
-			const track = broadcast.subscribe(updates.name, Catalog.PRIORITY.location);
+			const track = broadcast.track(updates.name).subscribe({ priority: Catalog.PRIORITY.location });
 			effect.cleanup(() => track.close());
 
 			effect.spawn(this.#runTrack.bind(this, track));
 		});
 	}
 
-	async #runTrack(track: Moq.Track) {
+	async #runTrack(track: Moq.TrackSubscriber) {
 		try {
 			for (;;) {
 				const position = await Zod.read(track, Catalog.PositionSchema);

--- a/js/watch/src/preview.ts
+++ b/js/watch/src/preview.ts
@@ -42,7 +42,7 @@ export class Preview {
 			const [_, broadcast, catalog] = values;
 
 			// Subscribe to the preview.json track directly
-			const track = broadcast.subscribe(catalog.name, Catalog.PRIORITY.preview);
+			const track = broadcast.track(catalog.name).subscribe({ priority: Catalog.PRIORITY.preview });
 			effect.cleanup(() => track.close());
 
 			effect.spawn(async () => {

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -254,7 +254,7 @@ class DecoderTrack {
 	}
 
 	#run(effect: Effect): void {
-		const sub = this.broadcast.subscribe(this.track, Catalog.PRIORITY.video);
+		const sub = this.broadcast.track(this.track).subscribe({ priority: Catalog.PRIORITY.video });
 		effect.cleanup(() => sub.close());
 
 		const decoder = new VideoDecoder({
@@ -312,7 +312,7 @@ class DecoderTrack {
 		}
 	}
 
-	#runLegacy(effect: Effect, sub: Moq.Track, decoder: VideoDecoder): void {
+	#runLegacy(effect: Effect, sub: Moq.TrackSubscriber, decoder: VideoDecoder): void {
 		const format =
 			this.config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer that reorders groups/frames up to the provided latency.
@@ -389,7 +389,7 @@ class DecoderTrack {
 		});
 	}
 
-	#runCmaf(effect: Effect, sub: Moq.Track, decoder: VideoDecoder): void {
+	#runCmaf(effect: Effect, sub: Moq.TrackSubscriber, decoder: VideoDecoder): void {
 		if (this.config.container.kind !== "cmaf") return;
 
 		const initSegment = base64ToBytes(this.config.container.init);

--- a/js/watch/src/video/mse.ts
+++ b/js/watch/src/video/mse.ts
@@ -110,7 +110,7 @@ export class Mse implements Backend {
 	): void {
 		if (config.container.kind !== "cmaf") throw new Error("unreachable");
 
-		const data = active.subscribe(track, Catalog.PRIORITY.video);
+		const data = active.track(track).subscribe({ priority: Catalog.PRIORITY.video });
 		effect.cleanup(() => data.close());
 
 		// Decode the catalog's authoritative init segment once and read the
@@ -150,7 +150,7 @@ export class Mse implements Backend {
 		sourceBuffer: SourceBuffer,
 		element: HTMLMediaElement,
 	): void {
-		const data = active.subscribe(track, Catalog.PRIORITY.video);
+		const data = active.track(track).subscribe({ priority: Catalog.PRIORITY.video });
 		effect.cleanup(() => data.close());
 
 		const format = config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -230,15 +230,22 @@ async fn broadcast_moq_lite_05_timestamps_webtransport() {
 }
 
 /// Lite05 FETCH round-trip: retrieve a past group by sequence without holding a
-/// subscription, exercising the FETCH / FETCH_OK control flow and per-frame
-/// timestamp decoding on the fetch stream.
+/// subscription, exercising the bare-FRAME fetch response and per-frame timestamp
+/// decoding on the fetch stream. The track is also `compress`-hinted, so the
+/// fetched frames are Deflate-compressed (matching TRACK_INFO) and inflated by the
+/// subscriber, exercising fetch/TRACK_INFO codec consistency.
 async fn lite05_fetch_roundtrip(scheme: &str) {
 	use moq_native::moq_net::{Timescale, Timestamp};
 
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
 	let mut track = broadcast
-		.create_track("video", moq_net::TrackInfo::default().with_timescale(Timescale::MICRO))
+		.create_track(
+			"video",
+			moq_net::TrackInfo::default()
+				.with_timescale(Timescale::MICRO)
+				.with_compress(true),
+		)
 		.expect("failed to create track");
 
 	// A group with a few timestamped frames (middle PTS goes backwards, so the

--- a/rs/moq-net/src/lite/fetch.rs
+++ b/rs/moq-net/src/lite/fetch.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::{
-	Compression, Path, Timescale,
+	Path,
 	coding::{Decode, DecodeError, Encode, EncodeError},
 };
 
@@ -69,97 +69,9 @@ impl Message for Fetch<'_> {
 	}
 }
 
-/// Publisher's response to a [`Fetch`], sent on the same bidirectional stream
-/// immediately before the group's frames.
-///
-/// Mirrors the codec/timescale negotiation in [`super::SubscribeOk`] so the
-/// subscriber can decode the frames that follow. There is no error variant: a
-/// failed fetch resets the stream instead. Lite05+ only.
-#[derive(Clone, Debug)]
-pub struct FetchOk {
-	/// Echo of the requested group sequence, for a sanity check.
-	pub group: u64,
-	/// Codec the publisher used for every frame in this group.
-	pub compression: Compression,
-	/// Per-frame timestamp scale, or `None` if the frames carry no timestamps.
-	/// On the wire `None` is `0` and `Some(n)` is `n`.
-	pub timescale: Option<Timescale>,
-}
-
-impl Message for FetchOk {
-	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		match version {
-			Version::Lite01 | Version::Lite02 | Version::Lite03 | Version::Lite04 => {
-				return Err(DecodeError::Version);
-			}
-			_ => {}
-		}
-
-		let group = u64::decode(r, version)?;
-		let timescale = Timescale::new(u64::decode(r, version)?).ok();
-		let compression = Compression::from_code(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)?;
-
-		Ok(Self {
-			group,
-			compression,
-			timescale,
-		})
-	}
-
-	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		match version {
-			Version::Lite01 | Version::Lite02 | Version::Lite03 | Version::Lite04 => {
-				return Err(EncodeError::Version);
-			}
-			_ => {}
-		}
-
-		self.group.encode(w, version)?;
-		self.timescale.map(u64::from).unwrap_or(0).encode(w, version)?;
-		self.compression.to_code().encode(w, version)?;
-		Ok(())
-	}
-}
-
 #[cfg(test)]
 mod test {
 	use super::*;
-
-	fn sample() -> FetchOk {
-		FetchOk {
-			group: 42,
-			compression: Compression::Deflate,
-			timescale: Some(Timescale::MICRO),
-		}
-	}
-
-	fn roundtrip(version: Version, ok: &FetchOk) -> FetchOk {
-		let mut buf = Vec::new();
-		ok.encode_msg(&mut buf, version).unwrap();
-		let mut slice = buf.as_slice();
-		FetchOk::decode_msg(&mut slice, version).unwrap()
-	}
-
-	#[test]
-	fn fetch_ok_roundtrips_on_lite05() {
-		let got = roundtrip(Version::Lite05Wip, &sample());
-		assert_eq!(got.group, 42);
-		assert_eq!(got.compression, Compression::Deflate);
-		assert_eq!(got.timescale, Some(Timescale::MICRO));
-	}
-
-	#[test]
-	fn fetch_ok_timescale_none_roundtrips() {
-		let mut ok = sample();
-		ok.timescale = None;
-		assert_eq!(roundtrip(Version::Lite05Wip, &ok).timescale, None);
-	}
-
-	#[test]
-	fn fetch_ok_errors_before_lite05() {
-		let mut buf = Vec::new();
-		assert!(sample().encode_msg(&mut buf, Version::Lite04).is_err());
-	}
 
 	fn fetch_sample() -> Fetch<'static> {
 		Fetch {

--- a/rs/moq-net/src/lite/mod.rs
+++ b/rs/moq-net/src/lite/mod.rs
@@ -19,6 +19,7 @@ mod session;
 mod stream;
 mod subscribe;
 mod subscriber;
+mod track;
 mod version;
 
 pub use announce::*;
@@ -37,4 +38,6 @@ pub(super) use session::*;
 pub use stream::*;
 pub use subscribe::*;
 use subscriber::*;
+#[allow(unused_imports)]
+pub use track::*;
 pub use version::Version;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -81,6 +81,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			lite::ControlType::Announce => self.recv_announce(stream).await,
 			lite::ControlType::Subscribe => self.recv_subscribe(stream).await,
 			lite::ControlType::Fetch => self.recv_fetch(stream).await,
+			lite::ControlType::Track => self.recv_track(stream).await,
 			lite::ControlType::Probe => {
 				self.recv_probe(stream).await;
 				Ok(())
@@ -387,6 +388,66 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		Some(hops)
 	}
 
+	pub async fn recv_track(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
+		// The Track Stream is lite-05+ only.
+		if !self.version.has_timestamps() {
+			return Err(Error::UnexpectedStream);
+		}
+
+		let request = stream.reader.decode::<lite::Track>().await?;
+		let track = request.track.clone();
+		let absolute = self.origin.absolute(&request.broadcast).to_owned();
+
+		tracing::debug!(broadcast = %absolute, %track, "track info requested");
+
+		if let Err(err) = self.run_track_info(&mut stream, &request).await {
+			match &err {
+				Error::Cancel | Error::Transport(_) => {
+					tracing::debug!(broadcast = %absolute, %track, "track info cancelled")
+				}
+				err => tracing::warn!(broadcast = %absolute, %track, %err, "track info error"),
+			}
+			stream.writer.abort(&err);
+		}
+
+		Ok(())
+	}
+
+	async fn run_track_info(&self, stream: &mut Stream<S, Version>, request: &lite::Track<'_>) -> Result<(), Error> {
+		// The peer requested this exact path, so it has already seen an announcement
+		// for it; a synchronous lookup is appropriate (as in recv_subscribe).
+		let broadcast = self.origin.get_broadcast(&request.broadcast).ok_or(Error::NotFound)?;
+		let info = broadcast.track(&request.track)?.info().await?;
+
+		// Same negotiation as a subscription, just answered once: codec only when
+		// both the producer asks for it and the draft can carry it; timescale only
+		// when the draft carries per-frame timestamps.
+		let compression = if info.compress {
+			Compression::Deflate
+		} else {
+			Compression::None
+		};
+		let timescale = if self.version.has_timestamps() {
+			info.timescale
+		} else {
+			None
+		};
+
+		stream
+			.writer
+			.encode(&lite::TrackInfo {
+				priority: info.priority,
+				ordered: info.ordered,
+				cache: info.cache,
+				timescale,
+				compression,
+			})
+			.await?;
+
+		stream.writer.finish()?;
+		stream.writer.closed().await
+	}
+
 	pub async fn recv_subscribe(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
 		let subscribe = stream.reader.decode::<lite::Subscribe>().await?;
 
@@ -459,12 +520,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let track = broadcast.track(&subscribe.track)?.subscribe(subscription)?.await?;
 
 		// Compress only when the producer marked the track worth it and the
-		// negotiated draft understands the SUBSCRIBE_OK codec field. Older drafts
-		// (lite-04 and below) get None and the frames stream verbatim.
-		let supports_compression = !matches!(
-			version,
-			Version::Lite01 | Version::Lite02 | Version::Lite03 | Version::Lite04
-		);
+		// negotiated draft can carry a codec. Older drafts (lite-04 and below) get
+		// None and the frames stream verbatim. On Lite05+ this matches the codec the
+		// subscriber already learned from TRACK_INFO.
+		let supports_compression = version.has_timestamps();
 		let compression = if track.info().compress && supports_compression {
 			Compression::Deflate
 		} else {
@@ -485,20 +544,19 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// broadcast. Dropping this guard (subscription end) releases it.
 		let _broadcast_sub = broadcasts.subscribe(&absolute);
 
-		let info = lite::SubscribeOk {
-			priority: subscribe.priority,
-			ordered: false,
-			max_latency: std::time::Duration::ZERO,
-			start_group: None,
-			end_group: None,
-			compression,
-			timescale,
-			// Announce the publisher's cache window so the subscriber (a relay)
-			// re-serves with the same eviction window. Pre-lite-05 peers ignore it.
-			cache: track.info().cache,
-		};
-
-		stream.writer.encode(&lite::SubscribeResponse::Ok(info)).await?;
+		// Lite05+ accepts implicitly: no SUBSCRIBE_OK, the immutable properties live
+		// in TRACK_INFO, and the resolved range arrives as SUBSCRIBE_START/END emitted
+		// from run_track. Older drafts still acknowledge with SUBSCRIBE_OK here.
+		if !version.has_timestamps() {
+			let info = lite::SubscribeOk {
+				priority: subscribe.priority,
+				ordered: false,
+				max_latency: std::time::Duration::ZERO,
+				start_group: None,
+				end_group: None,
+			};
+			stream.writer.encode(&lite::SubscribeResponse::Ok(info)).await?;
+		}
 
 		// Track-level subscriber priority. SUBSCRIBE_UPDATE messages broadcast new values
 		// to both run_track (so future groups inherit the new priority) and serve_group
@@ -529,6 +587,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			subscribe.start_group,
 			subscribe.end_group,
 			&mut stream.reader,
+			&mut stream.writer,
 			&track_priority_tx,
 		)
 		.await?;
@@ -538,7 +597,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	pub async fn recv_fetch(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
-		// FETCH is lite-05+ only; older drafts have no FETCH_OK / frame format.
+		// FETCH is lite-05+ only; older drafts have no per-frame timestamp format.
 		if !self.version.has_timestamps() {
 			return Err(Error::UnexpectedStream);
 		}
@@ -579,9 +638,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		version: Version,
 	) -> Result<(), Error> {
 		let broadcast = consumer.ok_or(Error::NotFound)?;
+		let track = broadcast.track(&fetch.track)?;
 
-		let group = broadcast
-			.track(&fetch.track)?
+		let group = track
 			.fetch_group(
 				fetch.group,
 				crate::Fetch {
@@ -597,17 +656,18 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		} else {
 			None
 		};
-		// v1: fetched groups stream uncompressed (the model carries no per-track compress hint).
-		let compression = Compression::None;
 
-		stream
-			.writer
-			.encode(&lite::FetchOk {
-				group: fetch.group,
-				compression,
-				timescale,
-			})
-			.await?;
+		// Compression is an immutable per-track property (reported in TRACK_INFO), so
+		// fetched frames use the same codec as live ones. The group resolved above, so
+		// the track's info is set and this resolves immediately.
+		let compression = if track.info().await?.compress && version.has_timestamps() {
+			Compression::Deflate
+		} else {
+			Compression::None
+		};
+
+		// Lite05+ FETCH responds with bare FRAME messages; the subscriber already has
+		// the codec/timescale from TRACK_INFO and the group sequence from its request.
 		track_stats.group();
 
 		// Honor frame_start: skip earlier frames, then stream the rest in order. The
@@ -693,8 +753,8 @@ struct Subscription<S: web_transport_trait::Session> {
 	priority: PriorityQueue,
 	track_priority: tokio::sync::watch::Receiver<u8>,
 	version: Version,
-	/// Codec announced in SUBSCRIBE_OK; every frame on this subscription is
-	/// compressed with it before hitting the wire.
+	/// Codec for this track (reported in TRACK_INFO on lite-05+); every frame on
+	/// this subscription is compressed with it before hitting the wire.
 	compression: Compression,
 	/// Negotiated timestamp scale for this track. `Some(_)` iff
 	/// [`Version::has_timestamps`] is true for `version` (gated in
@@ -709,6 +769,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		start_group: Option<u64>,
 		initial_end_group: Option<u64>,
 		reader: &mut crate::coding::Reader<S::RecvStream, Version>,
+		writer: &mut Writer<S::SendStream, Version>,
 		track_priority_tx: &tokio::sync::watch::Sender<u8>,
 	) -> Result<(), Error> {
 		let mut tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>> = FuturesUnordered::new();
@@ -721,6 +782,11 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		// Apply the initial cap from the original Subscribe. Subsequent updates
 		// flow through the SubscribeUpdate select arm below.
 		track.end_at(initial_end_group);
+
+		// Lite05+ resolves the range on the Subscribe Stream itself: SUBSCRIBE_START
+		// once the first group is known, SUBSCRIBE_END when the track finishes.
+		let emit_range = self.version.has_timestamps();
+		let mut start_sent = false;
 
 		loop {
 			tokio::select! {
@@ -735,9 +801,24 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 				// cap stay in the producer's cache (bounded by its cache window).
 				res = track.next_group() => {
 					match res? {
-						Some(group) => self.spawn_serve(group, &mut tasks),
+						Some(group) => {
+							if emit_range && !start_sent {
+								start_sent = true;
+								writer
+									.encode(&lite::SubscribeResponse::Start(lite::SubscribeStart { group: group.sequence }))
+									.await?;
+							}
+							self.spawn_serve(group, &mut tasks);
+						}
 						None => {
-							// Track finished cleanly; drain in-flight tasks and exit.
+							// Track finished cleanly. Tell the subscriber no group will
+							// follow, then drain in-flight tasks and exit.
+							if emit_range {
+								let group = track.latest().unwrap_or(0);
+								writer
+									.encode(&lite::SubscribeResponse::End(lite::SubscribeEnd { group }))
+									.await?;
+							}
 							while tasks.next().await.is_some() {}
 							return Ok(());
 						}
@@ -814,7 +895,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 	/// Send one frame. Uncompressed frames stream chunk-by-chunk so we never
 	/// buffer the whole payload; a compressed frame must buffer to feed the
 	/// codec, and its wire size becomes the compressed length (the subscriber
-	/// inflates it from the codec in SUBSCRIBE_OK).
+	/// inflates it from the track's codec, known from TRACK_INFO on lite-05+).
 	async fn serve_frame(
 		&mut self,
 		stream: &mut Writer<S::SendStream, Version>,

--- a/rs/moq-net/src/lite/stream.rs
+++ b/rs/moq-net/src/lite/stream.rs
@@ -13,6 +13,7 @@ pub enum ControlType {
 	Fetch = 3,
 	Probe = 4,
 	Goaway = 5,
+	Track = 6,
 }
 
 impl Decode<Version> for ControlType {

--- a/rs/moq-net/src/lite/subscribe.rs
+++ b/rs/moq-net/src/lite/subscribe.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::{
-	Compression, Path, Timescale,
+	Path,
 	coding::{Decode, DecodeError, Encode, EncodeError, Sizer},
 };
 
@@ -72,6 +72,11 @@ impl Message for Subscribe<'_> {
 	}
 }
 
+/// Publisher's acknowledgement on the Subscribe Stream for drafts 01-04.
+///
+/// Lite05+ replaced this with implicit acceptance plus
+/// [`SubscribeStart`]/[`SubscribeEnd`]; the immutable codec/timescale/cache moved
+/// to [`super::TrackInfo`].
 #[derive(Clone, Debug)]
 pub struct SubscribeOk {
 	pub priority: u8,
@@ -79,21 +84,6 @@ pub struct SubscribeOk {
 	pub max_latency: std::time::Duration,
 	pub start_group: Option<u64>,
 	pub end_group: Option<u64>,
-	/// Codec the publisher will use for every frame on this track. Negotiated
-	/// here (not in SUBSCRIBE) so the subscriber blocks on this message before it
-	/// can decode any frame payload. Lite05+ only; older drafts always get
-	/// [`Compression::None`].
-	pub compression: Compression,
-	/// Per-frame timestamp scale advertised by the publisher. `None` means the
-	/// publisher doesn't carry per-frame timestamps on the wire (so frame
-	/// headers omit them). Lite05+ only; older drafts always decode as `None`.
-	/// On the wire `None` is `0` and `Some(n)` is `n`.
-	pub timescale: Option<Timescale>,
-	/// How long the publisher keeps old groups available before evicting them.
-	/// A relay re-serves with the same window and clamps each subscriber's stale
-	/// preference to it. Lite05+ only; older drafts always get
-	/// [`crate::DEFAULT_CACHE`].
-	pub cache: std::time::Duration,
 }
 
 impl Message for SubscribeOk {
@@ -103,23 +93,14 @@ impl Message for SubscribeOk {
 				self.priority.encode(w, version)?;
 			}
 			Version::Lite02 => {}
-			Version::Lite03 | Version::Lite04 => {
-				self.priority.encode(w, version)?;
-				(self.ordered as u8).encode(w, version)?;
-				self.max_latency.encode(w, version)?;
-				self.start_group.encode(w, version)?;
-				self.end_group.encode(w, version)?;
-			}
+			// Lite05+ never sends SUBSCRIBE_OK, but keep the field layout matching
+			// Lite03/04 so a stray future use stays well-formed.
 			_ => {
 				self.priority.encode(w, version)?;
 				(self.ordered as u8).encode(w, version)?;
 				self.max_latency.encode(w, version)?;
 				self.start_group.encode(w, version)?;
 				self.end_group.encode(w, version)?;
-				// Order matches draft-lcurley-moq-lite-05 SUBSCRIBE_OK: Timescale, Cache, Compression.
-				self.timescale.map(u64::from).unwrap_or(0).encode(w, version)?;
-				self.cache.encode(w, version)?;
-				self.compression.to_code().encode(w, version)?;
 			}
 		}
 
@@ -134,9 +115,6 @@ impl Message for SubscribeOk {
 				max_latency: std::time::Duration::ZERO,
 				start_group: None,
 				end_group: None,
-				compression: Compression::None,
-				timescale: None,
-				cache: crate::DEFAULT_CACHE,
 			}),
 			Version::Lite02 => Ok(Self {
 				priority: 0,
@@ -144,39 +122,13 @@ impl Message for SubscribeOk {
 				max_latency: std::time::Duration::ZERO,
 				start_group: None,
 				end_group: None,
-				compression: Compression::None,
-				timescale: None,
-				cache: crate::DEFAULT_CACHE,
 			}),
-			Version::Lite03 | Version::Lite04 => {
-				let priority = u8::decode(r, version)?;
-				let ordered = u8::decode(r, version)? != 0;
-				let max_latency = std::time::Duration::decode(r, version)?;
-				let start_group = Option::<u64>::decode(r, version)?;
-				let end_group = Option::<u64>::decode(r, version)?;
-
-				Ok(Self {
-					priority,
-					ordered,
-					max_latency,
-					start_group,
-					end_group,
-					compression: Compression::None,
-					timescale: None,
-					cache: crate::DEFAULT_CACHE,
-				})
-			}
 			_ => {
 				let priority = u8::decode(r, version)?;
 				let ordered = u8::decode(r, version)? != 0;
 				let max_latency = std::time::Duration::decode(r, version)?;
 				let start_group = Option::<u64>::decode(r, version)?;
 				let end_group = Option::<u64>::decode(r, version)?;
-				// Order matches draft-lcurley-moq-lite-05 SUBSCRIBE_OK: Timescale, Cache, Compression.
-				let timescale = Timescale::new(u64::decode(r, version)?).ok();
-				let cache = std::time::Duration::decode(r, version)?;
-				let compression =
-					Compression::from_code(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)?;
 
 				Ok(Self {
 					priority,
@@ -184,12 +136,61 @@ impl Message for SubscribeOk {
 					max_latency,
 					start_group,
 					end_group,
-					compression,
-					timescale,
-					cache,
 				})
 			}
 		}
+	}
+}
+
+/// Resolves the absolute start group of a Lite05+ subscription. The first message
+/// the publisher sends, once the start group is known. A value greater than the
+/// requested start implicitly drops the leading range.
+#[derive(Clone, Debug)]
+pub struct SubscribeStart {
+	pub group: u64,
+}
+
+impl Message for SubscribeStart {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		if !version.has_timestamps() {
+			return Err(DecodeError::Version);
+		}
+		Ok(Self {
+			group: u64::decode(r, version)?,
+		})
+	}
+
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		if !version.has_timestamps() {
+			return Err(EncodeError::Version);
+		}
+		self.group.encode(w, version)
+	}
+}
+
+/// Signals that no group after `group` (inclusive upper bound) will be produced on
+/// a Lite05+ subscription. Bounds the range but doesn't end the stream: stragglers
+/// at or below it may still be dropped before FIN.
+#[derive(Clone, Debug)]
+pub struct SubscribeEnd {
+	pub group: u64,
+}
+
+impl Message for SubscribeEnd {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		if !version.has_timestamps() {
+			return Err(DecodeError::Version);
+		}
+		Ok(Self {
+			group: u64::decode(r, version)?,
+		})
+	}
+
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		if !version.has_timestamps() {
+			return Err(EncodeError::Version);
+		}
+		self.group.encode(w, version)
 	}
 }
 
@@ -319,17 +320,33 @@ impl Message for SubscribeDrop {
 	}
 }
 
-/// A response message on the subscribe stream.
+/// A response message on the subscribe stream, prefixed with a type discriminator
+/// on Lite03+.
 ///
-/// In Draft03, each response is prefixed with a type discriminator:
-/// - 0x0 for SUBSCRIBE_OK
-/// - 0x1 for SUBSCRIBE_DROP
-///
-/// SUBSCRIBE_OK must be the first message on the response stream.
+/// The discriminator is version-dependent:
+/// - Lite03/04: `0x0` SUBSCRIBE_OK, `0x1` SUBSCRIBE_DROP.
+/// - Lite05+: `0x0` SUBSCRIBE_START, `0x1` SUBSCRIBE_END, `0x2` SUBSCRIBE_DROP
+///   (SUBSCRIBE_OK was removed; acceptance is implicit).
 #[derive(Clone, Debug)]
 pub enum SubscribeResponse {
 	Ok(SubscribeOk),
+	Start(SubscribeStart),
+	End(SubscribeEnd),
 	Drop(SubscribeDrop),
+}
+
+/// Write a `type` varint followed by the size-prefixed message body.
+fn encode_typed<W: bytes::BufMut, M: Message>(
+	w: &mut W,
+	typ: u64,
+	msg: &M,
+	version: Version,
+) -> Result<(), EncodeError> {
+	typ.encode(w, version)?;
+	let mut sizer = Sizer::default();
+	msg.encode_msg(&mut sizer, version)?;
+	sizer.size.encode(w, version)?;
+	msg.encode_msg(w, version)
 }
 
 impl Encode<Version> for SubscribeResponse {
@@ -342,26 +359,19 @@ impl Encode<Version> for SubscribeResponse {
 					sizer.size.encode(w, version)?;
 					Message::encode_msg(ok, w, version)?;
 				}
-				Self::Drop(_) => {
-					return Err(EncodeError::Version);
-				}
+				_ => return Err(EncodeError::Version),
 			},
+			Version::Lite03 | Version::Lite04 => match self {
+				Self::Ok(ok) => encode_typed(w, 0, ok, version)?,
+				Self::Drop(drop) => encode_typed(w, 1, drop, version)?,
+				_ => return Err(EncodeError::Version),
+			},
+			// Lite05+: SUBSCRIBE_OK is gone; START/END/DROP carry the resolved range.
 			_ => match self {
-				Self::Ok(ok) => {
-					0u64.encode(w, version)?;
-					// Write size-prefixed body using Message trait
-					let mut sizer = Sizer::default();
-					Message::encode_msg(ok, &mut sizer, version)?;
-					sizer.size.encode(w, version)?;
-					Message::encode_msg(ok, w, version)?;
-				}
-				Self::Drop(drop) => {
-					1u64.encode(w, version)?;
-					let mut sizer = Sizer::default();
-					Message::encode_msg(drop, &mut sizer, version)?;
-					sizer.size.encode(w, version)?;
-					Message::encode_msg(drop, w, version)?;
-				}
+				Self::Start(start) => encode_typed(w, 0, start, version)?,
+				Self::End(end) => encode_typed(w, 1, end, version)?,
+				Self::Drop(drop) => encode_typed(w, 2, drop, version)?,
+				Self::Ok(_) => return Err(EncodeError::Version),
 			},
 		}
 
@@ -373,11 +383,20 @@ impl Decode<Version> for SubscribeResponse {
 	fn decode<B: bytes::Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
 		match version {
 			Version::Lite01 | Version::Lite02 => Ok(Self::Ok(SubscribeOk::decode(buf, version)?)),
-			_ => {
+			Version::Lite03 | Version::Lite04 => {
 				let typ = u64::decode(buf, version)?;
 				match typ {
 					0 => Ok(Self::Ok(SubscribeOk::decode(buf, version)?)),
 					1 => Ok(Self::Drop(SubscribeDrop::decode(buf, version)?)),
+					_ => Err(DecodeError::InvalidMessage(typ)),
+				}
+			}
+			_ => {
+				let typ = u64::decode(buf, version)?;
+				match typ {
+					0 => Ok(Self::Start(SubscribeStart::decode(buf, version)?)),
+					1 => Ok(Self::End(SubscribeEnd::decode(buf, version)?)),
+					2 => Ok(Self::Drop(SubscribeDrop::decode(buf, version)?)),
 					_ => Err(DecodeError::InvalidMessage(typ)),
 				}
 			}
@@ -387,85 +406,73 @@ impl Decode<Version> for SubscribeResponse {
 
 #[cfg(test)]
 mod test {
-	use std::time::Duration;
-
 	use super::*;
 
-	fn sample() -> SubscribeOk {
-		SubscribeOk {
-			priority: 7,
-			ordered: true,
-			max_latency: Duration::from_millis(250),
-			start_group: Some(3),
-			end_group: None,
-			compression: Compression::Deflate,
-			timescale: Some(Timescale::MICRO),
-			cache: Duration::from_secs(10),
+	#[test]
+	fn subscribe_start_roundtrips_on_lite05() {
+		let resp = SubscribeResponse::Start(SubscribeStart { group: 42 });
+		let mut buf = Vec::new();
+		resp.encode(&mut buf, Version::Lite05Wip).unwrap();
+		let mut slice = buf.as_slice();
+		match SubscribeResponse::decode(&mut slice, Version::Lite05Wip).unwrap() {
+			SubscribeResponse::Start(start) => assert_eq!(start.group, 42),
+			other => panic!("expected Start, got {other:?}"),
 		}
 	}
 
-	fn roundtrip(version: Version, ok: &SubscribeOk) -> SubscribeOk {
+	#[test]
+	fn subscribe_end_roundtrips_on_lite05() {
+		let resp = SubscribeResponse::End(SubscribeEnd { group: 7 });
 		let mut buf = Vec::new();
-		ok.encode_msg(&mut buf, version).unwrap();
+		resp.encode(&mut buf, Version::Lite05Wip).unwrap();
 		let mut slice = buf.as_slice();
-		SubscribeOk::decode_msg(&mut slice, version).unwrap()
+		match SubscribeResponse::decode(&mut slice, Version::Lite05Wip).unwrap() {
+			SubscribeResponse::End(end) => assert_eq!(end.group, 7),
+			other => panic!("expected End, got {other:?}"),
+		}
 	}
 
 	#[test]
-	fn compression_roundtrips_on_lite05() {
-		let got = roundtrip(Version::Lite05Wip, &sample());
-		assert_eq!(got.compression, Compression::Deflate);
-		assert_eq!(got.priority, 7);
-		assert!(got.ordered);
-		assert_eq!(got.start_group, Some(3));
-		assert_eq!(got.end_group, None);
+	fn subscribe_drop_is_type_2_on_lite05() {
+		let resp = SubscribeResponse::Drop(SubscribeDrop {
+			start: 1,
+			end: 3,
+			error: 0,
+		});
+		let mut buf = Vec::new();
+		resp.encode(&mut buf, Version::Lite05Wip).unwrap();
+		// Type discriminator is the first varint; on Lite05 DROP is 0x2.
+		assert_eq!(buf[0], 2);
+
+		let mut slice = buf.as_slice();
+		match SubscribeResponse::decode(&mut slice, Version::Lite05Wip).unwrap() {
+			SubscribeResponse::Drop(drop) => assert_eq!((drop.start, drop.end), (1, 3)),
+			other => panic!("expected Drop, got {other:?}"),
+		}
 	}
 
 	#[test]
-	fn compression_absent_before_lite05() {
-		let ok = sample();
-
-		// The compression varint only exists on lite-05+, so the older encoding is
-		// strictly shorter and always decodes back as None.
-		let mut buf04 = Vec::new();
-		ok.encode_msg(&mut buf04, Version::Lite04).unwrap();
-		let mut buf05 = Vec::new();
-		ok.encode_msg(&mut buf05, Version::Lite05Wip).unwrap();
-		assert!(
-			buf05.len() > buf04.len(),
-			"lite-05 carries extra compression + timescale varints"
-		);
-
-		assert_eq!(roundtrip(Version::Lite04, &ok).compression, Compression::None);
+	fn subscribe_drop_is_type_1_on_lite04() {
+		let resp = SubscribeResponse::Drop(SubscribeDrop {
+			start: 1,
+			end: 3,
+			error: 0,
+		});
+		let mut buf = Vec::new();
+		resp.encode(&mut buf, Version::Lite04).unwrap();
+		assert_eq!(buf[0], 1);
 	}
 
 	#[test]
-	fn timescale_roundtrips_on_lite05() {
-		let got = roundtrip(Version::Lite05Wip, &sample());
-		assert_eq!(got.timescale, Some(Timescale::MICRO));
-	}
-
-	#[test]
-	fn timescale_absent_before_lite05() {
-		// Lite04 doesn't carry the timescale varint, so it always decodes as None.
-		assert_eq!(roundtrip(Version::Lite04, &sample()).timescale, None);
-	}
-
-	#[test]
-	fn timescale_zero_on_wire_decodes_as_none() {
-		let mut ok = sample();
-		ok.timescale = None;
-		assert_eq!(roundtrip(Version::Lite05Wip, &ok).timescale, None);
-	}
-
-	#[test]
-	fn cache_roundtrips_on_lite05() {
-		assert_eq!(roundtrip(Version::Lite05Wip, &sample()).cache, Duration::from_secs(10));
-	}
-
-	#[test]
-	fn cache_absent_before_lite05() {
-		// Lite04 doesn't carry the cache varint, so it always decodes as the default.
-		assert_eq!(roundtrip(Version::Lite04, &sample()).cache, crate::DEFAULT_CACHE);
+	fn subscribe_ok_rejected_on_lite05() {
+		let resp = SubscribeResponse::Ok(SubscribeOk {
+			priority: 1,
+			ordered: true,
+			max_latency: std::time::Duration::ZERO,
+			start_group: None,
+			end_group: None,
+		});
+		let mut buf = Vec::new();
+		assert!(resp.encode(&mut buf, Version::Lite05Wip).is_err());
 	}
 }

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -70,10 +70,10 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 struct TrackEntry {
 	producer: TrackProducer,
 	stats: Arc<SubscriberTrack>,
-	/// The SUBSCRIBE_OK for this subscription. `None` until it arrives; group
-	/// streams block on it before decoding any frame, since a group can race
-	/// ahead of SUBSCRIBE_OK on its own QUIC stream.
-	subscribe_ok: kio::Consumer<Option<lite::SubscribeOk>>,
+	/// Codec + timestamp scale from this track's TRACK_INFO, known before the
+	/// SUBSCRIBE is even opened, so group streams decode frames without blocking.
+	compression: Compression,
+	timescale: Option<Timescale>,
 }
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
@@ -513,7 +513,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		let hdr: lite::Group = stream.decode().await?;
 
-		let (mut group, track, track_stats, subscribe_ok) = {
+		let (mut group, track, track_stats, compression, timescale) = {
 			let mut subs = self.subscribes.lock();
 			let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
 
@@ -523,33 +523,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				group,
 				entry.producer.clone(),
 				entry.stats.clone(),
-				entry.subscribe_ok.clone(),
+				entry.compression,
+				entry.timescale,
 			)
 		};
 
 		// Bump groups counter for this incoming group on the subscriber side.
 		track_stats.group();
 
-		// Block until SUBSCRIBE_OK arrives. The group's QUIC stream can arrive
-		// before SUBSCRIBE_OK lands on the subscribe stream, so we can't decode
-		// frames until this resolves. A closed channel means the subscription
-		// ended before SUBSCRIBE_OK, so treat it as cancelled.
-		//
-		// Map the closed `Ref` to `None` inside the poll closure (rather than using
-		// `Consumer::wait`) so the `!Send` guard never enters this spawned future.
-		let (compression, timescale) = kio::wait(|waiter| {
-			let poll = subscribe_ok.poll(waiter, |ok| match &**ok {
-				Some(ok) => Poll::Ready((ok.compression, ok.timescale)),
-				None => Poll::Pending,
-			});
-			match poll {
-				Poll::Ready(Ok(pair)) => Poll::Ready(Some(pair)),
-				Poll::Ready(Err(_closed)) => Poll::Ready(None),
-				Poll::Pending => Poll::Pending,
-			}
-		})
-		.await
-		.ok_or(Error::Cancel)?;
+		// The codec/timescale came from TRACK_INFO (read before this subscription was
+		// even registered), so frames decode immediately. No SUBSCRIBE_OK to wait on.
 
 		let res = tokio::select! {
 			err = track.closed() => Err(err),
@@ -675,8 +658,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 }
 
-/// The producer side of one track, before and after the upstream SUBSCRIBE_OK
-/// promotes the pending request into a full producer. Both observe subscription
+/// The producer side of one track. On Lite05+ it's `Active` from the start (the
+/// TRACK stream resolves the properties up front); on older drafts it stays
+/// `Pending` until the first SUBSCRIBE_OK promotes it. Both observe subscription
 /// demand, so [`TrackServe`] drives them uniformly. Fetches are served separately
 /// via the [`TrackDynamic`] handle.
 enum Track {
@@ -699,8 +683,8 @@ impl Track {
 		}
 	}
 
-	/// Latest cached sequence, used to cap the upstream while pausing. Always `None`
-	/// before the producer exists (no group has arrived yet).
+	/// Latest cached sequence, used to cap the upstream while pausing. `None` before
+	/// any group has arrived.
 	fn latest(&self) -> Option<u64> {
 		match self {
 			Track::Active(producer) => producer.latest(),
@@ -782,10 +766,32 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// whole task; dropping it stops fetch serving.
 		let dynamic = request.dynamic();
 
-		// `Option` so we can move the request out of `track` at accept time (and at
-		// teardown); it's always `Some` while the loop runs.
-		let mut track = Some(Track::Pending(request));
+		// Lite05+ learns the track's immutable properties once, up front, via a TRACK
+		// stream, and accepts the request immediately so downstream subscribers resolve.
+		// The codec/timescale then flow into every SUBSCRIBE and FETCH without a per-
+		// response header. Older drafts have no TRACK stream: the request stays pending
+		// until the first SUBSCRIBE_OK supplies the properties (see `establish`).
+		let (mut track, compression, timescale) = if self.subscriber.version.has_timestamps() {
+			match self.track_info().await {
+				Ok((info, compression)) => {
+					let timescale = info.timescale;
+					(Some(Track::Active(request.accept(info))), compression, timescale)
+				}
+				Err(err) => {
+					tracing::warn!(broadcast = %self.subscriber.log_path(&self.path), track = %self.name, %err, "track info failed");
+					request.reject(err);
+					return;
+				}
+			}
+		} else {
+			(Some(Track::Pending(request)), Compression::None, None)
+		};
+
 		let mut sub = Sub::None;
+		// True once the upstream subscription FIN'd: a later subscriber must not reopen
+		// it (the track is finished). Replaces the old "is the track still Pending" gate,
+		// which no longer holds now that Lite05 accepts up front.
+		let mut completed = false;
 		let mut fetches: FuturesUnordered<BoxFuture<'static, ()>> = FuturesUnordered::new();
 		let mut linger: Option<Pin<Box<tokio::time::Sleep>>> = None;
 
@@ -823,13 +829,22 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				// (2) An in-flight fetch completed.
 				Some(()) = fetches.next(), if !fetches.is_empty() => Event::FetchDone,
 
-				// (3) The upstream subscribe stream closed (FIN or transport error).
+				// (3) The upstream subscribe stream closed, or carried a START/END/DROP.
 				res = async {
 					match &mut sub {
-						Sub::Active(active) => active.stream.reader.closed().await,
+						Sub::Active(active) => active.stream.reader.decode_maybe::<lite::SubscribeResponse>().await,
 						Sub::None => std::future::pending().await,
 					}
-				}, if sub.is_active() => Event::SubClosed(res),
+				}, if sub.is_active() => match res {
+					// START/END/DROP resolve the range; we don't drive delivery off them
+					// (the producer already orders groups), so log and keep reading.
+					Ok(Some(msg)) => {
+						tracing::debug!(track = %self.name, ?msg, "subscribe response");
+						continue;
+					}
+					Ok(None) => Event::SubClosed(Ok(())),
+					Err(err) => Event::SubClosed(Err(err)),
+				},
 
 				// (4) The whole broadcast went away on the publisher side.
 				err = self.broadcast.closed() => Event::BroadcastClosed(err),
@@ -846,12 +861,20 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			match event {
 				Event::Fetch(req) => {
 					linger = None;
-					fetches.push(self.clone().serve_fetch(req).boxed());
+					fetches.push(self.clone().serve_fetch(req, compression, timescale).boxed());
 				}
 				Event::Subscription(pref) => {
 					linger = None;
 					if let Err(err) = self
-						.handle_subscription(&mut track, &mut sub, pref, supports_linger)
+						.handle_subscription(
+							&mut track,
+							&mut sub,
+							pref,
+							supports_linger,
+							completed,
+							compression,
+							timescale,
+						)
 						.await
 					{
 						return self.finish_track(track.take().unwrap(), sub, err);
@@ -873,6 +896,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					// Upstream FIN'd the live subscription. Finish the producer (no more
 					// live groups), but keep the task alive: past groups can still be
 					// fetched, and the linger countdown eventually stops us.
+					completed = true;
 					if let Sub::Active(active) = &mut sub {
 						self.subscriber.subscribes.lock().remove(&active.id);
 						let _ = active.stream.writer.finish();
@@ -898,24 +922,64 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		}
 	}
 
+	/// Open a TRACK stream, read the single TRACK_INFO, and map it to the model's
+	/// [`crate::TrackInfo`] plus the wire [`Compression`] (needed verbatim to decode
+	/// frames). Lite05+ only. Bails if the broadcast dies meanwhile.
+	async fn track_info(&self) -> Result<(crate::TrackInfo, Compression), Error> {
+		let mut stream = Stream::open(&self.subscriber.session, self.subscriber.version).await?;
+		stream.writer.encode(&lite::ControlType::Track).await?;
+		stream
+			.writer
+			.encode(&lite::Track {
+				broadcast: self.path.as_path(),
+				track: self.name.as_str().into(),
+			})
+			.await?;
+
+		let info = tokio::select! {
+			err = self.broadcast.closed() => return Err(err),
+			info = stream.reader.decode::<lite::TrackInfo>() => info?,
+		};
+		// The publisher FINs after TRACK_INFO; FIN our side too and let the stream drop.
+		let _ = stream.writer.finish();
+
+		let model = crate::TrackInfo {
+			compress: info.compression != Compression::None,
+			timescale: info.timescale,
+			cache: info.cache,
+			priority: info.priority,
+			ordered: info.ordered,
+		};
+		Ok((model, info.compression))
+	}
+
 	/// Apply a subscription-demand change: open the upstream SUBSCRIBE on the first
 	/// subscriber, resume/update it while live, or pause it when the last leaves.
+	#[allow(clippy::too_many_arguments)]
 	async fn handle_subscription(
 		&self,
 		track: &mut Option<Track>,
 		sub: &mut Sub<S>,
 		pref: Option<Subscription>,
 		supports_linger: bool,
+		completed: bool,
+		compression: Compression,
+		timescale: Option<Timescale>,
 	) -> Result<(), Error> {
 		match pref {
 			Some(subscription) => match sub {
 				Sub::None => {
-					// Only the first subscriber, while still pending, opens an upstream
-					// SUBSCRIBE. If the track is already Active a prior subscription
-					// finished and there's nothing live left; the new subscriber just
-					// sees the finished track.
-					if matches!(track.as_ref(), Some(Track::Pending(_))) {
-						self.establish(track, sub, subscription).await?;
+					// Open an upstream SUBSCRIBE for the first subscriber, unless the
+					// track already finished. On Lite05 the producer is `Active` from
+					// the start, so gate on `completed`; on older drafts a `Pending`
+					// track means it was never subscribed.
+					let establish = match track.as_ref() {
+						Some(Track::Pending(_)) => true,
+						Some(Track::Active(_)) => self.subscriber.version.has_timestamps() && !completed,
+						None => false,
+					};
+					if establish {
+						self.establish(track, sub, subscription, compression, timescale).await?;
 					}
 				}
 				Sub::Active(active) if active.paused => {
@@ -967,13 +1031,18 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		Ok(())
 	}
 
-	/// Open the upstream SUBSCRIBE, wait for SUBSCRIBE_OK, accept the pending request
-	/// (unblocking downstream subscribers), and start routing groups into it.
+	/// Open the upstream SUBSCRIBE and start routing groups into the producer.
+	///
+	/// On Lite05+ the producer already exists (accepted from TRACK_INFO) and the
+	/// subscription is accepted implicitly. On older drafts this waits for the first
+	/// SUBSCRIBE_OK and promotes the pending request to a producer.
 	async fn establish(
 		&self,
 		track: &mut Option<Track>,
 		sub: &mut Sub<S>,
 		subscription: Subscription,
+		compression: Compression,
+		timescale: Option<Timescale>,
 	) -> Result<(), Error> {
 		let id = self.subscriber.next_id.fetch_add(1, atomic::Ordering::Relaxed);
 
@@ -994,54 +1063,52 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		stream.writer.encode(&lite::ControlType::Subscribe).await?;
 		stream.writer.encode(&msg).await?;
 
-		// SUBSCRIBE_OK must arrive first; bail if the broadcast dies meanwhile.
-		let resp = tokio::select! {
-			err = self.broadcast.closed() => return Err(err),
-			resp = stream.reader.decode::<lite::SubscribeResponse>() => resp?,
-		};
-		let lite::SubscribeResponse::Ok(info) = resp else {
-			return Err(Error::ProtocolViolation);
+		let producer = if self.subscriber.version.has_timestamps() {
+			// Lite05+: implicit acceptance, no SUBSCRIBE_OK. The producer already exists.
+			let Some(Track::Active(producer)) = track.as_ref() else {
+				unreachable!("lite05 track is active before establish");
+			};
+			producer.clone()
+		} else {
+			// Older drafts: the first SUBSCRIBE_OK promotes the pending request. Bail if
+			// the broadcast dies meanwhile.
+			let resp = tokio::select! {
+				err = self.broadcast.closed() => return Err(err),
+				resp = stream.reader.decode::<lite::SubscribeResponse>() => resp?,
+			};
+			if !matches!(resp, lite::SubscribeResponse::Ok(_)) {
+				return Err(Error::ProtocolViolation);
+			}
+
+			// Accept with defaults: pre-lite-05 carries no codec/timescale, and the
+			// cache window falls back to the model default.
+			let Some(Track::Pending(request)) = track.take() else {
+				unreachable!("establish called without a pending track");
+			};
+			let mut producer = request.accept(crate::TrackInfo::default());
+			// The accepted producer starts with a fresh subscription cursor, so its first
+			// poll would re-report the subscription we just sent as a "change". Prime it
+			// now (the params are already on the wire) so only genuine later changes fire.
+			let _ = producer.poll_subscription_changed(&kio::Waiter::noop());
+			*track = Some(Track::Active(producer.clone()));
+			producer
 		};
 
-		// Upstream confirmed: this session is now actively feeding the broadcast, so
-		// take the per-(session, broadcast) viewer sentinel for the subscription's life.
+		// This session is now actively feeding the broadcast, so take the per-(session,
+		// broadcast) viewer sentinel for the subscription's life.
 		let abs = self.subscriber.origin.absolute(&self.path).to_owned();
 		let broadcast_sub = self.subscriber.broadcasts.subscribe(&abs);
 
-		// Stamp the negotiated timescale + cache window onto the local track so groups
-		// inherit them and downstream consumers validate per-frame timestamps and clamp
-		// their stale windows the same way.
-		let local_info = TrackInfo {
-			timescale: info.timescale,
-			cache: info.cache,
-			..Default::default()
-		};
-
-		// Accept the pending request → producer, unblocking downstream subscribers. No
-		// awaits between the take and the restore, so `track` is never left empty.
-		let Some(Track::Pending(request)) = track.take() else {
-			unreachable!("establish called without a pending track");
-		};
-		let mut producer = request.accept(local_info);
-
-		// The accepted producer starts with a fresh subscription cursor, so its first
-		// poll would re-report the subscription we just sent as a "change". Prime it
-		// now (the params are already on the wire) so only genuine later changes fire.
-		let _ = producer.poll_subscription_changed(&kio::Waiter::noop());
-
-		// SUBSCRIBE_OK is known now, so group streams never wait; they still read it
-		// through this channel (a group's QUIC stream can race ahead of SUBSCRIBE_OK).
-		let subscribe_ok = kio::Producer::new(Some(info)).consume();
 		self.subscriber.subscribes.lock().insert(
 			id,
 			TrackEntry {
-				producer: producer.clone(),
+				producer,
 				stats: self.track_stats.clone(),
-				subscribe_ok,
+				compression,
+				timescale,
 			},
 		);
 
-		*track = Some(Track::Active(producer));
 		*sub = Sub::Active(SubStream {
 			stream,
 			id,
@@ -1068,10 +1135,12 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		active.stream.writer.encode(&update).await
 	}
 
-	/// Serve one downstream fetch end-to-end on its own bidi stream: send FETCH, read
-	/// FETCH_OK, accept the group request, then fill the group. Runs to completion as
-	/// an independent future in the serve loop's `FuturesUnordered`.
-	async fn serve_fetch(self, request: GroupRequest) {
+	/// Serve one downstream fetch end-to-end on its own bidi stream: send FETCH, then
+	/// fill the group from the bare FRAME messages that follow. The codec/timescale
+	/// come from this track's TRACK_INFO (already known), and the group sequence is
+	/// implicit from the request. Runs to completion as an independent future in the
+	/// serve loop's `FuturesUnordered`.
+	async fn serve_fetch(self, request: GroupRequest, compression: Compression, timescale: Option<Timescale>) {
 		let TrackServe {
 			mut subscriber,
 			path,
@@ -1107,21 +1176,11 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			return;
 		}
 
-		// The first response MUST be a FETCH_OK; it carries the codec/timescale
-		// needed to decode the frames that follow on the same stream.
-		let info = match stream.reader.decode::<lite::FetchOk>().await {
-			Ok(info) => info,
-			Err(err) => {
-				stream.writer.abort(&err);
-				return;
-			}
-		};
-
 		// Make the group available (resolving the downstream fetch) and fill it. The
 		// TrackInfo only takes effect if the track isn't accepted yet (a fetch with no
 		// live subscription); otherwise the group inherits the accepted timescale.
 		let group_info = TrackInfo {
-			timescale: info.timescale,
+			timescale,
 			..Default::default()
 		};
 		let mut producer = match request.accept(group_info) {
@@ -1139,8 +1198,8 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				&mut stream.reader,
 				producer.clone(),
 				track_stats,
-				info.compression,
-				info.timescale,
+				compression,
+				timescale,
 			)
 			.await;
 		match res {

--- a/rs/moq-net/src/lite/track.rs
+++ b/rs/moq-net/src/lite/track.rs
@@ -1,0 +1,165 @@
+use std::borrow::Cow;
+
+use crate::{
+	Compression, Path, Timescale,
+	coding::{Decode, DecodeError, Encode, EncodeError},
+};
+
+use super::{Message, Version};
+
+/// Sent by the subscriber on a Track Stream (0x6) to request a track's immutable
+/// publisher properties, without subscribing or fetching.
+///
+/// Lite05+ only.
+#[derive(Clone, Debug)]
+pub struct Track<'a> {
+	pub broadcast: Path<'a>,
+	pub track: Cow<'a, str>,
+}
+
+impl Message for Track<'_> {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		if !version.has_timestamps() {
+			return Err(DecodeError::Version);
+		}
+
+		let broadcast = Path::decode(r, version)?;
+		let track = Cow::<str>::decode(r, version)?;
+
+		Ok(Self { broadcast, track })
+	}
+
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		if !version.has_timestamps() {
+			return Err(EncodeError::Version);
+		}
+
+		self.broadcast.encode(w, version)?;
+		self.track.encode(w, version)?;
+		Ok(())
+	}
+}
+
+/// The publisher's sole reply on a Track Stream, carrying the track's immutable
+/// properties. Every field is fixed for the lifetime of the track, so a subscriber
+/// fetches this once and reuses it across every SUBSCRIBE and FETCH.
+///
+/// Lite05+ only.
+#[derive(Clone, Debug)]
+pub struct TrackInfo {
+	/// The publisher's tie-break priority for this track.
+	pub priority: u8,
+	/// The publisher's group ordering preference (newest-first when `false`).
+	pub ordered: bool,
+	/// The minimum age the publisher guarantees to keep an old group around.
+	pub cache: std::time::Duration,
+	/// Per-frame timestamp scale, or `None` if frames carry no timestamps. On the
+	/// wire `None` is `0` and `Some(n)` is `n`.
+	pub timescale: Option<Timescale>,
+	/// Codec applied to every frame payload on this track.
+	pub compression: Compression,
+}
+
+impl Message for TrackInfo {
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		if !version.has_timestamps() {
+			return Err(DecodeError::Version);
+		}
+
+		let priority = u8::decode(r, version)?;
+		let ordered = u8::decode(r, version)? != 0;
+		let cache = std::time::Duration::decode(r, version)?;
+		let timescale = Timescale::new(u64::decode(r, version)?).ok();
+		let compression = Compression::from_code(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)?;
+
+		Ok(Self {
+			priority,
+			ordered,
+			cache,
+			timescale,
+			compression,
+		})
+	}
+
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		if !version.has_timestamps() {
+			return Err(EncodeError::Version);
+		}
+
+		self.priority.encode(w, version)?;
+		(self.ordered as u8).encode(w, version)?;
+		self.cache.encode(w, version)?;
+		self.timescale.map(u64::from).unwrap_or(0).encode(w, version)?;
+		self.compression.to_code().encode(w, version)?;
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	fn info_sample() -> TrackInfo {
+		TrackInfo {
+			priority: 7,
+			ordered: false,
+			cache: std::time::Duration::from_secs(10),
+			timescale: Some(Timescale::MICRO),
+			compression: Compression::Deflate,
+		}
+	}
+
+	fn info_roundtrip(version: Version, info: &TrackInfo) -> TrackInfo {
+		let mut buf = Vec::new();
+		info.encode_msg(&mut buf, version).unwrap();
+		let mut slice = buf.as_slice();
+		TrackInfo::decode_msg(&mut slice, version).unwrap()
+	}
+
+	#[test]
+	fn track_info_roundtrips_on_lite05() {
+		let got = info_roundtrip(Version::Lite05Wip, &info_sample());
+		assert_eq!(got.priority, 7);
+		assert!(!got.ordered);
+		assert_eq!(got.cache, std::time::Duration::from_secs(10));
+		assert_eq!(got.timescale, Some(Timescale::MICRO));
+		assert_eq!(got.compression, Compression::Deflate);
+	}
+
+	#[test]
+	fn track_info_timescale_none_roundtrips() {
+		let mut info = info_sample();
+		info.timescale = None;
+		assert_eq!(info_roundtrip(Version::Lite05Wip, &info).timescale, None);
+	}
+
+	#[test]
+	fn track_info_errors_before_lite05() {
+		let mut buf = Vec::new();
+		assert!(info_sample().encode_msg(&mut buf, Version::Lite04).is_err());
+	}
+
+	#[test]
+	fn track_request_roundtrips_on_lite05() {
+		let msg = Track {
+			broadcast: Path::new("room").to_owned(),
+			track: Cow::Borrowed("video"),
+		};
+		let mut buf = Vec::new();
+		msg.encode_msg(&mut buf, Version::Lite05Wip).unwrap();
+		let mut slice = buf.as_slice();
+		let got = Track::decode_msg(&mut slice, Version::Lite05Wip).unwrap();
+		assert_eq!(got.broadcast, Path::new("room"));
+		assert_eq!(got.track, "video");
+	}
+
+	#[test]
+	fn track_request_errors_before_lite05() {
+		let msg = Track {
+			broadcast: Path::new("room").to_owned(),
+			track: Cow::Borrowed("video"),
+		};
+		let mut buf = Vec::new();
+		assert!(msg.encode_msg(&mut buf, Version::Lite04).is_err());
+	}
+}

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -7,19 +7,19 @@ pub enum Version {
 	Lite02,
 	Lite03,
 	Lite04,
-	/// Work-in-progress placeholder for lite-05. Adds per-track timescale to
-	/// SUBSCRIBE_OK and zigzag-delta timestamps to per-frame headers. Not
-	/// advertised over ALPN or included in default version sets; callers must
-	/// opt in explicitly.
+	/// Work-in-progress placeholder for lite-05. Adds the TRACK stream (immutable
+	/// per-track properties incl. timescale), zigzag-delta timestamps in per-frame
+	/// headers, and drops SUBSCRIBE_OK/FETCH_OK. Not advertised over ALPN or
+	/// included in default version sets; callers must opt in explicitly.
 	Lite05Wip,
 }
 
 impl Version {
-	/// Whether SUBSCRIBE_OK can carry a per-track timescale. When the publisher
-	/// advertises one, the publisher and subscriber agree to prefix every frame
-	/// with a zigzag-delta timestamp varint; with `None` the wire skips the
-	/// byte entirely, so this method only governs whether the negotiation field
-	/// exists, not whether timestamps are always present.
+	/// Whether the track can carry a per-track timescale (reported in TRACK_INFO on
+	/// lite-05+). When the publisher advertises one, the publisher and subscriber
+	/// agree to prefix every frame with a zigzag-delta timestamp varint; with `None`
+	/// the wire skips the byte entirely, so this method only governs whether the
+	/// negotiation field exists, not whether timestamps are always present.
 	#[allow(clippy::match_like_matches_macro)]
 	pub fn has_timestamps(self) -> bool {
 		// Match form so future versions default forward (CLAUDE.md convention).

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -37,7 +37,7 @@ pub const DEFAULT_CACHE: Duration = Duration::from_secs(5);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrackInfo {
 	/// Hint that this track's frames are worth compressing (e.g. a JSON catalog).
-	/// The publisher honors it by negotiating a codec in SUBSCRIBE_OK; codec-less
+	/// The publisher honors it by negotiating a codec in TRACK_INFO; codec-less
 	/// peers (older drafts) ignore it and send frames verbatim.
 	#[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "std::ops::Not::not"))]
 	pub compress: bool,
@@ -45,7 +45,7 @@ pub struct TrackInfo {
 	///
 	/// `None` means the publisher hasn't advertised a timescale; subscribers
 	/// receive frames with `timestamp: None`. On Lite05+ a `Some(_)` value is
-	/// echoed in SUBSCRIBE_OK and the publisher zigzag-delta encodes
+	/// reported in TRACK_INFO and the publisher zigzag-delta encodes
 	/// per-frame timestamps at that scale on the wire; rejecting a frame at
 	/// the wrong scale prevents silent corruption.
 	#[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
@@ -53,7 +53,7 @@ pub struct TrackInfo {
 	/// How long the publisher keeps old groups available before evicting them
 	/// (the newest group is always retained). A subscriber's
 	/// [`Subscription::stale`] window is clamped to this, since a group can't be
-	/// waited for longer than it's kept around. Announced in SUBSCRIBE_OK so
+	/// waited for longer than it's kept around. Reported in TRACK_INFO so
 	/// relays re-serve with the same window. Defaults to [`DEFAULT_CACHE`].
 	#[cfg_attr(
 		feature = "serde",
@@ -64,6 +64,15 @@ pub struct TrackInfo {
 		)
 	)]
 	pub cache: Duration,
+	/// The publisher's priority for this track, used only to break ties between
+	/// subscriptions of equal subscriber priority. Reported in TRACK_INFO (Lite05+);
+	/// kept out of the catalog (a transport property, not media metadata).
+	#[cfg_attr(feature = "serde", serde(skip))]
+	pub priority: u8,
+	/// The publisher's group ordering preference (newest-first when `false`), used
+	/// only to break ties. Reported in TRACK_INFO (Lite05+); kept out of the catalog.
+	#[cfg_attr(feature = "serde", serde(skip))]
+	pub ordered: bool,
 }
 
 #[cfg(feature = "serde")]
@@ -97,6 +106,8 @@ impl Default for TrackInfo {
 			compress: false,
 			timescale: None,
 			cache: DEFAULT_CACHE,
+			priority: 0,
+			ordered: true,
 		}
 	}
 }
@@ -119,6 +130,18 @@ impl TrackInfo {
 	/// Set how long old groups stay available before eviction, returning `self` for chaining.
 	pub fn with_cache(mut self, cache: Duration) -> Self {
 		self.cache = cache;
+		self
+	}
+
+	/// Set the publisher's tie-break priority, returning `self` for chaining.
+	pub fn with_priority(mut self, priority: u8) -> Self {
+		self.priority = priority;
+		self
+	}
+
+	/// Set the publisher's group ordering preference, returning `self` for chaining.
+	pub fn with_ordered(mut self, ordered: bool) -> Self {
+		self.ordered = ordered;
 		self
 	}
 


### PR DESCRIPTION
Implements [moq-dev/drafts#25](https://github.com/moq-dev/drafts/pull/25) for `moq-lite-05-wip`. The previous `FETCH_OK` was wrong anyway.

Targets **`dev`** (wire-protocol change under `rs/moq-net`, plus breaking JS API changes).

## Wire protocol (`rs/moq-net`, gated to `Lite05Wip`; drafts 01–04 unchanged)

- **New Track stream (control type `0x6`)**: a subscriber sends `TRACK` (broadcast path + track name); the publisher replies with a single `TRACK_INFO` (`Publisher Priority`, `Ordered`, `Cache`, `Timescale`, `Compression`) and FINs, or resets on error. These properties are immutable, so they're fetched once and cached instead of echoed on every response.
- **Removed `SUBSCRIBE_OK` and `FETCH_OK`.** A subscription is accepted implicitly (rejection = stream reset); a FETCH returns bare `FRAME` messages.
- **Resolved range moved to `SUBSCRIBE_START` (`0x0`) / `SUBSCRIBE_END` (`0x1`)**; `SUBSCRIBE_DROP` renumbered to `0x2`.
- Added `priority` / `ordered` to `crate::TrackInfo` (serde-skipped, so the hang catalog is unchanged) so a relay round-trips the publisher's values.

The subscriber opens a TRACK stream **immediately** on a track request and accepts the producer up front (so downstream subscribers resolve and frames decode without blocking), then opens SUBSCRIBE / FETCH **on demand**. The relay drains `START`/`END`/`DROP` from the upstream subscribe stream (it previously only waited for FIN).

## JS mirror (`js/net`)

Same wire changes, plus a consumer-side API matching Rust:

- `Track` class renamed to **`TrackSubscriber`**; new **`TrackConsumer`** handle from `broadcast.track(name)` with `subscribe()` and `info()`. (`fetch()` is a follow-up PR.)
- `TrackRequest.accept(info): TrackSubscriber` (mirrors Rust `TrackRequest::accept`) and an async `Track.info()`; the consumer wire commits TRACK_INFO so apps never see placeholder defaults.
- Consumer call sites migrated to `broadcast.track(name).subscribe({ priority })`.

## Cross-package sync

- `rs/moq-net` wire ↔ `js/net`: done.
- `doc/concept` (SUBSCRIBE_OK → TRACK_INFO): **intentionally deferred** while the draft is WIP.
- JS `fetch()` support: **follow-up PR** (needs a publisher FETCH responder + group cache).

## Known limitation

The JS publisher resolves a track's real `TRACK_INFO` via a cached probe (`broadcast.subscribe(name)` → `await track.info()`). For a media track, the first such lookup briefly constructs and closes a `VideoEncoder`, because `js/publish` couples `accept()` and `serve()`. Bounded (cached, once per track per connection) and lite-05-wip is opt-in.

## Test plan

- [x] `just check` green: Rust 332 tests + clippy/doc/shear/sort; all JS packages typecheck + test; biome/remark/shfmt/taplo/nixfmt.
- [x] `rs/moq-native` integration tests exercise lite-05 end-to-end over WebTransport: timestamp round-trip, bare-FRAME FETCH with Deflate matching TRACK_INFO, concurrent fetch+subscribe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)