### PR TITLE
build(deps): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,11 @@ ignore = [
     # http-cache (via http-cache-reqwest in moq-relay) still depends on
     # bincode 1.x. Awaits upstream bump to bincode 2.x.
     "RUSTSEC-2025-0141",
+
+    # proc-macro-error2 unmaintained. Pulled in transitively as a build-time
+    # proc-macro via local-ip-address -> neli -> getset; no runtime exposure.
+    # Drop the ignore when getset migrates off proc-macro-error2.
+    "RUSTSEC-2026-0173",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

A new advisory, [RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173), was published on 2026-06-08 marking `proc-macro-error2` as **unmaintained**. `cargo deny` fails on it repo-wide, so `dev` and every open PR currently break in CI even though no source changed.

This adds the advisory to the `[advisories].ignore` list in `deny.toml`, matching the style of the existing entries (chain + exit condition documented inline).

## Why ignoring is safe

`proc-macro-error2` is a **build-time proc-macro** with no runtime exposure. It's a deep transitive dependency:

```
moq-native (quiche feature)
  -> web-transport-quiche -> tokio-quiche / qlog
      -> foundations (Cloudflare)
          -> cf-rustracing-jaeger      (Jaeger tracing)
              -> local-ip-address
                  -> neli              (Linux netlink)
                      -> getset
                          -> proc-macro-error2
```

Nothing in MoQ calls into this directly. `local-ip-address` itself only sits behind Cloudflare `foundations`' Jaeger telemetry (used to report the local IP in trace spans) and is only compiled when `moq-native`'s `quiche` feature is enabled. The exit condition: drop the ignore once `getset` migrates off `proc-macro-error2`.

## Test plan

- [x] `cargo deny check advisories` -> `advisories ok`

(Written by Claude)