### PR TITLE
Align audio and video timestamps to a shared epoch

### DIFF
--- a/js/publish/src/audio/capture-worklet.ts
+++ b/js/publish/src/audio/capture-worklet.ts
@@ -3,6 +3,12 @@ import type { AudioFrame } from "./capture";
 
 class Capture extends AudioWorkletProcessor {
 	#sampleCount = 0;
+	#zero: Time.Micro;
+
+	constructor(options?: AudioWorkletNodeOptions) {
+		super();
+		this.#zero = (options?.processorOptions?.zero ?? 0) as Time.Micro;
+	}
 
 	process(input: Float32Array[][]) {
 		if (input.length > 1) throw new Error("only one input is supported.");
@@ -10,8 +16,9 @@ class Capture extends AudioWorkletProcessor {
 		const channels = input[0];
 		if (channels.length === 0) return true; // TODO: No input hooked up?
 
-		// Convert sample count to microseconds
-		const timestamp = Time.Micro.fromSecond((this.#sampleCount / sampleRate) as Time.Second);
+		// Convert sample count to microseconds, offset onto the shared wall clock.
+		const timestamp = (Time.Micro.fromSecond((this.#sampleCount / sampleRate) as Time.Second) +
+			this.#zero) as Time.Micro;
 
 		const msg: AudioFrame = {
 			timestamp,

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -116,6 +116,9 @@ export class Encoder {
 				// worklet sees it. The default "max" just follows the input, which is the unreliable
 				// path on macOS. Only force it when we actually have a requested count to honor.
 				channelCountMode: requestedChannels !== undefined ? "explicit" : "max",
+				// Stamp audio against the same wall clock as video (see video/polyfill.ts), so both
+				// tracks share an epoch and stay in sync.
+				processorOptions: { zero: performance.now() * 1000 },
 			});
 
 			effect.set(this.#worklet, worklet);

--- a/js/publish/src/video/polyfill.ts
+++ b/js/publish/src/video/polyfill.ts
@@ -7,13 +7,17 @@ import type { StreamTrack } from "./types";
 export function TrackProcessor(track: StreamTrack): ReadableStream<VideoFrame> {
 	// @ts-expect-error No typescript types yet.
 	if (self.MediaStreamTrackProcessor) {
-		// Rewrite timestamps so they use our wall clock time instead of starting at 0.
-		// TODO verify all browsers actually start at 0.
-		const zero = performance.now() * 1000;
+		// Rewrite timestamps onto our wall clock so audio and video share one epoch.
+		let base: number | undefined;
+		let zero = 0;
 
 		const rewrite = new TransformStream<VideoFrame>({
 			transform(frame, controller) {
-				const rewrite = new VideoFrame(frame, { timestamp: frame.timestamp + zero });
+				if (base === undefined) {
+					base = frame.timestamp;
+					zero = performance.now() * 1000;
+				}
+				const rewrite = new VideoFrame(frame, { timestamp: frame.timestamp - base + zero });
 				frame.close();
 				controller.enqueue(rewrite);
 			},


### PR DESCRIPTION
Audio and video in the same broadcast were timestamped on different clocks so that a watcher couldn't line them up.

I put both on one `performance.now()` wall-clock epoch.