### PR TITLE
chore: run nix-collect-garbage in just clean when available

### DIFF
--- a/justfile
+++ b/justfile
@@ -140,6 +140,9 @@ clean:
     rm -rf result .direnv
     find . -name .claude -prune -o -type d -name .wrangler -prune -exec rm -rf {} +
 
+    # Reclaim Nix store space too, if Nix is installed.
+    if command -v nix-collect-garbage &> /dev/null; then nix-collect-garbage -d; fi
+
     # Agent worktrees each carry their own artifacts now that the shared
     # target dir is gone. Worktrees don't nest, so this recurses exactly one
     # level. Tolerate stale worktrees on branches that predate this recipe.


### PR DESCRIPTION
## Summary

`just clean` orchestrates per-language cleans and sweeps caches no language owns (nix `result`, `.direnv`, `.wrangler`), but it never touched the Nix store itself, which is frequently the biggest disk consumer.

This adds a `nix-collect-garbage -d` step to the `clean` recipe, guarded by `command -v nix-collect-garbage` so it's a no-op on machines without Nix, matching the existing `uv` guard pattern in the same recipe.

## Test plan

- [ ] `just clean` on a machine with Nix runs `nix-collect-garbage -d`
- [ ] `just clean` on a machine without Nix skips it cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)