### PR TITLE
feat(moq-json): JSON Merge Patch snapshot/delta helper, route hang catalog through it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3877,6 +3877,7 @@ dependencies = [
  "hang",
  "kio",
  "m3u8-rs",
+ "moq-json",
  "moq-loc",
  "moq-msf",
  "moq-net",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,6 +3435,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3811,6 +3833,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "moq-json"
+version = "0.0.1"
+dependencies = [
+ "bytes",
+ "json-patch",
+ "kio",
+ "moq-net",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "rs/moq-cli",
     "rs/moq-ffi",
     "rs/moq-gst",
+    "rs/moq-json",
     "rs/moq-loc",
     "rs/moq-msf",
     "rs/moq-mux",
@@ -27,6 +28,7 @@ default-members = [
     "rs/moq-cli",
     # "rs/moq-ffi",   # requires Python/maturin
     # "rs/moq-gst",   # requires GStreamer
+    "rs/moq-json",
     "rs/moq-loc",
     "rs/moq-msf",
     "rs/moq-net",
@@ -46,6 +48,7 @@ rust-version = "1.85"
 hang = { version = "0.18", path = "rs/hang" }
 kio = { version = "0.3", path = "rs/kio" }
 moq-audio = { version = "0.0.2", path = "rs/moq-audio" }
+moq-json = { version = "0.0.1", path = "rs/moq-json" }
 moq-loc = { version = "0.1", path = "rs/moq-loc" }
 moq-msf = { version = "0.2", path = "rs/moq-msf" }
 moq-mux = { version = "0.5", path = "rs/moq-mux" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rust-version = "1.85"
 hang = { version = "0.18", path = "rs/hang" }
 kio = { version = "0.3", path = "rs/kio" }
 moq-audio = { version = "0.0.2", path = "rs/moq-audio" }
+moq-json = { version = "0.0.1", path = "rs/moq-json" }
 moq-loc = { version = "0.1", path = "rs/moq-loc" }
 moq-msf = { version = "0.2", path = "rs/moq-msf" }
 moq-mux = { version = "0.5", path = "rs/moq-mux" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ rust-version = "1.85"
 hang = { version = "0.18", path = "rs/hang" }
 kio = { version = "0.3", path = "rs/kio" }
 moq-audio = { version = "0.0.2", path = "rs/moq-audio" }
-moq-json = { version = "0.0.1", path = "rs/moq-json" }
 moq-loc = { version = "0.1", path = "rs/moq-loc" }
 moq-msf = { version = "0.2", path = "rs/moq-msf" }
 moq-mux = { version = "0.5", path = "rs/moq-mux" }

--- a/bun.lock
+++ b/bun.lock
@@ -182,6 +182,7 @@
       "version": "0.2.10",
       "dependencies": {
         "@moq/hang": "workspace:^",
+        "@moq/json": "workspace:^",
         "@moq/net": "workspace:^",
         "@moq/signals": "workspace:^",
       },
@@ -239,6 +240,7 @@
       "version": "0.2.14",
       "dependencies": {
         "@moq/hang": "workspace:^",
+        "@moq/json": "workspace:^",
         "@moq/msf": "workspace:^",
         "@moq/net": "workspace:^",
         "@moq/signals": "workspace:^",

--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,22 @@
         "typescript": "^6.0.3",
       },
     },
+    "js/json": {
+      "name": "@moq/json",
+      "version": "0.0.1",
+      "dependencies": {
+        "@moq/net": "workspace:^",
+        "@moq/signals": "workspace:^",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.14",
+        "rimraf": "^6.1.3",
+        "typescript": "^6.0.3",
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0",
+      },
+    },
     "js/loc": {
       "name": "@moq/loc",
       "version": "0.1.0",
@@ -503,6 +519,8 @@
     "@moq/demo-boy": ["@moq/demo-boy@workspace:demo/boy"],
 
     "@moq/hang": ["@moq/hang@workspace:js/hang"],
+
+    "@moq/json": ["@moq/json@workspace:js/json"],
 
     "@moq/loc": ["@moq/loc@workspace:js/loc"],
 

--- a/js/json/README.md
+++ b/js/json/README.md
@@ -1,0 +1,36 @@
+<p align="center">
+	<img height="128px" src="https://github.com/moq-dev/moq/blob/main/.github/logo.svg" alt="Media over QUIC">
+</p>
+
+# @moq/json
+
+[![npm version](https://img.shields.io/npm/v/@moq/json)](https://www.npmjs.com/package/@moq/json)
+[![TypeScript](https://img.shields.io/badge/TypeScript-ready-blue.svg)](https://www.typescriptlang.org/)
+
+Snapshot/delta JSON publishing over [Media over QUIC](https://moq.dev/) tracks using [RFC 7396 JSON Merge Patch](https://www.rfc-editor.org/rfc/rfc7396.html).
+
+A JSON value is published over a [`@moq/net`](../net) track as a series of groups. Each group is self-contained: its first frame is a full snapshot and any following frames are JSON Merge Patch deltas applied in order. A consumer jumps to the newest group, reads the snapshot, and applies the deltas, so a late joiner never needs older groups.
+
+Deltas are opt-in via `maxDeltaRatio` (omit it to publish a full snapshot per group).
+
+## Quick Start
+
+```bash
+npm add @moq/json
+```
+
+```ts
+import { Producer, Consumer } from "@moq/json";
+
+// Publish: deltas off by default (one snapshot per group).
+const producer = new Producer(track);
+producer.update({ hello: "world" });
+
+// Consume: yields the reconstructed value after each update.
+const consumer = new Consumer(track);
+for await (const value of consumer) {
+	console.log(value);
+}
+```
+
+Pass `{ deltaRatio: x }` to `Producer` to emit merge-patch deltas while a group stays within `x` times the size of a fresh snapshot. Arrays are replaced wholesale within a delta; a value set to `null` falls back to a snapshot, since merge patch reads `null` as a key deletion.

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@moq/json",
+	"type": "module",
+	"version": "0.0.1",
+	"description": "Snapshot/delta JSON publishing over MoQ tracks using RFC 7396 JSON Merge Patch.",
+	"license": "(MIT OR Apache-2.0)",
+	"repository": "github:moq-dev/moq",
+	"sideEffects": false,
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
+		"check": "tsc --noEmit",
+		"test": "bun test --only-failures",
+		"release": "bun ../common/release.ts"
+	},
+	"dependencies": {
+		"@moq/net": "workspace:^",
+		"@moq/signals": "workspace:^"
+	},
+	"peerDependencies": {
+		"zod": "^4.0.0"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.3.14",
+		"rimraf": "^6.1.3",
+		"typescript": "^6.0.3"
+	}
+}

--- a/js/json/src/consumer.ts
+++ b/js/json/src/consumer.ts
@@ -1,0 +1,67 @@
+import type * as Moq from "@moq/net";
+import type * as z from "zod/mini";
+import { merge } from "./diff.ts";
+import type { Config } from "./producer.ts";
+
+/**
+ * Consumes a JSON value from a track, reconstructing it from snapshots and deltas.
+ *
+ * Reads each group's snapshot (frame 0) and applies the following frames as merge patches,
+ * yielding the reconstructed value after each one.
+ */
+export class Consumer<T> {
+	#track: Moq.Track;
+	#schema?: z.ZodMiniType<T>;
+
+	#group?: Moq.Group;
+	#current?: unknown;
+	#framesRead = 0;
+
+	constructor(track: Moq.Track, config: Config<T> = {}) {
+		this.#track = track;
+		this.#schema = config.schema;
+	}
+
+	/** Get the next reconstructed value, or `undefined` once the track ends. */
+	async next(): Promise<T | undefined> {
+		for (;;) {
+			if (!this.#group) {
+				// Advance to the next group with a higher sequence number (skipping late arrivals).
+				this.#group = await this.#track.nextGroupOrdered();
+				if (!this.#group) return undefined;
+				this.#current = undefined;
+				this.#framesRead = 0;
+			}
+
+			const frame = await this.#group.readFrame();
+			if (frame === undefined) {
+				// The group is exhausted; advance to the next one.
+				this.#group = undefined;
+				continue;
+			}
+
+			return this.#apply(frame);
+		}
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<T> {
+		for (;;) {
+			const value = await this.next();
+			if (value === undefined) return;
+			yield value;
+		}
+	}
+
+	// Frame 0 of a group is a snapshot, the rest are merge patches.
+	#apply(frame: Uint8Array): T {
+		const parsed = JSON.parse(new TextDecoder().decode(frame));
+		if (this.#framesRead === 0) {
+			this.#current = parsed;
+		} else {
+			this.#current = merge(this.#current, parsed);
+		}
+		this.#framesRead += 1;
+
+		return this.#schema ? this.#schema.parse(this.#current) : (this.#current as T);
+	}
+}

--- a/js/json/src/diff.test.ts
+++ b/js/json/src/diff.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { deepEqual, diff, merge } from "./diff.ts";
+
+// Applying the patch to old should reproduce new (RFC 7396 semantics).
+function assertRoundtrip(oldVal: unknown, newVal: unknown) {
+	const result = diff(oldVal, newVal);
+	expect(result.forcedSnapshot).toBe(false);
+	expect(merge(oldVal, result.patch)).toEqual(newVal as object);
+}
+
+test("changed scalar", () => {
+	assertRoundtrip({ a: 1, b: 2 }, { a: 1, b: 3 });
+});
+
+test("added key", () => {
+	const result = diff({ a: 1 }, { a: 1, b: 2 });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ b: 2 });
+});
+
+test("removed key is null", () => {
+	const result = diff({ a: 1, b: 2 }, { a: 1 });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ b: null });
+	assertRoundtrip({ a: 1, b: 2 }, { a: 1 });
+});
+
+test("nested object only includes changed keys", () => {
+	const result = diff({ o: { x: 1, y: 2 } }, { o: { x: 1, y: 9 } });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ o: { y: 9 } });
+});
+
+test("changed array is a wholesale delta", () => {
+	const result = diff({ a: [1, 2] }, { a: [1, 2, 3] });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ a: [1, 2, 3] });
+	assertRoundtrip({ a: [1, 2] }, { a: [1, 2, 3] });
+});
+
+test("added array is a delta", () => {
+	const result = diff({ a: 1 }, { a: 1, b: [1] });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ b: [1] });
+});
+
+test("nested array is a delta", () => {
+	const result = diff({ o: { x: 1 } }, { o: { x: 1, list: [1] } });
+	expect(result.forcedSnapshot).toBe(false);
+	expect(result.patch).toEqual({ o: { list: [1] } });
+	assertRoundtrip({ o: { x: 1 } }, { o: { x: 1, list: [1] } });
+});
+
+test("set to null forces snapshot", () => {
+	expect(diff({ a: 1 }, { a: null }).forcedSnapshot).toBe(true);
+});
+
+test("replacing object with scalar", () => {
+	assertRoundtrip({ a: { x: 1 } }, { a: 5 });
+});
+
+test("non-object root forces snapshot", () => {
+	expect(diff(1, 2).forcedSnapshot).toBe(true);
+});
+
+test("deepEqual", () => {
+	expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
+	expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+	expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+});

--- a/js/json/src/diff.ts
+++ b/js/json/src/diff.ts
@@ -1,0 +1,100 @@
+// RFC 7396 JSON Merge Patch: generate a patch between two values, and apply one.
+
+export interface Diff {
+	// A merge patch transforming the old value into the new one.
+	patch: unknown;
+
+	// Set when the change can't be faithfully expressed as a merge patch, so the caller should
+	// publish a full snapshot instead. This happens when a value is set to null, which merge
+	// patch reads as a key deletion. Arrays are fine: merge patch replaces them wholesale, which
+	// is still typically smaller than a full snapshot.
+	forcedSnapshot: boolean;
+}
+
+type Obj = Record<string, unknown>;
+
+function isObject(value: unknown): value is Obj {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Generate an RFC 7396 merge patch transforming `oldVal` into `newVal`.
+ *
+ * Only object roots produce a recursive patch; any other root forces a snapshot.
+ */
+export function diff(oldVal: unknown, newVal: unknown): Diff {
+	if (isObject(oldVal) && isObject(newVal)) {
+		const patch: Obj = {};
+		const forced = { value: false };
+		diffObjects(oldVal, newVal, patch, forced);
+		return { patch, forcedSnapshot: forced.value };
+	}
+	return { patch: newVal, forcedSnapshot: true };
+}
+
+function diffObjects(oldObj: Obj, newObj: Obj, patch: Obj, forced: { value: boolean }): void {
+	// Keys present in old but missing from new become explicit null deletions.
+	for (const key of Object.keys(oldObj)) {
+		if (!(key in newObj)) patch[key] = null;
+	}
+
+	for (const key of Object.keys(newObj)) {
+		const newV = newObj[key];
+		const oldV = oldObj[key];
+		const inOld = key in oldObj;
+
+		if (inOld && deepEqual(oldV, newV)) continue;
+
+		// Recurse into nested objects so unchanged sibling keys stay out of the patch.
+		if (isObject(oldV) && isObject(newV)) {
+			const sub: Obj = {};
+			diffObjects(oldV, newV, sub, forced);
+			if (Object.keys(sub).length > 0) patch[key] = sub;
+			continue;
+		}
+
+		// Added or replaced with a non-object value. A literal null can't be stored: merge patch
+		// would delete the key. Arrays are kept in the patch and replace the target wholesale.
+		if (newV === null) {
+			forced.value = true;
+		}
+		patch[key] = newV;
+	}
+}
+
+/**
+ * Apply an RFC 7396 merge patch to a target value, returning the result.
+ *
+ * Objects merge recursively; a null patch value deletes that key; any other patch value
+ * (scalar or array) replaces the target wholesale.
+ */
+export function merge(target: unknown, patch: unknown): unknown {
+	if (!isObject(patch)) return patch;
+
+	const base: Obj = isObject(target) ? { ...target } : {};
+	for (const [key, value] of Object.entries(patch)) {
+		if (value === null) {
+			delete base[key];
+		} else {
+			base[key] = merge(base[key], value);
+		}
+	}
+	return base;
+}
+
+/** Structural equality for JSON values. */
+export function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+
+	if (Array.isArray(a) && Array.isArray(b)) {
+		return a.length === b.length && a.every((item, i) => deepEqual(item, b[i]));
+	}
+
+	if (isObject(a) && isObject(b)) {
+		const keys = Object.keys(a);
+		if (keys.length !== Object.keys(b).length) return false;
+		return keys.every((key) => key in b && deepEqual(a[key], b[key]));
+	}
+
+	return false;
+}

--- a/js/json/src/index.ts
+++ b/js/json/src/index.ts
@@ -1,0 +1,3 @@
+export { Consumer } from "./consumer.ts";
+export { type Diff, deepEqual, diff, merge } from "./diff.ts";
+export { type Config, Producer } from "./producer.ts";

--- a/js/json/src/json.test.ts
+++ b/js/json/src/json.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test";
+import { Track } from "@moq/net";
+import { Consumer } from "./consumer.ts";
+import { Producer } from "./producer.ts";
+
+type Value = Record<string, unknown>;
+
+// Reconstruct every value a consumer yields, in order.
+async function drain(track: Track): Promise<Value[]> {
+	const out: Value[] = [];
+	for await (const value of new Consumer<Value>(track)) out.push(value);
+	return out;
+}
+
+// Inspect the published layout via the public API: the frame count of each group, in order.
+// The track must be finished first so group/frame reads terminate.
+async function structure(track: Track): Promise<number[]> {
+	const counts: number[] = [];
+	for (;;) {
+		const group = await track.nextGroupOrdered();
+		if (!group) break;
+
+		let frames = 0;
+		while ((await group.readFrame()) !== undefined) frames++;
+		counts.push(frames);
+	}
+	return counts;
+}
+
+test("deltas off: a snapshot group per change", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track);
+	producer.update({ a: 1 });
+	producer.update({ a: 2 });
+	producer.finish();
+
+	// Two changes => two single-frame snapshot groups, reconstructed in order.
+	expect(await drain(track)).toEqual([{ a: 1 }, { a: 2 }]);
+});
+
+test("live consumer sees each update", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track);
+	const consumer = new Consumer<Value>(track);
+
+	for (let n = 1; n <= 3; n++) {
+		producer.update({ a: n });
+		expect(await consumer.next()).toEqual({ a: n });
+	}
+});
+
+test("unchanged value writes nothing", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track);
+	producer.update({ a: 1 });
+	producer.update({ a: 1 });
+	producer.finish();
+
+	expect(await structure(track)).toEqual([1]);
+});
+
+test("deltas share one group", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { deltaRatio: 100 });
+	producer.update({ a: 1, b: 1 });
+	producer.update({ a: 1, b: 2 });
+	producer.update({ a: 1, b: 3 });
+	producer.finish();
+
+	// All updates fit in a single group as snapshot + two deltas.
+	expect(await structure(track)).toEqual([3]);
+});
+
+test("deltas reconstruct to the final value", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { deltaRatio: 100 });
+	producer.update({ a: 1, b: 1 });
+	producer.update({ a: 1, b: 2 });
+	producer.update({ a: 5, b: 2 });
+	producer.finish();
+
+	expect((await drain(track)).at(-1)).toEqual({ a: 5, b: 2 });
+});
+
+test("tight ratio rolls snapshots", async () => {
+	const track = new Track("test");
+	// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
+	const producer = new Producer<Value>(track, { deltaRatio: 1.0 });
+	producer.update({ a: 1 });
+	producer.update({ a: 2 });
+	producer.update({ a: 3 });
+	producer.finish();
+
+	expect(await structure(track)).toEqual([1, 1, 1]);
+});
+
+test("array change is a wholesale delta", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { deltaRatio: 100 });
+	producer.update({ list: [1, 2] });
+	producer.update({ list: [1, 2, 3] });
+	producer.finish();
+
+	// The array is replaced wholesale in a delta, so it stays in the same group.
+	expect(await structure(track)).toEqual([2]);
+});
+
+test("frame cap rolls snapshot", async () => {
+	const track = new Track("test");
+	const producer = new Producer<Value>(track, { deltaRatio: 1_000_000 });
+	// First update is the snapshot; deltas fill the group until the frame cap forces a roll.
+	for (let i = 0; i <= 256; i++) {
+		producer.update({ n: i });
+	}
+	producer.finish();
+
+	expect(await structure(track)).toEqual([256, 1]);
+});

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -1,0 +1,104 @@
+import type * as Moq from "@moq/net";
+import type * as z from "zod/mini";
+
+import { deepEqual, diff } from "./diff.ts";
+
+// Maximum frames (snapshot + deltas) in a single group before a new snapshot is forced. Kept
+// well below the per-group frame cap so a late joiner can always read the snapshot at frame 0.
+const MAX_DELTA_FRAMES = 256;
+
+export interface Config<T> {
+	// Controls whether the producer emits deltas (merge patches) instead of full snapshots.
+	//
+	// `undefined` disables deltas: every change is published as a new snapshot group.
+	//
+	// A number enables deltas: a delta is appended to the current group as long as the group's
+	// total size stays within `deltaRatio` times the size of a fresh snapshot; otherwise a new
+	// snapshot group is started.
+	deltaRatio?: number;
+
+	// Optional zod schema used to validate each value before publishing.
+	schema?: z.ZodMiniType<T>;
+}
+
+/** Publishes a JSON value over a track, choosing snapshots and deltas automatically. */
+export class Producer<T> {
+	#track: Moq.Track;
+	#config: Config<T>;
+
+	#group?: Moq.Group;
+	#last?: unknown;
+	#groupBytes = 0;
+	#groupFrames = 0;
+
+	constructor(track: Moq.Track, config: Config<T> = {}) {
+		this.#track = track;
+		this.#config = config;
+	}
+
+	/** Publish a new value, emitting a snapshot or delta automatically. No-op if unchanged. */
+	update(value: T): void {
+		const valid = this.#config.schema ? this.#config.schema.parse(value) : value;
+
+		// Serialize once; parse it back to a normalized JSON value for diffing and comparison
+		// (dropping `undefined` fields, matching what lands on the wire).
+		const text = JSON.stringify(valid);
+		const json = JSON.parse(text);
+		if (this.#last !== undefined && deepEqual(this.#last, json)) return;
+
+		const snapshot = new TextEncoder().encode(text);
+		const delta = this.#delta(json, snapshot.length);
+		if (delta && this.#group) {
+			this.#group.writeFrame(delta);
+			this.#groupBytes += delta.length;
+			this.#groupFrames += 1;
+		} else {
+			this.#snapshot(snapshot);
+		}
+
+		this.#last = json;
+	}
+
+	/** Finish the track, closing any open group. */
+	finish(): void {
+		this.#group?.close();
+		this.#group = undefined;
+		this.#track.close();
+	}
+
+	#delta(json: unknown, snapshotLen: number): Uint8Array | undefined {
+		const ratio = this.#config.deltaRatio;
+		if (ratio === undefined) return undefined;
+		if (this.#last === undefined) return undefined;
+		if (!this.#group || this.#groupFrames >= MAX_DELTA_FRAMES) return undefined;
+
+		const result = diff(this.#last, json);
+		if (result.forcedSnapshot) return undefined;
+
+		const delta = new TextEncoder().encode(JSON.stringify(result.patch));
+
+		// Roll a snapshot if appending the delta would bloat the group past the budget.
+		if (this.#groupBytes + delta.length > ratio * snapshotLen) return undefined;
+
+		return delta;
+	}
+
+	#snapshot(snapshot: Uint8Array): void {
+		// The previous group is complete; no more frames will be appended to it.
+		this.#group?.close();
+
+		const group = this.#track.appendGroup();
+		group.writeFrame(snapshot);
+		this.#groupBytes = snapshot.length;
+		this.#groupFrames = 1;
+
+		if (this.#config.deltaRatio !== undefined) {
+			// Keep the group open so future deltas can be appended.
+			this.#group = group;
+		} else {
+			// Deltas disabled: one frame per group, identical to a plain JSON track.
+			group.close();
+			this.#group = undefined;
+		}
+	}
+}

--- a/js/json/src/vectors.test.ts
+++ b/js/json/src/vectors.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { diff, merge } from "./diff.ts";
+
+// Shared cross-impl fixture, owned by the reference Rust crate. Both suites assert the same
+// vectors so the two implementations agree on every snapshot/delta decision and patch shape.
+const url = new URL("../../../rs/moq-json/tests/vectors.json", import.meta.url);
+const vectors = (await Bun.file(url).json()) as Array<{
+	name: string;
+	old: unknown;
+	new: unknown;
+	forced: boolean;
+	patch?: unknown;
+}>;
+
+for (const vector of vectors) {
+	test(`vector: ${vector.name}`, () => {
+		const result = diff(vector.old, vector.new);
+		expect(result.forcedSnapshot).toBe(vector.forced);
+
+		if (!vector.forced) {
+			expect(result.patch).toEqual(vector.patch as object);
+			expect(merge(vector.old, result.patch)).toEqual(vector.new as object);
+		}
+	});
+}

--- a/js/json/tsconfig.json
+++ b/js/json/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "./src",
+		"types": ["bun"]
+	},
+	"include": ["src"]
+}

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -24,6 +24,7 @@
 	},
 	"dependencies": {
 		"@moq/hang": "workspace:^",
+		"@moq/json": "workspace:^",
 		"@moq/net": "workspace:^",
 		"@moq/signals": "workspace:^"
 	},

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -1,4 +1,5 @@
 import * as Catalog from "@moq/hang/catalog";
+import * as Json from "@moq/json";
 import * as Moq from "@moq/net";
 import { Effect, Signal } from "@moq/signals";
 import * as Audio from "./audio";
@@ -84,7 +85,7 @@ export class Broadcast {
 
 				switch (request.track.name) {
 					case Broadcast.CATALOG_TRACK:
-						this.#serveCatalog(request.track, effect);
+						this.#serveCatalog(new Json.Producer<Catalog.Root>(request.track), effect);
 						break;
 					case Location.Window.TRACK:
 						this.location.window.serve(request.track, effect);
@@ -119,10 +120,10 @@ export class Broadcast {
 		}
 	}
 
-	#serveCatalog(track: Moq.Track, effect: Effect): void {
+	#serveCatalog(producer: Json.Producer<Catalog.Root>, effect: Effect): void {
 		if (!effect.get(this.enabled)) {
 			// Clear the catalog.
-			track.writeFrame(Catalog.encode({}));
+			producer.update({});
 			return;
 		}
 
@@ -136,8 +137,7 @@ export class Broadcast {
 			preview: effect.get(this.preview.catalog),
 		};
 
-		const encoded = Catalog.encode(catalog);
-		track.writeFrame(encoded);
+		producer.update(catalog);
 	}
 
 	close() {

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -25,6 +25,7 @@
 	},
 	"dependencies": {
 		"@moq/hang": "workspace:^",
+		"@moq/json": "workspace:^",
 		"@moq/net": "workspace:^",
 		"@moq/msf": "workspace:^",
 		"@moq/signals": "workspace:^"

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -1,4 +1,5 @@
 import * as Catalog from "@moq/hang/catalog";
+import * as Json from "@moq/json";
 import * as Msf from "@moq/msf";
 import type * as Moq from "@moq/net";
 import { Path } from "@moq/net";
@@ -156,13 +157,18 @@ export class Broadcast {
 		const track = broadcast.subscribe(trackName, Catalog.PRIORITY.catalog);
 		effect.cleanup(() => track.close());
 
-		const fetchNext =
-			format === "hang"
-				? async () => Catalog.fetch(track)
-				: async () => {
-						const update = await Msf.fetch(track);
-						return update ? toHang(update) : undefined;
-					};
+		// The hang catalog is reconstructed from snapshots (and future deltas) via @moq/json;
+		// MSF stays on its own one-blob-per-group fetch.
+		let fetchNext: () => Promise<Catalog.Root | undefined>;
+		if (format === "hang") {
+			const consumer = new Json.Consumer<Catalog.Root>(track, { schema: Catalog.RootSchema });
+			fetchNext = () => consumer.next();
+		} else {
+			fetchNext = async () => {
+				const update = await Msf.fetch(track);
+				return update ? toHang(update) : undefined;
+			};
+		}
 
 		effect.spawn(async () => {
 			try {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"js/net",
 		"js/clock",
 		"js/token",
+		"js/json",
 		"js/hang",
 		"js/loc",
 		"js/msf",

--- a/rs/moq-json/Cargo.toml
+++ b/rs/moq-json/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "moq-json"
+description = "Snapshot/delta JSON publishing over MoQ tracks using RFC 7396 JSON Merge Patch."
+authors = ["Luke Curley <kixelated@gmail.com>"]
+repository = "https://github.com/moq-dev/moq"
+license = "MIT OR Apache-2.0"
+
+version = "0.0.1"
+edition = "2024"
+rust-version.workspace = true
+
+keywords = ["quic", "http3", "webtransport", "json", "live"]
+categories = ["multimedia", "network-programming", "web-programming"]
+
+[lib]
+doctest = false
+
+[dependencies]
+bytes = "1"
+json-patch = "4"
+kio = { workspace = true }
+moq-net = { workspace = true }
+serde = { workspace = true }
+serde_json = "1"
+thiserror = "2"

--- a/rs/moq-json/src/diff.rs
+++ b/rs/moq-json/src/diff.rs
@@ -1,0 +1,176 @@
+use serde_json::{Map, Value};
+
+/// The result of diffing two JSON values into an RFC 7396 merge patch.
+pub struct Diff {
+	/// A merge patch that transforms the old value into the new one.
+	pub patch: Value,
+
+	/// Set when the change can't be faithfully expressed as a merge patch, so the caller
+	/// should publish a full snapshot instead. This happens when a value is set to JSON null,
+	/// which merge patch reads as a key deletion. Arrays are fine: merge patch replaces them
+	/// wholesale, which is still typically smaller than a full snapshot.
+	pub forced_snapshot: bool,
+}
+
+/// Generate an RFC 7396 merge patch transforming `old` into `new`.
+///
+/// Only object roots produce a recursive patch; any other root forces a snapshot.
+pub fn diff(old: &Value, new: &Value) -> Diff {
+	if let (Value::Object(old), Value::Object(new)) = (old, new) {
+		let mut patch = Map::new();
+		let mut forced = false;
+		diff_objects(old, new, &mut patch, &mut forced);
+		Diff {
+			patch: Value::Object(patch),
+			forced_snapshot: forced,
+		}
+	} else {
+		Diff {
+			patch: new.clone(),
+			forced_snapshot: true,
+		}
+	}
+}
+
+fn diff_objects(old: &Map<String, Value>, new: &Map<String, Value>, patch: &mut Map<String, Value>, forced: &mut bool) {
+	// Keys present in old but missing from new become explicit null deletions.
+	for key in old.keys() {
+		if !new.contains_key(key) {
+			patch.insert(key.clone(), Value::Null);
+		}
+	}
+
+	for (key, new_val) in new {
+		let old_val = old.get(key);
+		if old_val == Some(new_val) {
+			continue;
+		}
+
+		// Recurse into nested objects so unchanged sibling keys stay out of the patch.
+		if let (Some(Value::Object(old_obj)), Value::Object(new_obj)) = (old_val, new_val) {
+			let mut sub = Map::new();
+			diff_objects(old_obj, new_obj, &mut sub, forced);
+			if !sub.is_empty() {
+				patch.insert(key.clone(), Value::Object(sub));
+			}
+			continue;
+		}
+
+		// Added or replaced with a non-object value. A literal null can't be stored: merge patch
+		// would delete the key. Arrays are kept in the patch and replace the target wholesale.
+		if new_val.is_null() {
+			*forced = true;
+		}
+		patch.insert(key.clone(), new_val.clone());
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use serde_json::json;
+
+	/// Applying the patch to old should reproduce new (RFC 7396 semantics).
+	fn assert_roundtrip(old: Value, new: Value) {
+		let result = diff(&old, &new);
+		assert!(!result.forced_snapshot, "expected a delta, got a forced snapshot");
+		let mut applied = old;
+		json_patch::merge(&mut applied, &result.patch);
+		assert_eq!(applied, new);
+	}
+
+	#[test]
+	fn changed_scalar() {
+		assert_roundtrip(json!({ "a": 1, "b": 2 }), json!({ "a": 1, "b": 3 }));
+	}
+
+	#[test]
+	fn added_key() {
+		let result = diff(&json!({ "a": 1 }), &json!({ "a": 1, "b": 2 }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "b": 2 }));
+	}
+
+	#[test]
+	fn removed_key_is_null() {
+		let result = diff(&json!({ "a": 1, "b": 2 }), &json!({ "a": 1 }));
+		assert!(!result.forced_snapshot, "removing a key is a clean delete");
+		assert_eq!(result.patch, json!({ "b": null }));
+		assert_roundtrip(json!({ "a": 1, "b": 2 }), json!({ "a": 1 }));
+	}
+
+	#[test]
+	fn nested_object_only_includes_changed_keys() {
+		let result = diff(&json!({ "o": { "x": 1, "y": 2 } }), &json!({ "o": { "x": 1, "y": 9 } }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "o": { "y": 9 } }));
+	}
+
+	#[test]
+	fn changed_array_is_wholesale_delta() {
+		let result = diff(&json!({ "a": [1, 2] }), &json!({ "a": [1, 2, 3] }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "a": [1, 2, 3] }));
+		assert_roundtrip(json!({ "a": [1, 2] }), json!({ "a": [1, 2, 3] }));
+	}
+
+	#[test]
+	fn added_array_is_delta() {
+		let result = diff(&json!({ "a": 1 }), &json!({ "a": 1, "b": [1] }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "b": [1] }));
+	}
+
+	#[test]
+	fn nested_array_is_delta() {
+		let result = diff(&json!({ "o": { "x": 1 } }), &json!({ "o": { "x": 1, "list": [1] } }));
+		assert!(!result.forced_snapshot);
+		assert_eq!(result.patch, json!({ "o": { "list": [1] } }));
+		assert_roundtrip(json!({ "o": { "x": 1 } }), json!({ "o": { "x": 1, "list": [1] } }));
+	}
+
+	#[test]
+	fn set_to_null_forces_snapshot() {
+		// A genuine null value can't be represented: merge patch would delete the key.
+		let result = diff(&json!({ "a": 1 }), &json!({ "a": null }));
+		assert!(result.forced_snapshot);
+	}
+
+	#[test]
+	fn replacing_object_with_scalar() {
+		assert_roundtrip(json!({ "a": { "x": 1 } }), json!({ "a": 5 }));
+	}
+
+	#[test]
+	fn non_object_root_forces_snapshot() {
+		let result = diff(&json!(1), &json!(2));
+		assert!(result.forced_snapshot);
+	}
+
+	#[derive(serde::Deserialize)]
+	struct Vector {
+		name: String,
+		old: Value,
+		new: Value,
+		forced: bool,
+		patch: Option<Value>,
+	}
+
+	/// Shared cross-impl fixture: the TS suite (js/json) asserts the same vectors so both
+	/// implementations agree on every snapshot/delta decision and patch shape.
+	#[test]
+	fn golden_vectors() {
+		let vectors: Vec<Vector> = serde_json::from_str(include_str!("../tests/vectors.json")).unwrap();
+		for case in vectors {
+			let result = diff(&case.old, &case.new);
+			assert_eq!(result.forced_snapshot, case.forced, "{}: forced_snapshot", case.name);
+
+			if let Some(expected) = case.patch {
+				assert_eq!(result.patch, expected, "{}: patch", case.name);
+				let mut applied = case.old.clone();
+				json_patch::merge(&mut applied, &result.patch);
+				assert_eq!(applied, case.new, "{}: roundtrip", case.name);
+			}
+		}
+	}
+}

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -1,0 +1,465 @@
+//! Snapshot/delta JSON publishing over [`moq-net`](moq_net) tracks.
+//!
+//! A JSON value is published over a track as a series of groups, where each group is
+//! self-contained: its first frame is a full snapshot and any following frames are
+//! [RFC 7396](https://www.rfc-editor.org/rfc/rfc7396.html) JSON Merge Patch deltas applied in
+//! order. A consumer jumps to the newest group, reads the snapshot, and applies the deltas, so
+//! a late joiner never needs older groups.
+//!
+//! Deltas are opt-in via [`Config::delta_ratio`]. With deltas disabled (the default)
+//! every change is a fresh snapshot group, matching a plain "one JSON blob per group" track.
+
+mod diff;
+
+use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
+use std::task::Poll;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::diff::diff;
+
+/// Maximum frames (snapshot + deltas) in a single group before a new snapshot is forced.
+///
+/// Kept well below moq-net's per-group frame cap so a late joiner can always read the snapshot
+/// at frame 0 before the group is evicted.
+const MAX_DELTA_FRAMES: usize = 256;
+
+/// Errors produced while publishing or consuming JSON.
+#[derive(thiserror::Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum Error {
+	/// An error from the underlying track.
+	#[error(transparent)]
+	Net(#[from] moq_net::Error),
+
+	/// A value failed to serialize, deserialize, or apply as a merge patch.
+	///
+	/// Stored as a string since [`serde_json::Error`] is not [`Clone`].
+	#[error("json: {0}")]
+	Json(String),
+}
+
+impl From<serde_json::Error> for Error {
+	fn from(err: serde_json::Error) -> Self {
+		Error::Json(err.to_string())
+	}
+}
+
+/// A [`Result`](std::result::Result) using this crate's [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Configuration for a [`Producer`].
+#[derive(Debug, Clone, Default)]
+pub struct Config {
+	/// Controls whether the producer emits deltas (merge patches) instead of full snapshots.
+	///
+	/// `None` disables deltas: every change is published as a new snapshot group.
+	///
+	/// `Some(ratio)` enables deltas. A delta is appended to the current group as long as the
+	/// group's total size stays within `ratio` times the size of a fresh snapshot; otherwise a
+	/// new snapshot group is started. A larger ratio tolerates bigger groups before snapshotting.
+	pub delta_ratio: Option<f64>,
+}
+
+/// Publishes a JSON value over a track, choosing snapshots and deltas automatically.
+///
+/// Cheaply clonable: clones share one underlying track and publishing state, like other MoQ
+/// producers.
+pub struct Producer<T> {
+	inner: Arc<Mutex<Inner>>,
+	_marker: PhantomData<fn(T)>,
+}
+
+impl<T> Clone for Producer<T> {
+	fn clone(&self) -> Self {
+		Self {
+			inner: self.inner.clone(),
+			_marker: PhantomData,
+		}
+	}
+}
+
+impl<T> Producer<T> {
+	/// Create a subscriber for the underlying track.
+	pub fn consume(&self) -> moq_net::TrackConsumer {
+		self.inner.lock().unwrap().track.consume()
+	}
+}
+
+impl<T: Serialize> Producer<T> {
+	/// Create a producer that publishes to the given track.
+	pub fn new(track: moq_net::TrackProducer, config: Config) -> Self {
+		Self {
+			inner: Arc::new(Mutex::new(Inner {
+				track,
+				group: None,
+				last: None,
+				group_bytes: 0,
+				group_frames: 0,
+				config,
+			})),
+			_marker: PhantomData,
+		}
+	}
+
+	/// Publish a new value, emitting a snapshot or a delta automatically.
+	///
+	/// Does nothing if the value is unchanged from the previous publish.
+	pub fn update(&mut self, value: &T) -> Result<()> {
+		let json = serde_json::to_value(value)?;
+		// Serialize the value directly (not via `json`) so a snapshot preserves the type's own
+		// field order, keeping the wire bytes identical to serializing `T` straight to a frame.
+		let snapshot = serde_json::to_vec(value)?;
+		self.inner.lock().unwrap().update(json, snapshot)
+	}
+
+	/// Finish the track, closing any open group.
+	pub fn finish(&mut self) -> Result<()> {
+		self.inner.lock().unwrap().finish()
+	}
+}
+
+/// Shared publishing state behind [`Producer`]'s `Arc<Mutex>`.
+struct Inner {
+	track: moq_net::TrackProducer,
+	group: Option<moq_net::GroupProducer>,
+	last: Option<Value>,
+	group_bytes: u64,
+	group_frames: usize,
+	config: Config,
+}
+
+impl Inner {
+	fn update(&mut self, json: Value, snapshot: Vec<u8>) -> Result<()> {
+		if self.last.as_ref() == Some(&json) {
+			return Ok(());
+		}
+
+		match self.delta(&json, snapshot.len())? {
+			Some(delta) => {
+				let group = self.group.as_mut().expect("delta requires an open group");
+				let len = delta.len() as u64;
+				group.write_frame(delta)?;
+				self.group_bytes += len;
+				self.group_frames += 1;
+			}
+			None => self.snapshot(snapshot)?,
+		}
+
+		self.last = Some(json);
+		Ok(())
+	}
+
+	/// Serialize a delta if deltas are enabled and appending one keeps the group within budget;
+	/// otherwise `None`, signalling that a fresh snapshot should be published instead.
+	fn delta(&self, value: &Value, snapshot_len: usize) -> Result<Option<Vec<u8>>> {
+		let Some(ratio) = self.config.delta_ratio else {
+			return Ok(None);
+		};
+		let Some(last) = &self.last else {
+			return Ok(None);
+		};
+		if self.group.is_none() || self.group_frames >= MAX_DELTA_FRAMES {
+			return Ok(None);
+		}
+
+		let diff = diff(last, value);
+		if diff.forced_snapshot {
+			return Ok(None);
+		}
+
+		let delta = serde_json::to_vec(&diff.patch)?;
+
+		// Roll a snapshot if appending the delta would bloat the group past the budget.
+		let projected = (self.group_bytes + delta.len() as u64) as f64;
+		if projected > ratio * snapshot_len as f64 {
+			return Ok(None);
+		}
+
+		Ok(Some(delta))
+	}
+
+	/// Start a new group with a full snapshot as its first frame.
+	fn snapshot(&mut self, snapshot: Vec<u8>) -> Result<()> {
+		// The previous group is complete; no more frames will be appended to it.
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+
+		let len = snapshot.len() as u64;
+		let mut group = self.track.append_group()?;
+		group.write_frame(snapshot)?;
+		self.group_bytes = len;
+		self.group_frames = 1;
+
+		if self.config.delta_ratio.is_some() {
+			// Keep the group open so future deltas can be appended.
+			self.group = Some(group);
+		} else {
+			// Deltas disabled: one frame per group, identical to a plain JSON track.
+			group.finish()?;
+		}
+
+		Ok(())
+	}
+
+	fn finish(&mut self) -> Result<()> {
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+		self.track.finish()?;
+		Ok(())
+	}
+}
+
+/// Consumes a JSON value from a track, reconstructing it from snapshots and deltas.
+pub struct Consumer<T> {
+	track: moq_net::TrackConsumer,
+	group: Option<moq_net::GroupConsumer>,
+	current: Option<Value>,
+	frames_read: usize,
+	_marker: PhantomData<fn() -> T>,
+}
+
+impl<T: DeserializeOwned> Consumer<T> {
+	/// Create a consumer reading from the given track subscriber.
+	pub fn new(track: moq_net::TrackConsumer) -> Self {
+		Self {
+			track,
+			group: None,
+			current: None,
+			frames_read: 0,
+			_marker: PhantomData,
+		}
+	}
+
+	/// Get the next reconstructed value, or `None` once the track ends.
+	pub async fn next(&mut self) -> Result<Option<T>>
+	where
+		T: Unpin,
+	{
+		kio::wait(|waiter| self.poll_next(waiter)).await
+	}
+
+	/// Poll for the next reconstructed value, without blocking.
+	///
+	/// Jumps to the newest group, reads its snapshot, and applies deltas in order, yielding the
+	/// reconstructed value after each frame. Switching to a newer group discards the older one.
+	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<T>>> {
+		// Drain to the newest group, resetting reconstruction state whenever we switch.
+		let track_finished = loop {
+			match self.track.poll_next_group(waiter)? {
+				Poll::Ready(Some(group)) => {
+					self.group = Some(group);
+					self.current = None;
+					self.frames_read = 0;
+				}
+				Poll::Ready(None) => break true,
+				Poll::Pending => break false,
+			}
+		};
+
+		if let Some(group) = &mut self.group {
+			match group.poll_read_frame(waiter)? {
+				Poll::Ready(Some(frame)) => return Poll::Ready(Ok(Some(self.apply(frame)?))),
+				// The current group is exhausted; wait for a newer one.
+				Poll::Ready(None) => self.group = None,
+				Poll::Pending => return Poll::Pending,
+			}
+		}
+
+		if track_finished {
+			Poll::Ready(Ok(None))
+		} else {
+			Poll::Pending
+		}
+	}
+
+	/// Apply one frame: frame 0 of a group is a snapshot, the rest are merge patches.
+	fn apply(&mut self, frame: bytes::Bytes) -> Result<T> {
+		if self.frames_read == 0 {
+			self.current = Some(serde_json::from_slice(&frame)?);
+		} else {
+			let patch: Value = serde_json::from_slice(&frame)?;
+			let current = self.current.as_mut().expect("a snapshot precedes any delta");
+			json_patch::merge(current, &patch);
+		}
+		self.frames_read += 1;
+
+		let current = self
+			.current
+			.as_ref()
+			.expect("a value is present after applying a frame");
+		Ok(serde_json::from_value(current.clone())?)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use serde_json::json;
+
+	fn producer(config: Config) -> (Producer<Value>, moq_net::TrackConsumer) {
+		let track = moq_net::Track::new("test").produce();
+		let consumer = track.consume();
+		(Producer::new(track, config), consumer)
+	}
+
+	/// Drain every value currently available from a consumer without blocking.
+	fn drain(track: moq_net::TrackConsumer) -> Vec<Value> {
+		let mut consumer = Consumer::<Value>::new(track);
+		let waiter = kio::Waiter::noop();
+		let mut out = Vec::new();
+		while let Poll::Ready(Ok(Some(value))) = consumer.poll_next(&waiter) {
+			out.push(value);
+		}
+		out
+	}
+
+	#[test]
+	fn deltas_off_snapshot_per_group() {
+		let (mut producer, track) = producer(Config::default());
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.update(&json!({ "a": 2 })).unwrap();
+		producer.finish().unwrap();
+
+		// Two updates => two groups, each a full snapshot. A consumer that joins after both
+		// exist only sees the latest, like the existing catalog consumer.
+		assert_eq!(track.latest(), Some(1));
+		assert_eq!(drain(track), vec![json!({ "a": 2 })]);
+	}
+
+	#[test]
+	fn live_consumer_sees_each_update() {
+		let (mut producer, track) = producer(Config::default());
+		let mut consumer = Consumer::<Value>::new(track);
+		let waiter = kio::Waiter::noop();
+
+		for n in 1..=3 {
+			producer.update(&json!({ "a": n })).unwrap();
+			match consumer.poll_next(&waiter) {
+				Poll::Ready(Ok(Some(value))) => assert_eq!(value, json!({ "a": n })),
+				other => panic!("expected value, got {other:?}"),
+			}
+		}
+	}
+
+	#[test]
+	fn unchanged_value_writes_nothing() {
+		let (mut producer, track) = producer(Config::default());
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(track.latest(), Some(0));
+		assert_eq!(drain(track), vec![json!({ "a": 1 })]);
+	}
+
+	#[test]
+	fn deltas_share_one_group() {
+		let config = Config {
+			delta_ratio: Some(100.0),
+		};
+		let (mut producer, track) = producer(config);
+		producer.update(&json!({ "a": 1, "b": 1 })).unwrap();
+		producer.update(&json!({ "a": 1, "b": 2 })).unwrap();
+		producer.update(&json!({ "a": 1, "b": 3 })).unwrap();
+		producer.finish().unwrap();
+
+		// All updates fit in a single group as snapshot + deltas.
+		assert_eq!(track.latest(), Some(0));
+		let values = drain(track);
+		assert_eq!(values.last().unwrap(), &json!({ "a": 1, "b": 3 }));
+	}
+
+	#[test]
+	fn tight_ratio_rolls_snapshots() {
+		// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
+		let config = Config { delta_ratio: Some(1.0) };
+		let (mut producer, track) = producer(config);
+		producer.update(&json!({ "a": 1 })).unwrap();
+		producer.update(&json!({ "a": 2 })).unwrap();
+		producer.update(&json!({ "a": 3 })).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(track.latest(), Some(2));
+	}
+
+	#[test]
+	fn array_change_is_delta() {
+		let config = Config {
+			delta_ratio: Some(100.0),
+		};
+		let (mut producer, track) = producer(config);
+		producer.update(&json!({ "list": [1, 2] })).unwrap();
+		producer.update(&json!({ "list": [1, 2, 3] })).unwrap();
+		producer.finish().unwrap();
+
+		// The array is replaced wholesale in a delta, so it stays in the same group.
+		assert_eq!(track.latest(), Some(0));
+		assert_eq!(drain(track).last().unwrap(), &json!({ "list": [1, 2, 3] }));
+	}
+
+	#[test]
+	fn frame_cap_rolls_snapshot() {
+		let config = Config {
+			delta_ratio: Some(1_000_000.0),
+		};
+		let (mut producer, track) = producer(config);
+		// First update is the snapshot (frame 0); then MAX_DELTA_FRAMES - 1 deltas fill the group.
+		for i in 0..=MAX_DELTA_FRAMES {
+			producer.update(&json!({ "n": i })).unwrap();
+		}
+		producer.finish().unwrap();
+
+		// The frame cap forced exactly one extra snapshot group despite the huge ratio.
+		assert_eq!(track.latest(), Some(1));
+		assert_eq!(drain(track).last().unwrap(), &json!({ "n": MAX_DELTA_FRAMES }));
+	}
+
+	#[test]
+	fn late_joiner_reconstructs_from_deltas() {
+		let config = Config {
+			delta_ratio: Some(100.0),
+		};
+		let (mut producer, track) = producer(config);
+		producer.update(&json!({ "a": 1, "b": 1 })).unwrap();
+		producer.update(&json!({ "a": 1, "b": 2 })).unwrap();
+		producer.update(&json!({ "a": 5, "b": 2 })).unwrap();
+		producer.finish().unwrap();
+
+		// A consumer created only now still rebuilds the final value from snapshot + deltas.
+		assert_eq!(drain(track).last().unwrap(), &json!({ "a": 5, "b": 2 }));
+	}
+
+	#[test]
+	fn newer_group_supersedes_in_progress_reconstruction() {
+		// A tight ratio lets one delta fit, then forces the next update into a new snapshot group.
+		let config = Config { delta_ratio: Some(2.0) };
+		let (mut producer, track) = producer(config);
+		let observer = producer.consume();
+		let mut consumer = Consumer::<Value>::new(track);
+		let waiter = kio::Waiter::noop();
+
+		producer.update(&json!({ "a": 1 })).unwrap(); // snapshot, group 0
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(value))) => assert_eq!(value, json!({ "a": 1 })),
+			other => panic!("expected first value, got {other:?}"),
+		}
+
+		producer.update(&json!({ "a": 2 })).unwrap(); // delta in group 0
+		producer.update(&json!({ "a": 3 })).unwrap(); // exceeds budget, rolls group 1
+		producer.finish().unwrap();
+		assert_eq!(observer.latest(), Some(1));
+
+		// The consumer jumps to the newest group and never yields a stale value.
+		let mut last = None;
+		while let Poll::Ready(Ok(Some(value))) = consumer.poll_next(&waiter) {
+			last = Some(value);
+		}
+		assert_eq!(last.unwrap(), json!({ "a": 3 }));
+	}
+}

--- a/rs/moq-json/tests/vectors.json
+++ b/rs/moq-json/tests/vectors.json
@@ -1,0 +1,64 @@
+[
+	{
+		"name": "changed_scalar",
+		"old": { "a": 1, "b": 2 },
+		"new": { "a": 1, "b": 3 },
+		"forced": false,
+		"patch": { "b": 3 }
+	},
+	{
+		"name": "added_key",
+		"old": { "a": 1 },
+		"new": { "a": 1, "b": 2 },
+		"forced": false,
+		"patch": { "b": 2 }
+	},
+	{
+		"name": "removed_key_is_null",
+		"old": { "a": 1, "b": 2 },
+		"new": { "a": 1 },
+		"forced": false,
+		"patch": { "b": null }
+	},
+	{
+		"name": "nested_object",
+		"old": { "o": { "x": 1, "y": 2 } },
+		"new": { "o": { "x": 1, "y": 9 } },
+		"forced": false,
+		"patch": { "o": { "y": 9 } }
+	},
+	{
+		"name": "replace_object_with_scalar",
+		"old": { "a": { "x": 1 } },
+		"new": { "a": 5 },
+		"forced": false,
+		"patch": { "a": 5 }
+	},
+	{
+		"name": "catalog_like_add_user",
+		"old": { "video": { "renditions": {} }, "audio": { "renditions": {} } },
+		"new": { "video": { "renditions": {} }, "audio": { "renditions": {} }, "user": { "name": "alice" } },
+		"forced": false,
+		"patch": { "user": { "name": "alice" } }
+	},
+	{
+		"name": "changed_array_is_wholesale_delta",
+		"old": { "a": [1, 2] },
+		"new": { "a": [1, 2, 3] },
+		"forced": false,
+		"patch": { "a": [1, 2, 3] }
+	},
+	{
+		"name": "added_array_is_delta",
+		"old": { "a": 1 },
+		"new": { "a": 1, "b": [1] },
+		"forced": false,
+		"patch": { "b": [1] }
+	},
+	{
+		"name": "set_to_null_forces_snapshot",
+		"old": { "a": 1 },
+		"new": { "a": null },
+		"forced": true
+	}
+]

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -24,6 +24,7 @@ h264-parser = { version = "0.4.0" }
 hang = { workspace = true }
 kio = { workspace = true }
 m3u8-rs = { version = "6" }
+moq-json = { workspace = true }
 moq-loc = { workspace = true }
 moq-msf = { workspace = true }
 moq-net = { workspace = true, features = ["serde"] }

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -1,4 +1,4 @@
-use std::task::Poll;
+use std::task::{Poll, ready};
 
 use hang::Catalog;
 
@@ -6,49 +6,24 @@ use crate::Result;
 
 /// A catalog consumer, used to receive catalog updates and discover tracks.
 ///
-/// This wraps a `moq_net::TrackConsumer` and automatically deserializes JSON
-/// catalog data to discover available audio and video tracks in a broadcast.
-#[derive(Clone)]
+/// This wraps a [`moq_json::Consumer`], reconstructing the JSON catalog from the latest
+/// group's snapshot (plus any future deltas) to discover available audio and video tracks.
 pub struct Consumer {
-	/// Access to the underlying track consumer.
-	pub track: moq_net::TrackConsumer,
-	group: Option<moq_net::GroupConsumer>,
+	inner: moq_json::Consumer<Catalog>,
 }
 
 impl Consumer {
 	/// Create a new catalog consumer from a MoQ track consumer.
 	pub fn new(track: moq_net::TrackConsumer) -> Self {
-		Self { track, group: None }
+		Self {
+			inner: moq_json::Consumer::new(track),
+		}
 	}
 
 	/// Poll for the next catalog update.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Catalog>>> {
-		// Drain pending groups, keeping only the newest. Remember whether the track is done
-		// so we can distinguish "more groups may arrive" from "no more groups, ever".
-		let track_finished = loop {
-			match self.track.poll_next_group(waiter)? {
-				Poll::Ready(Some(group)) => self.group = Some(group),
-				Poll::Ready(None) => break true,
-				Poll::Pending => break false,
-			}
-		};
-
-		if let Some(group) = &mut self.group {
-			match group.poll_read_frame(waiter)? {
-				Poll::Ready(Some(frame)) => {
-					self.group = None;
-					return Poll::Ready(Ok(Some(Catalog::from_slice(&frame)?)));
-				}
-				Poll::Ready(None) => self.group = None,
-				Poll::Pending => return Poll::Pending,
-			}
-		}
-
-		if track_finished {
-			Poll::Ready(Ok(None))
-		} else {
-			Poll::Pending
-		}
+		let result = ready!(self.inner.poll_next(waiter));
+		Poll::Ready(result.map_err(Into::into))
 	}
 
 	/// Get the next catalog update.
@@ -56,7 +31,7 @@ impl Consumer {
 	/// This method waits for the next catalog publication and returns the
 	/// catalog data. If there are no more updates, `None` is returned.
 	pub async fn next(&mut self) -> Result<Option<Catalog>> {
-		kio::wait(|waiter| self.poll_next(waiter)).await
+		Ok(self.inner.next().await?)
 	}
 }
 

--- a/rs/moq-mux/src/catalog/hang/producer.rs
+++ b/rs/moq-mux/src/catalog/hang/producer.rs
@@ -8,9 +8,13 @@ use base64::Engine;
 /// The JSON catalog is updated when tracks are added/removed but is *not* automatically published.
 /// You'll have to call [`lock`](Self::lock) to update and publish the catalog.
 /// Both the hang (`catalog.json`) and MSF (`catalog`) tracks are published on drop of the guard.
+///
+/// The hang track is published through [`moq_json`], which currently emits one snapshot per
+/// group (deltas disabled). This routes catalog publishing through the JSON merge-patch helper
+/// so deltas can be enabled later without changing the wire format used today.
 #[derive(Clone)]
 pub struct Producer {
-	hang_track: moq_net::TrackProducer,
+	hang: moq_json::Producer<hang::Catalog>,
 	msf_track: moq_net::TrackProducer,
 
 	current: Arc<Mutex<hang::Catalog>>,
@@ -30,8 +34,10 @@ impl Producer {
 		let hang_track = broadcast.create_track(hang::Catalog::default_track())?;
 		let msf_track = broadcast.create_track(moq_net::Track::new(moq_msf::DEFAULT_NAME))?;
 
+		let hang = moq_json::Producer::new(hang_track, moq_json::Config::default());
+
 		Ok(Self {
-			hang_track,
+			hang,
 			msf_track,
 			current: Arc::new(Mutex::new(catalog)),
 		})
@@ -41,7 +47,7 @@ impl Producer {
 	pub fn lock(&mut self) -> Guard<'_> {
 		Guard {
 			catalog: self.current.lock().unwrap(),
-			hang_track: &mut self.hang_track,
+			hang: &mut self.hang,
 			msf_track: &mut self.msf_track,
 			updated: false,
 		}
@@ -54,14 +60,12 @@ impl Producer {
 
 	/// Create a consumer for this catalog, receiving updates as they're published.
 	pub fn consume(&self) -> Result<super::Consumer, moq_net::Error> {
-		let track = self.hang_track.consume();
-		let subscriber = track;
-		Ok(super::Consumer::new(subscriber))
+		Ok(super::Consumer::new(self.hang.consume()))
 	}
 
 	/// Finish publishing to this catalog.
-	pub fn finish(&mut self) -> Result<(), moq_net::Error> {
-		self.hang_track.finish()?;
+	pub fn finish(&mut self) -> crate::Result<()> {
+		self.hang.finish()?;
 		self.msf_track.finish()?;
 		Ok(())
 	}
@@ -74,7 +78,7 @@ impl Producer {
 /// On drop, both the hang and MSF catalog tracks are updated if the catalog was mutated.
 pub struct Guard<'a> {
 	catalog: MutexGuard<'a, hang::Catalog>,
-	hang_track: &'a mut moq_net::TrackProducer,
+	hang: &'a mut moq_json::Producer<hang::Catalog>,
 	msf_track: &'a mut moq_net::TrackProducer,
 	updated: bool,
 }
@@ -100,12 +104,9 @@ impl Drop for Guard<'_> {
 			return;
 		}
 
-		// Publish hang catalog
-		if let Ok(mut group) = self.hang_track.append_group() {
-			let frame = self.catalog.to_string().expect("invalid catalog");
-			let _ = group.write_frame(frame);
-			let _ = group.finish();
-		}
+		// Publish the hang catalog (one snapshot per group while deltas are disabled).
+		let catalog: &hang::Catalog = &self.catalog;
+		let _ = self.hang.update(catalog);
 
 		// Publish MSF catalog
 		let msf = to_msf(&self.catalog);

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -14,6 +14,10 @@ pub enum Error {
 	#[error("hang: {0}")]
 	Hang(#[from] hang::Error),
 
+	/// Error publishing or consuming JSON over a track.
+	#[error("json: {0}")]
+	Json(#[from] moq_json::Error),
+
 	/// Error parsing or building CMAF moof+mdat fragments.
 	#[error("cmaf: {0}")]
 	Cmaf(#[from] crate::container::fmp4::Error),


### PR DESCRIPTION
## Summary

Adds the `moq-json` crate and `@moq/json` package, and routes the hang catalog publish/consume paths through them: a JSON value is published over a track as self-contained groups, where each group's first frame is a full snapshot and any following frames are [RFC 7396](https://www.rfc-editor.org/rfc/rfc7396.html) JSON Merge Patch deltas applied in order. A late joiner jumps to the newest group, reads the snapshot, and applies the deltas, so it never needs older groups.

Deltas are opt-in via `delta_ratio` / `deltaRatio`. With deltas off (the default, and what the catalog uses) every change is a fresh snapshot group, byte-identical to a plain "one JSON blob per group" track.

## What's wired in

- **`rs/moq-json`** / **`js/json`** — the new packages (producer, consumer, RFC 7396 diff, shared golden vectors).
- **`rs/moq-mux` catalog** — the hang catalog producer publishes via `moq_json::Producer`; the consumer reconstructs via `moq_json::Consumer`. MSF catalog delivery is untouched.
- **`js/watch` / `js/publish`** — route their hang catalog through `@moq/json` the same way.

This makes the libraries actually consumed (and resolves a `cargo shear` unused-dependency failure). Because deltas are disabled, the catalog wire bytes are identical to the previous `to_string()` / `Catalog.encode()` output (verified: `to_string` == `to_vec` in Rust, `encode` == `JSON.stringify` in JS). This just moves the catalog onto the merge-patch path so deltas can be enabled later without a wire change.

## Why this targets `main`

The packages are additive and the catalog routing is wire-safe (byte-identical with deltas off). Nothing here touches `rs/moq-net` wire/API or the catalog *format*, so it doesn't trip the `dev` branch-targeting rules.

This is a port of the JSON work out of the dev batch (#1637), deliberately **without** the two things that PR also bundled and that belong on `dev`:

- the `moq-net` API rename (`TrackConsumer`→`TrackSubscriber`, `subscribe`, etc.) and the js/net `nextGroup` rename
- (nothing else — the catalog routing is included here)

A straight cherry-pick of #1637 wasn't viable: it carries the js/net rename, and the moq-net API the json code targets comes from several earlier dev commits that `main` never had. So the package files are copied verbatim and the call sites are translated to main's existing API (`TrackConsumer` / `consume()` / `Track::new(name).produce()` in Rust, `nextGroupOrdered()` in JS).

### Note on the Rust catalog `Consumer`

The catalog `Consumer` loses its `#[derive(Clone)]` and public `track` field (it now wraps `moq_json::Consumer`). Nothing consumed either — `moq-ffi` and `libmoq` only call `.next()` on it, and the cloned catalog handle in `moq-ffi` is the `Producer`, which stays `Clone`.

## Test plan

- [x] `cargo test -p moq-json` — 20 pass
- [x] `cargo test -p moq-mux` — 175 pass (includes catalog consumer tests against the moq-json-backed consumer)
- [x] `cargo clippy -p moq-mux -p moq-ffi -p libmoq --all-targets` — clean (downstream `finish()` signature change compiles)
- [x] `cargo shear` — clean
- [x] `cargo fmt --check` — clean
- [x] `bun test` (js/json) — 28 pass; (js/watch) — 64 pass
- [x] `tsc --noEmit` (js/json, js/watch, js/publish) — clean
- [x] biome (js/json, js/watch, js/publish) — clean

(Written by Claude)