### PR TITLE
feat(publish): configurable audio codec settings via a codec config

### DIFF
--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -10,7 +10,7 @@ import { type Kind, normalizeSource, type Source } from "./types";
 const GAIN_MIN = 0.001;
 const FADE_TIME = 0.2;
 const OPUS_BITRATE_PER_CHANNEL = 32_000;
-const OPUS_FRAME_DURATION = 20;
+const OPUS_FRAME_DURATION_MS = 20;
 
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import CaptureWorklet from "./capture-worklet.ts?worklet";
@@ -25,6 +25,12 @@ export type EncoderProps = {
 	sampleRate?: number | Signal<number | undefined>;
 	channelCount?: number | Signal<number | undefined>;
 
+	// Opus bitrate in bits/sec. Defaults to channelCount * 32kbps when unset.
+	bitrate?: number | Signal<number | undefined>;
+
+	// Opus frame duration in milliseconds. Opus supports 2.5-60ms; defaults to 20ms (the real-time default).
+	frameDuration?: number | Signal<number | undefined>;
+
 	container?: Catalog.Container;
 };
 
@@ -38,6 +44,8 @@ export class Encoder {
 	volume: Signal<number>;
 	sampleRate: Signal<number | undefined>;
 	channelCount: Signal<number | undefined>;
+	bitrate: Signal<number | undefined>;
+	frameDuration: Signal<number | undefined>;
 
 	source: Signal<Source | undefined>;
 
@@ -63,9 +71,12 @@ export class Encoder {
 		this.volume = Signal.from(props?.volume ?? 1);
 		this.sampleRate = Signal.from<number | undefined>(props?.sampleRate);
 		this.channelCount = Signal.from<number | undefined>(props?.channelCount);
+		this.bitrate = Signal.from<number | undefined>(props?.bitrate);
+		this.frameDuration = Signal.from<number | undefined>(props?.frameDuration);
 
 		this.#signals.run(this.#runSource.bind(this));
 		this.#signals.run(this.#runGain.bind(this));
+		this.#signals.run(this.#runConfig.bind(this));
 		this.#signals.run(this.#runCatalog.bind(this));
 	}
 
@@ -152,12 +163,24 @@ export class Encoder {
 			codec: "opus",
 			sampleRate: Catalog.u53(worklet.context.sampleRate),
 			numberOfChannels: Catalog.u53(channelCount),
-			bitrate: Catalog.u53(channelCount * OPUS_BITRATE_PER_CHANNEL),
+			bitrate: Catalog.u53(this.bitrate.peek() ?? channelCount * OPUS_BITRATE_PER_CHANNEL),
 			container: { kind: "legacy" } as const,
-			// TODO parse the actual frame duration instead of assuming 20ms.
-			// Opus supports 2.5–60ms but 20ms is the real-time default.
-			jitter: Catalog.u53(OPUS_FRAME_DURATION),
+			// jitter doubles as the Opus frame duration; toEncoderConfig converts it to µs for WebCodecs.
+			jitter: Catalog.u53(this.frameDuration.peek() ?? OPUS_FRAME_DURATION_MS),
 		};
+	}
+
+	// Reconcile the encoder knobs (bitrate, frame duration) when they change, without waiting for a
+	// channel-count change. The equality guard stops this from looping on its own #config write.
+	#runConfig(effect: Effect): void {
+		const config = effect.get(this.#config);
+		if (!config) return;
+
+		const bitrate = Catalog.u53(effect.get(this.bitrate) ?? config.numberOfChannels * OPUS_BITRATE_PER_CHANNEL);
+		const jitter = Catalog.u53(effect.get(this.frameDuration) ?? OPUS_FRAME_DURATION_MS);
+		if (config.bitrate === bitrate && config.jitter === jitter) return;
+
+		this.#config.set({ ...config, bitrate, jitter });
 	}
 
 	#runGain(effect: Effect): void {
@@ -299,12 +322,22 @@ function toEncoderConfig(config: Catalog.AudioConfig, kind: Kind): AudioEncoderC
 		bitrate: config.bitrate,
 	};
 
-	if (config.codec === "opus" && kind !== "auto") {
-		const opus: OpusEncoderConfigExt = {
-			application: kind === "voice" ? "voip" : "audio",
-			signal: kind,
-		};
-		encoderConfig.opus = opus;
+	if (config.codec === "opus") {
+		const opus: OpusEncoderConfigExt = {};
+
+		if (kind !== "auto") {
+			opus.application = kind === "voice" ? "voip" : "audio";
+			opus.signal = kind;
+		}
+
+		// jitter carries the frame duration in ms; WebCodecs wants µs.
+		if (config.jitter !== undefined) {
+			opus.frameDuration = config.jitter * 1000;
+		}
+
+		if (Object.keys(opus).length > 0) {
+			encoderConfig.opus = opus;
+		}
 	}
 
 	return encoderConfig;

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -15,6 +15,27 @@ const OPUS_FRAME_DURATION_MS = 20;
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import CaptureWorklet from "./capture-worklet.ts?worklet";
 
+// Selects the audio codec and its encoder settings. Either the bare codec name (all defaults) or an
+// object with the name plus tuning knobs. Only Opus is implemented today; AAC would slot in as
+// `| AacConfig` here and as another branch in normalizeCodec/#createConfig.
+export type Codec = OpusConfig;
+
+export type OpusConfig = "opus" | OpusOptions;
+
+// Opus encoder settings. bitrate and frameDuration also shape the catalog (decoders need them); the
+// rest are encode-only knobs that map directly to the matching OpusEncoderConfig fields:
+// https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/configure#opus
+export type OpusOptions = {
+	name: "opus";
+
+	bitrate?: number; // bits/sec, defaults to channelCount * 32kbps
+	frameDuration?: number; // ms, Opus supports 2.5-60ms, defaults to 20ms (the real-time default)
+	complexity?: number; // 0-10, higher is better quality but more CPU
+	packetlossperc?: number; // 0-100, expected loss the encoder optimizes for
+	useinbandfec?: boolean; // in-band forward error correction
+	usedtx?: boolean; // discontinuous transmission (silence suppression)
+};
+
 // The initial values for our signals.
 export type EncoderProps = {
 	enabled?: boolean | Signal<boolean>;
@@ -25,19 +46,8 @@ export type EncoderProps = {
 	sampleRate?: number | Signal<number | undefined>;
 	channelCount?: number | Signal<number | undefined>;
 
-	// Opus bitrate in bits/sec. Defaults to channelCount * 32kbps when unset.
-	bitrate?: number | Signal<number | undefined>;
-
-	// Opus frame duration in milliseconds. Opus supports 2.5-60ms; defaults to 20ms (the real-time default).
-	frameDuration?: number | Signal<number | undefined>;
-
-	// Opus-only encoder knobs that don't affect decoding, so they're not in the catalog.
-	// They map directly to the matching OpusEncoderConfig fields:
-	// https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/configure#opus
-	complexity?: number | Signal<number | undefined>; // 0-10, higher is better quality but more CPU
-	packetlossperc?: number | Signal<number | undefined>; // 0-100, expected loss the encoder optimizes for
-	useinbandfec?: boolean | Signal<boolean | undefined>; // in-band forward error correction
-	usedtx?: boolean | Signal<boolean | undefined>; // discontinuous transmission (silence suppression)
+	// Codec selection plus encoder settings. Defaults to "opus".
+	codec?: Codec | Signal<Codec>;
 
 	container?: Catalog.Container;
 };
@@ -52,12 +62,7 @@ export class Encoder {
 	volume: Signal<number>;
 	sampleRate: Signal<number | undefined>;
 	channelCount: Signal<number | undefined>;
-	bitrate: Signal<number | undefined>;
-	frameDuration: Signal<number | undefined>;
-	complexity: Signal<number | undefined>;
-	packetlossperc: Signal<number | undefined>;
-	useinbandfec: Signal<boolean | undefined>;
-	usedtx: Signal<boolean | undefined>;
+	codec: Signal<Codec>;
 
 	source: Signal<Source | undefined>;
 
@@ -83,12 +88,7 @@ export class Encoder {
 		this.volume = Signal.from(props?.volume ?? 1);
 		this.sampleRate = Signal.from<number | undefined>(props?.sampleRate);
 		this.channelCount = Signal.from<number | undefined>(props?.channelCount);
-		this.bitrate = Signal.from<number | undefined>(props?.bitrate);
-		this.frameDuration = Signal.from<number | undefined>(props?.frameDuration);
-		this.complexity = Signal.from<number | undefined>(props?.complexity);
-		this.packetlossperc = Signal.from<number | undefined>(props?.packetlossperc);
-		this.useinbandfec = Signal.from<boolean | undefined>(props?.useinbandfec);
-		this.usedtx = Signal.from<boolean | undefined>(props?.usedtx);
+		this.codec = Signal.from<Codec>(props?.codec ?? "opus");
 
 		this.#signals.run(this.#runSource.bind(this));
 		this.#signals.run(this.#runGain.bind(this));
@@ -175,46 +175,43 @@ export class Encoder {
 	}
 
 	#createConfig(worklet: AudioWorkletNode, channelCount: number): Catalog.AudioConfig {
+		const opus = normalizeCodec(this.codec.peek());
 		return {
 			codec: "opus",
 			sampleRate: Catalog.u53(worklet.context.sampleRate),
 			numberOfChannels: Catalog.u53(channelCount),
-			bitrate: Catalog.u53(this.bitrate.peek() ?? channelCount * OPUS_BITRATE_PER_CHANNEL),
+			bitrate: Catalog.u53(opus.bitrate ?? channelCount * OPUS_BITRATE_PER_CHANNEL),
 			container: { kind: "legacy" } as const,
 			// jitter doubles as the Opus frame duration; toEncoderConfig converts it to µs for WebCodecs.
-			jitter: Catalog.u53(this.frameDuration.peek() ?? OPUS_FRAME_DURATION_MS),
+			jitter: Catalog.u53(opus.frameDuration ?? OPUS_FRAME_DURATION_MS),
 		};
 	}
 
-	// Reconcile the encoder knobs (bitrate, frame duration) when they change, without waiting for a
-	// channel-count change. The equality guard stops this from looping on its own #config write.
+	// Reconcile the catalog-shaping codec settings (bitrate, frame duration) when the codec changes,
+	// without waiting for a channel-count change. The equality guard stops this from looping on its
+	// own #config write.
 	#runConfig(effect: Effect): void {
 		const config = effect.get(this.#config);
 		if (!config) return;
 
-		const bitrate = Catalog.u53(effect.get(this.bitrate) ?? config.numberOfChannels * OPUS_BITRATE_PER_CHANNEL);
-		const jitter = Catalog.u53(effect.get(this.frameDuration) ?? OPUS_FRAME_DURATION_MS);
+		const opus = normalizeCodec(effect.get(this.codec));
+		const bitrate = Catalog.u53(opus.bitrate ?? config.numberOfChannels * OPUS_BITRATE_PER_CHANNEL);
+		const jitter = Catalog.u53(opus.frameDuration ?? OPUS_FRAME_DURATION_MS);
 		if (config.bitrate === bitrate && config.jitter === jitter) return;
 
 		this.#config.set({ ...config, bitrate, jitter });
 	}
 
-	// Collect the Opus encoder knobs that are set, reading them through the effect so the encoder
-	// reconfigures when any change. Undefined values are omitted so the browser keeps its defaults.
+	// Collect the encode-only Opus knobs that are set, reading the codec through the effect so the
+	// encoder reconfigures when it changes. Undefined values are omitted so the browser keeps its defaults.
 	#opusOptions(effect: Effect): OpusEncoderConfigExt {
+		const codec = normalizeCodec(effect.get(this.codec));
 		const opus: OpusEncoderConfigExt = {};
 
-		const complexity = effect.get(this.complexity);
-		if (complexity !== undefined) opus.complexity = complexity;
-
-		const packetlossperc = effect.get(this.packetlossperc);
-		if (packetlossperc !== undefined) opus.packetlossperc = packetlossperc;
-
-		const useinbandfec = effect.get(this.useinbandfec);
-		if (useinbandfec !== undefined) opus.useinbandfec = useinbandfec;
-
-		const usedtx = effect.get(this.usedtx);
-		if (usedtx !== undefined) opus.usedtx = usedtx;
+		if (codec.complexity !== undefined) opus.complexity = codec.complexity;
+		if (codec.packetlossperc !== undefined) opus.packetlossperc = codec.packetlossperc;
+		if (codec.useinbandfec !== undefined) opus.useinbandfec = codec.useinbandfec;
+		if (codec.usedtx !== undefined) opus.usedtx = codec.usedtx;
 
 		return opus;
 	}
@@ -339,6 +336,12 @@ function requestedChannelCount(track: MediaStreamTrack): number | undefined {
 	if (constraint === undefined) return undefined;
 	if (typeof constraint === "number") return constraint;
 	return constraint.exact ?? constraint.ideal ?? constraint.max ?? constraint.min;
+}
+
+// Resolve the bare "opus" shorthand to the full options object so callers can read fields uniformly.
+function normalizeCodec(codec: Codec): OpusOptions {
+	if (codec === "opus") return { name: "opus" };
+	return codec;
 }
 
 // `application` and `signal` are in the WebCodecs spec but missing from lib.dom.d.ts.

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -31,6 +31,14 @@ export type EncoderProps = {
 	// Opus frame duration in milliseconds. Opus supports 2.5-60ms; defaults to 20ms (the real-time default).
 	frameDuration?: number | Signal<number | undefined>;
 
+	// Opus-only encoder knobs that don't affect decoding, so they're not in the catalog.
+	// They map directly to the matching OpusEncoderConfig fields:
+	// https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/configure#opus
+	complexity?: number | Signal<number | undefined>; // 0-10, higher is better quality but more CPU
+	packetlossperc?: number | Signal<number | undefined>; // 0-100, expected loss the encoder optimizes for
+	useinbandfec?: boolean | Signal<boolean | undefined>; // in-band forward error correction
+	usedtx?: boolean | Signal<boolean | undefined>; // discontinuous transmission (silence suppression)
+
 	container?: Catalog.Container;
 };
 
@@ -46,6 +54,10 @@ export class Encoder {
 	channelCount: Signal<number | undefined>;
 	bitrate: Signal<number | undefined>;
 	frameDuration: Signal<number | undefined>;
+	complexity: Signal<number | undefined>;
+	packetlossperc: Signal<number | undefined>;
+	useinbandfec: Signal<boolean | undefined>;
+	usedtx: Signal<boolean | undefined>;
 
 	source: Signal<Source | undefined>;
 
@@ -73,6 +85,10 @@ export class Encoder {
 		this.channelCount = Signal.from<number | undefined>(props?.channelCount);
 		this.bitrate = Signal.from<number | undefined>(props?.bitrate);
 		this.frameDuration = Signal.from<number | undefined>(props?.frameDuration);
+		this.complexity = Signal.from<number | undefined>(props?.complexity);
+		this.packetlossperc = Signal.from<number | undefined>(props?.packetlossperc);
+		this.useinbandfec = Signal.from<boolean | undefined>(props?.useinbandfec);
+		this.usedtx = Signal.from<boolean | undefined>(props?.usedtx);
 
 		this.#signals.run(this.#runSource.bind(this));
 		this.#signals.run(this.#runGain.bind(this));
@@ -183,6 +199,26 @@ export class Encoder {
 		this.#config.set({ ...config, bitrate, jitter });
 	}
 
+	// Collect the Opus encoder knobs that are set, reading them through the effect so the encoder
+	// reconfigures when any change. Undefined values are omitted so the browser keeps its defaults.
+	#opusOptions(effect: Effect): OpusEncoderConfigExt {
+		const opus: OpusEncoderConfigExt = {};
+
+		const complexity = effect.get(this.complexity);
+		if (complexity !== undefined) opus.complexity = complexity;
+
+		const packetlossperc = effect.get(this.packetlossperc);
+		if (packetlossperc !== undefined) opus.packetlossperc = packetlossperc;
+
+		const useinbandfec = effect.get(this.useinbandfec);
+		if (useinbandfec !== undefined) opus.useinbandfec = useinbandfec;
+
+		const usedtx = effect.get(this.usedtx);
+		if (usedtx !== undefined) opus.usedtx = usedtx;
+
+		return opus;
+	}
+
 	#runGain(effect: Effect): void {
 		const gain = effect.get(this.#gain);
 		if (!gain) return;
@@ -235,7 +271,7 @@ export class Encoder {
 
 				const source = effect.get(this.source);
 				const kind: Kind = source ? normalizeSource(source).kind : "auto";
-				const encoderConfig = toEncoderConfig(config, kind);
+				const encoderConfig = toEncoderConfig(config, kind, this.#opusOptions(effect));
 
 				console.debug("encoding audio", encoderConfig);
 				encoder.configure(encoderConfig);
@@ -312,9 +348,9 @@ interface OpusEncoderConfigExt extends OpusEncoderConfig {
 	signal?: "auto" | "voice" | "music";
 }
 
-// Build the WebCodecs encoder config from the catalog (decoder) config plus a Kind hint.
-// Opus-only knobs are kept out of the catalog since they only affect encoding.
-function toEncoderConfig(config: Catalog.AudioConfig, kind: Kind): AudioEncoderConfig {
+// Build the WebCodecs encoder config from the catalog (decoder) config, a Kind hint, and any
+// Opus-only knobs. Those knobs are kept out of the catalog since they only affect encoding.
+function toEncoderConfig(config: Catalog.AudioConfig, kind: Kind, opusOptions: OpusEncoderConfigExt): AudioEncoderConfig {
 	const encoderConfig: AudioEncoderConfig = {
 		codec: config.codec,
 		sampleRate: config.sampleRate,
@@ -323,7 +359,7 @@ function toEncoderConfig(config: Catalog.AudioConfig, kind: Kind): AudioEncoderC
 	};
 
 	if (config.codec === "opus") {
-		const opus: OpusEncoderConfigExt = {};
+		const opus: OpusEncoderConfigExt = { ...opusOptions };
 
 		if (kind !== "auto") {
 			opus.application = kind === "voice" ? "voip" : "audio";

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -52,6 +52,10 @@ export type EncoderProps = {
 	container?: Catalog.Container;
 };
 
+// The audio format observed from the capture worklet: the AudioContext sample rate and the actual
+// channel count (which can differ from the requested count on some platforms, e.g. Safari/macOS).
+type Captured = { sampleRate: number; channelCount: number };
+
 export class Encoder {
 	static readonly TRACK = "audio/data";
 	static readonly PRIORITY = Catalog.PRIORITY.audio;
@@ -68,6 +72,10 @@ export class Encoder {
 
 	#catalog = new Signal<Catalog.Audio | undefined>(undefined);
 	readonly catalog: Getter<Catalog.Audio | undefined> = this.#catalog;
+
+	// Observed capture format. #config (and thus #catalog) is derived from this plus the codec, so the
+	// worklet handlers only ever write here, never read-modify-write #config.
+	#captured = new Signal<Captured | undefined>(undefined);
 
 	#config = new Signal<Catalog.AudioConfig | undefined>(undefined);
 	readonly config: Getter<Catalog.AudioConfig | undefined> = this.#config;
@@ -148,7 +156,7 @@ export class Encoder {
 			effect.set(this.#worklet, worklet);
 
 			// The information about channels count can be unreliable on different platforms (Apple's Safari).
-			// Try to get the first audio frame and only then create the configuration.
+			// Try to get the first audio frame and only then record the captured format.
 			effect.event(
 				worklet.port,
 				"message",
@@ -157,13 +165,13 @@ export class Encoder {
 					const channelCount = data.channels.length;
 					if (!channelCount) return;
 
-					this.#config.set(this.#createConfig(worklet, channelCount));
+					this.#captured.set({ sampleRate: worklet.context.sampleRate, channelCount });
 				},
 				{ once: true },
 			);
 			worklet.port.start();
 			effect.cleanup(() => {
-				this.#config.set(undefined);
+				this.#captured.set(undefined);
 			});
 
 			gain.connect(worklet);
@@ -174,32 +182,29 @@ export class Encoder {
 		});
 	}
 
-	#createConfig(worklet: AudioWorkletNode, channelCount: number): Catalog.AudioConfig {
-		const opus = normalizeCodec(this.codec.peek());
+	#createConfig(captured: Captured, opus: OpusConfig): Catalog.AudioConfig {
 		return {
 			codec: "opus",
-			sampleRate: Catalog.u53(worklet.context.sampleRate),
-			numberOfChannels: Catalog.u53(channelCount),
-			bitrate: Catalog.u53(opus.bitrate ?? channelCount * OPUS_BITRATE_PER_CHANNEL),
+			sampleRate: Catalog.u53(captured.sampleRate),
+			numberOfChannels: Catalog.u53(captured.channelCount),
+			bitrate: Catalog.u53(opus.bitrate ?? captured.channelCount * OPUS_BITRATE_PER_CHANNEL),
 			container: { kind: "legacy" } as const,
 			// jitter doubles as the Opus frame duration; toEncoderConfig converts it to µs for WebCodecs.
 			jitter: Catalog.u53(opus.frameDuration ?? OPUS_FRAME_DURATION_MS),
 		};
 	}
 
-	// Reconcile the catalog-shaping codec settings (bitrate, frame duration) when the codec changes,
-	// without waiting for a channel-count change. The equality guard stops this from looping on its
-	// own #config write.
+	// Derive #config from the captured format and the codec. Re-runs whenever either changes, so a
+	// codec update (bitrate, frame duration) reconfigures without waiting for a channel-count change.
 	#runConfig(effect: Effect): void {
-		const config = effect.get(this.#config);
-		if (!config) return;
+		const captured = effect.get(this.#captured);
+		if (!captured) {
+			effect.set(this.#config, undefined);
+			return;
+		}
 
 		const opus = normalizeCodec(effect.get(this.codec));
-		const bitrate = Catalog.u53(opus.bitrate ?? config.numberOfChannels * OPUS_BITRATE_PER_CHANNEL);
-		const jitter = Catalog.u53(opus.frameDuration ?? OPUS_FRAME_DURATION_MS);
-		if (config.bitrate === bitrate && config.jitter === jitter) return;
-
-		this.#config.set({ ...config, bitrate, jitter });
+		effect.set(this.#config, this.#createConfig(captured, opus));
 	}
 
 	// Collect the encode-only Opus knobs that are set, reading the codec through the effect so the
@@ -280,7 +285,7 @@ export class Encoder {
 				if (!channelCount) return;
 
 				if (!config || channelCount !== config.numberOfChannels) {
-					this.#config.set(this.#createConfig(worklet, channelCount));
+					this.#captured.set({ sampleRate: worklet.context.sampleRate, channelCount });
 					return;
 				}
 

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -353,7 +353,11 @@ interface OpusEncoderConfigExt extends OpusEncoderConfig {
 
 // Build the WebCodecs encoder config from the catalog (decoder) config, a Kind hint, and any
 // Opus-only knobs. Those knobs are kept out of the catalog since they only affect encoding.
-function toEncoderConfig(config: Catalog.AudioConfig, kind: Kind, opusOptions: OpusEncoderConfigExt): AudioEncoderConfig {
+function toEncoderConfig(
+	config: Catalog.AudioConfig,
+	kind: Kind,
+	opusOptions: OpusEncoderConfigExt,
+): AudioEncoderConfig {
 	const encoderConfig: AudioEncoderConfig = {
 		codec: config.codec,
 		sampleRate: config.sampleRate,

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -16,17 +16,17 @@ const OPUS_FRAME_DURATION_MS = 20;
 import CaptureWorklet from "./capture-worklet.ts?worklet";
 
 // Selects the audio codec and its encoder settings. Either the bare codec name (all defaults) or an
-// object with the name plus tuning knobs. Only Opus is implemented today; AAC would slot in as
-// `| AacConfig` here and as another branch in normalizeCodec/#createConfig.
-export type Codec = OpusConfig;
+// object with the mime plus tuning knobs. Only Opus is implemented today; AAC would slot in as
+// `| Aac` here and as another branch in normalizeCodec/#createConfig.
+export type Codec = Opus;
 
-export type OpusConfig = "opus" | OpusOptions;
+export type Opus = "opus" | OpusConfig;
 
 // Opus encoder settings. bitrate and frameDuration also shape the catalog (decoders need them); the
 // rest are encode-only knobs that map directly to the matching OpusEncoderConfig fields:
 // https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/configure#opus
-export type OpusOptions = {
-	name: "opus";
+export type OpusConfig = {
+	mime: "opus";
 
 	bitrate?: number; // bits/sec, defaults to channelCount * 32kbps
 	frameDuration?: number; // ms, Opus supports 2.5-60ms, defaults to 20ms (the real-time default)
@@ -338,9 +338,9 @@ function requestedChannelCount(track: MediaStreamTrack): number | undefined {
 	return constraint.exact ?? constraint.ideal ?? constraint.max ?? constraint.min;
 }
 
-// Resolve the bare "opus" shorthand to the full options object so callers can read fields uniformly.
-function normalizeCodec(codec: Codec): OpusOptions {
-	if (codec === "opus") return { name: "opus" };
+// Resolve the bare "opus" shorthand to the full config object so callers can read fields uniformly.
+function normalizeCodec(codec: Codec): OpusConfig {
+	if (codec === "opus") return { mime: "opus" };
 	return codec;
 }
 


### PR DESCRIPTION
## Summary

The audio encoder ([`js/publish/src/audio/encoder.ts`](js/publish/src/audio/encoder.ts)) hardcoded its Opus settings: bitrate (`channelCount * 32kbps`) and frame duration (20ms), with no way to tune the rest of the Opus knobs. Worse, the frame duration only fed the catalog `jitter` field. It was never set on the actual WebCodecs `AudioEncoderConfig`, so the encoder always used its default.

This PR makes the encoder settings configurable through a single, codec-specific `codec` prop on `Audio.EncoderProps`, stored as a signal so callers can change it at runtime (e.g. `broadcast.audio.codec.set(...)`).

## API shape

```ts
type Codec = OpusConfig; // future: | AacConfig

type OpusConfig = "opus" | OpusOptions;

type OpusOptions = {
  name: "opus";
  bitrate?: number;        // bits/sec, default channelCount * 32kbps
  frameDuration?: number;  // ms (2.5-60), default 20
  complexity?: number;     // 0-10
  packetlossperc?: number; // 0-100
  useinbandfec?: boolean;  // in-band FEC
  usedtx?: boolean;        // discontinuous transmission
};
```

`codec` defaults to `"opus"`. Pass the bare string for all defaults, or an object to tune. Grouping the settings under `codec` keeps codec-specific tuning in one place and gives a clean extension point: AAC slots in as `| AacConfig` on the union plus a branch in `normalizeCodec`/`#createConfig`, instead of piling loosely-related knobs onto `EncoderProps`.

## Behavior

- **Catalog-shaping settings** (`bitrate`, `frameDuration`) flow through `#config`/`#createConfig` so decoders see them. `frameDuration` is converted to µs and set on `opus.frameDuration` in `toEncoderConfig` (previously it only affected catalog `jitter`, never the encoder), and is still reflected in catalog `jitter`.
- **Encode-only knobs** (`complexity`, `packetlossperc`, `useinbandfec`, `usedtx`) map directly to [`OpusEncoderConfig`](https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/configure#opus) and stay out of the catalog (they don't affect decoding). Collected by `#opusOptions`, omitting unset values so the browser keeps its defaults.
- A single `#runConfig` effect reconciles the catalog-shaping settings into `#config` when `codec` changes, with an equality guard so it can't loop on its own write. Both `#runConfig` and the `serve` reconfigure effect read the `codec` signal, so any runtime change reconfigures the encoder.
- Renamed `OPUS_FRAME_DURATION` → `OPUS_FRAME_DURATION_MS` to make the unit explicit.

## Deliberately not exposed

- **`format`** — the MoQ container relies on raw `"opus"` packets; `"ogg"` would break it.
- **`application` / `signal`** — already driven by the source `kind` (voice→voip/voice, other→audio/music).

The active `lib.dom.d.ts` already types `complexity`/`packetlossperc`/`useinbandfec`/`usedtx`/`frameDuration`/`format`; only `application`/`signal` are missing, which is why `OpusEncoderConfigExt` exists.

## Notes for reviewers

- The original task referenced `publish/src/main.ts` and a UI note about a fixed bitrate, but neither exists in the current tree. This PR is the encoder-side support only; UI controls can be wired to `broadcast.audio.codec` in a follow-up.
- Cross-Package Sync: a `js/publish` API addition with no Rust/`hang` counterpart, so no paired updates required.

## Test plan

- [x] `tsc --noEmit` passes (no encoder-related type errors)
- [x] `biome check` clean
- [ ] Manual: publish audio with `codec: { name: "opus", bitrate, frameDuration, complexity, useinbandfec, usedtx }` and confirm the encoder reconfigures and catalog jitter reflects the frame duration

(Written by Claude)