### PR TITLE
build(deps): bump @types/web from 0.0.241 to 0.0.350

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,7 +92,7 @@
       "devDependencies": {
         "@types/audioworklet": "^0.0.100",
         "@types/bun": "^1.3.14",
-        "@typescript/lib-dom": "npm:@types/web@^0.0.241",
+        "@typescript/lib-dom": "npm:@types/web@^0.0.350",
         "fast-glob": "^3.3.3",
         "rimraf": "^6.1.3",
         "typescript": "^6.0.3",
@@ -168,7 +168,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@types/node": "^25.9.1",
-        "@typescript/lib-dom": "npm:@types/web@^0.0.241",
+        "@typescript/lib-dom": "npm:@types/web@^0.0.350",
         "rimraf": "^6.1.3",
         "typescript": "^6.0.3",
         "vite-plugin-html": "^3.2.2",
@@ -188,7 +188,7 @@
       },
       "devDependencies": {
         "@types/audioworklet": "^0.0.100",
-        "@typescript/lib-dom": "npm:@types/web@^0.0.241",
+        "@typescript/lib-dom": "npm:@types/web@^0.0.350",
         "esbuild": "^0.28.0",
         "rimraf": "^6.1.3",
         "typescript": "^6.0.3",
@@ -248,7 +248,7 @@
       "devDependencies": {
         "@types/audioworklet": "^0.0.100",
         "@types/bun": "^1.3.14",
-        "@typescript/lib-dom": "npm:@types/web@^0.0.241",
+        "@typescript/lib-dom": "npm:@types/web@^0.0.350",
         "esbuild": "^0.28.0",
         "rimraf": "^6.1.3",
         "typescript": "^6.0.3",
@@ -760,7 +760,7 @@
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
 
-    "@typescript/lib-dom": ["@types/web@0.0.241", "", {}, "sha512-aHz73musjS4z8Sm0wLaEj4lOaRxhKZRD4XerKL4rxNhhqmvthKkYzS0kHLEVsjOFRN2zo3gQAlyf0EKL1QYYQg=="],
+    "@typescript/lib-dom": ["@types/web@0.0.350", "", {}, "sha512-XFISASo1wPsKKtI5v1nJ51YuZYkjUE9kduDFpfHCOKEMbHtRLHX0k3V3bpBeQx2L1VvcxTIECHvC3r3Rfmu0YA=="],
 
     "@ungap/global-this": ["@ungap/global-this@0.4.4", "", {}, "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA=="],
 

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -29,7 +29,7 @@
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.100",
 		"@types/bun": "^1.3.14",
-		"@typescript/lib-dom": "npm:@types/web@^0.0.241",
+		"@typescript/lib-dom": "npm:@types/web@^0.0.350",
 		"fast-glob": "^3.3.3",
 		"rimraf": "^6.1.3",
 		"typescript": "^6.0.3"

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -27,7 +27,7 @@
 	"devDependencies": {
 		"@types/bun": "^1.3.14",
 		"@types/node": "^25.9.1",
-		"@typescript/lib-dom": "npm:@types/web@^0.0.241",
+		"@typescript/lib-dom": "npm:@types/web@^0.0.350",
 		"rimraf": "^6.1.3",
 		"typescript": "^6.0.3",
 		"vite-plugin-html": "^3.2.2"

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -30,7 +30,7 @@
 	},
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.100",
-		"@typescript/lib-dom": "npm:@types/web@^0.0.241",
+		"@typescript/lib-dom": "npm:@types/web@^0.0.350",
 		"esbuild": "^0.28.0",
 		"rimraf": "^6.1.3",
 		"typescript": "^6.0.3",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@types/audioworklet": "^0.0.100",
 		"@types/bun": "^1.3.14",
-		"@typescript/lib-dom": "npm:@types/web@^0.0.241",
+		"@typescript/lib-dom": "npm:@types/web@^0.0.350",
 		"esbuild": "^0.28.0",
 		"rimraf": "^6.1.3",
 		"typescript": "^6.0.3",


### PR DESCRIPTION
## Summary

Bumps `@types/web` (aliased as `@typescript/lib-dom`) from `^0.0.241` to `^0.0.350`, the latest release, across the four JS packages that consume it:

- `js/net`
- `js/hang`
- `js/watch`
- `js/publish`

These provide the DOM type definitions used in place of TypeScript's bundled `lib.dom`. Keeping them current picks up newer Web Platform API typings.

## Test plan

- [x] `bun install` updates the lockfile cleanly
- [x] `tsc` typechecks pass for all four packages (`@moq/net`, `@moq/hang`, `@moq/watch`, `@moq/publish`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)