### PR TITLE
ci: run cargo-semver-checks on PRs targeting main

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,48 @@
+name: Semver
+
+permissions:
+  id-token: write
+  contents: read
+
+# Informational only: cargo-semver-checks flags accidental breaking changes
+# against the crates.io baseline. Scoped to PRs targeting main, since wire and
+# API breakage lands on dev where bumps are expected. This is not a required
+# check; a red result is a heads-up to bump the version, not a merge blocker.
+on:
+  pull_request:
+    branches: [main]
+
+# Cancel in-flight runs when a new commit lands on the same PR.
+concurrency:
+  group: semver-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semver:
+    name: Semver
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+        with:
+          tool-cache: false
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        with:
+          determinate: false
+      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
+      - uses: DeterminateSystems/flake-checker-action@89c01715e5d0dfdc0a1bfe9d59891ee4945c1483 # main
+
+      # Cache Rust dependencies and build artifacts
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - run: nix develop --command just rs semver


### PR DESCRIPTION
## Summary

Adds a new `Semver` GitHub Actions workflow (`.github/workflows/semver.yml`) that runs `cargo-semver-checks` against the crates.io baseline on every PR whose base branch is `main`.

- Triggers only on `pull_request` with `branches: [main]`. Wire/API breakage lands on `dev` where version bumps are expected, so there's no value running it there.
- Reuses the existing `just rs semver` recipe (`cargo semver-checks check-release` over the workspace default-members) inside the Nix dev shell, matching how `check.yml` runs.
- **Not required to merge.** The workflow is intentionally left out of branch protection's required checks, so a flagged breaking change shows up as a heads-up to bump the crate version rather than blocking the PR. If you ever want it to gate merges, add the `Semver` check to the branch protection rules for `main`.

`cargo-semver-checks` is already available in the flake dev shell and via `just install`, so no tooling changes were needed.

## Test plan

- [x] `python3` YAML parse of the new workflow succeeds.
- [ ] First PR run against `main` confirms the job executes (actionlint wasn't available locally in this environment to lint the YAML; CI's own `Check` job runs `actionlint` and will catch any issue).

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgfbHwF9onATeSPWvbHusa)_