### PR TITLE
fix(moq-relay): fail closed when mTLS alias resolution hits an API error

### DIFF
--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -167,7 +167,7 @@ This lets a project stay reachable by both its stable id and its current/old van
 auth_api = "https://api.moq.dev/cluster/auth"
 ```
 
-Unlike the standalone flags, the unified call **fails closed**: any network error, non-2xx status, or unparseable response rejects the connection. The verifying key itself comes from this call, so there is no safe fallback; the endpoint's `Cache-Control` softens transient failures. A root connection (`/`, e.g. a cluster peer) has no project segment, so mTLS peers skip the call entirely.
+Unlike the standalone flags, the unified call **fails closed**: any network error, non-2xx status, or unparseable response rejects the connection. The verifying key itself comes from this call, so there is no safe fallback; the endpoint's `Cache-Control` softens transient failures. This applies to mTLS peers as well, including root (`/`) connections such as cluster peers: when an auth API is configured it is the source of truth for every connection (so it can alias and tier the root too), and a failed lookup rejects the connection so the peer reconnects and self-heals once the API recovers. The only fail-open case is when **no** auth API is configured, where the client certificate is the sole credential and the path is used unchanged.
 
 ## Supported Algorithms
 

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -123,6 +123,9 @@ pub enum AuthError {
 	#[error("auth API request failed: {0}")]
 	ApiUnavailable(#[from] reqwest_middleware::Error),
 
+	#[error("auth API response was invalid: {0}")]
+	ApiInvalidResponse(#[from] serde_json::Error),
+
 	#[error("invalid URL: {0}")]
 	InvalidUrl(#[from] url::ParseError),
 
@@ -144,7 +147,7 @@ impl From<&AuthError> for http::StatusCode {
 		match err {
 			// Upstream auth API unreachable or misconfigured — this is a server-side
 			// problem, not a credential problem.
-			AuthError::ApiUnavailable(_) => http::StatusCode::BAD_GATEWAY,
+			AuthError::ApiUnavailable(_) | AuthError::ApiInvalidResponse(_) => http::StatusCode::BAD_GATEWAY,
 			AuthError::InvalidUrl(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
 			_ => http::StatusCode::UNAUTHORIZED,
 		}
@@ -865,7 +868,7 @@ impl Auth {
 	) -> Result<AuthApiResponse, AuthError> {
 		let url = Self::auth_api_url(base, path, kid, mtls);
 		let body = client.get(url).send().await?.error_for_status()?.text().await?;
-		serde_json::from_str(&body).map_err(|_| AuthError::DecodeFailed)
+		serde_json::from_str(&body).map_err(AuthError::from)
 	}
 
 	/// Verify a connection via the unified `--auth-api`: one call returns the
@@ -918,7 +921,7 @@ impl Auth {
 
 	async fn fetch_public_response(client: &ClientWithMiddleware, url: &url::Url) -> Result<PublicResponse, AuthError> {
 		let body = client.get(url.clone()).send().await?.error_for_status()?.text().await?;
-		serde_json::from_str(&body).map_err(|_| AuthError::DecodeFailed)
+		serde_json::from_str(&body).map_err(AuthError::from)
 	}
 
 	/// Parse the token from the user provided URL, returning the claims if successful.
@@ -2439,7 +2442,9 @@ api = "https://api.example.com/access"
 	}
 
 	#[tokio::test]
-	async fn test_public_api_invalid_json_returns_decode_failed() -> anyhow::Result<()> {
+	async fn test_public_api_invalid_json_returns_invalid_response() -> anyhow::Result<()> {
+		// Malformed upstream JSON is an upstream failure (502), not a bad-credential
+		// (401): the auth API answered, but with garbage.
 		let server = MockServer::start().await;
 		Mock::given(method("GET"))
 			.respond_with(ResponseTemplate::new(200).set_body_string("not json"))
@@ -2448,7 +2453,11 @@ api = "https://api.example.com/access"
 
 		let auth = auth_with_public_api(&server, &[], &[]).await;
 		let result = auth.verify(&AuthParams::new("/demo")).await;
-		assert!(matches!(result, Err(AuthError::DecodeFailed)));
+		assert!(matches!(result, Err(AuthError::ApiInvalidResponse(_))));
+		assert_eq!(
+			http::StatusCode::from(result.unwrap_err()),
+			http::StatusCode::BAD_GATEWAY
+		);
 		Ok(())
 	}
 
@@ -2971,7 +2980,10 @@ api = "https://api.example.com/access"
 			.await;
 
 		let auth = auth_with_api(&server).await;
-		assert_eq!(auth.resolve_mtls("/demo/room").await?, ("x7k2qp/room".to_string(), true));
+		assert_eq!(
+			auth.resolve_mtls("/demo/room").await?,
+			("x7k2qp/room".to_string(), true)
+		);
 		Ok(())
 	}
 
@@ -3023,6 +3035,26 @@ api = "https://api.example.com/access"
 		let auth = auth_with_api(&server).await;
 		let err = auth.resolve_mtls("/demo").await.unwrap_err();
 		assert!(matches!(err, AuthError::ApiUnavailable(_)));
+		assert_eq!(http::StatusCode::from(err), http::StatusCode::BAD_GATEWAY);
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn auth_api_mtls_fails_closed_on_invalid_json() -> anyhow::Result<()> {
+		// A 2xx with an unparseable body is still an upstream failure: classify it
+		// as 502 (not a credential 401) so the mTLS peer reconnects and self-heals.
+		let server = MockServer::start().await;
+		Mock::given(method("GET"))
+			.and(path_matcher("/auth"))
+			.and(query_param("root", "demo"))
+			.respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+			.mount(&server)
+			.await;
+
+		let auth = auth_with_api(&server).await;
+		let err = auth.resolve_mtls("/demo").await.unwrap_err();
+		assert!(matches!(err, AuthError::ApiInvalidResponse(_)));
+		assert_eq!(http::StatusCode::from(err), http::StatusCode::BAD_GATEWAY);
 		Ok(())
 	}
 

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -807,29 +807,31 @@ impl Auth {
 
 	/// Resolve the canonical root and billing tier for an mTLS peer via the
 	/// unified `--auth-api`. mTLS peers are already trusted (the cert is the
-	/// credential), so this only fetches the alias + tier and FAILS OPEN: with no
-	/// auth API, a root (`/`) connection, or any error, the path is used unchanged
-	/// and the tier defaults to internal (trusted peer).
-	pub(crate) async fn resolve_mtls(&self, path: &str) -> (String, bool) {
+	/// credential), so this only fetches the alias + tier.
+	///
+	/// Fails OPEN only when there is nothing to resolve: no auth API configured,
+	/// or a root (`/`) connection. A non-root path needs an alias, so an actual
+	/// API error FAILS CLOSED (returns `Err`) rather than accepting the
+	/// connection with the path unresolved. Accepting it would route the
+	/// broadcast to the literal vanity path (e.g. `demo`) instead of its canonical
+	/// root (e.g. `x7k2qp`), producing a zombie session: the publisher believes it
+	/// is connected and never reconnects, but nothing is ever served. Failing
+	/// closed lets the client retry and self-heal once the API recovers.
+	pub(crate) async fn resolve_mtls(&self, path: &str) -> Result<(String, bool), AuthError> {
 		let Some((base, client)) = &self.auth_api else {
-			return (path.to_string(), true);
+			return Ok((path.to_string(), true));
 		};
 
 		// Root connection ("/" or ""): nothing to resolve, skip the call.
 		if path.trim_matches('/').is_empty() {
-			return (path.to_string(), true);
+			return Ok((path.to_string(), true));
 		}
 
-		match Self::fetch_auth_api(client, base, path, None, true).await {
-			Ok(resp) => (
-				resp.alias.unwrap_or_else(|| path.to_string()),
-				resp.internal.unwrap_or(true),
-			),
-			Err(err) => {
-				tracing::warn!(%err, %path, "auth-api mTLS resolution failed; using path unchanged, internal tier");
-				(path.to_string(), true)
-			}
-		}
+		let resp = Self::fetch_auth_api(client, base, path, None, true).await?;
+		Ok((
+			resp.alias.unwrap_or_else(|| path.to_string()),
+			resp.internal.unwrap_or(true),
+		))
 	}
 
 	/// Build the unified auth-API request URL. The connection path (`root`), the
@@ -2969,7 +2971,7 @@ api = "https://api.example.com/access"
 			.await;
 
 		let auth = auth_with_api(&server).await;
-		assert_eq!(auth.resolve_mtls("/demo/room").await, ("x7k2qp/room".to_string(), true));
+		assert_eq!(auth.resolve_mtls("/demo/room").await?, ("x7k2qp/room".to_string(), true));
 		Ok(())
 	}
 
@@ -2985,7 +2987,7 @@ api = "https://api.example.com/access"
 			.await;
 
 		let auth = auth_with_api(&server).await;
-		assert_eq!(auth.resolve_mtls("/demo").await, ("x7k2qp".to_string(), false));
+		assert_eq!(auth.resolve_mtls("/demo").await?, ("x7k2qp".to_string(), false));
 		Ok(())
 	}
 
@@ -3001,7 +3003,26 @@ api = "https://api.example.com/access"
 			.await;
 
 		let auth = auth_with_api(&server).await;
-		assert_eq!(auth.resolve_mtls("/").await, ("/".to_string(), true));
+		assert_eq!(auth.resolve_mtls("/").await?, ("/".to_string(), true));
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn auth_api_mtls_fails_closed_on_api_error() -> anyhow::Result<()> {
+		// A non-root mTLS path needs an alias. If the API can't answer, reject the
+		// connection instead of accepting it with the path unresolved (which would
+		// route the broadcast to the literal vanity path and strand the publisher).
+		let server = MockServer::start().await;
+		Mock::given(method("GET"))
+			.and(path_matcher("/auth"))
+			.and(query_param("root", "demo"))
+			.respond_with(ResponseTemplate::new(404))
+			.mount(&server)
+			.await;
+
+		let auth = auth_with_api(&server).await;
+		let err = auth.resolve_mtls("/demo").await.unwrap_err();
+		assert!(matches!(err, AuthError::ApiUnavailable(_)));
 		Ok(())
 	}
 

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -568,10 +568,11 @@ impl AuthToken {
 	/// (verified against the configured CA) is the only credential we require;
 	/// nothing else in the cert is inspected.
 	///
-	/// `root` is taken from the connection URL path, the same scoping a JWT
-	/// gets. An mTLS publisher dialing `/demo` therefore announces under
-	/// `demo/`, not the cluster root. Cluster peers dial `/`, so they resolve
-	/// to an empty root and keep unscoped access.
+	/// `root` is the API-resolved canonical root for the connection URL path, the
+	/// same scoping a JWT gets. An mTLS publisher dialing `/demo` therefore
+	/// announces under its canonical root, not the cluster root. Cluster peers
+	/// dial `/`, which typically resolves to an empty root and keeps unscoped
+	/// access.
 	pub fn unrestricted(root: PathOwned) -> Self {
 		Self {
 			root,
@@ -812,23 +813,20 @@ impl Auth {
 	/// unified `--auth-api`. mTLS peers are already trusted (the cert is the
 	/// credential), so this only fetches the alias + tier.
 	///
-	/// Fails OPEN only when there is nothing to resolve: no auth API configured,
-	/// or a root (`/`) connection. A non-root path needs an alias, so an actual
-	/// API error FAILS CLOSED (returns `Err`) rather than accepting the
-	/// connection with the path unresolved. Accepting it would route the
-	/// broadcast to the literal vanity path (e.g. `demo`) instead of its canonical
-	/// root (e.g. `x7k2qp`), producing a zombie session: the publisher believes it
-	/// is connected and never reconnects, but nothing is ever served. Failing
-	/// closed lets the client retry and self-heal once the API recovers.
+	/// Fails OPEN only when there is no auth API configured: the cert is the
+	/// credential and there is nothing to resolve, so the path is used unchanged
+	/// at the internal tier. Otherwise the API is the source of truth for every
+	/// connection, including the root (`/`), so it can alias and tier root peers
+	/// too. An API error therefore FAILS CLOSED (returns `Err`) rather than
+	/// accepting the connection with the path unresolved. Accepting it would route
+	/// the broadcast to the literal vanity path (e.g. `demo`) instead of its
+	/// canonical root (e.g. `x7k2qp`), producing a zombie session: the publisher
+	/// believes it is connected and never reconnects, but nothing is ever served.
+	/// Failing closed lets the client retry and self-heal once the API recovers.
 	pub(crate) async fn resolve_mtls(&self, path: &str) -> Result<(String, bool), AuthError> {
 		let Some((base, client)) = &self.auth_api else {
 			return Ok((path.to_string(), true));
 		};
-
-		// Root connection ("/" or ""): nothing to resolve, skip the call.
-		if path.trim_matches('/').is_empty() {
-			return Ok((path.to_string(), true));
-		}
 
 		let resp = Self::fetch_auth_api(client, base, path, None, true).await?;
 		Ok((
@@ -3004,17 +3002,33 @@ api = "https://api.example.com/access"
 	}
 
 	#[tokio::test]
-	async fn auth_api_mtls_skips_api_for_root() -> anyhow::Result<()> {
-		// A root connection ("/") has no project segment, so cluster peers don't
-		// hit the API at all; they stay internal.
+	async fn auth_api_mtls_resolves_root_via_api() -> anyhow::Result<()> {
+		// Root connections go through the API too, so it owns the alias + tier for
+		// every mTLS peer. Here the API aliases the root and demotes it to external.
 		let server = MockServer::start().await;
 		Mock::given(method("GET"))
-			.respond_with(ResponseTemplate::new(500))
-			.expect(0)
+			.and(path_matcher("/auth"))
+			.and(query_param("root", ""))
+			.respond_with(ResponseTemplate::new(200).set_body_string(r#"{"alias":"x7k2qp","internal":false}"#))
 			.mount(&server)
 			.await;
 
 		let auth = auth_with_api(&server).await;
+		assert_eq!(auth.resolve_mtls("/").await?, ("x7k2qp".to_string(), false));
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn auth_api_mtls_no_api_fails_open() -> anyhow::Result<()> {
+		// With no auth API configured the cert is the only credential: use the path
+		// unchanged at the internal tier. This is the sole fail-open case. (A public
+		// path just makes the config valid; mTLS resolution ignores it.)
+		let auth = Auth::new(AuthConfig {
+			public: simple_public("anon"),
+			..Default::default()
+		})
+		.await?;
+		assert_eq!(auth.resolve_mtls("/demo").await?, ("/demo".to_string(), true));
 		assert_eq!(auth.resolve_mtls("/").await?, ("/".to_string(), true));
 		Ok(())
 	}

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -121,8 +121,8 @@ impl Connection {
 			tracing::debug!("mTLS peer authenticated");
 			// Scope the grant to the canonical root. An mTLS publisher dialing a
 			// vanity alias lands on the same tree a JWT would; cluster peers dial
-			// "/", which resolves to an empty (unscoped) root. The API also returns
-			// the billing tier (defaulting to internal for trusted peers).
+			// "/", which the API resolves (typically to an unscoped root). The API
+			// also returns the billing tier (defaulting to internal for trusted peers).
 			let (root, internal) = self.auth.resolve_mtls(&params.path).await?;
 			let mut token = AuthToken::unrestricted(Path::new(&root).to_owned());
 			token.internal = internal;

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -123,7 +123,7 @@ impl Connection {
 			// vanity alias lands on the same tree a JWT would; cluster peers dial
 			// "/", which resolves to an empty (unscoped) root. The API also returns
 			// the billing tier (defaulting to internal for trusted peers).
-			let (root, internal) = self.auth.resolve_mtls(&params.path).await;
+			let (root, internal) = self.auth.resolve_mtls(&params.path).await?;
 			let mut token = AuthToken::unrestricted(Path::new(&root).to_owned());
 			token.internal = internal;
 			return Ok(token);

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -501,7 +501,7 @@ async fn serve_announced(
 	};
 	let token = if mtls.is_some() {
 		// mTLS peers: the API returns the canonical root and the billing tier.
-		let (root, internal) = state.auth.resolve_mtls(&params.path).await;
+		let (root, internal) = state.auth.resolve_mtls(&params.path).await?;
 		let mut token = AuthToken::unrestricted(moq_net::Path::new(&root).to_owned());
 		token.internal = internal;
 		token
@@ -545,7 +545,7 @@ async fn serve_fetch(
 	};
 	let token = if mtls.is_some() {
 		// mTLS peers: the API returns the canonical root and the billing tier.
-		let (root, internal) = state.auth.resolve_mtls(&auth.path).await;
+		let (root, internal) = state.auth.resolve_mtls(&auth.path).await?;
 		let mut token = AuthToken::unrestricted(moq_net::Path::new(&root).to_owned());
 		token.internal = internal;
 		token

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -41,7 +41,7 @@ pub(crate) async fn serve_ws(
 	let params = AuthParams { path, jwt: query.jwt };
 	let token = if mtls.is_some() {
 		// mTLS peers: the API returns the canonical root and the billing tier.
-		let (root, internal) = state.auth.resolve_mtls(&params.path).await;
+		let (root, internal) = state.auth.resolve_mtls(&params.path).await?;
 		let mut token = AuthToken::unrestricted(moq_net::Path::new(&root).to_owned());
 		token.internal = internal;
 		token


### PR DESCRIPTION
## Summary

An mTLS peer dialing a vanity URL (e.g. `demo`, aliased to canonical root `x7k2qp`) could get stuck in a zombie session when the auth API was briefly unreachable.

`resolve_mtls` silently **failed open** on any auth-API error: it accepted the session but with the vanity path *unresolved*, so the broadcast routed to the literal `demo` tree instead of `x7k2qp`. The publisher believed it was connected and never reconnected, but nothing was ever served. It was the worst of both worlds, neither a true fail-open (full grant from the trusted cert) nor a fail-closed (drop so the client retries).

This makes the auth API the source of truth for **every** mTLS connection and **fails closed** on error: an API error returns `Err` (mapped to `502 BAD_GATEWAY`), so the client reconnects and self-heals once the API recovers. The **only** fail-open case is when no auth API is configured at all.

## What changed

- `resolve_mtls` now returns `Result<(String, bool), AuthError>` instead of swallowing errors into a path-unchanged tuple (`rs/moq-relay/src/auth.rs`).
- The four call sites (`connection.rs`, `websocket.rs`, two in `web.rs`) propagate with `?`; the error maps to a status the same way the JWT path already does.
- **Root connections now consult the API too.** Previously `/` short-circuited and skipped the API; that made "skip the API" a second fail-open path and left the API unable to alias/tier root peers (e.g. cluster relays). Now the only fail-open case is **no auth API configured** (cert is the sole credential, path used unchanged at the internal tier). With an API configured, root goes through it like any other connection and fails closed on error. Deployments that want cluster peers to stay unscoped simply return no alias for the empty root.
- **Error classification** (from review feedback): `DecodeFailed` was overloaded, covering both client JWT/JWK decode errors (genuinely `401`) *and* unparseable auth-API response bodies. A malformed upstream `/auth` body would therefore surface as a client-credential `401` instead of `502`, diverging from how network and 5xx failures are reported. Split out `AuthError::ApiInvalidResponse` (`#[from] serde_json::Error`) for the auth-API JSON parse failures in `fetch_auth_api` and `fetch_public_response`, mapped to `502 BAD_GATEWAY` alongside `ApiUnavailable`. The JWT/JWK decode sites keep `DecodeFailed` → `401`.

## Why this is correct

This brings the code in line with what `doc/bin/relay/auth.md` already documented: *"the unified call fails closed: any network error, non-2xx status, or unparseable response rejects the connection."* The mTLS resolution path was the one place silently violating that contract. The doc is updated to reflect that root connections are no longer a skip-the-call exception.

## Test plan

- [x] `auth_api_mtls_resolves_root_via_api` — root (`/`) now hits the API; alias + tier applied.
- [x] `auth_api_mtls_no_api_fails_open` — no auth API → path unchanged, internal tier (the sole fail-open case).
- [x] `auth_api_mtls_fails_closed_on_api_error` — 404 → `Err(ApiUnavailable)`, asserts `502`.
- [x] `auth_api_mtls_fails_closed_on_invalid_json` — 2xx + garbage body → `Err(ApiInvalidResponse)`, asserts `502`.
- [x] Updated `test_public_api_invalid_json_returns_invalid_response` to expect `ApiInvalidResponse`/`502`.
- [x] Updated the existing `resolve_mtls` tests to unwrap the new `Result`.
- [x] `cargo test -p moq-relay --lib auth::` — 86 passed.
- [x] `cargo clippy -p moq-relay --all-targets` clean (via nix), `cargo fmt` no changes.

(Written by Claude)