### PR TITLE
feat(watch): keep hidden canvas video subscribed

### DIFF
--- a/demo/web/src/index.html
+++ b/demo/web/src/index.html
@@ -24,7 +24,7 @@
 				- `name`: The broadcast name, otherwise we use the last part of the URL.
 				- `paused`: Video and audio are paused.
 				- `muted`: Audio is muted.
-				- `no-suspend-when-hidden`: Keep canvas video active when the tab is hidden.
+				- `background-playback`: Keep canvas video active when the tab is hidden.
 				- `volume`: The audio volume (0-1).
 				- `latency`: The target jitter buffer size in milliseconds, or "real-time" to use the RTT.
 				- `reload`: Whether to automatically reconnect when the broadcast goes offline/online.
@@ -82,7 +82,7 @@
 		Don't want video? Don't provide a canvas!
 		It won't be downloaded, decoded, or rendered.
 		This includes when the video is paused, minimized, not in the DOM, scrolled out of view, or in a hidden tab.
-		Add <code>no-suspend-when-hidden</code> if you need canvas video to keep downloading while the tab is hidden.
+		Add <code>background-playback</code> if you need canvas video to keep downloading while the tab is hidden.
 	</p>
 	<p>
 		Audio may start muted because the browser can require user interaction before autoplaying.

--- a/demo/web/src/index.html
+++ b/demo/web/src/index.html
@@ -24,6 +24,7 @@
 				- `name`: The broadcast name, otherwise we use the last part of the URL.
 				- `paused`: Video and audio are paused.
 				- `muted`: Audio is muted.
+				- `no-suspend-when-hidden`: Keep canvas video active when the tab is hidden.
 				- `volume`: The audio volume (0-1).
 				- `latency`: The target jitter buffer size in milliseconds, or "real-time" to use the RTT.
 				- `reload`: Whether to automatically reconnect when the broadcast goes offline/online.
@@ -80,8 +81,8 @@
 	<p>
 		Don't want video? Don't provide a canvas!
 		It won't be downloaded, decoded, or rendered.
-		This includes when the video is paused, minimized, not in the DOM, or scrolled out of view.
-		wowee the bandwidth savings!
+		This includes when the video is paused, minimized, not in the DOM, scrolled out of view, or in a hidden tab.
+		Add <code>no-suspend-when-hidden</code> if you need canvas video to keep downloading while the tab is hidden.
 	</p>
 	<p>
 		Audio may start muted because the browser can require user interaction before autoplaying.

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -73,6 +73,9 @@ The simplest way to publish a stream:
 | `video`    | boolean | false    | Enable video capture            |
 | `controls` | boolean | false    | Show simple publishing controls |
 
+Capture tracks are not stopped when the browser tab is hidden. They are stopped
+when the selected source is disabled, changed, or closed.
+
 ## JavaScript API
 
 For more control:

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -70,7 +70,7 @@ The simplest way to watch a stream:
 | `path`                    | string  | required | Broadcast path                           |
 | `paused`                  | boolean | false    | Pause playback                           |
 | `muted`                   | boolean | false    | Mute audio                               |
-| `no-suspend-when-hidden`  | boolean | false    | Keep canvas video active in hidden tabs  |
+| `background-playback`     | boolean | false    | Keep canvas video active in hidden tabs  |
 | `volume`                  | number  | 1        | Audio volume (0-1)                       |
 
 ## JavaScript API

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -64,13 +64,14 @@ The simplest way to watch a stream:
 
 ### Attributes
 
-| Attribute | Type    | Default  | Description           |
-|-----------|---------|----------|-----------------------|
-| `url`     | string  | required | Relay server URL      |
-| `path`    | string  | required | Broadcast path        |
-| `paused`  | boolean | false    | Pause playback        |
-| `muted`   | boolean | false    | Mute audio            |
-| `volume`  | number  | 1        | Audio volume (0-1)    |
+| Attribute                 | Type    | Default  | Description                              |
+|---------------------------|---------|----------|------------------------------------------|
+| `url`                     | string  | required | Relay server URL                         |
+| `path`                    | string  | required | Broadcast path                           |
+| `paused`                  | boolean | false    | Pause playback                           |
+| `muted`                   | boolean | false    | Mute audio                               |
+| `no-suspend-when-hidden`  | boolean | false    | Keep canvas video active in hidden tabs  |
+| `volume`                  | number  | 1        | Audio volume (0-1)                       |
 
 ## JavaScript API
 

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -54,7 +54,7 @@ export interface MultiBackendProps {
 	connection?: Signal<Moq.Connection.Established | undefined>;
 
 	paused?: boolean | Signal<boolean>;
-	noSuspendWhenHidden?: boolean | Signal<boolean>;
+	backgroundPlayback?: boolean | Signal<boolean>;
 }
 
 // We have to proxy some of these signals because we support both the MSE and WebCodecs.
@@ -112,7 +112,7 @@ export class MultiBackend implements Backend {
 	latency: Signal<Latency>;
 	jitter: Signal<Moq.Time.Milli>;
 	paused: Signal<boolean>;
-	noSuspendWhenHidden: Signal<boolean>;
+	backgroundPlayback: Signal<boolean>;
 
 	video: VideoBackend;
 	#videoSource: Video.Source;
@@ -143,7 +143,7 @@ export class MultiBackend implements Backend {
 		this.audio = new AudioBackend(this.#audioSource);
 
 		this.paused = Signal.from(props?.paused ?? false);
-		this.noSuspendWhenHidden = Signal.from(props?.noSuspendWhenHidden ?? false);
+		this.backgroundPlayback = Signal.from(props?.backgroundPlayback ?? false);
 
 		this.signals.run(this.#runElement.bind(this));
 	}
@@ -172,7 +172,7 @@ export class MultiBackend implements Backend {
 		const videoRenderer = new Video.Renderer(videoSource, {
 			canvas: element,
 			paused: this.paused,
-			noSuspendWhenHidden: this.noSuspendWhenHidden,
+			backgroundPlayback: this.backgroundPlayback,
 		});
 
 		effect.cleanup(() => {

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -54,6 +54,7 @@ export interface MultiBackendProps {
 	connection?: Signal<Moq.Connection.Established | undefined>;
 
 	paused?: boolean | Signal<boolean>;
+	noSuspendWhenHidden?: boolean | Signal<boolean>;
 }
 
 // We have to proxy some of these signals because we support both the MSE and WebCodecs.
@@ -111,6 +112,7 @@ export class MultiBackend implements Backend {
 	latency: Signal<Latency>;
 	jitter: Signal<Moq.Time.Milli>;
 	paused: Signal<boolean>;
+	noSuspendWhenHidden: Signal<boolean>;
 
 	video: VideoBackend;
 	#videoSource: Video.Source;
@@ -141,6 +143,7 @@ export class MultiBackend implements Backend {
 		this.audio = new AudioBackend(this.#audioSource);
 
 		this.paused = Signal.from(props?.paused ?? false);
+		this.noSuspendWhenHidden = Signal.from(props?.noSuspendWhenHidden ?? false);
 
 		this.signals.run(this.#runElement.bind(this));
 	}
@@ -169,6 +172,7 @@ export class MultiBackend implements Backend {
 		const videoRenderer = new Video.Renderer(videoSource, {
 			canvas: element,
 			paused: this.paused,
+			noSuspendWhenHidden: this.noSuspendWhenHidden,
 		});
 
 		effect.cleanup(() => {

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -12,7 +12,7 @@ const OBSERVED = [
 	"paused",
 	"volume",
 	"muted",
-	"no-suspend-when-hidden",
+	"background-playback",
 	"reload",
 	"latency",
 	"jitter",
@@ -119,11 +119,11 @@ export default class MoqWatch extends HTMLElement {
 		});
 
 		this.signals.run((effect) => {
-			const noSuspendWhenHidden = effect.get(this.backend.noSuspendWhenHidden);
-			if (noSuspendWhenHidden) {
-				this.setAttribute("no-suspend-when-hidden", "true");
+			const backgroundPlayback = effect.get(this.backend.backgroundPlayback);
+			if (backgroundPlayback) {
+				this.setAttribute("background-playback", "true");
 			} else {
-				this.removeAttribute("no-suspend-when-hidden");
+				this.removeAttribute("background-playback");
 			}
 		});
 
@@ -202,8 +202,8 @@ export default class MoqWatch extends HTMLElement {
 			this.backend.audio.volume.set(volume);
 		} else if (name === "muted") {
 			this.backend.audio.muted.set(newValue !== null);
-		} else if (name === "no-suspend-when-hidden") {
-			this.backend.noSuspendWhenHidden.set(newValue !== null);
+		} else if (name === "background-playback") {
+			this.backend.backgroundPlayback.set(newValue !== null);
 		} else if (name === "reload") {
 			this.broadcast.reload.set(newValue !== null);
 		} else if (name === "latency") {
@@ -263,12 +263,12 @@ export default class MoqWatch extends HTMLElement {
 		this.backend.audio.muted.set(value);
 	}
 
-	get noSuspendWhenHidden(): boolean {
-		return this.backend.noSuspendWhenHidden.peek();
+	get backgroundPlayback(): boolean {
+		return this.backend.backgroundPlayback.peek();
 	}
 
-	set noSuspendWhenHidden(value: boolean) {
-		this.backend.noSuspendWhenHidden.set(value);
+	set backgroundPlayback(value: boolean) {
+		this.backend.backgroundPlayback.set(value);
 	}
 
 	get reload(): boolean {

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -6,7 +6,18 @@ import { MultiBackend } from "./backend";
 import { Broadcast, type CatalogFormat, parseCatalogFormat } from "./broadcast";
 import type { Latency } from "./sync";
 
-const OBSERVED = ["url", "name", "paused", "volume", "muted", "reload", "latency", "jitter", "catalog-format"] as const;
+const OBSERVED = [
+	"url",
+	"name",
+	"paused",
+	"volume",
+	"muted",
+	"no-suspend-when-hidden",
+	"reload",
+	"latency",
+	"jitter",
+	"catalog-format",
+] as const;
 type Observed = (typeof OBSERVED)[number];
 
 // Close everything when this element is garbage collected.
@@ -108,6 +119,15 @@ export default class MoqWatch extends HTMLElement {
 		});
 
 		this.signals.run((effect) => {
+			const noSuspendWhenHidden = effect.get(this.backend.noSuspendWhenHidden);
+			if (noSuspendWhenHidden) {
+				this.setAttribute("no-suspend-when-hidden", "true");
+			} else {
+				this.removeAttribute("no-suspend-when-hidden");
+			}
+		});
+
+		this.signals.run((effect) => {
 			const volume = effect.get(this.backend.audio.volume);
 			this.setAttribute("volume", volume.toString());
 		});
@@ -182,6 +202,8 @@ export default class MoqWatch extends HTMLElement {
 			this.backend.audio.volume.set(volume);
 		} else if (name === "muted") {
 			this.backend.audio.muted.set(newValue !== null);
+		} else if (name === "no-suspend-when-hidden") {
+			this.backend.noSuspendWhenHidden.set(newValue !== null);
 		} else if (name === "reload") {
 			this.broadcast.reload.set(newValue !== null);
 		} else if (name === "latency") {
@@ -239,6 +261,14 @@ export default class MoqWatch extends HTMLElement {
 
 	set muted(value: boolean) {
 		this.backend.audio.muted.set(value);
+	}
+
+	get noSuspendWhenHidden(): boolean {
+		return this.backend.noSuspendWhenHidden.peek();
+	}
+
+	set noSuspendWhenHidden(value: boolean) {
+		this.backend.noSuspendWhenHidden.set(value);
 	}
 
 	get reload(): boolean {

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -5,6 +5,7 @@ import type { Decoder } from "./decoder";
 export type RendererProps = {
 	canvas?: HTMLCanvasElement | Signal<HTMLCanvasElement | undefined>;
 	paused?: boolean | Signal<boolean>;
+	noSuspendWhenHidden?: boolean | Signal<boolean>;
 };
 
 // An component to render a video to a canvas.
@@ -17,6 +18,9 @@ export class Renderer {
 	// Whether the video is paused.
 	paused: Signal<boolean>;
 
+	// Whether video keeps downloading while the tab is hidden.
+	noSuspendWhenHidden: Signal<boolean>;
+
 	// The most recently rendered frame, updated after each rAF paint.
 	readonly frame = new Signal<VideoFrame | undefined>(undefined);
 
@@ -24,13 +28,15 @@ export class Renderer {
 	readonly timestamp = new Signal<Time.Milli | undefined>(undefined);
 
 	#ctx = new Signal<CanvasRenderingContext2D | undefined>(undefined);
-	#visible = new Signal(false);
+	#foreground = new Signal(!document.hidden);
+	#onscreen = new Signal(false);
 	#signals = new Effect();
 
 	constructor(decoder: Decoder, props?: RendererProps) {
 		this.decoder = decoder;
 		this.canvas = Signal.from(props?.canvas);
 		this.paused = Signal.from(props?.paused ?? false);
+		this.noSuspendWhenHidden = Signal.from(props?.noSuspendWhenHidden ?? false);
 
 		this.#signals.run((effect) => {
 			const canvas = effect.get(this.canvas);
@@ -56,41 +62,42 @@ export class Renderer {
 		}
 	}
 
-	// Track whether the canvas is visible in the viewport and the tab is focused.
+	// Track whether the canvas is visible in the viewport and the tab is visible.
 	#runVisible(effect: Effect): void {
 		const canvas = effect.get(this.canvas);
 		if (!canvas) {
-			this.#visible.set(false);
+			this.#onscreen.set(false);
 			return;
 		}
 
-		let intersecting = false;
-
-		const update = () => {
-			this.#visible.set(intersecting && !document.hidden);
+		const updateForeground = () => {
+			this.#foreground.set(!document.hidden);
 		};
 
 		const observer = new IntersectionObserver(
 			(entries) => {
 				for (const entry of entries) {
-					intersecting = entry.isIntersecting;
-					update();
+					this.#onscreen.set(entry.isIntersecting);
 				}
 			},
 			{ threshold: 0.01 },
 		);
 
-		effect.event(document, "visibilitychange", update);
+		updateForeground();
+		effect.event(document, "visibilitychange", updateForeground);
 
 		observer.observe(canvas);
 		effect.cleanup(() => observer.disconnect());
-		effect.cleanup(() => this.#visible.set(false));
+		effect.cleanup(() => this.#onscreen.set(false));
 	}
 
 	// Detect when video should be downloaded.
 	#runEnabled(effect: Effect): void {
 		const paused = effect.get(this.paused);
-		const visible = effect.get(this.#visible);
+		const onscreen = effect.get(this.#onscreen);
+		const foreground = effect.get(this.#foreground);
+		const noSuspendWhenHidden = effect.get(this.noSuspendWhenHidden);
+		const visible = onscreen && (foreground || noSuspendWhenHidden);
 
 		effect.cleanup(() => this.decoder.enabled.set(false));
 

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -5,7 +5,7 @@ import type { Decoder } from "./decoder";
 export type RendererProps = {
 	canvas?: HTMLCanvasElement | Signal<HTMLCanvasElement | undefined>;
 	paused?: boolean | Signal<boolean>;
-	noSuspendWhenHidden?: boolean | Signal<boolean>;
+	backgroundPlayback?: boolean | Signal<boolean>;
 };
 
 // An component to render a video to a canvas.
@@ -19,7 +19,7 @@ export class Renderer {
 	paused: Signal<boolean>;
 
 	// Whether video keeps downloading while the tab is hidden.
-	noSuspendWhenHidden: Signal<boolean>;
+	backgroundPlayback: Signal<boolean>;
 
 	// The most recently rendered frame, updated after each rAF paint.
 	readonly frame = new Signal<VideoFrame | undefined>(undefined);
@@ -36,7 +36,7 @@ export class Renderer {
 		this.decoder = decoder;
 		this.canvas = Signal.from(props?.canvas);
 		this.paused = Signal.from(props?.paused ?? false);
-		this.noSuspendWhenHidden = Signal.from(props?.noSuspendWhenHidden ?? false);
+		this.backgroundPlayback = Signal.from(props?.backgroundPlayback ?? false);
 
 		this.#signals.run((effect) => {
 			const canvas = effect.get(this.canvas);
@@ -96,8 +96,8 @@ export class Renderer {
 		const paused = effect.get(this.paused);
 		const onscreen = effect.get(this.#onscreen);
 		const foreground = effect.get(this.#foreground);
-		const noSuspendWhenHidden = effect.get(this.noSuspendWhenHidden);
-		const visible = onscreen && (foreground || noSuspendWhenHidden);
+		const backgroundPlayback = effect.get(this.backgroundPlayback);
+		const visible = onscreen && (foreground || backgroundPlayback);
 
 		effect.cleanup(() => this.decoder.enabled.set(false));
 


### PR DESCRIPTION
Add a no-suspend-when-hidden option for WebCodecs canvas playback so hidden tabs can keep the video track subscription active. The default still suspends hidden-tab video, and offscreen canvas suspension is preserved.