### PR TITLE
fix(moq-net,js/net): draft-18 SUBSCRIBE_NAMESPACE, subgroup headers, and announce race

### DIFF
--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -172,6 +172,14 @@ export class Connection implements Established {
 	async #runBidi(stream: Stream) {
 		const typeId = await stream.reader.u53();
 
+		// SubscribeNamespace's type ID is version-dependent (0x11 pre-18, 0x50 in
+		// draft-18), so it can't be a static switch case.
+		if (typeId === SubscribeNamespace.wireId(this.#session.version)) {
+			const msg = await SubscribeNamespace.decode(stream.reader, this.#session.version);
+			await this.#publisher.runSubscribeNamespace(msg, stream);
+			return;
+		}
+
 		switch (typeId) {
 			case SubscribeUpdate.id: {
 				// REQUEST_UPDATE (0x02) is a follow-up, not a valid initial message
@@ -182,11 +190,6 @@ export class Connection implements Established {
 			case Subscribe.id: {
 				const msg = await Subscribe.decode(stream.reader, this.#session.version);
 				await this.#publisher.runSubscribe(msg, stream);
-				break;
-			}
-			case SubscribeNamespace.id: {
-				const msg = await SubscribeNamespace.decode(stream.reader, this.#session.version);
-				await this.#publisher.runSubscribeNamespace(msg, stream);
 				break;
 			}
 			case TrackStatusRequest.id: {

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -238,7 +238,7 @@ export class Connection implements Established {
 	}
 
 	async #runUni(stream: Reader) {
-		const header = await Group.decode(stream);
+		const header = await Group.decode(stream, this.#session.version);
 		await this.#subscriber.handleGroup(header, stream);
 	}
 

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -10,7 +10,7 @@ import { Publish } from "./publish.ts";
 import { PublishNamespace } from "./publish_namespace.ts";
 import { Publisher } from "./publisher.ts";
 import { Subscribe, SubscribeUpdate } from "./subscribe.ts";
-import { SubscribeNamespace } from "./subscribe_namespace.ts";
+import { SubscribeNamespace, SubscribeNamespaceLegacy } from "./subscribe_namespace.ts";
 import { Subscriber } from "./subscriber.ts";
 import { TrackStatusRequest } from "./track.ts";
 import { type IetfVersion, Version, versionName } from "./version.ts";
@@ -172,15 +172,20 @@ export class Connection implements Established {
 	async #runBidi(stream: Stream) {
 		const typeId = await stream.reader.u53();
 
-		// SubscribeNamespace's type ID is version-dependent (0x11 pre-18, 0x50 in
-		// draft-18), so it can't be a static switch case.
-		if (typeId === SubscribeNamespace.wireId(this.#session.version)) {
-			const msg = await SubscribeNamespace.decode(stream.reader, this.#session.version);
-			await this.#publisher.runSubscribeNamespace(msg, stream);
-			return;
-		}
-
 		switch (typeId) {
+			// Draft-18 SUBSCRIBE_NAMESPACE (0x50) and the legacy 0x11 message decode
+			// to the same request_id + namespace; the legacy options field is ignored.
+			case SubscribeNamespace.id: {
+				const msg = await SubscribeNamespace.decode(stream.reader, this.#session.version);
+				await this.#publisher.runSubscribeNamespace(msg, stream);
+				break;
+			}
+			case SubscribeNamespaceLegacy.id: {
+				const legacy = await SubscribeNamespaceLegacy.decode(stream.reader, this.#session.version);
+				const msg = new SubscribeNamespace({ requestId: legacy.requestId, namespace: legacy.namespace });
+				await this.#publisher.runSubscribeNamespace(msg, stream);
+				break;
+			}
 			case SubscribeUpdate.id: {
 				// REQUEST_UPDATE (0x02) is a follow-up, not a valid initial message
 				stream.abort(new Error("unexpected REQUEST_UPDATE as initial message"));

--- a/js/net/src/ietf/control.ts
+++ b/js/net/src/ietf/control.ts
@@ -15,8 +15,8 @@ import * as Setup from "./setup.ts";
 import { Subscribe, SubscribeError, SubscribeOk, SubscribeUpdate, Unsubscribe } from "./subscribe.ts";
 import {
 	SUBSCRIBE_TRACKS_ID,
-	SubscribeNamespace,
 	SubscribeNamespaceError,
+	SubscribeNamespaceLegacy,
 	SubscribeNamespaceOk,
 	UnsubscribeNamespace,
 } from "./subscribe_namespace.ts";
@@ -45,7 +45,7 @@ const MessagesV14 = {
 	[FetchCancel.id]: FetchCancel,
 	[FetchOk.id]: FetchOk,
 	[FetchError.id]: FetchError,
-	[SubscribeNamespace.id]: SubscribeNamespace,
+	[SubscribeNamespaceLegacy.id]: SubscribeNamespaceLegacy,
 	[SubscribeNamespaceOk.id]: SubscribeNamespaceOk,
 	[SubscribeNamespaceError.id]: SubscribeNamespaceError,
 	[UnsubscribeNamespace.id]: UnsubscribeNamespace,
@@ -76,7 +76,7 @@ const MessagesV15 = {
 	[Fetch.id]: Fetch,
 	[FetchCancel.id]: FetchCancel,
 	[FetchOk.id]: FetchOk,
-	[SubscribeNamespace.id]: SubscribeNamespace,
+	[SubscribeNamespaceLegacy.id]: SubscribeNamespaceLegacy,
 	[UnsubscribeNamespace.id]: UnsubscribeNamespace,
 	[Publish.id]: Publish,
 	[MaxRequestId.id]: MaxRequestId,
@@ -130,7 +130,7 @@ const MessagesV17 = {
 	[Fetch.id]: Fetch,
 	// FetchCancel (0x17) removed in d17
 	[FetchOk.id]: FetchOk,
-	[SubscribeNamespace.id]: SubscribeNamespace,
+	[SubscribeNamespaceLegacy.id]: SubscribeNamespaceLegacy,
 	[Publish.id]: Publish,
 	// MaxRequestId (0x15) removed in d17
 	// RequestsBlocked (0x1a) removed in d17

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -4,6 +4,7 @@ import { Reader, Writer } from "../stream.ts";
 import * as Varint from "../varint.ts";
 import * as GoAway from "./goaway.ts";
 import * as Namespace from "./namespace.ts";
+import { Group } from "./object.ts";
 import { SetupOptions } from "./parameters.ts";
 import { Publish, PublishDone } from "./publish.ts";
 import * as Announce from "./publish_namespace.ts";
@@ -1051,4 +1052,38 @@ test("SubscribeNamespace: draft-18 omits subscribe options", async () => {
 		expect(decoded.requestId).toBe(4n);
 		expect(decoded.namespace).toBe("example/meeting" as Path.Valid);
 	}
+});
+
+test("Group: draft-18 sets FIRST_OBJECT bit, draft-17 does not", async () => {
+	const makeGroup = () =>
+		new Group({
+			trackAlias: 7n,
+			groupId: 3,
+			subGroupId: 0,
+			publisherPriority: 0,
+			flags: {
+				hasExtensions: false,
+				hasSubgroup: false,
+				hasSubgroupObject: false,
+				hasEnd: true,
+				hasPriority: true,
+			},
+		});
+
+	// Round-trips on each version.
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18]) {
+		const encoded = await encodeVersioned(makeGroup(), version);
+		const decoded = await decodeVersioned(encoded, Group.decode, version);
+		expect(decoded.groupId).toBe(3);
+		expect(decoded.trackAlias).toBe(7n);
+		expect(decoded.flags.hasEnd).toBe(true);
+		expect(decoded.flags.hasPriority).toBe(true);
+	}
+
+	// The draft-18 header carries the 0x40 FIRST_OBJECT bit (type 0x18 -> 0x58),
+	// so the same bytes are not a valid draft-17 subgroup header.
+	const v18 = await encodeVersioned(makeGroup(), Version.DRAFT_18);
+	const v17 = await encodeVersioned(makeGroup(), Version.DRAFT_17);
+	expect(Array.from(v18)).not.toEqual(Array.from(v17));
+	await expect(decodeVersioned(v18, Group.decode, Version.DRAFT_17)).rejects.toThrow(/Unsupported group type/);
 });

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -1026,29 +1026,37 @@ test("Parameters v18 wire is identical to v17 (no count prefix, delta encoded ke
 	expect(Array.from(await v18)).toEqual(Array.from(await v17));
 });
 
-test("SubscribeNamespace: wireId is version-dependent", () => {
-	// 0x11 through draft-17, renumbered to 0x50 in draft-18 (#1542).
-	expect(SubscribeNamespace.SubscribeNamespace.wireId(Version.DRAFT_16)).toBe(0x11);
-	expect(SubscribeNamespace.SubscribeNamespace.wireId(Version.DRAFT_17)).toBe(0x11);
-	expect(SubscribeNamespace.SubscribeNamespace.wireId(Version.DRAFT_18)).toBe(0x50);
+test("SubscribeNamespace: message IDs", () => {
+	// 0x11 through draft-17 (legacy), renumbered to 0x50 in draft-18 (#1542).
+	expect(SubscribeNamespace.SubscribeNamespaceLegacy.id).toBe(0x11);
+	expect(SubscribeNamespace.SubscribeNamespace.id).toBe(0x50);
 });
 
 test("SubscribeNamespace: draft-18 omits subscribe options", async () => {
-	const msg = new SubscribeNamespace.SubscribeNamespace({ namespace: Path.empty(), requestId: 0n });
-
-	const v18 = await encodeVersioned(msg, Version.DRAFT_18);
-	const v17 = await encodeVersioned(msg, Version.DRAFT_17);
-
-	// Draft-18 dropped the Subscribe Options field, so its body is shorter.
+	// The legacy draft-17 body carries the Subscribe Options field, so it is
+	// longer than the modern draft-18 body.
+	const modern = new SubscribeNamespace.SubscribeNamespace({ namespace: Path.empty(), requestId: 0n });
+	const legacy = new SubscribeNamespace.SubscribeNamespaceLegacy({ namespace: Path.empty(), requestId: 0n });
+	const v18 = await encodeVersioned(modern, Version.DRAFT_18);
+	const v17 = await encodeVersioned(legacy, Version.DRAFT_17);
 	expect(v18.byteLength).toBeLessThan(v17.byteLength);
 
-	// Round-trips cleanly for both versions.
-	for (const version of [Version.DRAFT_16, Version.DRAFT_17, Version.DRAFT_18]) {
+	// Modern round-trips on draft-18.
+	const m = await encodeVersioned(
+		new SubscribeNamespace.SubscribeNamespace({ namespace: Path.from("example/meeting"), requestId: 4n }),
+		Version.DRAFT_18,
+	);
+	const dm = await decodeVersioned(m, SubscribeNamespace.SubscribeNamespace.decode, Version.DRAFT_18);
+	expect(dm.requestId).toBe(4n);
+	expect(dm.namespace).toBe("example/meeting" as Path.Valid);
+
+	// Legacy round-trips on draft-16/17.
+	for (const version of [Version.DRAFT_16, Version.DRAFT_17]) {
 		const encoded = await encodeVersioned(
-			new SubscribeNamespace.SubscribeNamespace({ namespace: Path.from("example/meeting"), requestId: 4n }),
+			new SubscribeNamespace.SubscribeNamespaceLegacy({ namespace: Path.from("example/meeting"), requestId: 4n }),
 			version,
 		);
-		const decoded = await decodeVersioned(encoded, SubscribeNamespace.SubscribeNamespace.decode, version);
+		const decoded = await decodeVersioned(encoded, SubscribeNamespace.SubscribeNamespaceLegacy.decode, version);
 		expect(decoded.requestId).toBe(4n);
 		expect(decoded.namespace).toBe("example/meeting" as Path.Valid);
 	}

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -1024,3 +1024,31 @@ test("Parameters v18 wire is identical to v17 (no count prefix, delta encoded ke
 
 	expect(Array.from(await v18)).toEqual(Array.from(await v17));
 });
+
+test("SubscribeNamespace: wireId is version-dependent", () => {
+	// 0x11 through draft-17, renumbered to 0x50 in draft-18 (#1542).
+	expect(SubscribeNamespace.SubscribeNamespace.wireId(Version.DRAFT_16)).toBe(0x11);
+	expect(SubscribeNamespace.SubscribeNamespace.wireId(Version.DRAFT_17)).toBe(0x11);
+	expect(SubscribeNamespace.SubscribeNamespace.wireId(Version.DRAFT_18)).toBe(0x50);
+});
+
+test("SubscribeNamespace: draft-18 omits subscribe options", async () => {
+	const msg = new SubscribeNamespace.SubscribeNamespace({ namespace: Path.empty(), requestId: 0n });
+
+	const v18 = await encodeVersioned(msg, Version.DRAFT_18);
+	const v17 = await encodeVersioned(msg, Version.DRAFT_17);
+
+	// Draft-18 dropped the Subscribe Options field, so its body is shorter.
+	expect(v18.byteLength).toBeLessThan(v17.byteLength);
+
+	// Round-trips cleanly for both versions.
+	for (const version of [Version.DRAFT_16, Version.DRAFT_17, Version.DRAFT_18]) {
+		const encoded = await encodeVersioned(
+			new SubscribeNamespace.SubscribeNamespace({ namespace: Path.from("example/meeting"), requestId: 4n }),
+			version,
+		);
+		const decoded = await decodeVersioned(encoded, SubscribeNamespace.SubscribeNamespace.decode, version);
+		expect(decoded.requestId).toBe(4n);
+		expect(decoded.namespace).toBe("example/meeting" as Path.Valid);
+	}
+});

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -1032,6 +1032,26 @@ test("SubscribeNamespace: message IDs", () => {
 	expect(SubscribeNamespace.SubscribeNamespace.id).toBe(0x50);
 });
 
+test("SubscribeNamespace: decode rejects the wrong draft version", async () => {
+	// Modern 0x50 is draft-18+ only.
+	const modern = await encodeVersioned(
+		new SubscribeNamespace.SubscribeNamespace({ namespace: Path.empty(), requestId: 0n }),
+		Version.DRAFT_18,
+	);
+	await expect(
+		decodeVersioned(modern, SubscribeNamespace.SubscribeNamespace.decode, Version.DRAFT_17),
+	).rejects.toThrow(/draft-18\+ only/);
+
+	// Legacy 0x11 is draft-14..17 only.
+	const legacy = await encodeVersioned(
+		new SubscribeNamespace.SubscribeNamespaceLegacy({ namespace: Path.empty(), requestId: 0n }),
+		Version.DRAFT_17,
+	);
+	await expect(
+		decodeVersioned(legacy, SubscribeNamespace.SubscribeNamespaceLegacy.decode, Version.DRAFT_18),
+	).rejects.toThrow(/draft-14\.\.17 only/);
+});
+
 test("SubscribeNamespace: draft-18 omits subscribe options", async () => {
 	// The legacy draft-17 body carries the Subscribe Options field, so it is
 	// longer than the modern draft-18 body.

--- a/js/net/src/ietf/object.ts
+++ b/js/net/src/ietf/object.ts
@@ -1,6 +1,24 @@
 import type { Reader, Writer } from "../stream.ts";
+import { type IetfVersion, Version } from "./version.ts";
 
 const GROUP_END = 0x03;
+
+// draft-18 adds bit 0x40 (FIRST_OBJECT) to the subgroup header type per spec
+// 11.4.2. moq-lite always starts subgroups at object 0, so the bit carries no
+// extra information for us: set it on emit, strip it on parse.
+const FIRST_OBJECT_BIT = 0x40;
+
+function hasFirstObjectBit(version: IetfVersion): boolean {
+	switch (version) {
+		case Version.DRAFT_14:
+		case Version.DRAFT_15:
+		case Version.DRAFT_16:
+		case Version.DRAFT_17:
+			return false;
+		default:
+			return true;
+	}
+}
 
 export interface GroupFlags {
 	hasExtensions: boolean;
@@ -43,7 +61,7 @@ export class Group {
 		this.publisherPriority = publisherPriority;
 	}
 
-	async encode(w: Writer): Promise<void> {
+	async encode(w: Writer, version: IetfVersion): Promise<void> {
 		if (!this.flags.hasSubgroup && this.subGroupId !== 0) {
 			throw new Error(`Subgroup ID must be 0 if hasSubgroup is false: ${this.subGroupId}`);
 		}
@@ -62,6 +80,9 @@ export class Group {
 		if (this.flags.hasEnd) {
 			id |= 0x08;
 		}
+		if (hasFirstObjectBit(version)) {
+			id |= FIRST_OBJECT_BIT;
+		}
 		await w.u53(id);
 		await w.u62(this.trackAlias);
 		await w.u53(this.groupId);
@@ -73,8 +94,10 @@ export class Group {
 		}
 	}
 
-	static async decode(r: Reader): Promise<Group> {
-		const id = await r.u53();
+	static async decode(r: Reader, version: IetfVersion): Promise<Group> {
+		const raw = await r.u53();
+		// Strip the draft-18 FIRST_OBJECT bit before the range check.
+		const id = hasFirstObjectBit(version) ? raw & ~FIRST_OBJECT_BIT : raw;
 
 		let hasPriority: boolean;
 		let baseId: number;

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -224,7 +224,7 @@ export class Publisher {
 				},
 			});
 
-			await header.encode(stream);
+			await header.encode(stream, this.#session.version);
 
 			try {
 				for (;;) {

--- a/js/net/src/ietf/subscribe_namespace.ts
+++ b/js/net/src/ietf/subscribe_namespace.ts
@@ -5,29 +5,57 @@ import * as Namespace from "./namespace.ts";
 import { Parameters } from "./parameters.ts";
 import { type IetfVersion, Version } from "./version.ts";
 
-// In draft-14, SUBSCRIBE_ANNOUNCES is renamed to SUBSCRIBE_NAMESPACE
-// In draft-16, this moves from the control stream to its own bidi stream
+// SUBSCRIBE_NAMESPACE message (draft-18+, type 0x50).
+//
+// Draft-18 renumbered the message from 0x11 to 0x50 and dropped the Subscribe
+// Options field when it split SUBSCRIBE_TRACKS (0x51) off into its own message
+// type (#1542). Draft-14 through draft-17 use SubscribeNamespaceLegacy.
 export class SubscribeNamespace {
-	static id = 0x11;
-
-	// Draft-18 renumbered SUBSCRIBE_NAMESPACE from 0x11 to 0x50 when it split
-	// SUBSCRIBE_TRACKS (0x51) off into its own message type (#1542). Earlier
-	// drafts keep 0x11.
-	static wireId(version: IetfVersion): number {
-		switch (version) {
-			case Version.DRAFT_14:
-			case Version.DRAFT_15:
-			case Version.DRAFT_16:
-			case Version.DRAFT_17:
-				return SubscribeNamespace.id;
-			default:
-				return 0x50;
-		}
-	}
+	static id = 0x50;
 
 	namespace: Path.Valid;
 	requestId: bigint;
-	subscribeOptions: number; // v16: default 0x01 (NAMESPACE only)
+
+	constructor({ namespace, requestId }: { namespace: Path.Valid; requestId: bigint }) {
+		this.namespace = namespace;
+		this.requestId = requestId;
+	}
+
+	async #encode(w: Writer, version: IetfVersion): Promise<void> {
+		await w.u62(this.requestId);
+		await Namespace.encode(w, this.namespace);
+		await new Parameters().encode(w, version);
+	}
+
+	async encode(w: Writer, version: IetfVersion): Promise<void> {
+		return Message.encode(w, (wr) => this.#encode(wr, version));
+	}
+
+	static async decode(r: Reader, version: IetfVersion): Promise<SubscribeNamespace> {
+		return Message.decode(r, (rd) => SubscribeNamespace.#decode(rd, version));
+	}
+
+	static async #decode(r: Reader, version: IetfVersion): Promise<SubscribeNamespace> {
+		const requestId = await r.u62();
+		const namespace = await Namespace.decode(r);
+		await Parameters.decode(r, version);
+
+		return new SubscribeNamespace({ namespace, requestId });
+	}
+}
+
+// SUBSCRIBE_NAMESPACE message for draft-14 through draft-17 (type 0x11).
+//
+// In v16 this moves from the control stream to its own bidi stream. Draft-16/17
+// carry a Subscribe Options field (NAMESPACE vs TRACKS); draft-17 additionally
+// prefixes a Required Request ID delta (removed in draft-18 per #1615).
+// Draft-18+ uses SubscribeNamespace.
+export class SubscribeNamespaceLegacy {
+	static id = 0x11;
+
+	namespace: Path.Valid;
+	requestId: bigint;
+	subscribeOptions: number; // v16/v17: default 0x01 (NAMESPACE only)
 
 	constructor({
 		namespace,
@@ -49,9 +77,6 @@ export class SubscribeNamespace {
 			await w.u62(0n); // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		await Namespace.encode(w, this.namespace);
-		// Draft-16/17 carried a Subscribe Options field to pick NAMESPACE vs TRACKS.
-		// Draft-18 dropped it, splitting the cases into SUBSCRIBE_NAMESPACE (0x50)
-		// and SUBSCRIBE_TRACKS (0x51) message types instead (#1542).
 		if (version === Version.DRAFT_16 || version === Version.DRAFT_17) {
 			await w.u53(this.subscribeOptions);
 		}
@@ -62,24 +87,23 @@ export class SubscribeNamespace {
 		return Message.encode(w, (wr) => this.#encode(wr, version));
 	}
 
-	static async decode(r: Reader, version: IetfVersion): Promise<SubscribeNamespace> {
-		return Message.decode(r, (rd) => SubscribeNamespace.#decode(rd, version));
+	static async decode(r: Reader, version: IetfVersion): Promise<SubscribeNamespaceLegacy> {
+		return Message.decode(r, (rd) => SubscribeNamespaceLegacy.#decode(rd, version));
 	}
 
-	static async #decode(r: Reader, version: IetfVersion): Promise<SubscribeNamespace> {
+	static async #decode(r: Reader, version: IetfVersion): Promise<SubscribeNamespaceLegacy> {
 		const requestId = await r.u62();
 		if (version === Version.DRAFT_17) {
 			await r.u62(); // required_request_id_delta (draft-17 only, removed in draft-18 per #1615)
 		}
 		const namespace = await Namespace.decode(r);
-		// Subscribe Options exists only in draft-16/17 (see #encode).
 		let subscribeOptions = 1;
 		if (version === Version.DRAFT_16 || version === Version.DRAFT_17) {
 			subscribeOptions = await r.u53();
 		}
 		await Parameters.decode(r, version);
 
-		return new SubscribeNamespace({ namespace, requestId, subscribeOptions });
+		return new SubscribeNamespaceLegacy({ namespace, requestId, subscribeOptions });
 	}
 }
 

--- a/js/net/src/ietf/subscribe_namespace.ts
+++ b/js/net/src/ietf/subscribe_namespace.ts
@@ -10,6 +10,21 @@ import { type IetfVersion, Version } from "./version.ts";
 export class SubscribeNamespace {
 	static id = 0x11;
 
+	// Draft-18 renumbered SUBSCRIBE_NAMESPACE from 0x11 to 0x50 when it split
+	// SUBSCRIBE_TRACKS (0x51) off into its own message type (#1542). Earlier
+	// drafts keep 0x11.
+	static wireId(version: IetfVersion): number {
+		switch (version) {
+			case Version.DRAFT_14:
+			case Version.DRAFT_15:
+			case Version.DRAFT_16:
+			case Version.DRAFT_17:
+				return SubscribeNamespace.id;
+			default:
+				return 0x50;
+		}
+	}
+
 	namespace: Path.Valid;
 	requestId: bigint;
 	subscribeOptions: number; // v16: default 0x01 (NAMESPACE only)
@@ -34,7 +49,10 @@ export class SubscribeNamespace {
 			await w.u62(0n); // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		await Namespace.encode(w, this.namespace);
-		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15) {
+		// Draft-16/17 carried a Subscribe Options field to pick NAMESPACE vs TRACKS.
+		// Draft-18 dropped it, splitting the cases into SUBSCRIBE_NAMESPACE (0x50)
+		// and SUBSCRIBE_TRACKS (0x51) message types instead (#1542).
+		if (version === Version.DRAFT_16 || version === Version.DRAFT_17) {
 			await w.u53(this.subscribeOptions);
 		}
 		await new Parameters().encode(w, version);
@@ -54,8 +72,9 @@ export class SubscribeNamespace {
 			await r.u62(); // required_request_id_delta (draft-17 only, removed in draft-18 per #1615)
 		}
 		const namespace = await Namespace.decode(r);
+		// Subscribe Options exists only in draft-16/17 (see #encode).
 		let subscribeOptions = 1;
-		if (version !== Version.DRAFT_14 && version !== Version.DRAFT_15) {
+		if (version === Version.DRAFT_16 || version === Version.DRAFT_17) {
 			subscribeOptions = await r.u53();
 		}
 		await Parameters.decode(r, version);

--- a/js/net/src/ietf/subscribe_namespace.ts
+++ b/js/net/src/ietf/subscribe_namespace.ts
@@ -5,6 +5,20 @@ import * as Namespace from "./namespace.ts";
 import { Parameters } from "./parameters.ts";
 import { type IetfVersion, Version } from "./version.ts";
 
+// True for the drafts that use the legacy 0x11 SUBSCRIBE_NAMESPACE message.
+// Draft-18+ uses the renumbered 0x50 message instead.
+function isLegacyVersion(version: IetfVersion): boolean {
+	switch (version) {
+		case Version.DRAFT_14:
+		case Version.DRAFT_15:
+		case Version.DRAFT_16:
+		case Version.DRAFT_17:
+			return true;
+		default:
+			return false;
+	}
+}
+
 // SUBSCRIBE_NAMESPACE message (draft-18+, type 0x50).
 //
 // Draft-18 renumbered the message from 0x11 to 0x50 and dropped the Subscribe
@@ -22,6 +36,9 @@ export class SubscribeNamespace {
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
+		if (isLegacyVersion(version)) {
+			throw new Error(`SUBSCRIBE_NAMESPACE (0x50) is draft-18+ only, not ${version}`);
+		}
 		await w.u62(this.requestId);
 		await Namespace.encode(w, this.namespace);
 		await new Parameters().encode(w, version);
@@ -36,6 +53,9 @@ export class SubscribeNamespace {
 	}
 
 	static async #decode(r: Reader, version: IetfVersion): Promise<SubscribeNamespace> {
+		if (isLegacyVersion(version)) {
+			throw new Error(`SUBSCRIBE_NAMESPACE (0x50) is draft-18+ only, not ${version}`);
+		}
 		const requestId = await r.u62();
 		const namespace = await Namespace.decode(r);
 		await Parameters.decode(r, version);
@@ -72,6 +92,9 @@ export class SubscribeNamespaceLegacy {
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
+		if (!isLegacyVersion(version)) {
+			throw new Error(`legacy SUBSCRIBE_NAMESPACE (0x11) is draft-14..17 only, not ${version}`);
+		}
 		await w.u62(this.requestId);
 		if (version === Version.DRAFT_17) {
 			await w.u62(0n); // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
@@ -92,6 +115,9 @@ export class SubscribeNamespaceLegacy {
 	}
 
 	static async #decode(r: Reader, version: IetfVersion): Promise<SubscribeNamespaceLegacy> {
+		if (!isLegacyVersion(version)) {
+			throw new Error(`legacy SUBSCRIBE_NAMESPACE (0x11) is draft-14..17 only, not ${version}`);
+		}
 		const requestId = await r.u62();
 		if (version === Version.DRAFT_17) {
 			await r.u62(); // required_request_id_delta (draft-17 only, removed in draft-18 per #1615)

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -85,8 +85,8 @@ export class Subscriber {
 					: await this.#session.openBi();
 
 			try {
-				// Write SubscribeNamespace
-				await stream.writer.u53(SubscribeNamespace.id);
+				// Write SubscribeNamespace (type ID is version-dependent: 0x11 pre-18, 0x50 in draft-18).
+				await stream.writer.u53(SubscribeNamespace.wireId(version));
 				const msg = new SubscribeNamespace({ namespace: prefix, requestId });
 				await msg.encode(stream.writer, version);
 				console.debug(`subscribe_namespace written: requestId=${requestId}`);

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -16,6 +16,7 @@ import {
 	SubscribeNamespace,
 	SubscribeNamespaceEntry,
 	SubscribeNamespaceEntryDone,
+	SubscribeNamespaceLegacy,
 	SubscribeNamespaceOk,
 	UnsubscribeNamespace,
 } from "./subscribe_namespace.ts";
@@ -85,10 +86,20 @@ export class Subscriber {
 					: await this.#session.openBi();
 
 			try {
-				// Write SubscribeNamespace (type ID is version-dependent: 0x11 pre-18, 0x50 in draft-18).
-				await stream.writer.u53(SubscribeNamespace.wireId(version));
-				const msg = new SubscribeNamespace({ namespace: prefix, requestId });
-				await msg.encode(stream.writer, version);
+				// Draft-18+ uses SUBSCRIBE_NAMESPACE (0x50); earlier drafts use the
+				// legacy 0x11 message with a Subscribe Options field.
+				if (
+					version === Version.DRAFT_14 ||
+					version === Version.DRAFT_15 ||
+					version === Version.DRAFT_16 ||
+					version === Version.DRAFT_17
+				) {
+					await stream.writer.u53(SubscribeNamespaceLegacy.id);
+					await new SubscribeNamespaceLegacy({ namespace: prefix, requestId }).encode(stream.writer, version);
+				} else {
+					await stream.writer.u53(SubscribeNamespace.id);
+					await new SubscribeNamespace({ namespace: prefix, requestId }).encode(stream.writer, version);
+				}
 				console.debug(`subscribe_namespace written: requestId=${requestId}`);
 
 				// Read response

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -80,6 +80,10 @@ test("integration: ietf draft-17", async () => {
 	await runPublishSubscribeFlow(Ietf.ALPN.DRAFT_17);
 });
 
+test("integration: ietf draft-18", async () => {
+	await runPublishSubscribeFlow(Ietf.ALPN.DRAFT_18);
+});
+
 test("integration: subscribe to non-existent broadcast", async () => {
 	const pair = createMockTransportPair("");
 

--- a/rs/moq-net/src/ietf/adapter.rs
+++ b/rs/moq-net/src/ietf/adapter.rs
@@ -481,7 +481,7 @@ impl<S: web_transport_trait::Session> ControlStreamAdapter<S> {
 				Ok(Route::NewRequest(id))
 			}
 			// SubscribeNamespace on control stream (v14/v15 only)
-			ietf::SubscribeNamespace::ID => match self.version {
+			ietf::SubscribeNamespaceLegacy::ID => match self.version {
 				Version::Draft14 | Version::Draft15 => {
 					let id = decode_request_id(body, self.version)?;
 					Ok(Route::NewRequest(id))
@@ -845,7 +845,7 @@ mod tests {
 				let id = decode_request_id(body, version)?;
 				Ok(Route::NewRequest(id))
 			}
-			ietf::SubscribeNamespace::ID => match version {
+			ietf::SubscribeNamespaceLegacy::ID => match version {
 				Version::Draft14 | Version::Draft15 => {
 					let id = decode_request_id(body, version)?;
 					Ok(Route::NewRequest(id))
@@ -1053,14 +1053,14 @@ mod tests {
 	#[test]
 	fn test_classify_subscribe_namespace_v14_new_request() {
 		let body = make_body_with_request_id(20, Version::Draft14);
-		let route = classify_msg(Version::Draft14, ietf::SubscribeNamespace::ID, &body).unwrap();
+		let route = classify_msg(Version::Draft14, ietf::SubscribeNamespaceLegacy::ID, &body).unwrap();
 		assert!(matches!(route, Route::NewRequest(RequestId(20))));
 	}
 
 	#[test]
 	fn test_classify_subscribe_namespace_v16_errors() {
 		let body = make_body_with_request_id(20, Version::Draft16);
-		let result = classify_msg(Version::Draft16, ietf::SubscribeNamespace::ID, &body);
+		let result = classify_msg(Version::Draft16, ietf::SubscribeNamespaceLegacy::ID, &body);
 		assert!(result.is_err());
 	}
 

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -78,9 +78,19 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					}
 				});
 			}
-			// SubscribeNamespace ID is version-dependent (0x11 pre-18, 0x50 in draft-18).
-			id if id == ietf::SubscribeNamespace::wire_id(this.version) => {
-				let msg = ietf::SubscribeNamespace::decode_msg(&mut data, this.version)?;
+			// Draft-18 SUBSCRIBE_NAMESPACE (0x50) and the legacy 0x11 message decode
+			// to the same request_id + namespace; the legacy Subscribe Options field
+			// is ignored (moq-lite never subscribes to tracks).
+			ietf::SubscribeNamespace::ID | ietf::SubscribeNamespaceLegacy::ID => {
+				let msg = if id == ietf::SubscribeNamespace::ID {
+					ietf::SubscribeNamespace::decode_msg(&mut data, this.version)?
+				} else {
+					let legacy = ietf::SubscribeNamespaceLegacy::decode_msg(&mut data, this.version)?;
+					ietf::SubscribeNamespace {
+						request_id: legacy.request_id,
+						namespace: legacy.namespace,
+					}
+				};
 				if !data.is_empty() {
 					return Err(Error::WrongSize);
 				}

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -78,7 +78,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					}
 				});
 			}
-			ietf::SubscribeNamespace::ID => {
+			// SubscribeNamespace ID is version-dependent (0x11 pre-18, 0x50 in draft-18).
+			id if id == ietf::SubscribeNamespace::wire_id(this.version) => {
 				let msg = ietf::SubscribeNamespace::decode_msg(&mut data, this.version)?;
 				if !data.is_empty() {
 					return Err(Error::WrongSize);

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -224,7 +224,11 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 
 		match id {
 			// Publisher handles: Subscribe, Fetch, SubscribeNamespace, TrackStatus
-			ietf::Subscribe::ID | ietf::Fetch::ID | ietf::SubscribeNamespace::ID | ietf::TrackStatus::ID => {
+			ietf::Subscribe::ID | ietf::Fetch::ID | ietf::TrackStatus::ID => {
+				publisher.handle_stream(id, data, stream)?;
+			}
+			// SubscribeNamespace ID is version-dependent (0x11 pre-18, 0x50 in draft-18).
+			id if id == ietf::SubscribeNamespace::wire_id(version) => {
 				publisher.handle_stream(id, data, stream)?;
 			}
 			// Subscriber handles: Publish, PublishNamespace

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -223,12 +223,13 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 		let data = stream.reader.read_exact(size as usize).await?;
 
 		match id {
-			// Publisher handles: Subscribe, Fetch, SubscribeNamespace, TrackStatus
-			ietf::Subscribe::ID | ietf::Fetch::ID | ietf::TrackStatus::ID => {
-				publisher.handle_stream(id, data, stream)?;
-			}
-			// SubscribeNamespace ID is version-dependent (0x11 pre-18, 0x50 in draft-18).
-			id if id == ietf::SubscribeNamespace::wire_id(version) => {
+			// Publisher handles: Subscribe, Fetch, SubscribeNamespace (0x50 modern /
+			// 0x11 legacy), TrackStatus
+			ietf::Subscribe::ID
+			| ietf::Fetch::ID
+			| ietf::SubscribeNamespace::ID
+			| ietf::SubscribeNamespaceLegacy::ID
+			| ietf::TrackStatus::ID => {
 				publisher.handle_stream(id, data, stream)?;
 			}
 			// Subscriber handles: Publish, PublishNamespace

--- a/rs/moq-net/src/ietf/subscribe_namespace.rs
+++ b/rs/moq-net/src/ietf/subscribe_namespace.rs
@@ -18,6 +18,15 @@ use super::Version;
 /// for a REQUEST_OK.
 pub const SUBSCRIBE_TRACKS_ID: u64 = 0x51;
 
+/// True for the drafts that use the legacy 0x11 SUBSCRIBE_NAMESPACE message.
+/// Draft-18+ uses the renumbered 0x50 message instead.
+fn is_legacy_version(version: Version) -> bool {
+	matches!(
+		version,
+		Version::Draft14 | Version::Draft15 | Version::Draft16 | Version::Draft17
+	)
+}
+
 /// SUBSCRIBE_NAMESPACE message (draft-18+, type 0x50).
 ///
 /// Draft-18 renumbered the message from 0x11 to 0x50 and dropped the Subscribe
@@ -33,6 +42,9 @@ impl Message for SubscribeNamespace<'_> {
 	const ID: u64 = 0x50;
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		if is_legacy_version(version) {
+			return Err(EncodeError::Version);
+		}
 		self.request_id.encode(w, version)?;
 		encode_namespace(w, &self.namespace, version)?;
 		encode_params!(w, version,);
@@ -40,6 +52,9 @@ impl Message for SubscribeNamespace<'_> {
 	}
 
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		if is_legacy_version(version) {
+			return Err(DecodeError::Version);
+		}
 		let request_id = RequestId::decode(r, version)?;
 		let namespace = decode_namespace(r, version)?;
 		decode_params!(r, version,);
@@ -66,6 +81,9 @@ impl Message for SubscribeNamespaceLegacy<'_> {
 	const ID: u64 = 0x11;
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		if !is_legacy_version(version) {
+			return Err(EncodeError::Version);
+		}
 		self.request_id.encode(w, version)?;
 		if version == Version::Draft17 {
 			0u64.encode(w, version)?; // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
@@ -79,6 +97,9 @@ impl Message for SubscribeNamespaceLegacy<'_> {
 	}
 
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		if !is_legacy_version(version) {
+			return Err(DecodeError::Version);
+		}
 		let request_id = RequestId::decode(r, version)?;
 		if version == Version::Draft17 {
 			let _required_request_id_delta = u64::decode(r, version)?;
@@ -307,5 +328,24 @@ mod tests {
 			assert_eq!(decoded.namespace.as_str(), "example/meeting");
 			assert_eq!(decoded.subscribe_options, 0x01);
 		}
+	}
+
+	#[test]
+	fn rejects_wrong_version() {
+		// The modern 0x50 message only exists in draft-18+.
+		for version in [Version::Draft14, Version::Draft16, Version::Draft17] {
+			let mut buf = bytes::Bytes::from(vec![0x00, 0x00, 0x00]);
+			assert!(matches!(
+				SubscribeNamespace::decode_msg(&mut buf, version),
+				Err(DecodeError::Version)
+			));
+		}
+
+		// The legacy 0x11 message only exists in draft-14..17.
+		let mut buf = bytes::Bytes::from(vec![0x00, 0x00, 0x00]);
+		assert!(matches!(
+			SubscribeNamespaceLegacy::decode_msg(&mut buf, Version::Draft18),
+			Err(DecodeError::Version)
+		));
 	}
 }

--- a/rs/moq-net/src/ietf/subscribe_namespace.rs
+++ b/rs/moq-net/src/ietf/subscribe_namespace.rs
@@ -18,29 +18,51 @@ use super::Version;
 /// for a REQUEST_OK.
 pub const SUBSCRIBE_TRACKS_ID: u64 = 0x51;
 
-/// SubscribeNamespace message.
-/// In v16, this moves from the control stream to its own bidirectional stream.
+/// SUBSCRIBE_NAMESPACE message (draft-18+, type 0x50).
+///
+/// Draft-18 renumbered the message from 0x11 to 0x50 and dropped the Subscribe
+/// Options field when it split SUBSCRIBE_TRACKS (0x51) off into its own message
+/// type (#1542). Draft-14 through draft-17 use [`SubscribeNamespaceLegacy`].
 #[derive(Clone, Debug)]
 pub struct SubscribeNamespace<'a> {
 	pub request_id: RequestId,
 	pub namespace: Path<'a>,
-	/// v16: Subscribe Options (default 0x01 = NAMESPACE only)
-	pub subscribe_options: u64,
-}
-
-impl SubscribeNamespace<'_> {
-	/// Wire message type ID. Draft-18 renumbered SUBSCRIBE_NAMESPACE from 0x11
-	/// to 0x50 when it split SUBSCRIBE_TRACKS (0x51) off into its own message
-	/// (#1542). Earlier drafts keep 0x11.
-	pub fn wire_id(version: Version) -> u64 {
-		match version {
-			Version::Draft14 | Version::Draft15 | Version::Draft16 | Version::Draft17 => Self::ID,
-			_ => 0x50,
-		}
-	}
 }
 
 impl Message for SubscribeNamespace<'_> {
+	const ID: u64 = 0x50;
+
+	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		self.request_id.encode(w, version)?;
+		encode_namespace(w, &self.namespace, version)?;
+		encode_params!(w, version,);
+		Ok(())
+	}
+
+	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let request_id = RequestId::decode(r, version)?;
+		let namespace = decode_namespace(r, version)?;
+		decode_params!(r, version,);
+
+		Ok(Self { request_id, namespace })
+	}
+}
+
+/// SUBSCRIBE_NAMESPACE message for draft-14 through draft-17 (type 0x11).
+///
+/// In v16 this moves from the control stream to its own bidirectional stream.
+/// Draft-16/17 carry a Subscribe Options field (NAMESPACE vs TRACKS); draft-17
+/// additionally prefixes a Required Request ID delta (removed in draft-18 per
+/// #1615). Draft-18+ uses [`SubscribeNamespace`].
+#[derive(Clone, Debug)]
+pub struct SubscribeNamespaceLegacy<'a> {
+	pub request_id: RequestId,
+	pub namespace: Path<'a>,
+	/// v16/v17: Subscribe Options (default 0x01 = NAMESPACE only).
+	pub subscribe_options: u64,
+}
+
+impl Message for SubscribeNamespaceLegacy<'_> {
 	const ID: u64 = 0x11;
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
@@ -49,9 +71,6 @@ impl Message for SubscribeNamespace<'_> {
 			0u64.encode(w, version)?; // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		encode_namespace(w, &self.namespace, version)?;
-		// Draft-16/17 carried a Subscribe Options field to pick NAMESPACE vs TRACKS.
-		// Draft-18 dropped it, splitting the two cases into SUBSCRIBE_NAMESPACE (0x50)
-		// and SUBSCRIBE_TRACKS (0x51) message types instead (#1542).
 		if matches!(version, Version::Draft16 | Version::Draft17) {
 			self.subscribe_options.encode(w, version)?;
 		}
@@ -65,7 +84,6 @@ impl Message for SubscribeNamespace<'_> {
 			let _required_request_id_delta = u64::decode(r, version)?;
 		}
 		let namespace = decode_namespace(r, version)?;
-		// Subscribe Options exists only in draft-16/17 (see encode_msg).
 		let subscribe_options = match version {
 			Version::Draft16 | Version::Draft17 => u64::decode(r, version)?,
 			_ => 0x01,
@@ -75,8 +93,8 @@ impl Message for SubscribeNamespace<'_> {
 		decode_params!(r, version,);
 
 		Ok(Self {
-			namespace,
 			request_id,
+			namespace,
 			subscribe_options,
 		})
 	}
@@ -236,42 +254,58 @@ mod tests {
 	}
 
 	#[test]
-	fn wire_id_is_version_dependent() {
-		// 0x11 through draft-17, renumbered to 0x50 in draft-18 (#1542).
-		assert_eq!(SubscribeNamespace::wire_id(Version::Draft16), 0x11);
-		assert_eq!(SubscribeNamespace::wire_id(Version::Draft17), 0x11);
-		assert_eq!(SubscribeNamespace::wire_id(Version::Draft18), 0x50);
+	fn message_ids() {
+		// 0x11 through draft-17 (legacy), renumbered to 0x50 in draft-18 (#1542).
+		assert_eq!(SubscribeNamespaceLegacy::ID, 0x11);
+		assert_eq!(SubscribeNamespace::ID, 0x50);
 	}
 
 	#[test]
 	fn draft18_omits_subscribe_options() {
-		let msg = SubscribeNamespace {
+		// Draft-18 modern body: Request ID (0x00), empty namespace field-count
+		// (0x00), Number of Parameters (0x00). No Subscribe Options field.
+		let modern = SubscribeNamespace {
+			request_id: RequestId(0),
+			namespace: Path::default(),
+		};
+		assert_eq!(body(&modern, Version::Draft18), vec![0x00, 0x00, 0x00]);
+
+		// The legacy draft-17 body keeps the options field, so it is one byte longer.
+		let legacy = SubscribeNamespaceLegacy {
 			request_id: RequestId(0),
 			namespace: Path::default(),
 			subscribe_options: 0x01,
 		};
-
-		// Draft-18 body: Request ID (0x00), empty namespace field-count (0x00),
-		// Number of Parameters (0x00). No Subscribe Options field in between.
-		assert_eq!(body(&msg, Version::Draft18), vec![0x00, 0x00, 0x00]);
-
-		// Draft-17 keeps the options field, so the same message is one byte longer.
-		assert!(body(&msg, Version::Draft17).len() > body(&msg, Version::Draft18).len());
+		assert!(body(&legacy, Version::Draft17).len() > body(&modern, Version::Draft18).len());
 	}
 
 	#[test]
-	fn round_trips_each_version() {
-		for version in [Version::Draft16, Version::Draft17, Version::Draft18] {
-			let msg = SubscribeNamespace {
+	fn modern_round_trips() {
+		let msg = SubscribeNamespace {
+			request_id: RequestId(4),
+			namespace: Path::new("example/meeting"),
+		};
+		let mut buf = bytes::Bytes::from(body(&msg, Version::Draft18));
+		let decoded = SubscribeNamespace::decode_msg(&mut buf, Version::Draft18).unwrap();
+		assert!(buf.is_empty());
+		assert_eq!(decoded.request_id, RequestId(4));
+		assert_eq!(decoded.namespace.as_str(), "example/meeting");
+	}
+
+	#[test]
+	fn legacy_round_trips() {
+		for version in [Version::Draft16, Version::Draft17] {
+			let msg = SubscribeNamespaceLegacy {
 				request_id: RequestId(4),
 				namespace: Path::new("example/meeting"),
 				subscribe_options: 0x01,
 			};
 			let mut buf = bytes::Bytes::from(body(&msg, version));
-			let decoded = SubscribeNamespace::decode_msg(&mut buf, version).unwrap();
+			let decoded = SubscribeNamespaceLegacy::decode_msg(&mut buf, version).unwrap();
 			assert!(buf.is_empty(), "trailing bytes for {version:?}");
 			assert_eq!(decoded.request_id, RequestId(4));
 			assert_eq!(decoded.namespace.as_str(), "example/meeting");
+			assert_eq!(decoded.subscribe_options, 0x01);
 		}
 	}
 }

--- a/rs/moq-net/src/ietf/subscribe_namespace.rs
+++ b/rs/moq-net/src/ietf/subscribe_namespace.rs
@@ -18,7 +18,7 @@ use super::Version;
 /// for a REQUEST_OK.
 pub const SUBSCRIBE_TRACKS_ID: u64 = 0x51;
 
-/// SubscribeNamespace message (0x11)
+/// SubscribeNamespace message.
 /// In v16, this moves from the control stream to its own bidirectional stream.
 #[derive(Clone, Debug)]
 pub struct SubscribeNamespace<'a> {
@@ -26,6 +26,18 @@ pub struct SubscribeNamespace<'a> {
 	pub namespace: Path<'a>,
 	/// v16: Subscribe Options (default 0x01 = NAMESPACE only)
 	pub subscribe_options: u64,
+}
+
+impl SubscribeNamespace<'_> {
+	/// Wire message type ID. Draft-18 renumbered SUBSCRIBE_NAMESPACE from 0x11
+	/// to 0x50 when it split SUBSCRIBE_TRACKS (0x51) off into its own message
+	/// (#1542). Earlier drafts keep 0x11.
+	pub fn wire_id(version: Version) -> u64 {
+		match version {
+			Version::Draft14 | Version::Draft15 | Version::Draft16 | Version::Draft17 => Self::ID,
+			_ => 0x50,
+		}
+	}
 }
 
 impl Message for SubscribeNamespace<'_> {
@@ -37,7 +49,10 @@ impl Message for SubscribeNamespace<'_> {
 			0u64.encode(w, version)?; // required_request_id_delta = 0 (draft-17 only, removed in draft-18 per #1615)
 		}
 		encode_namespace(w, &self.namespace, version)?;
-		if !matches!(version, Version::Draft14 | Version::Draft15) {
+		// Draft-16/17 carried a Subscribe Options field to pick NAMESPACE vs TRACKS.
+		// Draft-18 dropped it, splitting the two cases into SUBSCRIBE_NAMESPACE (0x50)
+		// and SUBSCRIBE_TRACKS (0x51) message types instead (#1542).
+		if matches!(version, Version::Draft16 | Version::Draft17) {
 			self.subscribe_options.encode(w, version)?;
 		}
 		encode_params!(w, version,);
@@ -50,9 +65,10 @@ impl Message for SubscribeNamespace<'_> {
 			let _required_request_id_delta = u64::decode(r, version)?;
 		}
 		let namespace = decode_namespace(r, version)?;
+		// Subscribe Options exists only in draft-16/17 (see encode_msg).
 		let subscribe_options = match version {
-			Version::Draft14 | Version::Draft15 => 0x01,
-			_ => u64::decode(r, version)?,
+			Version::Draft16 | Version::Draft17 => u64::decode(r, version)?,
+			_ => 0x01,
 		};
 
 		// Ignore parameters
@@ -205,5 +221,57 @@ impl Message for NamespaceDone<'_> {
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let suffix = decode_namespace(r, version)?;
 		Ok(Self { suffix })
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bytes::BytesMut;
+
+	fn body<M: Message>(msg: &M, version: Version) -> Vec<u8> {
+		let mut buf = BytesMut::new();
+		msg.encode_msg(&mut buf, version).unwrap();
+		buf.to_vec()
+	}
+
+	#[test]
+	fn wire_id_is_version_dependent() {
+		// 0x11 through draft-17, renumbered to 0x50 in draft-18 (#1542).
+		assert_eq!(SubscribeNamespace::wire_id(Version::Draft16), 0x11);
+		assert_eq!(SubscribeNamespace::wire_id(Version::Draft17), 0x11);
+		assert_eq!(SubscribeNamespace::wire_id(Version::Draft18), 0x50);
+	}
+
+	#[test]
+	fn draft18_omits_subscribe_options() {
+		let msg = SubscribeNamespace {
+			request_id: RequestId(0),
+			namespace: Path::default(),
+			subscribe_options: 0x01,
+		};
+
+		// Draft-18 body: Request ID (0x00), empty namespace field-count (0x00),
+		// Number of Parameters (0x00). No Subscribe Options field in between.
+		assert_eq!(body(&msg, Version::Draft18), vec![0x00, 0x00, 0x00]);
+
+		// Draft-17 keeps the options field, so the same message is one byte longer.
+		assert!(body(&msg, Version::Draft17).len() > body(&msg, Version::Draft18).len());
+	}
+
+	#[test]
+	fn round_trips_each_version() {
+		for version in [Version::Draft16, Version::Draft17, Version::Draft18] {
+			let msg = SubscribeNamespace {
+				request_id: RequestId(4),
+				namespace: Path::new("example/meeting"),
+				subscribe_options: 0x01,
+			};
+			let mut buf = bytes::Bytes::from(body(&msg, version));
+			let decoded = SubscribeNamespace::decode_msg(&mut buf, version).unwrap();
+			assert!(buf.is_empty(), "trailing bytes for {version:?}");
+			assert_eq!(decoded.request_id, RequestId(4));
+			assert_eq!(decoded.namespace.as_str(), "example/meeting");
+		}
 	}
 }

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -103,18 +103,27 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let prefix = self.origin.as_ref().ok_or(Error::InvalidRole)?.root().to_owned();
 		let request_id = self.control.next_request_id().await?;
 
-		// Write SubscribeNamespace
-		let msg = ietf::SubscribeNamespace {
-			request_id,
-			namespace: prefix.clone(),
-			subscribe_options: 0x01, // NAMESPACE only
-		};
-
-		stream
-			.writer
-			.encode(&ietf::SubscribeNamespace::wire_id(self.version))
-			.await?;
-		stream.writer.encode(&msg).await?;
+		// Draft-18+ uses SUBSCRIBE_NAMESPACE (0x50); earlier drafts use the legacy
+		// 0x11 message with a Subscribe Options field.
+		match self.version {
+			Version::Draft14 | Version::Draft15 | Version::Draft16 | Version::Draft17 => {
+				let msg = ietf::SubscribeNamespaceLegacy {
+					request_id,
+					namespace: prefix.clone(),
+					subscribe_options: 0x01, // NAMESPACE only
+				};
+				stream.writer.encode(&ietf::SubscribeNamespaceLegacy::ID).await?;
+				stream.writer.encode(&msg).await?;
+			}
+			_ => {
+				let msg = ietf::SubscribeNamespace {
+					request_id,
+					namespace: prefix.clone(),
+				};
+				stream.writer.encode(&ietf::SubscribeNamespace::ID).await?;
+				stream.writer.encode(&msg).await?;
+			}
+		}
 
 		tracing::debug!(%prefix, "subscribe_namespace sent");
 
@@ -483,10 +492,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 				let this = self.clone();
 				web_async::spawn(async move {
-					if let Err(err) = this.run_broadcast(path.clone(), dynamic).await {
+					// stop_announce is the authoritative remover: it drops the entry (and
+					// its producer) once the announce refcount hits zero, which is what
+					// makes run_broadcast exit. Removing here too would let a stale task
+					// delete a freshly re-announced entry for the same path.
+					if let Err(err) = this.run_broadcast(path, dynamic).await {
 						tracing::debug!(%err, "error running broadcast");
 					}
-					this.state.lock().broadcasts.remove(&path);
 				});
 
 				Ok(broadcast)

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -110,7 +110,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			subscribe_options: 0x01, // NAMESPACE only
 		};
 
-		stream.writer.encode(&ietf::SubscribeNamespace::ID).await?;
+		stream
+			.writer
+			.encode(&ietf::SubscribeNamespace::wire_id(self.version))
+			.await?;
 		stream.writer.encode(&msg).await?;
 
 		tracing::debug!(%prefix, "subscribe_namespace sent");
@@ -448,10 +451,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let abs = origin.absolute(&path).to_owned();
 
 		let mut state = self.state.lock();
-		let broadcast = match state.broadcasts.entry(path.clone()) {
+		match state.broadcasts.entry(path.clone()) {
 			Entry::Occupied(mut entry) => {
 				entry.get_mut().count += 1;
-				return Ok(entry.get().producer.clone());
+				Ok(entry.get().producer.clone())
 			}
 			Entry::Vacant(entry) => {
 				// Stamp this connection's origin as the sole hop so the route is
@@ -461,29 +464,34 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				hops.push(self.session_origin)
 					.expect("an empty hop chain has room for one entry");
 				let broadcast = Broadcast { hops }.produce();
+
+				// Create the dynamic handler BEFORE publishing so consumers see
+				// dynamic >= 1 the moment they receive the announce. Otherwise a
+				// consumer can call subscribe_track() before the spawned
+				// run_broadcast bumps the counter and get NotFound (mirrors the
+				// note in lite::Subscriber).
+				let dynamic = broadcast.dynamic();
+
 				origin.publish_broadcast(path.clone(), broadcast.consume());
 				entry.insert(BroadcastState {
 					producer: broadcast.clone(),
 					count: 1,
 					_stats: self.stats.broadcast(&abs).subscriber(),
 				});
-				broadcast
+
+				tracing::debug!(broadcast = %origin.absolute(&path), "announce");
+
+				let this = self.clone();
+				web_async::spawn(async move {
+					if let Err(err) = this.run_broadcast(path.clone(), dynamic).await {
+						tracing::debug!(%err, "error running broadcast");
+					}
+					this.state.lock().broadcasts.remove(&path);
+				});
+
+				Ok(broadcast)
 			}
-		};
-
-		tracing::debug!(broadcast = %origin.absolute(&path), "announce");
-
-		let this = self.clone();
-		let producer = broadcast.clone();
-
-		web_async::spawn(async move {
-			if let Err(err) = this.run_broadcast(path.clone(), producer.dynamic()).await {
-				tracing::debug!(%err, "error running broadcast");
-			}
-			this.state.lock().broadcasts.remove(&path);
-		});
-
-		Ok(broadcast)
+		}
 	}
 
 	fn stop_announce(&mut self, path: PathOwned) -> Result<(), Error> {


### PR DESCRIPTION
## Summary

Connecting clients to the moxygen/mvfst draft-18 relay surfaced several `moq-transport-18` interop bugs. This PR fixes four, across `rs/moq-net` and `js/net`, and validates the path live in both Rust and JS.

1. **SUBSCRIBE_NAMESPACE message type renumbered `0x11` → `0x50`.** Draft-18's [#1542](https://github.com/moq-wg/moq-transport/pull/1542) split `SUBSCRIBE_TRACKS` (`0x51`) off into its own message and renumbered `SUBSCRIBE_NAMESPACE` to `0x50`. We already handled `0x51` but kept sending the request as `0x11`, which the relay rejected as an unknown message type. Modeled as two fixed-ID message types: `SubscribeNamespace` (`0x50`, draft-18+) and `SubscribeNamespaceLegacy` (`0x11`, draft-14..17).

2. **SUBSCRIBE_NAMESPACE "Subscribe Options" field removed in draft-18.** That namespace-vs-tracks choice became the `0x50`/`0x51` split, so the field is gone from the body. We still encoded `0x01`; the relay read it as the parameter count and reset the session. The modern `SubscribeNamespace` has no options field; the legacy struct keeps it for draft-16/17 (and the draft-17 Required Request ID delta).

3. **Local announce race in the IETF subscriber (`rs/moq-net`).** `start_announce` bumped the broadcast's `dynamic` counter *inside* a spawned task *after* publishing the broadcast, so a consumer (the fmp4 catalog `subscribe_track`) could race ahead and get `NotFound`. Now creates the dynamic handle *before* publishing, mirroring the existing `lite::Subscriber` fix. (The redundant spawned `broadcasts.remove` cleanup was also dropped; `stop_announce` is the authoritative remover.)

4. **Draft-18 `FIRST_OBJECT` subgroup-header bit not handled (`js/net`).** Draft-18 (spec 11.4.2) adds bit `0x40` (FIRST_OBJECT) to the subgroup header type (extending the valid set to `0x50`-`0x5d`/`0x70`-`0x7d`). The JS object decoder rejected type `0x58` as "Unsupported group type", so draft-18 media could not be received even after the SUBSCRIBE fixes. Set the bit on emit / strip it on parse, matching the Rust `GroupFlags` implementation. (Rust already handled this; JS did not.)

Note: the moxygen relay's TLS cert is currently expired, so reproducing against it needs `--tls-disable-verify`. That's a relay-side issue, not addressed here.

## Validation

- **Rust ↔ moxygen (draft-18, real QUIC/WebTransport):** `moq-cli publish ... fmp4` → relay → `moq-cli subscribe ... --format fmp4`; received a valid H.264 stream that decodes cleanly (120 frames).
- **JS ↔ Rust (draft-18, live over WebSocket):** a bun `@moq/net` client (forced to `moqt-18`) against a local `moq-cli serve` draft-18 server negotiated `moq-transport-18`, discovered the broadcast via SUBSCRIBE_NAMESPACE, and received the hang catalog plus H.264 video frames. Cross-checked against the Rust QUIC client on the same server (210 frames decoded) to rule out any WebSocket/qmux-specific behavior.
- **In-process:** added a draft-18 case to the `js/net` integration test (full publish/announce/subscribe flow over the mock transport).

## Test plan

- [x] `cargo test -p moq-net` — 337 pass (incl. SUBSCRIBE_NAMESPACE legacy/modern wire-format/round-trip tests)
- [x] `bun test` in `js/net` — 141 pass (incl. draft-18 integration + SUBSCRIBE_NAMESPACE legacy/modern + Group FIRST_OBJECT tests)
- [x] `cargo clippy -p moq-net`, `cargo fmt`, `tsc --noEmit`, `biome check` — clean

## Cross-package sync

`rs/moq-net` wire change → `js/net` updated. Fixes 1, 2 touch both implementations; fix 3 is Rust-only (the JS announce path already creates the dynamic handle eagerly); fix 4 is JS-only (Rust already handled FIRST_OBJECT).

> [!NOTE]
> This is a wire-layer change and per `CLAUDE.md` Branch Targeting would normally go to `dev`. Opened against `main` per request; reviewers can retarget if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)