### PR TITLE
feat(moq-native): single connect() that reconnects by default; cluster + ffi auto-reconnect

### DIFF
--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -23,8 +23,13 @@ Create a [`ClientConfig`](https://docs.rs/moq-native/latest/moq_native/struct.Cl
 ```rust
 let client = moq_native::ClientConfig::default().init()?;
 let url = url::Url::parse("https://cdn.moq.dev/anon/my-broadcast")?;
-let session = client.connect(url).await?;
+let session = client.connect_once(url).await?;
 ```
+
+`connect_once` makes a single attempt and hands you the session. For a resilient client, prefer
+`client.connect(url)`, which stays connected and reconnects with exponential backoff whenever the
+session drops, returning a [`Connection`](https://docs.rs/moq-native/latest/moq_native/struct.Connection.html)
+handle (wire origins with `with_publisher`/`with_consumer` first; drop the handle to stop).
 
 The default configuration uses system TLS roots, enables WebSocket fallback, and gives QUIC a 200ms head-start.
 
@@ -52,7 +57,7 @@ Pass JWT tokens via URL query parameters:
 let url = Url::parse(&format!(
     "https://relay.example.com/room/123?jwt={}", token
 ))?;
-let session = client.connect(url).await?;
+let session = client.connect_once(url).await?;
 ```
 
 See the [Authentication guide](/bin/relay/auth) for how to generate tokens.
@@ -64,7 +69,7 @@ The [video example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/vi
 The connected [`Session`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html) exposes a [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) [`OriginProducer`](https://docs.rs/moq-net/latest/moq_net/struct.OriginProducer.html) you publish broadcasts into:
 
 ```rust
-let session = client.connect(url).await?;
+let session = client.connect_once(url).await?;
 
 let mut broadcast = moq_net::Broadcast::new().produce();
 // ... add catalog and tracks to the broadcast ...
@@ -80,7 +85,7 @@ The [subscribe example](https://github.com/moq-dev/moq/blob/main/rs/hang/example
 The session also exposes a [`consumer()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.consumer) [`OriginConsumer`](https://docs.rs/moq-net/latest/moq_net/struct.OriginConsumer.html) for receiving announcements:
 
 ```rust
-let session = client.connect(url).await?;
+let session = client.connect_once(url).await?;
 let mut announced = session.consumer().announced();
 
 // Wait for broadcasts to be announced.

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -23,13 +23,18 @@ Create a [`ClientConfig`](https://docs.rs/moq-native/latest/moq_native/struct.Cl
 ```rust
 let client = moq_native::ClientConfig::default().init()?;
 let url = url::Url::parse("https://cdn.moq.dev/anon/my-broadcast")?;
-let session = client.connect_once(url).await?;
+
+// Stays connected, reconnecting with exponential backoff if the session drops.
+let connection = client.connect(url);
+let session = connection.established().await?;
 ```
 
-`connect_once` makes a single attempt and hands you the session. For a resilient client, prefer
-`client.connect(url)`, which stays connected and reconnects with exponential backoff whenever the
-session drops, returning a [`Connection`](https://docs.rs/moq-native/latest/moq_native/struct.Connection.html)
-handle (wire origins with `with_publisher`/`with_consumer` first; drop the handle to stop).
+`connect` returns a [`Connection`](https://docs.rs/moq-native/latest/moq_native/struct.Connection.html)
+handle that stays connected and reconnects with backoff whenever the session drops. Wire origins with
+`with_publisher`/`with_consumer` before connecting; they're re-attached on every reconnect. Await
+[`established()`](https://docs.rs/moq-native/latest/moq_native/struct.Connection.html#method.established)
+to drive the session directly, and keep the handle alive while you use it (dropping it stops the loop
+and tears the session down).
 
 The default configuration uses system TLS roots, enables WebSocket fallback, and gives QUIC a 200ms head-start.
 
@@ -57,7 +62,8 @@ Pass JWT tokens via URL query parameters:
 let url = Url::parse(&format!(
     "https://relay.example.com/room/123?jwt={}", token
 ))?;
-let session = client.connect_once(url).await?;
+let connection = client.connect(url);
+let session = connection.established().await?;
 ```
 
 See the [Authentication guide](/bin/relay/auth) for how to generate tokens.
@@ -69,7 +75,8 @@ The [video example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/vi
 The connected [`Session`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html) exposes a [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) [`OriginProducer`](https://docs.rs/moq-net/latest/moq_net/struct.OriginProducer.html) you publish broadcasts into:
 
 ```rust
-let session = client.connect_once(url).await?;
+let connection = client.connect(url);
+let session = connection.established().await?; // keep `connection` alive while you use `session`
 
 let mut broadcast = moq_net::Broadcast::new().produce();
 // ... add catalog and tracks to the broadcast ...
@@ -85,7 +92,8 @@ The [subscribe example](https://github.com/moq-dev/moq/blob/main/rs/hang/example
 The session also exposes a [`consumer()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.consumer) [`OriginConsumer`](https://docs.rs/moq-net/latest/moq_net/struct.OriginConsumer.html) for receiving announcements:
 
 ```rust
-let session = client.connect_once(url).await?;
+let connection = client.connect(url);
+let session = connection.established().await?; // keep `connection` alive while you use `session`
 let mut announced = session.consumer().announced();
 
 // Wait for broadcasts to be announced.

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -231,7 +231,11 @@ a relay with a few lines:
 ```rust
 let client = moq_native::ClientConfig::default().init()?;
 let url = url::Url::parse("https://relay.moq.dev/anon")?;
-let session = client.connect_once(url).await?;
+
+// connect() reconnects with backoff; await established() for the session, and
+// keep the returned handle alive while you use it.
+let connection = client.connect(url);
+let session = connection.established().await?;
 ```
 
 To publish or consume, wire an [`Origin`](https://docs.rs/moq-net/latest/moq_net/struct.Origin.html)
@@ -241,7 +245,8 @@ into the session before connecting:
 // Subscribe: wait for broadcasts to be announced.
 let origin = moq_net::Origin::new().produce();
 let mut consumer = origin.consume();
-let session = client.with_consume(origin).connect_once(url).await?;
+let connection = client.with_consume(origin).connect(url);
+let session = connection.established().await?;
 
 while let Some((path, broadcast)) = consumer.announced().await {
     // ... subscribe to tracks on each broadcast ...

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -231,7 +231,7 @@ a relay with a few lines:
 ```rust
 let client = moq_native::ClientConfig::default().init()?;
 let url = url::Url::parse("https://relay.moq.dev/anon")?;
-let session = client.connect(url).await?;
+let session = client.connect_once(url).await?;
 ```
 
 To publish or consume, wire an [`Origin`](https://docs.rs/moq-net/latest/moq_net/struct.Origin.html)
@@ -241,7 +241,7 @@ into the session before connecting:
 // Subscribe: wait for broadcasts to be announced.
 let origin = moq_net::Origin::new().produce();
 let mut consumer = origin.consume();
-let session = client.with_consume(origin).connect(url).await?;
+let session = client.with_consume(origin).connect_once(url).await?;
 
 while let Some((path, broadcast)) = consumer.announced().await {
     // ... subscribe to tracks on each broadcast ...

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -39,6 +39,8 @@ let client = Client()
 let session = try await client.connect(to: "https://relay.example.com")
 ```
 
+`connect` resolves once the first session is established, then keeps it alive: if the session later drops it reconnects with exponential backoff. Call `shutdown()` (or `cancel()`) on the session to stop.
+
 `session.publisher` and `session.consumer` are always populated: by whatever origin you wired via `setPublish` / `setConsume` before connecting, or by a fresh auto-created one for any side you left unset. The duplex no-config path (the typical client) shares one origin between both.
 
 For development against a relay with a self-signed certificate:

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -33,7 +33,7 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	// Establish a connection with automatic reconnection.
 	// with_consumer() registers an OriginProducer for incoming data.
 	// Use with_publisher() if you also want to publish from the session.
-	let reconnect = client.with_consumer(origin).reconnect(url);
+	let reconnect = client.with_consumer(origin).connect(url);
 
 	// Wait until the reconnect loop stops (e.g. timeout exceeded).
 	reconnect.closed().await

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -33,7 +33,7 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	// with_publisher() registers an OriginProducer. moq-net reads from its
 	// consumer view internally. Pair with with_consumer() if you also want
 	// to subscribe to remote announcements.
-	let reconnect = client.with_publisher(origin).reconnect(url);
+	let reconnect = client.with_publisher(origin).connect(url);
 
 	// Wait until the reconnect loop stops (e.g. timeout exceeded).
 	reconnect.closed().await

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -79,7 +79,7 @@ impl Session {
 			client = client.with_consumer(consume);
 		}
 
-		let reconnect = client.reconnect(url);
+		let reconnect = client.connect(url);
 
 		// report() runs until the reconnect loop gives up; map its terminal error to Connect.
 		Self::report(callback, reconnect)
@@ -91,7 +91,7 @@ impl Session {
 	///
 	/// Returns the terminal error via `?`. Disconnects aren't reported: status 0 is reserved for a
 	/// clean close (delivered as the terminal callback once the task ends).
-	async fn report(callback: ffi::OnStatus, mut reconnect: moq_native::Reconnect) -> anyhow::Result<()> {
+	async fn report(callback: ffi::OnStatus, mut reconnect: moq_native::Connection) -> anyhow::Result<()> {
 		let mut connects: u64 = 0;
 		loop {
 			if let moq_native::Status::Connected = reconnect.status().await? {

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -238,7 +238,7 @@ async fn run(config: &Config) -> Result<()> {
 	let reconnect = client
 		.with_publisher(publish_origin.clone())
 		.with_consumer(consume_origin)
-		.reconnect(config.url.clone());
+		.connect(config.url.clone());
 
 	// Set up catalog and encoders.
 	let catalog = moq_mux::catalog::hang::Producer::new(&mut broadcast)?;

--- a/rs/moq-cli/src/client.rs
+++ b/rs/moq-cli/src/client.rs
@@ -13,7 +13,7 @@ pub async fn run_client(client: moq_native::Client, url: Url, name: String, publ
 
 	tracing::info!(%url, %name, "connecting");
 
-	let reconnect = client.with_publisher(origin.clone()).reconnect(url);
+	let reconnect = client.with_publisher(origin.clone()).connect(url);
 
 	#[cfg(unix)]
 	// Notify systemd that we're ready.

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -223,7 +223,7 @@ async fn run_subscribe(
 
 	tracing::info!(%url, %broadcast, "connecting");
 
-	let reconnect = client.with_consumer(origin).reconnect(url);
+	let reconnect = client.with_consumer(origin).connect(url);
 
 	#[cfg(unix)]
 	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -21,22 +21,34 @@ impl Client {
 			.init()
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;
 
-		// moq-net defaults both sides if unset; only override when the
-		// FFI caller wired their own.
-		let mut client = client;
-		if let Some(publish) = self.publish.as_ref() {
-			client = client.with_publisher(publish.inner().clone());
-		}
-		if let Some(consume) = self.consume.as_ref() {
-			client = client.with_consumer(consume.inner().clone());
-		}
+		// Wire stable publish/consume origins so they survive reconnects: the caller's if set,
+		// otherwise a shared origin (matching moq-net's default of wiring one origin as both sides).
+		let (publish, consume) = self.origins();
 
-		let session = client
-			.connect(url)
+		// Reconnect with backoff by default; wait for the first established session before returning.
+		let mut connection = client
+			.with_publisher(publish.clone())
+			.with_consumer(consume.clone())
+			.connect(url);
+		connection
+			.status()
 			.await
 			.map_err(|err| MoqError::Connect(format!("{err}")))?;
 
-		Ok(Arc::new(MoqSession::new(session)))
+		Ok(Arc::new(MoqSession::reconnecting(connection, publish, consume)))
+	}
+
+	/// The publish/consume origins to wire, held so they stay stable across reconnects.
+	fn origins(&self) -> (moq_net::OriginProducer, moq_net::OriginProducer) {
+		match (self.publish.as_ref(), self.consume.as_ref()) {
+			(Some(publish), Some(consume)) => (publish.inner().clone(), consume.inner().clone()),
+			(Some(publish), None) => (publish.inner().clone(), moq_net::Origin::random().produce()),
+			(None, Some(consume)) => (moq_net::Origin::random().produce(), consume.inner().clone()),
+			(None, None) => {
+				let shared = moq_net::Origin::random().produce();
+				(shared.clone(), shared)
+			}
+		}
 	}
 }
 
@@ -96,12 +108,14 @@ impl MoqClient {
 
 	/// Connect to a MoQ server and wait for the session to be established.
 	///
+	/// The returned session reconnects with exponential backoff if it later drops; call
+	/// `shutdown()` (or `cancel()`) on it to stop.
+	///
 	/// If neither [`set_publish`](Self::set_publish) nor
-	/// [`set_consume`](Self::set_consume) was called on this client, the
-	/// underlying moq-net layer auto-creates a fresh origin and wires it
-	/// as both sides. The producer and consumer sides are then accessible
-	/// via [`MoqSession::publisher`] and [`MoqSession::consumer`] so the
-	/// caller never has to construct a [`MoqOriginProducer`] themselves.
+	/// [`set_consume`](Self::set_consume) was called on this client, a fresh origin is created and
+	/// wired as both sides. The producer and consumer sides are then accessible via
+	/// [`MoqSession::publisher`] and [`MoqSession::consumer`] so the caller never has to construct a
+	/// [`MoqOriginProducer`] themselves.
 	///
 	/// Can be cancelled by calling `cancel()`.
 	pub async fn connect(&self, url: String) -> Result<Arc<MoqSession>, MoqError> {
@@ -118,21 +132,51 @@ impl MoqClient {
 
 #[derive(uniffi::Object)]
 pub struct MoqSession {
-	inner: Option<moq_net::Session>,
-	closed: Task<Session>,
+	kind: Kind,
 	publisher: Arc<MoqOriginProducer>,
 	consumer: Arc<MoqOriginConsumer>,
 }
 
+// `MoqSession` is always handed out behind an `Arc`, so the size gap between variants is moot.
+#[allow(clippy::large_enum_variant)]
+enum Kind {
+	/// Client side: a reconnecting connection. `closed` resolves only when it permanently stops.
+	Connection(Arc<moq_native::Connection>),
+	/// Server side: a single accepted session, with no client connection to reconnect.
+	Session {
+		inner: Option<moq_net::Session>,
+		closed: Task<Session>,
+	},
+}
+
 impl MoqSession {
+	/// Wrap a single server-accepted session (no reconnection).
 	pub(crate) fn new(session: moq_net::Session) -> Self {
 		// Eagerly wrap the always-set origin sides so each
 		// publisher()/consumer() call hands back the same Arc.
 		let publisher = Arc::new(MoqOriginProducer::from_inner(session.publisher().clone()));
 		let consumer = Arc::new(MoqOriginConsumer::from_inner(session.consumer().clone()));
 		Self {
-			inner: Some(session.clone()),
-			closed: Task::new(session),
+			kind: Kind::Session {
+				inner: Some(session.clone()),
+				closed: Task::new(session),
+			},
+			publisher,
+			consumer,
+		}
+	}
+
+	/// Wrap a client connection that reconnects with backoff. `publish`/`consume` are the wired
+	/// origins, stable across reconnects, so the publisher/consumer handles stay valid.
+	pub(crate) fn reconnecting(
+		connection: moq_native::Connection,
+		publish: moq_net::OriginProducer,
+		consume: moq_net::OriginProducer,
+	) -> Self {
+		let publisher = Arc::new(MoqOriginProducer::from_inner(publish));
+		let consumer = Arc::new(MoqOriginConsumer::from_inner(consume.consume()));
+		Self {
+			kind: Kind::Connection(Arc::new(connection)),
 			publisher,
 			consumer,
 		}
@@ -142,28 +186,49 @@ impl MoqSession {
 impl Drop for MoqSession {
 	fn drop(&mut self) {
 		let _guard = crate::ffi::RUNTIME.enter();
-		self.inner.take();
+		// Server: drop the held session. Client: the last `Arc<Connection>` drop aborts the loop.
+		if let Kind::Session { inner, .. } = &mut self.kind {
+			inner.take();
+		}
 	}
 }
 
 #[uniffi::export]
 impl MoqSession {
-	/// Wait until the session is closed.
+	/// Wait until the session is closed. For a reconnecting client, this only resolves once the
+	/// connection permanently stops (gives up, or `cancel`/`shutdown` is called).
 	pub async fn closed(&self) -> Result<(), MoqError> {
-		// We have a task to run all of the closed calls juuuuust so they use the same tokio runtime.
-		self.closed
-			.run(|session| async move { session.closed().await.map_err(Into::into) })
-			.await
+		match &self.kind {
+			// Drive on the shared runtime so the C callback keeps its thread affinity.
+			Kind::Connection(connection) => {
+				let connection = connection.clone();
+				match crate::ffi::RUNTIME
+					.spawn(async move { connection.closed().await })
+					.await
+				{
+					Ok(res) => res.map_err(|err| MoqError::Connect(format!("{err:#}"))),
+					Err(err) => Err(MoqError::Task(err)),
+				}
+			}
+			Kind::Session { closed, .. } => {
+				closed
+					.run(|session| async move { session.closed().await.map_err(Into::into) })
+					.await
+			}
+		}
 	}
 
-	/// Close the session with the given error code.
+	/// Stop the connection and close the current session with the given error code.
 	pub fn cancel(&self, code: u32) {
 		let _guard = crate::ffi::RUNTIME.enter();
-		if let Some(inner) = &self.inner {
-			inner.clone().close(moq_net::Error::Remote(code));
+		match &self.kind {
+			Kind::Connection(connection) => connection.close(moq_net::Error::Remote(code)),
+			Kind::Session { inner, .. } => {
+				if let Some(inner) = inner {
+					inner.clone().close(moq_net::Error::Remote(code));
+				}
+			}
 		}
-		// NOTE: we don't abort the closed Task because it will be aborted via above ^
-		// We'll get a slightly better error message instead of Cancelled.
 	}
 
 	/// Graceful shutdown. Equivalent to `cancel(0)`. Documents the

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -401,7 +401,7 @@ async fn run_session(
 		.context("failed to publish broadcast")?;
 
 	let client = client.with_publisher(origin.clone());
-	let session = client.connect(settings.url.clone()).await?;
+	let session = client.connect_once(settings.url.clone()).await?;
 
 	let mut runtime = RuntimeState {
 		session,

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -86,6 +86,8 @@ struct PadState {
 }
 
 struct RuntimeState {
+	// Held so the reconnecting connection (and its origins) stays alive for the run loop.
+	_connection: moq_native::Connection,
 	#[allow(dead_code)]
 	session: moq_net::Session,
 	broadcast: moq_net::BroadcastProducer,
@@ -401,9 +403,12 @@ async fn run_session(
 		.context("failed to publish broadcast")?;
 
 	let client = client.with_publisher(origin.clone());
-	let session = client.connect_once(settings.url.clone()).await?;
+	// Hold the connection for the lifetime of the loop; dropping it tears the session down.
+	let connection = client.connect(settings.url.clone());
+	let session = connection.established().await?;
 
 	let mut runtime = RuntimeState {
+		_connection: connection,
 		session,
 		broadcast,
 		catalog,

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -273,7 +273,9 @@ async fn run_session(
 	let origin_consumer = origin.consume();
 	let client = config.init()?.with_consumer(origin);
 
-	let _session = client.connect_once(settings.url.clone()).await?;
+	// Hold the connection for the rest of the function; dropping it tears the session down.
+	let connection = client.connect(settings.url.clone());
+	let _session = connection.established().await?;
 
 	// Wait for the broadcast to be announced. Synchronous lookup would race the gossip of
 	// announcements that happens after the session is established.

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -273,7 +273,7 @@ async fn run_session(
 	let origin_consumer = origin.consume();
 	let client = config.init()?.with_consumer(origin);
 
-	let _session = client.connect(settings.url.clone()).await?;
+	let _session = client.connect_once(settings.url.clone()).await?;
 
 	// Wait for the broadcast to be announced. Synchronous lookup would race the gossip of
 	// announcements that happens after the session is established.

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -28,11 +28,11 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	// The "anon" path is usually configured to bypass authentication; be careful!
 	let url = url::Url::parse("https://cdn.moq.dev/anon/chat-example").unwrap();
 
-	// Establish a WebTransport/QUIC connection and MoQ handshake.
-	let cs = client.with_publisher(origin).connect_once(url).await?;
+	// Connect and stay connected, reconnecting with backoff if the session drops.
+	let connection = client.with_publisher(origin).connect(url);
 
-	// Wait until the session is closed.
-	cs.closed().await.map_err(Into::into)
+	// Wait until the connection permanently stops.
+	connection.closed().await
 }
 
 // Produce a broadcast and publish it to the origin.

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -29,7 +29,7 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	let url = url::Url::parse("https://cdn.moq.dev/anon/chat-example").unwrap();
 
 	// Establish a WebTransport/QUIC connection and MoQ handshake.
-	let cs = client.with_publisher(origin).connect(url).await?;
+	let cs = client.with_publisher(origin).connect_once(url).await?;
 
 	// Wait until the session is closed.
 	cs.closed().await.map_err(Into::into)

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -74,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
 				.publish_broadcast(&config.broadcast, broadcast.consume())
 				.context("failed to publish broadcast")?;
 
-			let reconnect = client.with_publisher(origin.clone()).reconnect(config.url);
+			let reconnect = client.with_publisher(origin.clone()).connect(config.url);
 
 			tokio::select! {
 				res = reconnect.closed() => res,
@@ -82,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
 			}
 		}
 		Command::Subscribe => {
-			let reconnect = client.with_consumer(origin.clone()).reconnect(config.url);
+			let reconnect = client.with_consumer(origin.clone()).connect(config.url);
 
 			// IETF MoQ + the current OriginConsumer API don't let us call
 			// `session.consume_broadcast(&path)` directly, so loop on announces

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -1,5 +1,5 @@
 use crate::crypto;
-use crate::{Backoff, QuicBackend, Reconnect};
+use crate::{Backoff, Connection, QuicBackend};
 use anyhow::Context;
 use std::path::PathBuf;
 use std::{net, sync::Arc};
@@ -330,12 +330,40 @@ impl Client {
 		self
 	}
 
-	/// Start a background reconnect loop that connects to the given URL,
-	/// waits for the session to close, then reconnects with exponential backoff.
+	/// Override the reconnection [`Backoff`] used by [`connect`](Self::connect).
+	pub fn with_backoff(mut self, backoff: Backoff) -> Self {
+		self.backoff = backoff;
+		self
+	}
+
+	/// Connect to the given URL and stay connected, reconnecting with exponential backoff
+	/// whenever the session drops.
 	///
-	/// Returns a [`Reconnect`] handle; drop the last handle to stop the loop.
-	pub fn reconnect(&self, url: Url) -> Reconnect {
-		Reconnect::new(self.clone(), url, self.backoff.clone())
+	/// Spawns a background task and returns a [`Connection`] handle immediately; drop the handle to
+	/// stop the loop. Wire publish/consume origins with [`with_publisher`](Self::with_publisher) and
+	/// [`with_consumer`](Self::with_consumer) before calling, and they are re-attached on every
+	/// reconnect. Observe lifecycle changes with [`Connection::status`] and [`Connection::closed`].
+	///
+	/// For a single attempt that hands you the session directly, use [`connect_once`](Self::connect_once).
+	pub fn connect(&self, url: Url) -> Connection {
+		Connection::new(self.clone(), url, self.backoff.clone())
+	}
+
+	/// Deprecated alias for [`connect`](Self::connect), which now reconnects by default.
+	#[deprecated(note = "use `connect`, which now reconnects with backoff by default")]
+	pub fn reconnect(&self, url: Url) -> Connection {
+		self.connect(url)
+	}
+
+	/// Connect to the given URL exactly once, returning the established session.
+	///
+	/// This makes a single attempt and does not reconnect if the session later drops. The returned
+	/// session is self-contained: you own it and drive it directly. For automatic reconnection, use
+	/// [`connect`](Self::connect).
+	pub async fn connect_once(&self, url: Url) -> anyhow::Result<moq_net::Session> {
+		let session = self.connect_inner(url).await?;
+		tracing::info!(version = %session.version(), "connected");
+		Ok(session)
 	}
 
 	#[cfg(not(any(
@@ -345,7 +373,7 @@ impl Client {
 		feature = "iroh",
 		feature = "websocket"
 	)))]
-	pub async fn connect(&self, _url: Url) -> anyhow::Result<moq_net::Session> {
+	pub(crate) async fn connect_inner(&self, _url: Url) -> anyhow::Result<moq_net::Session> {
 		anyhow::bail!("no backend compiled; enable noq, quinn, quiche, iroh, or websocket feature");
 	}
 
@@ -356,20 +384,7 @@ impl Client {
 		feature = "iroh",
 		feature = "websocket"
 	))]
-	pub async fn connect(&self, url: Url) -> anyhow::Result<moq_net::Session> {
-		let cs = self.connect_inner(url).await?;
-		tracing::info!(version = %cs.version(), "connected");
-		Ok(cs)
-	}
-
-	#[cfg(any(
-		feature = "noq",
-		feature = "quinn",
-		feature = "quiche",
-		feature = "iroh",
-		feature = "websocket"
-	))]
-	async fn connect_inner(&self, url: Url) -> anyhow::Result<moq_net::Session> {
+	pub(crate) async fn connect_inner(&self, url: Url) -> anyhow::Result<moq_net::Session> {
 		#[cfg(feature = "iroh")]
 		if url.scheme() == "iroh" {
 			let endpoint = self.iroh.as_ref().context("Iroh support is not enabled")?;

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -342,9 +342,8 @@ impl Client {
 	/// Spawns a background task and returns a [`Connection`] handle immediately; drop the handle to
 	/// stop the loop. Wire publish/consume origins with [`with_publisher`](Self::with_publisher) and
 	/// [`with_consumer`](Self::with_consumer) before calling, and they are re-attached on every
-	/// reconnect. Observe lifecycle changes with [`Connection::status`] and [`Connection::closed`].
-	///
-	/// For a single attempt that hands you the session directly, use [`connect_once`](Self::connect_once).
+	/// reconnect. Observe lifecycle changes with [`Connection::status`] and [`Connection::closed`],
+	/// or await [`Connection::established`] to drive the session directly.
 	pub fn connect(&self, url: Url) -> Connection {
 		Connection::new(self.clone(), url, self.backoff.clone())
 	}
@@ -353,17 +352,6 @@ impl Client {
 	#[deprecated(note = "use `connect`, which now reconnects with backoff by default")]
 	pub fn reconnect(&self, url: Url) -> Connection {
 		self.connect(url)
-	}
-
-	/// Connect to the given URL exactly once, returning the established session.
-	///
-	/// This makes a single attempt and does not reconnect if the session later drops. The returned
-	/// session is self-contained: you own it and drive it directly. For automatic reconnection, use
-	/// [`connect`](Self::connect).
-	pub async fn connect_once(&self, url: Url) -> anyhow::Result<moq_net::Session> {
-		let session = self.connect_inner(url).await?;
-		tracing::info!(version = %session.version(), "connected");
-		Ok(session)
 	}
 
 	#[cfg(not(any(

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -106,8 +106,8 @@ struct State {
 /// [`closed`](Self::closed) waits for the loop to stop. Dropping the handle (or calling
 /// [`close`](Self::close)) stops the loop.
 ///
-/// For a single attempt that hands you the session directly, use
-/// [`Client::connect_once`](crate::Client::connect_once) instead.
+/// To drive the established session directly, await [`established`](Self::established) and keep this
+/// handle alive while you use it.
 pub struct Connection {
 	abort: tokio::task::AbortHandle,
 	state: kio::Consumer<State>,
@@ -198,6 +198,30 @@ impl Connection {
 			session.close(error);
 		}
 		self.abort.abort();
+	}
+
+	/// Poll for the established session.
+	///
+	/// `Ready(Ok(session))` once connected, `Ready(Err)` if the loop stopped before connecting,
+	/// `Pending` while still connecting.
+	pub fn poll_established(&self, waiter: &kio::Waiter) -> Poll<anyhow::Result<moq_net::Session>> {
+		match ready!(self.state.poll(waiter, |state| match &state.session {
+			Some(session) => Poll::Ready(session.clone()),
+			None => Poll::Pending,
+		})) {
+			Ok(session) => Poll::Ready(Ok(session)),
+			Err(state) => Poll::Ready(Err(terminal(&state))),
+		}
+	}
+
+	/// Wait for the established session.
+	///
+	/// Resolves once connected, returning the current [`moq_net::Session`]. With reconnection on (the
+	/// default), this is the first session; it goes stale once it drops and the loop establishes a
+	/// new one. Keep this `Connection` alive while you use the session: dropping the handle aborts
+	/// the loop and tears the session down.
+	pub async fn established(&self) -> anyhow::Result<moq_net::Session> {
+		kio::wait(|waiter| self.poll_established(waiter)).await
 	}
 
 	/// Poll for the next connection status change since this handle last reported one.

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -47,6 +47,19 @@ pub struct Backoff {
 	)]
 	#[serde(with = "humantime_serde")]
 	pub timeout: Duration,
+
+	/// Minimum session uptime to count as healthy. A session that closes sooner is treated as
+	/// churn: the backoff keeps escalating instead of resetting, so a peer that accepts then
+	/// immediately drops us can't become a tight reconnect loop. Set to 0 to disable.
+	#[arg(
+		id = "backoff-stable",
+		long,
+		default_value = "10s",
+		env = "MOQ_BACKOFF_STABLE",
+		value_parser = humantime::parse_duration,
+	)]
+	#[serde(with = "humantime_serde")]
+	pub stable: Duration,
 }
 
 impl Default for Backoff {
@@ -56,11 +69,12 @@ impl Default for Backoff {
 			multiplier: 2,
 			max: Duration::from_secs(30),
 			timeout: Duration::from_secs(300),
+			stable: Duration::from_secs(10),
 		}
 	}
 }
 
-/// A connection lifecycle transition reported by [`Reconnect::status`].
+/// A connection lifecycle transition reported by [`Connection::status`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Status {
 	/// A session connected (the first connect, or a reconnect after a drop).
@@ -69,7 +83,7 @@ pub enum Status {
 	Disconnected,
 }
 
-/// Shared reconnect state, observed by consumers through a [`kio`] channel.
+/// Shared connection state, observed by consumers through a [`kio`] channel.
 ///
 /// The channel closing (all producers dropped) is the terminal signal; `error`
 /// distinguishes a permanent give-up from a graceful close.
@@ -77,29 +91,37 @@ pub enum Status {
 struct State {
 	/// Current connection status, or `None` before the first connect.
 	status: Option<Status>,
+	/// The currently-established session, if any. Kept so [`Connection::close`] can close it with a
+	/// specific error code. Not exposed directly: handing it out would let callers outlive the loop.
+	session: Option<moq_net::Session>,
 	/// Set when the reconnect loop permanently gives up (reconnect timeout exceeded).
 	error: Option<anyhow::Error>,
 }
 
-/// Handle to a background reconnect loop.
+/// Handle to a background connection that reconnects with exponential backoff.
 ///
-/// Spawns a tokio task that connects, waits for session close, then reconnects with exponential
-/// backoff. [`status`](Self::status) reports connection changes; [`closed`](Self::closed) waits for
-/// the loop to stop. Dropping the handle aborts the background task.
-pub struct Reconnect {
+/// [`Client::connect`](crate::Client::connect) spawns a tokio task that connects, waits for the
+/// session to close, then reconnects. Wire publish/consume origins on the client first; they are
+/// re-attached on every reconnect. [`status`](Self::status) reports connection changes and
+/// [`closed`](Self::closed) waits for the loop to stop. Dropping the handle (or calling
+/// [`close`](Self::close)) stops the loop.
+///
+/// For a single attempt that hands you the session directly, use
+/// [`Client::connect_once`](crate::Client::connect_once) instead.
+pub struct Connection {
 	abort: tokio::task::AbortHandle,
 	state: kio::Consumer<State>,
 	/// The last status returned by [`status`](Self::status), for change detection.
 	last_reported: Option<Status>,
 }
 
-impl Reconnect {
+impl Connection {
 	pub(crate) fn new(client: Client, url: Url, backoff: Backoff) -> Self {
 		let producer = kio::Producer::<State>::default();
 		let state = producer.consume();
 		let task = tokio::spawn(async move {
 			if let Err(err) = Self::run(&producer, client, url, backoff).await {
-				tracing::error!(err = %format!("{err:#}"), "reconnect loop exited");
+				tracing::error!(err = %format!("{err:#}"), "connection loop exited");
 				if let Ok(mut state) = producer.write() {
 					state.error = Some(err);
 				}
@@ -128,20 +150,34 @@ impl Reconnect {
 
 			tracing::info!(%url, "connecting");
 
-			match client.connect(url.clone()).await {
-				Ok(cs) => {
-					tracing::info!(%url, "connected");
-					delay = backoff.initial;
+			match client.connect_inner(url.clone()).await {
+				Ok(session) => {
+					tracing::info!(%url, version = %session.version(), "connected");
 					last_error = None;
 					if let Ok(mut state) = state.write() {
+						state.session = Some(session.clone());
 						state.status = Some(Status::Connected);
 					}
-					let _ = cs.closed().await;
-					tracing::warn!(%url, "session closed, reconnecting");
+
+					let started = tokio::time::Instant::now();
+					let _ = session.closed().await;
+
 					if let Ok(mut state) = state.write() {
+						state.session = None;
 						state.status = Some(Status::Disconnected);
 					}
-					retry_start = tokio::time::Instant::now();
+
+					if started.elapsed() >= backoff.stable {
+						// Healthy session: reset backoff and reconnect promptly.
+						tracing::warn!(%url, "session closed, reconnecting");
+						delay = backoff.initial;
+						retry_start = tokio::time::Instant::now();
+					} else {
+						// Churn: a session this short means the peer is flapping; keep backing off.
+						tracing::warn!(%url, ?delay, "session closed quickly, backing off");
+						tokio::time::sleep(delay).await;
+						delay = std::cmp::min(delay * backoff.multiplier, backoff.max);
+					}
 				}
 				Err(err) => {
 					tracing::warn!(%url, %err, ?delay, "connection failed, retrying");
@@ -151,6 +187,17 @@ impl Reconnect {
 				}
 			}
 		}
+	}
+
+	/// Stop the connection: close the current session (if any) with `error`, then end the loop.
+	///
+	/// After this, [`closed`](Self::closed) resolves and no further reconnects happen. Idempotent;
+	/// dropping the handle does the same, minus the graceful close.
+	pub fn close(&self, error: moq_net::Error) {
+		if let Some(mut session) = self.state.read().session.clone() {
+			session.close(error);
+		}
+		self.abort.abort();
 	}
 
 	/// Poll for the next connection status change since this handle last reported one.
@@ -180,10 +227,10 @@ impl Reconnect {
 		kio::wait(|waiter| self.poll_status(waiter)).await
 	}
 
-	/// Poll whether the reconnect loop has stopped.
+	/// Poll whether the connection loop has stopped.
 	///
 	/// `Ready(Err)` if it permanently gave up (reconnect timeout exceeded), `Ready(Ok(()))` if
-	/// stopped by dropping the handle, `Pending` while it's still running.
+	/// stopped by dropping the handle or calling [`close`](Self::close), `Pending` while running.
 	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<anyhow::Result<()>> {
 		ready!(self.state.poll_closed(waiter));
 		Poll::Ready(match &self.state.read().error {
@@ -192,13 +239,13 @@ impl Reconnect {
 		})
 	}
 
-	/// Wait until the reconnect loop stops.
+	/// Wait until the connection loop stops.
 	pub async fn closed(&self) -> anyhow::Result<()> {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
 }
 
-impl Drop for Reconnect {
+impl Drop for Connection {
 	fn drop(&mut self) {
 		self.abort.abort();
 	}
@@ -223,5 +270,6 @@ mod tests {
 		assert_eq!(backoff.multiplier, 2);
 		assert_eq!(backoff.max, Duration::from_secs(30));
 		assert_eq!(backoff.timeout, Duration::from_secs(300));
+		assert_eq!(backoff.stable, Duration::from_secs(10));
 	}
 }

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -43,7 +43,7 @@ async fn connect_with_version(version: &str) {
 	});
 
 	let client = client.with_publisher(origin.clone());
-	let client_result = client.connect(url).await;
+	let client_result = client.connect_once(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");
 
@@ -94,7 +94,7 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	});
 
 	let client = client.with_publisher(origin.clone());
-	let client_result = client.connect(url).await;
+	let client_result = client.connect_once(url).await;
 
 	let server_result = server_handle.await.expect("server task panicked");
 

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -43,7 +43,8 @@ async fn connect_with_version(version: &str) {
 	});
 
 	let client = client.with_publisher(origin.clone());
-	let client_result = client.connect_once(url).await;
+	let connection = client.connect(url);
+	let client_result = connection.established().await;
 
 	let server_result = server_handle.await.expect("server task panicked");
 
@@ -94,7 +95,8 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	});
 
 	let client = client.with_publisher(origin.clone());
-	let client_result = client.connect_once(url).await;
+	let connection = client.connect(url);
+	let client_result = connection.established().await;
 
 	let server_result = server_handle.await.expect("server task panicked");
 

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -54,7 +54,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -208,7 +208,7 @@ async fn iroh_connect() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -54,7 +54,8 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -89,7 +90,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 
 	assert_eq!(&*frame, b"hello");
 
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -208,7 +209,8 @@ async fn iroh_connect() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -243,7 +245,7 @@ async fn iroh_connect() {
 
 	assert_eq!(&*frame, b"hello");
 
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -70,7 +70,8 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -110,7 +111,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	assert_eq!(&*frame, b"hello");
 
 	// Tear down: dropping the session closes the QUIC connection.
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -175,7 +176,8 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -216,7 +218,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 		let _ = frame_sub.read_all().await;
 	}
 
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -292,7 +294,8 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -338,7 +341,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 		.expect("next_frame failed");
 	assert!(end.is_none(), "group should finish after its frames");
 
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -414,7 +417,8 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -465,7 +469,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	assert_eq!(&*frame, b"old");
 
 	// The live subscription is unaffected: a freshly published group still arrives.
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -518,7 +522,8 @@ async fn broadcast_moq_lite_05_without_timescale() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -554,7 +559,7 @@ async fn broadcast_moq_lite_05_without_timescale() {
 		"no timescale negotiated, no per-frame timestamp"
 	);
 
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -928,7 +933,8 @@ async fn broadcast_websocket() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -967,7 +973,7 @@ async fn broadcast_websocket() {
 
 	assert_eq!(&*frame, b"hello");
 
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -1037,7 +1043,8 @@ async fn broadcast_websocket_fallback() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1074,7 +1081,7 @@ async fn broadcast_websocket_fallback() {
 
 	assert_eq!(&*frame, b"hello");
 
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -1139,14 +1146,15 @@ async fn broadcast_websocket_uses_newest_version() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let cs = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
 	assert_eq!(cs.version(), expected_version, "client negotiated stale version");
 
-	drop(cs);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -1213,14 +1221,15 @@ async fn broadcast_race_quic_wins() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let cs = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
 	assert_eq!(cs.version(), expected_version, "client negotiated stale version");
 
-	drop(cs);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")
@@ -1280,7 +1289,8 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
+	let connection = client.connect(url);
+	let _session = tokio::time::timeout(TIMEOUT, connection.established())
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -1360,7 +1370,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 		"expected group 1 to be delivered to the resubscribed consumer"
 	);
 
-	drop(session);
+	drop(connection);
 	server_handle
 		.await
 		.expect("server task panicked")

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -70,7 +70,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -175,7 +175,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -292,7 +292,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -414,7 +414,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -518,7 +518,7 @@ async fn broadcast_moq_lite_05_without_timescale() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");
@@ -928,7 +928,7 @@ async fn broadcast_websocket() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1037,7 +1037,7 @@ async fn broadcast_websocket_fallback() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1139,7 +1139,7 @@ async fn broadcast_websocket_uses_newest_version() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let cs = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1213,7 +1213,7 @@ async fn broadcast_race_quic_wins() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let cs = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let cs = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("client connect timed out")
 		.expect("client connect failed");
@@ -1280,7 +1280,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	});
 
 	let client = client.with_consumer(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let session = tokio::time::timeout(TIMEOUT, client.connect_once(url))
 		.await
 		.expect("connect timeout")
 		.expect("connect failed");

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -769,37 +769,6 @@ impl Cluster {
 			url.query_pairs_mut().append_pair("jwt", &token);
 		}
 
-		let base_backoff = tokio::time::Duration::from_secs(1);
-		let max_backoff = tokio::time::Duration::from_secs(300);
-		// Sessions shorter than this are treated as churn: we keep backing off
-		// instead of resetting, otherwise a peer that rejects us instantly would
-		// turn into a tight reconnect loop.
-		let stable_threshold = tokio::time::Duration::from_secs(10);
-
-		let mut backoff = base_backoff;
-
-		loop {
-			let started = tokio::time::Instant::now();
-			let result = self.run_remote_once(&url).await;
-			let elapsed = started.elapsed();
-
-			match result {
-				Ok(()) if elapsed >= stable_threshold => backoff = base_backoff,
-				Ok(()) => {
-					tracing::warn!(?elapsed, "cluster peer session closed cleanly but quickly; backing off");
-					backoff = (backoff * 2).min(max_backoff);
-				}
-				Err(err) => {
-					tracing::warn!(%err, "cluster peer error; will retry");
-					backoff = (backoff * 2).min(max_backoff);
-				}
-			}
-
-			tokio::time::sleep(backoff).await;
-		}
-	}
-
-	async fn run_remote_once(&self, url: &Url) -> anyhow::Result<()> {
 		let mut log_url = url.clone();
 		log_url.set_query(None);
 		tracing::info!(url = %log_url, "dialing cluster peer");
@@ -810,16 +779,30 @@ impl Cluster {
 			.clone()
 			.context("internal: cluster peer dial without an attached QUIC client")?;
 
-		// Cluster-to-cluster traffic is internal by definition.
-		let cs = client
+		// Cluster-to-cluster traffic is internal by definition. The connection reconnects with
+		// backoff internally (churn-protected); unlimited retries keep the dial alive until this
+		// task is aborted, which happens when the peer is abandoned.
+		let connection = client
+			.with_backoff(Self::dial_backoff())
 			.with_publisher(self.origin.clone())
 			.with_consumer(self.origin.clone())
 			.with_stats(self.stats.tier(Tier::Internal))
-			.connect(url.clone())
-			.await
-			.context("failed to connect to cluster peer")?;
+			.connect(url);
 
-		cs.closed().await.map_err(Into::into)
+		// With unlimited retries this only resolves on abort, but propagate the error just in case.
+		connection.closed().await.context("cluster peer connection gave up")
+	}
+
+	/// Backoff for cluster dials: never give up (the dial is torn down by aborting the task when the
+	/// peer is abandoned), and cap retries at 5 minutes apart.
+	fn dial_backoff() -> moq_native::Backoff {
+		moq_native::Backoff {
+			initial: Duration::from_secs(1),
+			multiplier: 2,
+			max: Duration::from_secs(300),
+			timeout: Duration::ZERO,
+			stable: Duration::from_secs(10),
+		}
 	}
 }
 

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -125,13 +125,11 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	group.write_frame(b"hello".as_ref()).expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(
-		TIMEOUT,
-		client().with_publisher(pub_origin.clone()).connect_once(url.clone()),
-	)
-	.await
-	.expect("publisher connect timeout")
-	.expect("publisher connect failed");
+	let pub_connection = client().with_publisher(pub_origin.clone()).connect(url.clone());
+	let pub_session = tokio::time::timeout(TIMEOUT, pub_connection.established())
+		.await
+		.expect("publisher connect timeout")
+		.expect("publisher connect failed");
 	assert_eq!(
 		pub_session.version(),
 		expected_version,
@@ -142,7 +140,8 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
 
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consumer(sub_origin).connect_once(url))
+	let sub_connection = client().with_consumer(sub_origin).connect(url);
+	let sub_session = tokio::time::timeout(TIMEOUT, sub_connection.established())
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -187,6 +186,8 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 
 	drop(pub_session);
 	drop(sub_session);
+	drop(pub_connection);
+	drop(sub_connection);
 	web_handle.abort();
 }
 

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -127,7 +127,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 
 	let pub_session = tokio::time::timeout(
 		TIMEOUT,
-		client().with_publisher(pub_origin.clone()).connect(url.clone()),
+		client().with_publisher(pub_origin.clone()).connect_once(url.clone()),
 	)
 	.await
 	.expect("publisher connect timeout")
@@ -142,7 +142,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
 
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consumer(sub_origin).connect(url))
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consumer(sub_origin).connect_once(url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");

--- a/rs/moq-rtc/bin/moq-rtc.rs
+++ b/rs/moq-rtc/bin/moq-rtc.rs
@@ -119,7 +119,7 @@ async fn main() -> anyhow::Result<()> {
 	let reconnect = moq_client
 		.with_publisher(publisher.clone())
 		.with_consumer(subscriber)
-		.reconnect(relay.clone());
+		.connect(relay.clone());
 
 	tracing::info!(%relay, %broadcast, "starting moq-rtc");
 


### PR DESCRIPTION
## Summary

Collapses the moq-native client connection API to a **single entrypoint** that reconnects by default, and moves the existing callers onto it.

- **`Client::connect(url)` returns a `Connection`** that reconnects with exponential backoff. Wire publish/consume origins on the client first; they're re-attached on every reconnect. Observe via `Connection::status` / `Connection::closed`; drop the handle (or call `Connection::close`) to stop.
- **`Connection::established().await`** waits for the first established session and hands you the `moq_net::Session` to drive directly. Keep the handle alive while you use it (dropping it tears the session down). This replaces the old single-attempt `connect`.
- **`reconnect()` is now a deprecated alias** of `connect()`.
- **`Backoff` gains a `stable` threshold** (churn protection): a session that closes before `stable` (default 10s) keeps escalating the backoff instead of resetting it, so a peer that accepts then instantly drops us can't become a tight reconnect loop. This generalizes the relay cluster's old hand-rolled logic to every reconnecting client.
- Added `Client::with_backoff` and `Connection::close(error)`.

### Relay cluster reuses the reconnect logic
`run_remote` dropped its bespoke dial/backoff loop (`run_remote_once`) and now holds a `Connection` with unlimited retries, aborted by the existing `DialMap` when a peer is abandoned. The churn handling it used to do inline now lives in the shared backoff.

### moq-ffi auto-reconnects by default
`MoqClient.connect` uses the reconnecting `connect()`, waits for the first session, and returns a `MoqSession` wrapping a `Connection`. `closed()` resolves only on permanent give-up (or `shutdown`/`cancel`); transient drops reconnect. The connector wires stable publish/consume origins (moq-net stores and re-clones them per connect), so `publisher()`/`consumer()` stay valid across reconnects. Server-accepted sessions keep their single-session path via an enum.

## Test plan
- [x] `cargo check` / `cargo clippy --workspace --all-targets --all-features` clean (via nix)
- [x] `cargo fmt --all`
- [x] moq-ffi tests pass (incl. connect round-trips)
- [x] moq-native tests pass (58 + 17 + 6, incl. backend/broadcast/alpn migrated to `connect()` + `established()`)
- [x] moq-relay tests pass (126, incl. cluster) + smoke (2)

## Notes
- Targets `dev`: breaking change to the `moq-native` / `rs/hang` / wrapper-facing API, and dev had already diverged (anyhow-based moq-native, `with_publisher`/`with_consumer`), so it was reimplemented against dev rather than cherry-picked.
- Single-attempt callers (tests, gst, examples) now bind the `Connection`, await `established()`, and keep the handle alive for the session's lifetime.
- Cross-package: updated `doc/lib/rs`, `doc/lib/swift`, and the ffi doc comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_(Written by Claude)_