### PR TITLE
feat(moq-ffi): expose dynamic track requests

### DIFF
--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -111,6 +111,8 @@ dynamic.requestedTracks().collect { track ->
     if (track.name() == "alerts") {
         track.writeFrame("ready".encodeToByteArray())
         track.finish()
+    } else {
+        track.abort(404)
     }
 }
 ```

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -94,6 +94,27 @@ audio.finish()
 broadcast.finish()
 ```
 
+### On-demand raw tracks
+
+Use a dynamic broadcast when subscribers should be able to request raw tracks that are not published yet:
+
+```kotlin
+import dev.moq.*
+import uniffi.moq.MoqBroadcastProducer
+
+val broadcast = MoqBroadcastProducer()
+val dynamic = broadcast.dynamic()
+
+origin.publish("events", broadcast)
+
+dynamic.requestedTracks().collect { track ->
+    if (track.name() == "alerts") {
+        track.writeFrame("ready".encodeToByteArray())
+        track.finish()
+    }
+}
+```
+
 ## Cancellation
 
 The wrapper exposes consumers as Kotlin `Flow`s. Cancelling the collector's coroutine scope calls `cancel()` on the native side via the wrapper's `onCompletion` hook, releasing resources promptly:

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -48,7 +48,7 @@ audio.finish()
 broadcast.finish()
 ```
 
-Supported codec formats include `opus`, `avc3`, `hev1`, `av01`, `vp09`, and others — see [`hang`](/lib/rs/crate/hang) for the full list.
+Supported codec formats include `opus`, `avc3`, `hev1`, `av01`, `vp09`, and others. See [`hang`](/lib/rs/crate/hang) for the full list.
 
 ### Subscribing to media
 
@@ -79,6 +79,23 @@ async for group in broadcast_consumer.subscribe_track("events"):
 
 `write_frame` on a track creates a one-frame group by default. Use `append_group()` for multi-frame groups (e.g., a video GOP).
 
+### On-demand raw tracks
+
+Use a dynamic broadcast when subscribers should be able to request raw tracks that are not published yet:
+
+```python
+broadcast = moq.BroadcastProducer()
+dynamic = broadcast.dynamic()
+client.publish("events", broadcast)
+
+async for track in dynamic:
+    if track.name == "alerts":
+        track.write_frame(b"ready")
+        track.finish()
+```
+
+Missing track subscriptions are accepted while the `BroadcastDynamic` object is alive. Each requested track is returned as a `TrackProducer`.
+
 ### Discovering broadcasts
 
 ```python
@@ -94,8 +111,8 @@ broadcast = await client.announced_broadcast("live/cam1")
 
 The repo ships [example scripts](https://github.com/moq-dev/moq/tree/main/py/moq-rs/examples) you can run end-to-end:
 
-- `clock.py` — publishes / subscribes a clock track (one frame per second, one group per minute).
-- `announced.py` — lists broadcasts under a prefix as they're announced.
+- `clock.py`: publishes / subscribes a clock track (one frame per second, one group per minute).
+- `announced.py`: lists broadcasts under a prefix as they're announced.
 
 ## See also
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -89,6 +89,24 @@ try audio.finish()
 try broadcast.finish()
 ```
 
+### On-demand raw tracks
+
+Use a dynamic broadcast when subscribers should be able to request raw tracks that are not published yet:
+
+```swift
+let broadcast = try MoqBroadcastProducer()
+let dynamic = try broadcast.dynamic()
+
+try origin.publish(path: "events", broadcast: broadcast)
+
+for try await track in dynamic.requestedTracks {
+    if try track.name() == "alerts" {
+        try track.writeFrame(payload: Data("ready".utf8))
+        try track.finish()
+    }
+}
+```
+
 ## Cancellation
 
 All async sequences cooperate with structured concurrency. Cancelling the surrounding `Task` propagates to the underlying `cancel()` call on the consumer:

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -103,6 +103,8 @@ for try await track in dynamic.requestedTracks {
     if try track.name() == "alerts" {
         try track.writeFrame(payload: Data("ready".utf8))
         try track.finish()
+    } else {
+        try track.abort(errorCode: 404)
     }
 }
 ```

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
@@ -10,12 +10,14 @@ import uniffi.moq.MoqAnnounced
 import uniffi.moq.MoqAnnouncement
 import uniffi.moq.MoqAudioConsumer
 import uniffi.moq.MoqAudioFrame
+import uniffi.moq.MoqBroadcastDynamic
 import uniffi.moq.MoqCatalog
 import uniffi.moq.MoqCatalogConsumer
 import uniffi.moq.MoqFrame
 import uniffi.moq.MoqGroupConsumer
 import uniffi.moq.MoqMediaConsumer
 import uniffi.moq.MoqTrackConsumer
+import uniffi.moq.MoqTrackProducer
 
 /**
  * Stream of catalog updates. Terminates when the underlying track ends.
@@ -71,6 +73,16 @@ fun MoqTrackConsumer.groupsAsArrived(): Flow<MoqGroupConsumer> = flow {
     while (true) {
         currentCoroutineContext().ensureActive()
         emit(recvGroup() ?: break)
+    }
+}.onCompletion { cause ->
+    if (cause is CancellationException) cancel()
+}
+
+/** Stream of tracks requested by subscribers. */
+fun MoqBroadcastDynamic.requestedTracks(): Flow<MoqTrackProducer> = flow {
+    while (true) {
+        currentCoroutineContext().ensureActive()
+        emit(requestedTrack() ?: break)
     }
 }.onCompletion { cause ->
     if (cause is CancellationException) cancel()

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
@@ -82,7 +82,7 @@ fun MoqTrackConsumer.groupsAsArrived(): Flow<MoqGroupConsumer> = flow {
 fun MoqBroadcastDynamic.requestedTracks(): Flow<MoqTrackProducer> = flow {
     while (true) {
         currentCoroutineContext().ensureActive()
-        emit(requestedTrack() ?: break)
+        emit(requestedTrack())
     }
 }.onCompletion { cause ->
     if (cause is CancellationException) cancel()

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -114,8 +114,12 @@ client = moq.Client(
 ### Publishing
 
 - **`BroadcastProducer()`**. Create a broadcast to publish tracks into.
+  - `.dynamic() → BroadcastDynamic`
   - `.publish_media(format, init) → MediaProducer`
   - `.finish()`
+- **`BroadcastDynamic`**. Async source of tracks requested by subscribers.
+  - `await .requested_track() → TrackProducer | None`
+  - Async iterator yielding `TrackProducer`
 - **`MediaProducer`**. Write frames to a track.
   - `.write_frame(payload, timestamp_us)`
   - `.finish()`

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -118,7 +118,7 @@ client = moq.Client(
   - `.publish_media(format, init) → MediaProducer`
   - `.finish()`
 - **`BroadcastDynamic`**. Async source of tracks requested by subscribers.
-  - `await .requested_track() → TrackProducer | None`
+  - `await .requested_track() → TrackProducer`
   - Async iterator yielding `TrackProducer`
 - **`MediaProducer`**. Write frames to a track.
   - `.write_frame(payload, timestamp_us)`

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -8,7 +8,7 @@ from moq_ffi import MoqSession as Session
 
 from .client import Client
 from .origin import Announced, AnnouncedBroadcast, Announcement, OriginConsumer, OriginProducer
-from .publish import AudioProducer, BroadcastProducer, GroupProducer, MediaProducer, TrackProducer
+from .publish import AudioProducer, BroadcastDynamic, BroadcastProducer, GroupProducer, MediaProducer, TrackProducer
 from .server import Request, Server, Transport
 from .subscribe import (
     AudioConsumer,
@@ -46,6 +46,7 @@ __all__ = [
     "AudioFrame",
     "AudioProducer",
     "BroadcastConsumer",
+    "BroadcastDynamic",
     "BroadcastProducer",
     "Catalog",
     "CatalogConsumer",

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -126,6 +126,10 @@ class TrackProducer:
 
         return TrackConsumer(self._inner.consume())
 
+    def abort(self, error_code: int) -> None:
+        """Abort this track with an application error code."""
+        self._inner.abort(error_code)
+
     def finish(self) -> None:
         self._inner.finish()
 
@@ -164,16 +168,10 @@ class BroadcastDynamic:
         return self
 
     async def __anext__(self) -> TrackProducer:
-        track = await self.requested_track()
-        if track is None:
-            raise StopAsyncIteration
-        return track
+        return await self.requested_track()
 
-    async def requested_track(self) -> TrackProducer | None:
-        track = await self._inner.requested_track()
-        if track is None:
-            return None
-        return TrackProducer(track)
+    async def requested_track(self) -> TrackProducer:
+        return TrackProducer(await self._inner.requested_track())
 
     def cancel(self) -> None:
         self._inner.cancel()

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -1,4 +1,4 @@
-"""Producer wrappers — publish broadcasts and media tracks."""
+"""Producer wrappers: publish broadcasts and media tracks."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from moq_ffi import (
     MoqAudioProducer,
+    MoqBroadcastDynamic,
     MoqBroadcastProducer,
     MoqGroupProducer,
     MoqMediaProducer,
@@ -46,7 +47,7 @@ class MediaProducer:
 
 
 class MediaStreamProducer:
-    """Wraps MoqMediaStreamProducer — feed a raw byte stream (e.g. Annex-B
+    """Wraps MoqMediaStreamProducer: feed a raw byte stream (e.g. Annex-B
     H.264) and let the importer infer frame boundaries.
 
     Built via :meth:`BroadcastProducer.publish_media_stream`. Unlike
@@ -90,7 +91,7 @@ class GroupProducer:
 
 
 class TrackProducer:
-    """Track producer — write arbitrary byte payloads with no codec required.
+    """Track producer: write arbitrary byte payloads with no codec required.
 
     Same pattern as moq-boy's status/command tracks.
     """
@@ -150,11 +151,43 @@ class AudioProducer:
         self._inner.finish()
 
 
+class BroadcastDynamic:
+    """Async source of tracks requested by subscribers.
+
+    Hold this object while subscriptions to unknown tracks should be accepted.
+    """
+
+    def __init__(self, inner: MoqBroadcastDynamic) -> None:
+        self._inner = inner
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> TrackProducer:
+        track = await self.requested_track()
+        if track is None:
+            raise StopAsyncIteration
+        return track
+
+    async def requested_track(self) -> TrackProducer | None:
+        track = await self._inner.requested_track()
+        if track is None:
+            return None
+        return TrackProducer(track)
+
+    def cancel(self) -> None:
+        self._inner.cancel()
+
+
 class BroadcastProducer:
     """Wraps MoqBroadcastProducer with a cleaner interface."""
 
     def __init__(self) -> None:
         self._inner = MoqBroadcastProducer()
+
+    def dynamic(self) -> BroadcastDynamic:
+        """Accept subscriptions to tracks that are not published yet."""
+        return BroadcastDynamic(self._inner.dynamic())
 
     def publish_media(self, format: str, init: bytes) -> MediaProducer:
         return MediaProducer(self._inner.publish_media(format, init))
@@ -174,7 +207,7 @@ class BroadcastProducer:
         return AudioProducer(self._inner.publish_audio(name, input, output))
 
     def publish_track(self, name: str) -> TrackProducer:
-        """Create a track — send any bytes, no codec validation."""
+        """Create a track. Send any bytes, no codec validation."""
         return TrackProducer(self._inner.publish_track(name))
 
     def consume(self) -> BroadcastConsumer:

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -1,5 +1,6 @@
-"""Local pub/sub tests — no network required."""
+"""Local pub/sub tests: no network required."""
 
+import asyncio
 import struct
 
 import moq
@@ -199,7 +200,7 @@ async def test_catalog_update_on_new_track():
         catalog1 = await anext(cat_consumer)
         assert len(catalog1.audio) == 1
 
-        # Add a second audio track — triggers catalog update.
+        # Add a second audio track, which triggers a catalog update.
         _media2 = broadcast.publish_media("opus", opus_head())
 
         catalog2 = await anext(cat_consumer)
@@ -236,6 +237,25 @@ def test_publish_lifecycle():
     track.write_frame(b'{"cmd": "ready"}')
     track.finish()
     broadcast.finish()
+
+
+async def test_dynamic_track_request():
+    broadcast = moq.BroadcastProducer()
+    dynamic = broadcast.dynamic()
+    consumer = broadcast.consume()
+    track_consumer = consumer.subscribe_track("events")
+
+    track = await asyncio.wait_for(dynamic.requested_track(), timeout=5.0)
+    assert track is not None
+    assert track.name == "events"
+
+    payload = b"hello dynamic track"
+    track.write_frame(payload)
+
+    frame = await asyncio.wait_for(track_consumer.read_frame(), timeout=5.0)
+    assert frame == payload
+
+    track.finish()
 
 
 def test_raw_append_group_sequence_increments():
@@ -414,7 +434,7 @@ async def test_raw_group_producer_consume_direct():
 
 
 async def test_broadcast_producer_consume_direct():
-    """Consume a broadcast directly from the producer — catalog + raw track."""
+    """Consume a broadcast directly from the producer with catalog and raw track."""
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("events")
     consumer = broadcast.consume()
@@ -461,7 +481,7 @@ async def test_raw_group_sequence():
 
 
 async def test_raw_multi_frame_group():
-    """A single group can carry multiple frames — not just one-per-group."""
+    """A single group can carry multiple frames, not just one per group."""
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("chunks")

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -246,7 +246,6 @@ async def test_dynamic_track_request():
     track_consumer = consumer.subscribe_track("events")
 
     track = await asyncio.wait_for(dynamic.requested_track(), timeout=5.0)
-    assert track is not None
     assert track.name == "events"
 
     payload = b"hello dynamic track"

--- a/rs/moq-ffi/src/error.rs
+++ b/rs/moq-ffi/src/error.rs
@@ -48,6 +48,9 @@ pub enum MoqError {
 	#[error("codec: {0}")]
 	Codec(String),
 
+	#[error("invalid error code: {0}")]
+	InvalidErrorCode(i32),
+
 	#[error("unauthorized")]
 	Unauthorized,
 

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -41,14 +41,11 @@ struct DynamicProducer {
 }
 
 impl DynamicProducer {
-	async fn requested_track(&mut self) -> Result<Option<Arc<MoqTrackProducer>>, MoqError> {
-		match self.inner.requested_track().await {
-			Ok(track) => Ok(Some(Arc::new(MoqTrackProducer {
-				inner: std::sync::Mutex::new(Some(track)),
-			}))),
-			Err(moq_net::Error::Closed | moq_net::Error::Dropped) => Ok(None),
-			Err(err) => Err(err.into()),
-		}
+	async fn requested_track(&mut self) -> Result<Arc<MoqTrackProducer>, MoqError> {
+		let track = self.inner.requested_track().await?;
+		Ok(Arc::new(MoqTrackProducer {
+			inner: std::sync::Mutex::new(Some(track)),
+		}))
 	}
 }
 
@@ -203,8 +200,8 @@ impl MoqBroadcastProducer {
 impl MoqBroadcastDynamic {
 	/// Wait for the next subscriber-requested track.
 	///
-	/// Returns `None` once the broadcast is closed.
-	pub async fn requested_track(&self) -> Result<Option<Arc<MoqTrackProducer>>, MoqError> {
+	/// Returns an error once the broadcast is closed or aborted.
+	pub async fn requested_track(&self) -> Result<Arc<MoqTrackProducer>, MoqError> {
 		self.task
 			.run(|mut state| async move { state.requested_track().await })
 			.await
@@ -282,6 +279,16 @@ impl MoqTrackProducer {
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.as_mut().ok_or_else(|| MoqError::Closed)?;
 		track.write_frame(payload)?;
+		Ok(())
+	}
+
+	/// Abort this track with an application error code.
+	pub fn abort(&self, error_code: i32) -> Result<(), MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		let error_code = u16::try_from(error_code).map_err(|_| MoqError::InvalidErrorCode(error_code))?;
+		let mut guard = self.inner.lock().unwrap();
+		let mut track = guard.take().ok_or_else(|| MoqError::Closed)?;
+		track.abort(moq_net::Error::App(error_code))?;
 		Ok(())
 	}
 

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -5,6 +5,7 @@ use bytes::Buf;
 
 use crate::consumer::{MoqBroadcastConsumer, MoqGroupConsumer, MoqTrackConsumer};
 use crate::error::MoqError;
+use crate::ffi::Task;
 
 // ---- UniFFI Objects ----
 
@@ -28,6 +29,27 @@ struct MediaStreamProducer {
 #[derive(uniffi::Object)]
 pub struct MoqBroadcastProducer {
 	state: std::sync::Mutex<Option<BroadcastProducer>>,
+}
+
+#[derive(uniffi::Object)]
+pub struct MoqBroadcastDynamic {
+	task: Task<DynamicProducer>,
+}
+
+struct DynamicProducer {
+	inner: moq_net::BroadcastDynamic,
+}
+
+impl DynamicProducer {
+	async fn requested_track(&mut self) -> Result<Option<Arc<MoqTrackProducer>>, MoqError> {
+		match self.inner.requested_track().await {
+			Ok(track) => Ok(Some(Arc::new(MoqTrackProducer {
+				inner: std::sync::Mutex::new(Some(track)),
+			}))),
+			Err(moq_net::Error::Closed | moq_net::Error::Dropped) => Ok(None),
+			Err(err) => Err(err.into()),
+		}
+	}
 }
 
 impl MoqBroadcastProducer {
@@ -66,6 +88,21 @@ impl MoqBroadcastProducer {
 	pub fn consume(&self) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		Ok(Arc::new(MoqBroadcastConsumer::new(self.consume_inner()?)))
+	}
+
+	/// Create a dynamic producer that yields tracks requested by subscribers.
+	///
+	/// Hold the returned object for as long as missing track requests should be
+	/// accepted. Dropping it makes future subscriptions to unknown tracks fail.
+	pub fn dynamic(&self) -> Result<Arc<MoqBroadcastDynamic>, MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		let guard = self.state.lock().unwrap();
+		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
+		Ok(Arc::new(MoqBroadcastDynamic {
+			task: Task::new(DynamicProducer {
+				inner: state.broadcast.dynamic(),
+			}),
+		}))
 	}
 
 	/// Create a new broadcast for publishing media tracks.
@@ -133,7 +170,7 @@ impl MoqBroadcastProducer {
 		}))
 	}
 
-	/// Create a track for arbitrary byte payloads — no codec or container.
+	/// Create a track for arbitrary byte payloads, no codec or container.
 	///
 	/// Same pattern as moq-boy's `status` and `command` tracks: raw UTF-8/JSON
 	/// bytes written directly to moq-lite groups with no media framing.
@@ -157,6 +194,25 @@ impl MoqBroadcastProducer {
 		let mut state = guard.take().ok_or_else(|| MoqError::Closed)?;
 		state.catalog.finish()?;
 		Ok(())
+	}
+}
+
+// ---- Dynamic Broadcast Producer ----
+
+#[uniffi::export]
+impl MoqBroadcastDynamic {
+	/// Wait for the next subscriber-requested track.
+	///
+	/// Returns `None` once the broadcast is closed.
+	pub async fn requested_track(&self) -> Result<Option<Arc<MoqTrackProducer>>, MoqError> {
+		self.task
+			.run(|mut state| async move { state.requested_track().await })
+			.await
+	}
+
+	/// Cancel all current and future `requested_track()` calls.
+	pub fn cancel(&self) {
+		self.task.cancel();
 	}
 }
 
@@ -219,7 +275,7 @@ impl MoqTrackProducer {
 		}))
 	}
 
-	/// Convenience: write a single-frame group in one call — the same pattern
+	/// Convenience: write a single-frame group in one call, the same pattern
 	/// used by moq-boy's status/command tracks.
 	pub fn write_frame(&self, payload: Vec<u8>) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -71,6 +71,34 @@ async fn raw_track_activity() {
 }
 
 #[tokio::test]
+async fn dynamic_track_request() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let dynamic = broadcast.dynamic().unwrap();
+	let consumer = broadcast.consume().unwrap();
+	let track_consumer = consumer.subscribe_track("events".into()).unwrap();
+
+	let track = tokio::time::timeout(TIMEOUT, dynamic.requested_track())
+		.await
+		.expect("timed out waiting for requested track")
+		.unwrap()
+		.expect("expected a requested track");
+
+	assert_eq!(track.name().unwrap(), "events");
+
+	let payload = b"hello dynamic track".to_vec();
+	track.write_frame(payload.clone()).unwrap();
+
+	let frame = tokio::time::timeout(TIMEOUT, track_consumer.read_frame())
+		.await
+		.expect("timed out waiting for dynamic track frame")
+		.unwrap()
+		.expect("expected a frame");
+
+	assert_eq!(frame, payload);
+	track.finish().unwrap();
+}
+
+#[tokio::test]
 async fn media_track_activity_and_name() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
@@ -368,7 +396,7 @@ fn without_runtime() {
 		drop(announced);
 	})
 	.join()
-	.expect("client thread panicked — FFI method missing runtime guard");
+	.expect("client thread panicked, FFI method missing runtime guard");
 }
 
 #[tokio::test]
@@ -515,7 +543,7 @@ async fn request_double_respond_returns_already_responded() {
 			.expect("accept errored")
 			.expect("accept returned None");
 
-		// Accept once, then try a second response — must error.
+		// Accept once, then try a second response. It must error.
 		let session = request.ok().await.expect("first ok succeeds");
 		let second_ok = request.ok().await;
 		assert!(

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -2,6 +2,7 @@ use super::origin::*;
 use super::producer::*;
 use super::server::MoqServer;
 use super::session::MoqClient;
+use crate::error::MoqError;
 
 use std::time::Duration;
 
@@ -80,8 +81,7 @@ async fn dynamic_track_request() {
 	let track = tokio::time::timeout(TIMEOUT, dynamic.requested_track())
 		.await
 		.expect("timed out waiting for requested track")
-		.unwrap()
-		.expect("expected a requested track");
+		.unwrap();
 
 	assert_eq!(track.name().unwrap(), "events");
 
@@ -96,6 +96,22 @@ async fn dynamic_track_request() {
 
 	assert_eq!(frame, payload);
 	track.finish().unwrap();
+}
+
+#[tokio::test]
+async fn dynamic_track_request_can_abort() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let dynamic = broadcast.dynamic().unwrap();
+	let consumer = broadcast.consume().unwrap();
+	let _track_consumer = consumer.subscribe_track("unknown".into()).unwrap();
+
+	let track = tokio::time::timeout(TIMEOUT, dynamic.requested_track())
+		.await
+		.expect("timed out waiting for requested track")
+		.unwrap();
+
+	track.abort(404).unwrap();
+	assert!(matches!(track.name(), Err(MoqError::Closed)));
 }
 
 #[tokio::test]

--- a/swift/Sources/Moq/AsyncSequences.swift
+++ b/swift/Sources/Moq/AsyncSequences.swift
@@ -116,16 +116,16 @@ extension MoqTrackConsumer {
 }
 
 extension MoqBroadcastDynamic {
-    /// Stream of tracks requested by subscribers. Terminates when the broadcast closes.
+    /// Stream of tracks requested by subscribers.
     public var requestedTracks: AsyncThrowingStream<MoqTrackProducer, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    while let track = try await self.requestedTrack() {
+                    while true {
+                        let track = try await self.requestedTrack()
                         try Task.checkCancellation()
                         continuation.yield(track)
                     }
-                    continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }

--- a/swift/Sources/Moq/AsyncSequences.swift
+++ b/swift/Sources/Moq/AsyncSequences.swift
@@ -115,6 +115,29 @@ extension MoqTrackConsumer {
     }
 }
 
+extension MoqBroadcastDynamic {
+    /// Stream of tracks requested by subscribers. Terminates when the broadcast closes.
+    public var requestedTracks: AsyncThrowingStream<MoqTrackProducer, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    while let track = try await self.requestedTrack() {
+                        try Task.checkCancellation()
+                        continuation.yield(track)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { [weak self] _ in
+                task.cancel()
+                self?.cancel()
+            }
+        }
+    }
+}
+
 extension MoqGroupConsumer {
     /// Stream of raw frame payloads in this group.
     public var frames: AsyncThrowingStream<Data, Error> {


### PR DESCRIPTION
Add a UniFFI BroadcastDynamic wrapper so publishers can observe subscriber requests for tracks that do not exist yet. Wrap the API for Python and add Swift/Kotlin stream helpers plus language docs.