### PR TITLE
Add rs/moq-bench: a relay load-generator CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Key architectural rule: The CDN/relay does not know anything about media. Anythi
   moq-token/         # JWT authentication library
   moq-token-cli/     # JWT token CLI tool (binary: moq-token-cli)
   moq-cli/           # CLI tool for media operations (binary: moq)
+  moq-bench/         # Load generator for benchmarking relays (binary: moq-bench)
   moq-mux/           # Media muxers/demuxers (fMP4, CMAF, HLS)
   moq-audio/         # Native PCM ↔ Opus encode/decode on top of moq-mux
   hang/              # Media encoding/streaming (catalog/container format)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,6 +3759,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moq-bench"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "humantime",
+ "humantime-serde",
+ "moq-native",
+ "moq-net",
+ "rand 0.10.1",
+ "rustls",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "moq-boy"
 version = "0.2.17"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "rs/kio",
     "rs/libmoq",
     "rs/moq-audio",
+    "rs/moq-bench",
     "rs/moq-boy",
     "rs/moq-cli",
     "rs/moq-ffi",
@@ -25,6 +26,7 @@ default-members = [
     # "rs/libmoq",    # requires C toolchain
     "rs/moq-boy",
     "rs/moq-audio",
+    "rs/moq-bench",
     "rs/moq-cli",
     # "rs/moq-ffi",   # requires Python/maturin
     # "rs/moq-gst",   # requires GStreamer

--- a/rs/moq-bench/Cargo.toml
+++ b/rs/moq-bench/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "moq-bench"
+description = "Media over QUIC - Load generator for benchmarking relays"
+authors = ["Luke Curley <kixelated@gmail.com>"]
+repository = "https://github.com/moq-dev/moq"
+license = "MIT OR Apache-2.0"
+
+version = "0.0.1"
+edition = "2024"
+rust-version.workspace = true
+
+keywords = ["quic", "http3", "webtransport", "media", "live"]
+categories = ["multimedia", "network-programming", "web-programming"]
+
+publish = false
+
+[[bin]]
+name = "moq-bench"
+path = "src/main.rs"
+doc = false
+
+[features]
+default = ["quinn", "websocket"]
+iroh = ["moq-native/iroh"]
+quinn = ["moq-native/quinn"]
+quiche = ["moq-native/quiche"]
+websocket = ["moq-native/websocket"]
+
+[dependencies]
+anyhow = { version = "1", features = ["backtrace"] }
+clap = { version = "4", features = ["derive", "env"] }
+humantime = "2.3"
+humantime-serde = "1.1"
+moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
+moq-net = { workspace = true, features = ["serde"] }
+rand = "0.10.1"
+rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { workspace = true, features = ["full"] }
+toml = "1.1"
+tracing = "0.1"
+url = { version = "2", features = ["serde"] }

--- a/rs/moq-bench/README.md
+++ b/rs/moq-bench/README.md
@@ -1,0 +1,69 @@
+# moq-bench
+
+A load generator for benchmarking a remote MoQ relay.
+
+`moq-bench` opens many QUIC connections to a server and drives synthetic media
+through them. Every knob is a `[min, max]` range that is rolled once per
+connection, so a single config can describe a heterogeneous swarm (some
+connections at 24fps, others at 60, etc).
+
+## What it does
+
+For a run, `moq-bench` establishes **A** connections. Each connection:
+
+- publishes **B** broadcasts, each with a single track;
+- subscribes to **C** other broadcasts discovered via announcements;
+- produces **D** frames per second per track, each **E** bytes large;
+- splits frames into groups of **F** frames each.
+
+The first frame of every group is a JSON keyframe describing the rolled
+parameters (connection id, broadcast path, group sequence, fps, frame size,
+group size, and a wall-clock timestamp). The remaining **F** frames in the group
+are zeroed. **F may be 0**, in which case each group is a lone JSON keyframe,
+which is useful for stressing the announce/subscribe control plane rather than
+the data path.
+
+To avoid a thundering herd at startup, connections and subscriptions are
+staggered over a `--startup` ramp window instead of all firing at once.
+
+## Usage
+
+```bash
+# Roll the dice with the built-in defaults (1 connection, 1 broadcast, 30fps).
+moq-bench --url https://relay.example.com
+
+# Use a preset, overriding the target and connection count on the CLI.
+moq-bench --file rs/moq-bench/config/hd.toml \
+  --url https://relay.example.com \
+  --connections 500
+```
+
+CLI flags always win over the TOML file, matching `moq-relay`. Every range
+accepts a scalar (`--fps 30`), a `min:max` string (`--fps 24:60`), or a TOML
+table (`fps = { min = 24, max = 60 }`).
+
+### Key flags
+
+| Flag | Var | Meaning |
+|---|---|---|
+| `--connections` | A | Connections to establish (rolled once for the run) |
+| `--broadcasts` | B | Broadcasts published per connection |
+| `--subscribe` | C | Peer broadcasts each connection watches |
+| `--fps` | D | Frames per second per track (0 = idle) |
+| `--frame-size` | E | Bytes per frame |
+| `--group-size` | F | Zeroed frames per group after the keyframe |
+| `--startup` | | Ramp window for staggering connections/subscriptions |
+| `--duration` | | Stop after this long (runs until interrupted otherwise) |
+| `--report` | | How often to log throughput stats |
+
+Client TLS/QUIC flags (`--tls-disable-verify`, `--client-bind`, ...) come from
+`moq-native` and behave the same as in `moq-cli` and `moq-relay`.
+
+## Presets
+
+The `config/` directory has a few starting points:
+
+- `hd.toml` — high-bitrate HD video (24-60fps, several Mbps per track).
+- `sd.toml` — standard-definition video with more viewers per publisher.
+- `audio.toml` — small, frequent frames with short groups (Opus-like).
+- `announce.toml` — many broadcasts, near-zero media, to stress announcements.

--- a/rs/moq-bench/README.md
+++ b/rs/moq-bench/README.md
@@ -63,7 +63,7 @@ Client TLS/QUIC flags (`--tls-disable-verify`, `--client-bind`, ...) come from
 
 The `config/` directory has a few starting points:
 
-- `hd.toml` — high-bitrate HD video (24-60fps, several Mbps per track).
-- `sd.toml` — standard-definition video with more viewers per publisher.
-- `audio.toml` — small, frequent frames with short groups (Opus-like).
-- `announce.toml` — many broadcasts, near-zero media, to stress announcements.
+- `hd.toml`: high-bitrate HD video (24-60fps, several Mbps per track).
+- `sd.toml`: standard-definition video with more viewers per publisher.
+- `audio.toml`: small, frequent frames with short groups (Opus-like).
+- `announce.toml`: many broadcasts, near-zero media, to stress announcements.

--- a/rs/moq-bench/README.md
+++ b/rs/moq-bench/README.md
@@ -26,6 +26,22 @@ the data path.
 To avoid a thundering herd at startup, connections and subscriptions are
 staggered over a `--startup` ramp window instead of all firing at once.
 
+## Stats
+
+Every `--report` interval, `moq-bench` logs throughput (`send_mbps`/`recv_mbps`
+and `send_fps`/`recv_fps`) plus delivery accounting for the subscribe side:
+
+- `recv_groups`: cumulative groups received across all subscriptions.
+- `lost_groups`: cumulative groups that never arrived.
+- `loss`: `lost_groups` as a percentage.
+
+Subscribers read groups in arrival order (out-of-order included) and track each
+subscription's sequence span. A span wider than the count received means groups
+in between were skipped, so loss reflects dropped groups rather than QUIC packet
+loss (which the transport already repairs). The JSON keyframe at the start of
+each group is parsed back to recover the publisher's shape, so a subscriber works
+against peers it didn't publish itself.
+
 ## Usage
 
 ```bash

--- a/rs/moq-bench/README.md
+++ b/rs/moq-bench/README.md
@@ -38,9 +38,11 @@ and `send_fps`/`recv_fps`) plus delivery accounting for the subscribe side:
 Subscribers read groups in arrival order (out-of-order included) and track each
 subscription's sequence span. A span wider than the count received means groups
 in between were skipped, so loss reflects dropped groups rather than QUIC packet
-loss (which the transport already repairs). The JSON keyframe at the start of
-each group is parsed back to recover the publisher's shape, so a subscriber works
-against peers it didn't publish itself.
+loss (which the transport already repairs). The newest group is the live frontier
+and is excluded from the count: groups just behind it may still be in flight, so a
+gap is only blamed once a higher group confirms it was truly skipped. The JSON
+keyframe at the start of each group is parsed back to recover the publisher's
+shape, so a subscriber works against peers it didn't publish itself.
 
 ## Usage
 

--- a/rs/moq-bench/build.rs
+++ b/rs/moq-bench/build.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+fn main() {
+	println!("cargo:rerun-if-changed=../../.git/HEAD");
+	println!("cargo:rerun-if-changed=../../.git/refs/heads");
+	println!("cargo:rerun-if-changed=../../.git/refs/tags");
+	println!("cargo:rerun-if-changed=../../.git/packed-refs");
+
+	let prefix = "moq-bench-v";
+	let version = git_version(prefix).unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+	println!("cargo:rustc-env=VERSION={version}");
+}
+
+fn git_version(prefix: &str) -> Option<String> {
+	let output = Command::new("git")
+		.args(["describe", "--tags", "--match", &format!("{prefix}*")])
+		.output()
+		.ok()?;
+	if !output.status.success() {
+		return None;
+	}
+	let desc = String::from_utf8(output.stdout).ok()?.trim().to_string();
+	let version = desc.strip_prefix(prefix)?;
+	// "0.7.13-3-gabcdef" -> "0.7.13-abcdef" (drop count, strip 'g')
+	if let Some((base, hash)) = version.rsplit_once("-g") {
+		let base = base.rsplit_once('-').map(|(b, _)| b).unwrap_or(base);
+		Some(format!("{base}-{hash}"))
+	} else {
+		Some(version.to_string())
+	}
+}

--- a/rs/moq-bench/config/announce.toml
+++ b/rs/moq-bench/config/announce.toml
@@ -1,0 +1,17 @@
+# Announcement / control-plane stress: many broadcasts, almost no media.
+#
+# Each connection publishes a large fan of broadcasts but produces only the JSON
+# keyframe per group (group_size = 0) at a slow rate. This hammers the relay's
+# announce/subscribe machinery rather than its data path.
+
+# url = "https://relay.example.com"
+
+startup = "30s"
+report = "5s"
+
+connections = "10:50"    # A
+broadcasts = "20:100"    # B: a wide announcement fan
+subscribe = "10:50"      # C
+fps = 1                  # D: one group per second
+frame_size = 0           # E: keyframe only, no payload bytes
+group_size = 0           # F: each group is a lone JSON keyframe

--- a/rs/moq-bench/config/announce.toml
+++ b/rs/moq-bench/config/announce.toml
@@ -9,9 +9,15 @@
 startup = "30s"
 report = "5s"
 
-connections = "10:50"    # A
-broadcasts = "20:100"    # B: a wide announcement fan
-subscribe = "10:50"      # C
-fps = 1                  # D: one group per second
-frame_size = 0           # E: keyframe only, no payload bytes
-group_size = 0           # F: each group is a lone JSON keyframe
+# A: number of connections
+connections = "10:50"
+# B: a wide announcement fan of broadcasts per connection
+broadcasts = "20:100"
+# C: peer broadcasts each connection watches
+subscribe = "10:50"
+# D: frames per second (one group per second)
+fps = 1
+# E: bytes per frame (keyframe only, no payload bytes)
+frame_size = 0
+# F: zeroed frames per group (each group is a lone JSON keyframe)
+group_size = 0

--- a/rs/moq-bench/config/audio.toml
+++ b/rs/moq-bench/config/audio.toml
@@ -1,0 +1,16 @@
+# Audio-only: small, frequent frames with short groups.
+#
+# Emulates Opus-style audio: 50 frames/sec (20ms each), a few hundred bytes per
+# frame, and short groups so keyframes (and thus new QUIC streams) are frequent.
+
+# url = "https://relay.example.com"
+
+startup = "20s"
+report = "5s"
+
+connections = "200:1000" # A
+broadcasts = 1           # B
+subscribe = "2:10"       # C
+fps = 50                 # D: 20ms frames
+frame_size = "200:600"   # E
+group_size = "4:9"       # F: short groups, frequent stream churn

--- a/rs/moq-bench/config/audio.toml
+++ b/rs/moq-bench/config/audio.toml
@@ -8,9 +8,15 @@
 startup = "20s"
 report = "5s"
 
-connections = "200:1000" # A
-broadcasts = 1           # B
-subscribe = "2:10"       # C
-fps = 50                 # D: 20ms frames
-frame_size = "200:600"   # E
-group_size = "4:9"       # F: short groups, frequent stream churn
+# A: number of connections
+connections = "200:1000"
+# B: broadcasts (tracks) per connection
+broadcasts = 1
+# C: peer broadcasts each connection watches
+subscribe = "2:10"
+# D: frames per second (20ms frames)
+fps = 50
+# E: bytes per frame
+frame_size = "200:600"
+# F: zeroed frames per group (short groups, frequent stream churn)
+group_size = "4:9"

--- a/rs/moq-bench/config/hd.toml
+++ b/rs/moq-bench/config/hd.toml
@@ -1,18 +1,25 @@
 # High-bitrate video: emulates HD broadcasts at 24-60fps.
 #
 # A swarm of publishers each pushing a single high-bitrate track, with a handful
-# of viewers per connection. Roughly 5-15 Mbps per track depending on the roll.
+# of viewers per connection. Roughly 4-29 Mbps per track depending on the roll.
 #
-# Override the target on the CLI: `moq-bench --file rs/moq-bench/config/hd.toml --url https://relay.example.com`
+# Override the target on the CLI:
+#   moq-bench --file rs/moq-bench/config/hd.toml --url https://relay.example.com
 
 # url = "https://relay.example.com"
 
 startup = "30s"
 report = "5s"
 
-connections = "50:200"   # A: number of connections
-broadcasts = 1           # B: broadcasts (tracks) per connection
-subscribe = "1:5"        # C: peer broadcasts each connection watches
-fps = "24:60"            # D: frames per second
-frame_size = "20000:60000" # E: bytes per frame (~4-29 Mbps at these rates)
-group_size = "23:59"     # F: zeroed frames per group (one GOP between keyframes)
+# A: number of connections
+connections = "50:200"
+# B: broadcasts (tracks) per connection
+broadcasts = 1
+# C: peer broadcasts each connection watches
+subscribe = "1:5"
+# D: frames per second
+fps = "24:60"
+# E: bytes per frame
+frame_size = "20000:60000"
+# F: zeroed frames per group (one GOP between keyframes)
+group_size = "23:59"

--- a/rs/moq-bench/config/hd.toml
+++ b/rs/moq-bench/config/hd.toml
@@ -1,0 +1,18 @@
+# High-bitrate video: emulates HD broadcasts at 24-60fps.
+#
+# A swarm of publishers each pushing a single high-bitrate track, with a handful
+# of viewers per connection. Roughly 5-15 Mbps per track depending on the roll.
+#
+# Override the target on the CLI: `moq-bench --file rs/moq-bench/config/hd.toml --url https://relay.example.com`
+
+# url = "https://relay.example.com"
+
+startup = "30s"
+report = "5s"
+
+connections = "50:200"   # A: number of connections
+broadcasts = 1           # B: broadcasts (tracks) per connection
+subscribe = "1:5"        # C: peer broadcasts each connection watches
+fps = "24:60"            # D: frames per second
+frame_size = "20000:60000" # E: bytes per frame (~4-29 Mbps at these rates)
+group_size = "23:59"     # F: zeroed frames per group (one GOP between keyframes)

--- a/rs/moq-bench/config/sd.toml
+++ b/rs/moq-bench/config/sd.toml
@@ -8,9 +8,15 @@
 startup = "30s"
 report = "5s"
 
-connections = "100:500"  # A
-broadcasts = 1           # B
-subscribe = "5:20"       # C
-fps = 30                 # D
-frame_size = "4000:12000" # E (~1-3 Mbps)
-group_size = 59          # F: 2s GOP at 30fps
+# A: number of connections
+connections = "100:500"
+# B: broadcasts (tracks) per connection
+broadcasts = 1
+# C: peer broadcasts each connection watches
+subscribe = "5:20"
+# D: frames per second
+fps = 30
+# E: bytes per frame (~1-3 Mbps)
+frame_size = "4000:12000"
+# F: zeroed frames per group (2s GOP at 30fps)
+group_size = 59

--- a/rs/moq-bench/config/sd.toml
+++ b/rs/moq-bench/config/sd.toml
@@ -1,0 +1,16 @@
+# Standard-definition video: lower bitrate, more viewers per publisher.
+#
+# Models a typical live-streaming fan-out: many subscribers per broadcast at a
+# modest ~1-3 Mbps per track.
+
+# url = "https://relay.example.com"
+
+startup = "30s"
+report = "5s"
+
+connections = "100:500"  # A
+broadcasts = 1           # B
+subscribe = "5:20"       # C
+fps = 30                 # D
+frame_size = "4000:12000" # E (~1-3 Mbps)
+group_size = 59          # F: 2s GOP at 30fps

--- a/rs/moq-bench/src/config.rs
+++ b/rs/moq-bench/src/config.rs
@@ -1,0 +1,212 @@
+use std::str::FromStr;
+use std::time::Duration;
+
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+use crate::Range;
+
+/// moq-bench configuration, loadable from CLI arguments, environment variables,
+/// or a TOML file. CLI flags always win over the TOML file.
+///
+/// Each `[min, max]` range is rolled once per connection, so a single config can
+/// describe a heterogeneous swarm (e.g. some connections at 24fps, others at 60).
+#[derive(Parser, Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(default, deny_unknown_fields)]
+#[command(version = env!("VERSION"))]
+#[non_exhaustive]
+pub struct Config {
+	/// The URL of the MoQ server to benchmark (e.g. `https://relay.example.com`).
+	#[arg(long, env = "MOQ_BENCH_URL")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub url: Option<url::Url>,
+
+	/// The broadcast namespace prefix. Each broadcast is published under
+	/// `<name>/<run>/<connection>/<index>` and subscribers discover peers under `<name>`.
+	#[arg(long, env = "MOQ_BENCH_NAME")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+
+	/// Spread connection and subscription startup over this duration to avoid a thundering herd.
+	#[arg(long, value_parser = humantime::parse_duration, env = "MOQ_BENCH_STARTUP")]
+	#[serde(default, with = "humantime_serde::option", skip_serializing_if = "Option::is_none")]
+	pub startup: Option<Duration>,
+
+	/// Stop the benchmark after this duration. Runs until interrupted if unset.
+	#[arg(long, value_parser = humantime::parse_duration, env = "MOQ_BENCH_DURATION")]
+	#[serde(default, with = "humantime_serde::option", skip_serializing_if = "Option::is_none")]
+	pub duration: Option<Duration>,
+
+	/// How often to log throughput stats.
+	#[arg(long, value_parser = humantime::parse_duration, env = "MOQ_BENCH_REPORT")]
+	#[serde(default, with = "humantime_serde::option", skip_serializing_if = "Option::is_none")]
+	pub report: Option<Duration>,
+
+	/// Number of connections (A) to establish. Rolled once for the whole run.
+	#[arg(long, value_parser = Range::from_str, env = "MOQ_BENCH_CONNECTIONS")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub connections: Option<Range>,
+
+	/// Broadcasts published per connection (B), each with a single track.
+	#[arg(long, value_parser = Range::from_str, env = "MOQ_BENCH_BROADCASTS")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub broadcasts: Option<Range>,
+
+	/// Other broadcasts each connection subscribes to (C), discovered via announcements.
+	#[arg(long, value_parser = Range::from_str, env = "MOQ_BENCH_SUBSCRIBE")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub subscribe: Option<Range>,
+
+	/// Frames per second per track (D). Zero leaves the track idle.
+	#[arg(long, value_parser = Range::from_str, env = "MOQ_BENCH_FPS")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub fps: Option<Range>,
+
+	/// Bytes per frame (E).
+	#[arg(long, value_parser = Range::from_str, env = "MOQ_BENCH_FRAME_SIZE")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub frame_size: Option<Range>,
+
+	/// Zeroed frames per group (F) following the JSON keyframe. May be zero.
+	#[arg(long, value_parser = Range::from_str, env = "MOQ_BENCH_GROUP_SIZE")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub group_size: Option<Range>,
+
+	/// The MoQ client (QUIC/TLS) configuration.
+	#[command(flatten)]
+	#[serde(default)]
+	pub client: moq_native::ClientConfig,
+
+	/// Log configuration.
+	#[command(flatten)]
+	#[serde(default)]
+	pub log: moq_native::Log,
+
+	/// Load configuration from this TOML file. CLI flags still take precedence.
+	#[arg(long)]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub file: Option<String>,
+}
+
+impl Config {
+	/// Parse from CLI args, optionally merging a TOML file, then init the logger.
+	pub fn load() -> anyhow::Result<Self> {
+		let config = Self::parse_and_merge(std::env::args_os())?;
+		config.log.init()?;
+		tracing::trace!(?config, "final config");
+		Ok(config)
+	}
+
+	/// Merge order mirrors moq-relay: CLI args (including `--file`) -> TOML file
+	/// (if set) -> CLI args re-applied so explicit flags override the TOML.
+	///
+	/// Every overridable field is `Option<T>`, so an absent CLI flag leaves the
+	/// TOML value untouched during the final `update_from` re-parse. See
+	/// `CLAUDE.md` for why bare fields would silently clobber the TOML.
+	pub(crate) fn parse_and_merge<I, T>(args: I) -> anyhow::Result<Self>
+	where
+		I: IntoIterator<Item = T>,
+		T: Into<std::ffi::OsString> + Clone,
+	{
+		let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
+		let mut config = Config::parse_from(&args);
+		if let Some(file) = config.file.clone() {
+			config = toml::from_str(&std::fs::read_to_string(file)?)?;
+			config.update_from(&args);
+		}
+		Ok(config)
+	}
+
+	pub fn name(&self) -> &str {
+		self.name.as_deref().unwrap_or("bench")
+	}
+
+	pub fn startup(&self) -> Duration {
+		self.startup.unwrap_or(Duration::from_secs(10))
+	}
+
+	pub fn report(&self) -> Duration {
+		self.report.unwrap_or(Duration::from_secs(1))
+	}
+
+	pub fn connections(&self) -> Range {
+		self.connections.unwrap_or(Range::new(1, 1))
+	}
+
+	pub fn broadcasts(&self) -> Range {
+		self.broadcasts.unwrap_or(Range::new(1, 1))
+	}
+
+	pub fn subscribe(&self) -> Range {
+		self.subscribe.unwrap_or(Range::new(0, 0))
+	}
+
+	pub fn fps(&self) -> Range {
+		self.fps.unwrap_or(Range::new(30, 30))
+	}
+
+	pub fn frame_size(&self) -> Range {
+		self.frame_size.unwrap_or(Range::new(1200, 1200))
+	}
+
+	pub fn group_size(&self) -> Range {
+		self.group_size.unwrap_or(Range::new(60, 60))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn cli_overrides_toml() {
+		let toml = r#"
+url = "https://example.com"
+connections = 100
+fps = "24:60"
+
+[client]
+tls.disable_verify = true
+"#;
+		let dir = std::env::temp_dir().join("moq-bench-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("bench.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		// No CLI flag: TOML values survive the re-parse.
+		let args = vec![
+			std::ffi::OsString::from("moq-bench"),
+			std::ffi::OsString::from("--file"),
+			path.clone().into(),
+		];
+		let config = Config::parse_and_merge(args).unwrap();
+		assert_eq!(config.connections(), Range::new(100, 100));
+		assert_eq!(config.fps(), Range::new(24, 60));
+		assert_eq!(config.client.tls.disable_verify, Some(true));
+
+		// CLI flag wins over the TOML value.
+		let args = vec![
+			std::ffi::OsString::from("moq-bench"),
+			std::ffi::OsString::from("--file"),
+			path.into(),
+			std::ffi::OsString::from("--connections"),
+			std::ffi::OsString::from("5:10"),
+		];
+		let config = Config::parse_and_merge(args).unwrap();
+		assert_eq!(config.connections(), Range::new(5, 10));
+		// Untouched TOML field is still intact.
+		assert_eq!(config.fps(), Range::new(24, 60));
+	}
+
+	#[test]
+	fn defaults_apply_without_toml() {
+		let config = Config::parse_and_merge(["moq-bench"]).unwrap();
+		assert_eq!(config.connections(), Range::new(1, 1));
+		assert_eq!(config.broadcasts(), Range::new(1, 1));
+		assert_eq!(config.subscribe(), Range::new(0, 0));
+		assert_eq!(config.fps(), Range::new(30, 30));
+		assert_eq!(config.frame_size(), Range::new(1200, 1200));
+		assert_eq!(config.group_size(), Range::new(60, 60));
+		assert_eq!(config.name(), "bench");
+	}
+}

--- a/rs/moq-bench/src/config.rs
+++ b/rs/moq-bench/src/config.rs
@@ -114,6 +114,9 @@ impl Config {
 			config = toml::from_str(&std::fs::read_to_string(file)?)?;
 			config.update_from(&args);
 		}
+		// `Stats::report` feeds this into `tokio::time::interval`, which panics on a
+		// zero period. Reject it up front with a clear message.
+		anyhow::ensure!(!config.report().is_zero(), "--report must be greater than 0s");
 		Ok(config)
 	}
 
@@ -196,6 +199,13 @@ tls.disable_verify = true
 		assert_eq!(config.connections(), Range::new(5, 10));
 		// Untouched TOML field is still intact.
 		assert_eq!(config.fps(), Range::new(24, 60));
+	}
+
+	#[test]
+	fn zero_report_is_rejected() {
+		// A zero report interval would panic `tokio::time::interval`; reject it early.
+		let err = Config::parse_and_merge(["moq-bench", "--report", "0s"]).unwrap_err();
+		assert!(err.to_string().contains("report"), "unexpected error: {err}");
 	}
 
 	#[test]

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use moq_native::Status;
 use moq_native::moq_net::{self, Broadcast, BroadcastConsumer, Origin, Track, TrackProducer, bytes::Bytes};
 use rand::RngExt;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::task::JoinSet;
 
 use crate::Stats;
@@ -38,6 +38,15 @@ struct GroupHeader<'a> {
 	subscribe: u64,
 	/// Wall-clock milliseconds, handy for rough one-way latency when clocks agree.
 	timestamp_ms: u128,
+}
+
+/// The subset of [`GroupHeader`] a subscriber reads back to learn the shape of a
+/// broadcast it didn't publish. Extra fields on the wire are ignored.
+#[derive(Deserialize)]
+struct RecvHeader {
+	fps: u64,
+	frame_size: u64,
+	group_size: u64,
 }
 
 /// Everything one benchmark connection needs to run: its identity, the rolled
@@ -255,17 +264,91 @@ async fn subscribe(
 	Ok(())
 }
 
-/// Subscribe to the broadcast's track and count every frame received.
+/// Subscribe to the broadcast's track, counting every frame received and tracking
+/// group-sequence gaps to report skipped groups.
 async fn drain(broadcast: BroadcastConsumer, stats: &Stats) -> anyhow::Result<()> {
 	let _gauge = Gauge::inc(&stats.subscriptions);
 
 	let mut track = broadcast.subscribe_track(&Track::new(TRACK))?;
-	while let Some(mut group) = track.next_group().await? {
+	let mut gaps = GapTracker::new(stats);
+	let mut learned_shape = false;
+
+	// `recv_group` yields groups in arrival order, including out of sequence, so we
+	// can spot holes. `next_group` would silently drop late arrivals and hide them.
+	while let Some(mut group) = track.recv_group().await? {
+		gaps.observe(group.sequence);
+
+		let mut first = true;
 		while let Some(frame) = group.read_frame().await? {
+			// The first frame of every group is the JSON keyframe. Parse it once to
+			// learn the publisher's shape (we may be watching a peer, not ourselves).
+			if first && !learned_shape {
+				if let Ok(header) = serde_json::from_slice::<RecvHeader>(&frame) {
+					tracing::debug!(
+						fps = header.fps,
+						frame_size = header.frame_size,
+						group_size = header.group_size,
+						"subscribed broadcast shape"
+					);
+					learned_shape = true;
+				}
+			}
+			first = false;
 			stats.frame_recv(frame.len());
 		}
 	}
 	Ok(())
+}
+
+/// Tracks group-sequence continuity for one subscription so we can report skipped
+/// groups. Groups can arrive out of order, so rather than diffing consecutive
+/// sequences we measure the span `[min, max]` against the count received: a span
+/// wider than the count means groups in between never showed up.
+///
+/// Each observation feeds the shared [`Stats`] incrementally so the periodic
+/// reporter sees losses live, and so spans from many subscriptions sum correctly
+/// (`groups_expected - groups_recv` is the total skipped across all of them).
+struct GapTracker<'a> {
+	stats: &'a Stats,
+	min: u64,
+	max: u64,
+	started: bool,
+}
+
+impl<'a> GapTracker<'a> {
+	fn new(stats: &'a Stats) -> Self {
+		Self {
+			stats,
+			min: 0,
+			max: 0,
+			started: false,
+		}
+	}
+
+	fn observe(&mut self, sequence: u64) {
+		self.stats.groups_recv.fetch_add(1, Ordering::Relaxed);
+
+		if !self.started {
+			self.started = true;
+			self.min = sequence;
+			self.max = sequence;
+			self.stats.groups_expected.fetch_add(1, Ordering::Relaxed);
+			return;
+		}
+
+		// Widen the span on either end, crediting the newly covered sequences as expected.
+		if sequence > self.max {
+			self.stats
+				.groups_expected
+				.fetch_add(sequence - self.max, Ordering::Relaxed);
+			self.max = sequence;
+		} else if sequence < self.min {
+			self.stats
+				.groups_expected
+				.fetch_add(self.min - sequence, Ordering::Relaxed);
+			self.min = sequence;
+		}
+	}
 }
 
 /// RAII counter: bumps a gauge on creation and restores it on drop, so a gauge
@@ -359,5 +442,30 @@ mod tests {
 		assert!(group.read_frame().await.unwrap().is_none(), "no payload frames");
 
 		task.abort();
+	}
+
+	/// A hole in the sequence (group 2 never arrives) shows up as one skipped group.
+	#[test]
+	fn gap_tracker_counts_skips() {
+		let stats = Stats::default();
+		let mut gaps = GapTracker::new(&stats);
+		for seq in [0, 1, 3, 4] {
+			gaps.observe(seq);
+		}
+		// Span 0..=4 is 5 groups, 4 received, so 1 skipped.
+		assert_eq!(stats.groups_recv.load(Ordering::Relaxed), 4);
+		assert_eq!(stats.groups_expected.load(Ordering::Relaxed), 5);
+	}
+
+	/// Out-of-order arrivals that fill the whole span count as zero loss.
+	#[test]
+	fn gap_tracker_handles_out_of_order() {
+		let stats = Stats::default();
+		let mut gaps = GapTracker::new(&stats);
+		for seq in [2, 0, 1, 3] {
+			gaps.observe(seq);
+		}
+		assert_eq!(stats.groups_recv.load(Ordering::Relaxed), 4);
+		assert_eq!(stats.groups_expected.load(Ordering::Relaxed), 4);
 	}
 }

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -301,17 +301,31 @@ async fn drain(broadcast: BroadcastConsumer, stats: &Stats) -> anyhow::Result<()
 }
 
 /// Tracks group-sequence continuity for one subscription so we can report skipped
-/// groups. Groups can arrive out of order, so rather than diffing consecutive
-/// sequences we measure the span `[min, max]` against the count received: a span
-/// wider than the count means groups in between never showed up.
+/// groups. Groups arrive out of order, so rather than diffing consecutive sequences
+/// we measure how many sequences the received groups span against how many actually
+/// landed: a span wider than the count means groups in between never showed up.
 ///
-/// Each observation feeds the shared [`Stats`] incrementally so the periodic
-/// reporter sees losses live, and so spans from many subscriptions sum correctly
-/// (`groups_expected - groups_recv` is the total skipped across all of them).
+/// The highest sequence (`max`) is the live frontier and is left out of the
+/// accounting: groups just below it may still be in flight (reordered behind the
+/// newest stream), so blaming them the instant `max` jumps would be a false
+/// positive. We only count up to `cap`, the second-highest sequence seen, which is
+/// settled once a higher group has confirmed it. A truly skipped group is counted
+/// once the frontier moves past it.
+///
+/// Each observation feeds the shared [`Stats`] incrementally so the reporter sees
+/// losses live and many subscriptions sum correctly: `groups_expected` is the size
+/// of every settled span, `groups_present` is how many of those groups arrived, and
+/// `groups_expected - groups_present` is the total skipped.
 struct GapTracker<'a> {
 	stats: &'a Stats,
 	min: u64,
 	max: u64,
+	/// Second-highest sequence seen: the settled frontier we count up to. `None`
+	/// until a second group arrives.
+	cap: Option<u64>,
+	/// This subscription's current contribution to `groups_expected` (`cap - min + 1`),
+	/// remembered so each update pushes only the delta.
+	expected: u64,
 	started: bool,
 }
 
@@ -321,6 +335,8 @@ impl<'a> GapTracker<'a> {
 			stats,
 			min: 0,
 			max: 0,
+			cap: None,
+			expected: 0,
 			started: false,
 		}
 	}
@@ -328,26 +344,33 @@ impl<'a> GapTracker<'a> {
 	fn observe(&mut self, sequence: u64) {
 		self.stats.groups_recv.fetch_add(1, Ordering::Relaxed);
 
+		// The first group is the lone frontier: nothing settled yet, so it doesn't count.
 		if !self.started {
 			self.started = true;
 			self.min = sequence;
 			self.max = sequence;
-			self.stats.groups_expected.fetch_add(1, Ordering::Relaxed);
 			return;
 		}
 
-		// Widen the span on either end, crediting the newly covered sequences as expected.
+		// Every later group sits at or below the settled frontier, so it's a present group.
+		self.stats.groups_present.fetch_add(1, Ordering::Relaxed);
+
+		self.min = self.min.min(sequence);
 		if sequence > self.max {
-			self.stats
-				.groups_expected
-				.fetch_add(sequence - self.max, Ordering::Relaxed);
+			// New frontier: the old `max` is now settled and becomes the cap.
+			self.cap = Some(self.max);
 			self.max = sequence;
-		} else if sequence < self.min {
-			self.stats
-				.groups_expected
-				.fetch_add(self.min - sequence, Ordering::Relaxed);
-			self.min = sequence;
+		} else if self.cap.is_none_or(|cap| sequence > cap) {
+			self.cap = Some(sequence);
 		}
+
+		// `cap` is always set here: either the branch above set it, or a prior group did.
+		let cap = self.cap.expect("cap set once a second group arrives");
+		let expected = cap - self.min + 1;
+		self.stats
+			.groups_expected
+			.fetch_add(expected - self.expected, Ordering::Relaxed);
+		self.expected = expected;
 	}
 }
 
@@ -444,7 +467,14 @@ mod tests {
 		task.abort();
 	}
 
-	/// A hole in the sequence (group 2 never arrives) shows up as one skipped group.
+	fn lost(stats: &Stats) -> u64 {
+		stats
+			.groups_expected
+			.load(Ordering::Relaxed)
+			.saturating_sub(stats.groups_present.load(Ordering::Relaxed))
+	}
+
+	/// A hole below the frontier (group 2 never arrives, but 3 and 4 do) is one skip.
 	#[test]
 	fn gap_tracker_counts_skips() {
 		let stats = Stats::default();
@@ -452,9 +482,8 @@ mod tests {
 		for seq in [0, 1, 3, 4] {
 			gaps.observe(seq);
 		}
-		// Span 0..=4 is 5 groups, 4 received, so 1 skipped.
 		assert_eq!(stats.groups_recv.load(Ordering::Relaxed), 4);
-		assert_eq!(stats.groups_expected.load(Ordering::Relaxed), 5);
+		assert_eq!(lost(&stats), 1);
 	}
 
 	/// Out-of-order arrivals that fill the whole span count as zero loss.
@@ -466,6 +495,24 @@ mod tests {
 			gaps.observe(seq);
 		}
 		assert_eq!(stats.groups_recv.load(Ordering::Relaxed), 4);
-		assert_eq!(stats.groups_expected.load(Ordering::Relaxed), 4);
+		assert_eq!(lost(&stats), 0);
+	}
+
+	/// The newest group is the live frontier: a hole directly behind it isn't blamed
+	/// yet (it may still be in flight), but once the frontier moves past, it counts.
+	#[test]
+	fn gap_tracker_excludes_live_frontier() {
+		let stats = Stats::default();
+		let mut gaps = GapTracker::new(&stats);
+
+		// 3 is missing, 4 is the live frontier: nothing is settled past 2 yet.
+		for seq in [0, 1, 2, 4] {
+			gaps.observe(seq);
+		}
+		assert_eq!(lost(&stats), 0);
+
+		// 5 advances the frontier, settling 4 and confirming 3 was skipped.
+		gaps.observe(5);
+		assert_eq!(lost(&stats), 1);
 	}
 }

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -1,0 +1,344 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use moq_native::Status;
+use moq_native::moq_net::{self, Broadcast, BroadcastConsumer, Origin, Track, TrackProducer, bytes::Bytes};
+use rand::RngExt;
+use serde::Serialize;
+use tokio::task::JoinSet;
+
+use crate::Stats;
+
+/// The single track name every broadcast publishes and subscribers look up.
+const TRACK: &str = "data";
+
+/// Per-connection parameters, rolled once from the configured ranges.
+#[derive(Clone, Copy, Debug)]
+pub struct Rolled {
+	pub broadcasts: u64,
+	pub subscribe: u64,
+	pub fps: u64,
+	pub frame_size: u64,
+	pub group_size: u64,
+}
+
+/// The JSON keyframe written at the start of every group, describing the rolled
+/// parameters so a subscriber (or a packet capture) can reconstruct the shape.
+#[derive(Serialize)]
+struct GroupHeader<'a> {
+	connection: u64,
+	broadcast: &'a str,
+	group: u64,
+	fps: u64,
+	frame_size: u64,
+	group_size: u64,
+	broadcasts: u64,
+	subscribe: u64,
+	/// Wall-clock milliseconds, handy for rough one-way latency when clocks agree.
+	timestamp_ms: u128,
+}
+
+/// Run a single benchmark connection: publish `broadcasts` tracks and subscribe
+/// to `subscribe` peer broadcasts discovered via announcements.
+///
+/// Returns only when the underlying reconnect loop permanently gives up.
+pub async fn run(
+	connection: u64,
+	run_id: u64,
+	rolled: Rolled,
+	config: Arc<crate::Config>,
+	client: moq_native::Client,
+	stats: Arc<Stats>,
+) {
+	let url = config.url.clone().expect("url required");
+
+	// Publish side: an origin we fill with our broadcasts and hand to the session.
+	let publish = Origin::random().produce();
+	// Consume side: the session fills this with peer announcements.
+	let consume = Origin::random().produce();
+	let announced = consume.consume();
+
+	let name = config.name();
+	let mut broadcasts = Vec::new();
+	let mut own = HashSet::new();
+	let mut tasks = JoinSet::new();
+
+	for index in 0..rolled.broadcasts {
+		let path = format!("{name}/{run_id:08x}/{connection}/{index}");
+
+		let mut broadcast = Broadcast::new().produce();
+		let track = match broadcast.create_track(Track::new(TRACK)) {
+			Ok(track) => track,
+			Err(err) => {
+				tracing::error!(connection, %err, "failed to create track");
+				continue;
+			}
+		};
+
+		publish.publish_broadcast(&path, broadcast.consume());
+		own.insert(path.clone());
+		// Hold the broadcast producer for the connection's lifetime so it stays announced.
+		broadcasts.push(broadcast);
+
+		let stats = stats.clone();
+		tasks.spawn(produce(connection, path, rolled, track, stats));
+	}
+
+	let client = client.with_publish(publish.consume()).with_consume(consume);
+	let mut reconnect = client.reconnect(url);
+
+	// Subscriber: drain up to `subscribe` peer broadcasts.
+	if rolled.subscribe > 0 {
+		tasks.spawn(subscribe(
+			announced,
+			own,
+			rolled.subscribe,
+			config.startup(),
+			stats.clone(),
+		));
+	}
+
+	// The status loop doubles as the keep-alive: it tracks connect/disconnect for
+	// the gauge and returns once the reconnect loop gives up.
+	let mut connected = false;
+	loop {
+		tokio::select! {
+			status = reconnect.status() => match status {
+				Ok(Status::Connected) => {
+					connected = true;
+					stats.connections.fetch_add(1, Ordering::Relaxed);
+				}
+				Ok(Status::Disconnected) => {
+					connected = false;
+					stats.connections.fetch_sub(1, Ordering::Relaxed);
+				}
+				Err(err) => {
+					tracing::warn!(connection, %err, "connection gave up");
+					break;
+				}
+			},
+			// Surface a fatal task error, but keep running otherwise.
+			Some(res) = tasks.join_next() => {
+				if let Ok(Err(err)) = res {
+					tracing::debug!(connection, %err, "task ended");
+				}
+			}
+		}
+	}
+
+	if connected {
+		stats.connections.fetch_sub(1, Ordering::Relaxed);
+	}
+}
+
+/// Produce frames for one track at `fps`, opening a new group every `group_size`
+/// frames. Each group starts with a JSON keyframe; the rest are zeroed.
+async fn produce(
+	connection: u64,
+	path: String,
+	rolled: Rolled,
+	mut track: TrackProducer,
+	stats: Arc<Stats>,
+) -> anyhow::Result<()> {
+	let _gauge = Gauge::inc(&stats.broadcasts);
+
+	// Zero fps means an idle track: keep it published but never produce.
+	if rolled.fps == 0 {
+		std::future::pending::<()>().await;
+		return Ok(());
+	}
+
+	let zeros = Bytes::from(vec![0u8; rolled.frame_size as usize]);
+	let period = Duration::from_secs_f64(1.0 / rolled.fps as f64);
+	let mut ticker = tokio::time::interval(period);
+	ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+	let mut sequence = 0u64;
+	loop {
+		let mut group = track.append_group()?;
+
+		// Keyframe: the JSON header describing this connection's rolled parameters.
+		ticker.tick().await;
+		let header = GroupHeader {
+			connection,
+			broadcast: &path,
+			group: sequence,
+			fps: rolled.fps,
+			frame_size: rolled.frame_size,
+			group_size: rolled.group_size,
+			broadcasts: rolled.broadcasts,
+			subscribe: rolled.subscribe,
+			timestamp_ms: SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.unwrap_or_default()
+				.as_millis(),
+		};
+		let header = Bytes::from(serde_json::to_vec(&header)?);
+		group.write_frame(header.clone())?;
+		stats.frame_sent(header.len());
+
+		// The remaining frames in the group are zeroed payload.
+		for _ in 0..rolled.group_size {
+			ticker.tick().await;
+			group.write_frame(zeros.clone())?;
+			stats.frame_sent(zeros.len());
+		}
+
+		group.finish()?;
+		sequence += 1;
+	}
+}
+
+/// Watch announcements and drain up to `want` peer broadcasts (excluding our own),
+/// spreading each subscription's start over `startup` to avoid a thundering herd.
+async fn subscribe(
+	mut announced: moq_net::OriginConsumer,
+	own: HashSet<String>,
+	want: u64,
+	startup: Duration,
+	stats: Arc<Stats>,
+) -> anyhow::Result<()> {
+	let mut tasks = JoinSet::new();
+	let mut seen: HashSet<String> = HashSet::new();
+
+	while (seen.len() as u64) < want {
+		let Some((path, broadcast)) = announced.announced().await else {
+			break;
+		};
+		let Some(broadcast) = broadcast else {
+			continue;
+		};
+
+		let path = path.as_str().to_string();
+		if own.contains(&path) || !seen.insert(path.clone()) {
+			continue;
+		}
+
+		// Stagger the subscription start somewhere within the startup window.
+		let delay = {
+			let mut rng = rand::rng();
+			startup.mul_f64(rng.random_range(0.0..1.0))
+		};
+
+		let stats = stats.clone();
+		tasks.spawn(async move {
+			tokio::time::sleep(delay).await;
+			if let Err(err) = drain(broadcast, &stats).await {
+				tracing::debug!(%path, %err, "subscription ended");
+			}
+		});
+	}
+
+	// Keep the drain tasks alive; they run until their broadcasts close.
+	while tasks.join_next().await.is_some() {}
+	Ok(())
+}
+
+/// Subscribe to the broadcast's track and count every frame received.
+async fn drain(broadcast: BroadcastConsumer, stats: &Stats) -> anyhow::Result<()> {
+	let _gauge = Gauge::inc(&stats.subscriptions);
+
+	let mut track = broadcast.subscribe_track(&Track::new(TRACK))?;
+	while let Some(mut group) = track.next_group().await? {
+		while let Some(frame) = group.read_frame().await? {
+			stats.frame_recv(frame.len());
+		}
+	}
+	Ok(())
+}
+
+/// RAII counter: bumps a gauge on creation and restores it on drop, so a gauge
+/// reflects live state even when the owning task is aborted.
+struct Gauge<'a>(&'a AtomicU64);
+
+impl<'a> Gauge<'a> {
+	fn inc(counter: &'a AtomicU64) -> Self {
+		counter.fetch_add(1, Ordering::Relaxed);
+		Self(counter)
+	}
+}
+
+impl Drop for Gauge<'_> {
+	fn drop(&mut self) {
+		self.0.fetch_sub(1, Ordering::Relaxed);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn rolled(fps: u64, frame_size: u64, group_size: u64) -> Rolled {
+		Rolled {
+			broadcasts: 1,
+			subscribe: 0,
+			fps,
+			frame_size,
+			group_size,
+		}
+	}
+
+	/// A produced group must start with the JSON keyframe describing the rolled
+	/// parameters, followed by `group_size` zeroed payload frames.
+	#[tokio::test]
+	async fn produce_keyframe_then_zeroed_payload() {
+		tokio::time::pause();
+
+		let stats = Arc::new(Stats::default());
+		let mut broadcast = Broadcast::new().produce();
+		let track = broadcast.create_track(Track::new(TRACK)).unwrap();
+		let consumer = broadcast.consume();
+
+		// 10fps (100ms/frame), 8-byte frames, 2 payload frames per group.
+		let task = tokio::spawn(produce(7, "bench/test".into(), rolled(10, 8, 2), track, stats.clone()));
+
+		// Advance past one full group (keyframe + 2 payload) into the next.
+		tokio::time::advance(Duration::from_millis(350)).await;
+
+		let mut sub = consumer.subscribe_track(&Track::new(TRACK)).unwrap();
+		let mut group = sub.next_group().await.unwrap().expect("a group");
+
+		let keyframe = group.read_frame().await.unwrap().expect("keyframe");
+		let header: serde_json::Value = serde_json::from_slice(&keyframe).unwrap();
+		assert_eq!(header["connection"], 7);
+		assert_eq!(header["broadcast"], "bench/test");
+		assert_eq!(header["group"], 0);
+		assert_eq!(header["fps"], 10);
+		assert_eq!(header["frame_size"], 8);
+		assert_eq!(header["group_size"], 2);
+
+		for _ in 0..2 {
+			let payload = group.read_frame().await.unwrap().expect("payload");
+			assert_eq!(payload.len(), 8);
+			assert!(payload.iter().all(|&b| b == 0));
+		}
+
+		assert!(stats.frames_sent.load(Ordering::Relaxed) >= 3);
+		task.abort();
+	}
+
+	/// `group_size = 0` is the documented edge case: each group is a lone keyframe.
+	#[tokio::test]
+	async fn produce_zero_group_size_is_keyframe_only() {
+		tokio::time::pause();
+
+		let stats = Arc::new(Stats::default());
+		let mut broadcast = Broadcast::new().produce();
+		let track = broadcast.create_track(Track::new(TRACK)).unwrap();
+		let consumer = broadcast.consume();
+
+		let task = tokio::spawn(produce(0, "bench/test".into(), rolled(10, 4, 0), track, stats.clone()));
+		tokio::time::advance(Duration::from_millis(250)).await;
+
+		let mut sub = consumer.subscribe_track(&Track::new(TRACK)).unwrap();
+		let mut group = sub.next_group().await.unwrap().expect("a group");
+
+		// Just the keyframe, then the group ends.
+		assert!(group.read_frame().await.unwrap().is_some(), "keyframe");
+		assert!(group.read_frame().await.unwrap().is_none(), "no payload frames");
+
+		task.abort();
+	}
+}

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -40,18 +40,32 @@ struct GroupHeader<'a> {
 	timestamp_ms: u128,
 }
 
-/// Run a single benchmark connection: publish `broadcasts` tracks and subscribe
-/// to `subscribe` peer broadcasts discovered via announcements.
+/// Everything one benchmark connection needs to run: its identity, the rolled
+/// parameters, and the shared client/stats handles. Bundled into a struct so
+/// `run` and its call site aren't drowning in positional arguments.
+pub struct Connection {
+	pub index: u64,
+	pub run_id: u64,
+	pub rolled: Rolled,
+	pub config: Arc<crate::Config>,
+	pub client: moq_native::Client,
+	pub stats: Arc<Stats>,
+}
+
+/// Publish `broadcasts` tracks and subscribe to `subscribe` peer broadcasts
+/// discovered via announcements.
 ///
 /// Returns only when the underlying reconnect loop permanently gives up.
-pub async fn run(
-	connection: u64,
-	run_id: u64,
-	rolled: Rolled,
-	config: Arc<crate::Config>,
-	client: moq_native::Client,
-	stats: Arc<Stats>,
-) {
+pub async fn run(ctx: Connection) {
+	let Connection {
+		index: connection,
+		run_id,
+		rolled,
+		config,
+		client,
+		stats,
+	} = ctx;
+
 	let url = config.url.clone().expect("url required");
 
 	// Publish side: an origin we fill with our broadcasts and hand to the session.
@@ -106,13 +120,18 @@ pub async fn run(
 	loop {
 		tokio::select! {
 			status = reconnect.status() => match status {
+				// Edge-triggered so repeated same-state events can't drift the gauge.
 				Ok(Status::Connected) => {
-					connected = true;
-					stats.connections.fetch_add(1, Ordering::Relaxed);
+					if !connected {
+						connected = true;
+						stats.connections.fetch_add(1, Ordering::Relaxed);
+					}
 				}
 				Ok(Status::Disconnected) => {
-					connected = false;
-					stats.connections.fetch_sub(1, Ordering::Relaxed);
+					if connected {
+						connected = false;
+						stats.connections.fetch_sub(1, Ordering::Relaxed);
+					}
 				}
 				Err(err) => {
 					tracing::warn!(connection, %err, "connection gave up");

--- a/rs/moq-bench/src/main.rs
+++ b/rs/moq-bench/src/main.rs
@@ -1,0 +1,90 @@
+mod config;
+mod connection;
+mod range;
+mod stats;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+pub use config::Config;
+pub use range::Range;
+pub use stats::Stats;
+
+use connection::Rolled;
+use rand::RngExt;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+	// TODO: It would be nice to remove this and rely on feature flags only.
+	// However, some dependency is pulling in `ring` and I don't know why, so meh for now.
+	rustls::crypto::aws_lc_rs::default_provider()
+		.install_default()
+		.expect("failed to install default crypto provider");
+
+	let config = Config::load()?;
+	anyhow::ensure!(config.url.is_some(), "--url is required (or set it in the TOML file)");
+
+	let config = Arc::new(config);
+	let client = config.client.clone().init()?;
+	let stats = Arc::new(Stats::default());
+
+	// Periodic throughput reporter.
+	{
+		let stats = stats.clone();
+		let interval = config.report();
+		tokio::spawn(async move { stats.report(interval).await });
+	}
+
+	// Roll the per-connection parameters up front: `ThreadRng` is not `Send`, so it
+	// can't cross the spawn boundary.
+	let mut rng = rand::rng();
+	let count = config.connections().sample(&mut rng).max(1);
+	let run_id = rng.random_range(0..=u64::MAX);
+	let startup = config.startup();
+
+	tracing::info!(connections = count, url = %config.url.as_ref().unwrap(), "starting benchmark");
+
+	let mut tasks = tokio::task::JoinSet::new();
+	for i in 0..count {
+		let rolled = Rolled {
+			broadcasts: config.broadcasts().sample(&mut rng),
+			subscribe: config.subscribe().sample(&mut rng),
+			fps: config.fps().sample(&mut rng),
+			frame_size: config.frame_size().sample(&mut rng),
+			group_size: config.group_size().sample(&mut rng),
+		};
+
+		// Stagger connection startup evenly across the ramp window.
+		let delay = if count > 1 {
+			startup.mul_f64(i as f64 / count as f64)
+		} else {
+			Duration::ZERO
+		};
+
+		let config = config.clone();
+		let client = client.clone();
+		let stats = stats.clone();
+		tasks.spawn(async move {
+			tokio::time::sleep(delay).await;
+			connection::run(i, run_id, rolled, config, client, stats).await;
+		});
+	}
+
+	let duration = config.duration;
+	let stop = async move {
+		match duration {
+			Some(d) => tokio::time::sleep(d).await,
+			None => std::future::pending::<()>().await,
+		}
+	};
+
+	let drained = async { while tasks.join_next().await.is_some() {} };
+
+	tokio::select! {
+		_ = stop => tracing::info!("duration elapsed, stopping"),
+		_ = tokio::signal::ctrl_c() => tracing::info!("interrupted, stopping"),
+		_ = drained => tracing::warn!("all connections ended"),
+	}
+
+	Ok(())
+}

--- a/rs/moq-bench/src/main.rs
+++ b/rs/moq-bench/src/main.rs
@@ -61,12 +61,17 @@ async fn main() -> anyhow::Result<()> {
 			Duration::ZERO
 		};
 
-		let config = config.clone();
-		let client = client.clone();
-		let stats = stats.clone();
+		let ctx = connection::Connection {
+			index: i,
+			run_id,
+			rolled,
+			config: config.clone(),
+			client: client.clone(),
+			stats: stats.clone(),
+		};
 		tasks.spawn(async move {
 			tokio::time::sleep(delay).await;
-			connection::run(i, run_id, rolled, config, client, stats).await;
+			connection::run(ctx).await;
 		});
 	}
 

--- a/rs/moq-bench/src/range.rs
+++ b/rs/moq-bench/src/range.rs
@@ -116,7 +116,11 @@ mod tests {
 			let v = range.sample(&mut rng);
 			assert!((5..=10).contains(&v));
 		}
-		// Inverted bounds still behave.
+		// Inverted bounds (min > max) are normalized, not panicked on.
+		for _ in 0..100 {
+			let v = Range::new(10, 5).sample(&mut rng);
+			assert!((5..=10).contains(&v));
+		}
 		assert_eq!(Range::new(7, 7).sample(&mut rng), 7);
 	}
 }

--- a/rs/moq-bench/src/range.rs
+++ b/rs/moq-bench/src/range.rs
@@ -1,0 +1,122 @@
+use std::str::FromStr;
+
+use rand::RngExt;
+use serde::{Deserialize, Serialize};
+
+/// An inclusive `[min, max]` range that is sampled per connection.
+///
+/// Accepts several spellings so configs stay terse:
+/// - a scalar `30` (both bounds equal)
+/// - a string `"24:60"` or `"24-60"` (CLI flags and TOML strings)
+/// - a table `{ min = 24, max = 60 }` (TOML sections)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "RangeRepr")]
+pub struct Range {
+	pub min: u64,
+	pub max: u64,
+}
+
+impl Range {
+	pub const fn new(min: u64, max: u64) -> Self {
+		Self { min, max }
+	}
+
+	/// Roll a value in `[min, max]`. Bounds are clamped if min > max.
+	pub fn sample(&self, rng: &mut impl RngExt) -> u64 {
+		let (lo, hi) = if self.min <= self.max {
+			(self.min, self.max)
+		} else {
+			(self.max, self.min)
+		};
+		if lo == hi { lo } else { rng.random_range(lo..=hi) }
+	}
+}
+
+impl From<u64> for Range {
+	fn from(value: u64) -> Self {
+		Self::new(value, value)
+	}
+}
+
+impl FromStr for Range {
+	type Err = String;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let s = s.trim();
+		// Try the range separators in order, falling back to a single scalar.
+		let sep = ["..", ":", "-"].into_iter().find(|sep| s.contains(sep));
+		match sep {
+			Some(sep) => {
+				let (min, max) = s.split_once(sep).expect("separator present");
+				let min = min.trim().parse().map_err(|_| format!("invalid min in range: {s:?}"))?;
+				let max = max.trim().parse().map_err(|_| format!("invalid max in range: {s:?}"))?;
+				Ok(Self::new(min, max))
+			}
+			None => {
+				let value = s.parse().map_err(|_| format!("invalid value: {s:?}"))?;
+				Ok(Self::new(value, value))
+			}
+		}
+	}
+}
+
+/// Parses the various accepted spellings of a [`Range`] on input only.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RangeRepr {
+	Scalar(u64),
+	Text(String),
+	Pair { min: u64, max: u64 },
+}
+
+impl TryFrom<RangeRepr> for Range {
+	type Error = String;
+
+	fn try_from(repr: RangeRepr) -> Result<Self, Self::Error> {
+		match repr {
+			RangeRepr::Scalar(value) => Ok(Self::new(value, value)),
+			RangeRepr::Text(text) => text.parse(),
+			RangeRepr::Pair { min, max } => Ok(Self::new(min, max)),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_scalar_and_ranges() {
+		assert_eq!("30".parse::<Range>().unwrap(), Range::new(30, 30));
+		assert_eq!("24:60".parse::<Range>().unwrap(), Range::new(24, 60));
+		assert_eq!("24-60".parse::<Range>().unwrap(), Range::new(24, 60));
+		assert_eq!("24..60".parse::<Range>().unwrap(), Range::new(24, 60));
+		assert!("nope".parse::<Range>().is_err());
+	}
+
+	#[test]
+	fn deserialize_all_forms() {
+		#[derive(Deserialize)]
+		struct Wrap {
+			v: Range,
+		}
+		assert_eq!(toml::from_str::<Wrap>("v = 30").unwrap().v, Range::new(30, 30));
+		assert_eq!(toml::from_str::<Wrap>(r#"v = "24:60""#).unwrap().v, Range::new(24, 60));
+		assert_eq!(
+			toml::from_str::<Wrap>("v = { min = 24, max = 60 }").unwrap().v,
+			Range::new(24, 60)
+		);
+	}
+
+	#[test]
+	fn sample_within_bounds() {
+		let mut rng = rand::rng();
+		let range = Range::new(5, 10);
+		for _ in 0..100 {
+			let v = range.sample(&mut rng);
+			assert!((5..=10).contains(&v));
+		}
+		// Inverted bounds still behave.
+		assert_eq!(Range::new(7, 7).sample(&mut rng), 7);
+	}
+}

--- a/rs/moq-bench/src/stats.rs
+++ b/rs/moq-bench/src/stats.rs
@@ -1,0 +1,82 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+/// Shared counters bumped by the connection tasks and drained by the reporter.
+#[derive(Default)]
+pub struct Stats {
+	pub connections: AtomicU64,
+	pub broadcasts: AtomicU64,
+	pub subscriptions: AtomicU64,
+	pub frames_sent: AtomicU64,
+	pub bytes_sent: AtomicU64,
+	pub frames_recv: AtomicU64,
+	pub bytes_recv: AtomicU64,
+}
+
+impl Stats {
+	pub fn frame_sent(&self, bytes: usize) {
+		self.frames_sent.fetch_add(1, Ordering::Relaxed);
+		self.bytes_sent.fetch_add(bytes as u64, Ordering::Relaxed);
+	}
+
+	pub fn frame_recv(&self, bytes: usize) {
+		self.frames_recv.fetch_add(1, Ordering::Relaxed);
+		self.bytes_recv.fetch_add(bytes as u64, Ordering::Relaxed);
+	}
+
+	/// Periodically log totals plus the throughput since the previous report.
+	pub async fn report(&self, interval: Duration) {
+		let mut ticker = tokio::time::interval(interval);
+		// Skip the immediate first tick so the first report covers a full interval.
+		ticker.tick().await;
+
+		let mut prev = Snapshot::take(self);
+		loop {
+			ticker.tick().await;
+			let now = Snapshot::take(self);
+			let secs = interval.as_secs_f64().max(f64::MIN_POSITIVE);
+
+			let send_mbps = (now.bytes_sent.saturating_sub(prev.bytes_sent) as f64 * 8.0) / secs / 1e6;
+			let recv_mbps = (now.bytes_recv.saturating_sub(prev.bytes_recv) as f64 * 8.0) / secs / 1e6;
+			let send_fps = now.frames_sent.saturating_sub(prev.frames_sent) as f64 / secs;
+			let recv_fps = now.frames_recv.saturating_sub(prev.frames_recv) as f64 / secs;
+
+			tracing::info!(
+				connections = now.connections,
+				broadcasts = now.broadcasts,
+				subscriptions = now.subscriptions,
+				send_mbps = format_args!("{send_mbps:.1}"),
+				send_fps = format_args!("{send_fps:.0}"),
+				recv_mbps = format_args!("{recv_mbps:.1}"),
+				recv_fps = format_args!("{recv_fps:.0}"),
+				"stats"
+			);
+
+			prev = now;
+		}
+	}
+}
+
+struct Snapshot {
+	connections: u64,
+	broadcasts: u64,
+	subscriptions: u64,
+	frames_sent: u64,
+	bytes_sent: u64,
+	frames_recv: u64,
+	bytes_recv: u64,
+}
+
+impl Snapshot {
+	fn take(stats: &Stats) -> Self {
+		Self {
+			connections: stats.connections.load(Ordering::Relaxed),
+			broadcasts: stats.broadcasts.load(Ordering::Relaxed),
+			subscriptions: stats.subscriptions.load(Ordering::Relaxed),
+			frames_sent: stats.frames_sent.load(Ordering::Relaxed),
+			bytes_sent: stats.bytes_sent.load(Ordering::Relaxed),
+			frames_recv: stats.frames_recv.load(Ordering::Relaxed),
+			bytes_recv: stats.bytes_recv.load(Ordering::Relaxed),
+		}
+	}
+}

--- a/rs/moq-bench/src/stats.rs
+++ b/rs/moq-bench/src/stats.rs
@@ -11,12 +11,13 @@ pub struct Stats {
 	pub bytes_sent: AtomicU64,
 	pub frames_recv: AtomicU64,
 	pub bytes_recv: AtomicU64,
-	/// Distinct groups received across all subscriptions.
+	/// Distinct groups received across all subscriptions (the displayed total).
 	pub groups_recv: AtomicU64,
-	/// Sum of each subscription's observed sequence span (`max - min + 1`). A group
-	/// that never arrives leaves a hole in the span, so `groups_expected - groups_recv`
-	/// is the number of skipped groups. See `connection::GapTracker`.
+	/// Size of every subscription's settled sequence span, excluding the live frontier.
 	pub groups_expected: AtomicU64,
+	/// How many groups within those settled spans actually arrived. The shortfall
+	/// `groups_expected - groups_present` is the number skipped. See `connection::GapTracker`.
+	pub groups_present: AtomicU64,
 }
 
 impl Stats {
@@ -48,7 +49,7 @@ impl Stats {
 			let recv_fps = now.frames_recv.saturating_sub(prev.frames_recv) as f64 / secs;
 
 			// Group loss is cumulative (a correctness signal), not a per-interval rate.
-			let lost_groups = now.groups_expected.saturating_sub(now.groups_recv);
+			let lost_groups = now.groups_expected.saturating_sub(now.groups_present);
 			let loss = if now.groups_expected > 0 {
 				lost_groups as f64 / now.groups_expected as f64 * 100.0
 			} else {
@@ -84,6 +85,7 @@ struct Snapshot {
 	bytes_recv: u64,
 	groups_recv: u64,
 	groups_expected: u64,
+	groups_present: u64,
 }
 
 impl Snapshot {
@@ -98,6 +100,7 @@ impl Snapshot {
 			bytes_recv: stats.bytes_recv.load(Ordering::Relaxed),
 			groups_recv: stats.groups_recv.load(Ordering::Relaxed),
 			groups_expected: stats.groups_expected.load(Ordering::Relaxed),
+			groups_present: stats.groups_present.load(Ordering::Relaxed),
 		}
 	}
 }

--- a/rs/moq-bench/src/stats.rs
+++ b/rs/moq-bench/src/stats.rs
@@ -11,6 +11,12 @@ pub struct Stats {
 	pub bytes_sent: AtomicU64,
 	pub frames_recv: AtomicU64,
 	pub bytes_recv: AtomicU64,
+	/// Distinct groups received across all subscriptions.
+	pub groups_recv: AtomicU64,
+	/// Sum of each subscription's observed sequence span (`max - min + 1`). A group
+	/// that never arrives leaves a hole in the span, so `groups_expected - groups_recv`
+	/// is the number of skipped groups. See `connection::GapTracker`.
+	pub groups_expected: AtomicU64,
 }
 
 impl Stats {
@@ -41,6 +47,14 @@ impl Stats {
 			let send_fps = now.frames_sent.saturating_sub(prev.frames_sent) as f64 / secs;
 			let recv_fps = now.frames_recv.saturating_sub(prev.frames_recv) as f64 / secs;
 
+			// Group loss is cumulative (a correctness signal), not a per-interval rate.
+			let lost_groups = now.groups_expected.saturating_sub(now.groups_recv);
+			let loss = if now.groups_expected > 0 {
+				lost_groups as f64 / now.groups_expected as f64 * 100.0
+			} else {
+				0.0
+			};
+
 			tracing::info!(
 				connections = now.connections,
 				broadcasts = now.broadcasts,
@@ -49,6 +63,9 @@ impl Stats {
 				send_fps = format_args!("{send_fps:.0}"),
 				recv_mbps = format_args!("{recv_mbps:.1}"),
 				recv_fps = format_args!("{recv_fps:.0}"),
+				recv_groups = now.groups_recv,
+				lost_groups,
+				loss = format_args!("{loss:.2}%"),
 				"stats"
 			);
 
@@ -65,6 +82,8 @@ struct Snapshot {
 	bytes_sent: u64,
 	frames_recv: u64,
 	bytes_recv: u64,
+	groups_recv: u64,
+	groups_expected: u64,
 }
 
 impl Snapshot {
@@ -77,6 +96,8 @@ impl Snapshot {
 			bytes_sent: stats.bytes_sent.load(Ordering::Relaxed),
 			frames_recv: stats.frames_recv.load(Ordering::Relaxed),
 			bytes_recv: stats.bytes_recv.load(Ordering::Relaxed),
+			groups_recv: stats.groups_recv.load(Ordering::Relaxed),
+			groups_expected: stats.groups_expected.load(Ordering::Relaxed),
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds `rs/moq-bench`, a new binary (`moq-bench`) for benchmarking a remote MoQ server by opening many QUIC connections and driving synthetic media through them.

Every knob is a `[min, max]` range that is **rolled once per connection**, so a single config can describe a heterogeneous swarm (some connections at 24fps, others at 60, etc).

For a run, `moq-bench` establishes **A** connections. Each connection:
- publishes **B** broadcasts, each with a single track;
- subscribes to **C** other broadcasts discovered via announcements;
- produces **D** frames/sec per track, each **E** bytes large;
- splits frames into groups of **F** frames.

The first frame of every group is a JSON keyframe describing the rolled parameters (connection id, broadcast path, group sequence, fps, frame size, group size, wall-clock timestamp). The remaining **F** frames are zeroed. **F may be 0**, in which case each group is a lone keyframe, useful for stressing the announce/subscribe control plane rather than the data path.

To avoid a thundering herd, connections and subscriptions are staggered over a `--startup` ramp window instead of all firing at once.

## Stats: received vs skipped groups

The subscribe side reports delivery, not just throughput. Subscribers read groups via `recv_group` (arrival order, out-of-order included) and track each subscription's sequence span; a span wider than the count received means groups in between were skipped. The periodic report gains `recv_groups`, `lost_groups`, and a `loss` percentage. The newest group of each subscription is the live frontier and is excluded from the count, since groups just behind it may still be in flight; a gap is only blamed once a higher group confirms it was skipped. The first keyframe of each subscription is parsed back into the publisher's shape (fps/frame size/group size), so a subscriber works against peers it didn't publish.

Loss here means dropped/skipped groups, not QUIC packet loss (which the transport already repairs). Latency is intentionally left out: groups carry only a per-group timestamp, so the meaningful metric would be jitter rather than one-way latency. That can come later, optionally behind a `hang` container with per-frame timestamps.

## Config

- CLI flags always win over the TOML file, mirroring `moq-relay`'s parse → merge → re-parse so an absent flag never clobbers a TOML value (every overridable field is `Option<T>`).
- Each range accepts a scalar (`--fps 30`), a `min:max` string (`--fps 24:60`), or a TOML table (`fps = { min = 24, max = 60 }`).
- Client TLS/QUIC flags come from `moq-native`, identical to `moq-cli`/`moq-relay`.
- Presets under `config/`: `hd.toml` (HD video 24-60fps), `sd.toml` (SD, more viewers), `audio.toml` (Opus-like), `announce.toml` (control-plane stress, `group_size = 0`).

```bash
moq-bench --file rs/moq-bench/config/hd.toml --url https://relay.example.com --connections 500
```

## Test plan

- [x] `cargo test -p moq-bench` — range parsing/sampling, CLI-overrides-TOML merge + defaults, two in-process media-loop tests (keyframe JSON + zeroed payload; the `group_size = 0` lone-keyframe edge case), and gap-tracker math (sequence holes and out-of-order arrival) using paused time.
- [x] `cargo clippy -p moq-bench --all-targets` clean; `cargo fmt` clean.
- [x] Smoke-ran the binary: it rolls per-connection params, staggers connection startup across the ramp, logs throughput stats, and shuts down cleanly on `--duration` / Ctrl-C.
- [x] End-to-end against a live relay (`cdn.moq.wtf`): a 4-connection publish→announce→subscribe mesh fully converges (12/12 subscriptions, steady recv_fps) at **0.00% group loss**, and the JSON keyframe shape round-trips over the wire (subscriber recovers fps/frame_size/group_size from peers).

## Cross-package sync

Added `moq-bench` to the crate index in `CLAUDE.md`. No existing wire/public APIs changed (new self-contained crate), so no paired packages needed updates. Targeting `main` as a self-contained additive change; happy to retarget `dev` if preferred.

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMx2iNsBh8LNi4LN1VKMv)_

