### PR TITLE
docs(interop): command-focused moq-transport quickstart

### DIFF
--- a/doc/concept/standard/interop.md
+++ b/doc/concept/standard/interop.md
@@ -1,90 +1,229 @@
+---
+title: Interoperability
+description: Point moq-cli at any MoQ relay to publish and subscribe
+---
+
 # Interoperability
 
-Want to test some standards against this code?
+This code speaks two wire protocols and negotiates one of them at connect time:
 
-It's recommended that you run the code locally for easier debugging. See the [Setup Guide](/setup/dev), it's pretty easy.
+- [moq-lite](/concept/layer/moq-lite), our simplified protocol.
+- The full IETF `moq-transport` draft.
+
+[moq-lite](/concept/layer/moq-lite) is a forwards-compatible subset of moq-transport,
+so a moq-lite client can talk to any moq-transport relay (but not necessarily the reverse).
+You don't have to pick: the client offers both and lets the relay choose.
+
+The fastest way to interop is `moq-cli`. Point it at your relay (or a third-party
+relay) and publish or subscribe. The rest of this page covers installing it,
+the protocols it negotiates, and the commands to run.
 
 ## Transport
 
-[moq-lite](/concept/layer/moq-lite) is a forwards-compatible subset of moq-transport.
-A moq-lite client can talk to any moq-transport relay, but not necessarily the other way around.
-
 ### Versions
 
+The client negotiates via ALPN, offering moq-lite and moq-transport drafts 14
+through 18. If the relay doesn't select a version through ALPN, the client falls
+back to draft-14 framing and negotiates the version after setup.
+
 - moq-transport-14
-- moq-transport-15 (untested)
+- moq-transport-15
 - moq-transport-16
 - moq-transport-17
+- moq-transport-18
+- moq-lite
+
+The ALPN list the client offers, in preference order:
+
+```
+moq-lite-04, moq-lite-03, moql, moqt-18, moqt-17, moqt-16, moqt-15, moq-00
+```
 
 ### Protocols
 
-- WebTransport
+- WebTransport (over HTTP/3)
 - QMux over WebSocket
-- (Rust) QUIC
+- (Rust) raw QUIC
 - (Rust) QMux over TLS
 
-### Client
+### TLS
 
-If you want to test your relay:
-
-```bash
-# Rust: Publishes a media broadcast
-just pub bbb https://<your relay>
-
-# Javascript: Subscribes to a media broadcast
-just web https://<your relay>
-```
-
-> **Note:** WebTransport automatically prepends the URL path (e.g., `/anon`) to broadcast names. Raw QUIC and iroh have no HTTP layer, so you must manually include that prefix in the broadcast name (e.g., publish as `/anon/bbb`).
-
-The publisher sends a `PUBLISH_NAMESPACE` and the subscriber **requires** a `SUBSCRIBE_NAMESPACE`.
-If you haven't implemented the latter yet, remove `reload` in `demo/web/src/index.html`.
-
-**Feeling spicy?**
-You can use [gstreamer](/bin/gstreamer) or [obs](/bin/obs) too, both support publishing and subscribing.
-There's also bindings for Rust, Javascript, C, Python, Kotlin, Swift, etc.
-
-### Relay
-
-The relay is less useful to test against because we purposely implement a shallow subset of the moq-transport draft.
+WebTransport and QUIC both require TLS. If the relay uses a self-signed or
+expired certificate (common for interop sandboxes), disable verification:
 
 ```bash
-# Rust: Runs a localhost relay
-# Also available at: https://cdn.moq.dev/anon
-just relay
+moq-cli subscribe --tls-disable-verify --url https://relay.example.com ...
 ```
 
-The relay **WILL IGNORE** the following:
+## Install the client
 
-- Any sub-group >0
-- Any datagrams
-- Any FETCH, except JOINING FETCH is a no-op.
-- Any objects with delta >0 (must be contiguous)
-- Any object properties
-- Any SUBSCRIBE `forward=0`
-- Any multi-publisher nonsense
-- Probably some other stuff
+`moq-cli` reads media from stdin (or writes it to stdout) and exchanges it with
+a relay. It pairs with FFmpeg for encoding and decoding.
 
-Note that all subscriptions start at the latest group.
+```bash
+# macOS / Linux: Homebrew
+brew install moq-dev/tap/moq-cli
+
+# Any platform with a Rust toolchain
+cargo install moq-cli
+
+# Docker / Podman (linux/amd64 + linux/arm64)
+docker pull moqdev/moq-cli            # or: podman pull moqdev/moq-cli
+docker run --rm moqdev/moq-cli --version
+```
+
+Debian/Ubuntu and Fedora/RHEL have native packages from `apt.moq.dev` and
+`rpm.moq.dev`. See [Linux Packages](/setup/linux) for the repository setup.
+
+To run an unreleased build straight from a checkout:
+
+```bash
+nix run github:moq-dev/moq#moq-cli -- subscribe --url https://relay.example.com ...
+# or
+cargo run -p moq-cli -- subscribe --url https://relay.example.com ...
+```
+
+You also need FFmpeg (`brew install ffmpeg`, `apt install ffmpeg`) for the
+encode/decode steps below.
+
+## Publish to a relay
+
+Pipe an encoded stream into `moq-cli publish`. The input container is selected
+by a subcommand; the broadcast name carries a `.hang` suffix so the catalog
+format is explicit.
+
+```bash
+# Fragmented MP4 / CMAF
+ffmpeg -re -i input.mp4 \
+    -c:v libx264 -preset ultrafast -tune zerolatency -g 60 -c:a aac \
+    -f mp4 -movflags cmaf+frag_keyframe+empty_moov+default_base_moof - \
+| moq-cli publish --url https://relay.example.com --broadcast my-stream.hang fmp4
+```
+
+```bash
+# MPEG-TS (remux without re-encoding)
+ffmpeg -re -i input.mp4 -c copy -f mpegts - \
+| moq-cli publish --url https://relay.example.com --broadcast my-stream.hang ts
+```
+
+Input containers (`publish` subcommand, read from stdin unless noted):
+
+- `avc3` - raw H.264 Annex-B
+- `fmp4` - fragmented MP4 / CMAF
+- `ts` - MPEG-TS (H.264 / H.265 video, AAC audio)
+- `hls --playlist <url-or-path>` - ingest an HLS playlist (does not read stdin)
+
+## Subscribe from a relay
+
+`moq-cli subscribe` pulls a broadcast and writes a container to stdout. Select
+the output container with `--format`, then play it with FFmpeg.
+
+```bash
+moq-cli subscribe --url https://relay.example.com --broadcast my-stream.hang --format fmp4 | ffplay -
+```
+
+Output containers (`--format`):
+
+- `fmp4` - fragmented MP4 / CMAF
+- `mkv` - Matroska / WebM
+- `ts` - MPEG-TS
+
+## Announce discovery and ordering
+
+The publisher sends a `PUBLISH_NAMESPACE` (announce); the subscriber sends a
+`SUBSCRIBE_NAMESPACE` and waits for a matching announce before it subscribes to
+any track. This means **the subscriber must learn about the broadcast through an
+announce**, which has an ordering implication on some relays:
+
+- A relay that **replays** current announcements (ours does) delivers the
+  announce whether the subscriber joins before or after the publisher. Order
+  doesn't matter.
+- A relay that does **not** replay (some third-party relays) only forwards an
+  announce live. A subscriber that connects after the publisher already
+  announced will sit idle and receive nothing. Start the subscriber first, then
+  the publisher.
+
+If your subscriber doesn't implement `SUBSCRIBE_NAMESPACE` yet, the web demo
+can subscribe to a known name directly: remove `reload` in
+`demo/web/src/index.html`.
+
+## URL paths and broadcast names
+
+WebTransport prepends the URL path to the broadcast name. A relay that serves a
+path like `/anon` turns broadcast `my-stream` into `/anon/my-stream` on the
+wire, so connect to `https://relay.example.com/anon` and publish `my-stream`.
+Raw QUIC and iroh have no HTTP layer, so include the prefix in the broadcast
+name yourself (e.g. `/anon/my-stream`).
+
+## Authentication
+
+Pass a JWT via the URL query string:
+
+```bash
+moq-cli publish --url "https://relay.example.com/room/123?jwt=<token>" --broadcast my-stream.hang fmp4
+```
+
+See [Authentication](/bin/relay/auth) for generating tokens.
+
+## Debugging
+
+```bash
+# Verbose protocol logs (connect, version, announce, subscribe)
+RUST_LOG=info,moq_net=debug moq-cli subscribe --url https://relay.example.com --broadcast my-stream.hang --format fmp4 > /dev/null
+```
+
+The log prints the negotiated version (e.g. `connected version=moq-transport-18`)
+and each `announce` / `subscribe started` event, which is usually enough to tell
+whether the relay is forwarding your broadcast.
+
+## Other clients
+
+`moq-cli` is the quickest, but not the only option:
+
+- [GStreamer](/bin/gstreamer) (`moqsink` / `moqsrc`) and [OBS](/bin/obs) both
+  publish and subscribe.
+- The browser stack ([web components](/lib/js/env/web)) subscribes and publishes
+  over WebTransport.
+- There are native bindings for Rust, TypeScript, C, Python, Kotlin, Swift, and Go.
 
 ## Media
 
-I'm primarily using `hang`, which is like a mix between MSF + LOC.
-I'd love to standardize eventually but I need more media homies that want to interop, not just write a spec.
+We primarily use [hang](/concept/layer/hang), a catalog plus container format
+(think a mix of MSF and LOC). The relay itself is media-agnostic, so this only
+matters for a client that needs to decode the payload.
 
-### Rust
-
-The publisher currently makes two catalog tracks pointing to the same media tracks:
+The Rust publisher writes two catalog tracks pointing at the same media tracks:
 
 - `catalog.json` ([hang](/concept/layer/hang))
 - `catalog` ([MSF](/concept/standard/msf))
 
-We support two possible containers, but currently `cmaf` is experimental:
+Two containers are supported, though `cmaf` is still experimental:
 
 - `legacy` ([hang](/concept/layer/hang))
 - `cmaf` ([CMAF](/concept/standard/cmaf))
 
-### Javascript
+The JavaScript code currently only produces `catalog.json`, but its subscriber
+consumes both `legacy` and `cmaf` containers.
 
-The Javascript code currently only supports `catalog.json`.
-However, the subscriber can consume both `legacy` and `cmaf` containers
+## Testing against our relay
+
+Our relay implements a deliberately shallow subset of the moq-transport draft,
+so it's more useful as a publish/subscribe target than as a strict conformance
+peer. Run one locally (also available at `https://cdn.moq.dev/anon`):
+
+```bash
+just relay
+```
+
+It currently **ignores** the following:
+
+- Any sub-group >0
+- Any datagrams
+- Any FETCH, except a JOINING FETCH, which is a no-op
+- Any objects with delta >0 (must be contiguous)
+- Any object properties
+- Any SUBSCRIBE `forward=0`
+- Any multi-publisher behavior
+- Probably some other things
+
+All subscriptions start at the latest group.

--- a/doc/concept/standard/interop.md
+++ b/doc/concept/standard/interop.md
@@ -7,8 +7,7 @@ description: Publish and subscribe to a moq-transport relay with moq-cli
 
 `moq-cli` speaks moq-transport drafts **14 through 18**, negotiated over ALPN at
 connect. Point it at your relay and it picks the newest version you both
-support. ([moq-lite](/concept/layer/moq-lite) is also offered, but you can
-ignore it.)
+support. (You should try [moq-lite](/concept/layer/moq-lite) too, btw. Just sayin'.)
 
 ## Install
 
@@ -22,8 +21,10 @@ You also need FFmpeg for encode/decode.
 
 ## Publish
 
+A test pattern plus tone, so you don't need a media file:
+
 ```bash
-ffmpeg -re -i input.mp4 \
+ffmpeg -re -f lavfi -i testsrc=size=1280x720:rate=30 -f lavfi -i sine=frequency=440 \
     -c:v libx264 -preset ultrafast -tune zerolatency -g 60 -c:a aac \
     -f mp4 -movflags cmaf+frag_keyframe+empty_moov+default_base_moof - \
 | moq-cli publish --url https://your-relay.example.com --broadcast bbb.hang fmp4

--- a/doc/concept/standard/interop.md
+++ b/doc/concept/standard/interop.md
@@ -1,229 +1,47 @@
 ---
 title: Interoperability
-description: Point moq-cli at any MoQ relay to publish and subscribe
+description: Publish and subscribe to a moq-transport relay with moq-cli
 ---
 
 # Interoperability
 
-This code speaks two wire protocols and negotiates one of them at connect time:
+`moq-cli` speaks moq-transport drafts **14 through 18**, negotiated over ALPN at
+connect. Point it at your relay and it picks the newest version you both
+support. ([moq-lite](/concept/layer/moq-lite) is also offered, but you can
+ignore it.)
 
-- [moq-lite](/concept/layer/moq-lite), our simplified protocol.
-- The full IETF `moq-transport` draft.
-
-[moq-lite](/concept/layer/moq-lite) is a forwards-compatible subset of moq-transport,
-so a moq-lite client can talk to any moq-transport relay (but not necessarily the reverse).
-You don't have to pick: the client offers both and lets the relay choose.
-
-The fastest way to interop is `moq-cli`. Point it at your relay (or a third-party
-relay) and publish or subscribe. The rest of this page covers installing it,
-the protocols it negotiates, and the commands to run.
-
-## Transport
-
-### Versions
-
-The client negotiates via ALPN, offering moq-lite and moq-transport drafts 14
-through 18. If the relay doesn't select a version through ALPN, the client falls
-back to draft-14 framing and negotiates the version after setup.
-
-- moq-transport-14
-- moq-transport-15
-- moq-transport-16
-- moq-transport-17
-- moq-transport-18
-- moq-lite
-
-The ALPN list the client offers, in preference order:
-
-```
-moq-lite-04, moq-lite-03, moql, moqt-18, moqt-17, moqt-16, moqt-15, moq-00
-```
-
-### Protocols
-
-- WebTransport (over HTTP/3)
-- QMux over WebSocket
-- (Rust) raw QUIC
-- (Rust) QMux over TLS
-
-### TLS
-
-WebTransport and QUIC both require TLS. If the relay uses a self-signed or
-expired certificate (common for interop sandboxes), disable verification:
+## Install
 
 ```bash
-moq-cli subscribe --tls-disable-verify --url https://relay.example.com ...
+brew install moq-dev/tap/moq-cli   # macOS / Linux
+cargo install moq-cli              # any platform with Rust
+docker pull moqdev/moq-cli         # or podman
 ```
 
-## Install the client
+You also need FFmpeg for encode/decode.
 
-`moq-cli` reads media from stdin (or writes it to stdout) and exchanges it with
-a relay. It pairs with FFmpeg for encoding and decoding.
-
-```bash
-# macOS / Linux: Homebrew
-brew install moq-dev/tap/moq-cli
-
-# Any platform with a Rust toolchain
-cargo install moq-cli
-
-# Docker / Podman (linux/amd64 + linux/arm64)
-docker pull moqdev/moq-cli            # or: podman pull moqdev/moq-cli
-docker run --rm moqdev/moq-cli --version
-```
-
-Debian/Ubuntu and Fedora/RHEL have native packages from `apt.moq.dev` and
-`rpm.moq.dev`. See [Linux Packages](/setup/linux) for the repository setup.
-
-To run an unreleased build straight from a checkout:
+## Publish
 
 ```bash
-nix run github:moq-dev/moq#moq-cli -- subscribe --url https://relay.example.com ...
-# or
-cargo run -p moq-cli -- subscribe --url https://relay.example.com ...
-```
-
-You also need FFmpeg (`brew install ffmpeg`, `apt install ffmpeg`) for the
-encode/decode steps below.
-
-## Publish to a relay
-
-Pipe an encoded stream into `moq-cli publish`. The input container is selected
-by a subcommand; the broadcast name carries a `.hang` suffix so the catalog
-format is explicit.
-
-```bash
-# Fragmented MP4 / CMAF
 ffmpeg -re -i input.mp4 \
     -c:v libx264 -preset ultrafast -tune zerolatency -g 60 -c:a aac \
     -f mp4 -movflags cmaf+frag_keyframe+empty_moov+default_base_moof - \
-| moq-cli publish --url https://relay.example.com --broadcast my-stream.hang fmp4
+| moq-cli publish --url https://your-relay.example.com --broadcast bbb.hang fmp4
 ```
+
+## Subscribe
 
 ```bash
-# MPEG-TS (remux without re-encoding)
-ffmpeg -re -i input.mp4 -c copy -f mpegts - \
-| moq-cli publish --url https://relay.example.com --broadcast my-stream.hang ts
+moq-cli subscribe --url https://your-relay.example.com --broadcast bbb.hang --format fmp4 | ffplay -
 ```
 
-Input containers (`publish` subcommand, read from stdin unless noted):
+If it plays, you interop. That's the whole test.
 
-- `avc3` - raw H.264 Annex-B
-- `fmp4` - fragmented MP4 / CMAF
-- `ts` - MPEG-TS (H.264 / H.265 video, AAC audio)
-- `hls --playlist <url-or-path>` - ingest an HLS playlist (does not read stdin)
+## Notes
 
-## Subscribe from a relay
-
-`moq-cli subscribe` pulls a broadcast and writes a container to stdout. Select
-the output container with `--format`, then play it with FFmpeg.
-
-```bash
-moq-cli subscribe --url https://relay.example.com --broadcast my-stream.hang --format fmp4 | ffplay -
-```
-
-Output containers (`--format`):
-
-- `fmp4` - fragmented MP4 / CMAF
-- `mkv` - Matroska / WebM
-- `ts` - MPEG-TS
-
-## Announce discovery and ordering
-
-The publisher sends a `PUBLISH_NAMESPACE` (announce); the subscriber sends a
-`SUBSCRIBE_NAMESPACE` and waits for a matching announce before it subscribes to
-any track. This means **the subscriber must learn about the broadcast through an
-announce**, which has an ordering implication on some relays:
-
-- A relay that **replays** current announcements (ours does) delivers the
-  announce whether the subscriber joins before or after the publisher. Order
-  doesn't matter.
-- A relay that does **not** replay (some third-party relays) only forwards an
-  announce live. A subscriber that connects after the publisher already
-  announced will sit idle and receive nothing. Start the subscriber first, then
-  the publisher.
-
-If your subscriber doesn't implement `SUBSCRIBE_NAMESPACE` yet, the web demo
-can subscribe to a known name directly: remove `reload` in
-`demo/web/src/index.html`.
-
-## URL paths and broadcast names
-
-WebTransport prepends the URL path to the broadcast name. A relay that serves a
-path like `/anon` turns broadcast `my-stream` into `/anon/my-stream` on the
-wire, so connect to `https://relay.example.com/anon` and publish `my-stream`.
-Raw QUIC and iroh have no HTTP layer, so include the prefix in the broadcast
-name yourself (e.g. `/anon/my-stream`).
-
-## Authentication
-
-Pass a JWT via the URL query string:
-
-```bash
-moq-cli publish --url "https://relay.example.com/room/123?jwt=<token>" --broadcast my-stream.hang fmp4
-```
-
-See [Authentication](/bin/relay/auth) for generating tokens.
-
-## Debugging
-
-```bash
-# Verbose protocol logs (connect, version, announce, subscribe)
-RUST_LOG=info,moq_net=debug moq-cli subscribe --url https://relay.example.com --broadcast my-stream.hang --format fmp4 > /dev/null
-```
-
-The log prints the negotiated version (e.g. `connected version=moq-transport-18`)
-and each `announce` / `subscribe started` event, which is usually enough to tell
-whether the relay is forwarding your broadcast.
-
-## Other clients
-
-`moq-cli` is the quickest, but not the only option:
-
-- [GStreamer](/bin/gstreamer) (`moqsink` / `moqsrc`) and [OBS](/bin/obs) both
-  publish and subscribe.
-- The browser stack ([web components](/lib/js/env/web)) subscribes and publishes
-  over WebTransport.
-- There are native bindings for Rust, TypeScript, C, Python, Kotlin, Swift, and Go.
-
-## Media
-
-We primarily use [hang](/concept/layer/hang), a catalog plus container format
-(think a mix of MSF and LOC). The relay itself is media-agnostic, so this only
-matters for a client that needs to decode the payload.
-
-The Rust publisher writes two catalog tracks pointing at the same media tracks:
-
-- `catalog.json` ([hang](/concept/layer/hang))
-- `catalog` ([MSF](/concept/standard/msf))
-
-Two containers are supported, though `cmaf` is still experimental:
-
-- `legacy` ([hang](/concept/layer/hang))
-- `cmaf` ([CMAF](/concept/standard/cmaf))
-
-The JavaScript code currently only produces `catalog.json`, but its subscriber
-consumes both `legacy` and `cmaf` containers.
-
-## Testing against our relay
-
-Our relay implements a deliberately shallow subset of the moq-transport draft,
-so it's more useful as a publish/subscribe target than as a strict conformance
-peer. Run one locally (also available at `https://cdn.moq.dev/anon`):
-
-```bash
-just relay
-```
-
-It currently **ignores** the following:
-
-- Any sub-group >0
-- Any datagrams
-- Any FETCH, except a JOINING FETCH, which is a no-op
-- Any objects with delta >0 (must be contiguous)
-- Any object properties
-- Any SUBSCRIBE `forward=0`
-- Any multi-publisher behavior
-- Probably some other things
-
-All subscriptions start at the latest group.
+- **Self-signed or expired cert?** Add `--tls-disable-verify`.
+- **Subscriber sees nothing?** The subscriber discovers broadcasts via
+  `SUBSCRIBE_NAMESPACE` and waits for a matching announce. If your relay doesn't
+  replay existing announcements, start the subscriber before the publisher.
+- **Verbose logs:** prefix with `RUST_LOG=info,moq_net=debug`. It prints the
+  negotiated version (e.g. `connected version=moq-transport-18`).

--- a/doc/concept/standard/interop.md
+++ b/doc/concept/standard/interop.md
@@ -7,7 +7,7 @@ description: Publish and subscribe to a moq-transport relay with moq-cli
 
 `moq-cli` speaks moq-transport drafts **14 through 18**, negotiated over ALPN at
 connect. Point it at your relay and it picks the newest version you both
-support. (You should try [moq-lite](/concept/layer/moq-lite) too, btw. Just sayin'.)
+support. (You should try [moq-lite](/concept/layer/moq-lite) too, btw.)
 
 ## Install
 

--- a/doc/concept/standard/interop.md
+++ b/doc/concept/standard/interop.md
@@ -39,9 +39,11 @@ If it plays, you interop. That's the whole test.
 
 ## Notes
 
+- **`SUBSCRIBE_NAMESPACE` is required.** The subscriber discovers broadcasts by
+  sending `SUBSCRIBE_NAMESPACE` and waiting for a matching announce, so your
+  relay must support it. The publisher announces with `PUBLISH_NAMESPACE`.
 - **Self-signed or expired cert?** Add `--tls-disable-verify`.
-- **Subscriber sees nothing?** The subscriber discovers broadcasts via
-  `SUBSCRIBE_NAMESPACE` and waits for a matching announce. If your relay doesn't
-  replay existing announcements, start the subscriber before the publisher.
+- **Subscriber sees nothing?** If your relay doesn't replay existing
+  announcements, start the subscriber before the publisher.
 - **Verbose logs:** prefix with `RUST_LOG=info,moq_net=debug`. It prints the
   negotiated version (e.g. `connected version=moq-transport-18`).


### PR DESCRIPTION
## Summary

The interop page (`doc/concept/standard/interop.md`) was stale: it listed moq-transport drafts 14-17 (no 18) and drove everything through the in-repo `just pub` recipe, with no plain commands for pointing the client at a relay.

This replaces it with a short, command-focused quickstart aimed at IETF moq-transport implementers: the supported version range, install, and copy-paste `publish` / `subscribe` commands. The commands were verified against a `moq-transport-18` relay (`lminiero.it:9000`, imquic) this session.

## What it covers now

- **Versions:** moq-transport drafts 14 through 18, negotiated over ALPN at connect (moq-lite mentioned in one aside).
- **Install:** brew / cargo / docker, plus FFmpeg.
- **Publish / Subscribe:** the real CLI surface (`--url` / `--broadcast` + format subcommand) with ffmpeg pipelines that actually round-trip. "If it plays, you interop."
- **Notes:** `--tls-disable-verify` for interop certs, the subscriber-first announce-ordering caveat, and the `RUST_LOG` line that prints the negotiated version.

Everything else from the old page (moq-lite framing, transport/protocol lists, JWT auth, media/catalog internals, the shallow-relay subset list) was cut as noise for this audience.

## Notes for reviewers

- No nav change needed: the `Interop` entry in `doc/.vitepress/config.ts` already points at this file.
- No em dashes (repo style); no `(Written by Claude)` marker on the doc page per the attribution rule.
- **Out of scope but worth a follow-up:** `doc/bin/cli.md` still has stale positional-arg examples *and* documents the `capture` subcommand as if it ships in the released binaries. It does not: brew/docker/deb/rpm/`cargo install` build default features only, and `capture` is gated behind `--features capture`. Happy to fix `cli.md` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)