### PR TITLE
feat(moq-cli): ship capture in release binaries (dynamic ffmpeg dependency)

### DIFF
--- a/.github/homebrew/Formula/moq-cli.rb.tmpl
+++ b/.github/homebrew/Formula/moq-cli.rb.tmpl
@@ -4,6 +4,11 @@ class MoqCli < Formula
   version "__VERSION__"
   license any_of: ["MIT", "Apache-2.0"]
 
+  # Capture links libav* dynamically; ffmpeg also provides the hardware
+  # encoders (videotoolbox / vaapi). A major ffmpeg bump needs a formula
+  # rebuild so the binary resolves the new libav* soname.
+  depends_on "ffmpeg"
+
   on_macos do
     on_arm do
       url "https://github.com/moq-dev/moq/releases/download/moq-cli-v#{version}/moq-cli-#{version}-aarch64-apple-darwin.tar.gz"

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -5,7 +5,9 @@ on:
     tags:
       - 'moq-relay-v*'
       - 'moq-token-cli-v*'
-      - 'moq-cli-v*'
+      # moq-cli caches itself in its own release workflow (moq-cli.yml) so the
+      # expensive static-ffmpeg compile runs once there instead of racing a
+      # second build here. See the cachix steps in moq-cli.yml.
       - 'moq-boy-v*'
       - 'libmoq-v*'
       - 'moq-gst-v*'

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -4,10 +4,8 @@ on:
   push:
     tags:
       - 'moq-relay-v*'
+      - 'moq-cli-v*'
       - 'moq-token-cli-v*'
-      # moq-cli caches itself in its own release workflow (moq-cli.yml) so the
-      # expensive static-ffmpeg compile runs once there instead of racing a
-      # second build here. See the cachix steps in moq-cli.yml.
       - 'moq-boy-v*'
       - 'libmoq-v*'
       - 'moq-gst-v*'

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -21,6 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # The target triple is just the asset label (Homebrew / apt / rpm
+          # expect these names). The binary itself is a fully-static musl build
+          # (nix .#moq-cli-static), so it has no glibc dependency and runs on
+          # any Linux. Each arch builds natively on its own runner.
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-22.04
             deb-arch: amd64
@@ -35,11 +39,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          targets: ${{ matrix.target }}
-
       - name: Parse version
         id: parse
         shell: bash
@@ -48,23 +47,30 @@ jobs:
       - name: Set up packaging tools
         uses: ./.github/actions/setup-packaging
 
-      - name: Build (release, glibc 2.34)
-        shell: bash
-        # Pin to glibc 2.34 so one binary covers Ubuntu 22.04+ (.deb)
-        # and AlmaLinux/RHEL/Rocky 9+ (.rpm).
-        run: cargo zigbuild --release --target ${{ matrix.target }}.2.34 -p moq-cli
+      # Adds kixelated as a substituter (so the build pulls cached deps) and
+      # authenticates the push below.
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: kixelated
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Rename binary
+      - name: Build (static, musl)
         shell: bash
-        env:
-          TARGET: ${{ matrix.target }}
+        # Fully-static musl build with capture (camera + H.264) compiled in and
+        # ffmpeg statically linked, so the shipped binary has zero dynamic
+        # dependencies. Replaces the old cargo-zigbuild glibc-2.34 pin. The
+        # ffmpeg compile is expensive, so push the result to Cachix here (this
+        # is now the only place moq-cli is cached; see cachix.yml) so re-runs
+        # and `nix run` consumers get a hit instead of rebuilding.
         run: |
-          # The crate is named moq-cli but the .deb / .rpm and Homebrew
-          # formula present the binary as `moq`. Cargo produces
-          # target/release/moq-cli by default (no [[bin]] override),
-          # so make a sibling copy that the downstream packaging steps
-          # can point at without each one needing to know the rename.
-          cp "target/${TARGET}/release/moq-cli" "target/${TARGET}/release/moq"
+          nix build .#moq-cli-static --out-link result --accept-flake-config --print-build-logs
+          cachix push kixelated ./result
+          # Pin so the released path is exempt from GC (see cachix.yml).
+          cachix pin kixelated "moq-cli-static-${{ matrix.target }}" ./result --keep-revisions 10
+          # crane installs to result/bin/<crate>. The .deb / .rpm and Homebrew
+          # formula present the binary as `moq`; copy it out of the read-only
+          # nix store under that name for the packaging steps below.
+          install -m0755 result/bin/moq-cli moq
 
       - name: Package bare binary
         shell: bash
@@ -73,7 +79,7 @@ jobs:
           target="${{ matrix.target }}"
           name="moq-cli-v${version}-${target}"
           mkdir -p dist
-          cp "target/${target}/release/moq" "dist/${name}"
+          cp moq "dist/${name}"
 
       - name: Package tarball (Homebrew)
         shell: bash
@@ -83,19 +89,19 @@ jobs:
         run: |
           name="moq-cli-${VERSION}-${TARGET}"
           mkdir -p "dist/${name}/bin"
-          cp "target/${TARGET}/release/moq-cli" "dist/${name}/bin/moq-cli"
+          cp moq "dist/${name}/bin/moq-cli"
           cp LICENSE-MIT LICENSE-APACHE "dist/${name}/"
           if [[ -f rs/moq-cli/README.md ]]; then
             cp rs/moq-cli/README.md "dist/${name}/"
           fi
           (cd dist && tar -czvf "${name}.tar.gz" "${name}" && rm -rf "${name}")
 
-      - name: Package .deb (Ubuntu 22.04 toolchain)
+      - name: Package .deb
         shell: bash
         env:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.deb-arch }}
-          BINARY_PATH: target/${{ matrix.target }}/release/moq
+          BINARY_PATH: moq
         run: |
           # nfpm doesn't expand ${VAR} in contents[].src or templating
           # there either, so render the env vars in ourselves.
@@ -109,7 +115,7 @@ jobs:
         env:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.rpm-arch }}
-          BINARY_PATH: target/${{ matrix.target }}/release/moq
+          BINARY_PATH: moq
         run: |
           # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
           envsubst '$VERSION $ARCH $BINARY_PATH' \
@@ -150,9 +156,8 @@ jobs:
           determinate: false
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
-      # The cross build links system libs only, but its dyld smoke test must
-      # actually run the x86_64 binary on this arm host. Idempotent no-op when
-      # Rosetta is already present.
+      # The cross build's dyld smoke test must run the x86_64 binary on this arm
+      # host. Idempotent no-op when Rosetta is already present.
       - name: Install Rosetta (x86_64 smoke test)
         if: matrix.target == 'x86_64-apple-darwin'
         run: softwareupdate --install-rosetta --agree-to-license
@@ -161,6 +166,27 @@ jobs:
         id: parse
         shell: bash
         run: .github/scripts/release.sh parse-version moq-cli
+
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: kixelated
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      # Build the nix output and push it to Cachix before packaging. The
+      # capture build statically links ffmpeg (an expensive compile), so this
+      # is the only place moq-cli is cached now (see cachix.yml). package-binary.sh
+      # below then re-resolves the same derivation from the local store (a hit)
+      # before scrubbing and tarring.
+      - name: Build and cache (nix)
+        shell: bash
+        run: |
+          attr=moq-cli
+          if [[ "${{ matrix.target }}" == "x86_64-apple-darwin" ]]; then
+            attr=moq-cli-x86_64-apple-darwin
+          fi
+          nix build ".#${attr}" --out-link result --accept-flake-config --print-build-logs
+          cachix push kixelated ./result
+          cachix pin kixelated "${attr}" ./result --keep-revisions 10
 
       - name: Build and package tarball
         shell: bash

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -65,15 +65,15 @@ jobs:
             echo "version=0.0.0-dryrun" >> "$GITHUB_OUTPUT"
           fi
 
-      # libav* dev headers for ffmpeg-sys-next (linked dynamically), pkg-config
-      # to locate them, and clang for bindgen. The runner's rustup honors
-      # rust-toolchain.toml.
+      # libav* dev headers for ffmpeg-sys-next (linked dynamically), ALSA for
+      # cpal's microphone capture, pkg-config to locate them, and clang for
+      # bindgen. The runner's rustup honors rust-toolchain.toml.
       - name: Install build dependencies
         shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            pkg-config clang libclang-dev \
+            pkg-config clang libclang-dev libasound2-dev \
             libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev \
             libavutil-dev libswscale-dev libswresample-dev
 

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -22,9 +22,11 @@ jobs:
       matrix:
         include:
           # The target triple is just the asset label (Homebrew / apt / rpm
-          # expect these names). The binary itself is a fully-static musl build
-          # (nix .#moq-cli-static), so it has no glibc dependency and runs on
-          # any Linux. Each arch builds natively on its own runner.
+          # expect these names). The binary links the distro's ffmpeg (libav*)
+          # dynamically and declares it as a runtime dependency, so it's built
+          # natively on each arch against that distro's headers. ubuntu-22.04
+          # (glibc 2.35) is the support floor; older distros need a source
+          # build. See doc/bin/cli.md.
           - target: x86_64-unknown-linux-gnu
             runs-on: ubuntu-22.04
             deb-arch: amd64
@@ -44,33 +46,30 @@ jobs:
         shell: bash
         run: .github/scripts/release.sh parse-version moq-cli
 
+      # libav* dev headers for ffmpeg-sys-next (linked dynamically), pkg-config
+      # to locate them, and clang for bindgen. The runner's rustup honors
+      # rust-toolchain.toml.
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config clang libclang-dev \
+            libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev \
+            libavutil-dev libswscale-dev libswresample-dev
+
       - name: Set up packaging tools
         uses: ./.github/actions/setup-packaging
 
-      # Adds kixelated as a substituter (so the build pulls cached deps) and
-      # authenticates the push below.
-      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        with:
-          name: kixelated
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - name: Build (static, musl)
+      - name: Build (native, dynamic ffmpeg)
         shell: bash
-        # Fully-static musl build with capture (camera + H.264) compiled in and
-        # ffmpeg statically linked, so the shipped binary has zero dynamic
-        # dependencies. Replaces the old cargo-zigbuild glibc-2.34 pin. The
-        # ffmpeg compile is expensive, so push the result to Cachix here (this
-        # is now the only place moq-cli is cached; see cachix.yml) so re-runs
-        # and `nix run` consumers get a hit instead of rebuilding.
+        # Capture (camera + H.264) compiled in, linking the system libav*
+        # dynamically. The hardware encoders (nvenc / vaapi / v4l2m2m) come from
+        # the distro ffmpeg the package depends on. The .deb / .rpm and Homebrew
+        # formula present the binary as `moq`.
         run: |
-          nix build .#moq-cli-static --out-link result --accept-flake-config --print-build-logs
-          cachix push kixelated ./result
-          # Pin so the released path is exempt from GC (see cachix.yml).
-          cachix pin kixelated "moq-cli-static-${{ matrix.target }}" ./result --keep-revisions 10
-          # crane installs to result/bin/<crate>. The .deb / .rpm and Homebrew
-          # formula present the binary as `moq`; copy it out of the read-only
-          # nix store under that name for the packaging steps below.
-          install -m0755 result/bin/moq-cli moq
+          cargo build --release -p moq-cli --features capture
+          install -m0755 target/release/moq-cli moq
 
       - name: Package bare binary
         shell: bash
@@ -136,12 +135,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both Apple targets build on the Apple Silicon runner. The
-          # Determinate Nix installer dropped Intel macOS, so x86_64 is
-          # cross-compiled (Apple clang is multi-arch) and its smoke test
-          # runs under Rosetta. See rs/scripts/package-binary.sh.
+          # Each Apple arch builds natively on its own runner (macos-13 is the
+          # last Intel image; macos-latest is Apple Silicon) so capture links a
+          # matching-arch Homebrew ffmpeg. No cross-compile or Rosetta needed.
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -151,51 +149,39 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
-        with:
-          determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
-
-      # The cross build's dyld smoke test must run the x86_64 binary on this arm
-      # host. Idempotent no-op when Rosetta is already present.
-      - name: Install Rosetta (x86_64 smoke test)
-        if: matrix.target == 'x86_64-apple-darwin'
-        run: softwareupdate --install-rosetta --agree-to-license
-
       - name: Parse version
         id: parse
         shell: bash
         run: .github/scripts/release.sh parse-version moq-cli
 
-      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        with:
-          name: kixelated
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      # ffmpeg provides the libav* headers/dylibs (linked dynamically) and the
+      # hardware encoders; pkg-config locates them. Xcode's clang serves
+      # bindgen. The runner's rustup honors rust-toolchain.toml.
+      - name: Install build dependencies
+        shell: bash
+        run: brew install ffmpeg pkg-config
 
-      # Build the nix output and push it to Cachix before packaging. The
-      # capture build statically links ffmpeg (an expensive compile), so this
-      # is the only place moq-cli is cached now (see cachix.yml). package-binary.sh
-      # below then re-resolves the same derivation from the local store (a hit)
-      # before scrubbing and tarring.
-      - name: Build and cache (nix)
+      - name: Build (native, dynamic ffmpeg)
         shell: bash
         run: |
-          attr=moq-cli
-          if [[ "${{ matrix.target }}" == "x86_64-apple-darwin" ]]; then
-            attr=moq-cli-x86_64-apple-darwin
+          export PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          cargo build --release -p moq-cli --features capture
+          install -m0755 target/release/moq-cli moq
+
+      - name: Package tarball (Homebrew)
+        shell: bash
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          name="moq-cli-${VERSION}-${TARGET}"
+          mkdir -p "dist/${name}/bin"
+          cp moq "dist/${name}/bin/moq-cli"
+          cp LICENSE-MIT LICENSE-APACHE "dist/${name}/"
+          if [[ -f rs/moq-cli/README.md ]]; then
+            cp rs/moq-cli/README.md "dist/${name}/"
           fi
-          nix build ".#${attr}" --out-link result --accept-flake-config --print-build-logs
-          cachix push kixelated ./result
-          cachix pin kixelated "${attr}" ./result --keep-revisions 10
-
-      - name: Build and package tarball
-        shell: bash
-        run: |
-          ./rs/scripts/package-binary.sh \
-            --crate moq-cli \
-            --target ${{ matrix.target }} \
-            --version ${{ steps.parse.outputs.version }} \
-            --output dist
+          (cd dist && tar -czvf "${name}.tar.gz" "${name}" && rm -rf "${name}")
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -154,11 +154,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Each Apple arch builds natively on its own runner (macos-13 is the
-          # last Intel image; macos-latest is Apple Silicon) so capture links a
+          # Each Apple arch builds natively on its own runner (macos-15-intel is
+          # the Intel image; macos-latest is Apple Silicon) so capture links a
           # matching-arch Homebrew ffmpeg. No cross-compile or Rosetta needed.
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
 
@@ -190,7 +190,8 @@ jobs:
       - name: Build (native, dynamic ffmpeg)
         shell: bash
         run: |
-          export PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          export PKG_CONFIG_PATH
           cargo build --release -p moq-cli --features capture
           install -m0755 target/release/moq-cli moq
 

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -4,9 +4,10 @@ on:
   push:
     tags:
       - "moq-cli-v*"
-  # Dry-run the release build/packaging (everything except publishing) when the
-  # moq-cli build or packaging inputs change, so regressions surface on the PR
-  # instead of only when a tag is cut. The `release` job is gated to tag pushes.
+  # Dry-run the Linux release build/packaging (everything except publishing)
+  # when the moq-cli build or packaging inputs change, so regressions surface on
+  # the PR instead of only when a tag is cut. macOS is excluded (cost) and the
+  # `release` job is gated to tag pushes; see their `if:` conditions.
   pull_request:
     paths:
       - "rs/moq-cli/**"
@@ -148,6 +149,9 @@ jobs:
 
   build-tarball-macos:
     name: Build macOS tarball (${{ matrix.target }})
+    # macOS runners are ~10x the cost, so skip them on the PR dry-run. They
+    # still run on release tags and on a manual workflow_dispatch.
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -4,10 +4,22 @@ on:
   push:
     tags:
       - "moq-cli-v*"
+  # Dry-run the release build/packaging (everything except publishing) when the
+  # moq-cli build or packaging inputs change, so regressions surface on the PR
+  # instead of only when a tag is cut. The `release` job is gated to tag pushes.
+  pull_request:
+    paths:
+      - "rs/moq-cli/**"
+      - "rs/moq-video/**"
+      - "packaging/moq-cli/**"
+      - ".github/homebrew/Formula/moq-cli.rb.tmpl"
+      - ".github/workflows/moq-cli.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  # Cancel superseded PR dry-runs, but never interrupt a release (tag) build.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -44,7 +56,14 @@ jobs:
       - name: Parse version
         id: parse
         shell: bash
-        run: .github/scripts/release.sh parse-version moq-cli
+        # On a release tag, parse the real version. On a PR/manual dry-run there
+        # is no tag, so use a placeholder; the artifacts are not published.
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            .github/scripts/release.sh parse-version moq-cli
+          else
+            echo "version=0.0.0-dryrun" >> "$GITHUB_OUTPUT"
+          fi
 
       # libav* dev headers for ffmpeg-sys-next (linked dynamically), pkg-config
       # to locate them, and clang for bindgen. The runner's rustup honors
@@ -152,7 +171,14 @@ jobs:
       - name: Parse version
         id: parse
         shell: bash
-        run: .github/scripts/release.sh parse-version moq-cli
+        # On a release tag, parse the real version. On a PR/manual dry-run there
+        # is no tag, so use a placeholder; the artifacts are not published.
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            .github/scripts/release.sh parse-version moq-cli
+          else
+            echo "version=0.0.0-dryrun" >> "$GITHUB_OUTPUT"
+          fi
 
       # ffmpeg provides the libav* headers/dylibs (linked dynamically) and the
       # hardware encoders; pkg-config locates them. Xcode's clang serves
@@ -192,6 +218,9 @@ jobs:
   release:
     name: Release
     needs: [build, build-tarball-macos]
+    # Publishing only happens for real release tags; PR/manual runs stop after
+    # the build + packaging jobs above (the dry-run).
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -64,11 +64,19 @@ ffmpeg -i input.mp4 -f mpegts - | moq-cli publish - https://relay.example.com/an
 
 The `capture` subcommand captures and encodes from local devices directly, no
 external FFmpeg process required. It publishes the camera as an H.264 video
-track and the microphone as an Opus audio track on the same broadcast. It is
-gated behind the `capture` feature, whose video path pulls in a system FFmpeg
-(libav\*) build dependency (audio is pure-Rust via cpal):
+track and the microphone as an Opus audio track on the same broadcast.
 
-Build (or run) with the feature enabled:
+The prebuilt binaries (releases, Homebrew, `.deb`/`.rpm`) ship with capture
+enabled and FFmpeg statically linked, so there's no separate FFmpeg install to
+manage. Their FFmpeg is LGPL: it encodes with a platform **hardware** encoder
+only (`h264_videotoolbox` on macOS, `h264_v4l2m2m` on Linux) and omits the GPL
+software encoder (libx264). On a machine without a supported hardware H.264
+encoder, use a source build with `--features capture` against a full FFmpeg
+(see below) to get the libx264 software fallback.
+
+From source, capture is gated behind the `capture` feature (off by default so
+plain builds don't pull the FFmpeg/libav\* build dependency; audio is pure-Rust
+via cpal). Build (or run) with the feature enabled:
 
 ```bash
 cargo build --release -p moq-cli --features capture
@@ -93,6 +101,12 @@ dshow on Windows) and picks a hardware encoder (`h264_videotoolbox` /
 `h264_nvenc` / `h264_vaapi`) when one is present, falling back to software
 (`libx264`); force either with `--hardware` / `--software`. Audio capture uses
 cpal (CoreAudio / WASAPI / ALSA) and encodes Opus.
+
+The prebuilt binaries' static FFmpeg includes only the hardware encoders
+`h264_videotoolbox` (macOS) and `h264_v4l2m2m` (Linux); `--software` (libx264)
+needs a source build against a full FFmpeg. VA-API / NVENC are also omitted
+(they dlopen system driver libraries at runtime, which a static binary
+can't rely on); build from source against a full FFmpeg to use them.
 
 Alternatively, pipe an external FFmpeg process as MPEG-TS:
 

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -67,16 +67,26 @@ external FFmpeg process required. It publishes the camera as an H.264 video
 track and the microphone as an Opus audio track on the same broadcast.
 
 The prebuilt binaries (releases, Homebrew, `.deb`/`.rpm`) ship with capture
-enabled and FFmpeg statically linked, so there's no separate FFmpeg install to
-manage. Their FFmpeg is LGPL: it encodes with a platform **hardware** encoder
-only (`h264_videotoolbox` on macOS, `h264_v4l2m2m` on Linux) and omits the GPL
-software encoder (libx264). On a machine without a supported hardware H.264
-encoder, use a source build with `--features capture` against a full FFmpeg
-(see below) to get the libx264 software fallback.
+enabled and link the system FFmpeg dynamically, so **FFmpeg is a runtime
+dependency**. The package managers install it for you: `brew install moq-cli`
+pulls FFmpeg, and the `.deb`/`.rpm` declare it as a dependency (on Fedora/RHEL,
+enable [RPM Fusion](https://rpmfusion.org/) first since FFmpeg lives there).
+Because the binary uses whatever FFmpeg the platform provides, every encoder
+that build includes is available: the hardware encoders `h264_videotoolbox`
+(macOS), `h264_nvenc` (NVIDIA), `h264_vaapi` (Intel/AMD), and `h264_v4l2m2m`
+(Linux/embedded), plus the `libx264` software encoder. NVENC and VA-API only
+need the matching GPU driver present at runtime; without it they report as
+unavailable and capture falls back to another encoder.
+
+The Linux packages are built on Ubuntu 22.04 (glibc 2.35), which is the support
+floor; older distros need a source build. They link the distro's libav\* ABI,
+so install the package matching your distro release.
 
 From source, capture is gated behind the `capture` feature (off by default so
 plain builds don't pull the FFmpeg/libav\* build dependency; audio is pure-Rust
-via cpal). Build (or run) with the feature enabled:
+via cpal). It links the system FFmpeg both at build and run time, so install
+FFmpeg's dev headers first (`apt install libavcodec-dev ...`, `brew install
+ffmpeg`, or use the Nix dev shell). Build (or run) with the feature enabled:
 
 ```bash
 cargo build --release -p moq-cli --features capture
@@ -99,14 +109,9 @@ moq-cli publish --url https://relay.example.com --broadcast cam.hang capture --n
 Video capture uses the platform backend (avfoundation on macOS, v4l2 on Linux,
 dshow on Windows) and picks a hardware encoder (`h264_videotoolbox` /
 `h264_nvenc` / `h264_vaapi`) when one is present, falling back to software
-(`libx264`); force either with `--hardware` / `--software`. Audio capture uses
-cpal (CoreAudio / WASAPI / ALSA) and encodes Opus.
-
-The prebuilt binaries' static FFmpeg includes only the hardware encoders
-`h264_videotoolbox` (macOS) and `h264_v4l2m2m` (Linux); `--software` (libx264)
-needs a source build against a full FFmpeg. VA-API / NVENC are also omitted
-(they dlopen system driver libraries at runtime, which a static binary
-can't rely on); build from source against a full FFmpeg to use them.
+(`libx264`); force either with `--hardware` / `--software`. Which encoders are
+actually available depends on how your FFmpeg was built; the encoders listed
+above are present in the FFmpeg that the package managers install.
 
 Alternatively, pipe an external FFmpeg process as MPEG-TS:
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,11 @@
           ];
         };
 
+        # Apply our overlay to get the package definitions. Defined here (rather
+        # than just before `in`) so the dev shell can pull the static-capable
+        # ffmpeg the package builds use.
+        overlayPkgs = pkgs.extend self.overlays.default;
+
         # GStreamer dependencies (for moq-gst plugin)
         gstreamerDeps = with pkgs; [
           gst_all_1.gstreamer
@@ -81,7 +86,12 @@
             pkg-config
             glib
             libressl
-            ffmpeg
+            # Static-capable ffmpeg (+ static x264) so a dev `cargo build
+            # --features capture` links dynamically while `just rs ci`'s
+            # `--all-features` run, which enables moq-video's `static` feature,
+            # finds the libav*.a / libx264.a archives. See nix/overlay.nix.
+            overlayPkgs.moqFfmpeg
+            overlayPkgs.moqX264
             curl
             cargo-sort
             cargo-shear
@@ -155,9 +165,6 @@
           taplo
           nixfmt
         ];
-
-        # Apply our overlay to get the package definitions
-        overlayPkgs = pkgs.extend self.overlays.default;
       in
       {
         packages = (rec {
@@ -200,6 +207,12 @@
             libmoq-x86_64-apple-darwin
             moq-gst-plugin-x86_64-apple-darwin
             ;
+        }
+        # Fully-static musl moq-cli for the portable Linux release artifacts.
+        # pkgsStatic only makes sense on Linux (darwin has no static libc), so
+        # gate it to keep `nix flake check` evaluating elsewhere.
+        // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          inherit (overlayPkgs) moq-cli-static;
         };
 
         # Re-export gst_all_1 so users can pair the plugin with a matching

--- a/flake.nix
+++ b/flake.nix
@@ -61,9 +61,7 @@
           ];
         };
 
-        # Apply our overlay to get the package definitions. Defined here (rather
-        # than just before `in`) so the dev shell can pull the static-capable
-        # ffmpeg the package builds use.
+        # Apply our overlay to get the package definitions.
         overlayPkgs = pkgs.extend self.overlays.default;
 
         # GStreamer dependencies (for moq-gst plugin)
@@ -86,12 +84,10 @@
             pkg-config
             glib
             libressl
-            # Static-capable ffmpeg (+ static x264) so a dev `cargo build
-            # --features capture` links dynamically while `just rs ci`'s
-            # `--all-features` run, which enables moq-video's `static` feature,
-            # finds the libav*.a / libx264.a archives. See nix/overlay.nix.
-            overlayPkgs.moqFfmpeg
-            overlayPkgs.moqX264
+            # Full ffmpeg (all hardware encoders + libx264) so a dev
+            # `cargo build --features capture` links the system libav*
+            # dynamically. See nix/overlay.nix.
+            pkgs.ffmpeg-full
             curl
             cargo-sort
             cargo-shear
@@ -202,17 +198,10 @@
         // pkgs.lib.optionalAttrs (system == "aarch64-darwin") {
           inherit (overlayPkgs)
             moq-relay-x86_64-apple-darwin
-            moq-cli-x86_64-apple-darwin
             moq-token-cli-x86_64-apple-darwin
             libmoq-x86_64-apple-darwin
             moq-gst-plugin-x86_64-apple-darwin
             ;
-        }
-        # Fully-static musl moq-cli for the portable Linux release artifacts.
-        # pkgsStatic only makes sense on Linux (darwin has no static libc), so
-        # gate it to keep `nix flake check` evaluating elsewhere.
-        // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-          inherit (overlayPkgs) moq-cli-static;
         };
 
         # Re-export gst_all_1 so users can pair the plugin with a matching

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -19,6 +19,106 @@ let
   };
   craneLib = (crane.mkLib final).overrideToolchain rustToolchain;
 
+  # ffmpeg for the moq-cli `capture` feature (camera + H.264 encode), built so
+  # we can statically link it: the shipped CLI then has no runtime ffmpeg
+  # dependency. We disable nixpkgs' dependency presets and re-enable only the
+  # libav* libraries ffmpeg-next links (codec/format/filter/device plus
+  # swscale/swresample). v4l2 covers Linux camera capture and the v4l2m2m
+  # hardware encoder; videotoolbox is auto-detected on darwin; both are
+  # link-dep-free. Everything else (x265/aom/dav1d/gnutls/bzip2/...) stays off,
+  # which keeps the static link closure small and avoids dragging in libraries
+  # that have no static archive on the link path.
+  #
+  # `gpl` adds libx264, the software H.264 encoder, which is GPL. The shipped
+  # binary keeps it OFF so the distributed artifact stays LGPL (the hardware
+  # encoders h264_videotoolbox / h264_v4l2m2m are LGPL ffmpeg built-ins, as are
+  # the mjpeg/rawvideo decoders the camera input needs). The dev shell turns it
+  # ON: that ffmpeg is a local build tool, never distributed, and the test
+  # suite and `demo/pub` recipes both want a software H.264 encoder.
+  #
+  # `withStatic` adds the .a archives; we leave `withShared` at its default
+  # (on, except under pkgsStatic) so the same package also serves plain dynamic
+  # dev builds (`cargo build --features capture`, without `moq-video/static`)
+  # and the `ffmpeg` CLI the demo recipes use.
+  moqFfmpegFor =
+    {
+      pkgs,
+      gpl ? false,
+    }:
+    (pkgs.ffmpeg.override (
+      {
+        withHeadlessDeps = false;
+        withSmallDeps = false;
+        withFullDeps = false;
+        buildAvcodec = true;
+        buildAvformat = true;
+        buildAvutil = true;
+        buildAvdevice = true;
+        buildAvfilter = true;
+        buildSwscale = true;
+        buildSwresample = true;
+        buildFfmpeg = true;
+        buildFfprobe = true;
+        withV4l2 = pkgs.stdenv.hostPlatform.isLinux;
+        withZlib = true;
+        withStatic = true;
+        withGPL = gpl;
+        withX264 = gpl;
+      }
+      // final.lib.optionalAttrs gpl { x264 = moqX264For pkgs; }
+    )).overrideAttrs
+      (_: {
+        # ffmpeg's bundled tests (e.g. libavutil/tests/pixelutils.c) miss a
+        # <string.h> include and fail under darwin's strict clang, which only
+        # treats the implicit-declaration as a warning for GNU cc. We only need
+        # the libraries, so skip the self-test build.
+        doCheck = false;
+      });
+
+  # nixpkgs' x264 hardcodes the `install-lib-shared` make target and declares a
+  # separate `lib` output; with `enableShared = false` it builds only libx264.a
+  # and the `lib` output comes up empty, which nix rejects. Install the static
+  # lib instead and collapse to one output so the .a / .pc / header land where
+  # pkg-config and the static ffmpeg link can find them. Only the dev-shell
+  # (GPL) ffmpeg references it.
+  moqX264For =
+    pkgs:
+    (pkgs.x264.override { enableShared = false; }).overrideAttrs (_: {
+      outputs = [ "out" ];
+      makeFlags = [ "install-lib-static" ];
+    });
+
+  # The dev shell links this (with libx264) so `just rs ci`'s `--all-features`
+  # test and the demo recipes have a software H.264 encoder; it is never
+  # distributed. The shipped builds use the LGPL variant via captureBuildArgs.
+  moqFfmpeg = moqFfmpegFor {
+    pkgs = final;
+    gpl = true;
+  };
+  moqX264 = moqX264For final;
+
+  # Build inputs that let ffmpeg-sys-next find and statically link the libav*
+  # archives (pkg-config + bindgen's clang). LGPL (no libx264): the shipped
+  # binary encodes with the platform hardware encoder only.
+  captureBuildArgs =
+    pkgs:
+    {
+      nativeBuildInputs = with final; [
+        pkg-config
+        clang
+      ];
+      buildInputs = [ (moqFfmpegFor { inherit pkgs; }) ];
+      LIBCLANG_PATH = "${final.libclang.lib}/lib";
+    }
+    // final.lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+      # ffmpeg-sys-next's static-macos path hardcodes -framework QTKit (and other
+      # legacy frameworks) into the link line. QTKit was removed from macOS, so
+      # the binary links against the SDK stub but dyld aborts at runtime ("no
+      # such file"). ffmpeg references no QTKit symbols, so -dead_strip_dylibs
+      # drops the load commands for frameworks nothing actually uses.
+      RUSTFLAGS = "-C link-arg=-Wl,-dead_strip_dylibs";
+    };
+
   # Helper function to get crate info from Cargo.toml
   crateInfo = cargoTomlPath: craneLib.crateNameFromCargoToml { cargoToml = cargoTomlPath; };
 
@@ -48,10 +148,17 @@ let
     hardeningDisable = [ "fortify" ];
   };
 
-  moqCliArgs = crateInfo ../rs/moq-cli/Cargo.toml // {
-    src = craneLib.cleanCargoSource ../.;
-    cargoExtraArgs = "-p moq-cli";
-  };
+  # Capture is on so the released CLI can publish a webcam out of the box.
+  # `moq-video/static` statically links ffmpeg (see moqFfmpeg) so there's no
+  # runtime libav* dependency. On macOS the cross x86_64 output below swaps in
+  # an x86_64 ffmpeg; the Linux release uses the fully-static moq-cli-static.
+  moqCliArgs =
+    crateInfo ../rs/moq-cli/Cargo.toml
+    // captureBuildArgs final
+    // {
+      src = craneLib.cleanCargoSource ../.;
+      cargoExtraArgs = "-p moq-cli --features capture,moq-video/static";
+    };
 
   moqTokenCliArgs = crateInfo ../rs/moq-token-cli/Cargo.toml // {
     src = craneLib.cleanCargoSource ../.;
@@ -198,8 +305,44 @@ in
   moq-relay = craneLib.buildPackage moqRelayArgs;
   moq-relay-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqRelayArgs);
 
+  # Exposed so flake.nix's dev shell links the same static-capable ffmpeg the
+  # package builds use (so `just rs ci`'s `--all-features` test can statically
+  # link without a second ffmpeg on the pkg-config path).
+  inherit moqFfmpeg moqX264;
+
   moq-cli = craneLib.buildPackage moqCliArgs;
-  moq-cli-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqCliArgs);
+  # The cross build links an x86_64 ffmpeg (built natively by pkgsX86Darwin,
+  # like the moq-gst cross plugin) so capture's static link resolves x86_64
+  # archives. crossX86Darwin's arg merge keeps captureBuildArgs' nativeBuildInputs.
+  moq-cli-x86_64-apple-darwin = craneLib.buildPackage (
+    crossX86Darwin (moqCliArgs // { buildInputs = (captureBuildArgs pkgsX86Darwin).buildInputs; })
+  );
+
+  # Fully static musl build for the portable Linux release artifacts. Under
+  # pkgsStatic everything (ffmpeg, x264, libc -> musl) links static by default,
+  # so the binary has zero dynamic dependencies and runs on any Linux
+  # regardless of glibc version. This replaces the old cargo-zigbuild glibc-2.34
+  # pin: a static binary is strictly more portable. Linux-only (see flake.nix);
+  # darwin can't fully static link.
+  moq-cli-static =
+    let
+      staticPkgs = final.pkgsStatic;
+      muslTarget = staticPkgs.stdenv.hostPlatform.rust.rustcTarget;
+      craneLibStatic = (crane.mkLib staticPkgs).overrideToolchain (
+        final.rust-bin.stable.latest.default.override { targets = [ muslTarget ]; }
+      );
+    in
+    craneLibStatic.buildPackage (
+      crateInfo ../rs/moq-cli/Cargo.toml
+      // captureBuildArgs staticPkgs
+      // {
+        src = craneLib.cleanCargoSource ../.;
+        cargoExtraArgs = "-p moq-cli --features capture,moq-video/static";
+        CARGO_BUILD_TARGET = muslTarget;
+        # Cross-target test binaries can't run in the build sandbox.
+        doCheck = false;
+      }
+    );
 
   moq-token-cli = craneLib.buildPackage moqTokenCliArgs;
   moq-token-cli-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqTokenCliArgs);

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -319,11 +319,11 @@ in
   );
 
   # Fully static musl build for the portable Linux release artifacts. Under
-  # pkgsStatic everything (ffmpeg, x264, libc -> musl) links static by default,
-  # so the binary has zero dynamic dependencies and runs on any Linux
-  # regardless of glibc version. This replaces the old cargo-zigbuild glibc-2.34
-  # pin: a static binary is strictly more portable. Linux-only (see flake.nix);
-  # darwin can't fully static link.
+  # pkgsStatic everything (ffmpeg, libc -> musl) links static by default, so the
+  # binary has zero dynamic dependencies and runs on any Linux regardless of
+  # glibc version. This replaces the old cargo-zigbuild glibc-2.34 pin: a static
+  # binary is strictly more portable. Linux-only (see flake.nix); darwin can't
+  # fully static link.
   moq-cli-static =
     let
       staticPkgs = final.pkgsStatic;
@@ -336,7 +336,7 @@ in
       crateInfo ../rs/moq-cli/Cargo.toml
       // captureBuildArgs staticPkgs
       // {
-        src = craneLib.cleanCargoSource ../.;
+        src = craneLibStatic.cleanCargoSource ../.;
         cargoExtraArgs = "-p moq-cli --features capture,moq-video/static";
         CARGO_BUILD_TARGET = muslTarget;
         # Cross-target test binaries can't run in the build sandbox.

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -19,112 +19,24 @@ let
   };
   craneLib = (crane.mkLib final).overrideToolchain rustToolchain;
 
-  # ffmpeg for the moq-cli `capture` feature (camera + H.264 encode), built so
-  # we can statically link it: the shipped CLI then has no runtime ffmpeg
-  # dependency. We disable nixpkgs' dependency presets and re-enable only the
-  # libav* libraries ffmpeg-next links (codec/format/filter/device plus
-  # swscale/swresample). v4l2 covers Linux camera capture and the v4l2m2m
-  # hardware encoder; videotoolbox is auto-detected on darwin; both are
-  # link-dep-free. Everything else (x265/aom/dav1d/gnutls/bzip2/...) stays off,
-  # which keeps the static link closure small and avoids dragging in libraries
-  # that have no static archive on the link path.
+  # Build inputs for the moq-cli `capture` feature (camera + H.264 encode):
+  # ffmpeg-sys-next finds the libav* libraries via pkg-config and bindgen needs
+  # clang. This is the nix moq-cli that feeds the Docker image and dev shell;
+  # it links nixpkgs' full ffmpeg dynamically (all hardware encoders: nvenc and
+  # vaapi on Linux, videotoolbox on darwin, plus the libx264 software encoder).
   #
-  # `gpl` adds libx264, the software H.264 encoder, which is GPL. The shipped
-  # binary keeps it OFF so the distributed artifact stays LGPL (the hardware
-  # encoders h264_videotoolbox / h264_v4l2m2m are LGPL ffmpeg built-ins, as are
-  # the mjpeg/rawvideo decoders the camera input needs). The dev shell turns it
-  # ON: that ffmpeg is a local build tool, never distributed, and the test
-  # suite and `demo/pub` recipes both want a software H.264 encoder.
-  #
-  # `withStatic` adds the .a archives; we leave `withShared` at its default
-  # (on, except under pkgsStatic) so the same package also serves plain dynamic
-  # dev builds (`cargo build --features capture`, without `moq-video/static`)
-  # and the `ffmpeg` CLI the demo recipes use.
-  moqFfmpegFor =
-    {
-      pkgs,
-      gpl ? false,
-    }:
-    (pkgs.ffmpeg.override (
-      {
-        withHeadlessDeps = false;
-        withSmallDeps = false;
-        withFullDeps = false;
-        buildAvcodec = true;
-        buildAvformat = true;
-        buildAvutil = true;
-        buildAvdevice = true;
-        buildAvfilter = true;
-        buildSwscale = true;
-        buildSwresample = true;
-        buildFfmpeg = true;
-        buildFfprobe = true;
-        withV4l2 = pkgs.stdenv.hostPlatform.isLinux;
-        withZlib = true;
-        withStatic = true;
-        withGPL = gpl;
-        withX264 = gpl;
-      }
-      // final.lib.optionalAttrs gpl { x264 = moqX264For pkgs; }
-      // final.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-        # withV4l2 pulls libv4l (v4l-utils), whose BPF keytable support drags in
-        # libbpf -> elfutils. elfutils declares badPlatforms = isStatic, so the
-        # pkgsStatic closure refuses to evaluate. We only need V4L2 capture and
-        # the v4l2m2m encoder, not IR keytable decoding, so drop BPF.
-        libv4l = pkgs.libv4l.override { withBPF = false; };
-      }
-    )).overrideAttrs
-      (_: {
-        # ffmpeg's bundled tests (e.g. libavutil/tests/pixelutils.c) miss a
-        # <string.h> include and fail under darwin's strict clang, which only
-        # treats the implicit-declaration as a warning for GNU cc. We only need
-        # the libraries, so skip the self-test build.
-        doCheck = false;
-      });
-
-  # nixpkgs' x264 hardcodes the `install-lib-shared` make target and declares a
-  # separate `lib` output; with `enableShared = false` it builds only libx264.a
-  # and the `lib` output comes up empty, which nix rejects. Install the static
-  # lib instead and collapse to one output so the .a / .pc / header land where
-  # pkg-config and the static ffmpeg link can find them. Only the dev-shell
-  # (GPL) ffmpeg references it.
-  moqX264For =
-    pkgs:
-    (pkgs.x264.override { enableShared = false; }).overrideAttrs (_: {
-      outputs = [ "out" ];
-      makeFlags = [ "install-lib-static" ];
-    });
-
-  # The dev shell links this (with libx264) so `just rs ci`'s `--all-features`
-  # test and the demo recipes have a software H.264 encoder; it is never
-  # distributed. The shipped builds use the LGPL variant via captureBuildArgs.
-  moqFfmpeg = moqFfmpegFor {
-    pkgs = final;
-    gpl = true;
+  # The shipped apt/deb/rpm/brew packages are NOT built here. They compile
+  # natively against the target distro's (or Homebrew's) ffmpeg and declare it
+  # as a runtime dependency, so each package matches its platform's libav* ABI.
+  # See .github/workflows/moq-cli.yml.
+  captureBuildArgs = {
+    nativeBuildInputs = with final; [
+      pkg-config
+      clang
+    ];
+    buildInputs = [ final.ffmpeg-full ];
+    LIBCLANG_PATH = "${final.libclang.lib}/lib";
   };
-  moqX264 = moqX264For final;
-
-  # Build inputs that let ffmpeg-sys-next find and statically link the libav*
-  # archives (pkg-config + bindgen's clang). LGPL (no libx264): the shipped
-  # binary encodes with the platform hardware encoder only.
-  captureBuildArgs =
-    pkgs:
-    {
-      nativeBuildInputs = with final; [
-        pkg-config
-        clang
-      ];
-      buildInputs = [ (moqFfmpegFor { inherit pkgs; }) ];
-      LIBCLANG_PATH = "${final.libclang.lib}/lib";
-    }
-    // final.lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
-      # ffmpeg-sys-next's static-macos path hardcodes -framework QTKit (and other
-      # legacy frameworks) into the link line. QTKit was removed from macOS, so
-      # the binary links against the SDK stub but dyld aborts at runtime ("no
-      # such file"). ffmpeg references no QTKit symbols, so -dead_strip_dylibs
-      # drops the load commands for frameworks nothing actually uses.
-      RUSTFLAGS = "-C link-arg=-Wl,-dead_strip_dylibs";
-    };
 
   # Helper function to get crate info from Cargo.toml
   crateInfo = cargoTomlPath: craneLib.crateNameFromCargoToml { cargoToml = cargoTomlPath; };
@@ -155,16 +67,15 @@ let
     hardeningDisable = [ "fortify" ];
   };
 
-  # Capture is on so the released CLI can publish a webcam out of the box.
-  # `moq-video/static` statically links ffmpeg (see moqFfmpeg) so there's no
-  # runtime libav* dependency. On macOS the cross x86_64 output below swaps in
-  # an x86_64 ffmpeg; the Linux release uses the fully-static moq-cli-static.
+  # Capture is on so the nix moq-cli (Docker image + dev shell) can publish a
+  # webcam. It links ffmpeg dynamically; the released distro/brew packages are
+  # built natively (see captureBuildArgs and moq-cli.yml).
   moqCliArgs =
     crateInfo ../rs/moq-cli/Cargo.toml
-    // captureBuildArgs final
+    // captureBuildArgs
     // {
       src = craneLib.cleanCargoSource ../.;
-      cargoExtraArgs = "-p moq-cli --features capture,moq-video/static";
+      cargoExtraArgs = "-p moq-cli --features capture";
     };
 
   moqTokenCliArgs = crateInfo ../rs/moq-token-cli/Cargo.toml // {
@@ -312,44 +223,10 @@ in
   moq-relay = craneLib.buildPackage moqRelayArgs;
   moq-relay-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqRelayArgs);
 
-  # Exposed so flake.nix's dev shell links the same static-capable ffmpeg the
-  # package builds use (so `just rs ci`'s `--all-features` test can statically
-  # link without a second ffmpeg on the pkg-config path).
-  inherit moqFfmpeg moqX264;
-
+  # The nix moq-cli links ffmpeg dynamically (Docker image + dev shell). The
+  # released distro/brew packages are built natively against the platform ffmpeg
+  # (see moq-cli.yml), so there is no static or cross-darwin nix output here.
   moq-cli = craneLib.buildPackage moqCliArgs;
-  # The cross build links an x86_64 ffmpeg (built natively by pkgsX86Darwin,
-  # like the moq-gst cross plugin) so capture's static link resolves x86_64
-  # archives. crossX86Darwin's arg merge keeps captureBuildArgs' nativeBuildInputs.
-  moq-cli-x86_64-apple-darwin = craneLib.buildPackage (
-    crossX86Darwin (moqCliArgs // { buildInputs = (captureBuildArgs pkgsX86Darwin).buildInputs; })
-  );
-
-  # Fully static musl build for the portable Linux release artifacts. Under
-  # pkgsStatic everything (ffmpeg, libc -> musl) links static by default, so the
-  # binary has zero dynamic dependencies and runs on any Linux regardless of
-  # glibc version. This replaces the old cargo-zigbuild glibc-2.34 pin: a static
-  # binary is strictly more portable. Linux-only (see flake.nix); darwin can't
-  # fully static link.
-  moq-cli-static =
-    let
-      staticPkgs = final.pkgsStatic;
-      muslTarget = staticPkgs.stdenv.hostPlatform.rust.rustcTarget;
-      craneLibStatic = (crane.mkLib staticPkgs).overrideToolchain (
-        final.rust-bin.stable.latest.default.override { targets = [ muslTarget ]; }
-      );
-    in
-    craneLibStatic.buildPackage (
-      crateInfo ../rs/moq-cli/Cargo.toml
-      // captureBuildArgs staticPkgs
-      // {
-        src = craneLibStatic.cleanCargoSource ../.;
-        cargoExtraArgs = "-p moq-cli --features capture,moq-video/static";
-        CARGO_BUILD_TARGET = muslTarget;
-        # Cross-target test binaries can't run in the build sandbox.
-        doCheck = false;
-      }
-    );
 
   moq-token-cli = craneLib.buildPackage moqTokenCliArgs;
   moq-token-cli-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqTokenCliArgs);

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -66,6 +66,13 @@ let
         withX264 = gpl;
       }
       // final.lib.optionalAttrs gpl { x264 = moqX264For pkgs; }
+      // final.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        # withV4l2 pulls libv4l (v4l-utils), whose BPF keytable support drags in
+        # libbpf -> elfutils. elfutils declares badPlatforms = isStatic, so the
+        # pkgsStatic closure refuses to evaluate. We only need V4L2 capture and
+        # the v4l2m2m encoder, not IR keytable decoding, so drop BPF.
+        libv4l = pkgs.libv4l.override { withBPF = false; };
+      }
     )).overrideAttrs
       (_: {
         # ffmpeg's bundled tests (e.g. libavutil/tests/pixelutils.c) miss a

--- a/packaging/moq-cli/nfpm.yaml
+++ b/packaging/moq-cli/nfpm.yaml
@@ -23,13 +23,9 @@ contents:
     file_info:
       mode: 0755
 
-overrides:
-  deb:
-    depends:
-      - libc6 (>= 2.34)
-  rpm:
-    depends:
-      - glibc >= 2.34
+# The binary is a fully-static musl build (no glibc / libc6 dependency), so
+# there are no runtime package dependencies to declare. It installs and runs
+# on any Linux regardless of libc flavor or version.
 
 deb:
   fields:

--- a/packaging/moq-cli/nfpm.yaml
+++ b/packaging/moq-cli/nfpm.yaml
@@ -23,9 +23,13 @@ contents:
     file_info:
       mode: 0755
 
-# The binary is a fully-static musl build (no glibc / libc6 dependency), so
-# there are no runtime package dependencies to declare. It installs and runs
-# on any Linux regardless of libc flavor or version.
+# Built natively against the target distro's ffmpeg and links libav*
+# dynamically (the `capture` feature). Depend on ffmpeg so the package manager
+# installs the matching libav* shared libraries; ffmpeg also carries the
+# hardware encoders (nvenc / vaapi / v4l2m2m). On Fedora/RHEL the ffmpeg package
+# lives in RPM Fusion, which the user must enable.
+depends:
+  - ffmpeg
 
 deb:
   fields:

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -19,9 +19,10 @@ quinn = ["moq-native/quinn"]
 quiche = ["moq-native/quiche"]
 websocket = ["moq-native/websocket"]
 # Device capture (camera + microphone) + encode/publish. Off by default because
-# the video path pulls in a system ffmpeg (libav*) build dependency (audio is
-# pure-Rust via cpal). Enable with `cargo build -p moq-cli --features capture`
-# (the nix dev shell provides ffmpeg).
+# the video path links the system ffmpeg (libav*), both at build time and at
+# runtime (audio is pure-Rust via cpal). Enable with
+# `cargo build -p moq-cli --features capture` (the nix dev shell provides
+# ffmpeg). The released packages compile this in and depend on ffmpeg.
 capture = ["dep:moq-video", "dep:moq-audio", "moq-audio/capture"]
 
 [dependencies]

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -15,6 +15,14 @@ categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 [lib]
 doctest = false
 
+[features]
+# Statically link the libav* libraries instead of the system's shared
+# ffmpeg. Requires static archives (.a) plus their .pc files on the
+# pkg-config path; release builds point this at a Nix-built static ffmpeg
+# so the shipped CLI has no runtime ffmpeg dependency. Plain dev builds
+# leave it off and link the dynamic system ffmpeg (the Nix dev shell's).
+static = ["ffmpeg-next/static"]
+
 [dependencies]
 anyhow = "1"
 bytes = "1"

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -15,14 +15,6 @@ categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 [lib]
 doctest = false
 
-[features]
-# Statically link the libav* libraries instead of the system's shared
-# ffmpeg. Requires static archives (.a) plus their .pc files on the
-# pkg-config path; release builds point this at a Nix-built static ffmpeg
-# so the shipped CLI has no runtime ffmpeg dependency. Plain dev builds
-# leave it off and link the dynamic system ffmpeg (the Nix dev shell's).
-static = ["ffmpeg-next/static"]
-
 [dependencies]
 anyhow = "1"
 bytes = "1"


### PR DESCRIPTION
## Summary

Ships the `capture` feature (webcam + microphone → H.264/Opus publish) in the released `moq-cli` binaries, linking the **system ffmpeg dynamically** and declaring it as a package dependency.

This started as a fully-static musl build with ffmpeg bundled, but hardware encoding forced a pivot: **NVENC and VA-API load the GPU driver via `dlopen` at runtime, which a fully-static binary cannot do.** Static linking and the hardware-encode requirement are mutually exclusive, so the release now links ffmpeg dynamically and depends on it.

### What you get

Every encoder the platform ffmpeg ships is available:
- `h264_videotoolbox` (macOS), `h264_nvenc` (NVIDIA), `h264_vaapi` (Intel/AMD), `h264_v4l2m2m` (Linux/embedded), plus `libx264` software.
- NVENC/VA-API only need the matching GPU driver present at runtime; otherwise capture falls back gracefully.

### Build mechanics

- **Linux `.deb`/`.rpm`**: built natively on `ubuntu-22.04` (glibc 2.35 floor) against the distro `libav*-dev`; `Depends: ffmpeg` (enable RPM Fusion on Fedora/RHEL). nfpm config gains the dependency.
- **macOS tarball**: built natively per arch (`macos-13` Intel, `macos-latest` arm) against Homebrew ffmpeg — no cross-compile or Rosetta. Formula gains `depends_on "ffmpeg"`.
- **nix** is retained for the Docker image + dev shell, now linking `ffmpeg-full` dynamically (a cached nixpkgs build). Drops `moq-cli-static`, the cross-darwin `moq-cli` output, the custom static ffmpeg/x264 machinery, and `moq-video`'s `static` feature.

### Side benefits

Removes the static-ffmpeg build (and its elfutils / x264 / QTKit warts) and the ffmpeg-redistribution / LGPL obligation, since we link the user's ffmpeg rather than ship one.

## Known limitations / follow-ups

- The `.deb`/`.rpm` declare a coarse `Depends: ffmpeg` rather than a precise versioned libav* soname (nfpm doesn't run `dpkg-shlibdeps`). A package built on 22.04 targets that libav* ABI; installing on a much newer distro could mismatch. Wiring up `dpkg-shlibdeps` (or per-release builds) is a follow-up.
- `macos-13` is the last Intel runner image; x86_64 macOS support tracks its availability.

## Test plan

- [x] `cargo build -p moq-cli --features capture` links libav* dynamically (verified locally, `otool -L`).
- [x] `nix flake check` evaluates on x86_64-linux and aarch64-darwin (no `moq-cli-static`).
- [x] `nixfmt --check`, `cargo fmt --check`, `cargo sort --check` clean.
- [ ] CI: native `.deb`/`.rpm` build + install, macOS tarball, NVENC/VA-API on a GPU host (CI-only).

(Written by Claude)