### PR TITLE
refactor(moq-gst): moqsrc reconcile follow-ups (#1647)

### DIFF
--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -246,12 +246,19 @@ impl MoqSrc {
 	}
 }
 
+/// The identity we reconcile a rendition on: a change to either field tears the pad down and
+/// recreates it. Caps cover codec/resolution; the container descriptor covers the wire framing
+/// (e.g. legacy -> cmaf).
+#[derive(Clone, PartialEq)]
+struct Shape {
+	caps: gst::Caps,
+	container: hang::catalog::Container,
+}
+
 /// A rendition we're currently serving, keyed in the session by moq track name.
 struct ActiveTrack {
-	/// The negotiated caps; a catalog update that changes them recreates the pad.
-	caps: gst::Caps,
-	/// The wire container; a change (e.g. legacy -> cmaf) also recreates the pad.
-	container: hang::catalog::Container,
+	/// Identity we diff against on each catalog update; a change recreates the pad.
+	shape: Shape,
 	/// Tells the pump to drop its pad and exit (set on shutdown or when reconcile
 	/// removes/replaces the rendition).
 	cancel: watch::Sender<bool>,
@@ -347,63 +354,67 @@ fn reconcile(
 ) -> Result<()> {
 	struct Desired {
 		kind: TrackKind,
-		caps: gst::Caps,
-		/// The hang container descriptor, kept for change detection against an [`ActiveTrack`].
-		container_hint: hang::catalog::Container,
-		/// The resolved wire container, moved into the pump when we spawn it.
-		container: moq_mux::catalog::hang::Container,
+		shape: Shape,
 	}
 
-	// Resolve caps and the wire container up front. A rendition we can't handle (unsupported
-	// codec, malformed CMAF init) is logged and skipped rather than failing the whole session,
-	// so one bad rendition in a catalog update can't tear down the others we're already serving.
-	let resolve = |kind, caps: Result<gst::Caps>, hint: &hang::catalog::Container| -> Result<Desired> {
-		Ok(Desired {
-			kind,
-			caps: caps?,
-			container: moq_mux::catalog::hang::Container::try_from(hint)?,
-			container_hint: hint.clone(),
-		})
-	};
-
+	// Build the desired shape for each rendition. This is deliberately cheap: caps come from the
+	// catalog config and the container is just the hang descriptor. We defer parsing the wire
+	// container (which re-parses the CMAF init) to spawn time below, so an unchanged rendition
+	// costs nothing here. A rendition whose caps we can't build (unsupported codec) is logged and
+	// skipped rather than failing the whole session, so one bad rendition can't tear down the
+	// others we're already serving.
 	let mut desired: HashMap<String, Desired> = HashMap::new();
-	for (name, config) in &catalog.video.renditions {
-		match resolve(TrackKind::Video, video_caps(config), &config.container) {
-			Ok(d) => {
-				desired.insert(name.clone(), d);
-			}
-			Err(err) => gst::warning!(CAT, "ignoring video rendition {name}: {err:?}"),
+	let mut insert = |name: &String, kind, caps: Result<gst::Caps>, container: &hang::catalog::Container| match caps {
+		Ok(caps) => {
+			let shape = Shape {
+				caps,
+				container: container.clone(),
+			};
+			desired.insert(name.clone(), Desired { kind, shape });
 		}
+		Err(err) => gst::warning!(CAT, "ignoring {kind:?} rendition {name}: {err:?}"),
+	};
+	for (name, config) in &catalog.video.renditions {
+		insert(name, TrackKind::Video, video_caps(config), &config.container);
 	}
 	for (name, config) in &catalog.audio.renditions {
-		match resolve(TrackKind::Audio, audio_caps(config), &config.container) {
-			Ok(d) => {
-				desired.insert(name.clone(), d);
-			}
-			Err(err) => gst::warning!(CAT, "ignoring audio rendition {name}: {err:?}"),
+		insert(name, TrackKind::Audio, audio_caps(config), &config.container);
+	}
+
+	// Pure set math: which active pads to tear down, which renditions to spawn.
+	let plan = plan_reconcile(
+		&desired
+			.iter()
+			.map(|(name, d)| (name.clone(), d.shape.clone()))
+			.collect(),
+		&active.iter().map(|(name, t)| (name.clone(), t.shape.clone())).collect(),
+	);
+
+	// Drop anything that disappeared or changed shape; each cancelled pump drops its own pad.
+	// Changed renditions also land in `plan.add`, so they respawn below under a fresh pad id.
+	for name in plan.remove {
+		if let Some(track) = active.remove(&name) {
+			let _ = track.cancel.send(true);
 		}
 	}
 
-	// Drop anything that disappeared or changed shape; survivors stay put, and the changed
-	// ones get respawned below under a fresh pad id. Each cancelled pump drops its own pad.
-	active.retain(|name, track| match desired.get(name) {
-		Some(d) if d.caps == track.caps && d.container_hint == track.container => true,
-		_ => {
-			let _ = track.cancel.send(true);
-			false
-		}
-	});
-
-	// Spawn pumps for the renditions we aren't already serving.
-	for (name, d) in desired {
-		if active.contains_key(&name) {
-			continue;
-		}
+	// Spawn pumps for new or changed renditions. The wire container is parsed here, lazily and
+	// only for renditions we're actually starting, since parsing a CMAF init is wasted work for
+	// renditions that didn't change. A parse failure (malformed init) skips just this rendition.
+	for name in plan.add {
+		let d = &desired[&name];
+		let container = match moq_mux::catalog::hang::Container::try_from(&d.shape.container) {
+			Ok(container) => container,
+			Err(err) => {
+				gst::warning!(CAT, "ignoring rendition {name}: {err:?}");
+				continue;
+			}
+		};
 
 		let id = NEXT_PAD_ID.fetch_add(1, Ordering::Relaxed);
 
 		let track_consumer = broadcast.subscribe_track(&moq_net::Track::new(&name))?;
-		let track = moq_mux::container::Consumer::new(track_consumer, d.container).with_latency(Duration::from_secs(1));
+		let track = moq_mux::container::Consumer::new(track_consumer, container).with_latency(Duration::from_secs(1));
 
 		let descriptor = TrackDescriptor {
 			kind: d.kind,
@@ -412,15 +423,14 @@ fn reconcile(
 		};
 		let (cancel_tx, cancel_rx) = watch::channel(false);
 		let task = pumps.spawn_on(
-			run_pump(element.clone(), descriptor, d.caps.clone(), track, cancel_rx),
+			run_pump(element.clone(), descriptor, d.shape.caps.clone(), track, cancel_rx),
 			RUNTIME.handle(),
 		);
 
 		active.insert(
 			name,
 			ActiveTrack {
-				caps: d.caps,
-				container: d.container_hint,
+				shape: d.shape.clone(),
 				cancel: cancel_tx,
 				task,
 			},
@@ -428,6 +438,28 @@ fn reconcile(
 	}
 
 	Ok(())
+}
+
+/// Tear-down / spawn decisions for one catalog update, computed purely from the desired and
+/// active rendition sets. A name present in both with an equal shape is left untouched; a name
+/// whose shape changed lands in both lists (cancel the old pump, spawn a fresh one).
+struct ReconcilePlan {
+	remove: Vec<String>,
+	add: Vec<String>,
+}
+
+fn plan_reconcile<S: PartialEq>(desired: &HashMap<String, S>, active: &HashMap<String, S>) -> ReconcilePlan {
+	let remove = active
+		.iter()
+		.filter(|(name, shape)| desired.get(*name) != Some(*shape))
+		.map(|(name, _)| name.clone())
+		.collect();
+	let add = desired
+		.iter()
+		.filter(|(name, shape)| active.get(*name) != Some(*shape))
+		.map(|(name, _)| name.clone())
+		.collect();
+	ReconcilePlan { remove, add }
 }
 
 /// Identifies a pump's pad. Pads are named `video_<id>` / `audio_<id>` from a
@@ -471,12 +503,16 @@ async fn run_pump(
 			frame = track.read() => match frame {
 				Ok(Some(frame)) => {
 					let buffer = build_buffer(frame, &mut reference_ts, descriptor.kind);
-					if pad.push(buffer).is_err() {
+					// pad.push() blocks until downstream accepts the buffer (full queues, a
+					// clock-synced sink). block_in_place hands our sibling tasks to another
+					// worker so a stalled downstream can't pin a runtime thread and starve
+					// the session loop or other pumps.
+					if tokio::task::block_in_place(|| pad.push(buffer)).is_err() {
 						break;
 					}
 				}
 				Ok(None) => {
-					let _ = pad.push_event(gst::event::Eos::builder().build());
+					let _ = tokio::task::block_in_place(|| pad.push_event(gst::event::Eos::builder().build()));
 					break;
 				}
 				Err(err) => {
@@ -643,8 +679,56 @@ fn audio_caps(config: &hang::catalog::AudioConfig) -> Result<gst::Caps> {
 
 #[cfg(test)]
 mod tests {
-	use super::relative_pts;
+	use super::{plan_reconcile, relative_pts};
 	use moq_mux::container::Timestamp;
+	use std::collections::HashMap;
+
+	// The shape type is generic, so the set math can be exercised with a plain integer standing
+	// in for (caps, container): equal value == unchanged rendition, different value == reshape.
+	fn renditions(pairs: &[(&str, u32)]) -> HashMap<String, u32> {
+		pairs.iter().map(|(name, shape)| (name.to_string(), *shape)).collect()
+	}
+
+	fn sorted(mut names: Vec<String>) -> Vec<String> {
+		names.sort();
+		names
+	}
+
+	#[test]
+	fn plan_reconcile_diffs_by_name_and_shape() {
+		// keep: same shape (untouched). gone: removed. added: new. changed: same name, new
+		// shape, so it must be both torn down and respawned.
+		let active = renditions(&[("keep", 1), ("gone", 1), ("changed", 1)]);
+		let desired = renditions(&[("keep", 1), ("changed", 2), ("added", 9)]);
+
+		let plan = plan_reconcile(&desired, &active);
+		assert_eq!(sorted(plan.remove), vec!["changed", "gone"]);
+		assert_eq!(sorted(plan.add), vec!["added", "changed"]);
+	}
+
+	#[test]
+	fn plan_reconcile_noops_on_identical_sets() {
+		let set = renditions(&[("a", 1), ("b", 2)]);
+		let plan = plan_reconcile(&set, &set);
+		assert!(plan.remove.is_empty());
+		assert!(plan.add.is_empty());
+	}
+
+	#[test]
+	fn plan_reconcile_empty_desired_removes_all() {
+		let active = renditions(&[("a", 1), ("b", 2)]);
+		let plan = plan_reconcile(&HashMap::new(), &active);
+		assert_eq!(sorted(plan.remove), vec!["a", "b"]);
+		assert!(plan.add.is_empty());
+	}
+
+	#[test]
+	fn plan_reconcile_empty_active_adds_all() {
+		let desired = renditions(&[("a", 1), ("b", 2)]);
+		let plan = plan_reconcile(&desired, &HashMap::new());
+		assert!(plan.remove.is_empty());
+		assert_eq!(sorted(plan.add), vec!["a", "b"]);
+	}
 
 	#[test]
 	fn relative_pts_clamps_backwards_timestamps() {


### PR DESCRIPTION
Closes #1647 — the three low-priority cleanups deferred from the #1633 review (the two real bugs were fixed in #1646). All `moqsrc`-internal; no wire, config, or public-API change.

## Changes

- **Isolate the blocking `pad.push()` on tokio workers.** Each pump pushes synchronously from a task on the shared `RUNTIME`. If several downstreams stall at once (full queues, clock-synced sinks), blocked pushes could occupy all worker threads and starve the session loop. The steady-state `pad.push()` and the end-of-stream EOS `push_event` now run inside `tokio::task::block_in_place`, so a stalled downstream hands sibling tasks to another worker instead of pinning a runtime thread.

- **Parse the wire container lazily.** `reconcile` previously called `Container::try_from` (which re-parses the fMP4 init via `fmp4::Wire::from_init`) for *every* rendition on *every* catalog update, then discarded the result for renditions that didn't change. It now diffs on a cheap `Shape` (caps + hang container descriptor) and only resolves the wire container for renditions it actually spawns. A malformed init still skips just that one rendition.

- **Unit-test the reconcile set math.** Extracted the desired-vs-active decision into a pure, generic `plan_reconcile(desired, active) -> ReconcilePlan { remove, add }`; the I/O-heavy `reconcile` just drives the plan. Added four tests (diff by name/shape, no-op on identical sets, empty-desired-removes-all, empty-active-adds-all) using a plain integer as the stand-in shape, so the math is exercised without constructing gst/hang types.

## Test plan

Run through `nix develop` to match CI's pinned toolchain:

- [x] `cargo test -p moq-gst` — 5 passed (4 new + existing `relative_pts`)
- [x] `cargo clippy -p moq-gst --all-targets` — clean
- [x] `cargo fmt -p moq-gst --check` — clean

Cross-Package Sync: moqsrc-internal refactor, no paired `doc/` or other-package updates needed.

(Written by Claude)