### PR TITLE
Mux import with existing track

### DIFF
--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -190,6 +190,9 @@ class BroadcastProducer:
     def publish_media(self, format: str, init: bytes) -> MediaProducer:
         return MediaProducer(self._inner.publish_media(format, init))
 
+    def publish_media_on_track(self, track: TrackProducer, format: str, init: bytes) -> MediaProducer:
+        return MediaProducer(self._inner.publish_media_on_track(track._inner, format, init))
+
     def publish_media_stream(self, format: str) -> MediaStreamProducer:
         """Publish a media track fed by a raw byte stream (unknown frame
         boundaries). `format` is a stream format (avc3, hev1, av01, fmp4, mkv)."""

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import struct
+from typing import cast
 
 import moq
 import pytest
@@ -255,6 +256,42 @@ async def test_dynamic_track_request():
     assert frame == payload
 
     track.finish()
+
+
+async def test_dynamic_track_request_can_publish_media():
+    broadcast = moq.BroadcastProducer()
+    dynamic = broadcast.dynamic()
+    consumer = broadcast.consume()
+    catalog_consumer = consumer.subscribe_catalog()
+    media_consumer = consumer.subscribe_media(
+        "requested-audio",
+        cast(moq.Container, moq.Container.LEGACY()),
+        10_000,
+    )
+
+    track = await asyncio.wait_for(dynamic.requested_track(), timeout=5.0)
+    assert track.name == "requested-audio"
+
+    media = broadcast.publish_media_on_track(track, "opus", opus_head())
+    assert media.name == "requested-audio"
+    with pytest.raises(Exception):
+        _ = track.name
+
+    catalog = await asyncio.wait_for(anext(catalog_consumer), timeout=5.0)
+    audio = catalog.audio["requested-audio"]
+    assert audio.codec == "opus"
+    assert audio.sample_rate == 48000
+    assert audio.channel_count == 2
+
+    payload = b"dynamic opus frame"
+    media.write_frame(payload, 20_000)
+
+    async for frame in media_consumer:
+        assert frame.payload == payload
+        assert frame.timestamp_us == 20_000
+        break
+
+    media.finish()
 
 
 def test_raw_append_group_sequence_increments():

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -143,6 +143,48 @@ impl MoqBroadcastProducer {
 		}))
 	}
 
+	/// Publish media on an existing track, usually one returned by
+	/// [`MoqBroadcastDynamic::requested_track`].
+	///
+	/// `format` controls the encoding of `init` and frame payloads. Only
+	/// single-track formats are supported.
+	pub fn publish_media_on_track(
+		&self,
+		track: &MoqTrackProducer,
+		format: String,
+		init: Vec<u8>,
+	) -> Result<Arc<MoqMediaProducer>, MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		let guard = self.state.lock().unwrap();
+		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
+		let format = moq_mux::import::FramedFormat::from_str(&format)
+			.map_err(|_| MoqError::Codec(format!("unknown format: {format}")))?;
+
+		let track_clone = {
+			let guard = track.inner.lock().unwrap();
+			guard.as_ref().ok_or_else(|| MoqError::Closed)?.clone()
+		};
+
+		let mut buf = init.as_slice();
+		let decoder =
+			moq_mux::import::Framed::new_with_track(track_clone.clone(), state.catalog.clone(), format, &mut buf)
+				.map_err(|err| MoqError::Codec(format!("init failed: {err}")))?;
+
+		if buf.has_remaining() {
+			return Err(MoqError::Codec("init failed: trailing bytes".into()));
+		}
+
+		let mut guard = track.inner.lock().unwrap();
+		guard.take().ok_or_else(|| MoqError::Closed)?;
+
+		Ok(Arc::new(MoqMediaProducer {
+			inner: std::sync::Mutex::new(Some(MediaProducer {
+				decoder,
+				track: track_clone,
+			})),
+		}))
+	}
+
 	/// Create a media track fed by a raw byte stream with unknown frame
 	/// boundaries (e.g. piped Annex-B H.264 straight from an encoder).
 	///

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -115,6 +115,55 @@ async fn dynamic_track_request_can_abort() {
 }
 
 #[tokio::test]
+async fn dynamic_track_request_can_publish_media() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let dynamic = broadcast.dynamic().unwrap();
+	let consumer = broadcast.consume().unwrap();
+	let catalog_consumer = consumer.subscribe_catalog().unwrap();
+	let media_consumer = consumer
+		.subscribe_media("requested-audio".into(), crate::media::Container::Legacy, 10_000)
+		.unwrap();
+
+	let track = tokio::time::timeout(TIMEOUT, dynamic.requested_track())
+		.await
+		.expect("timed out waiting for requested track")
+		.unwrap();
+	assert_eq!(track.name().unwrap(), "requested-audio");
+
+	let media = broadcast
+		.publish_media_on_track(&track, "opus".into(), opus_head())
+		.unwrap();
+	assert_eq!(media.name().unwrap(), "requested-audio");
+	assert!(matches!(track.name(), Err(MoqError::Closed)));
+
+	let catalog = tokio::time::timeout(TIMEOUT, catalog_consumer.next())
+		.await
+		.expect("timed out waiting for catalog")
+		.unwrap()
+		.expect("expected a catalog");
+	let audio = catalog
+		.audio
+		.get("requested-audio")
+		.expect("requested track should be in catalog");
+	assert_eq!(audio.codec, "opus");
+	assert_eq!(audio.sample_rate, 48000);
+	assert_eq!(audio.channel_count, 2);
+
+	let payload = b"dynamic opus frame".to_vec();
+	media.write_frame(payload.clone(), 20_000).unwrap();
+
+	let frame = tokio::time::timeout(TIMEOUT, media_consumer.next())
+		.await
+		.expect("timed out waiting for media frame")
+		.unwrap()
+		.expect("expected a frame");
+	assert_eq!(frame.payload, payload);
+	assert_eq!(frame.timestamp_us, 20_000);
+
+	media.finish().unwrap();
+}
+
+#[tokio::test]
 async fn media_track_activity_and_name() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -17,11 +17,31 @@ pub struct Import<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Import<E> {
 	pub fn new(
-		mut broadcast: moq_net::BroadcastProducer,
+		broadcast: moq_net::BroadcastProducer,
+		catalog: crate::catalog::Producer<E>,
+		config: Config,
+	) -> anyhow::Result<Self> {
+		Self::new_with_source(
+			crate::track_provider::TrackProvider::unique(broadcast, ".aac"),
+			catalog,
+			config,
+		)
+	}
+
+	pub fn new_with_track(
+		track: moq_net::TrackProducer,
+		catalog: crate::catalog::Producer<E>,
+		config: Config,
+	) -> anyhow::Result<Self> {
+		Self::new_with_source(crate::track_provider::TrackProvider::fixed(track), catalog, config)
+	}
+
+	fn new_with_source(
+		mut tracks: crate::track_provider::TrackProvider,
 		mut catalog: crate::catalog::Producer<E>,
 		config: Config,
 	) -> anyhow::Result<Self> {
-		let track = broadcast.unique_track(".aac")?;
+		let track = tracks.create()?;
 
 		let mut audio_config = hang::catalog::AudioConfig::new(
 			hang::catalog::AAC {

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -7,8 +7,8 @@ use scuffle_av1::seq::SequenceHeaderObu;
 
 /// A decoder for AV1 with inline sequence headers.
 pub struct Import {
-	// The broadcast being produced.
-	broadcast: moq_net::BroadcastProducer,
+	// Where new media tracks come from.
+	tracks: crate::track_provider::TrackProvider,
 
 	// The catalog being produced.
 	catalog: crate::catalog::Producer,
@@ -39,7 +39,19 @@ struct Frame {
 impl Import {
 	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer) -> Self {
 		Self {
-			broadcast,
+			tracks: crate::track_provider::TrackProvider::unique(broadcast, ".av01"),
+			catalog,
+			track: None,
+			config: None,
+			current: Default::default(),
+			zero: None,
+			jitter: MinFrameDuration::new(),
+		}
+	}
+
+	pub fn new_with_track(track: moq_net::TrackProducer, catalog: crate::catalog::Producer) -> Self {
+		Self {
+			tracks: crate::track_provider::TrackProvider::fixed(track),
 			catalog,
 			track: None,
 			config: None,
@@ -87,12 +99,16 @@ impl Import {
 			return Ok(());
 		}
 
-		if let Some(track) = &self.track.take() {
+		if self.track.is_some() && self.tracks.is_fixed() {
+			anyhow::bail!("fixed track cannot be reconfigured");
+		}
+
+		if let Some(track) = self.track.take() {
 			tracing::debug!(name = ?track.name, "reinitializing track");
 			self.catalog.lock().video.renditions.remove(&track.name);
 		}
 
-		let track = self.broadcast.unique_track(".av01")?;
+		let track = self.tracks.create()?;
 		tracing::debug!(name = ?track.name, ?config, "starting track");
 		self.catalog
 			.lock()
@@ -127,7 +143,11 @@ impl Import {
 		});
 		config.container = hang::catalog::Container::Legacy;
 
-		let track = self.broadcast.unique_track(".av01")?;
+		if self.track.is_some() && self.tracks.is_fixed() {
+			anyhow::bail!("fixed track cannot be reconfigured");
+		}
+
+		let track = self.tracks.create()?;
 		tracing::debug!(name = ?track.name, "starting track with minimal config");
 		self.catalog
 			.lock()
@@ -200,11 +220,15 @@ impl Import {
 			return Ok(());
 		}
 
-		if let Some(track) = &self.track.take() {
+		if self.track.is_some() && self.tracks.is_fixed() {
+			anyhow::bail!("fixed track cannot be reconfigured");
+		}
+
+		if let Some(track) = self.track.take() {
 			self.catalog.lock().video.renditions.remove(&track.name);
 		}
 
-		let track = self.broadcast.unique_track(".av01")?;
+		let track = self.tracks.create()?;
 		self.catalog
 			.lock()
 			.video

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -31,7 +31,7 @@ pub enum Mode {
 /// input streams; the shape is detected from the first bytes the caller
 /// supplies, or forced explicitly via [`with_mode`](Self::with_mode).
 pub struct Import<E: CatalogExt = ()> {
-	broadcast: moq_net::BroadcastProducer,
+	tracks: crate::track_provider::TrackProvider,
 	catalog: crate::catalog::Producer<E>,
 	track: Option<crate::container::Producer<crate::catalog::hang::Container>>,
 	config: Option<hang::catalog::VideoConfig>,
@@ -65,7 +65,19 @@ struct Avc3Frame {
 impl<E: CatalogExt> Import<E> {
 	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
 		Self {
-			broadcast,
+			tracks: crate::track_provider::TrackProvider::unique(broadcast, ".avc3"),
+			catalog,
+			track: None,
+			config: None,
+			state: State::Pending { mode_hint: None },
+			zero: None,
+			jitter: MinFrameDuration::new(),
+		}
+	}
+
+	pub fn new_with_track(track: moq_net::TrackProducer, catalog: crate::catalog::Producer<E>) -> Self {
+		Self {
+			tracks: crate::track_provider::TrackProvider::fixed(track),
 			catalog,
 			track: None,
 			config: None,
@@ -82,12 +94,14 @@ impl<E: CatalogExt> Import<E> {
 	pub fn with_mode(mut self, mode: Mode) -> anyhow::Result<Self> {
 		match mode {
 			Mode::Avc1 => {
+				self.tracks.set_suffix(".avc1");
 				self.state = State::Pending {
 					mode_hint: Some(Mode::Avc1),
 				};
 			}
 			Mode::Avc3 => {
-				let track = self.broadcast.unique_track(".avc3")?;
+				self.tracks.set_suffix(".avc3");
+				let track = self.tracks.create()?;
 				self.track = Some(
 					crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy)
 						.with_lenient_start(),
@@ -150,7 +164,8 @@ impl<E: CatalogExt> Import<E> {
 		config.description = Some(Bytes::copy_from_slice(avcc_bytes));
 		config.container = hang::catalog::Container::Legacy;
 
-		self.swap_config(config, ".avc1")?;
+		self.tracks.set_suffix(".avc1");
+		self.swap_config(config)?;
 		buf.advance(buf.remaining());
 
 		Ok(())
@@ -168,7 +183,8 @@ impl<E: CatalogExt> Import<E> {
 				pps: None,
 			};
 			if self.track.is_none() {
-				let track = self.broadcast.unique_track(".avc3")?;
+				self.tracks.set_suffix(".avc3");
+				let track = self.tracks.create()?;
 				self.track = Some(
 					crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy)
 						.with_lenient_start(),
@@ -428,7 +444,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Replace the current track + catalog rendition with `config`. Used by
 	/// the avc1 path on every (re)initialization.
-	fn swap_config(&mut self, config: hang::catalog::VideoConfig, suffix: &str) -> anyhow::Result<()> {
+	fn swap_config(&mut self, config: hang::catalog::VideoConfig) -> anyhow::Result<()> {
 		if let Some(old) = &self.config
 			&& old == &config
 		{
@@ -437,10 +453,14 @@ impl<E: CatalogExt> Import<E> {
 
 		let mut catalog = self.catalog.lock();
 		if let Some(track) = self.track.take() {
+			if self.tracks.is_fixed() {
+				self.track = Some(track);
+				anyhow::bail!("fixed track cannot be reconfigured");
+			}
 			tracing::debug!(name = ?track.name, "reinitializing H.264 track");
 			catalog.video.renditions.remove(&track.name);
 		}
-		let track = self.broadcast.unique_track(suffix)?;
+		let track = self.tracks.create()?;
 		tracing::debug!(name = ?track.name, ?config, "starting H.264 track");
 		catalog.video.renditions.insert(track.name.clone(), config.clone());
 

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -9,8 +9,8 @@ use scuffle_h265::{NALUnitType, SpsNALUnit};
 /// A decoder for H.265 with inline SPS/PPS.
 /// Only supports single layer streams (VPS is cached but not parsed).
 pub struct Import<E: CatalogExt = ()> {
-	// The broadcast being produced.
-	broadcast: moq_net::BroadcastProducer,
+	// Where new media tracks come from.
+	tracks: crate::track_provider::TrackProvider,
 
 	// The catalog being produced.
 	catalog: crate::catalog::Producer<E>,
@@ -40,7 +40,22 @@ pub struct Import<E: CatalogExt = ()> {
 impl<E: CatalogExt> Import<E> {
 	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
 		Self {
-			broadcast,
+			tracks: crate::track_provider::TrackProvider::unique(broadcast, ".hev1"),
+			catalog,
+			track: None,
+			config: None,
+			current: Default::default(),
+			zero: None,
+			vps: None,
+			sps: None,
+			pps: None,
+			jitter: MinFrameDuration::new(),
+		}
+	}
+
+	pub fn new_with_track(track: moq_net::TrackProducer, catalog: crate::catalog::Producer<E>) -> Self {
+		Self {
+			tracks: crate::track_provider::TrackProvider::fixed(track),
 			catalog,
 			track: None,
 			config: None,
@@ -81,12 +96,16 @@ impl<E: CatalogExt> Import<E> {
 
 		let mut catalog = self.catalog.lock();
 
-		if let Some(track) = &self.track.take() {
+		if self.track.is_some() && self.tracks.is_fixed() {
+			anyhow::bail!("fixed track cannot be reconfigured");
+		}
+
+		if let Some(track) = self.track.take() {
 			tracing::debug!(name = ?track.name, "reinitializing track");
 			catalog.video.renditions.remove(&track.name);
 		}
 
-		let track = self.broadcast.unique_track(".hev1")?;
+		let track = self.tracks.create()?;
 		tracing::debug!(name = ?track.name, ?config, "starting track");
 		catalog.video.renditions.insert(track.name.clone(), config.clone());
 

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -16,11 +16,31 @@ pub struct Import {
 
 impl Import {
 	pub fn new(
-		mut broadcast: moq_net::BroadcastProducer,
+		broadcast: moq_net::BroadcastProducer,
+		catalog: crate::catalog::Producer,
+		config: Config,
+	) -> anyhow::Result<Self> {
+		Self::new_with_source(
+			crate::track_provider::TrackProvider::unique(broadcast, ".opus"),
+			catalog,
+			config,
+		)
+	}
+
+	pub fn new_with_track(
+		track: moq_net::TrackProducer,
+		catalog: crate::catalog::Producer,
+		config: Config,
+	) -> anyhow::Result<Self> {
+		Self::new_with_source(crate::track_provider::TrackProvider::fixed(track), catalog, config)
+	}
+
+	fn new_with_source(
+		mut tracks: crate::track_provider::TrackProvider,
 		mut catalog: crate::catalog::Producer,
 		config: Config,
 	) -> anyhow::Result<Self> {
-		let track = broadcast.unique_track(".opus")?;
+		let track = tracks.create()?;
 
 		let mut audio_config = hang::catalog::AudioConfig::new(
 			hang::catalog::AudioCodec::Opus,

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -12,8 +12,8 @@ use super::FrameHeader;
 /// header supplies the catalog dimensions; the track is created lazily so the
 /// importer can be constructed before any media arrives.
 pub struct Import {
-	// The broadcast being produced.
-	broadcast: moq_net::BroadcastProducer,
+	// Where new media tracks come from.
+	tracks: crate::track_provider::TrackProvider,
 
 	// The catalog being produced.
 	catalog: crate::catalog::Producer,
@@ -34,7 +34,18 @@ pub struct Import {
 impl Import {
 	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer) -> Self {
 		Self {
-			broadcast,
+			tracks: crate::track_provider::TrackProvider::unique(broadcast, ".vp8"),
+			catalog,
+			track: None,
+			config: None,
+			zero: None,
+			jitter: MinFrameDuration::new(),
+		}
+	}
+
+	pub fn new_with_track(track: moq_net::TrackProducer, catalog: crate::catalog::Producer) -> Self {
+		Self {
+			tracks: crate::track_provider::TrackProvider::fixed(track),
 			catalog,
 			track: None,
 			config: None,
@@ -66,12 +77,16 @@ impl Import {
 			return Ok(());
 		}
 
+		if self.track.is_some() && self.tracks.is_fixed() {
+			anyhow::bail!("fixed track cannot be reconfigured");
+		}
+
 		if let Some(track) = self.track.take() {
 			tracing::debug!(name = ?track.name, "reinitializing track");
 			self.catalog.lock().video.renditions.remove(&track.name);
 		}
 
-		let track = self.broadcast.unique_track(".vp8")?;
+		let track = self.tracks.create()?;
 		tracing::debug!(name = ?track.name, ?config, "starting track");
 		self.catalog
 			.lock()

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -12,8 +12,8 @@ use super::FrameHeader;
 /// [`decode_frame`](Self::decode_frame). The first key frame's header supplies
 /// the catalog config; the track is created lazily.
 pub struct Import {
-	// The broadcast being produced.
-	broadcast: moq_net::BroadcastProducer,
+	// Where new media tracks come from.
+	tracks: crate::track_provider::TrackProvider,
 
 	// The catalog being produced.
 	catalog: crate::catalog::Producer,
@@ -34,7 +34,18 @@ pub struct Import {
 impl Import {
 	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer) -> Self {
 		Self {
-			broadcast,
+			tracks: crate::track_provider::TrackProvider::unique(broadcast, ".vp09"),
+			catalog,
+			track: None,
+			config: None,
+			zero: None,
+			jitter: MinFrameDuration::new(),
+		}
+	}
+
+	pub fn new_with_track(track: moq_net::TrackProducer, catalog: crate::catalog::Producer) -> Self {
+		Self {
+			tracks: crate::track_provider::TrackProvider::fixed(track),
 			catalog,
 			track: None,
 			config: None,
@@ -66,12 +77,16 @@ impl Import {
 			return Ok(());
 		}
 
+		if self.track.is_some() && self.tracks.is_fixed() {
+			anyhow::bail!("fixed track cannot be reconfigured");
+		}
+
 		if let Some(track) = self.track.take() {
 			tracing::debug!(name = ?track.name, "reinitializing track");
 			self.catalog.lock().video.renditions.remove(&track.name);
 		}
 
-		let track = self.broadcast.unique_track(".vp09")?;
+		let track = self.tracks.create()?;
 		tracing::debug!(name = ?track.name, ?config, "starting track");
 		self.catalog
 			.lock()

--- a/rs/moq-mux/src/import.rs
+++ b/rs/moq-mux/src/import.rs
@@ -193,6 +193,68 @@ impl Framed {
 		Ok(Self { decoder })
 	}
 
+	/// Create a new framed importer that publishes on an existing track.
+	///
+	/// Only single-track formats are supported. Container formats that may
+	/// create multiple MoQ tracks need an explicit track mapping API.
+	pub fn new_with_track<T: Buf + AsRef<[u8]>>(
+		track: moq_net::TrackProducer,
+		catalog: crate::catalog::Producer,
+		format: FramedFormat,
+		buf: &mut T,
+	) -> anyhow::Result<Self> {
+		use crate::codec::h264::Mode as H264Mode;
+		let decoder = match format {
+			FramedFormat::Avc1 => {
+				let mut decoder =
+					crate::codec::h264::Import::new_with_track(track, catalog).with_mode(H264Mode::Avc1)?;
+				decoder.initialize(buf)?;
+				FramedKind::H264(decoder)
+			}
+			FramedFormat::Avc3 => {
+				let mut decoder =
+					crate::codec::h264::Import::new_with_track(track, catalog).with_mode(H264Mode::Avc3)?;
+				decoder.initialize(buf)?;
+				FramedKind::H264(decoder)
+			}
+			FramedFormat::Hev1 => {
+				let mut decoder = crate::codec::h265::Import::new_with_track(track, catalog);
+				decoder.initialize(buf)?;
+				FramedKind::Hev1(decoder)
+			}
+			FramedFormat::Av01 => {
+				let mut decoder = crate::codec::av1::Import::new_with_track(track, catalog);
+				decoder.initialize(buf)?;
+				FramedKind::Av01(decoder)
+			}
+			FramedFormat::Vp8 => {
+				let mut decoder = crate::codec::vp8::Import::new_with_track(track, catalog);
+				decoder.initialize(buf)?;
+				FramedKind::Vp8(decoder)
+			}
+			FramedFormat::Vp9 => {
+				let mut decoder = crate::codec::vp9::Import::new_with_track(track, catalog);
+				decoder.initialize(buf)?;
+				FramedKind::Vp9(decoder)
+			}
+			FramedFormat::Aac => {
+				let config = crate::codec::aac::Config::parse(buf)?;
+				FramedKind::Aac(crate::codec::aac::Import::new_with_track(track, catalog, config)?)
+			}
+			FramedFormat::Opus => {
+				let config = crate::codec::opus::Config::parse(buf)?;
+				FramedKind::Opus(crate::codec::opus::Import::new_with_track(track, catalog, config)?)
+			}
+			FramedFormat::Fmp4 | FramedFormat::Mkv | FramedFormat::Ts => {
+				anyhow::bail!("{format} can publish multiple tracks")
+			}
+		};
+
+		anyhow::ensure!(!buf.has_remaining(), "buffer was not fully consumed");
+
+		Ok(Self { decoder })
+	}
+
 	/// Finish the decoder, flushing any buffered data.
 	pub fn finish(&mut self) -> anyhow::Result<()> {
 		match self.decoder {
@@ -288,6 +350,130 @@ impl From<crate::codec::aac::Import> for Framed {
 		Self {
 			decoder: FramedKind::Aac(aac),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::Duration;
+
+	use bytes::Bytes;
+
+	use super::*;
+	use crate::container::Timestamp;
+
+	fn opus_head() -> Vec<u8> {
+		let mut head = Vec::with_capacity(19);
+		head.extend_from_slice(b"OpusHead");
+		head.push(1);
+		head.push(2);
+		head.extend_from_slice(&0u16.to_le_bytes());
+		head.extend_from_slice(&48000u32.to_le_bytes());
+		head.extend_from_slice(&0u16.to_le_bytes());
+		head.push(0);
+		head
+	}
+
+	fn h264_init() -> Vec<u8> {
+		let mut init = Vec::new();
+		init.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+		init.extend_from_slice(&[
+			0x67, 0x64, 0x00, 0x1f, 0xac, 0x24, 0x84, 0x01, 0x40, 0x16, 0xec, 0x04, 0x40, 0x00, 0x00, 0x03, 0x00, 0x40,
+			0x00, 0x00, 0x0c, 0x23, 0xc6, 0x0c, 0x92,
+		]);
+		init.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+		init.extend_from_slice(&[0x68, 0xee, 0x32, 0xc8, 0xb0]);
+		init
+	}
+
+	fn new_broadcast() -> (moq_net::BroadcastProducer, crate::catalog::Producer) {
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+		(broadcast, catalog)
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn fixed_track_opus_uses_existing_name_and_delivers_frames() {
+		let (mut broadcast, catalog) = new_broadcast();
+		let track = broadcast.create_track(moq_net::Track::new("requested-audio")).unwrap();
+		let consumer = track.consume();
+		let init = opus_head();
+		let mut init = init.as_slice();
+
+		let mut framed = Framed::new_with_track(track, catalog.clone(), FramedFormat::Opus, &mut init).unwrap();
+
+		assert_eq!(framed.track().unwrap().name, "requested-audio");
+		let snapshot = catalog.snapshot();
+		assert!(snapshot.audio.renditions.contains_key("requested-audio"));
+		assert!(!snapshot.audio.renditions.contains_key("0.opus"));
+
+		let mut media = crate::container::Consumer::new(consumer, crate::catalog::hang::Container::Legacy);
+		let payload = b"opus payload".to_vec();
+		let mut frame = payload.as_slice();
+		framed
+			.decode_frame(&mut frame, Some(Timestamp::from_micros(1_000).unwrap()))
+			.unwrap();
+
+		let frame = tokio::time::timeout(Duration::from_secs(1), media.read())
+			.await
+			.unwrap()
+			.unwrap()
+			.unwrap();
+		assert_eq!(frame.payload, payload);
+		assert_eq!(frame.timestamp, Timestamp::from_micros(1_000).unwrap());
+
+		framed.finish().unwrap();
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn fixed_track_h264_uses_existing_name_in_catalog() {
+		let (mut broadcast, catalog) = new_broadcast();
+		let track = broadcast.create_track(moq_net::Track::new("camera")).unwrap();
+		let init = h264_init();
+		let mut init = init.as_slice();
+
+		let framed = Framed::new_with_track(track, catalog.clone(), FramedFormat::Avc3, &mut init).unwrap();
+
+		assert_eq!(framed.track().unwrap().name, "camera");
+		let snapshot = catalog.snapshot();
+		let video = snapshot.video.renditions.get("camera").unwrap();
+		assert_eq!(video.coded_width, Some(1280));
+		assert_eq!(video.coded_height, Some(720));
+		assert!(!snapshot.video.renditions.contains_key("0.avc3"));
+	}
+
+	#[test]
+	fn fixed_track_rejects_multi_track_formats() {
+		for format in [FramedFormat::Fmp4, FramedFormat::Mkv, FramedFormat::Ts] {
+			let (mut broadcast, catalog) = new_broadcast();
+			let track = broadcast.create_track(moq_net::Track::new("media")).unwrap();
+			let mut init = Bytes::new();
+
+			let err = match Framed::new_with_track(track, catalog, format, &mut init) {
+				Ok(_) => panic!("multi-track format should be rejected"),
+				Err(err) => err,
+			};
+			assert!(err.to_string().contains("multiple tracks"));
+		}
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn fixed_track_reconfiguration_errors() {
+		let (mut broadcast, catalog) = new_broadcast();
+		let track = broadcast.create_track(moq_net::Track::new("video")).unwrap();
+		let mut init = Bytes::new();
+		let mut framed = Framed::new_with_track(track, catalog, FramedFormat::Vp8, &mut init).unwrap();
+
+		let mut first = Bytes::from_static(&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x40, 0x01, 0xf0, 0x00]);
+		framed
+			.decode_frame(&mut first, Some(Timestamp::from_micros(0).unwrap()))
+			.unwrap();
+
+		let mut second = Bytes::from_static(&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a, 0x80, 0x02, 0xe0, 0x01]);
+		let err = framed
+			.decode_frame(&mut second, Some(Timestamp::from_micros(33_000).unwrap()))
+			.unwrap_err();
+		assert!(err.to_string().contains("fixed track cannot be reconfigured"));
 	}
 }
 

--- a/rs/moq-mux/src/lib.rs
+++ b/rs/moq-mux/src/lib.rs
@@ -21,6 +21,7 @@ pub mod codec;
 pub mod container;
 mod error;
 pub mod import;
+mod track_provider;
 
 pub use clock::Clock;
 pub use error::*;

--- a/rs/moq-mux/src/track_provider.rs
+++ b/rs/moq-mux/src/track_provider.rs
@@ -1,0 +1,34 @@
+pub(crate) enum TrackProvider {
+	Unique {
+		broadcast: moq_net::BroadcastProducer,
+		suffix: &'static str,
+	},
+	Fixed(moq_net::TrackProducer),
+}
+
+impl TrackProvider {
+	pub(crate) fn unique(broadcast: moq_net::BroadcastProducer, suffix: &'static str) -> Self {
+		Self::Unique { broadcast, suffix }
+	}
+
+	pub(crate) fn fixed(track: moq_net::TrackProducer) -> Self {
+		Self::Fixed(track)
+	}
+
+	pub(crate) fn is_fixed(&self) -> bool {
+		matches!(self, Self::Fixed(_))
+	}
+
+	pub(crate) fn set_suffix(&mut self, next: &'static str) {
+		if let Self::Unique { suffix, .. } = self {
+			*suffix = next;
+		}
+	}
+
+	pub(crate) fn create(&mut self) -> anyhow::Result<moq_net::TrackProducer> {
+		match self {
+			Self::Unique { broadcast, suffix } => Ok(broadcast.unique_track(suffix)?),
+			Self::Fixed(track) => Ok(track.clone()),
+		}
+	}
+}


### PR DESCRIPTION
The regular flow when creating mux import is to create a new track. This is fine most of the time but breaks when used together with dynamic tracks (produced by `requested_track`), we can't gracefully add the dynamic track to the catalog due to API limitations.

This PR adds support to moq-mux for importing from an already existing track.

There are no breaking changes, there is additional API and also the functionality has been added to moq-ffi.