### PR TITLE
ci: ship Windows binaries and automate winget releases

### DIFF
--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -177,9 +177,56 @@ jobs:
           name: moq-cli-${{ matrix.target }}
           path: dist/*
 
+  build-windows:
+    name: Build Windows zip (${{ matrix.target }})
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      # aws-lc-rs assembles its x86_64 crypto with NASM on Windows.
+      - name: Install NASM
+        shell: pwsh
+        run: |
+          choco install nasm -y --no-progress
+          "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Parse version
+        id: parse
+        shell: bash
+        run: .github/scripts/release.sh parse-version moq-cli
+
+      - name: Build and package zip
+        shell: bash
+        run: |
+          ./rs/scripts/package-windows.sh \
+            --crate moq-cli \
+            --target ${{ matrix.target }} \
+            --version ${{ steps.parse.outputs.version }} \
+            --output dist
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: moq-cli-${{ matrix.target }}
+          path: dist/*
+
   release:
     name: Release
-    needs: [build, build-tarball-macos]
+    needs: [build, build-tarball-macos, build-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/moq-relay.yml
+++ b/.github/workflows/moq-relay.yml
@@ -166,9 +166,56 @@ jobs:
           name: moq-relay-${{ matrix.target }}
           path: dist/*
 
+  build-windows:
+    name: Build Windows zip (${{ matrix.target }})
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      # aws-lc-rs assembles its x86_64 crypto with NASM on Windows.
+      - name: Install NASM
+        shell: pwsh
+        run: |
+          choco install nasm -y --no-progress
+          "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Parse version
+        id: parse
+        shell: bash
+        run: .github/scripts/release.sh parse-version moq-relay
+
+      - name: Build and package zip
+        shell: bash
+        run: |
+          ./rs/scripts/package-windows.sh \
+            --crate moq-relay \
+            --target ${{ matrix.target }} \
+            --version ${{ steps.parse.outputs.version }} \
+            --output dist
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: moq-relay-${{ matrix.target }}
+          path: dist/*
+
   release:
     name: Release
-    needs: [build, build-tarball-macos]
+    needs: [build, build-tarball-macos, build-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -163,9 +163,56 @@ jobs:
           name: moq-token-cli-${{ matrix.target }}
           path: dist/*
 
+  build-windows:
+    name: Build Windows zip (${{ matrix.target }})
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      # aws-lc-rs assembles its x86_64 crypto with NASM on Windows.
+      - name: Install NASM
+        shell: pwsh
+        run: |
+          choco install nasm -y --no-progress
+          "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Parse version
+        id: parse
+        shell: bash
+        run: .github/scripts/release.sh parse-version moq-token-cli
+
+      - name: Build and package zip
+        shell: bash
+        run: |
+          ./rs/scripts/package-windows.sh \
+            --crate moq-token-cli \
+            --target ${{ matrix.target }} \
+            --version ${{ steps.parse.outputs.version }} \
+            --output dist
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: moq-token-cli-${{ matrix.target }}
+          path: dist/*
+
   release:
     name: Release
-    needs: [build, build-tarball-macos]
+    needs: [build, build-tarball-macos, build-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -5,14 +5,20 @@ name: release-winget
 # created by the default GITHUB_TOKEN, which can't trigger a `release` event,
 # so this triggers on workflow_run like release-brew.yml.
 #
+# workflow_dispatch runs the same logic as a dry run: it resolves the winget
+# identifier and verifies the Windows .zip asset exists on the release, then
+# stops without opening a winget-pkgs PR. Use it to sanity-check a tag before
+# (or instead of) a real submission. winget-releaser itself has no dry-run
+# flag, hence the separate path.
+#
 # One-time bootstrap (winget-pkgs only lets you UPDATE an existing package):
 #   1. A maintainer lands the first manifest once via `wingetcreate new` (or a
 #      manual PR) for each PackageIdentifier below.
 #   2. Set the WINGET_TOKEN repo secret: a classic PAT with `public_repo`
 #      scope, owned by an account that has forked microsoft/winget-pkgs. By
 #      default the fork is looked up under the token owner.
-# After that every release is hands-off. Until the secret exists this is a
-# clean no-op.
+# After that every release is hands-off. Until the secret exists the real
+# submit is a clean no-op (the dry run still works without it).
 
 on:
   workflow_run:
@@ -22,6 +28,12 @@ on:
       - moq-token-cli
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to dry-run (e.g. moq-cli-v0.7.31)"
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,32 +42,40 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Single source of truth: the dry-run asset check and the winget-releaser
+  # submission must agree on which assets are the Windows installers.
+  INSTALLERS_REGEX: '-x86_64-pc-windows-msvc\.zip$'
+
 jobs:
   publish:
     name: Submit winget manifest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'moq-') }}
+    # workflow_run: only after a successful release of a moq-* tag.
+    # workflow_dispatch: always (it's an explicit dry run).
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'moq-')) }}
     runs-on: windows-latest
 
     steps:
-      - name: Check for WINGET_TOKEN
-        id: gate
+      - name: Resolve mode and tag
+        id: mode
         shell: bash
         env:
-          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+          RUN_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [[ -z "${WINGET_TOKEN}" ]]; then
-            echo "WINGET_TOKEN not configured; skipping winget submission." >&2
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$DISPATCH_TAG" >> "$GITHUB_OUTPUT"
           else
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "tag=$RUN_TAG" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Parse crate and version
-        if: steps.gate.outputs.enabled == 'true'
         id: parse
         shell: bash
         env:
-          TAG: ${{ github.event.workflow_run.head_branch }}
+          TAG: ${{ steps.mode.outputs.tag }}
         run: |
           if [[ ! "$TAG" =~ ^(.+)-v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)$ ]]; then
             echo "Tag format not recognized: $TAG" >&2
@@ -77,14 +97,48 @@ jobs:
             echo "tag=$TAG"
             echo "identifier=$identifier"
           } >> "$GITHUB_OUTPUT"
-          echo "Submitting $identifier $version (tag $TAG)"
+          echo "$identifier $version (tag $TAG)"
+
+      # Dry run: prove the release carries a Windows installer that the
+      # submission would match, then stop without opening a PR.
+      - name: Dry run (validate, do not submit)
+        if: steps.mode.outputs.dry_run == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.parse.outputs.tag }}
+        run: |
+          names=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
+          matched=$(echo "$names" | grep -E -e "$INSTALLERS_REGEX" || true)
+          if [[ -z "$matched" ]]; then
+            echo "No asset on $TAG matches $INSTALLERS_REGEX" >&2
+            echo "Available assets:" >&2
+            echo "$names" >&2
+            exit 1
+          fi
+          echo "Dry run OK. Would submit ${{ steps.parse.outputs.identifier }} ${{ steps.parse.outputs.version }} with installer(s):"
+          echo "$matched"
+
+      - name: Check for WINGET_TOKEN
+        if: steps.mode.outputs.dry_run == 'false'
+        id: gate
+        shell: bash
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if [[ -z "${WINGET_TOKEN}" ]]; then
+            echo "WINGET_TOKEN not configured; skipping winget submission." >&2
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Submit to winget-pkgs
-        if: steps.gate.outputs.enabled == 'true'
+        if: steps.mode.outputs.dry_run == 'false' && steps.gate.outputs.enabled == 'true'
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: ${{ steps.parse.outputs.identifier }}
           version: ${{ steps.parse.outputs.version }}
           release-tag: ${{ steps.parse.outputs.tag }}
-          installers-regex: '-x86_64-pc-windows-msvc\.zip$'
+          installers-regex: ${{ env.INSTALLERS_REGEX }}
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -36,7 +36,10 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Key on the release tag, not github.ref (which is the default branch on
+  # workflow_run), so different packages submit in parallel and only repeat
+  # runs of the same tag serialize.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || inputs.tag }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -1,0 +1,90 @@
+name: release-winget
+
+# Submits/updates the winget manifest for a CLI after its release workflow
+# publishes the GitHub Release (with the Windows .zip assets). The release is
+# created by the default GITHUB_TOKEN, which can't trigger a `release` event,
+# so this triggers on workflow_run like release-brew.yml.
+#
+# One-time bootstrap (winget-pkgs only lets you UPDATE an existing package):
+#   1. A maintainer lands the first manifest once via `wingetcreate new` (or a
+#      manual PR) for each PackageIdentifier below.
+#   2. Set the WINGET_TOKEN repo secret: a classic PAT with `public_repo`
+#      scope, owned by an account that has forked microsoft/winget-pkgs. By
+#      default the fork is looked up under the token owner.
+# After that every release is hands-off. Until the secret exists this is a
+# clean no-op.
+
+on:
+  workflow_run:
+    workflows:
+      - moq-cli
+      - moq-relay
+      - moq-token-cli
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Submit winget manifest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'moq-') }}
+    runs-on: windows-latest
+
+    steps:
+      - name: Check for WINGET_TOKEN
+        id: gate
+        shell: bash
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if [[ -z "${WINGET_TOKEN}" ]]; then
+            echo "WINGET_TOKEN not configured; skipping winget submission." >&2
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Parse crate and version
+        if: steps.gate.outputs.enabled == 'true'
+        id: parse
+        shell: bash
+        env:
+          TAG: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [[ ! "$TAG" =~ ^(.+)-v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)$ ]]; then
+            echo "Tag format not recognized: $TAG" >&2
+            exit 1
+          fi
+          crate="${BASH_REMATCH[1]}"
+          version="${BASH_REMATCH[2]}"
+          case "$crate" in
+            moq-cli)       identifier="moq-dev.moq-cli" ;;
+            moq-relay)     identifier="moq-dev.moq-relay" ;;
+            moq-token-cli) identifier="moq-dev.moq-token-cli" ;;
+            *)
+              echo "No winget identifier mapped for crate: $crate" >&2
+              exit 1
+              ;;
+          esac
+          {
+            echo "version=$version"
+            echo "tag=$TAG"
+            echo "identifier=$identifier"
+          } >> "$GITHUB_OUTPUT"
+          echo "Submitting $identifier $version (tag $TAG)"
+
+      - name: Submit to winget-pkgs
+        if: steps.gate.outputs.enabled == 'true'
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: ${{ steps.parse.outputs.identifier }}
+          version: ${{ steps.parse.outputs.version }}
+          release-tag: ${{ steps.parse.outputs.tag }}
+          installers-regex: '-x86_64-pc-windows-msvc\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -15,6 +15,12 @@ description: Command-line tools for MoQ media
 cargo install moq-cli
 ```
 
+### Using winget (Windows)
+
+```powershell
+winget install moq-dev.moq-cli
+```
+
 ### Using Nix
 
 ```bash

--- a/doc/bin/relay/index.md
+++ b/doc/bin/relay/index.md
@@ -37,6 +37,12 @@ The binary will be in `target/release/moq-relay`.
 cargo install moq-relay
 ```
 
+### Using winget (Windows)
+
+```powershell
+winget install moq-dev.moq-relay
+```
+
 ### Using Nix
 
 ```bash

--- a/rs/scripts/package-windows.sh
+++ b/rs/scripts/package-windows.sh
@@ -59,6 +59,10 @@ fi
 
 if [[ -z "$VERSION" ]]; then
     VERSION=$(grep '^version' "$CRATE_DIR/Cargo.toml" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+    if [[ -z "$VERSION" ]]; then
+        echo "Error: could not detect version from $CRATE_DIR/Cargo.toml" >&2
+        exit 1
+    fi
     echo "Detected version: $VERSION"
 fi
 

--- a/rs/scripts/package-windows.sh
+++ b/rs/scripts/package-windows.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and package a workspace binary as a Windows .zip for release.
+# Usage: ./package-windows.sh --crate CRATE [--version VERSION] [--target TARGET] [--output DIR]
+#
+# Runs under Git Bash on a windows-latest runner. Unlike package-binary.sh
+# (nix, macOS + Linux), this is a plain cargo build against the MSVC target.
+# Produces <output>/<crate>-<version>-<target>.zip with the .exe and licenses
+# at the archive root. Keeping the layout flat (no versioned top folder) means
+# the winget portable manifest's RelativeFilePath stays the same across
+# releases, so wingetcreate can carry it forward unchanged.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_DIR="$(cd "$RS_DIR/.." && pwd)"
+
+CRATE=""
+VERSION=""
+TARGET="x86_64-pc-windows-msvc"
+OUTPUT_DIR="dist"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --crate | --version | --target | --output)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: $1 requires a value" >&2
+                exit 1
+            fi
+            case $1 in
+                --crate) CRATE="$2" ;;
+                --version) VERSION="$2" ;;
+                --target) TARGET="$2" ;;
+                --output) OUTPUT_DIR="$2" ;;
+            esac
+            shift 2
+            ;;
+        -h | --help)
+            echo "Usage: $0 --crate CRATE [--version VERSION] [--target TARGET] [--output DIR]"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$CRATE" ]]; then
+    echo "Error: --crate is required" >&2
+    exit 1
+fi
+
+CRATE_DIR="$RS_DIR/$CRATE"
+if [[ ! -f "$CRATE_DIR/Cargo.toml" ]]; then
+    echo "Error: no Cargo.toml found at $CRATE_DIR" >&2
+    exit 1
+fi
+
+if [[ -z "$VERSION" ]]; then
+    VERSION=$(grep '^version' "$CRATE_DIR/Cargo.toml" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+    echo "Detected version: $VERSION"
+fi
+
+echo "Building $CRATE for $TARGET..."
+cargo build --release --target "$TARGET" -p "$CRATE"
+
+# The command name matches the crate, like `cargo install` and the Homebrew
+# formula (only the .deb/.rpm rename moq-cli to moq).
+BIN_FILE="$WORKSPACE_DIR/target/$TARGET/release/$CRATE.exe"
+if [[ ! -f "$BIN_FILE" ]]; then
+    echo "Error: no binary found at $BIN_FILE" >&2
+    ls "$WORKSPACE_DIR/target/$TARGET/release" >&2 || true
+    exit 1
+fi
+
+# Smoke test: a release we can't even --help is not worth shipping.
+"$BIN_FILE" --help >/dev/null
+
+NAME="$CRATE-$VERSION-$TARGET"
+STAGING="$(mktemp -d)"
+trap 'rm -rf "$STAGING"' EXIT
+
+cp "$BIN_FILE" "$STAGING/$CRATE.exe"
+cp "$WORKSPACE_DIR/LICENSE-MIT" "$STAGING/"
+cp "$WORKSPACE_DIR/LICENSE-APACHE" "$STAGING/"
+if [[ -f "$CRATE_DIR/README.md" ]]; then
+    cp "$CRATE_DIR/README.md" "$STAGING/"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+ZIP_ABS="$(cd "$OUTPUT_DIR" && pwd)/$NAME.zip"
+rm -f "$ZIP_ABS"
+
+# 7z ships on the windows-latest runner. Zip from inside the staging dir so
+# the entries land at the archive root rather than under a temp path.
+(cd "$STAGING" && 7z a -tzip -mx=9 "$ZIP_ABS" ./* >/dev/null)
+
+echo ""
+echo "Created: $OUTPUT_DIR/$NAME.zip"
+echo "$NAME.zip"


### PR DESCRIPTION
## Summary

There was no Windows release path: the per-crate workflows only built Linux (`.deb`/`.rpm` → apt/rpm repos) and macOS (tarballs → Homebrew tap). This adds Windows binaries plus a fully-automated winget channel, modeled on the existing Homebrew flow.

- **Windows `.zip` artifacts** for `moq-cli`, `moq-relay`, and `moq-token-cli`. Each release workflow gets a `build-windows` job that builds the `x86_64-pc-windows-msvc` binary and packages it via the new `rs/scripts/package-windows.sh` (exe + licenses + README at the archive root, smoke-tested with `--help`). The zip is attached to the GitHub Release next to the existing Linux/macOS assets. NASM is installed for aws-lc-rs's Windows assembly.
- **Automated winget** (`release-winget.yml`): mirrors `release-brew.yml`'s `workflow_run` trigger (the release is created by `GITHUB_TOKEN`, which can't fire a `release` event), then runs `winget-releaser` to submit/update the manifest. No human in the loop on our side.
- **Dry-run** (`workflow_dispatch`): winget-releaser has no dry-run flag, so the manual-dispatch path runs the same tag → identifier/version mapping and verifies the Windows `.zip` asset exists and matches the installers regex, then stops **without** opening a winget-pkgs PR (no token/bootstrap needed). Use it to sanity-check a tag. The installers regex is a single job-level env shared by the dry-run check and the real submit.
- **Docs**: `winget install moq-dev.moq-cli` / `moq-dev.moq-relay`.

The Windows command names match `cargo install` / Homebrew / the docs (`moq-cli`, `moq-relay`, `moq-token-cli`); only the `.deb`/`.rpm` rename `moq-cli` to `moq`.

## One-time winget bootstrap (required before automation kicks in)

winget-pkgs only lets the automation **update** an existing package, so each PackageIdentifier (`moq-dev.moq-cli`, `moq-dev.moq-relay`, `moq-dev.moq-token-cli`) must be submitted **once** by hand. After that, every release is hands-off.

**Two prerequisites for either method below:**
1. A **published Windows `.zip` asset** to point at, so do the bootstrap *after* the first release tag that includes this PR's `build-windows` job. The asset URL looks like:
   `https://github.com/moq-dev/moq/releases/download/moq-cli-v0.7.31/moq-cli-0.7.31-x86_64-pc-windows-msvc.zip`
2. A **classic GitHub PAT with `public_repo` scope**, from an account that has forked `microsoft/winget-pkgs`. (This is also the `WINGET_TOKEN` repo secret the ongoing automation needs — set it once and the `release-winget.yml` submit step stops being a no-op.)

> Note: `wingetcreate` is **Windows-only** and won't run on macOS. Use `komac` (below), which is the cross-platform equivalent, or hand-write the manifests.

### Method A — komac (recommended; runs on macOS/Linux/Windows)

```bash
brew install komac
komac token add          # paste the classic PAT (public_repo)

# Interactive: paste the .zip URL when prompted. komac detects the
# zip -> nested-portable layout, hashes the asset, asks for metadata
# (publisher, license, description) and the command alias (e.g. moq-cli),
# then --submit forks/branches and opens the winget-pkgs PR.
komac new moq-dev.moq-cli --submit
```

Repeat for `moq-dev.moq-relay` and `moq-dev.moq-token-cli`. komac also auto-selects a valid `ManifestVersion` and validates structure, so it's less error-prone than hand-writing YAML.

### Method B — hand-write the manifests + PR (full control, no tools)

Hash the asset on any OS:

```bash
curl -sL -o moq-cli.zip \
  https://github.com/moq-dev/moq/releases/download/moq-cli-v0.7.31/moq-cli-0.7.31-x86_64-pc-windows-msvc.zip
shasum -a 256 moq-cli.zip   # uppercase the hex for the manifest
```

In a fork of `microsoft/winget-pkgs`, create three files under `manifests/m/moq-dev/moq-cli/0.7.31/`:

`moq-dev.moq-cli.installer.yaml`
```yaml
PackageIdentifier: moq-dev.moq-cli
PackageVersion: 0.7.31
InstallerType: zip
NestedInstallerType: portable
NestedInstallerFiles:
  - RelativeFilePath: moq-cli.exe
    PortableCommandAlias: moq-cli
Installers:
  - Architecture: x64
    InstallerUrl: https://github.com/moq-dev/moq/releases/download/moq-cli-v0.7.31/moq-cli-0.7.31-x86_64-pc-windows-msvc.zip
    InstallerSha256: <SHA256_FROM_ABOVE>
ManifestType: installer
ManifestVersion: 1.6.0
```

`moq-dev.moq-cli.locale.en-US.yaml`
```yaml
PackageIdentifier: moq-dev.moq-cli
PackageVersion: 0.7.31
PackageLocale: en-US
Publisher: moq-dev
PublisherUrl: https://moq.dev
PackageName: moq-cli
PackageUrl: https://moq.dev
License: MIT OR Apache-2.0
ShortDescription: CLI for publishing and subscribing to Media over QUIC broadcasts
Moniker: moq-cli
ManifestType: defaultLocale
ManifestVersion: 1.6.0
```

`moq-dev.moq-cli.yaml`
```yaml
PackageIdentifier: moq-dev.moq-cli
PackageVersion: 0.7.31
DefaultLocale: en-US
ManifestType: version
ManifestVersion: 1.6.0
```

Then fork + branch + PR (e.g. `gh repo fork microsoft/winget-pkgs`, add the files, `gh pr create`). winget-pkgs runs its own manifest validation + sandbox-install check on the PR; `winget validate` can't run on macOS, so rely on those CI checks. For `moq-relay` / `moq-token-cli`, copy the three files into `manifests/m/moq-dev/moq-<name>/<version>/` and swap the identifier, exe name, command alias, description, and URL.

**Why `RelativeFilePath` has no subfolder:** `package-windows.sh` stages the exe flat at the archive root, so the path stays version-independent and the automated `release-winget.yml` updates carry it forward unchanged across releases.

## Notes / trade-offs

- The Windows build path runs for the first time on the next release tag (same as how the macOS path was introduced). I did **not** add a `windows-latest` job to `check.yml`, since that CI is entirely Nix/Linux via `just ci` and a per-PR Windows job would be real ongoing cost. A PR-time Windows compile check is a reasonable follow-up if desired.
- Only `x86_64` for now; `aarch64-pc-windows-msvc` slots into the single-entry build matrix later.
- `moq-gst` is excluded (Windows GStreamer setup is involved, and it wasn't requested).

## Test plan

- [x] `bash -n` on `package-windows.sh`; `shfmt` clean (whole-repo); YAML parses for all four workflows.
- [x] Installers regex matches only the Windows `.zip` against representative `.deb`/`.tar.gz`/linux-binary asset names.
- [ ] Cut a `moq-cli-v*` tag and confirm the `.zip` is attached to the Release and the winget submit behaves (no-op without the secret; submits with it).
- [ ] Run the `release-winget` workflow via `workflow_dispatch` against an existing tag and confirm the dry-run reports the matched installer and opens no PR.
- [ ] Bootstrap each PackageIdentifier once (komac or manual) and set `WINGET_TOKEN`.

(Written by Claude)