### PR TITLE
chore(js): bump JS package versions to publish pending changes

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/json",
 	"type": "module",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Snapshot/delta JSON publishing over MoQ tracks using RFC 7396 JSON Merge Patch.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/signals",
 	"type": "module",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"description": "Reactive and safe signals",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.14",
+	"version": "0.2.15",
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",


### PR DESCRIPTION
## Summary

Local package versions all matched what's on npm, so changes that merged to `main` since the last bump have been sitting unpublished (the release workflow only publishes a package when its version differs from the registry). This bumps every JS package with unreleased source changes so the next push to `main` ships them.

| Package | Bump | Unreleased changes |
|---|---|---|
| `@moq/net` | 0.1.2 → 0.1.3 | IETF draft-18 interop fixes (subscribe_namespace, object/control framing) |
| `@moq/hang` | 0.2.7 → 0.2.8 | Catalog reshape: app sections (chat/location/user/preview) removed from base |
| `@moq/watch` | 0.2.14 → 0.2.15 | Catalog-extensions reshape; audio/video source + broadcast updates |
| `@moq/publish` | 0.2.11 → 0.2.12 | Catalog producer changes; chat/location/user/preview removed |
| `@moq/signals` | 0.1.7 → 0.1.8 | New `index.ts` API |
| `@moq/json` | 0.0.1 → 0.0.2 | New producer functionality |

All patch bumps, matching the existing convention (e.g. ab08b0c5 "bump JS package versions to publish pending changes").

## Notes for reviewers

- **Not bumped (no source changes since last release):** `@moq/token`, `@moq/loc`, `@moq/msf`, `@moq/boy`. Dependents that didn't change themselves (`loc`, `msf`, `clock`) don't need a republish; their workspace deps resolve to caret ranges that float to the new versions.
- **`@moq/clock`** has changes but was never published to npm, so it'll publish at its current `0.1.0` on the next main push regardless. Left as-is.
- The hang/watch/publish changes are technically **breaking** (catalog sections moved out), which would normally target `dev`. They're already merged on `main`, so this follows the established patch-bump-on-main convention rather than minor-bumping. Happy to switch to minor bumps if preferred.
- `bun.lock` is unchanged: workspace packages are keyed by path, not version, so `--frozen-lockfile` installs stay green.

(Written by Claude)