### PR TITLE
chore(demo,doc): drop redundant /anon prefix from localhost URLs

### DIFF
--- a/demo/boy/justfile
+++ b/demo/boy/justfile
@@ -50,11 +50,11 @@ gb-run:
     just start rom/gb-run.gbc
 
 # Start a Game Boy emulator publisher.
-start rom url='http://localhost:4443/anon':
+start rom url='http://localhost:4443':
     cargo run --bin moq-boy -- --url "{{ url }}" --rom "{{ rom }}" --location localhost
 
 # Host the web server
-web url='http://localhost:4443/anon':
+web url='http://localhost:4443':
     VITE_RELAY_URL="{{ url }}" bun --bun vite --open
 
 # --- rom.moq.dev (R2 hosting) ---

--- a/demo/boy/src/index.ts
+++ b/demo/boy/src/index.ts
@@ -1,7 +1,7 @@
 import "@moq/boy/element";
 import { Effect } from "@moq/signals";
 
-const url = import.meta.env.VITE_RELAY_URL || "http://localhost:4443/anon";
+const url = import.meta.env.VITE_RELAY_URL || "http://localhost:4443";
 
 const boy = document.querySelector("moq-boy");
 if (boy) boy.url = url;

--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -41,24 +41,24 @@ list:
 # --- Publishing ---
 
 # Publish Big Buck Bunny to a relay server.
-bbb url='http://localhost:4443/anon' *args:
+bbb url='http://localhost:4443' *args:
     just download bbb
     just cmaf bbb "{{ url }}" {{ args }}
 
 # Publish Tears of Steel to a relay server.
-tos url='http://localhost:4443/anon' *args:
+tos url='http://localhost:4443' *args:
     just download tos
     just cmaf tos "{{ url }}" {{ args }}
 
 # Publish a video using ffmpeg (CMAF / fMP4) to a relay server.
-cmaf name url='http://localhost:4443/anon' *args:
+cmaf name url='http://localhost:4443' *args:
     cargo build --bin moq-cli
     just ffmpeg-cmaf "media/{{ name }}.mp4" |\
     cargo run --bin moq-cli -- \
     	{{ args }} publish --url "{{ url }}" --name "{{ name }}.hang" fmp4
 
 # Publish a video using ffmpeg (MPEG-TS) to a relay server.
-ts name url='http://localhost:4443/anon' *args:
+ts name url='http://localhost:4443' *args:
     cargo build --bin moq-cli
     just ffmpeg-ts "media/{{ name }}.mp4" |\
     cargo run --bin moq-cli -- \
@@ -73,7 +73,7 @@ iroh name url prefix="":
     	--iroh-enabled publish --url "{{ url }}" --name "{{ prefix }}{{ name }}.hang" fmp4
 
 # Generate and ingest an HLS stream from a video file.
-hls name relay="http://localhost:4443/anon":
+hls name relay="http://localhost:4443":
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -149,7 +149,7 @@ hls name relay="http://localhost:4443/anon":
     exit $EXIT_CODE
 
 # Publish a video using H.264 Annex B format.
-h264 name url="http://localhost:4443/anon" *args:
+h264 name url="http://localhost:4443" *args:
     just download "{{ name }}"
     cargo build --bin moq-cli
 
@@ -213,7 +213,7 @@ serve-hls name port="8000":
     cd "$OUT_DIR" && python3 -m http.server {{ port }}
 
 # Publish the clock broadcast.
-clock action url="http://localhost:4443/anon" *args:
+clock action url="http://localhost:4443" *args:
     @if [ "{{ action }}" != "publish" ] && [ "{{ action }}" != "subscribe" ]; then \
     	echo "Error: action must be 'publish' or 'subscribe', got '{{ action }}'" >&2; \
     	exit 1; \
@@ -228,7 +228,7 @@ console:
 # --- GStreamer ---
 
 # Publish a video using GStreamer to a relay server.
-gst name url='http://localhost:4443/anon' *args:
+gst name url='http://localhost:4443' *args:
     just download "{{ name }}"
     cargo build -p moq-gst
 

--- a/demo/sub/justfile
+++ b/demo/sub/justfile
@@ -1,7 +1,7 @@
 set fallback
 
 # Subscribe to a broadcast using GStreamer and render to the screen.
-gst name url='http://localhost:4443/anon' *args:
+gst name url='http://localhost:4443' *args:
     cargo build -p moq-gst
 
     GST_PLUGIN_PATH_1_0="${PWD}/../../target/debug${GST_PLUGIN_PATH_1_0:+:$GST_PLUGIN_PATH_1_0}" \

--- a/demo/web/.env
+++ b/demo/web/.env
@@ -1,1 +1,1 @@
-VITE_RELAY_URL=http://localhost:4443/anon
+VITE_RELAY_URL=http://localhost:4443

--- a/demo/web/justfile
+++ b/demo/web/justfile
@@ -5,5 +5,5 @@ default:
     just serve
 
 # Run the web server targeting the specified relay.
-serve url='http://localhost:4443/anon':
+serve url='http://localhost:4443':
     VITE_RELAY_URL="{{ url }}" bun --bun vite --open

--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -100,11 +100,11 @@ nix shell github:moq-dev/moq#moq-gst --command gst-launch-1.0 -v -e \
   multifilesrc location=bbb.mp4 loop=true ! parsebin name=parse \
     parse. ! queue ! identity sync=true ! mux.sink_0 \
     parse. ! queue ! identity sync=true ! mux.sink_1 \
-    moqsink name=mux url=http://localhost:4443/anon broadcast=bbb.hang
+    moqsink name=mux url=http://localhost:4443 broadcast=bbb.hang
 
 # Terminal 3: subscribe.
 nix shell github:moq-dev/moq#moq-gst --command gst-launch-1.0 -v -e \
-  moqsrc url=http://localhost:4443/anon broadcast=bbb.hang \
+  moqsrc url=http://localhost:4443 broadcast=bbb.hang \
   ! decodebin3 ! videoconvert ! autovideosink
 ```
 
@@ -151,7 +151,7 @@ gst-launch-1.0 -v -e \
   multifilesrc location=demo/pub/media/bbb.mp4 loop=true ! parsebin name=parse \
     parse. ! queue ! identity sync=true ! mux.sink_0 \
     parse. ! queue ! identity sync=true ! mux.sink_1 \
-    moqsink name=mux url="http://localhost:4443/anon" broadcast="bbb"
+    moqsink name=mux url="http://localhost:4443" broadcast="bbb"
 ```
 
 ::: tip
@@ -181,7 +181,7 @@ Or directly:
 export GST_PLUGIN_PATH_1_0="$PWD/target/debug${GST_PLUGIN_PATH_1_0:+:$GST_PLUGIN_PATH_1_0}"
 
 gst-launch-1.0 -v -e \
-  moqsrc url="http://localhost:4443/anon" broadcast="bbb" \
+  moqsrc url="http://localhost:4443" broadcast="bbb" \
     ! decodebin3 ! videoconvert ! autovideosink
 ```
 

--- a/doc/setup/dev.md
+++ b/doc/setup/dev.md
@@ -45,7 +45,7 @@ Want more? See the [justfile](https://github.com/moq-dev/moq/blob/main/justfile)
 
 ### The Internet
 
-Most of the commands default to `http://localhost:4443/anon`.
+Most of the commands default to `http://localhost:4443`.
 That's pretty lame.
 
 If you want to do a real test of how MoQ works over the internet, you're going to need a remote server.

--- a/js/clock/README.md
+++ b/js/clock/README.md
@@ -18,7 +18,7 @@ bun ./src/main.ts --url https://cdn.moq.dev/anon --broadcast myclock publish
 bun ./src/main.ts --url https://cdn.moq.dev/anon --broadcast myclock subscribe
 ```
 
-If you're running a relay server locally, use `http://localhost:4443/anon` instead.
+If you're running a relay server locally, use `http://localhost:4443` instead.
 
 ## Wire Format
 

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -24,7 +24,7 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 
-	// For local development, use: http://localhost:4443/anon/video-example
+	// For local development, use: http://localhost:4443/video-example
 	// The "anon" path is usually configured to bypass authentication; be careful!
 	let url = url::Url::parse("https://cdn.moq.dev/anon/video-example").unwrap();
 

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -24,7 +24,7 @@ async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 
-	// For local development, use: http://localhost:4443/anon
+	// For local development, use: http://localhost:4443
 	// The "anon" path is usually configured to bypass authentication; be careful!
 	let url = url::Url::parse("https://cdn.moq.dev/anon/video-example").unwrap();
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -22,7 +22,7 @@ async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 
-	// For local development, use: http://localhost:4443/anon
+	// For local development, use: http://localhost:4443
 	// The "anon" path is usually configured to bypass authentication; be careful!
 	let url = url::Url::parse("https://cdn.moq.dev/anon/chat-example").unwrap();
 


### PR DESCRIPTION
## Summary

The localhost relay ([`demo/relay/localhost.toml`](https://github.com/moq-dev/moq/blob/main/demo/relay/localhost.toml)) sets `public = ""`, which grants anonymous access to **every** path. That makes the `/anon` prefix on localhost URLs pure noise. This drops it from:

- **justfile defaults** — `demo/pub`, `demo/sub`, `demo/web`, `demo/boy` now default to `http://localhost:4443`
- **demo code** — `demo/boy/src/index.ts`, `demo/web/.env`
- **docs** — `doc/setup/dev.md`, `doc/bin/gstreamer.md`, `js/clock/README.md`
- **rust example comments** — `rs/hang/examples/{subscribe,video}.rs`, `rs/moq-native/examples/chat.rs`

## Why

Anonymous access to localhost is already wide open, so appending `/anon` to every dev command was just busywork that confused the simplest path.

## Out of scope

Public/cloud relay references (`cdn.moq.dev/anon`, `relay.example.com/anon`) are **left untouched** — those relays are configured with `public = "anon"` and still require the prefix.

## Test plan

- [ ] `just pub bbb` publishes against a local relay started with `just relay`
- [ ] `just web` connects and plays it back

(Written by Claude)