### PR TITLE
feat(publish): canvas preview + encoded "real" preview mode

### DIFF
--- a/demo/web/src/publish.html
+++ b/demo/web/src/publish.html
@@ -24,6 +24,13 @@
 	-->
 	<moq-publish-ui>
 		<moq-publish url="%VITE_RELAY_URL%" name="me.hang">
+			<!--
+				The preview can be a <video> (raw camera/screen source, shown here) or a <canvas>.
+				A <canvas> with `preview="encoded"` on <moq-publish> shows a decoded copy of the encoded
+				video, i.e. what a viewer actually receives (codec artifacts and all), at the cost of an
+				extra encode + decode. Swap the line below to try it:
+				<canvas style="width: 100%; height: auto; border-radius: 4px; margin: 0 auto;"></canvas>
+			-->
 			<video style="width: 100%; height: auto; border-radius: 4px; margin: 0 auto;" muted autoplay></video>
 		</moq-publish>
 	</moq-publish-ui>

--- a/demo/web/src/publish.html
+++ b/demo/web/src/publish.html
@@ -25,11 +25,12 @@
 	<moq-publish-ui>
 		<moq-publish url="%VITE_RELAY_URL%" name="me.hang">
 			<!--
-				The preview can be a <video> (raw camera/screen source, shown here) or a <canvas>.
-				A <canvas> with `preview="encoded"` on <moq-publish> shows a decoded copy of the encoded
-				video, i.e. what a viewer actually receives (codec artifacts and all), at the cost of an
-				extra encode + decode. Swap the line below to try it:
+				The preview element can be a <video> (raw camera/screen source, shown here) or a <canvas>.
+				A <canvas> draws the frames directly. To preview what a viewer actually receives over the
+				network (a decoded copy of the encoded video, codec artifacts and all), do BOTH: add
+				preview="encoded" to the <moq-publish> element above, and replace the <video> below with:
 				<canvas style="width: 100%; height: auto; border-radius: 4px; margin: 0 auto;"></canvas>
+				The encoded preview costs an extra encode + decode pass.
 			-->
 			<video style="width: 100%; height: auto; border-radius: 4px; margin: 0 auto;" muted autoplay></video>
 		</moq-publish>

--- a/demo/web/src/publish.html
+++ b/demo/web/src/publish.html
@@ -24,15 +24,15 @@
 	-->
 	<moq-publish-ui>
 		<moq-publish url="%VITE_RELAY_URL%" name="me.hang">
-			<!--
-				The preview element can be a <video> (raw camera/screen source, shown here) or a <canvas>.
-				A <canvas> draws the frames directly. To preview what a viewer actually receives over the
-				network (a decoded copy of the encoded video, codec artifacts and all), do BOTH: add
-				preview="encoded" to the <moq-publish> element above, and replace the <video> below with:
-				<canvas style="width: 100%; height: auto; border-radius: 4px; margin: 0 auto;"></canvas>
-				The encoded preview costs an extra encode + decode pass.
-			-->
 			<video style="width: 100%; height: auto; border-radius: 4px; margin: 0 auto;" muted autoplay></video>
+
+			<!--
+				Alternatively, preview a decoded copy of the encoded video, i.e. what a viewer actually
+				receives over the network (codec artifacts and all), at the cost of an extra encode +
+				decode. Add preview="encoded" to <moq-publish> above and use this <canvas> instead of the
+				<video>:
+			-->
+			<!-- <canvas style="width: 100%; height: auto; border-radius: 4px; margin: 0 auto;"></canvas> -->
 		</moq-publish>
 	</moq-publish-ui>
 

--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -70,6 +70,22 @@ a real bundler (the examples below).
 - `audio` — Enable audio capture (boolean)
 - `video` — Enable video capture (boolean)
 - `controls` — Show publishing controls (boolean)
+- `preview` — What a `<canvas>` preview renders: `"source"` (default) or `"encoded"` (see [Preview element](#preview-element))
+
+## Preview element
+
+`<moq-publish>` discovers a nested `<video>` or `<canvas>` and uses it for a local preview.
+
+- `<video>` attaches the raw capture stream via `srcObject`. This is the cheapest preview and the default.
+- `<canvas>` draws the frames itself. With `preview="source"` (default) it draws the raw capture; with `preview="encoded"` it draws a decoded copy of the encoded video, so the preview shows exactly what a viewer receives over the network, codec artifacts and all.
+
+The `encoded` mode costs a full extra encode + decode pass (it re-encodes with the same settings as the published rendition), so reach for it when you want to monitor the transmitted quality, not as the default preview.
+
+```html
+<moq-publish url="https://relay.example.com/anon" name="room/alice.hang" source="camera" preview="encoded">
+    <canvas></canvas>
+</moq-publish>
+```
 
 ## UI Overlay
 

--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -70,7 +70,7 @@ a real bundler (the examples below).
 - `audio` — Enable audio capture (boolean)
 - `video` — Enable video capture (boolean)
 - `controls` — Show publishing controls (boolean)
-- `preview` — What a `<canvas>` preview renders: `"source"` (default) or `"encoded"` (see [Preview element](#preview-element))
+- `preview` — What the preview renders: `"source"` (default), `"encoded"`, or `"none"` to disable it (see [Preview element](#preview-element))
 
 ## Preview element
 
@@ -79,7 +79,7 @@ a real bundler (the examples below).
 - `<video>` attaches the raw capture stream via `srcObject`. This is the cheapest preview and the default.
 - `<canvas>` draws the frames itself. With `preview="source"` (default) it draws the raw capture; with `preview="encoded"` it draws a decoded copy of the encoded video, so the preview shows exactly what a viewer receives over the network, codec artifacts and all.
 
-The `encoded` mode costs a full extra encode + decode pass (it re-encodes with the same settings as the published rendition), so reach for it when you want to monitor the transmitted quality, not as the default preview.
+The `encoded` mode costs a full extra encode + decode pass (it re-encodes with the same settings as the published rendition), so reach for it when you want to monitor the transmitted quality, not as the default preview. Set `preview="none"` to disable the preview without removing the element.
 
 ```html
 <moq-publish url="https://relay.example.com/anon" name="room/alice.hang" source="camera" preview="encoded">

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -1,9 +1,10 @@
 import * as Moq from "@moq/net";
 import { Effect, Signal } from "@moq/signals";
 import { Broadcast } from "./broadcast";
+import * as Preview from "./preview";
 import * as Source from "./source";
 
-const OBSERVED = ["url", "name", "muted", "invisible", "source"] as const;
+const OBSERVED = ["url", "name", "muted", "invisible", "source", "preview"] as const;
 type Observed = (typeof OBSERVED)[number];
 
 type SourceType = "camera" | "screen" | "file";
@@ -22,12 +23,15 @@ export default class MoqPublish extends HTMLElement {
 		source: new Signal<SourceType | File | undefined>(undefined),
 		muted: new Signal(false),
 		invisible: new Signal(false),
+		// What a <canvas> preview renders: the raw capture, or a decoded copy of the encoded video.
+		preview: new Signal<Preview.Mode>("source"),
 	};
 
 	connection: Moq.Connection.Reload;
 	broadcast: Broadcast;
 
-	#preview = new Signal<HTMLVideoElement | undefined>(undefined);
+	// The preview element, either a <video> (raw source via srcObject) or a <canvas> (rendered frames).
+	#preview = new Signal<HTMLVideoElement | HTMLCanvasElement | undefined>(undefined);
 
 	video = new Signal<Source.Camera | Source.Screen | undefined>(undefined);
 	audio = new Signal<Source.Microphone | Source.Screen | undefined>(undefined);
@@ -84,7 +88,7 @@ export default class MoqPublish extends HTMLElement {
 
 		// Watch to see if the preview element is added or removed.
 		const setPreview = () => {
-			this.#preview.set(this.querySelector("video") as HTMLVideoElement | undefined);
+			this.#preview.set(this.querySelector("video, canvas") as HTMLVideoElement | HTMLCanvasElement | undefined);
 		};
 		const observer = new MutationObserver(setPreview);
 		observer.observe(this, { childList: true, subtree: true });
@@ -94,6 +98,18 @@ export default class MoqPublish extends HTMLElement {
 		this.signals.run((effect) => {
 			const preview = effect.get(this.#preview);
 			if (!preview) return;
+
+			// A <canvas> renders the decoded frames; a <video> shows the raw source via srcObject.
+			if (preview instanceof HTMLCanvasElement) {
+				const renderer = new Preview.Renderer({
+					canvas: preview,
+					video: this.broadcast.video,
+					mode: this.state.preview,
+					enabled: this.#videoEnabled,
+				});
+				effect.cleanup(() => renderer.close());
+				return;
+			}
 
 			const source = effect.get(this.broadcast.video.source);
 			if (!source) {
@@ -107,6 +123,14 @@ export default class MoqPublish extends HTMLElement {
 			effect.cleanup(() => {
 				preview.srcObject = null;
 			});
+		});
+
+		// `encoded` decodes the wire output to a <canvas>; a <video> can only show the raw source.
+		// Warn once per state change rather than on every source/frame update.
+		this.signals.run((effect) => {
+			if (!(effect.get(this.#preview) instanceof HTMLVideoElement)) return;
+			if (effect.get(this.state.preview) !== "encoded") return;
+			console.warn('moq-publish: preview="encoded" requires a <canvas> element; showing the raw source.');
 		});
 
 		this.signals.run(this.#runSource.bind(this));
@@ -137,6 +161,14 @@ export default class MoqPublish extends HTMLElement {
 			this.state.muted.set(newValue !== null);
 		} else if (name === "invisible") {
 			this.state.invisible.set(newValue !== null);
+		} else if (name === "preview") {
+			if (newValue === "encoded" || newValue === "source") {
+				this.state.preview.set(newValue);
+			} else if (newValue === null) {
+				this.state.preview.set("source");
+			} else {
+				throw new Error(`Invalid preview: ${newValue}`);
+			}
 		} else {
 			const exhaustive: never = name;
 			throw new Error(`Invalid attribute: ${exhaustive}`);
@@ -257,6 +289,14 @@ export default class MoqPublish extends HTMLElement {
 
 	set invisible(value: boolean) {
 		this.state.invisible.set(value);
+	}
+
+	get preview(): Preview.Mode {
+		return this.state.preview.peek();
+	}
+
+	set preview(value: Preview.Mode) {
+		this.state.preview.set(value);
 	}
 }
 

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -111,6 +111,12 @@ export default class MoqPublish extends HTMLElement {
 				return;
 			}
 
+			// preview="none" disables the preview entirely.
+			if (effect.get(this.state.preview) === "none") {
+				preview.style.display = "none";
+				return;
+			}
+
 			const source = effect.get(this.broadcast.video.source);
 			if (!source) {
 				preview.style.display = "none";
@@ -162,7 +168,7 @@ export default class MoqPublish extends HTMLElement {
 		} else if (name === "invisible") {
 			this.state.invisible.set(newValue !== null);
 		} else if (name === "preview") {
-			if (newValue === "encoded" || newValue === "source") {
+			if (newValue === "encoded" || newValue === "source" || newValue === "none") {
 				this.state.preview.set(newValue);
 			} else if (newValue === null) {
 				this.state.preview.set("source");

--- a/js/publish/src/index.ts
+++ b/js/publish/src/index.ts
@@ -6,6 +6,7 @@ export * as Signals from "@moq/signals";
 export * as Audio from "./audio";
 export * from "./broadcast";
 export * from "./catalog";
+export * as Preview from "./preview";
 export * as Source from "./source";
 export * as Video from "./video";
 

--- a/js/publish/src/preview.ts
+++ b/js/publish/src/preview.ts
@@ -3,10 +3,11 @@ import { Effect, type Getter, Signal } from "@moq/signals";
 import type * as Video from "./video";
 
 // What the canvas preview renders.
+// - `none`: nothing, an easy way to toggle the preview off without removing the element.
 // - `source`: the raw captured frames, drawn directly (cheap, no extra codec work).
 // - `encoded`: a decoded copy of the encoded video, so the preview shows the same codec
 //   artifacts a viewer would receive. This costs a full extra encode + decode pass.
-export type Mode = "source" | "encoded";
+export type Mode = "none" | "source" | "encoded";
 
 export type RendererProps = {
 	canvas: HTMLCanvasElement | Signal<HTMLCanvasElement | undefined>;
@@ -47,12 +48,13 @@ export class Renderer {
 
 	// Pick the frame source based on the mode, spinning up a transcoder for `encoded`.
 	#runSelect(effect: Effect): void {
-		if (!effect.get(this.enabled)) {
+		const mode = effect.get(this.mode);
+		if (mode === "none" || !effect.get(this.enabled)) {
 			effect.set(this.#frame, undefined);
 			return;
 		}
 
-		if (effect.get(this.mode) === "encoded") {
+		if (mode === "encoded") {
 			const transcode = new Transcode({
 				source: this.#video.frame,
 				config: this.#video.hd.resolved,

--- a/js/publish/src/preview.ts
+++ b/js/publish/src/preview.ts
@@ -56,6 +56,7 @@ export class Renderer {
 			const transcode = new Transcode({
 				source: this.#video.frame,
 				config: this.#video.hd.resolved,
+				settings: this.#video.hd.config,
 			});
 			effect.cleanup(() => transcode.close());
 			effect.proxy(this.#frame, transcode.frame);
@@ -73,10 +74,16 @@ export class Renderer {
 		const display = effect.get(this.#video.display);
 		const flip = effect.get(this.#video.flip);
 
+		// Size the canvas to the frame we're drawing so `encoded` mode shows the true transmitted
+		// resolution (which can be smaller than the capture). Fall back to the capture dimensions
+		// until the first frame arrives.
+		const width = frame?.displayWidth ?? display?.width;
+		const height = frame?.displayHeight ?? display?.height;
+
 		// Setting width/height clears the canvas, so only resize when the dimensions actually change.
-		if (display && (ctx.canvas.width !== display.width || ctx.canvas.height !== display.height)) {
-			ctx.canvas.width = display.width;
-			ctx.canvas.height = display.height;
+		if (width && height && (ctx.canvas.width !== width || ctx.canvas.height !== height)) {
+			ctx.canvas.width = width;
+			ctx.canvas.height = height;
 		}
 
 		ctx.fillStyle = "#000";
@@ -101,6 +108,8 @@ export class Renderer {
 type TranscodeProps = {
 	source: Getter<VideoFrame | undefined>;
 	config: Getter<VideoEncoderConfig | undefined>;
+	// The rendition's encoder settings, read for keyframe cadence so the preview's GOP matches the wire.
+	settings?: Getter<Video.EncoderConfig | undefined>;
 };
 
 // Encodes the captured frames with the live rendition settings and decodes the result, so the
@@ -111,11 +120,13 @@ export class Transcode {
 
 	#source: Getter<VideoFrame | undefined>;
 	#config: Getter<VideoEncoderConfig | undefined>;
+	#settings?: Getter<Video.EncoderConfig | undefined>;
 	#signals = new Effect();
 
 	constructor(props: TranscodeProps) {
 		this.#source = props.source;
 		this.#config = props.config;
+		this.#settings = props.settings;
 		this.#signals.run(this.#run.bind(this));
 	}
 
@@ -158,7 +169,6 @@ export class Transcode {
 		decoder.configure({ codec: config.codec, optimizeForLatency: true });
 
 		// Re-key on the same cadence as the real encoder so the decoder can start and recover.
-		const interval = Time.Micro.fromSecond(2 as Time.Second);
 		let lastKeyframe: Time.Micro | undefined;
 
 		effect.run((inner) => {
@@ -166,8 +176,12 @@ export class Transcode {
 			if (!frame) return;
 			if (encoder.state !== "configured") return;
 
+			// Mirror Encoder.serve: default to a 2s GOP unless the rendition overrides it.
+			const settings = this.#settings ? inner.get(this.#settings) : undefined;
+			const interval = settings?.keyframeInterval ?? Time.Milli.fromSecond(2 as Time.Second);
+
 			const timestamp = frame.timestamp as Time.Micro;
-			const keyFrame = lastKeyframe === undefined || lastKeyframe + interval <= timestamp;
+			const keyFrame = lastKeyframe === undefined || lastKeyframe + Time.Micro.fromMilli(interval) <= timestamp;
 			if (keyFrame) lastKeyframe = timestamp;
 
 			// The capture pipeline owns and closes the frame, so we just read it here.

--- a/js/publish/src/preview.ts
+++ b/js/publish/src/preview.ts
@@ -1,0 +1,192 @@
+import { Time } from "@moq/net";
+import { Effect, type Getter, Signal } from "@moq/signals";
+import type * as Video from "./video";
+
+// What the canvas preview renders.
+// - `source`: the raw captured frames, drawn directly (cheap, no extra codec work).
+// - `encoded`: a decoded copy of the encoded video, so the preview shows the same codec
+//   artifacts a viewer would receive. This costs a full extra encode + decode pass.
+export type Mode = "source" | "encoded";
+
+export type RendererProps = {
+	canvas: HTMLCanvasElement | Signal<HTMLCanvasElement | undefined>;
+	video: Video.Root;
+	mode?: Mode | Signal<Mode>;
+	enabled?: boolean | Signal<boolean>;
+};
+
+// Renders a <canvas> preview of the locally published video.
+export class Renderer {
+	canvas: Signal<HTMLCanvasElement | undefined>;
+	mode: Signal<Mode>;
+	enabled: Signal<boolean>;
+
+	#video: Video.Root;
+
+	// The frame to draw. Just a pointer to a frame owned elsewhere (the capture pipeline or the
+	// transcoder), so we never close it ourselves.
+	#frame = new Signal<VideoFrame | undefined>(undefined);
+
+	#ctx = new Signal<CanvasRenderingContext2D | undefined>(undefined);
+	#signals = new Effect();
+
+	constructor(props: RendererProps) {
+		this.canvas = Signal.from(props.canvas);
+		this.mode = Signal.from(props.mode ?? "source");
+		this.enabled = Signal.from(props.enabled ?? true);
+		this.#video = props.video;
+
+		this.#signals.run((effect) => {
+			const canvas = effect.get(this.canvas);
+			this.#ctx.set(canvas?.getContext("2d") ?? undefined);
+		});
+
+		this.#signals.run(this.#runSelect.bind(this));
+		this.#signals.run(this.#runRender.bind(this));
+	}
+
+	// Pick the frame source based on the mode, spinning up a transcoder for `encoded`.
+	#runSelect(effect: Effect): void {
+		if (!effect.get(this.enabled)) {
+			effect.set(this.#frame, undefined);
+			return;
+		}
+
+		if (effect.get(this.mode) === "encoded") {
+			const transcode = new Transcode({
+				source: this.#video.frame,
+				config: this.#video.hd.resolved,
+			});
+			effect.cleanup(() => transcode.close());
+			effect.proxy(this.#frame, transcode.frame);
+			return;
+		}
+
+		effect.proxy(this.#frame, this.#video.frame);
+	}
+
+	#runRender(effect: Effect): void {
+		const ctx = effect.get(this.#ctx);
+		if (!ctx) return;
+
+		const frame = effect.get(this.#frame);
+		const display = effect.get(this.#video.display);
+		const flip = effect.get(this.#video.flip);
+
+		// Setting width/height clears the canvas, so only resize when the dimensions actually change.
+		if (display && (ctx.canvas.width !== display.width || ctx.canvas.height !== display.height)) {
+			ctx.canvas.width = display.width;
+			ctx.canvas.height = display.height;
+		}
+
+		ctx.fillStyle = "#000";
+		ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+		if (!frame) return;
+
+		ctx.save();
+		if (flip) {
+			ctx.scale(-1, 1);
+			ctx.translate(-ctx.canvas.width, 0);
+		}
+		ctx.drawImage(frame, 0, 0, ctx.canvas.width, ctx.canvas.height);
+		ctx.restore();
+	}
+
+	close(): void {
+		this.#signals.close();
+	}
+}
+
+type TranscodeProps = {
+	source: Getter<VideoFrame | undefined>;
+	config: Getter<VideoEncoderConfig | undefined>;
+};
+
+// Encodes the captured frames with the live rendition settings and decodes the result, so the
+// output frame is what a viewer would actually see after transmission.
+export class Transcode {
+	// The decoded output frame. Owned here, closed on each update and on close().
+	frame = new Signal<VideoFrame | undefined>(undefined);
+
+	#source: Getter<VideoFrame | undefined>;
+	#config: Getter<VideoEncoderConfig | undefined>;
+	#signals = new Effect();
+
+	constructor(props: TranscodeProps) {
+		this.#source = props.source;
+		this.#config = props.config;
+		this.#signals.run(this.#run.bind(this));
+	}
+
+	#run(effect: Effect): void {
+		const config = effect.get(this.#config);
+		if (!config) return;
+
+		const decoder = new VideoDecoder({
+			output: (frame: VideoFrame) => {
+				this.frame.update((prev) => {
+					prev?.close();
+					return frame;
+				});
+			},
+			error: (err: Error) => {
+				console.warn("preview: decode error", err);
+				effect.close();
+			},
+		});
+		effect.cleanup(() => {
+			if (decoder.state !== "closed") decoder.close();
+		});
+
+		const encoder = new VideoEncoder({
+			output: (chunk: EncodedVideoChunk) => {
+				if (decoder.state === "configured") decoder.decode(chunk);
+			},
+			error: (err: Error) => {
+				console.warn("preview: encode error", err);
+				effect.close();
+			},
+		});
+		effect.cleanup(() => {
+			if (encoder.state !== "closed") encoder.close();
+		});
+
+		encoder.configure(config);
+
+		// The encoder emits Annex B (inline SPS/PPS on keyframes), so the decoder needs no description.
+		decoder.configure({ codec: config.codec, optimizeForLatency: true });
+
+		// Re-key on the same cadence as the real encoder so the decoder can start and recover.
+		const interval = Time.Micro.fromSecond(2 as Time.Second);
+		let lastKeyframe: Time.Micro | undefined;
+
+		effect.run((inner) => {
+			const frame = inner.get(this.#source);
+			if (!frame) return;
+			if (encoder.state !== "configured") return;
+
+			const timestamp = frame.timestamp as Time.Micro;
+			const keyFrame = lastKeyframe === undefined || lastKeyframe + interval <= timestamp;
+			if (keyFrame) lastKeyframe = timestamp;
+
+			// The capture pipeline owns and closes the frame, so we just read it here.
+			encoder.encode(frame, { keyFrame });
+		});
+
+		effect.cleanup(() => {
+			this.frame.update((prev) => {
+				prev?.close();
+				return undefined;
+			});
+		});
+	}
+
+	close(): void {
+		this.#signals.close();
+		this.frame.update((prev) => {
+			prev?.close();
+			return undefined;
+		});
+	}
+}

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -55,6 +55,10 @@ export class Encoder {
 	// The video encoder config.
 	#config = new Signal<VideoEncoderConfig | undefined>(undefined);
 
+	// The resolved encoder config (codec, bitrate, dimensions), available even with no subscriber.
+	// Exposed so a local preview can re-encode with identical settings to mirror the wire output.
+	readonly resolved: Getter<VideoEncoderConfig | undefined> = this.#config;
+
 	// True when the encoder is actively serving a track.
 	active = new Signal<boolean>(false);
 


### PR DESCRIPTION
## Summary

`<moq-publish>` previously only previewed the raw capture stream via a `<video>` element (`srcObject`). This adds a `<canvas>` preview path and a new `preview` attribute to toggle a "real" preview that decodes the actually-encoded video, so you can see exactly what a viewer receives over the network.

| Preview element | `preview="source"` (default) | `preview="encoded"` |
|---|---|---|
| `<video>` | raw source via `srcObject` (unchanged) | not possible without MSE → warns once, falls back to source |
| `<canvas>` | draws raw captured frames | **re-encodes + decodes → draws the wire output** |

```html
<moq-publish url="..." name="me.hang" preview="encoded">
    <canvas></canvas>
</moq-publish>
```

## Why

A `<video srcObject>` preview shows the pristine camera/screen source, which hides what's actually being transmitted. The `encoded` mode surfaces real compression artifacts, keyframe cadence, and frames the encoder dropped, useful for monitoring transmitted quality.

## How it works

The `encoded` path ([`preview.ts`](https://github.com/moq-dev/moq/blob/claude/quirky-napier-fdfbcc/js/publish/src/preview.ts)) runs a `VideoEncoder → VideoDecoder` chain fed by the same captured-frame signal the real encoder uses, configured with the **HD rendition's resolved config** (same codec, dimensions, and bandwidth-capped bitrate). That config resolves even with no remote subscriber, so the preview always shows something rather than going blank when nobody is watching. The renderer mirrors `@moq/watch`'s canvas renderer (flip + resize handling).

Tradeoff: this is a full extra encode + decode pass, incurred only while an `encoded`-mode canvas is active. (An exact-bytes loopback would need a local `consume()` on the Broadcast producer so publish could embed a `@moq/watch` element pointed at itself; that's a larger `js/net` change left as a follow-up.)

## Changes

- `js/publish/src/video/encoder.ts` — expose `resolved: Getter<VideoEncoderConfig>`.
- `js/publish/src/preview.ts` (new) — `Renderer` (canvas draw) + `Transcode` (encode→decode). Exported as `Publish.Preview`.
- `js/publish/src/element.ts` — discover `video, canvas`; add `preview` attribute + `state.preview` signal + JS property; branch the preview effect; warn-once on `<video>` + `encoded`.
- `js/publish/src/index.ts` — export `Preview`.
- `demo/web/src/publish.html`, `doc/lib/js/@moq/publish.md` — document the option.

## Branch targeting

Targeting `main`: additive only. New optional attribute defaulting to existing behavior, new module, no wire/protocol or catalog/container changes, and no breaking changes to existing public APIs (`resolved` and `Preview` are new surface).

## Test plan

- [x] `just check` (JS): `@moq/publish` and `@moq/demo` typecheck/lint/biome pass.
- [ ] Manual: `<canvas>` + `preview="source"` draws the live capture.
- [ ] Manual: `<canvas>` + `preview="encoded"` draws decoded output; toggling `invisible` blanks it.
- [ ] Manual: `<video>` + `preview="encoded"` logs the one-time warning and still shows the raw source.

(Written by Claude)