### PR TITLE
feat(ffi): surface auth connect errors in language wrappers

### DIFF
--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -111,6 +111,8 @@ if (rc < 0) {
 
 `moq_error()` returns the reason for the most recent failed call **on the calling thread**, including detail the numeric code can't carry (which URL failed to parse, why a decode failed, etc.). The returned pointer is valid until the next libmoq call on that thread, so copy it if you need to keep it. It is only meaningful after a call returned a negative code; check the code first. Errors delivered through status callbacks carry their code directly, so read `moq_error()` from inside the callback if you want the matching reason.
 
+A server can reject the connection on auth grounds: unauthorized (HTTP 401) or forbidden (HTTP 403). Each returns its own distinct negative code (with `moq_error()` reporting `"unauthorized"` / `"forbidden"`). These are terminal, so distinguish them from a transient transport failure and stop rather than reconnecting.
+
 Failed calls are reported only through the return code and `moq_error()`, not logged. To surface libmoq's internal logs (moq-net / QUIC activity), call `moq_log_level("debug")` (or `"trace"`, `"info"`, etc.) to install a tracing subscriber.
 
 ## Use cases

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -21,6 +21,17 @@ import "github.com/moq-dev/moq-go/moq"
 
 The module bundles prebuilt `libmoq_ffi.a` for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, and `windows/amd64`. cgo selects the right archive at link time via build tags.
 
+## Error handling
+
+A server can reject the connection on auth grounds: `ErrMoqErrorUnauthorized` (HTTP 401) or `ErrMoqErrorForbidden` (HTTP 403). These are terminal: retrying without new credentials won't help, so handle them separately from a transient transport failure. The `moq.IsAuthError` helper catches both:
+
+```go
+session, err := client.Connect("https://relay.example.com")
+if moq.IsAuthError(err) {
+    // Prompt for credentials; don't reconnect.
+}
+```
+
 ## Local development
 
 The in-tree `go/` directory is the source skeleton; it's not a buildable Go module on its own (the generated `moq.go` and per-platform `.a` files are added at release time by CI, not committed). To exercise it locally:

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -60,6 +60,20 @@ When you're done, signal graceful shutdown to the peer:
 session.shutdown()  // alias for cancel(0u)
 ```
 
+A server can reject the connection on auth grounds: `MoqException.Unauthorized` (HTTP 401) or `MoqException.Forbidden` (HTTP 403). These are terminal: retrying without new credentials won't help, so handle them separately from a transient transport failure. Use the `isAuth` helper to catch both:
+
+```kotlin
+import dev.moq.isAuth
+
+try {
+    val session = client.connect("https://relay.example.com")
+} catch (e: MoqException) {
+    if (e.isAuth) {
+        // Prompt for credentials; don't reconnect.
+    }
+}
+```
+
 ## Subscribe
 
 ```kotlin

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -36,6 +36,16 @@ async with moq.Client("https://relay.example.com") as client:
 
 `Client(url, *, tls_verify=True, publish=None, subscribe=None)`. Without `publish` / `subscribe` an internal origin is created automatically. Pass an `OriginProducer` to share state across multiple clients.
 
+A server can reject the connection on auth grounds: `moq.MoqError.Unauthorized` (HTTP 401) or `moq.MoqError.Forbidden` (HTTP 403). These are terminal, so handle them separately from a transient transport failure rather than reconnecting:
+
+```python
+try:
+    async with moq.Client("https://relay.example.com") as client:
+        ...
+except (moq.MoqError.Unauthorized, moq.MoqError.Forbidden):
+    ...  # Prompt for credentials; don't reconnect.
+```
+
 ### Publishing media
 
 ```python

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -61,6 +61,16 @@ When you're done, signal graceful shutdown to the peer:
 session.shutdown()  // alias for cancel(code: 0)
 ```
 
+A server can reject the connection on auth grounds: `MoqError.Unauthorized` (HTTP 401) or `MoqError.Forbidden` (HTTP 403). These are terminal: retrying without new credentials won't help, so handle them separately from a transient transport failure. Use the `isAuth` helper to catch both:
+
+```swift
+do {
+    let session = try await client.connect(url: "https://relay.example.com")
+} catch let error as MoqError where error.isAuth {
+    // Prompt for credentials; don't reconnect.
+}
+```
+
 ## Subscribe
 
 ```swift

--- a/go/moq/errors.go
+++ b/go/moq/errors.go
@@ -1,0 +1,14 @@
+package moq
+
+import "errors"
+
+// IsAuthError reports whether err is a connection rejected by the server on
+// authentication or authorization grounds: Unauthorized (HTTP 401) or Forbidden
+// (HTTP 403). Unlike a transport failure, retrying without new credentials won't
+// help, so callers should surface these rather than reconnect.
+//
+// The ErrMoqError* sentinels live in the generated bindings (moq.go), so this
+// file, like cgo.go, only builds once those are staged alongside it.
+func IsAuthError(err error) bool {
+	return errors.Is(err, ErrMoqErrorUnauthorized) || errors.Is(err, ErrMoqErrorForbidden)
+}

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Errors.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Errors.kt
@@ -9,3 +9,13 @@ import uniffi.moq.MoqException
  */
 val MoqException.isShutdown: Boolean
     get() = this is MoqException.Cancelled || this is MoqException.Closed
+
+/**
+ * True for [MoqException.Unauthorized] (HTTP 401) and [MoqException.Forbidden]
+ * (HTTP 403), which the server returns to reject the connection on
+ * authentication or authorization grounds. Unlike a transport failure, retrying
+ * without new credentials won't help, so callers should surface these rather
+ * than reconnect.
+ */
+val MoqException.isAuth: Boolean
+    get() = this is MoqException.Unauthorized || this is MoqException.Forbidden

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -3,7 +3,7 @@
 Real-time pub/sub with built-in caching, fan-out, and prioritization.
 """
 
-from moq_ffi import Container
+from moq_ffi import Container, MoqError
 from moq_ffi import MoqSession as Session
 
 from .client import Client
@@ -58,6 +58,7 @@ __all__ = [
     "GroupProducer",
     "MediaConsumer",
     "MediaProducer",
+    "MoqError",
     "OriginConsumer",
     "OriginProducer",
     "Request",

--- a/swift/Sources/Moq/Errors.swift
+++ b/swift/Sources/Moq/Errors.swift
@@ -11,4 +11,15 @@ extension MoqError {
         default: return false
         }
     }
+
+    /// True for `Unauthorized` (HTTP 401) and `Forbidden` (HTTP 403), which the
+    /// server returns to reject the connection on authentication or authorization
+    /// grounds. Unlike a transport failure, retrying without new credentials won't
+    /// help, so callers should surface these rather than reconnect.
+    public var isAuth: Bool {
+        switch self {
+        case .Unauthorized, .Forbidden: return true
+        default: return false
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #1649, which added `Unauthorized` (HTTP 401) and `Forbidden` (HTTP 403) variants to the moq-ffi `MoqError` so callers can distinguish an auth rejection from a retryable transport failure. That PR landed the Rust side but left the language wrappers without an ergonomic way to act on the new variants (the [Cross-Package Sync](../blob/main/CLAUDE.md) row for `rs/moq-ffi`). This closes that gap.

## Summary

Parity helpers next to the existing `isShutdown`:

- **Swift** — `MoqError.isAuth` (true for `.Unauthorized` / `.Forbidden`)
- **Kotlin** — `MoqException.isAuth`
- **Go** — `moq.IsAuthError(err)`, using `errors.Is` over the generated `ErrMoqErrorUnauthorized` / `ErrMoqErrorForbidden` sentinels
- **Python** — re-export `MoqError` from the `moq` package so callers can `except moq.MoqError.Unauthorized` without reaching into `moq_ffi`

Plus an auth-error note in each wrapper's guide (`doc/lib/{swift,kt,go,py}`) and the C library doc (`doc/lib/c`), which documents the distinct return codes + `moq_error()` strings since libmoq has no named C constants for them.

The variants themselves are already emitted by every binding (flat UniFFI error), so this is purely the ergonomic + documentation surface.

## Test plan

- [ ] CI `just ci` runs `just {py,kt,go} check` on the Linux runner (these wrappers were skipped for #1649 since it didn't touch them); Go compiles `IsAuthError` against freshly-regenerated bindings that now include `ErrMoqErrorForbidden`.
- [ ] `swift check` is macOS-only and skips on the Linux runner; the `isAuth` helper mirrors the existing `isShutdown` exactly.
- [x] `gofmt` clean; Python isort/`__all__` ordering consistent with existing style.

(Written by Claude)