### PR TITLE
demo: auto-select a free relay port for `just dev`

### DIFF
--- a/demo/justfile
+++ b/demo/justfile
@@ -7,12 +7,40 @@ mod sub
 mod web
 
 # Run the web demo (default).
+#
+# Picks the first free port at/after 4443 (both UDP for QUIC and TCP for HTTP)
+# so multiple worktrees can run `just dev` without colliding. The relay reads
+# the port from MOQ_SERVER_BIND/MOQ_WEB_HTTP_LISTEN, overriding localhost.toml.
 default:
+    #!/usr/bin/env bash
+    set -euo pipefail
     bun install
+
+    port=$(just port)
+    if [ "$port" != "4443" ]; then
+    	echo ">>> Port 4443 is busy, using $port instead" >&2
+    fi
+
+    export MOQ_SERVER_BIND="[::]:$port"
+    export MOQ_WEB_HTTP_LISTEN="[::]:$port"
+    base="http://localhost:$port"
+
     bun run concurrently --kill-others --names srv,bbb,web --prefix-colors auto \
     	"just relay" \
-    	"just wait && just pub bbb" \
-    	"just wait && just web"
+    	"just wait $base/certificate.sha256 && just pub bbb $base/anon" \
+    	"just wait $base/certificate.sha256 && just web $base/anon"
+
+# Find the first free port at/after `start` (checked on both TCP and UDP).
+[private]
+port start="4443":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    port={{ start }}
+    while lsof -nP -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1 \
+    	|| lsof -nP -iUDP:"$port" -t >/dev/null 2>&1; do
+    	port=$((port + 1))
+    done
+    echo "$port"
 
 # Wait for the localhost relay to be ready by repeatedly requesting the cert
 [private]


### PR DESCRIPTION
## Summary

`just dev` hardcoded port 4443 for the relay (QUIC UDP + HTTP/WebSocket TCP), the publisher, and the web UI. Running it from more than one worktree collided on the bind, which is annoying when juggling multiple checkouts. This makes `just dev` pick the first free port at/after 4443 so multiple worktrees can run concurrently.

## What changed

- New private `port` recipe in `demo/justfile`: walks up from 4443 to the first port free on **both** TCP (HTTP) and UDP (QUIC), since the relay binds both.
- The `default` recipe now computes the port, prints a notice if it had to move off 4443, exports `MOQ_SERVER_BIND` / `MOQ_WEB_HTTP_LISTEN` (inherited by the `just relay` subprocess, overriding `localhost.toml` — no relay-recipe or TOML changes needed), and threads the matching `http://localhost:$port/...` URL into `wait`, `pub bbb`, and `web`.

## Why the env override works

`Config::parse_and_merge` (rs/moq-relay/src/config.rs) re-applies env vars *after* loading the TOML, and both `MOQ_SERVER_BIND` and `MOQ_WEB_HTTP_LISTEN` are env-backed clap args, so they win over `localhost.toml`'s `listen = "[::]:4443"`.

## Test plan

- [x] `just port` returns `4443` when free.
- [x] `just port` skips to `4444` when 4443 is occupied on TCP or UDP.
- [x] `just --fmt --check` passes on `demo/justfile`.

## Notes for reviewers

- The `cluster` recipe in `demo/relay/justfile` still hardcodes 4443–4445; left untouched since it's a separate multi-node setup and less collision-prone.

(Written by Claude)