### PR TITLE
perf(moq-mux): SIMD-accelerate MPEG-TS sync byte resync

### DIFF
--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -142,10 +142,11 @@ impl<E: scte35::Catalog> Import<E> {
 			// (which only re-aligns on exact multiples of 188, so a sub-packet
 			// misalignment would desync permanently).
 			if self.scratch[off] != 0x47 {
-				off = match memchr::memchr(0x47, &self.scratch[off..]) {
-					Some(rel) => off + rel,
-					None => self.scratch.len(),
-				};
+				if let Some(rel) = memchr::memchr(0x47, &self.scratch[off..]) {
+					off += rel;
+				} else {
+					off = self.scratch.len();
+				}
 				continue;
 			}
 			let pkt: [u8; TsPacket::SIZE] = self.scratch[off..off + TsPacket::SIZE].try_into().unwrap();

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -142,11 +142,7 @@ impl<E: scte35::Catalog> Import<E> {
 			// (which only re-aligns on exact multiples of 188, so a sub-packet
 			// misalignment would desync permanently).
 			if self.scratch[off] != 0x47 {
-				if let Some(rel) = memchr::memchr(0x47, &self.scratch[off..]) {
-					off += rel;
-				} else {
-					off = self.scratch.len();
-				}
+				off = memchr::memchr(0x47, &self.scratch[off..]).map_or(self.scratch.len(), |rel| off + rel);
 				continue;
 			}
 			let pkt: [u8; TsPacket::SIZE] = self.scratch[off..off + TsPacket::SIZE].try_into().unwrap();

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -137,12 +137,15 @@ impl<E: scte35::Catalog> Import<E> {
 		// registered) before the packets that follow it in the same chunk route.
 		let mut off = 0;
 		while off + TsPacket::SIZE <= self.scratch.len() {
-			// TS packets start with 0x47. On a lost sync byte, scan forward one byte
-			// at a time for the next one instead of skipping a whole 188-byte stride
+			// TS packets start with 0x47. On a lost sync byte, jump to the next one
+			// (SIMD-accelerated via memchr) instead of skipping a whole 188-byte stride
 			// (which only re-aligns on exact multiples of 188, so a sub-packet
 			// misalignment would desync permanently).
 			if self.scratch[off] != 0x47 {
-				off += 1;
+				off = match memchr::memchr(0x47, &self.scratch[off..]) {
+					Some(rel) => off + rel,
+					None => self.scratch.len(),
+				};
 				continue;
 			}
 			let pkt: [u8; TsPacket::SIZE] = self.scratch[off..off + TsPacket::SIZE].try_into().unwrap();


### PR DESCRIPTION
## Summary

You asked me to look for code that could be SIMD-optimized, but only where it's a simple change. After surveying the byte-scanning hot loops across `rs/` and `js/`, there was exactly one clean win.

The MPEG-TS demuxer (`rs/moq-mux/src/container/ts/import.rs`) resyncs after a lost sync byte by scanning forward **one byte at a time** looking for the next `0x47`:

```rust
if self.scratch[off] != 0x47 {
    off += 1;
    continue;
}
```

This now jumps straight to the next sync byte with `memchr::memchr`, which is SIMD-accelerated (SSE2/AVX2/NEON) and was already a dependency of the crate:

```rust
if self.scratch[off] != 0x47 {
    off = match memchr::memchr(0x47, &self.scratch[off..]) {
        Some(rel) => off + rel,
        None => self.scratch.len(),
    };
    continue;
}
```

The end state is identical to the old loop (advance to the next sync byte, or drop the whole buffer when none remains), so resync semantics are unchanged. This matters most when a live capture joins mid-stream or a stream loses sync, where the old path crawled byte-by-byte over the buffer.

## What I deliberately left alone

- **H.264/H.265 Annex-B start-code scanning** (`rs/moq-mux/src/codec/annexb.rs`) already uses `memchr::memmem::find`, which is SIMD-accelerated. No change needed.
- There is **no TypeScript packet finder** to optimize. The MPEG-TS demuxer lives in Rust; the JS side doesn't scan for sync bytes / start codes.
- Other candidates (ADTS frame parsing, ESDS descriptor scan, length-prefix decode) were either too small to matter or not a clean drop-in, so they didn't meet the "simple change" bar.

## Test plan

- [x] `cargo test -p moq-mux` (all 36 `container::ts` tests pass, including `import_resyncs_after_byte_misalignment`, `stays_desynced_until_next_pusi`, `tei_continuation_drops_partial_and_resyncs`)
- [x] `cargo clippy -p moq-mux` clean

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhkuD6AxGqVr6UZExHBPPU)_