### PR TITLE
moq-mux: harden the scte35_inject fixture generator

### DIFF
--- a/rs/moq-mux/examples/scte35_inject.rs
+++ b/rs/moq-mux/examples/scte35_inject.rs
@@ -90,10 +90,14 @@ fn main() -> anyhow::Result<()> {
 		match pkt.payload {
 			Some(TsPayload::Pat(pat)) => pmt_pid = pat.table.first().map(|p| p.program_map_pid),
 			Some(TsPayload::Pmt(pmt)) => {
+				// Fall back to the carrying PID if the PAT hasn't been seen yet (PAT-late streams).
+				pmt_pid.get_or_insert(pkt.header.pid);
 				orig = Some(pmt);
-				break;
 			}
 			_ => {}
+		}
+		if pmt_pid.is_some() && orig.is_some() {
+			break;
 		}
 	}
 	let pmt_pid = pmt_pid.context("input has no PAT/PMT PID")?;
@@ -179,13 +183,15 @@ fn main() -> anyhow::Result<()> {
 		.collect();
 	// Force strictly increasing positions so two cues never collapse onto one packet; the
 	// per-packet `position()` lookup below would otherwise emit only the first and drop the
-	// rest. Clamp to the last packet so we never index past the end.
-	let last = packets.len().saturating_sub(1);
+	// rest. Don't clamp: a collision at the tail must error rather than silently drop a cue.
 	for i in 1..cue_at.len() {
-		if cue_at[i] <= cue_at[i - 1] {
-			cue_at[i] = (cue_at[i - 1] + 1).min(last);
-		}
+		cue_at[i] = cue_at[i].max(cue_at[i - 1] + 1);
 	}
+	anyhow::ensure!(
+		cue_at.last().is_none_or(|&pos| pos < packets.len()),
+		"input too short to place {} cues after the PMT without collisions",
+		cue_at.len()
+	);
 
 	let mut out = Vec::new();
 	for (i, p) in packets.iter().enumerate() {

--- a/rs/moq-mux/examples/scte35_inject.rs
+++ b/rs/moq-mux/examples/scte35_inject.rs
@@ -10,8 +10,10 @@
 //!
 //! `<set>` picks the cue set (one per fixture family, see [`SETS`]).
 
+use std::collections::HashSet;
 use std::io::Cursor;
 
+use anyhow::Context;
 use base64::Engine;
 use mpeg2ts::es::StreamType;
 use mpeg2ts::ts::payload::Pmt;
@@ -20,7 +22,9 @@ use mpeg2ts::ts::{
 	TsPacketReader, TsPacketWriter, TsPayload, VersionNumber, WriteTsPacket,
 };
 
-const SCTE_PID: u16 = 0x0021;
+// First PID we try for the injected SCTE-35 stream. We walk upward from here to dodge any
+// PID the input program already uses.
+const SCTE_PID_START: u16 = 0x0021;
 
 // One cue set per fixture: 4 real splice_info_sections from the threefive project
 // (MIT, github.com/futzu/threefive) plus 1 custom built for these fixtures and
@@ -65,22 +69,24 @@ const SETS: [(&str, [&str; 5]); 3] = [
 	),
 ];
 
-fn main() {
+fn main() -> anyhow::Result<()> {
 	let args: Vec<String> = std::env::args().collect();
-	let input = std::fs::read(&args[1]).expect("read input TS");
-	let out_path = &args[2];
-	let set = args.get(3).expect("usage: scte35_inject input.ts output.ts <set>");
+	let usage = "usage: scte35_inject input.ts output.ts <set>";
+	let input_path = args.get(1).context(usage)?;
+	let out_path = args.get(2).context(usage)?;
+	let set = args.get(3).context(usage)?;
+	let input = std::fs::read(input_path).context("reading input TS")?;
 	let cues_b64 = &SETS
 		.iter()
 		.find(|(name, _)| name == set)
-		.unwrap_or_else(|| panic!("unknown set '{set}'; available: gst480i, bbb5s, ffmpeg"))
+		.with_context(|| format!("unknown set '{set}'; available: gst480i, bbb5s, ffmpeg"))?
 		.1;
 
 	// Learn the PMT PID and the original program tables.
 	let mut pmt_pid = None;
 	let mut orig = None;
 	let mut reader = TsPacketReader::new(Cursor::new(&input));
-	while let Some(pkt) = reader.read_ts_packet().unwrap() {
+	while let Some(pkt) = reader.read_ts_packet().context("reading TS packet")? {
 		match pkt.payload {
 			Some(TsPayload::Pat(pat)) => pmt_pid = pat.table.first().map(|p| p.program_map_pid),
 			Some(TsPayload::Pmt(pmt)) => {
@@ -90,8 +96,8 @@ fn main() {
 			_ => {}
 		}
 	}
-	let pmt_pid = pmt_pid.expect("input has no PAT/PMT PID");
-	let orig = orig.expect("input has no PMT");
+	let pmt_pid = pmt_pid.context("input has no PAT/PMT PID")?;
+	let orig = orig.context("input has no PMT")?;
 
 	// Augmented PMT: keep every original ES (so the reader keeps routing video/audio) and
 	// add the SCTE-35 PID plus the program-level CUEI registration descriptor.
@@ -99,9 +105,20 @@ fn main() {
 	let pcr_pid = orig.pcr_pid;
 	let mut es_info = orig.es_info;
 	let mut program_info = orig.program_info;
+
+	// Pick a SCTE-35 PID that doesn't collide with an ES (or the PMT) the input already uses.
+	let used: HashSet<u16> = es_info
+		.iter()
+		.map(|e| e.elementary_pid.as_u16())
+		.chain(std::iter::once(pmt_pid.as_u16()))
+		.collect();
+	let scte_pid = (SCTE_PID_START..Pid::NULL)
+		.find(|pid| !used.contains(pid))
+		.context("no free PID for SCTE-35")?;
+
 	es_info.push(EsInfo {
 		stream_type: StreamType::Dts8ChannelLosslessAudio,
-		elementary_pid: Pid::new(SCTE_PID).unwrap(),
+		elementary_pid: Pid::new(scte_pid).context("SCTE-35 PID")?,
 		descriptors: vec![],
 	});
 	program_info.push(Descriptor {
@@ -127,7 +144,9 @@ fn main() {
 		adaptation_field: None,
 		payload: Some(TsPayload::Pmt(pmt)),
 	};
-	TsPacketWriter::new(&mut aug_pmt).write_ts_packet(&packet).unwrap();
+	TsPacketWriter::new(&mut aug_pmt)
+		.write_ts_packet(&packet)
+		.context("writing augmented PMT")?;
 
 	// Decode the cue sections and wrap each in a TS packet.
 	let cues: Vec<Vec<u8>> = cues_b64
@@ -136,23 +155,37 @@ fn main() {
 		.map(|(i, b64)| {
 			let section = base64::engine::general_purpose::STANDARD
 				.decode(b64)
-				.expect("valid base64 cue");
-			cue_packet(i as u8, &section)
+				.context("decoding base64 cue")?;
+			cue_packet(i as u8, scte_pid, &section)
 		})
-		.collect();
+		.collect::<anyhow::Result<_>>()?;
 
 	// Pass the input packets through; insert the augmented PMT right after the first PMT,
 	// and splice the cues in at evenly spread positions so each lands on a later PTS.
-	let packets: Vec<&[u8]> = input.chunks(188).collect();
+	anyhow::ensure!(
+		input.len() % 188 == 0,
+		"input TS length {} is not a multiple of 188",
+		input.len()
+	);
+	let packets: Vec<&[u8]> = input.chunks_exact(188).collect();
 	let pmt_idx = packets
 		.iter()
 		.position(|p| pid_of(p) == pmt_pid.as_u16())
-		.expect("input has no PMT packet");
+		.context("input has no PMT packet")?;
 	let span = packets.len() - pmt_idx;
-	let cue_at: Vec<usize> = [5, 25, 50, 70, 85]
+	let mut cue_at: Vec<usize> = [5, 25, 50, 70, 85]
 		.iter()
 		.map(|pct| pmt_idx + pct * span / 100)
 		.collect();
+	// Force strictly increasing positions so two cues never collapse onto one packet; the
+	// per-packet `position()` lookup below would otherwise emit only the first and drop the
+	// rest. Clamp to the last packet so we never index past the end.
+	let last = packets.len().saturating_sub(1);
+	for i in 1..cue_at.len() {
+		if cue_at[i] <= cue_at[i - 1] {
+			cue_at[i] = (cue_at[i - 1] + 1).min(last);
+		}
+	}
 
 	let mut out = Vec::new();
 	for (i, p) in packets.iter().enumerate() {
@@ -164,28 +197,29 @@ fn main() {
 			out.extend_from_slice(&cues[c]);
 		}
 	}
-	std::fs::write(out_path, &out).expect("write output TS");
+	std::fs::write(out_path, &out).context("writing output TS")?;
 	eprintln!(
-		"wrote {out_path}: {} packets, {} cues from set '{set}' (pmt_pid={pmt_pid:?})",
+		"wrote {out_path}: {} packets, {} cues from set '{set}' (pmt_pid={pmt_pid:?}, scte_pid={scte_pid:#06x})",
 		out.len() / 188,
 		cues.len()
 	);
+	Ok(())
 }
 
 fn pid_of(pkt: &[u8]) -> u16 {
 	(((pkt[1] & 0x1f) as u16) << 8) | pkt[2] as u16
 }
 
-fn cue_packet(cc: u8, section: &[u8]) -> Vec<u8> {
+fn cue_packet(cc: u8, scte_pid: u16, section: &[u8]) -> anyhow::Result<Vec<u8>> {
 	let mut p = vec![
 		0x47,
-		0x40 | ((SCTE_PID >> 8) as u8 & 0x1f),
-		(SCTE_PID & 0xff) as u8,
+		0x40 | ((scte_pid >> 8) as u8 & 0x1f),
+		(scte_pid & 0xff) as u8,
 		0x10 | (cc & 0x0f),
 		0x00, // pointer_field
 	];
 	p.extend_from_slice(section);
-	assert!(p.len() <= 188, "section too large for a single TS packet");
+	anyhow::ensure!(p.len() <= 188, "section too large for a single TS packet");
 	p.resize(188, 0xff);
-	p
+	Ok(p)
 }


### PR DESCRIPTION
## Summary

Hardens the `scte35_inject` example (the SCTE-35 fixture generator) against the issues CodeRabbit flagged. The SCTE-35 feature itself merged via #1685; this is a follow-up to the example tool only.

- `main` returns `anyhow::Result<()>`; every `unwrap`/`expect`/`panic` becomes a `?` with `.context()`, so routine failures print a clean error instead of a backtrace.
- Allocate the SCTE-35 PID by walking up from `0x0021` to the first PID the input program doesn't already use, instead of hardcoding `0x0021` and risking a collision with an existing ES. Fresh clips that leave `0x0021` free still land on it, so existing fixtures regenerate byte-identically.
- Iterate full packets via `chunks_exact(188)` and reject inputs whose length isn't a multiple of 188, so `pid_of` never indexes a short trailing slice.
- Force the cue insertion positions strictly increasing so two cues can't collapse onto one packet and get silently dropped by `position()`.

## Test plan

- [x] `scte35_inject` compiles.
- [x] Smoke-tested end-to-end: clean `Error:` output on bad args / unknown set; picks `0x0021` for fresh inputs (byte-compatible with prior behavior).
- [x] All 7 `moq-mux` SCTE-35 tests pass.
- [x] `cargo clippy -D warnings` and `cargo fmt --check` clean via nix.

(Written by Claude)