### PR TITLE
fix(moq-mux): confirm TS sync lock before trusting a candidate sync byte

### DIFF
--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -61,12 +61,6 @@ pub struct Import<E: scte35::Catalog = ()> {
 	/// PIDs diverted, the rest fed to the reader); a trailing partial packet is
 	/// kept here for the next call.
 	scratch: Vec<u8>,
-	/// Sync lock. 0x47 is the packet sync byte but also occurs freely in payload
-	/// (TS has no byte stuffing), so a lone 0x47 isn't a boundary. While false we
-	/// confirm a candidate against the next packet's sync byte before trusting it;
-	/// once locked we stride 188 at a time, dropping the lock the instant a stride
-	/// misses. Persists across `decode` calls so a retained partial stays locked.
-	aligned: bool,
 	/// SCTE-35 PIDs, intercepted before the reader. SCTE-35 is carried as private
 	/// sections (table_id 0xFC), not PES, so the reader would `Pes::read_from` and
 	/// abort. Keyed by PID. Detected via the PMT 'CUEI' registration descriptor.
@@ -100,7 +94,6 @@ impl<E: scte35::Catalog> Import<E> {
 			initialized: false,
 			audio_burst: None,
 			scratch: Vec::new(),
-			aligned: false,
 			scte: HashMap::new(),
 			supports_scte35,
 			last_pts: None,
@@ -144,30 +137,32 @@ impl<E: scte35::Catalog> Import<E> {
 		// registered) before the packets that follow it in the same chunk route.
 		let mut off = 0;
 		while off + TsPacket::SIZE <= self.scratch.len() {
-			// TS packets start with 0x47. On a missed sync byte we lost alignment: jump
-			// to the next 0x47 (SIMD-accelerated via memchr) instead of skipping a whole
-			// 188-byte stride (which only re-aligns on exact multiples of 188, so a
-			// sub-packet misalignment would desync permanently).
+			// A TS packet starts with the 0x47 sync byte. While aligned we trust it and
+			// stride 188 at a time; a miss means we lost sync and must re-acquire it.
 			if self.scratch[off] != 0x47 {
-				self.aligned = false;
-				off = memchr::memchr(0x47, &self.scratch[off..]).map_or(self.scratch.len(), |rel| off + rel);
-				continue;
-			}
-			// 0x47 also occurs in payload, so while unlocked confirm the candidate against
-			// the next packet's sync byte before trusting it; otherwise a stray payload
-			// 0x47 emits one bogus packet. Once locked we stride freely (the check above is
-			// the tripwire that drops the lock), so the final packet of a buffer still emits.
-			if !self.aligned {
-				match self.scratch.get(off + TsPacket::SIZE) {
-					Some(&0x47) => self.aligned = true,
-					// The byte 188 ahead isn't a sync byte: this 0x47 was payload. Keep scanning.
-					Some(_) => {
-						off += 1;
-						continue;
+				// 0x47 also occurs freely in payload (TS has no byte stuffing), so a lone one
+				// isn't a boundary. Scan (SIMD via memchr) for a candidate whose next packet
+				// also begins with 0x47, confirming the 188 stride before trusting it.
+				// Striding past a false candidate would route one bogus packet; jumping a flat
+				// 188 instead would only re-align on exact multiples and could desync forever.
+				loop {
+					let Some(rel) = memchr::memchr(0x47, &self.scratch[off..]) else {
+						// No sync byte left: the buffer is junk, drop it.
+						off = self.scratch.len();
+						break;
+					};
+					off += rel;
+					match self.scratch.get(off + TsPacket::SIZE) {
+						// Next packet also starts with a sync byte: lock onto this candidate.
+						Some(&0x47) => break,
+						// The byte 188 ahead isn't a sync byte: this 0x47 was payload, keep scanning.
+						Some(_) => off += 1,
+						// Can't confirm yet (candidate is near the buffer tail); the outer loop
+						// either processes it (a full packet fits) or retains it for the next call.
+						None => break,
 					}
-					// Not enough buffered to confirm yet; retain the candidate and retry next call.
-					None => break,
 				}
+				continue;
 			}
 			let pkt: [u8; TsPacket::SIZE] = self.scratch[off..off + TsPacket::SIZE].try_into().unwrap();
 			off += TsPacket::SIZE;

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -61,6 +61,12 @@ pub struct Import<E: scte35::Catalog = ()> {
 	/// PIDs diverted, the rest fed to the reader); a trailing partial packet is
 	/// kept here for the next call.
 	scratch: Vec<u8>,
+	/// Sync lock. 0x47 is the packet sync byte but also occurs freely in payload (TS
+	/// has no byte stuffing), so a lone 0x47 isn't a boundary. False until a candidate
+	/// is confirmed by the next packet's sync byte; once true we stride 188 at a time
+	/// and trust the per-packet check. Persists across `decode` calls so a candidate
+	/// pending confirmation at a buffer tail is re-confirmed, not trusted blindly.
+	synced: bool,
 	/// SCTE-35 PIDs, intercepted before the reader. SCTE-35 is carried as private
 	/// sections (table_id 0xFC), not PES, so the reader would `Pes::read_from` and
 	/// abort. Keyed by PID. Detected via the PMT 'CUEI' registration descriptor.
@@ -94,6 +100,7 @@ impl<E: scte35::Catalog> Import<E> {
 			initialized: false,
 			audio_burst: None,
 			scratch: Vec::new(),
+			synced: false,
 			scte: HashMap::new(),
 			supports_scte35,
 			last_pts: None,
@@ -137,12 +144,13 @@ impl<E: scte35::Catalog> Import<E> {
 		// registered) before the packets that follow it in the same chunk route.
 		let mut off = 0;
 		while off + TsPacket::SIZE <= self.scratch.len() {
-			// A TS packet starts with the 0x47 sync byte. While aligned we trust it and
-			// stride 188 at a time; a miss means we lost sync and must re-acquire it.
-			if self.scratch[off] != 0x47 {
+			// A TS packet starts with the 0x47 sync byte. Once synced we trust it and stride
+			// 188 at a time; until then (or after a miss) we must (re)acquire the lock.
+			if !self.synced || self.scratch[off] != 0x47 {
+				self.synced = false;
 				// 0x47 also occurs freely in payload (TS has no byte stuffing), so a lone one
 				// isn't a boundary. Scan (SIMD via memchr) for a candidate whose next packet
-				// also begins with 0x47, confirming the 188 stride before trusting it.
+				// also begins with 0x47, confirming the 188 stride before locking onto it.
 				// Striding past a false candidate would route one bogus packet; jumping a flat
 				// 188 instead would only re-align on exact multiples and could desync forever.
 				loop {
@@ -154,13 +162,21 @@ impl<E: scte35::Catalog> Import<E> {
 					off += rel;
 					match self.scratch.get(off + TsPacket::SIZE) {
 						// Next packet also starts with a sync byte: lock onto this candidate.
-						Some(&0x47) => break,
+						Some(&0x47) => {
+							self.synced = true;
+							break;
+						}
 						// The byte 188 ahead isn't a sync byte: this 0x47 was payload, keep scanning.
 						Some(_) => off += 1,
-						// Can't confirm yet (candidate is near the buffer tail); the outer loop
-						// either processes it (a full packet fits) or retains it for the next call.
+						// Can't confirm yet (candidate is near the buffer tail). Stay unsynced so
+						// it's re-confirmed next call (with the trailing bytes) instead of trusted.
 						None => break,
 					}
+				}
+				// Unsynced means the buffer had no confirmable sync byte, or the candidate is
+				// pending confirmation; either way there's nothing to route until more arrives.
+				if !self.synced {
+					break;
 				}
 				continue;
 			}

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -142,10 +142,11 @@ impl<E: scte35::Catalog> Import<E> {
 			// (which only re-aligns on exact multiples of 188, so a sub-packet
 			// misalignment would desync permanently).
 			if self.scratch[off] != 0x47 {
-				off = match memchr::memchr(0x47, &self.scratch[off..]) {
-					Some(rel) => off + rel,
-					None => self.scratch.len(),
-				};
+				if let Some(rel) = memchr::memchr(0x47, &self.scratch[off..]) {
+					off += rel;
+				} else {
+					off = self.scratch.len();
+				}
 				continue;
 			}
 			let pkt: [u8; TsPacket::SIZE] = self.scratch[off..off + TsPacket::SIZE].try_into().unwrap();

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -61,6 +61,12 @@ pub struct Import<E: scte35::Catalog = ()> {
 	/// PIDs diverted, the rest fed to the reader); a trailing partial packet is
 	/// kept here for the next call.
 	scratch: Vec<u8>,
+	/// Sync lock. 0x47 is the packet sync byte but also occurs freely in payload
+	/// (TS has no byte stuffing), so a lone 0x47 isn't a boundary. While false we
+	/// confirm a candidate against the next packet's sync byte before trusting it;
+	/// once locked we stride 188 at a time, dropping the lock the instant a stride
+	/// misses. Persists across `decode` calls so a retained partial stays locked.
+	aligned: bool,
 	/// SCTE-35 PIDs, intercepted before the reader. SCTE-35 is carried as private
 	/// sections (table_id 0xFC), not PES, so the reader would `Pes::read_from` and
 	/// abort. Keyed by PID. Detected via the PMT 'CUEI' registration descriptor.
@@ -94,6 +100,7 @@ impl<E: scte35::Catalog> Import<E> {
 			initialized: false,
 			audio_burst: None,
 			scratch: Vec::new(),
+			aligned: false,
 			scte: HashMap::new(),
 			supports_scte35,
 			last_pts: None,
@@ -137,13 +144,30 @@ impl<E: scte35::Catalog> Import<E> {
 		// registered) before the packets that follow it in the same chunk route.
 		let mut off = 0;
 		while off + TsPacket::SIZE <= self.scratch.len() {
-			// TS packets start with 0x47. On a lost sync byte, jump to the next one
-			// (SIMD-accelerated via memchr) instead of skipping a whole 188-byte stride
-			// (which only re-aligns on exact multiples of 188, so a sub-packet
-			// misalignment would desync permanently).
+			// TS packets start with 0x47. On a missed sync byte we lost alignment: jump
+			// to the next 0x47 (SIMD-accelerated via memchr) instead of skipping a whole
+			// 188-byte stride (which only re-aligns on exact multiples of 188, so a
+			// sub-packet misalignment would desync permanently).
 			if self.scratch[off] != 0x47 {
+				self.aligned = false;
 				off = memchr::memchr(0x47, &self.scratch[off..]).map_or(self.scratch.len(), |rel| off + rel);
 				continue;
+			}
+			// 0x47 also occurs in payload, so while unlocked confirm the candidate against
+			// the next packet's sync byte before trusting it; otherwise a stray payload
+			// 0x47 emits one bogus packet. Once locked we stride freely (the check above is
+			// the tripwire that drops the lock), so the final packet of a buffer still emits.
+			if !self.aligned {
+				match self.scratch.get(off + TsPacket::SIZE) {
+					Some(&0x47) => self.aligned = true,
+					// The byte 188 ahead isn't a sync byte: this 0x47 was payload. Keep scanning.
+					Some(_) => {
+						off += 1;
+						continue;
+					}
+					// Not enough buffered to confirm yet; retain the candidate and retry next call.
+					None => break,
+				}
 			}
 			let pkt: [u8; TsPacket::SIZE] = self.scratch[off..off + TsPacket::SIZE].try_into().unwrap();
 			off += TsPacket::SIZE;

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -142,11 +142,7 @@ impl<E: scte35::Catalog> Import<E> {
 			// (which only re-aligns on exact multiples of 188, so a sub-packet
 			// misalignment would desync permanently).
 			if self.scratch[off] != 0x47 {
-				if let Some(rel) = memchr::memchr(0x47, &self.scratch[off..]) {
-					off += rel;
-				} else {
-					off = self.scratch.len();
-				}
+				off = memchr::memchr(0x47, &self.scratch[off..]).map_or(self.scratch.len(), |rel| off + rel);
 				continue;
 			}
 			let pkt: [u8; TsPacket::SIZE] = self.scratch[off..off + TsPacket::SIZE].try_into().unwrap();

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -137,12 +137,15 @@ impl<E: scte35::Catalog> Import<E> {
 		// registered) before the packets that follow it in the same chunk route.
 		let mut off = 0;
 		while off + TsPacket::SIZE <= self.scratch.len() {
-			// TS packets start with 0x47. On a lost sync byte, scan forward one byte
-			// at a time for the next one instead of skipping a whole 188-byte stride
+			// TS packets start with 0x47. On a lost sync byte, jump to the next one
+			// (SIMD-accelerated via memchr) instead of skipping a whole 188-byte stride
 			// (which only re-aligns on exact multiples of 188, so a sub-packet
 			// misalignment would desync permanently).
 			if self.scratch[off] != 0x47 {
-				off += 1;
+				off = match memchr::memchr(0x47, &self.scratch[off..]) {
+					Some(rel) => off + rel,
+					None => self.scratch.len(),
+				};
 				continue;
 			}
 			let pkt: [u8; TsPacket::SIZE] = self.scratch[off..off + TsPacket::SIZE].try_into().unwrap();

--- a/rs/moq-mux/src/container/ts/import_test.rs
+++ b/rs/moq-mux/src/container/ts/import_test.rs
@@ -72,6 +72,28 @@ fn resyncs_past_false_sync_byte() {
 	assert_eq!(catalog.audio.renditions.len(), 1, "false sync derailed demux: no audio");
 }
 
+#[test]
+fn resyncs_across_chunk_boundaries() {
+	// Misaligned start fed in small chunks, so a resync candidate often lands at a buffer
+	// tail and is carried, pending confirmation, into the next decode call. The sync lock
+	// must re-confirm it there (with the trailing bytes) rather than trust it blindly.
+	let data = include_bytes!("test_data/bbb.ts");
+	let mut misaligned = vec![0x00, 0x11, 0x22];
+	misaligned.extend_from_slice(data);
+
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	for chunk in misaligned.chunks(100) {
+		import.decode(&mut BytesMut::from(chunk)).unwrap();
+	}
+	import.finish().unwrap();
+
+	let snapshot = catalog.snapshot();
+	assert_eq!(snapshot.video.renditions.len(), 1);
+	assert_eq!(snapshot.audio.renditions.len(), 1);
+}
+
 #[tokio::test(start_paused = true)]
 async fn import_export_import_roundtrip() {
 	let data = include_bytes!("test_data/bbb.ts");

--- a/rs/moq-mux/src/container/ts/import_test.rs
+++ b/rs/moq-mux/src/container/ts/import_test.rs
@@ -61,12 +61,11 @@ fn import_resyncs_after_byte_misalignment() {
 #[test]
 fn resyncs_past_false_sync_byte() {
 	let data = include_bytes!("test_data/bbb.ts");
-	// Prepend a stray 0x47 (a payload-like sync byte) that is NOT a real boundary:
-	// the byte 188 ahead is 0x00, so the sync-lock confirmation rejects it and keeps
-	// scanning to the real stream. Without the +188 check this 0x47 would be trusted
-	// and the all-zero "packet" routed as a bogus PAT before resync.
-	let mut misaligned = vec![0u8; 189];
-	misaligned[0] = 0x47;
+	// Lead with a non-sync byte so demux enters resync, then a stray 0x47 (payload-like)
+	// whose byte 188 ahead is not a sync byte. The confirmation must reject that candidate
+	// and scan on to the real stream rather than locking onto it and routing a bogus packet.
+	let mut misaligned = vec![0x00, 0x47];
+	misaligned.resize(202, 0x00);
 	misaligned.extend_from_slice(data);
 	let catalog = import_ts(&misaligned);
 	assert_eq!(catalog.video.renditions.len(), 1, "false sync derailed demux: no video");

--- a/rs/moq-mux/src/container/ts/import_test.rs
+++ b/rs/moq-mux/src/container/ts/import_test.rs
@@ -90,8 +90,16 @@ fn resyncs_across_chunk_boundaries() {
 	import.finish().unwrap();
 
 	let snapshot = catalog.snapshot();
-	assert_eq!(snapshot.video.renditions.len(), 1, "chunked resync failed: no video track");
-	assert_eq!(snapshot.audio.renditions.len(), 1, "chunked resync failed: no audio track");
+	assert_eq!(
+		snapshot.video.renditions.len(),
+		1,
+		"chunked resync failed: no video track"
+	);
+	assert_eq!(
+		snapshot.audio.renditions.len(),
+		1,
+		"chunked resync failed: no audio track"
+	);
 }
 
 #[tokio::test(start_paused = true)]

--- a/rs/moq-mux/src/container/ts/import_test.rs
+++ b/rs/moq-mux/src/container/ts/import_test.rs
@@ -58,6 +58,21 @@ fn import_resyncs_after_byte_misalignment() {
 	assert_eq!(catalog.audio.renditions.len(), 1, "resync failed: no audio track");
 }
 
+#[test]
+fn resyncs_past_false_sync_byte() {
+	let data = include_bytes!("test_data/bbb.ts");
+	// Prepend a stray 0x47 (a payload-like sync byte) that is NOT a real boundary:
+	// the byte 188 ahead is 0x00, so the sync-lock confirmation rejects it and keeps
+	// scanning to the real stream. Without the +188 check this 0x47 would be trusted
+	// and the all-zero "packet" routed as a bogus PAT before resync.
+	let mut misaligned = vec![0u8; 189];
+	misaligned[0] = 0x47;
+	misaligned.extend_from_slice(data);
+	let catalog = import_ts(&misaligned);
+	assert_eq!(catalog.video.renditions.len(), 1, "false sync derailed demux: no video");
+	assert_eq!(catalog.audio.renditions.len(), 1, "false sync derailed demux: no audio");
+}
+
 #[tokio::test(start_paused = true)]
 async fn import_export_import_roundtrip() {
 	let data = include_bytes!("test_data/bbb.ts");

--- a/rs/moq-mux/src/container/ts/import_test.rs
+++ b/rs/moq-mux/src/container/ts/import_test.rs
@@ -90,8 +90,8 @@ fn resyncs_across_chunk_boundaries() {
 	import.finish().unwrap();
 
 	let snapshot = catalog.snapshot();
-	assert_eq!(snapshot.video.renditions.len(), 1);
-	assert_eq!(snapshot.audio.renditions.len(), 1);
+	assert_eq!(snapshot.video.renditions.len(), 1, "chunked resync failed: no video track");
+	assert_eq!(snapshot.audio.renditions.len(), 1, "chunked resync failed: no audio track");
 }
 
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary

Follow-up to #1695. While reviewing the MPEG-TS sync logic we noticed a latent correctness gap: the demuxer trusted **any** single `0x47` at the expected offset as a packet boundary.

But `0x47` is only the sync byte at byte 0 of each 188-byte packet. The other 187 bytes (header continuation, adaptation field, payload, raw codec bitstream) are arbitrary, and TS has **no byte stuffing or escaping** to keep `0x47` out of them (unlike HDLC byte-stuffing or H.264 NAL emulation-prevention). So `0x47` appears in payload roughly once per packet on average. The format relies on the fixed 188-byte *periodicity*, not on the sync byte being unique.

Consequence: during sync acquisition (a misaligned start, mid-stream join, or post-corruption resync), a stray payload `0x47` could be mistaken for a boundary and route one bogus 188-byte "packet" before the next packet revealed the misalignment.

## Fix

Add a sync lock, a persisted `Import::synced` flag:

- **Until synced** (start, or after a missed sync byte), scan (SIMD `memchr`) for a candidate `0x47` whose **next** packet also begins with `0x47`, skipping payload `0x47`s, before locking onto it. If no sync byte remains, drop the buffer. If the candidate sits within 188 bytes of the buffer tail (its `+188` neighbor isn't buffered yet), stay unsynced and retain it, so it's re-confirmed on the next `decode` call with the trailing bytes rather than trusted blindly.
- **Once synced**, trust the `0x47` sync byte and stride 188 at a time; the per-packet check stays the tripwire that drops the lock the instant a stride misses.

The flag persists across `decode` calls, which closes the cross-call hole: a candidate pending confirmation at a buffer tail is confirmed next call, never trusted on faith.

## Test plan

- [x] `resyncs_past_false_sync_byte`: enters resync, then a stray `0x47` whose `+188` byte isn't a sync byte, proving the confirmation rejects it and scans on.
- [x] `resyncs_across_chunk_boundaries`: a misaligned stream fed in 100-byte chunks, exercising resync candidates carried (pending confirmation) across `decode` calls.
- [x] `cargo test -p moq-mux` (all 38 `container::ts` tests pass, including `import_resyncs_after_byte_misalignment`, `survives_midstream_join`, `import_handles_unaligned_chunks`, `kyrion_dirtystart_extracts_real_cues`)
- [x] `cargo clippy -p moq-mux` clean

(Written by Claude)