### PR TITLE
feat: certificate pinning for native and browser clients

### DIFF
--- a/js/net/src/connection/cert.test.ts
+++ b/js/net/src/connection/cert.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import * as Hex from "../util/hex.ts";
+import { certificateHash } from "./connect.ts";
+
+// SHA-256("abc"), a well-known test vector. We feed "abc" as the cert bytes so
+// the expected digest is independent of our own implementation.
+const ABC = new TextEncoder().encode("abc");
+const ABC_SHA256 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+test("certificateHash hashes raw DER bytes", async () => {
+	const hash = await certificateHash(ABC);
+	expect(Hex.fromBytes(hash)).toBe(ABC_SHA256);
+});
+
+test("certificateHash decodes PEM armor before hashing", async () => {
+	// base64("abc") === "YWJj"
+	const pem = "-----BEGIN CERTIFICATE-----\nYWJj\n-----END CERTIFICATE-----\n";
+	const hash = await certificateHash(pem);
+	expect(Hex.fromBytes(hash)).toBe(ABC_SHA256);
+});
+
+test("hex round-trips through fromBytes/toBytes", () => {
+	expect(Hex.fromBytes(Hex.toBytes(ABC_SHA256))).toBe(ABC_SHA256);
+});

--- a/js/net/src/connection/cert.test.ts
+++ b/js/net/src/connection/cert.test.ts
@@ -19,6 +19,11 @@ test("certificateHash decodes PEM armor before hashing", async () => {
 	expect(Hex.fromBytes(hash)).toBe(ABC_SHA256);
 });
 
+test("certificateHash rejects a PEM string without armor", async () => {
+	// Valid base64, but no -----BEGIN CERTIFICATE----- wrapper.
+	await expect(certificateHash("YWJj")).rejects.toThrow(/armor/);
+});
+
 test("hex round-trips through fromBytes/toBytes", () => {
 	expect(Hex.fromBytes(Hex.toBytes(ABC_SHA256))).toBe(ABC_SHA256);
 });

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -288,11 +288,12 @@ type WebTransportHash = NonNullable<WebTransportOptions["serverCertificateHashes
 
 // Strip PEM armor and base64-decode to the raw DER bytes.
 function pemToDer(pem: string): Uint8Array<ArrayBuffer> {
-	const body = pem
-		.replace(/-----BEGIN CERTIFICATE-----/g, "")
-		.replace(/-----END CERTIFICATE-----/g, "")
-		.replace(/\s+/g, "");
-	const binary = atob(body);
+	const match = pem.match(/-----BEGIN CERTIFICATE-----([\s\S]+?)-----END CERTIFICATE-----/);
+	if (!match) {
+		throw new Error("invalid PEM certificate: missing -----BEGIN/END CERTIFICATE----- armor");
+	}
+
+	const binary = atob(match[1].replace(/\s+/g, ""));
 	const der = new Uint8Array(binary.length);
 	for (let i = 0; i < binary.length; i++) {
 		der[i] = binary.charCodeAt(i);
@@ -352,10 +353,9 @@ async function connectWebTransport(
 		...webtransport,
 	};
 
-	const hashes = await resolveCertificateHashes(options);
-	if (hashes) {
-		finalOptions.serverCertificateHashes = hashes;
-	}
+	// Accumulate caller-provided pins first, then append anything we fetch below,
+	// so a fetched fingerprint never clobbers hashes passed in via options.
+	const hashes = (await resolveCertificateHashes(options)) ?? [];
 
 	// Only perform certificate fetch and URL rewrite when polyfill is not needed
 	// This is needed because WebTransport is a butt to work with in local development.
@@ -373,15 +373,14 @@ async function connectWebTransport(
 		const fingerprintText = await Promise.race([fingerprint.text(), cancel]);
 		if (fingerprintText === undefined) return undefined;
 
-		finalOptions.serverCertificateHashes = (finalOptions.serverCertificateHashes || []).concat([
-			{
-				algorithm: "sha-256",
-				value: Hex.toBytes(fingerprintText),
-			},
-		]);
+		hashes.push({ algorithm: "sha-256", value: Hex.toBytes(fingerprintText) });
 
 		finalUrl = new URL(url);
 		finalUrl.protocol = "https:";
+	}
+
+	if (hashes.length > 0) {
+		finalOptions.serverCertificateHashes = hashes;
 	}
 
 	const quic = new WebTransport(finalUrl, finalOptions);

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -22,9 +22,29 @@ export interface WebSocketOptions {
 	delay?: DOMHighResTimeStamp;
 }
 
+// One entry of `serverCertificateHashes`, used to pin a self-signed server.
+// Unlike the DOM type, `value` also accepts a hex string (the format moq
+// servers report via their certificate fingerprints), decoded automatically.
+export interface CertificateHash {
+	algorithm?: "sha-256";
+	value: BufferSource | string;
+}
+
+// WebTransport options, extended with friendlier certificate pinning.
+export interface WebTransportProps extends Omit<WebTransportOptions, "serverCertificateHashes"> {
+	// Pin the server to one or more certificate hashes. Each `value` may be raw
+	// bytes or a hex string; the algorithm defaults to `sha-256`.
+	serverCertificateHashes?: CertificateHash[];
+
+	// Pin the server by supplying its certificate directly; the SHA-256 hash is
+	// computed for you. Accepts a PEM string or raw DER bytes. Use this when you
+	// have the certificate but not its precomputed fingerprint.
+	serverCertificate?: string | BufferSource;
+}
+
 export interface ConnectProps {
 	// WebTransport options.
-	webtransport?: WebTransportOptions;
+	webtransport?: WebTransportProps;
 
 	// WebSocket (fallback) options.
 	websocket?: WebSocketOptions;
@@ -263,12 +283,59 @@ async function handshakeAlpn(url: URL, session: WebTransport, version: Ietf.Ietf
 	});
 }
 
+// One entry of the DOM `serverCertificateHashes`, derived without naming the lib type.
+type WebTransportHash = NonNullable<WebTransportOptions["serverCertificateHashes"]>[number];
+
+// Strip PEM armor and base64-decode to the raw DER bytes.
+function pemToDer(pem: string): Uint8Array<ArrayBuffer> {
+	const body = pem
+		.replace(/-----BEGIN CERTIFICATE-----/g, "")
+		.replace(/-----END CERTIFICATE-----/g, "")
+		.replace(/\s+/g, "");
+	const binary = atob(body);
+	const der = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		der[i] = binary.charCodeAt(i);
+	}
+	return der;
+}
+
+/**
+ * Compute the SHA-256 hash of a certificate, the value `serverCertificateHashes`
+ * pins. Accepts a PEM string or raw DER bytes. Matches the hex fingerprints a moq
+ * server reports, so `Hex.fromBytes(await certificateHash(pem))` round-trips.
+ */
+export async function certificateHash(cert: string | BufferSource): Promise<Uint8Array<ArrayBuffer>> {
+	const der = typeof cert === "string" ? pemToDer(cert) : cert;
+	const digest = await crypto.subtle.digest("SHA-256", der);
+	return new Uint8Array(digest);
+}
+
+// Normalize our friendlier pinning options into the DOM `serverCertificateHashes`.
+async function resolveCertificateHashes(options?: WebTransportProps): Promise<WebTransportHash[] | undefined> {
+	const hashes: WebTransportHash[] = [];
+
+	for (const hash of options?.serverCertificateHashes ?? []) {
+		const value = typeof hash.value === "string" ? Hex.toBytes(hash.value) : hash.value;
+		hashes.push({ algorithm: hash.algorithm ?? "sha-256", value });
+	}
+
+	if (options?.serverCertificate !== undefined) {
+		hashes.push({ algorithm: "sha-256", value: await certificateHash(options.serverCertificate) });
+	}
+
+	return hashes.length > 0 ? hashes : undefined;
+}
+
 async function connectWebTransport(
 	url: URL,
 	cancel: Promise<void>,
-	options?: WebTransportOptions,
+	options?: WebTransportProps,
 ): Promise<WebTransport | undefined> {
 	let finalUrl = url;
+
+	// Our custom pinning fields are normalized separately; the rest are DOM options.
+	const { serverCertificate: _cert, serverCertificateHashes: _hashes, ...webtransport } = options ?? {};
 
 	const finalOptions: WebTransportOptions = {
 		allowPooling: false,
@@ -282,8 +349,13 @@ async function connectWebTransport(
 			Ietf.ALPN.DRAFT_16,
 			Ietf.ALPN.DRAFT_15,
 		],
-		...options,
+		...webtransport,
 	};
+
+	const hashes = await resolveCertificateHashes(options);
+	if (hashes) {
+		finalOptions.serverCertificateHashes = hashes;
+	}
 
 	// Only perform certificate fetch and URL rewrite when polyfill is not needed
 	// This is needed because WebTransport is a butt to work with in local development.

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -1,7 +1,7 @@
 import { Effect, type Getter, Signal } from "@moq/signals";
 import type * as Path from "../path.ts";
 import { empty as emptyPath } from "../path.ts";
-import { type ConnectProps, connect, type WebSocketOptions } from "./connect.ts";
+import { type ConnectProps, connect, type WebSocketOptions, type WebTransportProps } from "./connect.ts";
 import type { Established } from "./established.ts";
 
 export type ReloadDelay = {
@@ -49,7 +49,7 @@ export class Reload {
 	readonly announced: Getter<Set<Path.Valid>> = this.#announced;
 
 	// WebTransport options (not reactive).
-	webtransport?: WebTransportOptions;
+	webtransport?: WebTransportProps;
 
 	// WebSocket (fallback) options (not reactive).
 	websocket: WebSocketOptions | undefined;

--- a/js/net/src/util/hex.ts
+++ b/js/net/src/util/hex.ts
@@ -1,4 +1,4 @@
-export function toBytes(hex: string) {
+export function toBytes(hex: string): Uint8Array<ArrayBuffer> {
 	hex = hex.startsWith("0x") ? hex.slice(2) : hex;
 	if (hex.length % 2) {
 		throw new Error("invalid hex string length");
@@ -10,4 +10,8 @@ export function toBytes(hex: string) {
 	}
 
 	return new Uint8Array(matches.map((byte) => parseInt(byte, 16)));
+}
+
+export function fromBytes(bytes: Uint8Array): string {
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -99,7 +99,9 @@ client = moq.Client(
 
 ### Connection
 
-- **`Client(url, *, tls_verify=True, bind=None, publish=None, subscribe=None)`**. Async context manager for connecting to a relay.
+- **`Client(url, *, tls_verify=True, tls_roots=None, tls_fingerprints=None, bind=None, publish=None, subscribe=None)`**. Async context manager for connecting to a relay.
+  - `tls_roots`. PEM root certificate file path(s) to trust instead of the system roots.
+  - `tls_fingerprints`. Hex SHA-256 fingerprint(s) to pin the peer's certificate to, the native equivalent of `serverCertificateHashes`. Accepts the values a server reports via `cert_fingerprints()`, so you can trust a self-signed certificate without `tls_verify=False`.
 - **`Server(bind="[::]:443", *, tls_cert=(), tls_key=(), tls_generate=(), publish=None, subscribe=None)`**. Async context manager + async iterator of incoming `Request`s.
   - `.local_addr`. The bound address (useful when binding to port `0`).
   - `.cert_fingerprints()`. SHA-256 fingerprints of the configured TLS certificates, for `serverCertificateHashes` browser cert pinning.

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -28,12 +28,16 @@ class Client:
         url: str,
         *,
         tls_verify: bool = True,
+        tls_roots: list[str] | None = None,
+        tls_fingerprints: list[str] | None = None,
         bind: str | None = None,
         publish: OriginProducer | None = None,
         subscribe: OriginProducer | None = None,
     ) -> None:
         self._url = url
         self._tls_verify = tls_verify
+        self._tls_roots = tls_roots
+        self._tls_fingerprints = tls_fingerprints
         self._bind = bind
 
         # If neither origin is provided, create a shared internal one.
@@ -55,6 +59,10 @@ class Client:
 
         if not self._tls_verify:
             self._inner.set_tls_disable_verify(True)
+        if self._tls_roots:
+            self._inner.set_tls_roots(self._tls_roots)
+        if self._tls_fingerprints:
+            self._inner.set_tls_fingerprints(self._tls_fingerprints)
         if self._bind is not None:
             self._inner.set_bind(self._bind)
 

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -83,6 +83,28 @@ impl MoqClient {
 		}
 	}
 
+	/// Trust these PEM root certificate file(s) instead of the system roots.
+	///
+	/// Pass the paths to PEM-encoded CA certificates. An empty list restores the
+	/// default behavior of using the platform's native root store.
+	pub fn set_tls_roots(&self, paths: Vec<String>) {
+		if let Some(mut state) = self.task.lock() {
+			state.config.tls.root = paths.into_iter().map(Into::into).collect();
+		}
+	}
+
+	/// Pin the peer to a certificate with one of these SHA-256 fingerprints, encoded as hex.
+	///
+	/// This is the native equivalent of the browser's WebTransport `serverCertificateHashes`
+	/// and accepts the same values a server reports (see `MoqServer.cert_fingerprints`). Use it
+	/// to trust a self-signed certificate without disabling verification. An empty list clears
+	/// any pinned fingerprints.
+	pub fn set_tls_fingerprints(&self, fingerprints: Vec<String>) {
+		if let Some(mut state) = self.task.lock() {
+			state.config.tls.fingerprint = fingerprints;
+		}
+	}
+
 	/// Set the local UDP socket bind address. Defaults to `[::]:0`.
 	///
 	/// Returns an error if the address cannot be parsed.

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -460,6 +460,36 @@ mod tests {
 	}
 
 	#[test]
+	fn test_toml_fingerprint_survives_update_from() {
+		let toml = r#"
+			tls.fingerprint = ["abcd1234", "ef567890"]
+		"#;
+
+		let mut config: ClientConfig = toml::from_str(toml).unwrap();
+		assert_eq!(config.tls.fingerprint, vec!["abcd1234", "ef567890"]);
+
+		// Simulate: TOML loaded, then CLI args re-applied (no --tls-fingerprint flag).
+		config.update_from(["test"]);
+		assert_eq!(config.tls.fingerprint, vec!["abcd1234", "ef567890"]);
+	}
+
+	#[test]
+	fn test_toml_fingerprint_accepts_single_string() {
+		let toml = r#"
+			tls.fingerprint = "abcd1234"
+		"#;
+
+		let config: ClientConfig = toml::from_str(toml).unwrap();
+		assert_eq!(config.tls.fingerprint, vec!["abcd1234"]);
+	}
+
+	#[test]
+	fn test_cli_fingerprint() {
+		let config = ClientConfig::parse_from(["test", "--tls-fingerprint", "abcd1234"]);
+		assert_eq!(config.tls.fingerprint, vec!["abcd1234"]);
+	}
+
+	#[test]
 	fn test_toml_version_survives_update_from() {
 		let toml = r#"
 			version = ["moq-lite-02"]

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -185,7 +185,7 @@ impl NoqClient {
 			let fingerprint = resp.text().await.map_err(Error::ReadFingerprint)?;
 			let fingerprint = hex::decode(fingerprint.trim())?;
 
-			let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), fingerprint);
+			let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), vec![fingerprint]);
 			config.dangerous().set_certificate_verifier(Arc::new(verifier));
 
 			url.set_scheme("https").expect("failed to set scheme");

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -187,7 +187,7 @@ impl QuinnClient {
 			let fingerprint = resp.text().await.map_err(Error::ReadFingerprint)?;
 			let fingerprint = hex::decode(fingerprint.trim())?;
 
-			let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), fingerprint);
+			let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), vec![fingerprint]);
 			config.dangerous().set_certificate_verifier(Arc::new(verifier));
 
 			url.set_scheme("https").expect("failed to set scheme");

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -38,6 +38,9 @@ pub enum Error {
 	#[error("invalid TLS fingerprint (expected hex-encoded SHA-256)")]
 	Fingerprint(#[source] hex::FromHexError),
 
+	#[error("invalid TLS fingerprint length: expected 32 bytes (SHA-256), got {0}")]
+	FingerprintLength(usize),
+
 	#[error("failed to add root certificate")]
 	AddRoot(#[source] rustls::Error),
 
@@ -211,7 +214,13 @@ impl Client {
 			let fingerprints = self
 				.fingerprint
 				.iter()
-				.map(|fp| hex::decode(fp.trim()).map_err(Error::Fingerprint))
+				.map(|fp| {
+					let bytes = hex::decode(fp.trim()).map_err(Error::Fingerprint)?;
+					match bytes.len() {
+						32 => Ok(bytes),
+						len => Err(Error::FingerprintLength(len)),
+					}
+				})
 				.collect::<Result<Vec<_>>>()?;
 
 			let verifier = FingerprintVerifier::new(provider, fingerprints);
@@ -448,6 +457,16 @@ mod tests {
 			..Default::default()
 		};
 		assert!(matches!(config.build(), Err(Error::Fingerprint(_))));
+	}
+
+	#[test]
+	fn build_rejects_wrong_length_fingerprint() {
+		// Valid hex, but only 2 bytes instead of 32.
+		let config = Client {
+			fingerprint: vec!["abcd".to_string()],
+			..Default::default()
+		};
+		assert!(matches!(config.build(), Err(Error::FingerprintLength(2))));
 	}
 }
 

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -35,6 +35,9 @@ pub enum Error {
 	#[error("no roots found in {}", .0.display())]
 	EmptyRoots(PathBuf),
 
+	#[error("invalid TLS fingerprint (expected hex-encoded SHA-256)")]
+	Fingerprint(#[source] hex::FromHexError),
+
 	#[error("failed to add root certificate")]
 	AddRoot(#[source] rustls::Error),
 
@@ -99,6 +102,21 @@ pub struct Client {
 	#[arg(id = "tls-root", long = "tls-root", env = "MOQ_CLIENT_TLS_ROOT")]
 	#[serde_as(as = "serde_with::OneOrMany<_>")]
 	pub root: Vec<PathBuf>,
+
+	/// Pin the peer to a certificate with one of these SHA-256 fingerprints, encoded as hex.
+	///
+	/// This is the native equivalent of the browser's WebTransport `serverCertificateHashes`,
+	/// and accepts the same values a server reports via its certificate fingerprints. Use it to
+	/// trust a self-signed certificate without disabling verification or fetching the hash over
+	/// an insecure `http://` request. When set, the normal CA/root chain is bypassed: only the
+	/// leaf certificate's fingerprint is checked.
+	///
+	/// This value can be provided multiple times to accept any of several fingerprints (e.g.
+	/// across a certificate rotation). In config files, accepts either a single string or a TOML array.
+	#[serde(skip_serializing_if = "Vec::is_empty")]
+	#[arg(id = "tls-fingerprint", long = "tls-fingerprint", env = "MOQ_CLIENT_TLS_FINGERPRINT")]
+	#[serde_as(as = "serde_with::OneOrMany<_>")]
+	pub fingerprint: Vec<String>,
 
 	/// PEM file containing the client certificate chain for mTLS.
 	///
@@ -189,6 +207,15 @@ impl Client {
 			tracing::warn!("TLS server certificate verification is disabled; A man-in-the-middle attack is possible.");
 			let noop = NoCertificateVerification(provider);
 			tls.dangerous().set_certificate_verifier(Arc::new(noop));
+		} else if !self.fingerprint.is_empty() {
+			let fingerprints = self
+				.fingerprint
+				.iter()
+				.map(|fp| hex::decode(fp.trim()).map_err(Error::Fingerprint))
+				.collect::<Result<Vec<_>>>()?;
+
+			let verifier = FingerprintVerifier::new(provider, fingerprints);
+			tls.dangerous().set_certificate_verifier(Arc::new(verifier));
 		}
 
 		Ok(tls)
@@ -319,21 +346,18 @@ impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
 
 // ── FingerprintVerifier ─────────────────────────────────────────────
 
-#[cfg(any(feature = "quinn", feature = "noq"))]
 #[derive(Debug)]
 pub(crate) struct FingerprintVerifier {
 	provider: crypto::Provider,
-	fingerprint: Vec<u8>,
+	fingerprints: Vec<Vec<u8>>,
 }
 
-#[cfg(any(feature = "quinn", feature = "noq"))]
 impl FingerprintVerifier {
-	pub fn new(provider: crypto::Provider, fingerprint: Vec<u8>) -> Self {
-		Self { provider, fingerprint }
+	pub fn new(provider: crypto::Provider, fingerprints: Vec<Vec<u8>>) -> Self {
+		Self { provider, fingerprints }
 	}
 }
 
-#[cfg(any(feature = "quinn", feature = "noq"))]
 impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
 	fn verify_server_cert(
 		&self,
@@ -344,7 +368,7 @@ impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
 		_now: UnixTime,
 	) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
 		let fingerprint = crypto::sha256(&self.provider, end_entity);
-		if fingerprint.as_ref() == self.fingerprint.as_slice() {
+		if self.fingerprints.iter().any(|fp| fingerprint.as_ref() == fp.as_slice()) {
 			Ok(rustls::client::danger::ServerCertVerified::assertion())
 		} else {
 			Err(rustls::Error::General("fingerprint mismatch".into()))
@@ -371,6 +395,59 @@ impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
 
 	fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
 		self.provider.signature_verification_algorithms.supported_schemes()
+	}
+}
+
+#[cfg(test)]
+#[cfg(all(any(feature = "quinn", feature = "noq", feature = "quiche"), feature = "aws-lc-rs"))]
+mod tests {
+	use super::*;
+	use rustls::client::danger::ServerCertVerifier;
+	use rustls::pki_types::ServerName;
+
+	fn self_signed() -> CertificateDer<'static> {
+		let key = rcgen::KeyPair::generate().unwrap();
+		let params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+		params.self_signed(&key).unwrap().into()
+	}
+
+	#[test]
+	fn fingerprint_verifier_matches_and_rejects() {
+		let provider = crypto::provider();
+		let cert = self_signed();
+		let fingerprint = crypto::sha256(&provider, cert.as_ref()).as_ref().to_vec();
+
+		let name = ServerName::try_from("localhost").unwrap();
+		let now = UnixTime::now();
+
+		let verifier = FingerprintVerifier::new(provider.clone(), vec![fingerprint]);
+		assert!(verifier.verify_server_cert(&cert, &[], &name, &[], now).is_ok());
+
+		// A different leaf certificate must not satisfy the pin.
+		let other = self_signed();
+		assert!(verifier.verify_server_cert(&other, &[], &name, &[], now).is_err());
+	}
+
+	#[test]
+	fn build_installs_fingerprint_verifier() {
+		let cert = self_signed();
+		let fingerprint = hex::encode(crypto::sha256(&crypto::provider(), cert.as_ref()));
+
+		// A bogus hash still builds; verification happens at handshake time.
+		let config = Client {
+			fingerprint: vec![fingerprint],
+			..Default::default()
+		};
+		assert!(config.build().is_ok());
+	}
+
+	#[test]
+	fn build_rejects_invalid_fingerprint_hex() {
+		let config = Client {
+			fingerprint: vec!["not-hex".to_string()],
+			..Default::default()
+		};
+		assert!(matches!(config.build(), Err(Error::Fingerprint(_))));
 	}
 }
 


### PR DESCRIPTION
## Summary

Trusting a self-signed or privately-issued peer previously meant disabling TLS verification entirely. This adds proper pinning to both the native and browser clients so callers can trust a specific certificate without turning verification off.

The unifying idea: a server already reports its certificate's SHA-256 fingerprint as **hex** (native `cert_fingerprints()`, the `/certificate.sha256` endpoint). Now **both** clients accept that same hex value directly — no insecure runtime fetch, no manual byte-wrangling.

### Native (`moq-native` / `moq-ffi` / `py`)

- New `tls::Client.fingerprint` field (`--tls-fingerprint`, `MOQ_CLIENT_TLS_FINGERPRINT`): pin the peer's leaf certificate to one or more hex SHA-256 hashes, bypassing the CA chain, hostname match, and expiry. The native equivalent of WebTransport `serverCertificateHashes`. `FingerprintVerifier` is ungated from the quinn/noq backends so it applies to every transport, and matches against a set to support rotation.
- The existing PEM-root knob (`--tls-root`) is now reachable from the FFI too.
- FFI: `MoqClient.set_tls_roots(paths)` and `set_tls_fingerprints(hashes)` alongside `set_tls_disable_verify`.
- Python: `Client(url, tls_roots=..., tls_fingerprints=...)`.
- `moq-cli` picks up `--tls-root` / `--tls-fingerprint` for free via the flattened config.

### Browser (`js/net`)

- `connect()`'s `webtransport.serverCertificateHashes` values now accept a **hex string** (decoded automatically), not just raw bytes.
- New `webtransport.serverCertificate` option: pin from a PEM string or DER bytes with the SHA-256 computed in JS.
- Exported `certificateHash(cert)` helper and `Hex.fromBytes` (counterpart to `toBytes`).

## Motivation / scope

This came out of looking at [pipecat#4629](https://github.com/pipecat-ai/pipecat/pull/4629). Worth being precise about what helps where:

- **pipecat's serve mode** (bot = server, browser pins via `serverCertificateHashes`) is a **browser-side** flow. The native client change doesn't touch it; the JS ergonomics here do (hex-string + `serverCertificate` instead of hand-built hash structs).
- **pipecat's client mode** (bot dials a relay as a native `moq.Client(tls_verify=...)`) only had a bool. `tls_fingerprints` / `tls_roots` is the upgrade if that relay is ever self-signed.

So neither half is strictly *required* by that PR, but both close a real "verify or disable, nothing in between" gap on their respective clients.

## Notes for reviewers

- **Public API**: additive only — `#[non_exhaustive]` config field + new FFI methods (native); widened option types (existing `{value: BufferSource}` callers still compile) + new exports (JS). Non-breaking, hence `main`.
- Hex chosen everywhere to match `cert_fingerprints()` / `/certificate.sha256`.
- swift/kt/go have no hand-written client wrappers, so uniffi auto-generates `setTlsRoots` / `setTlsFingerprints` on the next `moq-ffi-v*` mirror. libmoq exposes no client TLS-verify surface today, so nothing to mirror there.

## Test plan

- [x] `cargo test -p moq-native` — `--tls-fingerprint` TOML/CLI parsing, the TOML→CLI merge-clobber regression, and a `FingerprintVerifier` roundtrip (match / mismatch / invalid-hex)
- [x] `bun test` in `js/net` — `certificateHash` over DER and PEM against a known SHA-256 vector, hex round-trip (145/145 pass)
- [x] clippy + fmt (nix) on `moq-native` + `moq-ffi`; tsc + biome on `js/net`
- [ ] End-to-end against a live self-signed peer (native needs a maturin rebuild of `moq_ffi`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)