### PR TITLE
demo: call the web module's serve recipe in `just dev`

### DIFF
--- a/demo/justfile
+++ b/demo/justfile
@@ -28,7 +28,7 @@ default:
     bun run concurrently --kill-others --names srv,bbb,web --prefix-colors auto \
     	"just relay" \
     	"just wait $base/certificate.sha256 && just pub bbb $base/anon" \
-    	"just wait $base/certificate.sha256 && just web $base/anon"
+    	"just wait $base/certificate.sha256 && just web serve $base/anon"
 
 # Find the first free port at/after `start` (checked on both TCP and UDP).
 [private]


### PR DESCRIPTION
## Summary

`just dev` (via `demo/justfile`'s `default` recipe) was broken: it invoked the web module as `just web $base/anon`, so `just` looked for a recipe literally named `http://localhost:<port>/anon` in the `web` module and errored out, killing the whole concurrently group.

The fix names the `serve` recipe explicitly — `just web serve $base/anon` — mirroring the working sibling line `just pub bbb $base/anon`. The `serve` recipe is the one that takes a relay URL (`serve url='http://localhost:4443'`).

## Test plan

- [x] `just dev` brings up the srv, bbb, and web processes without the `justfile does not contain recipe` error

(Written by Claude)