### PR TITLE
feat(js/publish): add `announce` option to gate publishing on source selection

### DIFF
--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -66,12 +66,11 @@ a real bundler (the examples below).
 
 - `url` (required) — Relay server URL
 - `name` (required) — Broadcast name
-- `device` — "camera" or "screen" (default: "camera")
-- `audio` — Enable audio capture (boolean)
-- `video` — Enable video capture (boolean)
-- `controls` — Show publishing controls (boolean)
-- `announce` — When to publish the broadcast: `"true"` (default, announce as soon as the element connects), `"false"` (never announce), or `"source"` (hold off until a `source` is selected). The JS property takes a real boolean or `"source"` (`el.announce = false`)
+- `source` — Input to capture: `"camera"`, `"screen"`, or `"file"`
+- `muted` — Mute audio capture (boolean)
+- `invisible` — Disable video capture (boolean)
 - `preview` — What the preview renders: `"source"` (default), `"encoded"`, or `"none"` to disable it (see [Preview element](#preview-element))
+- `announce` — When to publish the broadcast: `"true"` (default, announce as soon as the element connects), `"false"` (never announce), or `"source"` (hold off until a `source` is selected). The JS property takes a real boolean or `"source"` (`el.announce = false`)
 
 ## Preview element
 

--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -70,6 +70,7 @@ a real bundler (the examples below).
 - `audio` — Enable audio capture (boolean)
 - `video` — Enable video capture (boolean)
 - `controls` — Show publishing controls (boolean)
+- `announce` — When to publish the broadcast: `"true"` (default, announce as soon as the element connects), `"false"` (never announce), or `"source"` (hold off until a `source` is selected). The JS property takes a real boolean or `"source"` (`el.announce = false`)
 - `preview` — What the preview renders: `"source"` (default), `"encoded"`, or `"none"` to disable it (see [Preview element](#preview-element))
 
 ## Preview element

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -69,6 +69,7 @@ The simplest way to publish a stream:
 | `url`      | string  | required | Relay server URL                |
 | `path`     | string  | required | Broadcast path                  |
 | `source`   | string  | —        | `"camera"`, `"screen"`, `"file"` |
+| `announce` | string  | `"true"` | When to publish: `"true"` (always), `"false"` (never), `"source"` (once a source is selected) |
 | `audio`    | boolean | false    | Enable audio capture            |
 | `video`    | boolean | false    | Enable video capture            |
 | `controls` | boolean | false    | Show simple publishing controls |

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -64,15 +64,15 @@ The simplest way to publish a stream:
 
 ### Attributes
 
-| Attribute  | Type    | Default  | Description                     |
-|------------|---------|----------|---------------------------------|
-| `url`      | string  | required | Relay server URL                |
-| `path`     | string  | required | Broadcast path                  |
-| `source`   | string  | —        | `"camera"`, `"screen"`, `"file"` |
-| `announce` | string  | `"true"` | When to publish: `"true"` (always), `"false"` (never), `"source"` (once a source is selected) |
-| `audio`    | boolean | false    | Enable audio capture            |
-| `video`    | boolean | false    | Enable video capture            |
-| `controls` | boolean | false    | Show simple publishing controls |
+| Attribute   | Type    | Default  | Description                     |
+|-------------|---------|----------|---------------------------------|
+| `url`       | string  | required | Relay server URL                |
+| `name`      | string  | required | Broadcast name                  |
+| `source`    | string  | —        | `"camera"`, `"screen"`, `"file"` |
+| `muted`     | boolean | false    | Mute audio capture              |
+| `invisible` | boolean | false    | Disable video capture           |
+| `preview`   | string  | `"source"` | What the preview renders: `"source"`, `"encoded"`, `"none"` |
+| `announce`  | string  | `"true"` | When to publish: `"true"` (always), `"false"` (never), `"source"` (once a source is selected) |
 
 ## JavaScript API
 

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -4,10 +4,13 @@ import { Broadcast } from "./broadcast";
 import * as Preview from "./preview";
 import * as Source from "./source";
 
-const OBSERVED = ["url", "name", "muted", "invisible", "source", "preview"] as const;
+const OBSERVED = ["url", "name", "muted", "invisible", "source", "preview", "announce"] as const;
 type Observed = (typeof OBSERVED)[number];
 
 type SourceType = "camera" | "screen" | "file";
+
+// `true` announces immediately, `false` never announces, "source" waits until a source is selected.
+type AnnounceMode = boolean | "source";
 
 // Close everything when this element is garbage collected.
 // This is primarily to avoid a console.warn that we didn't close() before GC.
@@ -25,6 +28,8 @@ export default class MoqPublish extends HTMLElement {
 		invisible: new Signal(false),
 		// What a <canvas> preview renders: the raw capture, or a decoded copy of the encoded video.
 		preview: new Signal<Preview.Mode>("source"),
+		// When to announce/publish the broadcast: always, never, or only once a source is selected.
+		announce: new Signal<AnnounceMode>(true),
 	};
 
 	connection: Moq.Connection.Reload;
@@ -44,6 +49,9 @@ export default class MoqPublish extends HTMLElement {
 
 	// Set when the element is connected to the DOM.
 	#enabled = new Signal(false);
+
+	// Whether to actually publish the broadcast: connected to the DOM and allowed by the `announce` mode.
+	#publishEnabled = new Signal(false);
 
 	signals = new Effect();
 
@@ -71,9 +79,17 @@ export default class MoqPublish extends HTMLElement {
 			this.#eitherEnabled.set(!muted || !invisible);
 		});
 
+		this.signals.run((effect) => {
+			const enabled = effect.get(this.#enabled);
+			const announce = effect.get(this.state.announce);
+			const hasSource = effect.get(this.state.source) !== undefined;
+			const announcing = announce === true || (announce === "source" && hasSource);
+			this.#publishEnabled.set(enabled && announcing);
+		});
+
 		this.broadcast = new Broadcast({
 			connection: this.connection.established,
-			enabled: this.#enabled,
+			enabled: this.#publishEnabled,
 
 			audio: {
 				enabled: this.#audioEnabled,
@@ -162,6 +178,16 @@ export default class MoqPublish extends HTMLElement {
 				this.state.source.set(newValue as SourceType | undefined);
 			} else {
 				throw new Error(`Invalid source: ${newValue}`);
+			}
+		} else if (name === "announce") {
+			if (newValue === "true" || newValue === null) {
+				this.state.announce.set(true);
+			} else if (newValue === "false") {
+				this.state.announce.set(false);
+			} else if (newValue === "source") {
+				this.state.announce.set("source");
+			} else {
+				throw new Error(`Invalid announce: ${newValue}`);
 			}
 		} else if (name === "muted") {
 			this.state.muted.set(newValue !== null);
@@ -303,6 +329,14 @@ export default class MoqPublish extends HTMLElement {
 
 	set preview(value: Preview.Mode) {
 		this.state.preview.set(value);
+	}
+
+	get announce(): AnnounceMode {
+		return this.state.announce.peek();
+	}
+
+	set announce(value: AnnounceMode) {
+		this.state.announce.set(value);
 	}
 }
 


### PR DESCRIPTION
## Summary

`<moq-publish>` announced the broadcast to the relay as soon as the element connected to the DOM, even before any camera/screen/file source was selected. This adds an `announce` option so callers can control when publishing happens.

| Value | Behavior |
|-------|----------|
| `true` (default) | Announce as soon as the element connects. Current behavior, so existing users are unaffected. |
| `false` | Never announce (pause publishing without tearing down the element). |
| `"source"` | Only announce once a `source` is selected; stops again if the source is cleared. |

- **HTML attribute** takes the string forms: `announce="true" \| "false" \| "source"` (HTML attributes are always strings; invalid values throw, matching the existing `preview`/`source` validation).
- **JS property** is a real `boolean | "source"`: `el.announce = false`.

Internally a derived `#publishEnabled` signal (`#enabled && (announce === true || (announce === "source" && hasSource))`) feeds `Broadcast.enabled` in place of the old DOM-connected-only `#enabled`.

## Public API

- `js/publish` — new `announce` observed attribute + `announce: boolean | "source"` property on `MoqPublish`. Additive, non-breaking.

## Notes for reviewers

- `"source"` gates on the source *type* being chosen (`state.source`), which flips the moment the user picks camera/screen/file, not when frames actually start flowing. If we'd rather wait for a live media track, that's a small change to what `#publishEnabled` observes.
- Docs updated per the cross-package sync table: `js/publish/README.md` and `doc/lib/js/@moq/publish.md`.

## Test plan

- [x] `tsc --noEmit` passes for `js/publish`
- [x] Biome clean
- [ ] Manual: `announce="source"` holds the broadcast until a source is picked; `announce="false"` never publishes; default/`"true"` unchanged

(Written by Claude)