### PR TITLE
feat(moq-relay): accept a full URL for cluster.connect

### DIFF
--- a/demo/relay/leaf0.toml
+++ b/demo/relay/leaf0.toml
@@ -37,7 +37,7 @@ listen = "[::]:4444"
 [cluster]
 # Connect only to the root. leaf1 will dial us directly, forming a loop
 # (leaf1 -> root, leaf1 -> leaf0, leaf0 -> root) to exercise cluster loop detection.
-connect = ["localhost:4443"]
+connect = ["https://localhost:4443/"]
 
 [auth]
 # Allow JWT tokens that are signed by this root key.

--- a/demo/relay/leaf1.toml
+++ b/demo/relay/leaf1.toml
@@ -37,7 +37,7 @@ listen = "[::]:4445"
 [cluster]
 # Connect to both the root and leaf0, forming a loop to exercise cluster loop detection.
 # ex. imagine us-east connects to us-central AND directly to us-west.
-connect = ["localhost:4443", "localhost:4444"]
+connect = ["https://localhost:4443/", "https://localhost:4444/"]
 
 [auth]
 # Allow JWT tokens that are signed by this root key.

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -11,7 +11,7 @@ A broadcast carries a small hop list as it travels. Each relay it passes through
 
 ## Topology
 
-Each relay lists the peers it wants to dial in `cluster.connect`. That's it; the topology is whatever you draw with those links.
+Each relay lists the peers it wants to dial in `cluster.connect`. That's it; the topology is whatever you draw with those links. Each peer is a full URL (e.g. `https://us-east.example.com/`); a bare host or `host:port` is deprecated but still accepted, and is wrapped in `https://.../` with a warning.
 
 A simple chain works well when one region is the source and others are caches:
 
@@ -22,11 +22,11 @@ eu-west  <---  us-east  <---  us-west
 ```toml
 # us-east.toml
 [cluster]
-connect = ["eu-west.example.com:4443"]
+connect = ["https://eu-west.example.com/"]
 
 # us-west.toml
 [cluster]
-connect = ["us-east.example.com:4443"]
+connect = ["https://us-east.example.com/"]
 ```
 
 A publisher on `eu-west` reaches a viewer on `us-west` through `us-east`. If a second `us-west` viewer subscribes to the same broadcast, `us-east` already has it cached, so only one fetch crosses the Atlantic. A full mesh (every relay dialing every other) would skip the cache entirely and waste an outbound link per pair.
@@ -39,7 +39,7 @@ Listing every peer by hand can get tedious in larger clusters. Tell the relay it
 
 ```toml
 [cluster]
-connect = ["us-east.example.com:4443"]
+connect = ["https://us-east.example.com/"]
 node    = "us-west.example.com:4443"
 mesh    = true
 ```
@@ -78,7 +78,7 @@ If a fetch fails or returns garbage, the relay logs and keeps the last good list
 Cluster peers must authenticate to each other:
 
 - **mTLS** (recommended). Set `tls.root` to the CA that signed the cluster certificates. Inbound connections presenting a valid client cert are granted full access; outbound dials use `client.tls.cert` / `client.tls.key`.
-- **JWT**. Each relay reads a token from `cluster.token` and presents it on outbound dials. The token needs broad enough scope to cover whatever paths the cluster carries.
+- **JWT**. For static `connect` peers, supply the token inline as a `?jwt=` query parameter on the URL. For gossip- and `connect_api`-discovered peers (whose addresses can't carry an inline token), set `cluster.token` to a file holding the JWT; it's presented on any dial whose URL has no inline `?jwt=` (so an inline token wins per-peer). Either way the token needs broad enough scope to cover whatever paths the cluster carries.
 
 See [Authentication](/bin/relay/auth) for the full setup.
 
@@ -86,11 +86,14 @@ See [Authentication](/bin/relay/auth) for the full setup.
 
 `cluster.root` was removed; setting it errors at startup with a message pointing at the replacement. `cluster.mesh` is now a boolean gossip toggle (it used to take this relay's URL); the URL moved to `cluster.node`. The old `mesh = "<url>"` form still works for backwards compatibility: it enables gossip and is treated as `cluster.node`, with a deprecation warning (or an error if it conflicts with an explicit `cluster.node`).
 
+`cluster.connect` entries are now full URLs; a bare host or `host:port` still works but logs a deprecation warning. A JWT for a static peer belongs inline as a `?jwt=` query parameter (the `cluster.token` file remains for gossip / `connect_api` peers, which can't carry an inline token).
+
 | Old | New |
 |---|---|
 | `root = "rendezvous:4443"` + `node = "us-east:4443"` | `connect = ["rendezvous:4443"]` + `node = "us-east:4443"` + `mesh = true` |
 | `root = "rendezvous:4443"` only | `node = "rendezvous:4443"` + `mesh = true` (passive rendezvous) |
 | `mesh = "us-east:4443"` | `node = "us-east:4443"` + `mesh = true` |
+| `connect = ["host:4443"]` + `token = "c.jwt"` | `connect = ["https://host/?jwt=<token>"]` |
 
 ## Next steps
 

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -136,8 +136,10 @@ Clustering configuration for multi-relay deployments.
 
 ```toml
 [cluster]
-# Peers this relay dials. The topology is whatever you draw with these links.
-connect = ["us-east.example.com:4443"]
+# Peers this relay dials, as full URLs. The topology is whatever you draw with
+# these links. A JWT may be supplied inline as a ?jwt= query parameter. A bare
+# host or "host:port" is deprecated but still accepted (wrapped in https://.../).
+connect = ["https://us-east.example.com/?jwt=..."]
 
 # Optional. This relay's own externally-reachable URL (identity). Advertised to
 # peers when gossip is on, and sent to connect_api as ?node=.
@@ -151,7 +153,9 @@ mesh = true
 # array of hostnames) and reconcile it at runtime, no restart needed.
 connect_api = "https://api.example.com/cluster/connect"
 
-# JWT used for outbound cluster dials (alternative to mTLS).
+# JWT for outbound cluster dials (alternative to mTLS), applied to any peer
+# whose URL has no inline ?jwt=. Required to authenticate gossip / connect_api
+# discovered peers; for static `connect` peers, prefer an inline ?jwt=.
 token = "cluster.jwt"
 ```
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -491,7 +491,8 @@ impl Cluster {
 		let mut tasks = tokio::task::JoinSet::new();
 
 		for peer in &self.config.connect {
-			if dialed.contains(peer) {
+			let key = canonicalize_peer_key(peer);
+			if dialed.contains(&key) {
 				continue;
 			}
 			if is_legacy_peer(peer) {
@@ -503,14 +504,13 @@ impl Cluster {
 			}
 			let this = self.clone();
 			let token = token.clone();
-			let peer = peer.clone();
 			let peer_for_task = peer.clone();
 			let handle = tasks.spawn(async move {
 				if let Err(err) = this.run_remote(&peer_for_task, token).await {
 					tracing::warn!(%err, peer = %peer_for_task, "cluster peer connection ended");
 				}
 			});
-			dialed.insert(peer, handle, DialSource::Static);
+			dialed.insert(key, handle, DialSource::Static);
 		}
 
 		if let Some(source) = self.config.connect_api.clone() {
@@ -597,12 +597,13 @@ impl Cluster {
 						continue;
 					}
 					let peer = peer.to_owned();
+					let key = canonicalize_peer_key(&peer);
 					match announced {
 						Some(_) => {
-							if dialed.contains(&peer) {
+							if dialed.contains(&key) {
 								// Already dialed (possibly via another source). Mark gossip as
 								// a wanter and cancel any pending stale-sweep.
-								if dialed.add_source(&peer, DialSource::Gossip) {
+								if dialed.add_source(&key, DialSource::Gossip) {
 									tracing::debug!(%peer, "reannounce within sweep window; keeping dial");
 								}
 								continue;
@@ -616,10 +617,10 @@ impl Cluster {
 									tracing::warn!(%err, peer = %peer_for_task, "cluster peer connection ended");
 								}
 							});
-							dialed.insert(peer, handle.abort_handle(), DialSource::Gossip);
+							dialed.insert(key, handle.abort_handle(), DialSource::Gossip);
 						}
 						None => {
-							dialed.mark_unannounced(&peer, Instant::now());
+							dialed.mark_unannounced(&key, Instant::now());
 						}
 					}
 				}
@@ -755,9 +756,14 @@ impl Cluster {
 	/// are new and drop API peers that disappeared. The relay's own [`node`] URL
 	/// is filtered out so it never dials itself.
 	fn apply_peer_list(&self, list: Vec<String>, node: &Option<String>, token: &str, dialed: &DialMap) {
+		// Dedupe against the shared dial map (and filter out self) on the canonical
+		// key, so an API entry matches the same peer reached via `connect`/gossip
+		// regardless of how each spells it. reconcile_api then yields canonical keys.
+		let self_key = node.as_deref().map(canonicalize_peer_key);
 		let desired: HashSet<String> = list
 			.into_iter()
-			.filter(|peer| Some(peer.as_str()) != node.as_deref())
+			.map(|peer| canonicalize_peer_key(&peer))
+			.filter(|key| Some(key) != self_key.as_ref())
 			.collect();
 
 		for peer in dialed.reconcile_api(&desired) {
@@ -778,9 +784,10 @@ impl Cluster {
 	async fn run_remote(self, remote: &str, token: String) -> anyhow::Result<()> {
 		let mut url = peer_url(remote)?;
 		// Apply the shared cluster token unless the URL already carries its own
-		// `?jwt=` (an inline token on a static `connect` peer wins; the shared
-		// token still covers discovered peers that have none).
-		if !token.is_empty() && !url.query_pairs().any(|(key, _)| key == "jwt") {
+		// non-empty `?jwt=` (an inline token on a static `connect` peer wins; the
+		// shared token still covers discovered peers that have none). An empty
+		// `?jwt=` counts as absent, matching `AuthParams::from_url`.
+		if !token.is_empty() && !url.query_pairs().any(|(key, value)| key == "jwt" && !value.is_empty()) {
 			url.query_pairs_mut().append_pair("jwt", &token);
 		}
 
@@ -864,6 +871,22 @@ fn peer_url(peer: &str) -> anyhow::Result<Url> {
 /// than a full URL. Used to warn on legacy `--cluster-connect` entries.
 fn is_legacy_peer(peer: &str) -> bool {
 	!peer.contains("://")
+}
+
+/// Canonical dedupe key for a cluster peer, so the same relay reached via
+/// different spellings (a full URL vs a bare `host:port`, with or without an
+/// inline `?jwt=`) shares one [`DialMap`] entry instead of opening a duplicate
+/// session. Drops the query (the jwt isn't part of a peer's identity) and lets
+/// `Url` normalize the scheme, host case, and default port. Falls back to the
+/// raw string if the peer can't be parsed.
+fn canonicalize_peer_key(peer: &str) -> String {
+	match peer_url(peer) {
+		Ok(mut url) => {
+			url.set_query(None);
+			url.into()
+		}
+		Err(_) => peer.to_string(),
+	}
 }
 
 /// Deserialize a field that accepts either a TOML boolean or string into an
@@ -1213,6 +1236,28 @@ mod tests {
 		assert!(is_legacy_peer("cdn.example.com"));
 		assert!(is_legacy_peer("localhost:4443"));
 		assert!(!is_legacy_peer("https://cdn.example.com/?jwt=abc"));
+	}
+
+	/// The same relay spelled as a bare `host:port`, a full URL, or a URL with an
+	/// inline jwt all canonicalize to one key, so they share a single dial entry.
+	#[tokio::test]
+	async fn canonicalize_peer_key_dedupes_spellings() {
+		let key = canonicalize_peer_key("host:4443");
+		assert_eq!(key, "https://host:4443/");
+		assert_eq!(canonicalize_peer_key("https://host:4443/"), key);
+		assert_eq!(canonicalize_peer_key("https://host:4443/?jwt=abc"), key);
+
+		// A URL form and the legacy host:port form dedupe against each other.
+		let dialed = DialMap::default();
+		dialed.insert(
+			canonicalize_peer_key("https://host:4443/?jwt=abc"),
+			placeholder_handle(),
+			DialSource::Static,
+		);
+		assert!(dialed.contains(&canonicalize_peer_key("host:4443")));
+
+		// Different ports stay distinct.
+		assert_ne!(canonicalize_peer_key("host:4443"), canonicalize_peer_key("host:5555"));
 	}
 
 	/// A legacy mesh URL that disagrees with an explicit `--cluster-node` is a

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -237,8 +237,10 @@ impl DialMap {
 #[non_exhaustive]
 #[group(id = "cluster-config")]
 pub struct ClusterConfig {
-	/// Connect to one or more other cluster nodes. Accepts a comma-separated list on the CLI
-	/// or repeat the flag; in config files use a TOML array.
+	/// Connect to one or more other cluster nodes. Each peer is a full URL, e.g.
+	/// `https://host/?jwt=TOKEN`; a bare host or `host:port` is deprecated but
+	/// still accepted (wrapped in `https://.../`). Accepts a comma-separated list
+	/// on the CLI or repeat the flag; in config files use a TOML array.
 	#[serde(alias = "connect")]
 	#[arg(
 		id = "cluster-connect",
@@ -294,7 +296,10 @@ pub struct ClusterConfig {
 	#[serde(default, deserialize_with = "deserialize_bool_or_string")]
 	pub mesh: Option<String>,
 
-	/// Use the token in this file when connecting to other nodes.
+	/// JWT presented on outbound cluster dials, read from this file. Applied to
+	/// any peer whose URL doesn't already carry a `?jwt=` (so it authenticates
+	/// gossip- and `connect_api`-discovered peers, whose addresses can't embed a
+	/// token). For static `--cluster-connect` peers, prefer an inline `?jwt=`.
 	#[arg(id = "cluster-token", long = "cluster-token", env = "MOQ_CLUSTER_TOKEN")]
 	pub token: Option<PathBuf>,
 
@@ -463,6 +468,10 @@ impl Cluster {
 			);
 		}
 
+		// Token presented on outbound dials whose URL doesn't already carry a
+		// `?jwt=`. This is how gossip- and connect_api-discovered peers (whose
+		// addresses can't carry an inline token) authenticate, so it isn't
+		// deprecated; for static `connect` peers, an inline `?jwt=` is preferred.
 		let token = match &self.config.token {
 			Some(path) => std::fs::read_to_string(path)
 				.context("failed to read cluster token")?
@@ -484,6 +493,13 @@ impl Cluster {
 		for peer in &self.config.connect {
 			if dialed.contains(peer) {
 				continue;
+			}
+			if is_legacy_peer(peer) {
+				tracing::warn!(
+					%peer,
+					"DEPRECATED: pass --cluster-connect as a full URL like \"https://<host>/?jwt=TOKEN\"; \
+					 a bare host or \"host:port\" is deprecated and will be removed in a future release"
+				);
 			}
 			let this = self.clone();
 			let token = token.clone();
@@ -760,8 +776,11 @@ impl Cluster {
 
 	#[tracing::instrument("remote", skip_all, err, fields(%remote))]
 	async fn run_remote(self, remote: &str, token: String) -> anyhow::Result<()> {
-		let mut url = Url::parse(&format!("https://{remote}/"))?;
-		if !token.is_empty() {
+		let mut url = peer_url(remote)?;
+		// Apply the shared cluster token unless the URL already carries its own
+		// `?jwt=` (an inline token on a static `connect` peer wins; the shared
+		// token still covers discovered peers that have none).
+		if !token.is_empty() && !url.query_pairs().any(|(key, _)| key == "jwt") {
 			url.query_pairs_mut().append_pair("jwt", &token);
 		}
 
@@ -823,6 +842,28 @@ impl Cluster {
 /// treated as a local file path, which needs no TLS client).
 fn connect_api_is_http(source: &str) -> bool {
 	Url::parse(source).is_ok_and(|url| matches!(url.scheme(), "http" | "https"))
+}
+
+/// Resolve a cluster peer to the URL we dial.
+///
+/// The modern form is a full URL, e.g. `https://host/?jwt=TOKEN`, which is used
+/// verbatim. A bare host or `host:port` is still accepted for backwards
+/// compatibility and wrapped in `https://.../` (callers warn about this legacy
+/// form for user-supplied `--cluster-connect` entries).
+fn peer_url(peer: &str) -> anyhow::Result<Url> {
+	// A full URL has a scheme separator; a bare host or `host:port` does not
+	// (and `Url::parse` would otherwise mis-read `host:port` as scheme `host`).
+	if peer.contains("://") {
+		return Url::parse(peer).with_context(|| format!("invalid cluster peer URL: {peer}"));
+	}
+
+	Url::parse(&format!("https://{peer}/")).with_context(|| format!("invalid cluster peer host: {peer}"))
+}
+
+/// Whether a peer string uses the deprecated bare-host / `host:port` form rather
+/// than a full URL. Used to warn on legacy `--cluster-connect` entries.
+fn is_legacy_peer(peer: &str) -> bool {
+	!peer.contains("://")
 }
 
 /// Deserialize a field that accepts either a TOML boolean or string into an
@@ -1153,6 +1194,25 @@ mod tests {
 		let (gossip, node) = cluster.resolve_mesh().expect("legacy mesh url resolves");
 		assert!(gossip);
 		assert_eq!(node.as_deref(), Some("rendezvous.example.com:4443"));
+	}
+
+	/// `--cluster-connect` accepts a full URL verbatim (preserving its `?jwt=`)
+	/// and falls back to wrapping a bare host / `host:port` in `https://.../`.
+	#[test]
+	fn peer_url_full_url_and_legacy_host() {
+		// Full URL used verbatim, including its jwt query.
+		assert_eq!(
+			peer_url("https://cdn.example.com/?jwt=abc").unwrap().as_str(),
+			"https://cdn.example.com/?jwt=abc"
+		);
+		// Bare host (legacy) wrapped in https://.../.
+		assert_eq!(peer_url("cdn.example.com").unwrap().as_str(), "https://cdn.example.com/");
+		// `host:port` (legacy) is NOT mis-parsed as scheme `host`.
+		assert_eq!(peer_url("localhost:4443").unwrap().as_str(), "https://localhost:4443/");
+
+		assert!(is_legacy_peer("cdn.example.com"));
+		assert!(is_legacy_peer("localhost:4443"));
+		assert!(!is_legacy_peer("https://cdn.example.com/?jwt=abc"));
 	}
 
 	/// A legacy mesh URL that disagrees with an explicit `--cluster-node` is a

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -1229,7 +1229,10 @@ mod tests {
 			"https://cdn.example.com/?jwt=abc"
 		);
 		// Bare host (legacy) wrapped in https://.../.
-		assert_eq!(peer_url("cdn.example.com").unwrap().as_str(), "https://cdn.example.com/");
+		assert_eq!(
+			peer_url("cdn.example.com").unwrap().as_str(),
+			"https://cdn.example.com/"
+		);
 		// `host:port` (legacy) is NOT mis-parsed as scheme `host`.
 		assert_eq!(peer_url("localhost:4443").unwrap().as_str(), "https://localhost:4443/");
 


### PR DESCRIPTION
## Summary

`cluster.connect` (a.k.a. `--cluster-connect`) peers were specified as a bare host or `host:port` and wrapped in `https://{peer}/` at dial time, with the JWT supplied separately via `cluster.token`. Passing a full URL silently broke: the value was interpolated straight into `https://{peer}/`, producing `https://https://host/?jwt=.../`, which `Url::parse` then read as host `https` and a failed DNS lookup.

This makes `cluster.connect` accept a **full URL** and use it verbatim, with an inline `?jwt=` token preserved. The legacy bare-host / `host:port` form still works (wrapped as before) but is deprecated.

```toml
# before (still works, now warns)
connect = ["us-east.example.com:4443"]
token   = "cluster.jwt"

# after
connect = ["https://us-east.example.com/?jwt=<token>"]
```

## Behavior

- A peer containing `://` is parsed as a URL and dialed verbatim (inline `?jwt=` kept).
- A bare host / `host:port` is still wrapped in `https://.../`, but logs a deprecation warning for user-supplied `cluster.connect` entries (gossip- and `connect_api`-discovered peers don't warn, to avoid log spam).
- **`cluster.token` is unchanged and *not* deprecated.** It remains the way gossip- and `connect_api`-discovered peers authenticate, since their addresses (the advertised `node` value / the API's hostname list) can't carry an inline token and you wouldn't want to broadcast a JWT in a gossip advertisement. It's applied to any dial whose URL has no inline `?jwt=`. An empty `?jwt=` counts as absent (matching `AuthParams::from_url`), so the token-file fallback still applies.
- **Dedupe by canonical key.** Because a relay can now be spelled as a URL *or* a bare `host:port` (and with or without an inline jwt), the shared `DialMap` keys on a canonical form (`canonicalize_peer_key`: scheme/host/default-port normalized, query dropped) so the same relay reached via `connect` + gossip + `connect_api` still opens a single session. `should_dial` (the gossip tiebreaker, which only ever compares node-form strings) and the `DialMap` internals are unchanged.

## Testing

- Unit tests `peer_url_full_url_and_legacy_host` and `canonicalize_peer_key_dedupes_spellings`; full `cargo test -p moq-relay` green (21 cluster tests).
- Verified against a live relay (debug build):
  - Full URL `https://actionstreamer.cdn.moq.dev/?jwt=...` now dials `https://actionstreamer.cdn.moq.dev/` and reaches `connected version=moq-lite-04` (previously mangled to `https://https//...` + DNS failure).
  - Legacy bare host + `--cluster-token` still connects, and emits the connect deprecation warning.

## Docs / configs

- `doc/bin/relay/cluster.md` and `doc/bin/relay/config.md` updated for the URL form, clarifying that `cluster.token` stays for discovered peers (incl. a migration-table row).
- `demo/relay/leaf0.toml` / `leaf1.toml` moved to the URL form so the demo doesn't emit the new deprecation warning.

(Written by Claude)