### PR TITLE
feat(moq-native): enable BBR3 congestion control on the noq backend

### DIFF
--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -127,6 +127,7 @@ impl NoqClient {
 		transport.max_idle_timeout(Some(time::Duration::from_secs(30).try_into().unwrap()));
 		transport.keep_alive_interval(Some(time::Duration::from_secs(5)));
 		transport.mtu_discovery_config(None); // Disable MTU discovery
+		transport.congestion_controller_factory(Arc::new(noq::congestion::Bbr3Config::default()));
 
 		let max_streams = config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS);
 		let max_streams = noq::VarInt::from_u64(max_streams).unwrap_or(noq::VarInt::MAX);
@@ -299,6 +300,7 @@ impl NoqServer {
 		transport.max_idle_timeout(Some(Duration::from_secs(30).try_into().unwrap()));
 		transport.keep_alive_interval(Some(Duration::from_secs(5)));
 		transport.mtu_discovery_config(None); // Disable MTU discovery
+		transport.congestion_controller_factory(Arc::new(noq::congestion::Bbr3Config::default()));
 
 		let max_streams = config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS);
 		let max_streams = noq::VarInt::from_u64(max_streams).unwrap_or(noq::VarInt::MAX);


### PR DESCRIPTION
## Summary

The `noq` QUIC backend defaults to **Cubic** congestion control. This switches both the client and server transport configs to **BBR3** (`noq::congestion::Bbr3Config::default()`), which generally behaves better for live media under loss and bufferbloat.

```rust
transport.congestion_controller_factory(Arc::new(noq::congestion::Bbr3Config::default()));
```

Only the `noq` backend is affected. The `quinn` backend doesn't expose a BBR3 implementation yet (its `// Enable BBR congestion control` / `// TODO Validate the BBR implementation before enabling it` comments still describe an unimplemented path), so it keeps its default. The `quiche` and `iroh` backends use different config APIs and are untouched.

## Test plan

- [x] `cargo check -p moq-native --features noq`

(Written by Claude)