### PR TITLE
moq-net: tighten public API surface (coding module + Track*Pending aliases)

### DIFF
--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -50,7 +50,7 @@ impl VideoTransform {
 /// A subscription that resolves on first poll, then the live consumer.
 enum SourceState {
 	/// Waiting for the subscription to resolve (blocks on the publisher's SUBSCRIBE_OK).
-	Subscribing(moq_net::TrackSubscriberPending),
+	Subscribing(kio::Pending<moq_net::TrackSubscribe>),
 	/// The resolved consumer, reading frames.
 	Active(Consumer<HangContainer>),
 }

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -49,7 +49,7 @@
 //! standard [`std::task::Waker`] API and any [`std::task::Waker`] is a valid driver.
 
 mod client;
-pub mod coding;
+mod coding;
 mod error;
 mod ietf;
 mod lite;

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -411,7 +411,7 @@ mod test {
 	use super::*;
 
 	/// Subscribe and assert the result hasn't resolved yet (it stays pending until
-	/// a publisher accepts). Returns the [`TrackSubscriberPending`] to resolve after accepting.
+	/// a publisher accepts). Returns the pending subscription to resolve after accepting.
 	macro_rules! subscribe_pending {
 		($consumer:expr, $name:expr) => {{
 			let pending = $consumer.track($name).unwrap().subscribe(None).unwrap();

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -431,7 +431,7 @@ impl TrackState {
 	/// if it isn't accepted yet. The group's timescale comes from that info, so a
 	/// fetch can serve an as-yet-unaccepted track (e.g. a relay with no live
 	/// subscription). The group lands in the cache so a waiting
-	/// [`TrackFetchPending`] resolves via [`Self::poll_fetch`].
+	/// [`TrackFetch`] resolves via [`Self::poll_fetch`].
 	fn insert_group_request(&mut self, sequence: u64, info: Option<TrackInfo>) -> Result<GroupProducer> {
 		if let Some(err) = &self.abort {
 			return Err(err.clone());
@@ -822,7 +822,7 @@ impl Drop for TrackDynamic {
 ///
 /// Iterates `subscriptions` immutably so it never flags the [`TrackState`] as
 /// modified on a no-op poll. Marking it modified would drain and wake unrelated
-/// waiters on the channel (e.g. a [`TrackSubscriberPending`] parked on track
+/// waiters on the channel (e.g. a [`TrackSubscribe`] parked on track
 /// info), which races with [`TrackRequest::accept`] and can drop that wakeup.
 /// Closed subscribers are pruned only when one has actually closed, which is a
 /// real change that legitimately wakes other waiters.
@@ -904,7 +904,7 @@ impl TrackConsumer {
 	}
 
 	/// Open a live subscription.
-	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> Result<TrackSubscriberPending> {
+	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> Result<kio::Pending<TrackSubscribe>> {
 		let subscription = kio::Producer::new(subscription.into().unwrap_or_default());
 
 		match self.state.write() {
@@ -928,7 +928,7 @@ impl TrackConsumer {
 
 	/// Fetch a single past group, without holding a live subscription.
 	///
-	/// Returns a [`TrackFetchPending`] that resolves to the [`GroupConsumer`]:
+	/// Returns a [`kio::Pending`] that resolves to the [`GroupConsumer`]:
 	/// immediately if the group is cached, otherwise once a [`TrackDynamic`] serves
 	/// the request (a wire FETCH for a relay). `options` accepts `None`, a [`Fetch`],
 	/// or `Fetch::default()`.
@@ -936,7 +936,7 @@ impl TrackConsumer {
 	/// Fails synchronously with [`Error::NotFound`] when the group can never be served
 	/// (past the final sequence, or no [`TrackDynamic`] on the track), or the track's
 	/// abort error if it's already closed.
-	pub fn fetch_group(&self, sequence: u64, options: impl Into<Option<Fetch>>) -> Result<TrackFetchPending> {
+	pub fn fetch_group(&self, sequence: u64, options: impl Into<Option<Fetch>>) -> Result<kio::Pending<TrackFetch>> {
 		let options = options.into().unwrap_or_default();
 
 		let mut state = self
@@ -962,7 +962,7 @@ impl TrackConsumer {
 		}))
 	}
 
-	pub fn info(&self) -> TrackInfoPending {
+	pub fn info(&self) -> kio::Pending<TrackInfoQuery> {
 		kio::Pending::new(TrackInfoQuery {
 			state: self.state.clone(),
 		})
@@ -970,7 +970,7 @@ impl TrackConsumer {
 }
 
 /// The pollable state of a [`TrackConsumer::subscribe`]; awaited via the
-/// [`TrackSubscriberPending`] wrapper, whose `DerefMut` exposes [`Self::update`].
+/// [`kio::Pending`] wrapper, whose `DerefMut` exposes [`Self::update`].
 pub struct TrackSubscribe {
 	name: Arc<str>,
 	state: kio::Consumer<TrackState>,
@@ -1013,13 +1013,8 @@ impl kio::Future for TrackSubscribe {
 	}
 }
 
-/// A pending subscription returned by [`TrackConsumer::subscribe`]. `.await` it for
-/// the [`TrackSubscriber`], or call [`TrackSubscribe::update`] / [`TrackSubscribe::poll_ok`]
-/// through its `Deref`.
-pub type TrackSubscriberPending = kio::Pending<TrackSubscribe>;
-
 /// The pollable state of a [`TrackConsumer::info`]; awaited via the
-/// [`TrackInfoPending`] wrapper.
+/// [`kio::Pending`] wrapper.
 pub struct TrackInfoQuery {
 	state: kio::Consumer<TrackState>,
 }
@@ -1040,9 +1035,6 @@ impl kio::Future for TrackInfoQuery {
 		self.poll_ok(waiter)
 	}
 }
-
-/// A pending [`TrackInfo`] lookup returned by [`TrackConsumer::info`]. `.await` it.
-pub type TrackInfoPending = kio::Pending<TrackInfoQuery>;
 
 /// A specific group requested via [`TrackConsumer::fetch_group`], queued on the
 /// track for a [`TrackDynamic`] to serve.
@@ -1093,7 +1085,7 @@ impl GroupRequest {
 
 /// The pollable state of a [`TrackConsumer::fetch_group`].
 ///
-/// Awaited via the [`TrackFetchPending`] wrapper; resolves to the
+/// Awaited via the [`kio::Pending`] wrapper; resolves to the
 /// [`GroupConsumer`] once the group lands in the track's cache (already present,
 /// or produced after a wire FETCH), or [`Error::NotFound`] if it can never exist.
 pub struct TrackFetch {
@@ -1115,10 +1107,6 @@ impl kio::Future for TrackFetch {
 		)
 	}
 }
-
-/// A pending fetch returned by [`TrackConsumer::fetch_group`]. `.await` it for the
-/// [`GroupConsumer`].
-pub type TrackFetchPending = kio::Pending<TrackFetch>;
 
 /// A live subscription to a track, used to read its groups.
 ///


### PR DESCRIPTION
## Summary

Two small public-surface tightenings found while auditing moq-net with `cargo semver-checks`. Both are breaking (narrowing), hence `dev`.

### 1. Make the `coding` module private again

`coding` was flipped from `mod` to `pub mod` in #1439, publicly exporting the entire low-level wire toolkit (`Reader`, `Writer`, `Stream`, `Sizer`, the `Encode`/`Decode` traits, the wire-level `coding::Version`/`Versions`) on top of the four types we actually share. Every external consumer (e.g. `moq-loc`) only uses the flat re-exports `VarInt`/`DecodeError`/`EncodeError`/`BoundsExceeded`, and nothing references the `moq_net::coding::` path. Reverted to `mod coding`; the flat re-export stays. Only public-API delta is dropping the unused `moq_net::coding::*` path.

### 2. Drop the `Track*Pending` type aliases

`TrackSubscriberPending`, `TrackInfoPending`, and `TrackFetchPending` were one-line aliases for `kio::Pending<TrackSubscribe / TrackInfoQuery / TrackFetch>`. The methods now return `kio::Pending<T>` directly: the inner type stays public so callers keep the kio-native `poll` (drivable from a `kio::Waiter` without a tokio runtime), and the signature names the real type. moq-mux's one stored handle moves to the inlined form.

## Test plan

- [x] `cargo check -p moq-net --all-features` (no `private_interfaces` warnings)
- [x] `cargo test -p moq-net --all-features` (374 unit + doctests pass)
- [x] `cargo check`/build across dependents: moq-loc, moq-mux, hang, moq-native, moq-relay, moq-token, moq-cli, moq-audio, moq-json, moq-msf, moq-ffi
- [x] `cargo doc -p moq-net` with `-D rustdoc::broken_intra_doc_links`
- [x] fmt + clippy (via nix) clean

Not included: the `with_consumer` -> `with_subscriber` rename + origin-default reshape, which is a larger cross-crate change landing in a separate PR.

(Written by Claude)