### PR TITLE
fix(moq-audio): surface denied/unavailable mic instead of hanging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,11 +3766,14 @@ dependencies = [
 name = "moq-audio"
 version = "0.0.3"
 dependencies = [
+ "block2",
  "bytes",
  "cpal",
  "hang",
  "moq-mux",
  "moq-net",
+ "objc2",
+ "objc2-av-foundation",
  "rubato",
  "thiserror 2.0.18",
  "tokio",
@@ -4664,6 +4667,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-avf-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-image-io",
+ "objc2-media-toolbox",
+ "objc2-quartz-core",
+]
+
+[[package]]
 name = "objc2-avf-audio"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4711,6 +4736,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-core-wlan"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,6 +4820,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-io-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4751,6 +4838,40 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-media-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
+dependencies = [
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-media",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -18,8 +18,17 @@ doctest = false
 [features]
 # Microphone capture via cpal (pure-Rust: CoreAudio / WASAPI / ALSA). Off by
 # default so audio-only consumers (e.g. moq-ffi) don't pull cpal and, on Linux,
-# the ALSA build dependency.
-capture = ["dep:cpal", "dep:tokio", "dep:tracing"]
+# the ALSA build dependency. On macOS it also pulls AVFoundation for the TCC
+# permission pre-check (the objc deps below are target-gated, so this is a no-op
+# elsewhere).
+capture = [
+	"dep:cpal",
+	"dep:tokio",
+	"dep:tracing",
+	"dep:block2",
+	"dep:objc2",
+	"dep:objc2-av-foundation",
+]
 
 [dependencies]
 bytes = "1"
@@ -47,6 +56,14 @@ tracing = { version = "0.1", optional = true }
 # 20 ms Opus frames moq-audio publishes that's still well under any
 # real-time budget.
 unsafe-libopus = "0.2"
+
+# macOS-only: query/request the microphone TCC permission so a denied mic fails
+# fast with a clear error instead of feeding silence into the capture loop. Only
+# pulled in by the `capture` feature (see above); a no-op on other platforms.
+[target.'cfg(target_os="macos")'.dependencies]
+block2 = { version = "0.6.2", optional = true }
+objc2 = { version = "0.6.4", optional = true }
+objc2-av-foundation = { version = "0.3.2", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -21,14 +21,7 @@ doctest = false
 # the ALSA build dependency. On macOS it also pulls AVFoundation for the TCC
 # permission pre-check (the objc deps below are target-gated, so this is a no-op
 # elsewhere).
-capture = [
-	"dep:cpal",
-	"dep:tokio",
-	"dep:tracing",
-	"dep:block2",
-	"dep:objc2",
-	"dep:objc2-av-foundation",
-]
+capture = ["dep:cpal", "dep:tokio", "dep:tracing", "dep:block2", "dep:objc2", "dep:objc2-av-foundation"]
 
 [dependencies]
 bytes = "1"

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -5,12 +5,21 @@
 //! an [`EncoderInput`] of `format = AudioFormat::F32`.
 //! Encoding stays on `unsafe-libopus`, so audio never touches ffmpeg.
 
-use std::sync::mpsc::{Receiver, Sender};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 
 use crate::{AudioError, AudioFormat, AudioProducer, EncoderInput, EncoderOutput, Frame};
+
+mod permission;
+
+/// How long `open` waits for the first buffer before assuming the mic never
+/// started (e.g. permission denied), mirroring the camera path's first-frame
+/// timeout. Without this the capture loop hangs silently forever when macOS TCC
+/// denies microphone access.
+const FIRST_BUFFER_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Microphone capture configuration. All fields are hints; the backend picks
 /// the closest supported mode and the [`AudioProducer`]
@@ -35,6 +44,9 @@ pub struct Microphone {
 	sample_rate: u32,
 	channels: u32,
 	frames_read: u64,
+	/// The first buffer, captured during `open` to surface a permission failure
+	/// as an error rather than a silent hang.
+	pending: Option<Vec<f32>>,
 }
 
 impl Microphone {
@@ -47,6 +59,10 @@ impl Microphone {
 
 	/// Open (and start) the microphone described by `config`.
 	pub fn open(config: &Config) -> Result<Self, AudioError> {
+		// Fail fast on a denied/restricted mic (macOS TCC) instead of opening a
+		// stream that silently delivers nothing. A no-op on other platforms.
+		permission::ensure_microphone_access()?;
+
 		let (device, sample_format, stream_config) = resolve(config)?;
 		let sample_rate = stream_config.sample_rate;
 		let channels = stream_config.channels as u32;
@@ -84,6 +100,22 @@ impl Microphone {
 
 		stream.play().map_err(cpal_err)?;
 
+		// Block for the first buffer to surface a permission failure (or dead
+		// device) as an error rather than a silent hang in the capture loop.
+		let pending = match rx.recv_timeout(FIRST_BUFFER_TIMEOUT) {
+			Ok(samples) => samples,
+			Err(RecvTimeoutError::Timeout) => {
+				return Err(AudioError::Unsupported(format!(
+					"no samples from microphone {device} within {FIRST_BUFFER_TIMEOUT:?} (permission denied?)"
+				)));
+			}
+			Err(RecvTimeoutError::Disconnected) => {
+				return Err(AudioError::Unsupported(format!(
+					"microphone {device} stopped before any samples"
+				)));
+			}
+		};
+
 		tracing::info!(device = %device, sample_rate, channels, "opened microphone");
 
 		Ok(Self {
@@ -92,6 +124,7 @@ impl Microphone {
 			sample_rate,
 			channels,
 			frames_read: 0,
+			pending: Some(pending),
 		})
 	}
 
@@ -107,8 +140,14 @@ impl Microphone {
 	/// stream stops. The returned [`Frame`] holds interleaved little-endian
 	/// `f32` samples (i.e. `AudioFormat::F32`).
 	pub fn read(&mut self) -> Result<Option<Frame>, AudioError> {
-		let Ok(samples) = self.rx.recv() else {
-			return Ok(None); // stream dropped / device gone
+		let samples = match self.pending.take() {
+			Some(samples) => samples,
+			None => {
+				let Ok(samples) = self.rx.recv() else {
+					return Ok(None); // stream dropped / device gone
+				};
+				samples
+			}
 		};
 
 		let timestamp_us = self.frames_read * 1_000_000 / self.sample_rate as u64;

--- a/rs/moq-audio/src/capture/permission.rs
+++ b/rs/moq-audio/src/capture/permission.rs
@@ -1,0 +1,75 @@
+//! Microphone permission pre-check.
+//!
+//! cpal can't see macOS TCC, so a denied mic just yields silence (or no
+//! callbacks at all) and the capture loop would otherwise hang until the
+//! first-buffer timeout. Querying AVFoundation lets us fail fast with a precise
+//! error, and trigger the system prompt when access hasn't been decided yet.
+//!
+//! On every other platform this is a no-op: permission, if any, is enforced by
+//! the OS audio stack and surfaces through cpal or the timeout.
+
+use crate::AudioError;
+
+#[cfg(target_os = "macos")]
+pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
+	use objc2_av_foundation::{AVAuthorizationStatus, AVCaptureDevice, AVMediaTypeAudio};
+
+	let media =
+		unsafe { AVMediaTypeAudio }.ok_or_else(|| AudioError::Unsupported("AVMediaTypeAudio unavailable".into()))?;
+
+	let status = unsafe { AVCaptureDevice::authorizationStatusForMediaType(media) };
+
+	if status == AVAuthorizationStatus::Authorized {
+		return Ok(());
+	}
+	if status == AVAuthorizationStatus::Denied {
+		return Err(denied());
+	}
+	if status == AVAuthorizationStatus::Restricted {
+		return Err(AudioError::Unsupported(
+			"microphone access is restricted by system policy (parental controls / MDM)".into(),
+		));
+	}
+	if status == AVAuthorizationStatus::NotDetermined {
+		return request_access(media);
+	}
+
+	// Unknown future status: don't block capture, let the stream open and the
+	// first-buffer timeout catch a genuine hang.
+	Ok(())
+}
+
+/// Trigger the system prompt and block (on this `spawn_blocking` thread) until
+/// the user answers. Unbundled CLIs usually get auto-denied without UI, which we
+/// surface as the same clear error.
+#[cfg(target_os = "macos")]
+fn request_access(media: &objc2_av_foundation::AVMediaType) -> Result<(), AudioError> {
+	use objc2_av_foundation::AVCaptureDevice;
+
+	let (tx, rx) = std::sync::mpsc::channel::<bool>();
+	let handler = block2::RcBlock::new(move |granted: objc2::runtime::Bool| {
+		let _ = tx.send(granted.as_bool());
+	});
+
+	unsafe { AVCaptureDevice::requestAccessForMediaType_completionHandler(media, &handler) };
+
+	match rx.recv() {
+		Ok(true) => Ok(()),
+		Ok(false) => Err(denied()),
+		// The completion handler was dropped without firing; fall through to the
+		// stream + timeout rather than hard-failing.
+		Err(_) => Ok(()),
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn denied() -> AudioError {
+	AudioError::Unsupported(
+		"microphone access denied; grant it in System Settings > Privacy & Security > Microphone".into(),
+	)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
+	Ok(())
+}

--- a/rs/moq-audio/src/capture/permission.rs
+++ b/rs/moq-audio/src/capture/permission.rs
@@ -39,6 +39,14 @@ pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
 	Ok(())
 }
 
+/// How long to wait for the user to answer the permission prompt before giving
+/// up. Generous, since the dialog blocks on a human, but bounded so a callback
+/// that never fires can't hang capture forever (the unbundled-CLI path answers
+/// near-instantly). On expiry we fall through to the stream open, where the
+/// first-buffer timeout becomes the final backstop.
+#[cfg(target_os = "macos")]
+const PROMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Trigger the system prompt and block (on this `spawn_blocking` thread) until
 /// the user answers. Unbundled CLIs usually get auto-denied without UI, which we
 /// surface as the same clear error.
@@ -47,17 +55,20 @@ fn request_access(media: &objc2_av_foundation::AVMediaType) -> Result<(), AudioE
 	use objc2_av_foundation::AVCaptureDevice;
 
 	let (tx, rx) = std::sync::mpsc::channel::<bool>();
+	// `handler` owns `tx` and stays alive until this function returns, so the
+	// channel never reports `Disconnected`; a never-firing callback surfaces as
+	// `Timeout` instead of hanging.
 	let handler = block2::RcBlock::new(move |granted: objc2::runtime::Bool| {
 		let _ = tx.send(granted.as_bool());
 	});
 
 	unsafe { AVCaptureDevice::requestAccessForMediaType_completionHandler(media, &handler) };
 
-	match rx.recv() {
+	match rx.recv_timeout(PROMPT_TIMEOUT) {
 		Ok(true) => Ok(()),
 		Ok(false) => Err(denied()),
-		// The completion handler was dropped without firing; fall through to the
-		// stream + timeout rather than hard-failing.
+		// Callback never fired within the window: don't hard-fail, fall through to
+		// the stream open and let the first-buffer timeout catch a real hang.
 		Err(_) => Ok(()),
 	}
 }


### PR DESCRIPTION
## Summary

`moq_audio::capture::publish_microphone` (used by `moq-cli publish ... capture`) hung silently and **indefinitely** when the microphone was unavailable or its macOS TCC permission was denied. It connected to the relay and then produced no frames, no error, and no timeout. cpal happily opens a stream that delivers no callbacks, and `Microphone::read` blocked forever on an unbounded `recv`.

Repro (without granted mic permission):
```
target/debug/moq-cli publish --url http://localhost:4463 --broadcast mic.hang capture --no-video
```

This mirrors the camera path in `rs/moq-video/src/capture/avfoundation.rs`, which already bounds the first frame with a 5s timeout and returns a clear error. The fix adds the audio equivalent, plus a macOS permission pre-check that can actually trigger the system prompt.

## What changed

**1. First-buffer timeout (cross-platform backstop)** — [`rs/moq-audio/src/capture.rs`](../blob/claude/audio-mic-permission/rs/moq-audio/src/capture.rs)
- `Microphone::open` blocks for the first PCM buffer via `recv_timeout(FIRST_BUFFER_TIMEOUT = 5s)`, stashes it as `pending`, and drains it on the first `read()` (no audio dropped).
- On timeout: `"no samples from microphone {device} within 5s (permission denied?)"`. Also catches a dead device or hung driver, on any platform.

**2. macOS permission pre-check** — [`rs/moq-audio/src/capture/permission.rs`](../blob/claude/audio-mic-permission/rs/moq-audio/src/capture/permission.rs)
- Runs before the cpal stream opens (cpal's CoreAudio path can't see TCC).
- `Authorized` → proceed. `Denied`/`Restricted` → fail fast with a precise message. `NotDetermined` → `requestAccessForMediaType` to **trigger the system prompt**, blocking the `spawn_blocking` worker until the user answers.
- No-op on every other platform.

## Dependency gating

`objc2`, `block2`, and `objc2-av-foundation` are declared under `[target.'cfg(target_os="macos")'.dependencies]` as `optional` and pulled in only by the `capture` feature. Verified:
- macOS + `capture`: builds, clippy clean, fmt clean, tests pass; `moq-cli --features capture` builds.
- Linux target: feature resolves, **cpal only, no objc/block2**.
- `moq-ffi` (uses moq-audio *without* `capture`): stays objc-free.

The Cargo.lock additions are the AVFoundation objc2 stack — new to `main` because `main`'s moq-video still uses ffmpeg (the native-codec objc2 work lives on `dev`). They're macOS + capture-only transitive deps.

## Caveat: the prompt and unbundled CLIs

The system prompt only reliably appears for a properly bundled/signed app (with `NSMicrophoneUsageDescription`). A bare `target/debug/moq-cli` run from a terminal is unbundled, so macOS typically attributes the TCC request to the **terminal app** (which is fine — the grant persists there) or auto-denies without UI — which this code now surfaces as a clear error rather than a silent hang. Getting a CLI-owned prompt is a packaging change (embedded Info.plist + code signing), separate from this fix.

## Test plan

- [x] `cargo check/clippy/fmt -p moq-audio --features capture` (macOS, via pinned Nix toolchain)
- [x] `cargo test -p moq-audio --features capture` — 19 unit + 2 integration tests pass
- [x] `cargo build -p moq-cli --features capture`
- [x] Linux-target feature resolution (`cargo tree --target x86_64-unknown-linux-gnu`): no objc2/block2
- [ ] Live denied-mic repro — not exercised; this machine has mic granted (status reads `Authorized`, so the new error paths aren't hit here). Framework linking / `AVMediaType` resolution reuse the exact pattern moq-video's camera path already ships.

No public API signature changes (internal `pending` field on `Microphone`; `Config`/`open`/`read` signatures unchanged), so no Cross-Package Sync rows apply.

(Written by Claude)