### PR TITLE
chore: drop cargo-sweep from tooling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,6 @@
             cargo-sort
             cargo-shear
             cargo-edit
-            cargo-sweep
             cargo-semver-checks
             cargo-deny
           ]

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ dev:
 # of `just <lang> check`.
 install:
     bun install
-    cargo install --locked cargo-shear cargo-sort cargo-upgrades cargo-edit cargo-sweep cargo-semver-checks release-plz
+    cargo install --locked cargo-shear cargo-sort cargo-upgrades cargo-edit cargo-semver-checks release-plz
 
 # Fast inner-loop checks. Runs JS, Rust, and Markdown lints.
 # Shell + workflow + TOML + Nix + justfile lints skip silently if their

--- a/rs/justfile
+++ b/rs/justfile
@@ -42,13 +42,12 @@ ci FILES="":
     just rs test --all-features
     just build
 
-# Auto-fix clippy/format/shear/sort, then sweep stale target/.
+# Auto-fix clippy/format/shear/sort.
 fix:
     cargo clippy --fix --allow-staged --allow-dirty --all-targets
     cargo fmt --all
     cargo shear --fix
     cargo sort --workspace --no-format
-    if command -v cargo-sweep >/dev/null 2>&1; then cargo sweep --time 3; fi
 
 test *args:
     cargo test --all-targets {{ args }}


### PR DESCRIPTION
## Summary

Removes `cargo-sweep` from the repo tooling:

- `rs/justfile` `fix` recipe: drops the trailing `cargo sweep --time 3` step (and the "sweep stale target/" mention in its comment).
- `flake.nix`: removes `cargo-sweep` from the dev shell packages.
- `justfile` `install`: removes `cargo-sweep` from the `cargo install` list.

## Why

`cargo sweep` only prunes stale `target/` artifacts. It isn't part of any check (`just check` / `just ci`), so dropping it has no effect on lint, fmt, or test coverage. In practice a broken local `cargo-sweep` (e.g. a `libintl` dylib mismatch) aborts the whole `just fix` run after the real formatters have already succeeded, which is more friction than the cleanup is worth.

(Written by Claude)