### PR TITLE
fix(libmoq): update tests for moq_origin_publish handle return

### DIFF
--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -240,10 +240,7 @@ fn publish_catalog_roundtrip() {
 
 	// Publish and consume the broadcast to verify the catalog round-trips.
 	let path = b"catalog-producer";
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0
-	);
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
 	let catalog_cb = Callback::new();
@@ -330,10 +327,7 @@ fn raw_track_publish_consume() {
 	let track = id(unsafe { moq_publish_track(broadcast, track_name.as_ptr() as *const c_char, track_name.len()) });
 
 	let path = b"raw-track";
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0
-	);
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
 
@@ -452,10 +446,7 @@ fn double_close_all_resource_types() {
 		)
 	});
 	let path = b"double-close-test";
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0
-	);
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
 	let catalog_cb = Callback::new();
@@ -522,11 +513,7 @@ fn local_announce() {
 
 	let broadcast = id(moq_publish_create());
 	let path = b"test/broadcast";
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0,
-		"moq_origin_publish should succeed"
-	);
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let announced_id = id(cb.recv());
 
@@ -556,10 +543,7 @@ fn announced_deactivation() {
 
 	let broadcast = id(moq_publish_create());
 	let path = b"deactivate/test";
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0
-	);
+	let publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let announced_id = id(cb.recv());
 	let mut info = moq_announced {
@@ -570,14 +554,17 @@ fn announced_deactivation() {
 	assert_eq!(unsafe { moq_origin_announced_info(announced_id, &mut info) }, 0);
 	assert!(info.active);
 
-	assert_eq!(moq_publish_close(broadcast), 0);
+	// Dropping the publish guard is what unannounces the broadcast; closing the
+	// broadcast producer itself no longer deactivates the announcement.
+	assert_eq!(moq_origin_unpublish(publish), 0);
 
 	let deactivated_id = id(cb.recv());
 	assert_eq!(unsafe { moq_origin_announced_info(deactivated_id, &mut info) }, 0);
-	assert!(!info.active, "broadcast should be inactive after publisher closes");
+	assert!(!info.active, "broadcast should be inactive after unpublish");
 
 	assert_eq!(moq_origin_announced_close(announced_task), 0);
 	assert_eq!(cb.recv_terminal(), 0, "announced close delivers terminal 0");
+	assert_eq!(moq_publish_close(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -599,10 +586,7 @@ fn local_publish_consume() {
 	});
 
 	let path = b"live";
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0
-	);
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
 	let catalog_cb = Callback::new();
@@ -714,10 +698,7 @@ fn consume_announced_local() {
 			init.len(),
 		)
 	});
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0
-	);
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	// First the broadcast handle, then a terminal 0 once the wait finishes.
 	let consume = id(cb.recv());
@@ -793,10 +774,7 @@ fn video_publish_consume() {
 	});
 
 	let path = b"video-test";
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0
-	);
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
 	let catalog_cb = Callback::new();
@@ -904,10 +882,7 @@ fn multiple_frames_ordering() {
 	});
 
 	let path = b"ordering-test";
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0
-	);
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
 	let catalog_cb = Callback::new();
@@ -973,10 +948,7 @@ fn catalog_update_on_new_track() {
 	});
 
 	let path = b"catalog-update";
-	assert_eq!(
-		unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) },
-		0
-	);
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
 	let catalog_cb = Callback::new();


### PR DESCRIPTION
## Summary

`cargo test -p libmoq --all-features` was crashing with a SIGSEGV (signal 11) and a non-unwinding panic. The failing tests (`local_announce`, `catalog_update_on_new_track`, `announced_deactivation`, `consume_announced_local`, `double_close_all_resource_types`, and others) all panicked first on an assertion like `assert_eq!(moq_origin_publish(...), 0)`.

**Root cause: stale tests, not a callback bug.** [#1640](https://github.com/moq-dev/moq/pull/1640) changed `moq_origin_publish` to return a *positive publish handle* (paired with the new `moq_origin_unpublish`) under the RAII `OriginPublish` model, but never updated `rs/libmoq/src/test.rs`, which still asserted a `0` return. This went unnoticed because CI's `cargo check --workspace --all-features` failed to compile (NVENC) since [#1691](https://github.com/moq-dev/moq/pull/1691), so `cargo test --all-features` never actually ran until the moq-video CI plumbing was fixed in [#1704](https://github.com/moq-dev/moq/pull/1704).

**Why it segfaulted.** The failed `== 0` assertion panicked each test mid-flight, which dropped the test's `Callback` (freeing `user_data`) *without* draining the terminal callback via `recv_terminal()`. The still-alive background announce/catalog task then fired its callback into freed memory: a use-after-free → SIGSEGV. The terminal-callback contract in the production code (free `user_data` exactly once, in the final callback) was already correct ([#1546](https://github.com/moq-dev/moq/pull/1546)) and is unchanged.

## Changes (test-only)

- Capture the publish handle with `id()` (which still asserts it is positive) at all 10 call sites, instead of asserting `== 0`.
- `announced_deactivation` previously deactivated by closing the broadcast producer. Under the `OriginPublish` model, dropping the producer no longer unannounces, so it now deactivates via `moq_origin_unpublish(publish)` and closes the broadcast at the end.

## Test plan

- [x] `cargo test -p libmoq --all-features` — 23 passed, 0 failed, no abort (run 3×, repeatable)
- [x] `cargo test -p libmoq` (default features) — 23 passed
- [x] `cargo fmt -p libmoq --check` — clean
- [x] `cargo clippy -p libmoq --all-features` — clean

No public API or wire behavior changes (test-only). Targets `dev`, since the `moq_origin_publish` handle change (#1640) and the CI fix that surfaced this (#1704) both live there.

(Written by Claude)