### PR TITLE
fix(moq-ffi): unblock deadlocking dynamic_track_request tests

### DIFF
--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -76,12 +76,15 @@ async fn dynamic_track_request() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let dynamic = broadcast.dynamic().unwrap();
 	let consumer = broadcast.consume().unwrap();
-	let track_consumer = consumer.subscribe_track("events".into()).await.unwrap();
 
-	let track = tokio::time::timeout(TIMEOUT, dynamic.requested_track())
-		.await
-		.expect("timed out waiting for requested track")
-		.unwrap();
+	// subscribe_track stays pending until the dynamic producer accepts the request
+	// via requested_track(), so drive both sides concurrently to avoid a deadlock.
+	let (track_consumer, track) = tokio::join!(
+		consumer.subscribe_track("events".into()),
+		tokio::time::timeout(TIMEOUT, dynamic.requested_track()),
+	);
+	let track_consumer = track_consumer.unwrap();
+	let track = track.expect("timed out waiting for requested track").unwrap();
 
 	assert_eq!(track.name().unwrap(), "events");
 
@@ -103,12 +106,15 @@ async fn dynamic_track_request_can_abort() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let dynamic = broadcast.dynamic().unwrap();
 	let consumer = broadcast.consume().unwrap();
-	let _track_consumer = consumer.subscribe_track("unknown".into()).await.unwrap();
 
-	let track = tokio::time::timeout(TIMEOUT, dynamic.requested_track())
-		.await
-		.expect("timed out waiting for requested track")
-		.unwrap();
+	// subscribe_track stays pending until the dynamic producer accepts the request
+	// via requested_track(), so drive both sides concurrently to avoid a deadlock.
+	let (track_consumer, track) = tokio::join!(
+		consumer.subscribe_track("unknown".into()),
+		tokio::time::timeout(TIMEOUT, dynamic.requested_track()),
+	);
+	let _track_consumer = track_consumer.unwrap();
+	let track = track.expect("timed out waiting for requested track").unwrap();
 
 	track.abort(404).unwrap();
 	assert!(matches!(track.name(), Err(MoqError::Closed)));


### PR DESCRIPTION
## Summary

Two moq-ffi tests deadlocked (hung forever): `dynamic_track_request` and `dynamic_track_request_can_abort` in `rs/moq-ffi/src/test.rs`.

**Root cause:** the tests called `consumer.subscribe_track("...").await` *before* `dynamic.requested_track()` on the next line. For a not-yet-published (dynamic) track, `subscribe_track().await` stays pending until the producer accepts the request via `requested_track()`. But `requested_track()` only runs on the line after the one the test is blocked on, so it's never reached. Classic single-task deadlock. The sibling `media_track_activity_and_name` doesn't hang because it publishes the track first, so `subscribe_track` finds an existing producer and returns immediately.

The `await` itself is correct: the pending-until-accepted contract is intentional (see the `subscribe_pending!` macro in `rs/moq-net/src/model/broadcast.rs`, which asserts subscribe stays pending until the request is accepted). The bug was the test driving the two sides sequentially.

## Fix

Drive the consumer subscribe and the producer `requested_track()` concurrently with `tokio::join!`, so the producer accepts the request while the consumer is still awaiting acceptance. The `requested_track()` side keeps its existing `TIMEOUT` wrapper, so a real regression fails fast instead of hanging.

## Why this was never caught

`b1580b48` made `subscribe_track` async (correct) but moq-ffi's tests have never actually run in CI: `just rs ci`'s `cargo test --workspace --all-features` died at the NVENC compile (since #1691) before reaching the test phase. #1704 fixed that pipeline, so the tests now run — and hung. This is pre-existing moq-ffi debt, unrelated to the moq-video work.

## Test plan

- [x] `nix develop --command cargo test -p moq-ffi` — 20 passed, 0 failed (the two previously-hanging tests now finish in 0.42s total)
- [x] `nix develop --command cargo test --workspace --all-features --exclude moq-video` — exit 0, whole suite green, no hang

(Written by Claude)