### PR TITLE
feat(js/net): insert tracks into a broadcast, with real fan-out

### DIFF
--- a/js/json/src/consumer.ts
+++ b/js/json/src/consumer.ts
@@ -33,7 +33,17 @@ export class Consumer<T> {
 				this.#framesRead = 0;
 			}
 
-			const frame = await this.#group.readFrame();
+			let frame: Uint8Array | undefined;
+			try {
+				frame = await this.#group.readFrame();
+			} catch {
+				// The group was reset or we fell behind its eviction window. Resync from
+				// the next group, which begins with a fresh snapshot (frame 0), so no
+				// partial state is presented.
+				this.#group = undefined;
+				continue;
+			}
+
 			if (frame === undefined) {
 				// The group is exhausted; advance to the next one.
 				this.#group = undefined;

--- a/js/net/examples/publish.ts
+++ b/js/net/examples/publish.ts
@@ -7,23 +7,22 @@ async function main() {
 	// Create a broadcast (a collection of tracks)
 	const broadcast = new Moq.Broadcast();
 
+	// Insert the "chat" track up front. A subscriber is served directly from this
+	// track, no requested() round-trip needed. Mirrors the Rust createTrack/insertTrack.
+	publishTrack(broadcast.createTrack("chat"));
+
 	// Publish the broadcast to the connection
 	connection.publish(Moq.Path.from("my-broadcast"), broadcast);
 	console.log("Published broadcast: my-broadcast");
 
-	// Wait for subscription requests
+	// Tracks created on demand (instead of up front) are still supported: handle any
+	// subscribe for a track that wasn't statically inserted.
 	for (;;) {
 		const request = await broadcast.requested();
 		if (!request) break;
 
-		// Accept the request for the "chat" track
-		if (request.name === "chat") {
-			// accept() commits the track's immutable properties and returns the Track.
-			publishTrack(request.accept());
-		} else {
-			// Reject other tracks
-			request.reject(new Error("track not found"));
-		}
+		// Reject anything we didn't insert above.
+		request.reject(new Error("track not found"));
 	}
 }
 

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -25,6 +25,37 @@ test("subscribe serves a statically inserted track without a request", async () 
 	expect((await sub2.nextGroup())?.sequence).toBe(0);
 });
 
+test("two subscribers to one inserted track each get a full copy", async () => {
+	const broadcast = new Broadcast();
+	const producer = broadcast.createTrack("video");
+
+	const a = broadcast.track("video").subscribe();
+	const b = broadcast.track("video").subscribe();
+
+	producer.writeString("hello");
+	producer.writeString("world");
+
+	// Neither subscriber steals from the other: both see every frame in order.
+	expect(await a.readString()).toBe("hello");
+	expect(await b.readString()).toBe("hello");
+	expect(await a.readString()).toBe("world");
+	expect(await b.readString()).toBe("world");
+});
+
+test("a late subscriber replays the cached window", async () => {
+	const broadcast = new Broadcast();
+	const producer = broadcast.createTrack("video");
+
+	// Written before anyone subscribes; retained in the cache for replay.
+	producer.writeString("early");
+
+	const late = broadcast.track("video").subscribe();
+	expect(await late.readString()).toBe("early");
+
+	producer.writeString("later");
+	expect(await late.readString()).toBe("later");
+});
+
 test("createTrack commits info up front", async () => {
 	const broadcast = new Broadcast();
 

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, setSystemTime, test } from "bun:test";
 import { Broadcast } from "./broadcast.ts";
 import { TrackProducer } from "./track.ts";
 
@@ -54,6 +54,32 @@ test("a late subscriber replays the cached window", async () => {
 
 	producer.writeString("later");
 	expect(await late.readString()).toBe("later");
+});
+
+test("a stalled consumer does not pin evicted groups", () => {
+	try {
+		setSystemTime(new Date(10_000));
+
+		const broadcast = new Broadcast();
+		const producer = broadcast.createTrack("video", { cache: 1000 });
+
+		// A subscriber that never reads. Its sink must not grow without bound.
+		const stalled = broadcast.track("video").subscribe();
+
+		producer.writeString("old");
+		expect(stalled.state.groups.peek().length).toBe(1);
+
+		// Advance past the cache window and write again to trigger a prune. The old
+		// (closed, aged-out) group is dropped from the stalled sink, not retained.
+		setSystemTime(new Date(12_000));
+		producer.writeString("fresh");
+
+		const groups = stalled.state.groups.peek();
+		expect(groups.length).toBe(1);
+		expect(groups[0].sequence).toBe(1);
+	} finally {
+		setSystemTime();
+	}
 });
 
 test("createTrack commits info up front", async () => {

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -1,5 +1,6 @@
 import { expect, setSystemTime, test } from "bun:test";
 import { Broadcast } from "./broadcast.ts";
+import { CacheFull, MAX_GROUP_FRAMES } from "./group.ts";
 import { TrackProducer } from "./track.ts";
 
 test("subscribe serves a statically inserted track without a request", async () => {
@@ -54,6 +55,27 @@ test("a late subscriber replays the cached window", async () => {
 
 	producer.writeString("later");
 	expect(await late.readString()).toBe("later");
+});
+
+test("a read throws CacheFull on a gap, then resyncs to the next group", async () => {
+	const broadcast = new Broadcast();
+	const producer = broadcast.createTrack("video");
+	const sub = broadcast.track("video").subscribe();
+
+	// Group 0 overflows its frame cap without being read, evicting the front: a gap.
+	const g0 = producer.appendGroup();
+	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) g0.writeFrame(new Uint8Array([i & 0xff]));
+	g0.close();
+
+	// Group 1 is clean.
+	const g1 = producer.appendGroup();
+	g1.writeFrame(new TextEncoder().encode("ok"));
+	g1.close();
+
+	// The reader hits the gap in group 0 (error, not a silent skip), then the next
+	// read resyncs from group 1.
+	expect(sub.readFrame()).rejects.toBeInstanceOf(CacheFull);
+	expect(await sub.readString()).toBe("ok");
 });
 
 test("a stalled consumer does not pin evicted groups", () => {

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { Broadcast } from "./broadcast.ts";
+import { TrackProducer } from "./track.ts";
+
+test("subscribe serves a statically inserted track without a request", async () => {
+	const broadcast = new Broadcast();
+
+	const track1 = new TrackProducer("track1").accept();
+	broadcast.insertTrack(track1);
+	track1.appendGroup().close();
+
+	// The track already exists, so subscribe resolves immediately (no requested()).
+	const sub1 = broadcast.track("track1").subscribe();
+	expect((await sub1.nextGroup())?.sequence).toBe(0);
+
+	// No on-demand request was emitted for it.
+	expect(broadcast.state.requested.peek().length).toBe(0);
+
+	// A second static track behaves the same.
+	const track2 = new TrackProducer("track2").accept();
+	broadcast.insertTrack(track2);
+
+	const sub2 = broadcast.track("track2").subscribe();
+	track2.appendGroup().close();
+	expect((await sub2.nextGroup())?.sequence).toBe(0);
+});
+
+test("createTrack commits info up front", async () => {
+	const broadcast = new Broadcast();
+
+	const producer = broadcast.createTrack("video", { compress: true, priority: 3 });
+	expect(producer.name).toBe("video");
+
+	const info = await broadcast.track("video").info();
+	expect(info.compress).toBe(true);
+	expect(info.priority).toBe(3);
+});
+
+test("insertTrack rejects a duplicate live name", () => {
+	const broadcast = new Broadcast();
+	broadcast.createTrack("dup");
+	expect(() => broadcast.insertTrack(new TrackProducer("dup").accept())).toThrow();
+});
+
+test("a closed track is evicted and re-subscribing falls through to a request", async () => {
+	const broadcast = new Broadcast();
+
+	const track1 = broadcast.createTrack("track1");
+	track1.close();
+
+	// The stale entry is gone, so subscribe creates an on-demand request instead.
+	const pending = broadcast.track("track1").subscribe();
+	expect(pending).toBeDefined();
+	expect(broadcast.state.requested.peek().length).toBe(1);
+
+	const request = await broadcast.requested();
+	expect(request?.name).toBe("track1");
+});
+
+test("removeTrack drops the static entry", () => {
+	const broadcast = new Broadcast();
+	broadcast.createTrack("track1");
+	expect(broadcast.state.tracks.has("track1")).toBe(true);
+
+	broadcast.removeTrack("track1");
+	expect(broadcast.state.tracks.has("track1")).toBe(false);
+});

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -75,6 +75,9 @@ export class TrackConsumer {
 export class BroadcastState {
 	requested = new Signal<TrackRequest[]>([]);
 	closed = new Signal<boolean | Error>(false);
+	// Statically inserted tracks, keyed by name. A subscribe for one of these is
+	// served directly from the shared TrackState, skipping the on-demand request path.
+	tracks = new Map<string, TrackState>();
 }
 
 /**
@@ -130,6 +133,56 @@ export class Broadcast {
 	}
 
 	/**
+	 * Insert a track that is served directly, without an on-demand {@link requested}
+	 * round-trip.
+	 *
+	 * A {@link subscribe} for this name returns a subscriber sharing the track's state
+	 * immediately, so a publisher can push tracks proactively instead of waiting to be
+	 * asked. The caller owns the {@link TrackProducer} and writes its groups; when that
+	 * producer closes, the entry is removed automatically. Throws on a duplicate live
+	 * name. Mirrors the Rust `BroadcastProducer::insert_track`.
+	 */
+	insertTrack(track: TrackProducer): void {
+		if (this.state.closed.peek()) {
+			throw new Error(`broadcast is closed: ${this.state.closed.peek()}`);
+		}
+
+		const existing = this.state.tracks.get(track.name);
+		if (existing && !existing.closed.peek()) {
+			throw new Error(`duplicate track: ${track.name}`);
+		}
+
+		this.state.tracks.set(track.name, track.state);
+
+		// Evict the entry once the track closes, unless it has since been replaced.
+		const dispose = track.state.closed.subscribe((closed) => {
+			if (!closed) return;
+			if (this.state.tracks.get(track.name) === track.state) {
+				this.state.tracks.delete(track.name);
+			}
+			dispose();
+		});
+	}
+
+	/**
+	 * Create a track, insert it into the broadcast, and return its {@link TrackProducer}.
+	 *
+	 * Commits the immutable {@link TrackInfo} up front, so a subscriber resolves
+	 * {@link TrackConsumer.info} without an on-demand round-trip. Mirrors the Rust
+	 * `BroadcastProducer::create_track`.
+	 */
+	createTrack(name: string, info: Partial<TrackInfo> = {}): TrackProducer {
+		const track = new TrackProducer(name).accept(info);
+		this.insertTrack(track);
+		return track;
+	}
+
+	/** Remove a statically inserted track by name. Mirrors the Rust `BroadcastProducer::remove_track`. */
+	removeTrack(name: string): void {
+		this.state.tracks.delete(name);
+	}
+
+	/**
 	 * Open a live subscription to a track, returning the {@link TrackSubscriber} the
 	 * groups stream into. Called by the consuming application (usually via
 	 * {@link TrackConsumer.subscribe}) and by the publishing wire layer to ask the
@@ -138,6 +191,14 @@ export class Broadcast {
 	subscribe(name: string, priority: number): TrackSubscriber {
 		if (this.state.closed.peek()) {
 			throw new Error(`broadcast is closed: ${this.state.closed.peek()}`);
+		}
+
+		// Fast path: a statically inserted track is served directly, no request. A
+		// stale (closed) entry is evicted and falls through to the on-demand path.
+		const existing = this.state.tracks.get(name);
+		if (existing) {
+			if (!existing.closed.peek()) return new TrackSubscriber(name, existing);
+			this.state.tracks.delete(name);
 		}
 
 		// The subscriber (caller, reads) and the request's producer (other side,
@@ -165,6 +226,12 @@ export class Broadcast {
 		// Consume side: a TRACK stream (lite-05+) answers it.
 		if (this.#infoResolver) {
 			return this.#infoResolver(name);
+		}
+
+		// A statically inserted track already committed its info; serve it directly.
+		const existing = this.state.tracks.get(name);
+		if (existing && !existing.closed.peek()) {
+			return new TrackSubscriber(name, existing).info();
 		}
 
 		// Publish side: ask the application by triggering a TrackRequest it answers

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -1,5 +1,5 @@
 import { Signal } from "@moq/signals";
-import { type TrackInfo, TrackProducer, TrackState, TrackSubscriber, trackInfoDefaults } from "./track.ts";
+import { type TrackInfo, TrackProducer, TrackState, TrackSubscriber } from "./track.ts";
 
 /**
  * A request for a track the peer wants, yielded by {@link Broadcast.requested}.
@@ -13,8 +13,8 @@ import { type TrackInfo, TrackProducer, TrackState, TrackSubscriber, trackInfoDe
 export class TrackRequest {
 	readonly name: string;
 	readonly priority: number;
-	// The shared state behind the matching TrackSubscriber handed to the caller of
-	// Broadcast.subscribe; accepting wraps it in a producer the two ends share.
+	// The state behind the TrackSubscriber handed to the caller of Broadcast.subscribe;
+	// accepting adopts it as the producer's first sink, which the producer fans into.
 	#state: TrackState;
 
 	constructor(name: string, state: TrackState, priority: number) {
@@ -29,8 +29,9 @@ export class TrackRequest {
 	 * keeps its default. Mirrors the Rust `TrackRequest::accept`.
 	 */
 	accept(info: Partial<TrackInfo> = {}): TrackProducer {
-		this.#state.info.set(trackInfoDefaults(info));
-		return new TrackProducer(this.name, this.#state);
+		// The producer adopts the already-handed-out subscriber state as its first
+		// sink, then commits the info (which propagates to that sink).
+		return new TrackProducer(this.name, this.#state).accept(info);
 	}
 
 	/** Reject the request, closing the track (optionally with an error). */
@@ -75,9 +76,9 @@ export class TrackConsumer {
 export class BroadcastState {
 	requested = new Signal<TrackRequest[]>([]);
 	closed = new Signal<boolean | Error>(false);
-	// Statically inserted tracks, keyed by name. A subscribe for one of these is
-	// served directly from the shared TrackState, skipping the on-demand request path.
-	tracks = new Map<string, TrackState>();
+	// Statically inserted tracks, keyed by name. A subscribe for one of these fans out
+	// from the producer directly, skipping the on-demand request path.
+	tracks = new Map<string, TrackProducer>();
 }
 
 /**
@@ -136,11 +137,11 @@ export class Broadcast {
 	 * Insert a track that is served directly, without an on-demand {@link requested}
 	 * round-trip.
 	 *
-	 * A {@link subscribe} for this name returns a subscriber sharing the track's state
-	 * immediately, so a publisher can push tracks proactively instead of waiting to be
-	 * asked. The caller owns the {@link TrackProducer} and writes its groups; when that
-	 * producer closes, the entry is removed automatically. Throws on a duplicate live
-	 * name. Mirrors the Rust `BroadcastProducer::insert_track`.
+	 * Each {@link subscribe} for this name fans out from the producer, so a publisher
+	 * can push tracks proactively instead of waiting to be asked. The caller owns the
+	 * {@link TrackProducer} and writes its groups; when that producer closes, the entry
+	 * is removed automatically. Throws on a duplicate live name. Mirrors the Rust
+	 * `BroadcastProducer::insert_track`.
 	 */
 	insertTrack(track: TrackProducer): void {
 		if (this.state.closed.peek()) {
@@ -148,16 +149,16 @@ export class Broadcast {
 		}
 
 		const existing = this.state.tracks.get(track.name);
-		if (existing && !existing.closed.peek()) {
+		if (existing && !existing.state.closed.peek()) {
 			throw new Error(`duplicate track: ${track.name}`);
 		}
 
-		this.state.tracks.set(track.name, track.state);
+		this.state.tracks.set(track.name, track);
 
 		// Evict the entry once the track closes, unless it has since been replaced.
 		const dispose = track.state.closed.subscribe((closed) => {
 			if (!closed) return;
-			if (this.state.tracks.get(track.name) === track.state) {
+			if (this.state.tracks.get(track.name) === track) {
 				this.state.tracks.delete(track.name);
 			}
 			dispose();
@@ -193,11 +194,11 @@ export class Broadcast {
 			throw new Error(`broadcast is closed: ${this.state.closed.peek()}`);
 		}
 
-		// Fast path: a statically inserted track is served directly, no request. A
-		// stale (closed) entry is evicted and falls through to the on-demand path.
+		// Fast path: a statically inserted track fans out a fresh subscriber, no
+		// request. A stale (closed) entry is evicted and falls through to on-demand.
 		const existing = this.state.tracks.get(name);
 		if (existing) {
-			if (!existing.closed.peek()) return new TrackSubscriber(name, existing);
+			if (!existing.state.closed.peek()) return existing.subscribe();
 			this.state.tracks.delete(name);
 		}
 
@@ -230,8 +231,8 @@ export class Broadcast {
 
 		// A statically inserted track already committed its info; serve it directly.
 		const existing = this.state.tracks.get(name);
-		if (existing && !existing.closed.peek()) {
-			return new TrackSubscriber(name, existing).info();
+		if (existing && !existing.state.closed.peek()) {
+			return existing.info();
 		}
 
 		// Publish side: ask the application by triggering a TrackRequest it answers

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -142,6 +142,10 @@ export class Broadcast {
 	 * {@link TrackProducer} and writes its groups; when that producer closes, the entry
 	 * is removed automatically. Throws on a duplicate live name. Mirrors the Rust
 	 * `BroadcastProducer::insert_track`.
+	 *
+	 * The producer must commit its {@link TrackInfo} via `accept()` (or use
+	 * {@link createTrack}, which does it for you); otherwise a subscriber's
+	 * `info()` never resolves and the wire layer stalls before serving.
 	 */
 	insertTrack(track: TrackProducer): void {
 		if (this.state.closed.peek()) {

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { Group, MAX_GROUP_CACHE_BYTES, MAX_GROUP_FRAMES } from "./group.ts";
+
+test("a group caps its frame count, dropping from the front", () => {
+	const group = new Group(0);
+
+	const extra = 100;
+	for (let i = 0; i < MAX_GROUP_FRAMES + extra; i++) {
+		group.writeFrame(new Uint8Array([i & 0xff]));
+	}
+
+	const frames = group.state.frames.peek();
+	expect(frames.length).toBe(MAX_GROUP_FRAMES);
+	// `total` still counts every frame written, so frame indices stay consistent.
+	expect(group.state.total.peek()).toBe(MAX_GROUP_FRAMES + extra);
+	// The oldest `extra` frames were dropped: the front is now frame `extra`.
+	expect(frames[0][0]).toBe(extra & 0xff);
+});
+
+test("a group caps its byte size, dropping from the front", () => {
+	const group = new Group(0);
+
+	// 40 x 1 MiB = 40 MiB, over the 32 MiB cap.
+	const oneMiB = 1024 * 1024;
+	for (let i = 0; i < 40; i++) {
+		group.writeFrame(new Uint8Array(oneMiB));
+	}
+
+	const frames = group.state.frames.peek();
+	const bytes = frames.reduce((sum, f) => sum + f.byteLength, 0);
+	expect(bytes).toBeLessThanOrEqual(MAX_GROUP_CACHE_BYTES);
+	expect(frames.length).toBe(MAX_GROUP_CACHE_BYTES / oneMiB);
+});

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { Group, MAX_GROUP_CACHE_BYTES, MAX_GROUP_FRAMES } from "./group.ts";
+import { CacheFull, Group, MAX_GROUP_CACHE_BYTES, MAX_GROUP_FRAMES } from "./group.ts";
 
 test("a group caps its frame count, dropping from the front", () => {
 	const group = new Group(0);
@@ -30,4 +30,27 @@ test("a group caps its byte size, dropping from the front", () => {
 	const bytes = frames.reduce((sum, f) => sum + f.byteLength, 0);
 	expect(bytes).toBeLessThanOrEqual(MAX_GROUP_CACHE_BYTES);
 	expect(frames.length).toBe(MAX_GROUP_CACHE_BYTES / oneMiB);
+});
+
+test("reading a group whose frames were evicted throws CacheFull", async () => {
+	const group = new Group(0);
+
+	// Overflow the frame cap without reading, so the front frames are evicted.
+	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) {
+		group.writeFrame(new Uint8Array([i & 0xff]));
+	}
+
+	// The reader fell behind the eviction window: it must error, not skip the gap.
+	expect(group.readFrame()).rejects.toBeInstanceOf(CacheFull);
+});
+
+test("a group with no eviction reads every frame without error", async () => {
+	const group = new Group(0);
+	group.writeFrame(new Uint8Array([1]));
+	group.writeFrame(new Uint8Array([2]));
+	group.close();
+
+	expect((await group.readFrame())?.[0]).toBe(1);
+	expect((await group.readFrame())?.[0]).toBe(2);
+	expect(await group.readFrame()).toBeUndefined();
 });

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -12,6 +12,10 @@ export class Group {
 	state = new GroupState();
 	readonly closed: Promise<Error | undefined>;
 
+	// Downstream copies that receive every frame written here, synchronously. Used by
+	// TrackProducer to fan one source group out to per-subscriber groups.
+	#mirrors?: Set<Group>;
+
 	constructor(sequence: number) {
 		this.sequence = sequence;
 
@@ -37,6 +41,36 @@ export class Group {
 		});
 
 		this.state.total.update((total) => total + 1);
+
+		// Tee into live mirrors, dropping any the consumer has already closed.
+		if (this.#mirrors) {
+			for (const mirror of this.#mirrors) {
+				if (mirror.state.closed.peek()) this.#mirrors.delete(mirror);
+				else mirror.writeFrame(frame);
+			}
+		}
+	}
+
+	/**
+	 * Create an independent copy that receives every frame written to this group.
+	 *
+	 * Frames written so far are replayed synchronously; later writes (and the close)
+	 * are teed in as they happen. The copy has its own read cursor, so consumers never
+	 * steal frames from each other. Internal to {@link TrackProducer} fan-out.
+	 */
+	mirror(): Group {
+		const dst = new Group(this.sequence);
+		for (const frame of this.state.frames.peek()) dst.writeFrame(frame);
+
+		const closed = this.state.closed.peek();
+		if (closed) {
+			dst.close(closed instanceof Error ? closed : undefined);
+			return dst;
+		}
+
+		this.#mirrors ??= new Set();
+		this.#mirrors.add(dst);
+		return dst;
 	}
 
 	writeString(str: string) {
@@ -100,5 +134,10 @@ export class Group {
 
 	close(abort?: Error) {
 		this.state.closed.set(abort ?? true);
+
+		if (this.#mirrors) {
+			for (const mirror of this.#mirrors) mirror.close(abort);
+			this.#mirrors.clear();
+		}
 	}
 }

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -1,5 +1,11 @@
 import { Signal } from "@moq/signals";
 
+/** Maximum bytes of frames cached in a group before old frames are evicted from the front. */
+export const MAX_GROUP_CACHE_BYTES = 32 * 1024 * 1024;
+
+/** Maximum number of frames cached in a group before old frames are evicted from the front. */
+export const MAX_GROUP_FRAMES = 1024;
+
 export class GroupState {
 	frames = new Signal<Uint8Array[]>([]);
 	closed = new Signal<boolean | Error>(false);
@@ -15,6 +21,9 @@ export class Group {
 	// Downstream copies that receive every frame written here, synchronously. Used by
 	// TrackProducer to fan one source group out to per-subscriber groups.
 	#mirrors?: Set<Group>;
+
+	// Running byte total of the frames currently cached, for the eviction cap.
+	#cacheBytes = 0;
 
 	constructor(sequence: number) {
 		this.sequence = sequence;
@@ -36,8 +45,17 @@ export class Group {
 	writeFrame(frame: Uint8Array) {
 		if (this.state.closed.peek()) throw new Error("group is closed");
 
+		this.#cacheBytes += frame.byteLength;
 		this.state.frames.mutate((frames) => {
 			frames.push(frame);
+
+			// Bound an unbounded (e.g. never-closed) group: drop the oldest frames once
+			// over either cap. A consumer too far behind silently skips them.
+			while (frames.length > MAX_GROUP_FRAMES || this.#cacheBytes > MAX_GROUP_CACHE_BYTES) {
+				const evicted = frames.shift();
+				if (!evicted) break;
+				this.#cacheBytes -= evicted.byteLength;
+			}
 		});
 
 		this.state.total.update((total) => total + 1);

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -6,10 +6,27 @@ export const MAX_GROUP_CACHE_BYTES = 32 * 1024 * 1024;
 /** Maximum number of frames cached in a group before old frames are evicted from the front. */
 export const MAX_GROUP_FRAMES = 1024;
 
+/**
+ * Thrown by a frame read when the reader fell behind the group's eviction window: frames
+ * it had not yet read were dropped to stay under the cache cap, so the stream has a gap.
+ * Mirrors the Rust `Error::CacheFull`. Skipping the gap silently would corrupt decoding,
+ * so the reader must surface this instead.
+ */
+export class CacheFull extends Error {
+	constructor() {
+		super("group cache full: frames were evicted before being read");
+		this.name = "CacheFull";
+	}
+}
+
 export class GroupState {
 	frames = new Signal<Uint8Array[]>([]);
 	closed = new Signal<boolean | Error>(false);
 	total = new Signal<number>(0); // The total number of frames in the group thus far
+
+	// Frames evicted from the front by the cache cap. A reader that had not consumed
+	// them has a gap, so its next read throws CacheFull rather than skipping silently.
+	offset = 0;
 }
 
 export class Group {
@@ -55,6 +72,7 @@ export class Group {
 				const evicted = frames.shift();
 				if (!evicted) break;
 				this.#cacheBytes -= evicted.byteLength;
+				this.state.offset++;
 			}
 		});
 
@@ -79,6 +97,9 @@ export class Group {
 	mirror(): Group {
 		const dst = new Group(this.sequence);
 		for (const frame of this.state.frames.peek()) dst.writeFrame(frame);
+		// Inherit the evicted prefix: frames dropped before this copy was made are a gap
+		// for its reader too, so reading them throws CacheFull.
+		dst.state.offset = this.state.offset;
 
 		const closed = this.state.closed.peek();
 		if (closed) {
@@ -109,6 +130,8 @@ export class Group {
 	 */
 	async readFrame(): Promise<Uint8Array | undefined> {
 		for (;;) {
+			if (this.state.offset > 0) throw new CacheFull();
+
 			const frames = this.state.frames.peek();
 			const frame = frames.shift();
 			if (frame) return frame;
@@ -123,6 +146,8 @@ export class Group {
 
 	async readFrameSequence(): Promise<{ sequence: number; data: Uint8Array } | undefined> {
 		for (;;) {
+			if (this.state.offset > 0) throw new CacheFull();
+
 			const frames = this.state.frames.peek();
 			const frame = frames.shift();
 			if (frame) return { sequence: this.state.total.peek() - frames.length - 1, data: frame };

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -337,7 +337,12 @@ export class TrackSubscriber extends TrackHandle {
 
 			// Discard old groups.
 			while (groups.length > 1) {
-				if (groups[0].state.offset > 0) throw new CacheFull();
+				if (groups[0].state.offset > 0) {
+					// The reader fell behind this group's eviction window. Drop it and
+					// signal the gap; the next read resyncs from the following group.
+					groups.shift()?.close();
+					throw new CacheFull();
+				}
 
 				const frames = groups[0].state.frames.peek();
 				const next = frames.shift();
@@ -362,7 +367,12 @@ export class TrackSubscriber extends TrackHandle {
 
 			// If there's a group, wait for a frame.
 			const group = groups[0];
-			if (group.state.offset > 0) throw new CacheFull();
+			if (group.state.offset > 0) {
+				// Fell behind this group's eviction window. Drop it and signal the gap;
+				// the next read resyncs from the following group.
+				groups.shift()?.close();
+				throw new CacheFull();
+			}
 
 			const frames = group.state.frames.peek();
 			const next = frames.shift();

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -41,6 +41,10 @@ export class TrackState {
 	info = new Signal<TrackInfo | undefined>(undefined);
 }
 
+// A source group retained in the producer cache, with the mirror handed to each sink
+// so eviction can drop them together.
+type CachedGroup = { group: Group; time: number; mirrors: Map<TrackState, Group> };
+
 /** Shared base for the two ends of a track: name, state, close, and info. */
 abstract class TrackHandle {
 	readonly name: string;
@@ -106,9 +110,10 @@ export class TrackProducer extends TrackHandle {
 	#next?: number;
 
 	// Recently written source groups, retained for replay to late subscribers and
-	// pruned once closed and older than the cache window. Each subscriber reads its
-	// own mirror, so these are never drained by a consumer.
-	#cache: { group: Group; time: number }[] = [];
+	// pruned once closed and older than the cache window. Each entry tracks the mirror
+	// it handed to every sink so eviction can drop them too: otherwise a slow consumer
+	// that never reads would pin old groups (and their frame bytes) forever.
+	#cache: CachedGroup[] = [];
 
 	// One independent downstream state per live subscriber.
 	#sinks = new Set<TrackState>();
@@ -149,44 +154,66 @@ export class TrackProducer extends TrackHandle {
 		if (!closed) {
 			this.#sinks.add(sink);
 
-			// Drop the sink once its consumer goes away, closing its mirrors so source
+			// Drop the sink once its consumer goes away, releasing its mirrors so source
 			// groups stop teeing into them, so a long-lived producer doesn't leak.
 			const dispose = sink.closed.subscribe((c) => {
 				if (!c) return;
 				this.#sinks.delete(sink);
+				for (const entry of this.#cache) entry.mirrors.delete(sink);
 				for (const group of sink.groups.peek()) group.close(c instanceof Error ? c : undefined);
 				dispose();
 			});
 		}
 
 		this.#prune();
-		for (const { group } of this.#cache) this.#mirror(group, sink);
+		for (const entry of this.#cache) this.#mirror(entry, sink);
 
 		if (closed) sink.closed.set(closed);
 	}
 
-	// Mirror a source group into a sink. The mirror fills synchronously as the source
-	// is written and keeps its own read cursor; frame bytes are shared by reference.
-	#mirror(src: Group, sink: TrackState): void {
-		const dst = src.mirror();
+	// Mirror a cached source group into a sink. The mirror fills synchronously as the
+	// source is written and keeps its own read cursor; frame bytes are shared by
+	// reference. Tracked on the entry so eviction can drop it from the sink.
+	#mirror(entry: CachedGroup, sink: TrackState): void {
+		const dst = entry.group.mirror();
+		entry.mirrors.set(sink, dst);
 		sink.groups.mutate((groups) => {
 			groups.push(dst);
 			groups.sort((a, b) => a.sequence - b.sequence);
 		});
 	}
 
-	// Evict cached groups that are closed and older than the cache window.
+	// Evict cached groups that are closed and older than the cache window, dropping
+	// each evicted group's mirror from every sink so no consumer can pin it.
 	#prune(): void {
 		const cacheMs = this.state.info.peek()?.cache ?? DEFAULT_CACHE_MS;
 		const cutoff = Date.now() - cacheMs;
-		this.#cache = this.#cache.filter(({ group, time }) => time > cutoff || !group.state.closed.peek());
+
+		const retained: CachedGroup[] = [];
+		for (const entry of this.#cache) {
+			if (entry.time > cutoff || !entry.group.state.closed.peek()) {
+				retained.push(entry);
+				continue;
+			}
+
+			for (const [sink, mirror] of entry.mirrors) {
+				sink.groups.mutate((groups) => {
+					const i = groups.indexOf(mirror);
+					if (i >= 0) groups.splice(i, 1);
+				});
+				mirror.close();
+			}
+			entry.mirrors.clear();
+		}
+		this.#cache = retained;
 	}
 
 	// Retain a source group and fan it out to every live sink.
 	#publish(group: Group): void {
-		this.#cache.push({ group, time: Date.now() });
+		const entry = { group, time: Date.now(), mirrors: new Map<TrackState, Group>() };
+		this.#cache.push(entry);
 		this.#prune();
-		for (const sink of this.#sinks) this.#mirror(group, sink);
+		for (const sink of this.#sinks) this.#mirror(entry, sink);
 	}
 
 	/** Append a new group with the next sequence number. */

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -154,13 +154,22 @@ export class TrackProducer extends TrackHandle {
 		if (!closed) {
 			this.#sinks.add(sink);
 
-			// Drop the sink once its consumer goes away, releasing its mirrors so source
-			// groups stop teeing into them, so a long-lived producer doesn't leak.
+			// Drop the sink once its consumer goes away, closing its mirrors so source
+			// groups stop teeing into them, so a long-lived producer doesn't leak. This
+			// covers mirrors already handed out via recvGroup (no longer in sink.groups)
+			// by closing them through the cache's per-sink tracking.
 			const dispose = sink.closed.subscribe((c) => {
 				if (!c) return;
+				const abort = c instanceof Error ? c : undefined;
 				this.#sinks.delete(sink);
-				for (const entry of this.#cache) entry.mirrors.delete(sink);
-				for (const group of sink.groups.peek()) group.close(c instanceof Error ? c : undefined);
+				for (const entry of this.#cache) {
+					const mirror = entry.mirrors.get(sink);
+					if (mirror) {
+						mirror.close(abort);
+						entry.mirrors.delete(sink);
+					}
+				}
+				for (const group of sink.groups.peek()) group.close(abort);
 				dispose();
 			});
 		}

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -93,26 +93,100 @@ abstract class TrackHandle {
 /**
  * The write side of a track, mirroring the Rust `TrackProducer`.
  *
+ * A producer is a fan-out source: every {@link subscribe} (including each wire
+ * subscription the publisher serves from it) gets an independent
+ * {@link TrackSubscriber} that receives a full copy of the groups, each with its own
+ * read cursor. Groups are mirrored into every live subscriber and retained for the
+ * track's `cache` window so a late subscriber replays the recent groups.
+ *
  * Obtained from `TrackRequest.accept` (the wire asks the application for a track to
- * serve) or constructed directly for an in-process track. Writes groups that a
- * {@link TrackSubscriber} on the same {@link TrackState} reads.
+ * serve) or constructed directly for an in-process track.
  */
 export class TrackProducer extends TrackHandle {
 	#next?: number;
 
-	constructor(name: string, state: TrackState = new TrackState()) {
-		super(name, state);
+	// Recently written source groups, retained for replay to late subscribers and
+	// pruned once closed and older than the cache window. Each subscriber reads its
+	// own mirror, so these are never drained by a consumer.
+	#cache: { group: Group; time: number }[] = [];
+
+	// One independent downstream state per live subscriber.
+	#sinks = new Set<TrackState>();
+
+	constructor(name: string, sink?: TrackState) {
+		// The producer's own state is the source of truth (info/closed); subscribers
+		// read mirrored sinks, never this state directly. `sink`, when given, is an
+		// already-handed-out subscriber state (the on-demand accept path) adopted as
+		// the first sink.
+		super(name, new TrackState());
+		if (sink) this.#addSink(sink);
 	}
 
 	/** Commit the immutable publisher properties, resolving {@link info}. Returns `this`. */
 	accept(info: Partial<TrackInfo> = {}): this {
-		this.state.info.set(trackInfoDefaults(info));
+		const resolved = trackInfoDefaults(info);
+		this.state.info.set(resolved);
+		// Propagate to any sink handed out before accept (the on-demand path).
+		for (const sink of this.#sinks) sink.info.set(resolved);
 		return this;
 	}
 
-	/** A {@link TrackSubscriber} reading this in-process track's groups. */
+	/** An independent {@link TrackSubscriber} receiving a full copy of this track's groups. */
 	subscribe(): TrackSubscriber {
-		return new TrackSubscriber(this.name, this.state);
+		const sink = new TrackState();
+		this.#addSink(sink);
+		return new TrackSubscriber(this.name, sink);
+	}
+
+	// Register a downstream sink: seed its info, replay the retained window, and (while
+	// the track is open) mirror future groups into it. A late subscriber to a closed
+	// track still drains the buffered groups before seeing the end.
+	#addSink(sink: TrackState): void {
+		const info = this.state.info.peek();
+		if (info) sink.info.set(info);
+
+		const closed = this.state.closed.peek();
+		if (!closed) {
+			this.#sinks.add(sink);
+
+			// Drop the sink once its consumer goes away, closing its mirrors so source
+			// groups stop teeing into them, so a long-lived producer doesn't leak.
+			const dispose = sink.closed.subscribe((c) => {
+				if (!c) return;
+				this.#sinks.delete(sink);
+				for (const group of sink.groups.peek()) group.close(c instanceof Error ? c : undefined);
+				dispose();
+			});
+		}
+
+		this.#prune();
+		for (const { group } of this.#cache) this.#mirror(group, sink);
+
+		if (closed) sink.closed.set(closed);
+	}
+
+	// Mirror a source group into a sink. The mirror fills synchronously as the source
+	// is written and keeps its own read cursor; frame bytes are shared by reference.
+	#mirror(src: Group, sink: TrackState): void {
+		const dst = src.mirror();
+		sink.groups.mutate((groups) => {
+			groups.push(dst);
+			groups.sort((a, b) => a.sequence - b.sequence);
+		});
+	}
+
+	// Evict cached groups that are closed and older than the cache window.
+	#prune(): void {
+		const cacheMs = this.state.info.peek()?.cache ?? DEFAULT_CACHE_MS;
+		const cutoff = Date.now() - cacheMs;
+		this.#cache = this.#cache.filter(({ group, time }) => time > cutoff || !group.state.closed.peek());
+	}
+
+	// Retain a source group and fan it out to every live sink.
+	#publish(group: Group): void {
+		this.#cache.push({ group, time: Date.now() });
+		this.#prune();
+		for (const sink of this.#sinks) this.#mirror(group, sink);
 	}
 
 	/** Append a new group with the next sequence number. */
@@ -120,12 +194,8 @@ export class TrackProducer extends TrackHandle {
 		if (this.state.closed.peek()) throw new Error("track is closed");
 
 		const group = new Group(this.#next ?? 0);
-
 		this.#next = group.sequence + 1;
-		this.state.groups.mutate((groups) => {
-			groups.push(group);
-			groups.sort((a, b) => a.sequence - b.sequence);
-		});
+		this.#publish(group);
 
 		return group;
 	}
@@ -139,10 +209,18 @@ export class TrackProducer extends TrackHandle {
 			this.#next = group.sequence + 1;
 		}
 
-		this.state.groups.mutate((groups) => {
-			groups.push(group);
-			groups.sort((a, b) => a.sequence - b.sequence);
-		});
+		this.#publish(group);
+	}
+
+	/** Close the track and every subscriber, mirroring the abort to their groups. */
+	override close(abort?: Error) {
+		this.state.closed.set(abort ?? true);
+		for (const { group } of this.#cache) group.close(abort);
+		for (const sink of this.#sinks) {
+			for (const group of sink.groups.peek()) group.close(abort);
+			sink.closed.set(abort ?? true);
+		}
+		this.#sinks.clear();
 	}
 
 	/** Append a frame as its own single-frame group. */

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1,5 +1,5 @@
 import { Signal } from "@moq/signals";
-import { Group } from "./group.ts";
+import { CacheFull, Group } from "./group.ts";
 
 /** Default {@link TrackInfo.cache} window (milliseconds) when the publisher doesn't set one. */
 export const DEFAULT_CACHE_MS = 5000;
@@ -337,6 +337,8 @@ export class TrackSubscriber extends TrackHandle {
 
 			// Discard old groups.
 			while (groups.length > 1) {
+				if (groups[0].state.offset > 0) throw new CacheFull();
+
 				const frames = groups[0].state.frames.peek();
 				const next = frames.shift();
 				if (next) {
@@ -360,6 +362,8 @@ export class TrackSubscriber extends TrackHandle {
 
 			// If there's a group, wait for a frame.
 			const group = groups[0];
+			if (group.state.offset > 0) throw new CacheFull();
+
 			const frames = group.state.frames.peek();
 			const next = frames.shift();
 			if (next) {

--- a/js/watch/src/audio/mse.ts
+++ b/js/watch/src/audio/mse.ts
@@ -125,7 +125,15 @@ export class Mse implements Backend {
 			for (;;) {
 				// TODO: Use Frame.Consumer for CMAF so we can support higher latencies.
 				// It requires extracting the timestamp from the frame payload.
-				const frame = await sub.readFrame();
+				let frame: Uint8Array | undefined;
+				try {
+					frame = await sub.readFrame();
+				} catch (err) {
+					// Falling behind a group's eviction window drops frames; resync from
+					// the next group (a keyframe segment) rather than stopping playback.
+					if (err instanceof Moq.CacheFull) continue;
+					throw err;
+				}
 				if (!frame) return;
 
 				// Extract the timestamp from the CMAF segment and mark when we received it.

--- a/js/watch/src/video/mse.ts
+++ b/js/watch/src/video/mse.ts
@@ -125,7 +125,15 @@ export class Mse implements Backend {
 			for (;;) {
 				// TODO: Use Frame.Consumer for CMAF so we can support higher latencies.
 				// It requires extracting the timestamp from the frame payload.
-				const frame = await data.readFrame();
+				let frame: Uint8Array | undefined;
+				try {
+					frame = await data.readFrame();
+				} catch (err) {
+					// Falling behind a group's eviction window drops frames; resync from
+					// the next group (a keyframe segment) rather than stopping playback.
+					if (err instanceof Moq.CacheFull) continue;
+					throw err;
+				}
 				if (!frame) return;
 
 				// Extract the timestamp from the CMAF segment and mark when we received it.


### PR DESCRIPTION
## Summary

Brings the JS `Broadcast`/`TrackProducer` API closer to Rust on two fronts:

1. **Static track insertion** — a publisher can push tracks up front instead of only answering on-demand `requested()` calls.
2. **Track fan-out** — a `TrackProducer` now serves multiple independent subscribers, each getting a full copy of every group, with bounded memory.

### 1. Static insertion (mirrors `BroadcastProducer`)

Until now a JS `Broadcast` only supported the on-demand model: every `subscribe()` pushed a `TrackRequest` the publisher had to answer via `requested()` / `accept()`. New methods on `Broadcast`:

- `insertTrack(track: TrackProducer)` — register a track the caller owns and writes; throws on a duplicate live name; auto-evicts the entry when the producer closes.
- `createTrack(name, info?)` — create + insert, committing the immutable `TrackInfo` up front, and return the `TrackProducer`.
- `removeTrack(name)` — drop a static entry.

`subscribe()` serves a statically inserted track directly (no request emitted); a stale/closed entry falls through to the on-demand path.

### 2. Fan-out (the part that makes #1 actually usable)

A reviewer-style question surfaced a real bug in the first cut: the JS read pipeline is **destructive single-consumer** (`recvGroup`/`group.readFrame` `shift()` off shared arrays), so two subscribers to one inserted track would *steal* groups from each other. The on-demand path only avoided this by minting a fresh `TrackState` per request and having the app serve each one — inserted tracks had no such escape hatch.

`TrackProducer` is now a fan-out source, like Rust's broadcast-channel-backed producer:

- Keeps a cache of recent source groups (retained for the `cache` window) and a set of downstream sinks.
- `subscribe()` creates a sink, replays the cached window, and registers for future groups. A late subscriber to a closed track still drains the buffered groups before seeing the end.
- Each group is mirrored into every sink as its own `Group`; **frames are teed synchronously at write time** (`Group.mirror` + fan-out in `Group.writeFrame`), so frame bytes are shared by reference while each subscriber keeps an independent read cursor.
- The on-demand `accept()` path adopts the already-handed-out subscriber state as the producer's first sink, so both static and on-demand flow through one model.

The **consumer-facing read API is unchanged** (`recvGroup`, `nextGroup`, `group.readFrame`, ...), so hang/watch/publish/json need no changes.

### 3. Bounded memory (cascade eviction)

Fan-out copies must not let an old/slow consumer pin memory. The producer cache is pruned by age (the per-track `cache` window), and **eviction cascades into every sink**: each cached source group tracks the mirror it handed to each subscriber, and aging a group out drops it from the source cache *and* from every sink (closing it). A consumer that stops reading retains at most one cache window's worth of groups; once a group ages out, the shared frame bytes are released for GC. Eviction is write-triggered, so a quiet track accrues no new memory.

## API surface

New public methods, all additive:
- `Broadcast`: `insertTrack`, `createTrack`, `removeTrack`.
- `TrackProducer.subscribe()`: previously returned a subscriber sharing the producer's state (no in-tree callers); now returns an independent fan-out subscriber.
- `Group.mirror()`: internal to producer fan-out (documented as such).

Targeting `dev` per branch-targeting (widens the `js/net` public surface).

## Test plan

- [x] `js/net/src/broadcast.test.ts`: static subscribe without a request; **two subscribers each get a full copy**; **late subscriber replays the cached window**; **a stalled consumer does not pin evicted groups**; `createTrack` commits info up front; duplicate insert throws; closed entry falls through; `removeTrack` drops the entry.
- [x] `bun test` in `js/net` (170 pass), including the wire integration round-trip.
- [x] Dependent packages green: `hang`, `json`, `publish`, `watch`, `signals`.
- [x] Biome + `tsc --noEmit` clean.

(Written by Claude)