### PR TITLE
fix(moq-net): release cached state when a producer is aborted or dropped

### DIFF
--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -212,6 +212,16 @@ impl<T> Producer<T> {
 		self.state.is_clone(&other.state)
 	}
 
+	/// Returns `true` if this is the only remaining producer.
+	///
+	/// Inherently racy if other handles may clone this producer or upgrade a
+	/// [`Weak`] / [`Consumer`] concurrently. Intended for a producer's own
+	/// `Drop`, where this handle has not yet been counted out, to gate
+	/// last-producer cleanup.
+	pub fn is_last(&self) -> bool {
+		self.counts.producers.load(Ordering::Acquire) == 1
+	}
+
 	/// Create a [`Weak`] reference that doesn't affect the producer/consumer ref counts.
 	pub fn weak(&self) -> Weak<T> {
 		Weak {
@@ -334,5 +344,28 @@ impl<T> Deref for Ref<'_, T> {
 
 	fn deref(&self) -> &Self::Target {
 		&self.state.value
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn is_last_tracks_producer_count() {
+		let producer = Producer::new(0u8);
+		assert!(producer.is_last());
+
+		let clone = producer.clone();
+		assert!(!producer.is_last());
+		assert!(!clone.is_last());
+
+		drop(clone);
+		assert!(producer.is_last());
+
+		// Consumers and weak handles don't count as producers.
+		let _consumer = producer.consume();
+		let _weak = producer.weak();
+		assert!(producer.is_last());
 	}
 }

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -191,6 +191,23 @@ impl BroadcastProducer {
 	}
 }
 
+impl Drop for BroadcastProducer {
+	fn drop(&mut self) {
+		// The last producer dropping releases the track lookup so a stale
+		// consumer can't pin it (and the track state it weakly references)
+		// forever, the same as an explicit abort.
+		if !self.state.is_last() {
+			return;
+		}
+		if let Ok(mut state) = modify(&self.state) {
+			state.tracks.clear();
+			for mut request in state.requests.drain(..) {
+				request.abort(Error::Cancel).ok();
+			}
+		}
+	}
+}
+
 /// Handles on-demand track creation for a broadcast.
 ///
 /// When a consumer requests a track that doesn't exist, a [TrackProducer] is created
@@ -305,7 +322,14 @@ impl BroadcastDynamic {
 
 impl Drop for BroadcastDynamic {
 	fn drop(&mut self) {
+		// Release the track lookup if we're the last producer overall, matching
+		// BroadcastProducer::drop and an explicit abort.
+		let last = self.state.is_last();
 		if let Ok(mut state) = self.state.write() {
+			if last {
+				state.tracks.clear();
+			}
+
 			// We do a saturating sub so Producer::dynamic() can avoid returning an error.
 			state.dynamic = state.dynamic.saturating_sub(1);
 			if state.dynamic != 0 {
@@ -526,6 +550,23 @@ mod test {
 		);
 
 		drop(track);
+	}
+
+	#[tokio::test]
+	async fn drop_clears_track_lookup() {
+		let mut producer = Broadcast::new().produce();
+		let _track = producer.assert_create_track(&Track::new("track1"));
+
+		// A stale consumer keeps the channel (and thus the lookup) alive.
+		let consumer = producer.consume();
+		assert_eq!(consumer.state.read().tracks.len(), 1);
+
+		// Dropping the last producer releases the lookup, same as an abort.
+		drop(producer);
+		assert!(
+			consumer.state.read().tracks.is_empty(),
+			"track lookup should be cleared when the last producer drops"
+		);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -157,7 +157,8 @@ impl BroadcastProducer {
 	/// inserted tracks are referenced via weak handles so that consumers can
 	/// finish reading them. Pending dynamic track requests, however, are owned
 	/// by the broadcast and have no other producer to fulfill them, so they are
-	/// aborted here.
+	/// aborted here. The track lookup is also cleared so a stale
+	/// [`BroadcastConsumer`] can't pin it in memory forever.
 	pub fn abort(&mut self, err: Error) -> Result<(), Error> {
 		let mut guard = modify(&self.state)?;
 
@@ -167,6 +168,7 @@ impl BroadcastProducer {
 			request.abort(err.clone()).ok();
 		}
 
+		guard.tracks.clear();
 		guard.abort = Some(err);
 		guard.close();
 		Ok(())
@@ -278,7 +280,8 @@ impl BroadcastDynamic {
 	/// Externally-owned tracks are independent and must be aborted separately;
 	/// inserted tracks are referenced via weak handles. Pending dynamic track
 	/// requests are owned by the broadcast and aborted here so consumers don't
-	/// stay stuck waiting on producers nobody will fulfill.
+	/// stay stuck waiting on producers nobody will fulfill. The track lookup is
+	/// also cleared so a stale [`BroadcastConsumer`] can't pin it in memory forever.
 	pub fn abort(&mut self, err: Error) -> Result<(), Error> {
 		let mut guard = modify(&self.state)?;
 
@@ -288,6 +291,7 @@ impl BroadcastDynamic {
 			request.abort(err.clone()).ok();
 		}
 
+		guard.tracks.clear();
 		guard.abort = Some(err);
 		guard.close();
 		Ok(())
@@ -504,6 +508,24 @@ mod test {
 		// track1's producer is held outside the broadcast, so it survives.
 		assert!(!track1.is_closed());
 		track1c.assert_not_closed();
+	}
+
+	#[tokio::test]
+	async fn abort_clears_track_lookup() {
+		let mut producer = Broadcast::new().produce();
+		let track = producer.assert_create_track(&Track::new("track1"));
+
+		// A stale consumer that never drops must not pin the lookup entries.
+		let _consumer = producer.consume();
+		assert_eq!(producer.state.read().tracks.len(), 1);
+
+		producer.abort(Error::Cancel).unwrap();
+		assert!(
+			producer.state.read().tracks.is_empty(),
+			"track lookup should be cleared on abort"
+		);
+
+		drop(track);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -209,12 +209,16 @@ impl GroupProducer {
 
 	/// Abort the group with the given error.
 	///
-	/// No updates can be made after this point. Child frames are independent and
-	/// must be aborted separately if desired; existing frame consumers can still
-	/// finish reading any frames that were already created.
+	/// No updates can be made after this point. Drops the cached frames so a stale
+	/// [`GroupConsumer`] can't pin their buffers in memory forever; consumers that
+	/// haven't drained yet surface the abort error instead of the leftover cache.
+	/// Child frames are independent: a consumer that already pulled a
+	/// [`FrameConsumer`] keeps its own handle and can finish reading it.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
 		let mut guard = modify(&self.state)?;
 		guard.abort = Some(err);
+		guard.frames.clear();
+		guard.cache = 0;
 		guard.close();
 		Ok(())
 	}
@@ -452,6 +456,22 @@ mod test {
 
 		let result = consumer.next_frame().now_or_never().unwrap();
 		assert!(matches!(result, Err(crate::Error::Cancel)));
+	}
+
+	#[test]
+	fn abort_clears_cached_frames() {
+		let mut producer = Group { sequence: 0 }.produce();
+		producer.write_frame(Bytes::from_static(b"data")).unwrap();
+
+		// A stale consumer that never reads must not pin the cached frames.
+		let _consumer = producer.consume();
+		assert_eq!(producer.state.read().frames.len(), 1);
+
+		producer.abort(crate::Error::Cancel).unwrap();
+
+		let state = producer.state.read();
+		assert!(state.frames.is_empty(), "cached frames should be dropped on abort");
+		assert_eq!(state.cache, 0);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -256,6 +256,23 @@ impl Clone for GroupProducer {
 	}
 }
 
+impl Drop for GroupProducer {
+	fn drop(&mut self) {
+		// See TrackProducer::drop: the last producer dropping without a clean
+		// finish releases the cached frames so a stale consumer can't pin their
+		// buffers forever. A finished group keeps its cache so consumers can drain.
+		if !self.state.is_last() {
+			return;
+		}
+		if let Ok(mut state) = modify(&self.state)
+			&& !state.fin
+		{
+			state.frames.clear();
+			state.cache = 0;
+		}
+	}
+}
+
 impl From<Group> for GroupProducer {
 	fn from(info: Group) -> Self {
 		GroupProducer::new(info)
@@ -472,6 +489,38 @@ mod test {
 		let state = producer.state.read();
 		assert!(state.frames.is_empty(), "cached frames should be dropped on abort");
 		assert_eq!(state.cache, 0);
+	}
+
+	#[test]
+	fn drop_unfinished_clears_cached_frames() {
+		let producer = Group { sequence: 0 }.produce();
+		let mut writer = producer.clone();
+		writer.write_frame(Bytes::from_static(b"data")).unwrap();
+
+		// A stale consumer keeps the channel (and thus the cache) alive.
+		let mut consumer = producer.consume();
+		assert_eq!(producer.state.read().frames.len(), 1);
+
+		// Drop every producer without finishing: the cache is released.
+		drop(writer);
+		drop(producer);
+
+		let result = consumer.next_frame().now_or_never().unwrap();
+		assert!(matches!(result, Err(crate::Error::Dropped)));
+	}
+
+	#[test]
+	fn drop_finished_keeps_cached_frames() {
+		let mut producer = Group { sequence: 0 }.produce();
+		producer.write_frame(Bytes::from_static(b"data")).unwrap();
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		drop(producer);
+
+		// A cleanly finished group keeps its cache so the consumer can still drain.
+		let frame = consumer.read_frame().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(frame, Bytes::from_static(b"data"));
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -396,6 +396,24 @@ impl Clone for TrackProducer {
 	}
 }
 
+impl Drop for TrackProducer {
+	fn drop(&mut self) {
+		// The last producer going away without finishing is an abrupt teardown:
+		// release the cached groups so a stale consumer can't pin them (and their
+		// frame buffers) forever, the same as an explicit abort. A cleanly
+		// finished track keeps its cache so consumers can still drain it.
+		if !self.state.is_last() {
+			return;
+		}
+		if let Ok(mut state) = self.state.write()
+			&& state.final_sequence.is_none()
+		{
+			state.groups.clear();
+			state.duplicates.clear();
+		}
+	}
+}
+
 impl From<Track> for TrackProducer {
 	fn from(info: Track) -> Self {
 		TrackProducer::new(info)
@@ -869,6 +887,39 @@ mod test {
 		// The consumer now surfaces the abort error rather than the leftover cache.
 		let result = consumer.recv_group().now_or_never().expect("should not block");
 		assert!(matches!(result, Err(Error::Cancel)));
+	}
+
+	#[tokio::test]
+	async fn drop_unfinished_clears_cached_groups() {
+		let producer = Track::new("test").produce();
+		let mut writer = producer.clone();
+		writer.append_group().unwrap();
+
+		// A stale consumer keeps the channel (and thus the cache) alive.
+		let mut consumer = producer.consume();
+		assert_eq!(live_groups(&producer.state.read()), 1);
+
+		// Drop every producer without finishing: the cache is released.
+		drop(writer);
+		drop(producer);
+
+		let result = consumer.recv_group().now_or_never().expect("should not block");
+		assert!(matches!(result, Err(Error::Dropped)));
+	}
+
+	#[tokio::test]
+	async fn drop_finished_keeps_cached_groups() {
+		let mut producer = Track::new("test").produce();
+		producer.append_group().unwrap();
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		drop(producer);
+
+		// A cleanly finished track keeps its cache so the consumer can still drain.
+		assert_eq!(consumer.assert_group().sequence, 0);
+		let done = consumer.recv_group().now_or_never().expect("should not block").unwrap();
+		assert!(done.is_none(), "consumer should drain then see clean finish");
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -315,12 +315,16 @@ impl TrackProducer {
 
 	/// Abort the track with the given error.
 	///
-	/// Child groups are independent and must be aborted separately if desired;
-	/// existing group consumers can still finish reading any groups that were
-	/// already created.
+	/// Drops the cached groups so a stale [`TrackConsumer`] can't pin them (and
+	/// their frame buffers) in memory forever. Consumers that haven't drained yet
+	/// surface the abort error instead of the leftover cache. Child groups are
+	/// independent: a consumer that already pulled a [`GroupConsumer`] keeps its
+	/// own handle and can finish reading it.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
 		let mut guard = self.modify()?;
 		guard.abort = Some(err);
+		guard.groups.clear();
+		guard.duplicates.clear();
 		guard.close();
 		Ok(())
 	}
@@ -842,6 +846,29 @@ mod test {
 		let group = consumer.assert_group();
 		// consume() starts at index 0, first non-tombstoned group is seq 5.
 		assert_eq!(group.sequence, 5);
+	}
+
+	#[tokio::test]
+	async fn abort_clears_cached_groups() {
+		let mut producer = Track::new("test").produce();
+		producer.append_group().unwrap();
+		producer.append_group().unwrap();
+
+		// A stale consumer that never drains must not pin the cached groups.
+		let mut consumer = producer.consume();
+		assert_eq!(live_groups(&producer.state.read()), 2);
+
+		producer.abort(Error::Cancel).unwrap();
+
+		{
+			let state = producer.state.read();
+			assert!(state.groups.is_empty(), "cached groups should be dropped on abort");
+			assert!(state.duplicates.is_empty());
+		}
+
+		// The consumer now surfaces the abort error rather than the leftover cache.
+		let result = consumer.recv_group().now_or_never().expect("should not block");
+		assert!(matches!(result, Err(Error::Cancel)));
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

Tearing down a moq-net producer left its cached state intact, so a stale `Consumer` could pin the buffers in memory forever.

`kio` keeps the shared state value alive as long as **any** handle exists, and that includes `kio::Weak` (it skips bumping the producer/consumer *counts* but still holds an `Arc` clone of the state lock, so it pins the value). A late/abandoned `TrackConsumer`/`GroupConsumer`, or a `Weak` held in the broadcast track lookup, kept the whole cached tree alive:

```
Track.State.groups -> GroupProducer -> Group.State.frames -> FrameProducer -> FrameBuf (heap buffer)
```

This happened on **both** teardown paths:
- **Explicit abort** (`abort()`) only flipped kio's close flag and stored the error; it never dropped the cache.
- **Plain drop** of all producers (e.g. a publisher task ending without an explicit abort) only flipped kio's close flag too. There were no `Drop` impls doing any moq-net-level cleanup.

## Fix

Release the cache on teardown, treating an abrupt drop like an abort while preserving a clean finish:

**On `abort()`:**
- `TrackProducer::abort` clears `groups` + `duplicates`.
- `GroupProducer::abort` clears `frames` + resets `cache`.
- `BroadcastProducer` / `BroadcastDynamic::abort` clear the track lookup (on top of draining owned dynamic requests).

**On drop of the last producer, when not cleanly finished:**
- `TrackProducer::drop` clears `groups` + `duplicates` (kept if `finish()`/`finish_at()` was called).
- `GroupProducer::drop` clears `frames` + resets `cache` (kept if `finish()` was called).
- `BroadcastProducer::drop` / `BroadcastDynamic::drop` clear the track lookup.

A new `kio::Producer::is_last()` gates the drop cleanup so it only runs for the final producer, not a dropped clone.

The frame layer needs no change: its payload lives in an `Arc<FrameBuf>` held directly by the producer/consumer handles, not in the shared `kio` state, so it is released by refcount when the handles drop.

## Behavior

After abort, or after the last producer drops **without** a clean finish, a consumer that hasn't pulled yet surfaces the terminal error (the abort error, or `Error::Dropped`) instead of draining the leftover cache. This matches teardown semantics and avoids serving a truncated stream as if complete. A **cleanly finished** producer keeps its cache so consumers can still drain it (e.g. a relay forwarding a finished track), and child consumers that already pulled a handle (`GroupConsumer`/`FrameConsumer`) own independent state and finish reading what they hold.

Public API signatures and wire behavior are unchanged; `kio::Producer::is_last()` is additive. Targeting `main`; happy to retarget `dev` if reviewers consider the drop/abort drain behavior change disruptive.

## Test plan

- [x] `cargo test -p kio -p moq-net` (347 passed)
- [x] `cargo clippy -p kio -p moq-net --all-targets` clean
- [x] `cargo test -p hang` (unaffected)
- [x] New regression tests:
  - kio: `producer::is_last_tracks_producer_count`
  - abort: `track::abort_clears_cached_groups`, `group::abort_clears_cached_frames`, `broadcast::abort_clears_track_lookup`
  - drop: `track::{drop_unfinished_clears_cached_groups, drop_finished_keeps_cached_groups}`, `group::{drop_unfinished_clears_cached_frames, drop_finished_keeps_cached_frames}`, `broadcast::drop_clears_track_lookup`

> Note: `moq-relay` requires rustc 1.95 and didn't build on the local 1.94.1 toolchain; verified via CI.

(Written by Claude)