### PR TITLE
fix(moq-net): don't tear down session on unauthorized announce-interest

### DIFF
--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -879,11 +879,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 		.scope(&["allowed".into()])
 		.expect("failed to scope publish origin");
 
-	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".to_string());
-	server_config.tls.generate = vec!["localhost".into()];
-	let mut server = server_config.init().expect("failed to init server");
-	let addr = server.local_addr().expect("failed to get local addr");
+	let (mut server, addr) = test_server();
 
 	// ── subscriber (client): interested in both "allowed" and "denied" ──
 	// "denied" is disjoint from the publisher's scope, so its announce stream is FINed.
@@ -893,9 +889,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 		.expect("failed to scope consume origin");
 	let mut announcements = consume.consume();
 
-	let mut client_config = moq_native::ClientConfig::default();
-	client_config.tls.disable_verify = Some(true);
-	let client = client_config.init().expect("failed to init client");
+	let client = test_client();
 	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
 
 	let server_handle = tokio::spawn(async move {
@@ -934,6 +928,114 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 		.await
 		.expect("server task panicked")
 		.expect("server task failed");
+}
+
+/// Reverse of the usual direction: a publish-only client (`with_publish`, no `with_consume`)
+/// serving a subscribe-only server (`with_consume`, no `with_publish`). The server is also
+/// interested in a disjoint "denied" prefix the client can't serve, so the server's
+/// subscriber must survive that FIN and still receive the served broadcast.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn publish_only_client_to_subscribe_only_server() {
+	use moq_native::moq_net::{Origin, Track};
+
+	// ── subscriber (server): interested in both "allowed" and "denied" ──
+	let sub_origin = Origin::random().produce();
+	let consume = sub_origin
+		.scope(&["allowed".into(), "denied".into()])
+		.expect("failed to scope consume origin");
+	let mut announcements = consume.consume();
+
+	let (mut server, addr) = test_server();
+	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
+
+	let server_handle = tokio::spawn(async move {
+		let session = server
+			.accept()
+			.await
+			.expect("no incoming connection")
+			.with_consume(consume)
+			.ok()
+			.await?;
+
+		// The client serves "allowed/test"; the "denied" interest is FINed but must not
+		// tear down the session.
+		let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+			.await
+			.expect("announce timed out")
+			.expect("origin closed");
+		assert_eq!(path.as_str(), "allowed/test");
+		let bc = bc.expect("expected announce, got unannounce");
+
+		let mut track_sub = bc.subscribe_track(&Track::new("video")).expect("subscribe_track failed");
+		let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
+			.await
+			.expect("recv_group timed out")
+			.expect("recv_group failed")
+			.expect("track closed prematurely");
+		let frame = tokio::time::timeout(TIMEOUT, group_sub.read_frame())
+			.await
+			.expect("read_frame timed out")
+			.expect("read_frame failed")
+			.expect("group closed prematurely");
+		assert_eq!(&*frame, b"hello");
+
+		// The disjoint "denied" interest must not have torn down the session.
+		assert!(
+			tokio::time::timeout(Duration::from_millis(200), session.closed())
+				.await
+				.is_err(),
+			"server session closed after unauthorized announce interest",
+		);
+
+		Ok::<_, anyhow::Error>(())
+	});
+
+	// ── publisher (client): only allowed to serve under "allowed" ──
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin.create_broadcast("allowed/test").expect("failed to create broadcast");
+	let mut track = broadcast
+		.create_track(Track::new("video"))
+		.expect("failed to create track");
+	let mut group = track.append_group().expect("failed to append group");
+	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.finish().expect("failed to finish group");
+
+	let publish = pub_origin
+		.consume()
+		.scope(&["allowed".into()])
+		.expect("failed to scope publish origin");
+
+	let session = tokio::time::timeout(TIMEOUT, test_client().with_publish(publish).connect(url))
+		.await
+		.expect("client connect timed out")
+		.expect("client connect failed");
+
+	server_handle
+		.await
+		.expect("server task panicked")
+		.expect("server task failed");
+
+	drop(session);
+	drop(track);
+	drop(broadcast);
+}
+
+/// A test server bound to a free port with a generated localhost certificate.
+fn test_server() -> (moq_native::Server, std::net::SocketAddr) {
+	let mut config = moq_native::ServerConfig::default();
+	config.bind = Some("[::]:0".to_string());
+	config.tls.generate = vec!["localhost".into()];
+	let server = config.init().expect("failed to init server");
+	let addr = server.local_addr().expect("failed to get local addr");
+	(server, addr)
+}
+
+/// A test client that skips TLS verification (servers use self-signed certs).
+fn test_client() -> moq_native::Client {
+	let mut config = moq_native::ClientConfig::default();
+	config.tls.disable_verify = Some(true);
+	config.init().expect("failed to init client")
 }
 
 fn assert_connect_error(err: &moq_native::Error, expected: moq_native::ConnectError) {

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -856,6 +856,86 @@ async fn reconnect_stops_on_websocket_unauthorized() {
 		.expect("server task failed");
 }
 
+/// A peer that expresses announce-interest in a prefix the publisher can't serve (e.g. a
+/// subscribe-restricted token) must not tear down the whole session. The publisher FINs that
+/// announce stream cleanly; the connection and other announce streams keep working.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn announce_interest_unauthorized_keeps_session_alive() {
+	use moq_native::moq_net::{Origin, Track};
+
+	// ── publisher (server): only allowed to announce under "allowed" ──
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin.create_broadcast("allowed/test").expect("failed to create broadcast");
+	let mut track = broadcast
+		.create_track(Track::new("video"))
+		.expect("failed to create track");
+	let mut group = track.append_group().expect("failed to append group");
+	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.finish().expect("failed to finish group");
+
+	let publish = pub_origin
+		.consume()
+		.scope(&["allowed".into()])
+		.expect("failed to scope publish origin");
+
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some("[::]:0".to_string());
+	server_config.tls.generate = vec!["localhost".into()];
+	let mut server = server_config.init().expect("failed to init server");
+	let addr = server.local_addr().expect("failed to get local addr");
+
+	// ── subscriber (client): interested in both "allowed" and "denied" ──
+	// "denied" is disjoint from the publisher's scope, so its announce stream is FINed.
+	let sub_origin = Origin::random().produce();
+	let consume = sub_origin
+		.scope(&["allowed".into(), "denied".into()])
+		.expect("failed to scope consume origin");
+	let mut announcements = consume.consume();
+
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	let client = client_config.init().expect("failed to init client");
+	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
+
+	let server_handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("no incoming connection");
+		let session = request.with_publish(publish).ok().await?;
+		let _broadcast = broadcast;
+		let _track = track;
+		let _ = session.closed().await;
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let client = client.with_consume(consume);
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+		.await
+		.expect("client connect timed out")
+		.expect("client connect failed");
+
+	// The "allowed" announce stream still delivers even though "denied" was FINed.
+	let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+		.await
+		.expect("announce timed out")
+		.expect("origin closed");
+	assert_eq!(path.as_str(), "allowed/test");
+	assert!(bc.is_some(), "expected announce, got unannounce");
+
+	// The unauthorized "denied" interest must not have torn down the session.
+	assert!(
+		tokio::time::timeout(Duration::from_millis(200), session.closed())
+			.await
+			.is_err(),
+		"session closed after unauthorized announce interest",
+	);
+
+	drop(session);
+	server_handle
+		.await
+		.expect("server task panicked")
+		.expect("server task failed");
+}
+
 fn assert_connect_error(err: &moq_native::Error, expected: moq_native::ConnectError) {
 	assert_eq!(err.connect_error(), Some(expected), "unexpected error: {err}",);
 }

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -866,7 +866,9 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 
 	// ── publisher (server): only allowed to announce under "allowed" ──
 	let pub_origin = Origin::random().produce();
-	let mut broadcast = pub_origin.create_broadcast("allowed/test").expect("failed to create broadcast");
+	let mut broadcast = pub_origin
+		.create_broadcast("allowed/test")
+		.expect("failed to create broadcast");
 	let mut track = broadcast
 		.create_track(Track::new("video"))
 		.expect("failed to create track");
@@ -967,7 +969,9 @@ async fn publish_only_client_to_subscribe_only_server() {
 		assert_eq!(path.as_str(), "allowed/test");
 		let bc = bc.expect("expected announce, got unannounce");
 
-		let mut track_sub = bc.subscribe_track(&Track::new("video")).expect("subscribe_track failed");
+		let mut track_sub = bc
+			.subscribe_track(&Track::new("video"))
+			.expect("subscribe_track failed");
 		let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 			.await
 			.expect("recv_group timed out")
@@ -993,7 +997,9 @@ async fn publish_only_client_to_subscribe_only_server() {
 
 	// ── publisher (client): only allowed to serve under "allowed" ──
 	let pub_origin = Origin::random().produce();
-	let mut broadcast = pub_origin.create_broadcast("allowed/test").expect("failed to create broadcast");
+	let mut broadcast = pub_origin
+		.create_broadcast("allowed/test")
+		.expect("failed to create broadcast");
 	let mut track = broadcast
 		.create_track(Track::new("video"))
 		.expect("failed to create track");

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -611,7 +611,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		tracing::debug!(prefix = %self.origin.absolute(&prefix), "subscribe_namespace stream");
 
-		let mut origin = self.origin.scope(&[prefix.as_path()]).ok_or(Error::Unauthorized)?;
+		// A peer may subscribe to a namespace this session can't serve (e.g. a publish-only
+		// token). Hand back an empty consumer that never announces rather than erroring,
+		// which would tear down the whole session.
+		let mut origin = self.origin.scope_or_empty(&[prefix.as_path()]);
 
 		// Send OK response
 		match self.version {

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -612,10 +612,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		tracing::debug!(prefix = %self.origin.absolute(&prefix), "subscribe_namespace stream");
 
 		// A peer may subscribe to a namespace this session can't serve (e.g. a publish-only
-		// token). Hand back a closed empty consumer so the stream is FINed (telling the peer
-		// no namespaces will ever come) rather than erroring, which would tear down the
-		// whole session.
-		let mut origin = self.origin.scope_or_empty(&[prefix.as_path()]);
+		// token). Acknowledge with OK and then FIN the stream (no namespaces follow), rather
+		// than erroring, which would tear down the whole session. `None` here is handled the
+		// same as an origin with no matching broadcasts.
+		let origin = self.origin.scope(&[prefix.as_path()]);
 
 		// Send OK response
 		match self.version {
@@ -652,6 +652,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			}
 			// v16+: Send Namespace/NamespaceDone entries on this bidi stream.
 			_ => {
+				let Some(mut origin) = origin else {
+					// Nothing to serve (e.g. a publish-only token): FIN so the peer's
+					// namespace subscription completes cleanly instead of waiting forever.
+					stream.writer.finish()?;
+					return stream.writer.closed().await;
+				};
+
 				// Send initial NAMESPACE messages for currently active namespaces
 				while let Some((path, active)) = origin.try_announced() {
 					let suffix = path.strip_prefix(&prefix).expect("origin returned invalid path");

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -612,8 +612,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		tracing::debug!(prefix = %self.origin.absolute(&prefix), "subscribe_namespace stream");
 
 		// A peer may subscribe to a namespace this session can't serve (e.g. a publish-only
-		// token). Hand back an empty consumer that never announces rather than erroring,
-		// which would tear down the whole session.
+		// token). Hand back a closed empty consumer so the stream is FINed (telling the peer
+		// no namespaces will ever come) rather than erroring, which would tear down the
+		// whole session.
 		let mut origin = self.origin.scope_or_empty(&[prefix.as_path()]);
 
 		// Send OK response

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -149,8 +149,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let exclude_hop = interest.exclude_hop;
 
 		// A peer may announce-interest in a prefix this session can't serve (e.g. a
-		// publish-only token). Hand back an empty consumer that never announces rather
-		// than erroring, which would tear down the whole session.
+		// publish-only token). Hand back a closed empty consumer so run_announce FINs the
+		// stream (telling the peer no announcements will ever come) rather than erroring,
+		// which would tear down the whole session.
 		let mut origin = self.origin.scope_or_empty(&[prefix.as_path()]);
 
 		let version = self.version;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -147,14 +147,20 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let interest = stream.reader.decode::<lite::AnnounceInterest>().await?;
 		let prefix = interest.prefix.to_owned();
 		let exclude_hop = interest.exclude_hop;
-
-		// A peer may announce-interest in a prefix this session can't serve (e.g. a
-		// publish-only token). Hand back a closed empty consumer so run_announce FINs the
-		// stream (telling the peer no announcements will ever come) rather than erroring,
-		// which would tear down the whole session.
-		let mut origin = self.origin.scope_or_empty(&[prefix.as_path()]);
-
 		let version = self.version;
+
+		let Some(mut origin) = self.origin.scope(&[prefix.as_path()]) else {
+			// A peer may announce-interest in a prefix this session can't serve (e.g. a
+			// publish-only token). FIN the stream so the peer's announce subscription
+			// completes cleanly, rather than erroring and tearing down the whole session.
+			web_async::spawn(async move {
+				if let Err(err) = Self::finish_empty_announce(&mut stream, version).await {
+					stream.writer.abort(&err);
+				}
+			});
+			return Ok(());
+		};
+
 		let self_origin = self.self_origin;
 		let stats = self.stats.clone();
 		web_async::spawn(async move {
@@ -183,6 +189,17 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		});
 
 		Ok(())
+	}
+
+	// FIN an announce stream that will never carry any announcements (the peer asked for a
+	// prefix this session can't serve). Lite01/02 peers block reading ANNOUNCE_INIT, so send
+	// an empty one before finishing; Lite03+ has no init.
+	async fn finish_empty_announce(stream: &mut Stream<S, Version>, version: Version) -> Result<(), Error> {
+		if let Version::Lite01 | Version::Lite02 = version {
+			stream.writer.encode(&lite::AnnounceInit { suffixes: Vec::new() }).await?;
+		}
+		stream.writer.finish()?;
+		stream.writer.closed().await
 	}
 
 	async fn run_announce(

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -196,7 +196,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	// an empty one before finishing; Lite03+ has no init.
 	async fn finish_empty_announce(stream: &mut Stream<S, Version>, version: Version) -> Result<(), Error> {
 		if let Version::Lite01 | Version::Lite02 = version {
-			stream.writer.encode(&lite::AnnounceInit { suffixes: Vec::new() }).await?;
+			stream
+				.writer
+				.encode(&lite::AnnounceInit { suffixes: Vec::new() })
+				.await?;
 		}
 		stream.writer.finish()?;
 		stream.writer.closed().await

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -148,7 +148,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let prefix = interest.prefix.to_owned();
 		let exclude_hop = interest.exclude_hop;
 
-		let mut origin = self.origin.scope(&[prefix.as_path()]).ok_or(Error::Unauthorized)?;
+		// A peer may announce-interest in a prefix this session can't serve (e.g. a
+		// publish-only token). Hand back an empty consumer that never announces rather
+		// than erroring, which would tear down the whole session.
+		let mut origin = self.origin.scope_or_empty(&[prefix.as_path()]);
 
 		let version = self.version;
 		let self_origin = self.self_origin;

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -210,9 +210,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		}
 
-		// Close the stream when there's nothing more to announce.
-		stream.writer.finish()?;
-		stream.writer.closed().await
+		// The read loop ended because the publisher FINed: it has nothing (more) to announce
+		// for this prefix (e.g. a publish-only peer). That's a clean completion of this
+		// announce stream, not a session error, so finish our side and return Ok. Tearing
+		// down only the announce stream is correct since no further progress can be made,
+		// but we must not propagate an error that would kill the whole connection.
+		stream.writer.finish().ok();
+		Ok(())
 	}
 
 	/// Opens a PROBE stream on demand while a consumer is interested.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -963,25 +963,6 @@ impl OriginConsumer {
 		))
 	}
 
-	/// Like [`Self::scope`], but returns an already-closed empty consumer instead of `None`
-	/// when the prefixes are disjoint from this consumer's scope.
-	///
-	/// The empty consumer has no broadcasts and is closed, so `announced()` resolves to
-	/// `None` immediately. Use this on the publisher's announce path so a peer that
-	/// subscribes to a prefix we can't serve (e.g. a publish-only token) gets a clean FIN
-	/// on the announce stream rather than an error that tears down the whole session, or
-	/// silence that leaves it waiting forever for announcements that can never come.
-	pub fn scope_or_empty(&self, prefixes: &[Path]) -> OriginConsumer {
-		match self.scope(prefixes) {
-			Some(scoped) => scoped,
-			None => {
-				let empty = OriginConsumer::new(self.info, self.root.clone(), OriginNodes { nodes: Vec::new() });
-				empty.state.close().ok();
-				empty
-			}
-		}
-	}
-
 	/// Returns a new OriginConsumer that automatically strips out the provided prefix.
 	///
 	/// Returns None if the provided root is not authorized; when [`Self::scope`] was
@@ -2086,33 +2067,6 @@ mod tests {
 
 		// Path is outside allowed prefixes — should return None immediately.
 		assert!(limited.announced_broadcast("notallowed").await.is_none());
-	}
-
-	#[tokio::test]
-	async fn test_scope_or_empty_disjoint_is_closed() {
-		let origin = Origin::random().produce();
-		let limited = origin
-			.consume()
-			.scope(&["allowed".into()])
-			.expect("should create limited");
-
-		// Disjoint prefix: scope() bails, but scope_or_empty() hands back a closed consumer.
-		assert!(limited.scope(&["other".into()]).is_none());
-		let mut empty = limited.scope_or_empty(&["other".into()]);
-
-		// Publishing anything (even under the original allowed prefix) is never announced.
-		let broadcast = Broadcast::new().produce();
-		origin.publish_broadcast("allowed/thing", broadcast.consume());
-		origin.publish_broadcast("other/thing", broadcast.consume());
-		tokio::task::yield_now().await;
-
-		assert!(empty.try_announced().is_none(), "empty consumer must never announce");
-
-		// Already closed: announced() resolves to None immediately (rather than pending) so
-		// the announce loop FINs the stream instead of leaving the peer waiting forever.
-		let resolved = empty.announced().now_or_never();
-		assert!(resolved.is_some(), "must resolve immediately, not pend");
-		assert!(resolved.unwrap().is_none(), "must resolve to None (closed)");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -963,17 +963,22 @@ impl OriginConsumer {
 		))
 	}
 
-	/// Like [`Self::scope`], but returns an empty consumer instead of `None` when the
-	/// prefixes are disjoint from this consumer's scope.
+	/// Like [`Self::scope`], but returns an already-closed empty consumer instead of `None`
+	/// when the prefixes are disjoint from this consumer's scope.
 	///
-	/// The empty consumer never announces anything: `announced()` stays pending forever.
-	/// Use this on the publisher's announce path so a peer that subscribes to a prefix we
-	/// can't serve gets silence rather than an error that tears down the whole session. A
-	/// publish-only token can then coexist with subscribe interest from the same peer.
+	/// The empty consumer has no broadcasts and is closed, so `announced()` resolves to
+	/// `None` immediately. Use this on the publisher's announce path so a peer that
+	/// subscribes to a prefix we can't serve (e.g. a publish-only token) gets a clean FIN
+	/// on the announce stream rather than an error that tears down the whole session, or
+	/// silence that leaves it waiting forever for announcements that can never come.
 	pub fn scope_or_empty(&self, prefixes: &[Path]) -> OriginConsumer {
 		match self.scope(prefixes) {
 			Some(scoped) => scoped,
-			None => OriginConsumer::new(self.info, self.root.clone(), OriginNodes { nodes: Vec::new() }),
+			None => {
+				let empty = OriginConsumer::new(self.info, self.root.clone(), OriginNodes { nodes: Vec::new() });
+				empty.state.close().ok();
+				empty
+			}
 		}
 	}
 
@@ -2084,14 +2089,14 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_scope_or_empty_disjoint_is_noop() {
+	async fn test_scope_or_empty_disjoint_is_closed() {
 		let origin = Origin::random().produce();
 		let limited = origin
 			.consume()
 			.scope(&["allowed".into()])
 			.expect("should create limited");
 
-		// Disjoint prefix: scope() bails, but scope_or_empty() hands back a live consumer.
+		// Disjoint prefix: scope() bails, but scope_or_empty() hands back a closed consumer.
 		assert!(limited.scope(&["other".into()]).is_none());
 		let mut empty = limited.scope_or_empty(&["other".into()]);
 
@@ -2102,10 +2107,12 @@ mod tests {
 		tokio::task::yield_now().await;
 
 		assert!(empty.try_announced().is_none(), "empty consumer must never announce");
-		assert!(
-			empty.announced().now_or_never().is_none(),
-			"empty consumer must pend, not close"
-		);
+
+		// Already closed: announced() resolves to None immediately (rather than pending) so
+		// the announce loop FINs the stream instead of leaving the peer waiting forever.
+		let resolved = empty.announced().now_or_never();
+		assert!(resolved.is_some(), "must resolve immediately, not pend");
+		assert!(resolved.unwrap().is_none(), "must resolve to None (closed)");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -963,6 +963,20 @@ impl OriginConsumer {
 		))
 	}
 
+	/// Like [`Self::scope`], but returns an empty consumer instead of `None` when the
+	/// prefixes are disjoint from this consumer's scope.
+	///
+	/// The empty consumer never announces anything: `announced()` stays pending forever.
+	/// Use this on the publisher's announce path so a peer that subscribes to a prefix we
+	/// can't serve gets silence rather than an error that tears down the whole session. A
+	/// publish-only token can then coexist with subscribe interest from the same peer.
+	pub fn scope_or_empty(&self, prefixes: &[Path]) -> OriginConsumer {
+		match self.scope(prefixes) {
+			Some(scoped) => scoped,
+			None => OriginConsumer::new(self.info, self.root.clone(), OriginNodes { nodes: Vec::new() }),
+		}
+	}
+
 	/// Returns a new OriginConsumer that automatically strips out the provided prefix.
 	///
 	/// Returns None if the provided root is not authorized; when [`Self::scope`] was
@@ -2067,6 +2081,31 @@ mod tests {
 
 		// Path is outside allowed prefixes — should return None immediately.
 		assert!(limited.announced_broadcast("notallowed").await.is_none());
+	}
+
+	#[tokio::test]
+	async fn test_scope_or_empty_disjoint_is_noop() {
+		let origin = Origin::random().produce();
+		let limited = origin
+			.consume()
+			.scope(&["allowed".into()])
+			.expect("should create limited");
+
+		// Disjoint prefix: scope() bails, but scope_or_empty() hands back a live consumer.
+		assert!(limited.scope(&["other".into()]).is_none());
+		let mut empty = limited.scope_or_empty(&["other".into()]);
+
+		// Publishing anything (even under the original allowed prefix) is never announced.
+		let broadcast = Broadcast::new().produce();
+		origin.publish_broadcast("allowed/thing", broadcast.consume());
+		origin.publish_broadcast("other/thing", broadcast.consume());
+		tokio::task::yield_now().await;
+
+		assert!(empty.try_announced().is_none(), "empty consumer must never announce");
+		assert!(
+			empty.announced().now_or_never().is_none(),
+			"empty consumer must pend, not close"
+		);
 	}
 
 	#[tokio::test]

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -184,6 +184,77 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	web_handle.abort();
 }
 
+/// Two publish-only clients (each `with_publish`, no `with_consume`) coexist on one relay;
+/// a single subscriber sees broadcasts forwarded from both. Verifies that multiple
+/// publish-only connections don't interfere with each other or get torn down.
+#[tokio::test]
+async fn two_publish_only_clients_coexist() {
+	let (port, web_handle) = spawn_relay().await;
+	let url: url::Url = format!("ws://127.0.0.1:{port}/smoke").parse().expect("parse url");
+
+	// ── two publish-only publishers, each serving a distinct broadcast ──
+	let pub_a = Origin::random().produce();
+	let mut broadcast_a = pub_a.create_broadcast("alpha").expect("create broadcast a");
+	let mut track_a = broadcast_a.create_track(Track::new("video")).expect("create track a");
+	track_a
+		.append_group()
+		.expect("append group a")
+		.write_frame(b"a".as_ref())
+		.expect("write frame a");
+
+	let pub_b = Origin::random().produce();
+	let mut broadcast_b = pub_b.create_broadcast("beta").expect("create broadcast b");
+	let mut track_b = broadcast_b.create_track(Track::new("video")).expect("create track b");
+	track_b
+		.append_group()
+		.expect("append group b")
+		.write_frame(b"b".as_ref())
+		.expect("write frame b");
+
+	let sess_a = tokio::time::timeout(TIMEOUT, client().with_publish(pub_a.consume()).connect(url.clone()))
+		.await
+		.expect("publisher a connect timeout")
+		.expect("publisher a connect failed");
+	let sess_b = tokio::time::timeout(TIMEOUT, client().with_publish(pub_b.consume()).connect(url.clone()))
+		.await
+		.expect("publisher b connect timeout")
+		.expect("publisher b connect failed");
+
+	// ── one subscriber should see broadcasts from both publish-only clients ──
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume();
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consume(sub_origin).connect(url))
+		.await
+		.expect("subscriber connect timeout")
+		.expect("subscriber connect failed");
+
+	let mut seen = std::collections::HashSet::new();
+	while seen.len() < 2 {
+		let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+			.await
+			.expect("announcement timeout")
+			.expect("origin closed");
+		if bc.is_some() {
+			seen.insert(path.as_str().to_owned());
+		}
+	}
+	assert!(
+		seen.contains("alpha") && seen.contains("beta"),
+		"expected both publish-only broadcasts, saw {seen:?}"
+	);
+
+	// Hold producers until announcements are observed.
+	drop(track_a);
+	drop(broadcast_a);
+	drop(track_b);
+	drop(broadcast_b);
+
+	drop(sess_a);
+	drop(sess_b);
+	drop(sub_session);
+	web_handle.abort();
+}
+
 /// With no thresholds configured, `/health` is a pure liveness probe that
 /// returns `200 ok`.
 #[tokio::test]


### PR DESCRIPTION
## Summary

A peer expressing announce-interest (`moq-lite`) or subscribing to a namespace (IETF) under a prefix the session can't serve caused the publisher to return `Error::Unauthorized`, which aborted the stream and tore down the **whole session**. A token that only allows publishing could not coexist with subscribe interest from the same peer: as soon as the peer asked to subscribe to anything, the connection died.

Now the publisher acknowledges the interest and cleanly FINs the announce stream, signalling that no announcements will ever arrive for that prefix. The session stays alive.

## What changed

**Publisher** (`scope()` keeps its `Option` API; no new helper):
- `rs/moq-net/src/lite/publisher.rs` (`recv_announce`): when `scope()` returns `None`, FIN the announce stream via a small `finish_empty_announce` helper instead of `.ok_or(Error::Unauthorized)?`. Lite01/02 peers block reading `ANNOUNCE_INIT`, so an empty one is sent before the FIN; Lite03+ just FINs.
- `rs/moq-net/src/ietf/publisher.rs` (`run_subscribe_namespace_stream`): on `None`, still send the `OK` response, then FIN the bidi stream for v16+ (v14/v15 namespaces travel on the control stream and are unaffected).

**Subscriber** — handle the FIN as a terminal-but-non-error case:
- `rs/moq-net/src/lite/subscriber.rs` (`run_announce_prefix`): the read loop ends cleanly when the publisher FINs (`decode_maybe` → `None`). Previously the function then returned `stream.writer.closed().await`, whose `Err` propagated through `run_announce`'s `result?` and was caught by `Subscriber::run`'s `Err(err) = run_announce() => Err(err)` arm, killing the session. It now finishes its side and returns `Ok`, so the select arm simply disables that branch and the connection survives. Only the announce stream for that prefix is torn down, which is correct since no further progress can be made.
- The IETF subscriber already breaks cleanly on FIN and its errors are swallowed by the session loop, so no change was needed there.

## Why FIN rather than error or silence

The subscriber handles a clean FIN gracefully (`decode_maybe` returns `None`, the receive loop exits). FINing is strictly better than holding the stream open with no data, the peer learns definitively that no announcements will arrive instead of waiting forever, and better than `Unauthorized`, which killed the connection.

## Notes for reviewers

- No public API change. An earlier revision of this PR added an `OriginConsumer::scope_or_empty`; that has been removed in favour of handling `None` at the call sites.
- Not a wire-protocol change (framing/drafts untouched), so targeting `main`.

## Test plan

- [x] `announce_interest_unauthorized_keeps_session_alive` (`rs/moq-native/tests/broadcast.rs`): a subscriber interested in both a served prefix (`allowed`) and a disjoint one (`denied`) still receives the `allowed/test` announcement and keeps its session alive after the `denied` announce stream is FINed. Exercises the lite **subscriber** FIN handling.
- [x] `publish_only_client_to_subscribe_only_server` (`rs/moq-native/tests/broadcast.rs`): reverse data direction (publish-only client → subscribe-only server); the server is also interested in a disjoint `denied` prefix, so its subscriber survives that FIN while still receiving the served broadcast. Exercises the fix from the server-side role.
- [x] `two_publish_only_clients_coexist` (`rs/moq-relay/tests/smoke.rs`): two publish-only clients on one relay, a subscriber sees broadcasts forwarded from both. Confirms multiple publish-only connections coexist without tearing down.
- [x] `cargo test -p moq-net` — 338 + 4 passed.
- [x] `cargo test -p moq-native --test broadcast` — 57 passed.
- [x] `cargo test -p moq-relay --test smoke` — 3 passed.
- [x] `cargo clippy` clean, `cargo fmt --check` clean.

(Written by Claude)