### PR TITLE
feat(moq-video): Windows D3D11 zero-copy GPU capture + hardware H.264 encoder

### DIFF
--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -62,7 +62,21 @@ objc2-screen-capture-kit = "0.3.2"
 objc2-video-toolbox = "0.3.2"
 
 [target.'cfg(target_os="windows")'.dependencies]
-# Native Media Foundation webcam capture (replaces nokhwa). An `IMFSourceReader`
-# with its video processor enabled converts the camera's native format to NV12,
-# which we deinterleave to I420. Links only system import libs, no vendor SDK.
-windows = { version = "0.62", features = ["Win32_Foundation", "Win32_System_Com", "Win32_Media_MediaFoundation"] }
+# Native Media Foundation webcam capture + hardware H.264 encode (replaces
+# nokhwa). An `IMFSourceReader` backed by a D3D11 device hands us NV12 textures
+# that feed a hardware encoder MFT zero-copy; without a GPU it falls back to CPU
+# NV12 deinterleaved to I420 for openh264. Links only system import libs, no
+# vendor SDK. The Direct3D11 / Dxgi features cover the shared D3D11 device and
+# the `IMFDXGIBuffer` surfaces wrapping each captured texture.
+windows = { version = "0.62", features = [
+	"Win32_Foundation",
+	"Win32_System_Com",
+	"Win32_Media_MediaFoundation",
+	"Win32_Graphics_Direct3D",
+	"Win32_Graphics_Direct3D10",
+	"Win32_Graphics_Direct3D11",
+	"Win32_Graphics_Dxgi",
+	"Win32_Graphics_Dxgi_Common",
+	"Win32_System_Ole",
+	"Win32_System_Variant",
+] }

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -8,6 +8,11 @@ license = "MIT OR Apache-2.0"
 version = "0.0.3"
 edition = "2024"
 rust-version.workspace = true
+# Not publishable to crates.io while the `vaapi` feature pulls cros-codecs from
+# git; flip back once that fork is published (tracked separately). This also lets
+# cargo-deny's allow-wildcard-paths exempt the git dep, which it only does for
+# unpublished crates.
+publish = false
 
 keywords = ["quic", "http3", "webtransport", "media", "video"]
 categories = ["multimedia", "multimedia::video", "multimedia::encoding"]

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -69,14 +69,14 @@ objc2-video-toolbox = "0.3.2"
 # vendor SDK. The Direct3D11 / Dxgi features cover the shared D3D11 device and
 # the `IMFDXGIBuffer` surfaces wrapping each captured texture.
 windows = { version = "0.62", features = [
-	"Win32_Foundation",
-	"Win32_System_Com",
-	"Win32_Media_MediaFoundation",
-	"Win32_Graphics_Direct3D",
-	"Win32_Graphics_Direct3D10",
-	"Win32_Graphics_Direct3D11",
-	"Win32_Graphics_Dxgi",
-	"Win32_Graphics_Dxgi_Common",
-	"Win32_System_Ole",
-	"Win32_System_Variant",
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_Media_MediaFoundation",
+    "Win32_Graphics_Direct3D",
+    "Win32_Graphics_Direct3D10",
+    "Win32_Graphics_Direct3D11",
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Dxgi_Common",
+    "Win32_System_Ole",
+    "Win32_System_Variant",
 ] }

--- a/rs/moq-video/src/capture/mediafoundation.rs
+++ b/rs/moq-video/src/capture/mediafoundation.rs
@@ -1,29 +1,39 @@
 //! Native Windows webcam capture via Media Foundation.
 //!
-//! Drives an [`IMFSourceReader`] over the selected capture device with the source
-//! reader's video processor enabled, so whatever the camera emits (MJPEG / YUY2 /
-//! NV12) is converted to NV12 for us. Each sample is copied to a tightly packed
-//! CPU [`I420`] for the encoder. This is the CPU path feeding openh264 / NVENC;
-//! there's no GPU surface here.
+//! Drives an [`IMFSourceReader`] over the selected capture device. When a
+//! Direct3D11 device is available the reader runs with that device's DXGI
+//! manager and the advanced video processor, so each sample arrives as a
+//! GPU-resident NV12 texture ([`Frame::Texture`]) that the hardware encoder MFT
+//! consumes zero-copy. Without a GPU (e.g. a headless VM) it falls back to the
+//! source reader's software video processor, copying each sample to a packed CPU
+//! [`I420`] ([`Frame::I420`]) for openh264.
 
 use std::ffi::c_void;
 use std::ptr;
 use std::slice;
 
+use windows::Win32::Foundation::HMODULE;
+use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
+use windows::Win32::Graphics::Direct3D10::ID3D10Multithread;
+use windows::Win32::Graphics::Direct3D11::{
+	D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_VIDEO_SUPPORT, D3D11_SDK_VERSION, D3D11CreateDevice,
+	ID3D11Device, ID3D11Texture2D,
+};
 use windows::Win32::Media::MediaFoundation::{
-	IMF2DBuffer, IMFActivate, IMFAttributes, IMFMediaSource, IMFSample, IMFSourceReader,
-	MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
+	IMF2DBuffer, IMFActivate, IMFAttributes, IMFDXGIBuffer, IMFDXGIDeviceManager, IMFMediaSource, IMFSample,
+	IMFSourceReader, MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
 	MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_MAJOR_TYPE,
-	MF_MT_SUBTYPE, MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, MF_SOURCE_READER_FIRST_VIDEO_STREAM,
-	MF_SOURCE_READERF_ENDOFSTREAM, MF_VERSION, MFCreateAttributes, MFCreateMediaType,
-	MFCreateSourceReaderFromMediaSource, MFEnumDeviceSources, MFMediaType_Video, MFSTARTUP_FULL, MFShutdown, MFStartup,
-	MFVideoFormat_NV12,
+	MF_MT_SUBTYPE, MF_SOURCE_READER_D3D_MANAGER, MF_SOURCE_READER_ENABLE_ADVANCED_VIDEO_PROCESSING,
+	MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, MF_SOURCE_READER_FIRST_VIDEO_STREAM, MF_SOURCE_READERF_ENDOFSTREAM,
+	MF_VERSION, MFCreateAttributes, MFCreateDXGIDeviceManager, MFCreateMediaType, MFCreateSourceReaderFromMediaSource,
+	MFEnumDeviceSources, MFMediaType_Video, MFSTARTUP_FULL, MFShutdown, MFStartup, MFVideoFormat_NV12,
 };
 use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoTaskMemFree, CoUninitialize};
 use windows::core::{Interface, PWSTR};
 
 use super::{Config, FrameSource};
 use crate::Error;
+use crate::frame::d3d11::Texture;
 use crate::frame::{Frame, I420};
 
 fn mf_err(ctx: &str, e: windows::core::Error) -> Error {
@@ -73,10 +83,16 @@ impl Drop for ComGuard {
 pub(crate) struct Camera {
 	source: IMFMediaSource,
 	reader: IMFSourceReader,
+	/// The shared Direct3D11 device when capturing on the GPU; `None` on the CPU
+	/// fallback. Its presence is what selects the texture vs I420 read path.
+	device: Option<ID3D11Device>,
 	width: u32,
 	height: u32,
 	framerate: Option<u32>,
-	device: String,
+	device_name: String,
+	// Keep the DXGI manager alive for the reader's lifetime (the reader holds its
+	// own ref, but we own the pairing). Drops before `_com`.
+	_manager: Option<IMFDXGIDeviceManager>,
 	// Drop last: tear down Media Foundation only after the reader/source release.
 	_com: ComGuard,
 }
@@ -84,16 +100,41 @@ pub(crate) struct Camera {
 impl Camera {
 	pub(crate) fn open(config: &Config) -> Result<Self, Error> {
 		let com = ComGuard::new()?;
-		let (source, device) = open_source(config)?;
+		let (source, device_name) = open_source(config)?;
 
-		let reader_attrs = create_attributes(1)?;
+		// Try for a GPU device; fall back to the CPU video processor if it (or any
+		// of its setup) fails, e.g. on a headless VM with no D3D11 hardware.
+		let gpu = match create_d3d_device() {
+			Ok(gpu) => Some(gpu),
+			Err(e) => {
+				tracing::debug!(error = %e, "no D3D11 device; using CPU capture path");
+				None
+			}
+		};
+
+		let reader_attrs = create_attributes(2)?;
 		unsafe {
-			// Insert the video processor so it converts the camera's native
-			// format (MJPEG / YUY2 / ...) to the NV12 we request below.
-			reader_attrs
-				.SetUINT32(&MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, 1)
-				.map_err(|e| mf_err("enable video processing", e))?;
+			match &gpu {
+				Some((_, manager)) => {
+					// Bind the reader to our device and enable the advanced
+					// (D3D-capable) video processor, so output stays a GPU texture.
+					reader_attrs
+						.SetUnknown(&MF_SOURCE_READER_D3D_MANAGER, manager)
+						.map_err(|e| mf_err("set D3D manager", e))?;
+					reader_attrs
+						.SetUINT32(&MF_SOURCE_READER_ENABLE_ADVANCED_VIDEO_PROCESSING, 1)
+						.map_err(|e| mf_err("enable advanced video processing", e))?;
+				}
+				None => {
+					// Software video processor: converts the camera's native format
+					// (MJPEG / YUY2 / ...) to NV12 in system memory.
+					reader_attrs
+						.SetUINT32(&MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, 1)
+						.map_err(|e| mf_err("enable video processing", e))?;
+				}
+			}
 		}
+
 		let reader = unsafe {
 			MFCreateSourceReaderFromMediaSource(&source, &reader_attrs)
 				.map_err(|e| mf_err("create source reader", e))?
@@ -143,19 +184,60 @@ impl Camera {
 			(den != 0).then(|| (num / den).max(1))
 		});
 
-		tracing::info!(device = %device, width, height, framerate, "opened Media Foundation capture");
-		Ok(Self {
-			source,
-			reader,
+		let (device, manager) = match gpu {
+			Some((device, manager)) => (Some(device), Some(manager)),
+			None => (None, None),
+		};
+		tracing::info!(
+			device = %device_name,
 			width,
 			height,
 			framerate,
+			gpu = device.is_some(),
+			"opened Media Foundation capture"
+		);
+		Ok(Self {
+			source,
+			reader,
 			device,
+			width,
+			height,
+			framerate,
+			device_name,
+			_manager: manager,
 			_com: com,
 		})
 	}
 
-	fn sample_to_i420(&self, sample: &IMFSample) -> Result<I420, Error> {
+	/// Wrap a GPU sample's DXGI texture as a zero-copy [`Frame::Texture`].
+	fn sample_to_texture(&self, device: &ID3D11Device, sample: &IMFSample) -> Result<Frame, Error> {
+		let buffer = unsafe { sample.GetBufferByIndex(0).map_err(|e| mf_err("get buffer", e))? };
+		let dxgi = buffer
+			.cast::<IMFDXGIBuffer>()
+			.map_err(|e| mf_err("buffer is not a DXGI surface", e))?;
+		// GetResource returns a fresh ref (`AddRef`) we take ownership of.
+		let mut raw: *mut c_void = ptr::null_mut();
+		unsafe {
+			dxgi.GetResource(&ID3D11Texture2D::IID, &mut raw)
+				.map_err(|e| mf_err("get DXGI resource", e))?;
+		}
+		let texture = unsafe { ID3D11Texture2D::from_raw(raw) };
+		let subresource = unsafe {
+			dxgi.GetSubresourceIndex()
+				.map_err(|e| mf_err("get subresource index", e))?
+		};
+
+		Ok(Frame::Texture(Texture::new(
+			device.clone(),
+			texture,
+			subresource,
+			self.width,
+			self.height,
+		)))
+	}
+
+	/// Copy a CPU sample's NV12 to a packed [`Frame::I420`] (the fallback path).
+	fn sample_to_i420(&self, sample: &IMFSample) -> Result<Frame, Error> {
 		let buffer = unsafe {
 			sample
 				.ConvertToContiguousBuffer()
@@ -193,7 +275,7 @@ impl Camera {
 			data
 		};
 
-		I420::from_nv12(&nv12, self.width, self.height)
+		Ok(Frame::I420(I420::from_nv12(&nv12, self.width, self.height)?))
 	}
 }
 
@@ -223,7 +305,11 @@ impl FrameSource for Camera {
 			let Some(sample) = sample else {
 				continue;
 			};
-			return Ok(Some(Frame::I420(self.sample_to_i420(&sample)?)));
+			let frame = match &self.device {
+				Some(device) => self.sample_to_texture(device, &sample)?,
+				None => self.sample_to_i420(&sample)?,
+			};
+			return Ok(Some(frame));
 		}
 	}
 
@@ -240,7 +326,7 @@ impl FrameSource for Camera {
 	}
 
 	fn device(&self) -> &str {
-		&self.device
+		&self.device_name
 	}
 }
 
@@ -252,6 +338,49 @@ impl Drop for Camera {
 			let _ = self.source.Shutdown();
 		}
 	}
+}
+
+/// Create a hardware Direct3D11 device plus a DXGI device manager wrapping it.
+/// The device is marked multithread-protected: the source reader's internal
+/// threads and our capture thread both touch it.
+fn create_d3d_device() -> Result<(ID3D11Device, IMFDXGIDeviceManager), Error> {
+	let mut device: Option<ID3D11Device> = None;
+	unsafe {
+		D3D11CreateDevice(
+			None,
+			D3D_DRIVER_TYPE_HARDWARE,
+			HMODULE::default(),
+			D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT,
+			None,
+			D3D11_SDK_VERSION,
+			Some(&mut device),
+			None,
+			None,
+		)
+		.map_err(|e| mf_err("D3D11CreateDevice", e))?;
+	}
+	let device = device.ok_or_else(|| Error::Codec(anyhow::anyhow!("D3D11CreateDevice returned null")))?;
+
+	let multithread = device
+		.cast::<ID3D10Multithread>()
+		.map_err(|e| mf_err("query ID3D10Multithread", e))?;
+	unsafe {
+		let _ = multithread.SetMultithreadProtected(true);
+	}
+
+	let mut token: u32 = 0;
+	let mut manager: Option<IMFDXGIDeviceManager> = None;
+	unsafe {
+		MFCreateDXGIDeviceManager(&mut token, &mut manager).map_err(|e| mf_err("MFCreateDXGIDeviceManager", e))?;
+	}
+	let manager = manager.ok_or_else(|| Error::Codec(anyhow::anyhow!("MFCreateDXGIDeviceManager returned null")))?;
+	unsafe {
+		manager
+			.ResetDevice(&device, token)
+			.map_err(|e| mf_err("ResetDevice", e))?;
+	}
+
+	Ok((device, manager))
 }
 
 fn create_attributes(capacity: u32) -> Result<IMFAttributes, Error> {

--- a/rs/moq-video/src/capture/mediafoundation.rs
+++ b/rs/moq-video/src/capture/mediafoundation.rs
@@ -25,58 +25,20 @@ use windows::Win32::Media::MediaFoundation::{
 	MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_MAJOR_TYPE,
 	MF_MT_SUBTYPE, MF_SOURCE_READER_D3D_MANAGER, MF_SOURCE_READER_ENABLE_ADVANCED_VIDEO_PROCESSING,
 	MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, MF_SOURCE_READER_FIRST_VIDEO_STREAM, MF_SOURCE_READERF_ENDOFSTREAM,
-	MF_VERSION, MFCreateAttributes, MFCreateDXGIDeviceManager, MFCreateMediaType, MFCreateSourceReaderFromMediaSource,
-	MFEnumDeviceSources, MFMediaType_Video, MFSTARTUP_FULL, MFShutdown, MFStartup, MFVideoFormat_NV12,
+	MFCreateAttributes, MFCreateDXGIDeviceManager, MFCreateMediaType, MFCreateSourceReaderFromMediaSource,
+	MFEnumDeviceSources, MFMediaType_Video, MFVideoFormat_NV12,
 };
-use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoTaskMemFree, CoUninitialize};
+use windows::Win32::System::Com::CoTaskMemFree;
 use windows::core::{Interface, PWSTR};
 
 use super::{Config, FrameSource};
 use crate::Error;
 use crate::frame::d3d11::Texture;
 use crate::frame::{Frame, I420};
-
-fn mf_err(ctx: &str, e: windows::core::Error) -> Error {
-	Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
-}
-
-/// Pack two 32-bit values into the high/low halves of a u64, the layout Media
-/// Foundation uses for `MF_MT_FRAME_SIZE` (width/height) and `MF_MT_FRAME_RATE`
-/// (numerator/denominator).
-fn pack_2x32(hi: u32, lo: u32) -> u64 {
-	((hi as u64) << 32) | lo as u64
-}
+use crate::mf::{ComGuard, mf_err, pack_2x32};
 
 fn unpack_2x32(v: u64) -> (u32, u32) {
 	((v >> 32) as u32, v as u32)
-}
-
-/// Initialize COM (MTA) + Media Foundation for the calling thread, balanced by
-/// `MFShutdown` + `CoUninitialize` on drop. The capture loop runs on one blocking
-/// thread, so each open/close pair stays on the same thread.
-struct ComGuard;
-
-impl ComGuard {
-	fn new() -> Result<Self, Error> {
-		unsafe {
-			// MTA: the blocking capture thread has no message pump. `S_FALSE`
-			// (already initialized on this thread) is success, which `.ok()` keeps.
-			CoInitializeEx(None, COINIT_MULTITHREADED)
-				.ok()
-				.map_err(|e| mf_err("CoInitializeEx", e))?;
-			MFStartup(MF_VERSION, MFSTARTUP_FULL).map_err(|e| mf_err("MFStartup", e))?;
-		}
-		Ok(Self)
-	}
-}
-
-impl Drop for ComGuard {
-	fn drop(&mut self) {
-		unsafe {
-			let _ = MFShutdown();
-			CoUninitialize();
-		}
-	}
 }
 
 /// An open camera, read frame-by-frame via [`read`](FrameSource::read).

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -1,0 +1,594 @@
+//! Hardware H.264 backend via a Media Foundation encoder MFT.
+//!
+//! Enumerates a hardware (`MFT_ENUM_FLAG_HARDWARE`) H.264 encoder and drives it
+//! through the async-MFT event model. When capture hands us a [`Frame::Texture`]
+//! the encoder runs on that texture's Direct3D11 device (via a DXGI device
+//! manager) and consumes the surface zero-copy; a CPU [`Frame::I420`] is uploaded
+//! into a system-memory NV12 sample instead.
+//!
+//! The MFT emits an Annex-B byte stream for `MFVideoFormat_H264`, with SPS/PPS
+//! inline ahead of each IDR, which is exactly what `moq_mux` avc3 mode wants, so
+//! unlike VideoToolbox there's no AVCC -> Annex-B rewrite. Used only from the one
+//! capture/encode thread, so the COM handles are wrapped in a thread-confined
+//! `Send` type.
+
+use std::mem::ManuallyDrop;
+use std::ptr;
+
+use bytes::Bytes;
+use windows::Win32::Foundation::{VARIANT_BOOL, VARIANT_TRUE};
+use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
+use windows::Win32::Media::MediaFoundation::{
+	CODECAPI_AVEncCommonMeanBitRate, CODECAPI_AVEncCommonRateControlMode, CODECAPI_AVEncMPVGOPSize,
+	CODECAPI_AVEncVideoForceKeyFrame, CODECAPI_AVLowLatencyMode, ICodecAPI, IMFDXGIDeviceManager, IMFMediaBuffer,
+	IMFMediaEventGenerator, IMFSample, IMFTransform, MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT,
+	MF_E_TRANSFORM_STREAM_CHANGE, MF_EVENT_FLAG_NO_WAIT, MF_EVENT_FLAG_NONE, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE,
+	MF_MT_FRAME_SIZE, MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE, MF_MT_MPEG2_PROFILE, MF_MT_SUBTYPE,
+	MF_TRANSFORM_ASYNC_UNLOCK, MFCreateDXGIDeviceManager, MFCreateDXGISurfaceBuffer, MFCreateMediaType,
+	MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video, MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE,
+	MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
+	MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER,
+	MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264,
+	MFVideoFormat_NV12, MFVideoInterlace_Progressive, eAVEncCommonRateControlMode_CBR, eAVEncH264VProfile_High,
+};
+use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize};
+use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_UI4};
+use windows::core::Interface;
+
+use super::super::encoder::Config;
+use super::Backend;
+use crate::Error;
+use crate::frame::Frame;
+
+pub(crate) const NAME: &str = "mediafoundation";
+
+/// Stream tick for sample timestamps, in 100ns units (the Media Foundation time
+/// base). Timestamps only need to increase; the moq timestamp is applied
+/// downstream, so a monotonic index over the framerate is enough.
+const HNS_PER_SEC: i64 = 10_000_000;
+
+fn mf_err(ctx: &str, e: windows::core::Error) -> Error {
+	Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
+}
+
+/// COM (MTA) + Media Foundation lifetime for the encode thread, balanced on
+/// drop. Refcounted, so it nests fine with the capture source's own guard when
+/// both run on the same blocking thread.
+struct ComGuard;
+
+impl ComGuard {
+	fn new() -> Result<Self, Error> {
+		unsafe {
+			CoInitializeEx(None, COINIT_MULTITHREADED)
+				.ok()
+				.map_err(|e| mf_err("CoInitializeEx", e))?;
+			windows::Win32::Media::MediaFoundation::MFStartup(
+				windows::Win32::Media::MediaFoundation::MF_VERSION,
+				windows::Win32::Media::MediaFoundation::MFSTARTUP_FULL,
+			)
+			.map_err(|e| mf_err("MFStartup", e))?;
+		}
+		Ok(Self)
+	}
+}
+
+impl Drop for ComGuard {
+	fn drop(&mut self) {
+		unsafe {
+			let _ = windows::Win32::Media::MediaFoundation::MFShutdown();
+			CoUninitialize();
+		}
+	}
+}
+
+pub(crate) struct MediaFoundation {
+	transform: IMFTransform,
+	events: IMFMediaEventGenerator,
+	codec_api: ICodecAPI,
+	width: u32,
+	height: u32,
+	framerate: u32,
+	bitrate: u32,
+	gop: u32,
+	/// Lazily configured on the first frame, since the Direct3D11 device to bind
+	/// (for zero-copy texture input) comes from the frame itself.
+	started: bool,
+	/// The MFT allocates its own output samples (true for hardware encoders).
+	provides_samples: bool,
+	/// True once the MFT has asked for input and we haven't fed it since.
+	needs_input: bool,
+	sample_index: i64,
+	/// Kept alive for the MFT's lifetime once a texture frame binds a device.
+	_manager: Option<IMFDXGIDeviceManager>,
+	_com: ComGuard,
+}
+
+// The MFT and its COM handles are only ever touched from the one capture/encode
+// thread (see `publish_capture`'s `spawn_blocking`).
+unsafe impl Send for MediaFoundation {}
+
+impl MediaFoundation {
+	pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
+		let com = ComGuard::new()?;
+		let transform = enumerate_encoder()?;
+
+		// Unlock the async interface before any other use (hardware MFTs are async).
+		let attrs = unsafe { transform.GetAttributes().map_err(|e| mf_err("MFT GetAttributes", e))? };
+		unsafe {
+			attrs
+				.SetUINT32(&MF_TRANSFORM_ASYNC_UNLOCK, 1)
+				.map_err(|e| mf_err("async unlock", e))?;
+		}
+
+		let events = transform
+			.cast::<IMFMediaEventGenerator>()
+			.map_err(|e| mf_err("MFT is not an event generator", e))?;
+		let codec_api = transform
+			.cast::<ICodecAPI>()
+			.map_err(|e| mf_err("MFT has no ICodecAPI", e))?;
+
+		tracing::info!(
+			encoder = NAME,
+			width = config.width,
+			height = config.height,
+			"opened H.264 encoder"
+		);
+		Ok(Box::new(Self {
+			transform,
+			events,
+			codec_api,
+			width: config.width,
+			height: config.height,
+			framerate: config.framerate,
+			bitrate: clamp_u32(config.resolved_bitrate()),
+			gop: config.gop,
+			started: false,
+			provides_samples: false,
+			needs_input: false,
+			sample_index: 0,
+			_manager: None,
+			_com: com,
+		}))
+	}
+
+	/// One-time configuration, deferred to the first frame so a texture frame can
+	/// bind its own Direct3D11 device for zero-copy input.
+	fn start(&mut self, frame: &Frame) -> Result<(), Error> {
+		// Bind the frame's D3D11 device when it's a texture, so the MFT reads the
+		// captured surface directly. A CPU frame runs the MFT in system memory.
+		if let Frame::Texture(texture) = frame {
+			let manager = device_manager(&texture.device)?;
+			let raw = manager.as_raw() as usize;
+			unsafe {
+				self.transform
+					.ProcessMessage(MFT_MESSAGE_SET_D3D_MANAGER, raw)
+					.map_err(|e| mf_err("set D3D manager", e))?;
+			}
+			self._manager = Some(manager);
+		}
+
+		self.configure_codec_api()?;
+		self.set_output_type()?;
+		self.set_input_type()?;
+
+		let info = unsafe {
+			self.transform
+				.GetOutputStreamInfo(0)
+				.map_err(|e| mf_err("GetOutputStreamInfo", e))?
+		};
+		self.provides_samples = info.dwFlags & MFT_OUTPUT_STREAM_PROVIDES_SAMPLES.0 as u32 != 0;
+
+		unsafe {
+			self.transform
+				.ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, 0)
+				.map_err(|e| mf_err("begin streaming", e))?;
+			self.transform
+				.ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0)
+				.map_err(|e| mf_err("start of stream", e))?;
+		}
+		self.started = true;
+		Ok(())
+	}
+
+	fn configure_codec_api(&self) -> Result<(), Error> {
+		// Low latency: no B-frames / lookahead, so output tracks input closely.
+		self.set_codec(&CODECAPI_AVLowLatencyMode, variant_bool(true))?;
+		self.set_codec(
+			&CODECAPI_AVEncCommonRateControlMode,
+			variant_u32(eAVEncCommonRateControlMode_CBR.0 as u32),
+		)?;
+		self.set_codec(&CODECAPI_AVEncCommonMeanBitRate, variant_u32(self.bitrate))?;
+		self.set_codec(&CODECAPI_AVEncMPVGOPSize, variant_u32(self.gop))?;
+		Ok(())
+	}
+
+	fn set_codec(&self, api: *const windows::core::GUID, value: VARIANT) -> Result<(), Error> {
+		// Some knobs are advisory; a failure here shouldn't sink the encoder, but
+		// it's worth surfacing in logs.
+		if let Err(e) = unsafe { self.codec_api.SetValue(api, &value) } {
+			tracing::debug!(error = %e, "encoder codec-api set failed");
+		}
+		Ok(())
+	}
+
+	fn set_output_type(&self) -> Result<(), Error> {
+		let media = unsafe { MFCreateMediaType().map_err(|e| mf_err("create output type", e))? };
+		unsafe {
+			media
+				.SetGUID(&MF_MT_MAJOR_TYPE, &MFMediaType_Video)
+				.map_err(|e| mf_err("output major type", e))?;
+			media
+				.SetGUID(&MF_MT_SUBTYPE, &MFVideoFormat_H264)
+				.map_err(|e| mf_err("output subtype", e))?;
+			media
+				.SetUINT32(&MF_MT_AVG_BITRATE, self.bitrate)
+				.map_err(|e| mf_err("output bitrate", e))?;
+			media
+				.SetUINT32(&MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive.0 as u32)
+				.map_err(|e| mf_err("output interlace", e))?;
+			media
+				.SetUINT32(&MF_MT_MPEG2_PROFILE, eAVEncH264VProfile_High.0 as u32)
+				.map_err(|e| mf_err("output profile", e))?;
+			media
+				.SetUINT64(&MF_MT_FRAME_SIZE, pack_2x32(self.width, self.height))
+				.map_err(|e| mf_err("output frame size", e))?;
+			media
+				.SetUINT64(&MF_MT_FRAME_RATE, pack_2x32(self.framerate, 1))
+				.map_err(|e| mf_err("output frame rate", e))?;
+			self.transform
+				.SetOutputType(0, &media, 0)
+				.map_err(|e| mf_err("SetOutputType", e))?;
+		}
+		Ok(())
+	}
+
+	fn set_input_type(&self) -> Result<(), Error> {
+		let media = unsafe { MFCreateMediaType().map_err(|e| mf_err("create input type", e))? };
+		unsafe {
+			media
+				.SetGUID(&MF_MT_MAJOR_TYPE, &MFMediaType_Video)
+				.map_err(|e| mf_err("input major type", e))?;
+			media
+				.SetGUID(&MF_MT_SUBTYPE, &MFVideoFormat_NV12)
+				.map_err(|e| mf_err("input subtype", e))?;
+			media
+				.SetUINT32(&MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive.0 as u32)
+				.map_err(|e| mf_err("input interlace", e))?;
+			media
+				.SetUINT64(&MF_MT_FRAME_SIZE, pack_2x32(self.width, self.height))
+				.map_err(|e| mf_err("input frame size", e))?;
+			media
+				.SetUINT64(&MF_MT_FRAME_RATE, pack_2x32(self.framerate, 1))
+				.map_err(|e| mf_err("input frame rate", e))?;
+			self.transform
+				.SetInputType(0, &media, 0)
+				.map_err(|e| mf_err("SetInputType", e))?;
+		}
+		Ok(())
+	}
+
+	/// Wrap a captured frame as an input [`IMFSample`]: a zero-copy DXGI surface
+	/// buffer for a texture, or a freshly uploaded NV12 memory buffer for I420.
+	fn build_sample(&self, frame: &Frame) -> Result<IMFSample, Error> {
+		let buffer = match frame {
+			Frame::Texture(texture) => unsafe {
+				let buffer =
+					MFCreateDXGISurfaceBuffer(&ID3D11Texture2D::IID, &texture.texture, texture.subresource, false)
+						.map_err(|e| mf_err("MFCreateDXGISurfaceBuffer", e))?;
+				let length = buffer
+					.cast::<windows::Win32::Media::MediaFoundation::IMF2DBuffer>()
+					.map_err(|e| mf_err("DXGI buffer is not 2D", e))?
+					.GetContiguousLength()
+					.map_err(|e| mf_err("DXGI contiguous length", e))?;
+				buffer
+					.SetCurrentLength(length)
+					.map_err(|e| mf_err("set DXGI length", e))?;
+				buffer
+			},
+			Frame::I420(_) => self.upload_nv12(frame)?,
+			#[allow(unreachable_patterns)]
+			_ => {
+				return Err(Error::Codec(anyhow::anyhow!(
+					"unsupported frame for mediafoundation encoder"
+				)));
+			}
+		};
+
+		let sample = unsafe { MFCreateSample().map_err(|e| mf_err("MFCreateSample", e))? };
+		unsafe {
+			sample.AddBuffer(&buffer).map_err(|e| mf_err("AddBuffer", e))?;
+			let tick = HNS_PER_SEC / self.framerate.max(1) as i64;
+			sample
+				.SetSampleTime(self.sample_index * tick)
+				.map_err(|e| mf_err("SetSampleTime", e))?;
+			sample
+				.SetSampleDuration(tick)
+				.map_err(|e| mf_err("SetSampleDuration", e))?;
+		}
+		Ok(sample)
+	}
+
+	/// Copy a CPU I420 frame into a system-memory NV12 buffer (the fallback when
+	/// capture isn't producing GPU textures).
+	fn upload_nv12(&self, frame: &Frame) -> Result<IMFMediaBuffer, Error> {
+		let i420 = frame.to_i420()?;
+		let (w, h) = (self.width as usize, self.height as usize);
+		let (cw, ch) = (w / 2, h / 2);
+		let len = w * h + 2 * cw * ch;
+
+		let buffer = unsafe { MFCreateMemoryBuffer(len as u32).map_err(|e| mf_err("MFCreateMemoryBuffer", e))? };
+		let mut ptr_out: *mut u8 = ptr::null_mut();
+		unsafe {
+			buffer
+				.Lock(&mut ptr_out, None, None)
+				.map_err(|e| mf_err("lock NV12 buffer", e))?;
+		}
+		// Y plane verbatim, then interleave U/V into the NV12 chroma plane.
+		let (u, v) = (i420.u(), i420.v());
+		unsafe {
+			ptr::copy_nonoverlapping(i420.y().as_ptr(), ptr_out, w * h);
+			let uv = ptr_out.add(w * h);
+			for i in 0..cw * ch {
+				*uv.add(i * 2) = u[i];
+				*uv.add(i * 2 + 1) = v[i];
+			}
+			let _ = buffer.Unlock();
+			buffer
+				.SetCurrentLength(len as u32)
+				.map_err(|e| mf_err("set NV12 length", e))?;
+		}
+		Ok(buffer)
+	}
+
+	/// Block on events until the MFT is ready for input, collecting any output
+	/// that arrives meanwhile.
+	fn wait_for_input(&mut self, out: &mut Vec<Bytes>) -> Result<(), Error> {
+		while !self.needs_input {
+			let event = unsafe {
+				self.events
+					.GetEvent(MF_EVENT_FLAG_NONE)
+					.map_err(|e| mf_err("GetEvent", e))?
+			};
+			self.handle_event(&event, out)?;
+		}
+		Ok(())
+	}
+
+	/// Drain events already queued without blocking (called after feeding input).
+	fn drain_ready(&mut self, out: &mut Vec<Bytes>) -> Result<(), Error> {
+		loop {
+			match unsafe { self.events.GetEvent(MF_EVENT_FLAG_NO_WAIT) } {
+				Ok(event) => self.handle_event(&event, out)?,
+				Err(e) if e.code() == MF_E_NO_EVENTS_AVAILABLE => return Ok(()),
+				Err(e) => return Err(mf_err("GetEvent (drain)", e)),
+			}
+		}
+	}
+
+	fn handle_event(
+		&mut self,
+		event: &windows::Win32::Media::MediaFoundation::IMFMediaEvent,
+		out: &mut Vec<Bytes>,
+	) -> Result<(), Error> {
+		let kind = unsafe { event.GetType().map_err(|e| mf_err("event GetType", e))? };
+		// METransformNeedInput / METransformHaveOutput aren't exposed as named
+		// constants in this binding; their numeric values are part of the ABI.
+		const NEED_INPUT: u32 = 601;
+		const HAVE_OUTPUT: u32 = 602;
+		match kind {
+			NEED_INPUT => self.needs_input = true,
+			HAVE_OUTPUT => {
+				if let Some(packet) = self.process_output()? {
+					out.push(packet);
+				}
+			}
+			_ => {}
+		}
+		Ok(())
+	}
+
+	/// Pull one encoded access unit. Returns `None` if the MFT had nothing ready
+	/// or asked us to renegotiate the output type.
+	fn process_output(&mut self) -> Result<Option<Bytes>, Error> {
+		let provided = if self.provides_samples {
+			None
+		} else {
+			let info = unsafe {
+				self.transform
+					.GetOutputStreamInfo(0)
+					.map_err(|e| mf_err("GetOutputStreamInfo", e))?
+			};
+			let buffer = unsafe { MFCreateMemoryBuffer(info.cbSize).map_err(|e| mf_err("output buffer", e))? };
+			let sample = unsafe { MFCreateSample().map_err(|e| mf_err("output sample", e))? };
+			unsafe { sample.AddBuffer(&buffer).map_err(|e| mf_err("output AddBuffer", e))? };
+			Some(sample)
+		};
+
+		let mut data = [MFT_OUTPUT_DATA_BUFFER {
+			dwStreamID: 0,
+			pSample: ManuallyDrop::new(provided),
+			dwStatus: 0,
+			pEvents: ManuallyDrop::new(None),
+		}];
+		let mut status = 0u32;
+		let result = unsafe { self.transform.ProcessOutput(0, &mut data, &mut status) };
+
+		// Take ownership of whatever sample slot now holds (ours or the MFT's),
+		// and release any event collection the MFT attached.
+		let sample = ManuallyDrop::into_inner(unsafe { ptr::read(&data[0].pSample) });
+		let _events = ManuallyDrop::into_inner(unsafe { ptr::read(&data[0].pEvents) });
+
+		match result {
+			Ok(()) => {}
+			Err(e) if e.code() == MF_E_TRANSFORM_NEED_MORE_INPUT => return Ok(None),
+			Err(e) if e.code() == MF_E_TRANSFORM_STREAM_CHANGE => {
+				// The encoder revised its output format; re-apply ours and retry
+				// on the next event.
+				self.set_output_type()?;
+				return Ok(None);
+			}
+			Err(e) => return Err(mf_err("ProcessOutput", e)),
+		}
+
+		let Some(sample) = sample else { return Ok(None) };
+		Ok(Some(sample_to_bytes(&sample)?))
+	}
+}
+
+impl Backend for MediaFoundation {
+	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+		if !self.started {
+			self.start(frame)?;
+		}
+
+		let mut out = Vec::new();
+		self.wait_for_input(&mut out)?;
+
+		if keyframe {
+			self.set_codec(&CODECAPI_AVEncVideoForceKeyFrame, variant_u32(1))?;
+		}
+
+		let sample = self.build_sample(frame)?;
+		unsafe {
+			self.transform
+				.ProcessInput(0, &sample, 0)
+				.map_err(|e| mf_err("ProcessInput", e))?;
+		}
+		self.needs_input = false;
+		self.sample_index += 1;
+
+		self.drain_ready(&mut out)?;
+		Ok(out)
+	}
+
+	fn finish(&mut self) -> Result<Vec<Bytes>, Error> {
+		if !self.started {
+			return Ok(Vec::new());
+		}
+		unsafe {
+			let _ = self.transform.ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0);
+			let _ = self.transform.ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, 0);
+		}
+		// Low-latency CBR buffers almost nothing, so a non-blocking sweep of the
+		// queued events flushes the tail without risking a hang.
+		let mut out = Vec::new();
+		self.drain_ready(&mut out)?;
+		Ok(out)
+	}
+
+	fn name(&self) -> &str {
+		NAME
+	}
+}
+
+/// Pick the first hardware H.264 encoder MFT (NV12 in, H.264 out).
+fn enumerate_encoder() -> Result<IMFTransform, Error> {
+	let input = MFT_REGISTER_TYPE_INFO {
+		guidMajorType: MFMediaType_Video,
+		guidSubtype: MFVideoFormat_NV12,
+	};
+	let output = MFT_REGISTER_TYPE_INFO {
+		guidMajorType: MFMediaType_Video,
+		guidSubtype: MFVideoFormat_H264,
+	};
+
+	let mut activates: *mut Option<windows::Win32::Media::MediaFoundation::IMFActivate> = ptr::null_mut();
+	let mut count: u32 = 0;
+	unsafe {
+		MFTEnumEx(
+			MFT_CATEGORY_VIDEO_ENCODER,
+			MFT_ENUM_FLAG_HARDWARE | MFT_ENUM_FLAG_SORTANDFILTER,
+			Some(&input),
+			Some(&output),
+			&mut activates,
+			&mut count,
+		)
+		.map_err(|e| mf_err("MFTEnumEx", e))?;
+	}
+	if count == 0 {
+		return Err(Error::Codec(anyhow::anyhow!("no hardware H.264 encoder found")));
+	}
+
+	let entries = unsafe { std::slice::from_raw_parts_mut(activates, count as usize) };
+	let mut transform: Option<IMFTransform> = None;
+	for slot in entries.iter_mut() {
+		let Some(activate) = slot.take() else { continue };
+		if transform.is_none() {
+			if let Ok(mft) = unsafe { activate.ActivateObject::<IMFTransform>() } {
+				transform = Some(mft);
+			}
+		}
+	}
+	unsafe {
+		windows::Win32::System::Com::CoTaskMemFree(Some(activates as *const std::ffi::c_void));
+	}
+
+	transform.ok_or_else(|| Error::Codec(anyhow::anyhow!("failed to activate H.264 encoder MFT")))
+}
+
+/// A DXGI device manager wrapping `device`, so the MFT shares the capture
+/// device and reads its textures directly.
+fn device_manager(device: &ID3D11Device) -> Result<IMFDXGIDeviceManager, Error> {
+	let mut token: u32 = 0;
+	let mut manager: Option<IMFDXGIDeviceManager> = None;
+	unsafe {
+		MFCreateDXGIDeviceManager(&mut token, &mut manager).map_err(|e| mf_err("MFCreateDXGIDeviceManager", e))?;
+	}
+	let manager = manager.ok_or_else(|| Error::Codec(anyhow::anyhow!("MFCreateDXGIDeviceManager returned null")))?;
+	unsafe {
+		manager
+			.ResetDevice(device, token)
+			.map_err(|e| mf_err("ResetDevice", e))?;
+	}
+	Ok(manager)
+}
+
+/// Copy an output sample's contiguous Annex-B bytes into an owned [`Bytes`].
+fn sample_to_bytes(sample: &IMFSample) -> Result<Bytes, Error> {
+	let buffer = unsafe {
+		sample
+			.ConvertToContiguousBuffer()
+			.map_err(|e| mf_err("output contiguous buffer", e))?
+	};
+	let mut ptr_out: *mut u8 = ptr::null_mut();
+	let mut len: u32 = 0;
+	unsafe {
+		buffer
+			.Lock(&mut ptr_out, None, Some(&mut len))
+			.map_err(|e| mf_err("lock output", e))?;
+	}
+	let bytes = Bytes::copy_from_slice(unsafe { std::slice::from_raw_parts(ptr_out, len as usize) });
+	unsafe {
+		let _ = buffer.Unlock();
+	}
+	Ok(bytes)
+}
+
+fn pack_2x32(hi: u32, lo: u32) -> u64 {
+	((hi as u64) << 32) | lo as u64
+}
+
+fn clamp_u32(value: u64) -> u32 {
+	value.min(u32::MAX as u64) as u32
+}
+
+fn variant_u32(value: u32) -> VARIANT {
+	let mut variant = VARIANT::default();
+	// SAFETY: write the union field that matches the tag we set.
+	unsafe {
+		let inner = &mut variant.Anonymous.Anonymous;
+		inner.vt = VT_UI4;
+		inner.Anonymous.ulVal = value;
+	}
+	variant
+}
+
+fn variant_bool(value: bool) -> VARIANT {
+	let mut variant = VARIANT::default();
+	unsafe {
+		let inner = &mut variant.Anonymous.Anonymous;
+		inner.vt = VT_BOOL;
+		inner.Anonymous.boolVal = if value { VARIANT_TRUE } else { VARIANT_BOOL(0) };
+	}
+	variant
+}

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -21,24 +21,25 @@ use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
 use windows::Win32::Media::MediaFoundation::{
 	CODECAPI_AVEncCommonMeanBitRate, CODECAPI_AVEncCommonRateControlMode, CODECAPI_AVEncMPVGOPSize,
 	CODECAPI_AVEncVideoForceKeyFrame, CODECAPI_AVLowLatencyMode, ICodecAPI, IMFDXGIDeviceManager, IMFMediaBuffer,
-	IMFMediaEventGenerator, IMFSample, IMFTransform, MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT,
-	MF_E_TRANSFORM_STREAM_CHANGE, MF_EVENT_FLAG_NO_WAIT, MF_EVENT_FLAG_NONE, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE,
-	MF_MT_FRAME_SIZE, MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE, MF_MT_MPEG2_PROFILE, MF_MT_SUBTYPE,
-	MF_TRANSFORM_ASYNC_UNLOCK, MFCreateDXGIDeviceManager, MFCreateDXGISurfaceBuffer, MFCreateMediaType,
-	MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video, MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE,
-	MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
-	MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER,
-	MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264,
-	MFVideoFormat_NV12, MFVideoInterlace_Progressive, eAVEncCommonRateControlMode_CBR, eAVEncH264VProfile_High,
+	IMFMediaEvent, IMFMediaEventGenerator, IMFSample, IMFTransform, METransformHaveOutput, METransformNeedInput,
+	MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE, MF_EVENT_FLAG_NO_WAIT,
+	MF_EVENT_FLAG_NONE, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE,
+	MF_MT_MPEG2_PROFILE, MF_MT_SUBTYPE, MF_TRANSFORM_ASYNC_UNLOCK, MFCreateDXGIDeviceManager,
+	MFCreateDXGISurfaceBuffer, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video,
+	MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN,
+	MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM,
+	MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO,
+	MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_NV12, MFVideoInterlace_Progressive, eAVEncCommonRateControlMode_CBR,
+	eAVEncH264VProfile_High,
 };
-use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize};
 use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_UI4};
 use windows::core::Interface;
 
 use super::super::encoder::Config;
 use super::Backend;
 use crate::Error;
-use crate::frame::Frame;
+use crate::frame::{Frame, interleave_uv};
+use crate::mf::{ComGuard, mf_err, pack_2x32};
 
 pub(crate) const NAME: &str = "mediafoundation";
 
@@ -46,40 +47,6 @@ pub(crate) const NAME: &str = "mediafoundation";
 /// base). Timestamps only need to increase; the moq timestamp is applied
 /// downstream, so a monotonic index over the framerate is enough.
 const HNS_PER_SEC: i64 = 10_000_000;
-
-fn mf_err(ctx: &str, e: windows::core::Error) -> Error {
-	Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
-}
-
-/// COM (MTA) + Media Foundation lifetime for the encode thread, balanced on
-/// drop. Refcounted, so it nests fine with the capture source's own guard when
-/// both run on the same blocking thread.
-struct ComGuard;
-
-impl ComGuard {
-	fn new() -> Result<Self, Error> {
-		unsafe {
-			CoInitializeEx(None, COINIT_MULTITHREADED)
-				.ok()
-				.map_err(|e| mf_err("CoInitializeEx", e))?;
-			windows::Win32::Media::MediaFoundation::MFStartup(
-				windows::Win32::Media::MediaFoundation::MF_VERSION,
-				windows::Win32::Media::MediaFoundation::MFSTARTUP_FULL,
-			)
-			.map_err(|e| mf_err("MFStartup", e))?;
-		}
-		Ok(Self)
-	}
-}
-
-impl Drop for ComGuard {
-	fn drop(&mut self) {
-		unsafe {
-			let _ = windows::Win32::Media::MediaFoundation::MFShutdown();
-			CoUninitialize();
-		}
-	}
-}
 
 pub(crate) struct MediaFoundation {
 	transform: IMFTransform,
@@ -95,6 +62,9 @@ pub(crate) struct MediaFoundation {
 	started: bool,
 	/// The MFT allocates its own output samples (true for hardware encoders).
 	provides_samples: bool,
+	/// Output buffer size we must allocate when `provides_samples` is false.
+	/// Cached from `GetOutputStreamInfo` so the output hot path doesn't re-query.
+	output_size: u32,
 	/// True once the MFT has asked for input and we haven't fed it since.
 	needs_input: bool,
 	sample_index: i64,
@@ -144,6 +114,7 @@ impl MediaFoundation {
 			gop: config.gop,
 			started: false,
 			provides_samples: false,
+			output_size: 0,
 			needs_input: false,
 			sample_index: 0,
 			_manager: None,
@@ -170,13 +141,7 @@ impl MediaFoundation {
 		self.configure_codec_api()?;
 		self.set_output_type()?;
 		self.set_input_type()?;
-
-		let info = unsafe {
-			self.transform
-				.GetOutputStreamInfo(0)
-				.map_err(|e| mf_err("GetOutputStreamInfo", e))?
-		};
-		self.provides_samples = info.dwFlags & MFT_OUTPUT_STREAM_PROVIDES_SAMPLES.0 as u32 != 0;
+		self.read_output_info()?;
 
 		unsafe {
 			self.transform
@@ -187,6 +152,19 @@ impl MediaFoundation {
 				.map_err(|e| mf_err("start of stream", e))?;
 		}
 		self.started = true;
+		Ok(())
+	}
+
+	/// Cache whether the MFT provides its own output samples and, if not, how
+	/// big a buffer we must allocate. Re-read after a format renegotiation.
+	fn read_output_info(&mut self) -> Result<(), Error> {
+		let info = unsafe {
+			self.transform
+				.GetOutputStreamInfo(0)
+				.map_err(|e| mf_err("GetOutputStreamInfo", e))?
+		};
+		self.provides_samples = info.dwFlags & MFT_OUTPUT_STREAM_PROVIDES_SAMPLES.0 as u32 != 0;
+		self.output_size = info.cbSize;
 		Ok(())
 	}
 
@@ -323,15 +301,14 @@ impl MediaFoundation {
 				.Lock(&mut ptr_out, None, None)
 				.map_err(|e| mf_err("lock NV12 buffer", e))?;
 		}
+		// SAFETY: we wrote `len` bytes' worth via the slice below and hold the lock
+		// until `Unlock`.
+		let nv12 = unsafe { std::slice::from_raw_parts_mut(ptr_out, len) };
 		// Y plane verbatim, then interleave U/V into the NV12 chroma plane.
-		let (u, v) = (i420.u(), i420.v());
+		let (y_dst, uv_dst) = nv12.split_at_mut(w * h);
+		y_dst.copy_from_slice(i420.y());
+		interleave_uv(i420.u(), i420.v(), uv_dst);
 		unsafe {
-			ptr::copy_nonoverlapping(i420.y().as_ptr(), ptr_out, w * h);
-			let uv = ptr_out.add(w * h);
-			for i in 0..cw * ch {
-				*uv.add(i * 2) = u[i];
-				*uv.add(i * 2 + 1) = v[i];
-			}
 			let _ = buffer.Unlock();
 			buffer
 				.SetCurrentLength(len as u32)
@@ -365,17 +342,18 @@ impl MediaFoundation {
 		}
 	}
 
-	fn handle_event(
-		&mut self,
-		event: &windows::Win32::Media::MediaFoundation::IMFMediaEvent,
-		out: &mut Vec<Bytes>,
-	) -> Result<(), Error> {
-		let kind = unsafe { event.GetType().map_err(|e| mf_err("event GetType", e))? };
-		// METransformNeedInput / METransformHaveOutput aren't exposed as named
-		// constants in this binding; their numeric values are part of the ABI.
-		const NEED_INPUT: u32 = 601;
-		const HAVE_OUTPUT: u32 = 602;
-		match kind {
+	fn handle_event(&mut self, event: &IMFMediaEvent, out: &mut Vec<Bytes>) -> Result<(), Error> {
+		// Surface an async failure (e.g. an MEError event) instead of looping in
+		// `wait_for_input` forever for an input request that will never come.
+		unsafe { event.GetStatus() }
+			.map_err(|e| mf_err("event GetStatus", e))?
+			.ok()
+			.map_err(|e| mf_err("encoder reported a failed event", e))?;
+
+		// `GetType` returns the raw `MF_EVENT_TYPE` value as a u32.
+		const NEED_INPUT: u32 = METransformNeedInput.0 as u32;
+		const HAVE_OUTPUT: u32 = METransformHaveOutput.0 as u32;
+		match unsafe { event.GetType().map_err(|e| mf_err("event GetType", e))? } {
 			NEED_INPUT => self.needs_input = true,
 			HAVE_OUTPUT => {
 				if let Some(packet) = self.process_output()? {
@@ -393,12 +371,7 @@ impl MediaFoundation {
 		let provided = if self.provides_samples {
 			None
 		} else {
-			let info = unsafe {
-				self.transform
-					.GetOutputStreamInfo(0)
-					.map_err(|e| mf_err("GetOutputStreamInfo", e))?
-			};
-			let buffer = unsafe { MFCreateMemoryBuffer(info.cbSize).map_err(|e| mf_err("output buffer", e))? };
+			let buffer = unsafe { MFCreateMemoryBuffer(self.output_size).map_err(|e| mf_err("output buffer", e))? };
 			let sample = unsafe { MFCreateSample().map_err(|e| mf_err("output sample", e))? };
 			unsafe { sample.AddBuffer(&buffer).map_err(|e| mf_err("output AddBuffer", e))? };
 			Some(sample)
@@ -422,9 +395,10 @@ impl MediaFoundation {
 			Ok(()) => {}
 			Err(e) if e.code() == MF_E_TRANSFORM_NEED_MORE_INPUT => return Ok(None),
 			Err(e) if e.code() == MF_E_TRANSFORM_STREAM_CHANGE => {
-				// The encoder revised its output format; re-apply ours and retry
-				// on the next event.
+				// The encoder revised its output format; re-apply ours, refresh the
+				// cached output-buffer info, and retry on the next event.
 				self.set_output_type()?;
+				self.read_output_info()?;
 				return Ok(None);
 			}
 			Err(e) => return Err(mf_err("ProcessOutput", e)),
@@ -562,10 +536,6 @@ fn sample_to_bytes(sample: &IMFSample) -> Result<Bytes, Error> {
 		let _ = buffer.Unlock();
 	}
 	Ok(bytes)
-}
-
-fn pack_2x32(hi: u32, lo: u32) -> u64 {
-	((hi as u64) << 32) | lo as u64
 }
 
 fn clamp_u32(value: u64) -> u32 {

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -21,6 +21,9 @@ mod openh264;
 #[cfg(target_os = "macos")]
 mod videotoolbox;
 
+#[cfg(target_os = "windows")]
+mod mediafoundation;
+
 #[cfg(all(target_os = "linux", feature = "nvenc"))]
 mod nvenc;
 
@@ -51,6 +54,11 @@ const HARDWARE: &[Candidate] = &[
 	Candidate {
 		name: videotoolbox::NAME,
 		open: videotoolbox::VideoToolbox::open,
+	},
+	#[cfg(target_os = "windows")]
+	Candidate {
+		name: mediafoundation::NAME,
+		open: mediafoundation::MediaFoundation::open,
 	},
 	#[cfg(all(target_os = "linux", feature = "nvenc"))]
 	Candidate {

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -1,14 +1,17 @@
 //! The frame handed from capture to an encoder backend.
 //!
-//! Two representations so the common path stays zero-copy:
-//! - [`Frame::Surface`] is a platform GPU surface (a macOS `CVPixelBuffer`,
-//!   IOSurface-backed). The capture source produces it and a hardware encoder
-//!   (VideoToolbox) consumes it directly, no copy and no color conversion.
+//! Representations chosen so the common path stays zero-copy:
+//! - [`Frame::Surface`] is a macOS `CVPixelBuffer` (IOSurface-backed NV12). The
+//!   capture source produces it and VideoToolbox consumes it directly, no copy
+//!   and no color conversion.
+//! - [`Frame::Texture`] is a Windows Direct3D11 NV12 texture. Media Foundation
+//!   capture produces it on a shared D3D11 device and the hardware encoder MFT
+//!   consumes it on that same device, also zero-copy.
 //! - [`Frame::I420`] is CPU-resident planar I420, for the software path
-//!   (openh264) and platforms without a zero-copy capture yet.
+//!   (openh264) and platforms without a zero-copy capture.
 //!
-//! A hardware backend takes a surface as-is; a software backend asks for I420
-//! via [`Frame::to_i420`], which downloads the surface only when necessary.
+//! A hardware backend takes the GPU frame as-is; a software backend asks for
+//! I420 via [`Frame::to_i420`], which downloads the GPU frame only when needed.
 
 use std::borrow::Cow;
 
@@ -20,6 +23,9 @@ pub(crate) enum Frame {
 	/// Zero-copy GPU surface (macOS `CVPixelBuffer`).
 	#[cfg(target_os = "macos")]
 	Surface(macos::Surface),
+	/// Zero-copy GPU texture (Windows Direct3D11 NV12).
+	#[cfg(target_os = "windows")]
+	Texture(d3d11::Texture),
 	/// CPU-resident planar I420.
 	I420(I420),
 }
@@ -29,6 +35,8 @@ impl Frame {
 		match self {
 			#[cfg(target_os = "macos")]
 			Frame::Surface(s) => s.width,
+			#[cfg(target_os = "windows")]
+			Frame::Texture(t) => t.width,
 			Frame::I420(i) => i.width,
 		}
 	}
@@ -37,15 +45,19 @@ impl Frame {
 		match self {
 			#[cfg(target_os = "macos")]
 			Frame::Surface(s) => s.height,
+			#[cfg(target_os = "windows")]
+			Frame::Texture(t) => t.height,
 			Frame::I420(i) => i.height,
 		}
 	}
 
-	/// A CPU I420 view, downloading a GPU surface only if necessary.
+	/// A CPU I420 view, downloading a GPU frame only if necessary.
 	pub(crate) fn to_i420(&self) -> Result<Cow<'_, I420>, Error> {
 		match self {
 			#[cfg(target_os = "macos")]
 			Frame::Surface(s) => Ok(Cow::Owned(s.download_i420()?)),
+			#[cfg(target_os = "windows")]
+			Frame::Texture(t) => Ok(Cow::Owned(t.download_i420()?)),
 			Frame::I420(i) => Ok(Cow::Borrowed(i)),
 		}
 	}
@@ -276,6 +288,140 @@ pub(crate) mod macos {
 	impl Drop for UnlockGuard<'_> {
 		fn drop(&mut self) {
 			unsafe { CVPixelBufferUnlockBaseAddress(self.0, LOCK_READ_ONLY) };
+		}
+	}
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) mod d3d11 {
+	use std::ptr;
+
+	use windows::Win32::Graphics::Direct3D11::{
+		D3D11_CPU_ACCESS_READ, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING,
+		ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D,
+	};
+
+	use super::I420;
+	use crate::Error;
+
+	fn err(ctx: &str, e: windows::core::Error) -> Error {
+		Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
+	}
+
+	/// A captured GPU texture (NV12) on the Media Foundation source reader's
+	/// Direct3D11 device. Holds the device so the download fallback and the
+	/// hardware encoder run on the same device that owns the texture. Cloning the
+	/// COM handles is a cheap `AddRef`, which is what keeps capture -> encode
+	/// zero-copy.
+	pub(crate) struct Texture {
+		pub(crate) device: ID3D11Device,
+		pub(crate) texture: ID3D11Texture2D,
+		/// The texture-array slice this frame lives in. Media Foundation pools the
+		/// reader's output as one texture array and reports the index per sample.
+		pub(crate) subresource: u32,
+		pub(crate) width: u32,
+		pub(crate) height: u32,
+	}
+
+	impl Texture {
+		pub(crate) fn new(
+			device: ID3D11Device,
+			texture: ID3D11Texture2D,
+			subresource: u32,
+			width: u32,
+			height: u32,
+		) -> Self {
+			Self {
+				device,
+				texture,
+				subresource,
+				width,
+				height,
+			}
+		}
+
+		/// Copy the NV12 texture to a CPU-readable staging texture and
+		/// deinterleave it into packed I420 (the software-encode fallback, e.g.
+		/// openh264 when no hardware encoder is selected).
+		pub(crate) fn download_i420(&self) -> Result<I420, Error> {
+			let context = unsafe { self.device.GetImmediateContext() }.map_err(|e| err("GetImmediateContext", e))?;
+
+			// A CPU-readable copy of the source texture's single slice.
+			let mut desc = D3D11_TEXTURE2D_DESC::default();
+			unsafe { self.texture.GetDesc(&mut desc) };
+			desc.ArraySize = 1;
+			desc.MipLevels = 1;
+			desc.Usage = D3D11_USAGE_STAGING;
+			desc.BindFlags = 0;
+			desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ.0 as u32;
+			desc.MiscFlags = 0;
+
+			let mut staging: Option<ID3D11Texture2D> = None;
+			unsafe {
+				self.device
+					.CreateTexture2D(&desc, None, Some(&mut staging))
+					.map_err(|e| err("CreateTexture2D (staging)", e))?;
+			}
+			let staging = staging.ok_or_else(|| Error::Codec(anyhow::anyhow!("CreateTexture2D returned null")))?;
+
+			unsafe {
+				context.CopySubresourceRegion(&staging, 0, 0, 0, 0, &self.texture, self.subresource, None);
+			}
+
+			let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+			unsafe {
+				context
+					.Map(&staging, 0, D3D11_MAP_READ, 0, Some(&mut mapped))
+					.map_err(|e| err("Map (staging)", e))?;
+			}
+			let _guard = UnmapGuard {
+				context: &context,
+				resource: &staging,
+			};
+
+			let (w, h) = (self.width as usize, self.height as usize);
+			let (cw, ch) = (w / 2, h / 2);
+			let pitch = mapped.RowPitch as usize;
+			let base = mapped.pData as *const u8;
+
+			let mut data = vec![0u8; I420::len(self.width, self.height)];
+			let (luma, chroma) = data.split_at_mut(w * h);
+			let (u_plane, v_plane) = chroma.split_at_mut(cw * ch);
+
+			// Y plane: h rows of `pitch` bytes, only the first w used.
+			for row in 0..h {
+				unsafe {
+					ptr::copy_nonoverlapping(base.add(row * pitch), luma[row * w..].as_mut_ptr(), w);
+				}
+			}
+			// Interleaved UV plane sits right after Y at `pitch * h`, h/2 rows.
+			let uv_base = unsafe { base.add(pitch * h) };
+			for row in 0..ch {
+				let src = unsafe { uv_base.add(row * pitch) };
+				for col in 0..cw {
+					unsafe {
+						u_plane[row * cw + col] = *src.add(col * 2);
+						v_plane[row * cw + col] = *src.add(col * 2 + 1);
+					}
+				}
+			}
+
+			Ok(I420 {
+				width: self.width,
+				height: self.height,
+				data,
+			})
+		}
+	}
+
+	struct UnmapGuard<'a> {
+		context: &'a ID3D11DeviceContext,
+		resource: &'a ID3D11Texture2D,
+	}
+
+	impl Drop for UnmapGuard<'_> {
+		fn drop(&mut self) {
+			unsafe { self.context.Unmap(self.resource, 0) };
 		}
 	}
 }

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -154,12 +154,8 @@ impl I420 {
 
 		let mut data = vec![0u8; Self::len(width, height)];
 		data[..luma].copy_from_slice(&nv12[..luma]);
-		let uv = &nv12[luma..need];
 		let (u_dst, v_dst) = data[luma..].split_at_mut(chroma);
-		for i in 0..chroma {
-			u_dst[i] = uv[i * 2];
-			v_dst[i] = uv[i * 2 + 1];
-		}
+		deinterleave_uv(&nv12[luma..need], u_dst, v_dst);
 		Ok(Self { width, height, data })
 	}
 
@@ -193,6 +189,26 @@ impl I420 {
 	pub(crate) fn v(&self) -> &[u8] {
 		let start = self.luma_len() + self.chroma_len();
 		&self.data[start..start + self.chroma_len()]
+	}
+}
+
+/// Interleave separate U and V planes into a packed NV12 chroma plane
+/// (`u[i], v[i]` -> `uv[2i], uv[2i+1]`). `uv` must be twice the length of `u`.
+#[cfg(target_os = "windows")]
+pub(crate) fn interleave_uv(u: &[u8], v: &[u8], uv: &mut [u8]) {
+	for (pair, (u, v)) in uv.chunks_exact_mut(2).zip(u.iter().zip(v)) {
+		pair[0] = *u;
+		pair[1] = *v;
+	}
+}
+
+/// Split a packed NV12 chroma plane into separate U and V planes, the inverse of
+/// [`interleave_uv`].
+#[cfg(target_os = "windows")]
+pub(crate) fn deinterleave_uv(uv: &[u8], u: &mut [u8], v: &mut [u8]) {
+	for (pair, (u, v)) in uv.chunks_exact(2).zip(u.iter_mut().zip(v)) {
+		*u = pair[0];
+		*v = pair[1];
 	}
 }
 

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -36,4 +36,7 @@ pub mod encode;
 mod error;
 mod frame;
 
+#[cfg(target_os = "windows")]
+mod mf;
+
 pub use error::Error;

--- a/rs/moq-video/src/mf.rs
+++ b/rs/moq-video/src/mf.rs
@@ -1,0 +1,48 @@
+//! Shared Media Foundation / COM helpers used by both the capture source and the
+//! hardware encoder backend on Windows.
+
+use windows::Win32::Media::MediaFoundation::{MF_VERSION, MFSTARTUP_FULL, MFShutdown, MFStartup};
+use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize};
+
+use crate::Error;
+
+/// Wrap a `windows` error with context as a codec error.
+pub(crate) fn mf_err(ctx: &str, e: windows::core::Error) -> Error {
+	Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
+}
+
+/// Pack two 32-bit values into the high/low halves of a u64, the layout Media
+/// Foundation uses for `MF_MT_FRAME_SIZE` (width/height) and `MF_MT_FRAME_RATE`
+/// (numerator/denominator).
+pub(crate) fn pack_2x32(hi: u32, lo: u32) -> u64 {
+	((hi as u64) << 32) | lo as u64
+}
+
+/// COM (MTA) + Media Foundation lifetime for the calling thread, balanced by
+/// `MFShutdown` + `CoUninitialize` on drop. Both calls are refcounted, so a
+/// capture source and an encoder backend can each hold one on the same blocking
+/// thread without stepping on each other.
+pub(crate) struct ComGuard;
+
+impl ComGuard {
+	pub(crate) fn new() -> Result<Self, Error> {
+		unsafe {
+			// MTA: the blocking capture thread has no message pump. `S_FALSE`
+			// (already initialized on this thread) is success, which `.ok()` keeps.
+			CoInitializeEx(None, COINIT_MULTITHREADED)
+				.ok()
+				.map_err(|e| mf_err("CoInitializeEx", e))?;
+			MFStartup(MF_VERSION, MFSTARTUP_FULL).map_err(|e| mf_err("MFStartup", e))?;
+		}
+		Ok(Self)
+	}
+}
+
+impl Drop for ComGuard {
+	fn drop(&mut self) {
+		unsafe {
+			let _ = MFShutdown();
+			CoUninitialize();
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Makes the Windows capture/encode path stay on the GPU end to end, so Windows joins macOS (VideoToolbox) as a zero-copy platform. Before this, Windows capture handed back CPU NV12 deinterleaved to I420 for openh264 only.

- **Capture** (`capture/mediafoundation.rs`): creates a shared hardware Direct3D11 device + `IMFDXGIDeviceManager`, drives the source reader with `MF_SOURCE_READER_D3D_MANAGER` + advanced video processing, and hands back NV12 `ID3D11Texture2D` surfaces.
- **Frame** (`frame.rs`): new `Frame::Texture` variant (texture + device + subresource). Cloning is an `AddRef`, so the surface flows capture → encode without a copy. `to_i420()` downloads via a staging texture for the software fallback.
- **Encoder** (`encode/backend/mediafoundation.rs`): new hardware H.264 encoder MFT (`MFTEnumEx` HARDWARE). It adopts the D3D11 device from the first texture frame via `MFT_MESSAGE_SET_D3D_MANAGER`, which preserves the existing capture/encode seam (the `Frame` carries its device, the backend binds lazily). Drives the async-MFT event pump and emits Annex-B directly (no AVCC rewrite, unlike VideoToolbox). Registered hardware-first in Auto mode, mirroring VideoToolbox.

The new path: camera → MF advanced video processor → NV12 texture on the GPU → hardware H.264 MFT → Annex-B, no system-memory round trip.

### Graceful fallback

Both halves degrade: with no D3D11 device, capture uses the source reader's software video processor (`Frame::I420`) and the MFT uploads NV12 from system memory. A GPU-less box still works via openh264. In practice the I420 → hardware-MFT case is near-unreachable: no GPU means `MFTEnumEx(HARDWARE)` finds nothing and it falls back to openh264 anyway.

## Public API

No public API or wire change. `Frame` is `pub(crate)`; `capture::Config` / `encode` surface unchanged. `encode::Kind::Named("mediafoundation")` is a new valid selector but additive.

## Why `dev`

Major feature that changes Windows Auto-mode to prefer the new MFT over openh264, and it's runtime-unvalidated. No breaking change, but per the branch-targeting rules it should settle on `dev` first.

## Test plan

- [x] Cross-compiled for `x86_64-pc-windows` from macOS (rustup-stable std + `cargo-zigbuild`), clean build, zero warnings.
- [x] Host (macOS) `cargo build` + `cargo test -p moq-video`: all 10 tests pass, the macOS path is untouched.
- [x] `cargo fmt --check` clean.
- [ ] **Runtime validation on real Windows hardware is still pending** (same status as the NVENC backend). The async-MFT pump, the "SPS/PPS inline at each IDR" assumption, and the I420 → hardware sysmem upload all need to be exercised on a Windows box with a real camera + GPU.

> [!WARNING]
> Because Auto mode now prefers the hardware MFT, a runtime bug in the encoder would break Windows capture versus today's working openh264. If you'd rather be cautious until validated, the MFT can be gated behind `Kind::Hardware` / `Kind::Named("mediafoundation")` instead of being hardware-first.

(Written by Claude)