### PR TITLE
docs(moq-cli): fix stale ffmpeg claim on capture feature

### DIFF
--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -19,9 +19,11 @@ quinn = ["moq-native/quinn"]
 quiche = ["moq-native/quiche"]
 websocket = ["moq-native/websocket"]
 # Device capture (camera + microphone) + encode/publish. Off by default because
-# the video path pulls in a system ffmpeg (libav*) build dependency (audio is
-# pure-Rust via cpal). Enable with `cargo build -p moq-cli --features capture`
-# (the nix dev shell provides ffmpeg).
+# it pulls in moq-video + moq-audio capture, which add system build deps on Linux
+# (camera: `v4l`/v4l2-sys-mit needs libclang + V4L2 headers via bindgen; mic: cpal
+# needs ALSA/libasound), plus binary size. macOS/Windows use OS frameworks, no
+# extra install. H.264 is vendored static (openh264), so no system ffmpeg/libav.
+# Enable with `cargo build -p moq-cli --features capture`.
 capture = ["dep:moq-video", "dep:moq-audio", "moq-audio/capture"]
 
 [dependencies]


### PR DESCRIPTION
## Summary

The `capture` feature in `rs/moq-cli/Cargo.toml` had a stale comment claiming it's off by default because "the video path pulls in a system ffmpeg (libav*) build dependency ... (the nix dev shell provides ffmpeg)". That's been false since #1691 removed `ffmpeg-next` from `moq-video`.

This updates the comment to describe the actual current reason `capture` is off by default, verified against `rs/moq-video/Cargo.toml` and `rs/moq-audio/Cargo.toml`:

- Enabling `capture` pulls in `moq-video` + `moq-audio` capture, which add system build deps **on Linux**: the camera path (`v4l`/`v4l2-sys-mit`) needs libclang + V4L2 headers via bindgen, and the mic path (`cpal`) needs ALSA/libasound.
- macOS/Windows use OS frameworks (AVFoundation/VideoToolbox, Media Foundation), no extra install.
- H.264 is now vendored static (`openh264`), so there is no system ffmpeg/libav anymore.
- Also factors in binary size.

Dropped the ffmpeg / nix-shell-provides-ffmpeg claim entirely. Comment-only change, no behavior impact.

Note: there is no `vaapi` feature in the current `moq-video` crate, so I didn't reference one.

## Test plan

- [x] Verified `rs/moq-video/Cargo.toml` (openh264 vendored, `v4l`/`v4l2-sys-mit` on Linux, objc2/Media Foundation on macOS/Windows, no ffmpeg) and `rs/moq-audio/Cargo.toml` (cpal capture → ALSA) match the new comment
- [x] Confirmed `v4l2-sys-mit` → bindgen in `Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)