### PR TITLE
feat(moq-video): reintroduce VAAPI via discord/cros-codecs + NV12 surface upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,26 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -748,6 +768,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -918,6 +952,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1293,6 +1333,36 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "cros-codecs"
+version = "0.0.5"
+source = "git+https://github.com/discord/cros-codecs.git?branch=discord-0.0.5#25fcb363f842107b2622490dbd2cc1c6372216b6"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "crc32fast",
+ "cros-libva",
+ "drm",
+ "drm-fourcc",
+ "log",
+ "nix 0.28.0",
+ "thiserror 1.0.69",
+ "zerocopy",
+]
+
+[[package]]
+name = "cros-libva"
+version = "0.0.13"
+source = "git+https://github.com/discord/cros-libva.git?branch=discord-0.0.13#896a248e003caae7a7120812f7eaa423c93a920d"
+dependencies = [
+ "bindgen 0.70.1",
+ "bitflags 2.13.0",
+ "log",
+ "pkg-config",
+ "regex",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "crossbeam"
@@ -1765,6 +1835,45 @@ dependencies = [
  "libc",
  "once_cell",
  "winapi",
+]
+
+[[package]]
+name = "drm"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98888c4bbd601524c11a7ed63f814b8825f420514f78e96f752c437ae9cbb5d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "drm-ffi",
+ "drm-fourcc",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm-ffi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c98727e48b7ccb4f4aea8cfe881e5b07f702d17b7875991881b41af7278d53"
+dependencies = [
+ "drm-sys",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm-fourcc"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
+
+[[package]]
+name = "drm-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.6.5",
 ]
 
 [[package]]
@@ -3314,7 +3423,7 @@ dependencies = [
  "backon",
  "blake3",
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "ctutils",
  "data-encoding",
  "derive_more",
@@ -3387,7 +3496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
 dependencies = [
  "arc-swap",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "derive_more",
  "hickory-resolver",
  "iroh-base",
@@ -3439,7 +3548,7 @@ checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
 dependencies = [
  "blake3",
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "data-encoding",
  "derive_more",
  "getrandom 0.4.2",
@@ -3776,6 +3885,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4326,6 +4441,7 @@ dependencies = [
  "anyhow",
  "block2",
  "bytes",
+ "cros-codecs",
  "cudarc",
  "dispatch2",
  "moq-mux",
@@ -4423,7 +4539,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "derive_more",
  "futures-buffered",
  "futures-lite",
@@ -4608,7 +4724,7 @@ checksum = "b5bfbba77b994ce69f1d40fc66fd8abbd23df62ce4aea61fbb34d638106a2549"
 dependencies = [
  "atomic-waker",
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "derive_more",
  "js-sys",
  "libc",
@@ -4638,13 +4754,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -4681,7 +4809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22739e0831e40f5ab7d6ac5317ed80bfe5fb3f44be57d23fa2eea8bff83fb303"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "derive_more",
  "noq-proto",
  "noq-udp",
@@ -4731,7 +4859,7 @@ version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "socket2",
  "tracing",
@@ -6004,7 +6132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -6047,7 +6175,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -7695,7 +7823,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "log",
- "nix",
+ "nix 0.30.1",
  "octets",
  "pin-project",
  "qlog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,3 +109,9 @@ strip = true
 # doesn't have that feature yet, so consume a fork branch until it's merged.
 [patch.crates-io]
 nvidia-video-codec-sdk = { git = "https://github.com/kixelated/nvidia-video-codec-sdk.git", branch = "dynamic-loading" }
+# moq-video's `vaapi` feature uses discord/cros-codecs (`vaapi_dlopen`), which
+# pulls cros-libva 0.0.13. The `dlopen` feature it needs (load libva at runtime
+# so a vaapi-enabled binary still links without libva-dev and still loads on a
+# libva-less machine, falling back to software) lives only on discord's fork, so
+# point the published 0.0.13 at it. Drop once `dlopen` is upstreamed.
+cros-libva = { git = "https://github.com/discord/cros-libva.git", branch = "discord-0.0.13" }

--- a/deny.toml
+++ b/deny.toml
@@ -70,4 +70,12 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # moq-video patches nvidia-video-codec-sdk to a fork that adds dlopen
 # (`dynamic-loading`); see the root Cargo.toml [patch.crates-io]. Drop this once
 # the feature is upstreamed and the patch is removed.
-allow-git = ["https://github.com/kixelated/nvidia-video-codec-sdk"]
+#
+# The `vaapi` feature pulls discord/cros-codecs (the maintained fork: cros-libva
+# 0.0.13 + a hardened H.264 VAAPI encoder) and patches cros-libva to discord's
+# fork for the `dlopen` feature. Drop these once `dlopen` is upstreamed.
+allow-git = [
+    "https://github.com/kixelated/nvidia-video-codec-sdk",
+    "https://github.com/discord/cros-codecs",
+    "https://github.com/discord/cros-libva",
+]

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -90,9 +90,9 @@ moq-cli publish --url https://relay.example.com --broadcast cam.hang capture --n
 
 Video capture uses a native per-platform backend (AVFoundation on macOS, V4L2 on
 Linux, Media Foundation on Windows) and picks a hardware H.264 encoder
-(VideoToolbox on macOS, NVENC on Linux NVIDIA) when one is present, falling back
-to the built-in software encoder (openh264); force either with `--hardware` /
-`--software`. `--camera` takes a bare integer as a device index, otherwise a
+(VideoToolbox on macOS, NVENC on Linux NVIDIA, VAAPI on Linux Intel/AMD) when one
+is present, falling back to the built-in software encoder (openh264); force either
+with `--hardware` / `--software`. `--camera` takes a bare integer as a device index, otherwise a
 device path (Linux) or name (a friendly-name substring on Windows, the
 AVFoundation `uniqueID` on macOS). Audio capture uses cpal (CoreAudio / WASAPI /
 ALSA) and encodes Opus.

--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,10 @@
             # cpal's `alsa-sys` (moq-audio `capture` feature) links libasound on
             # Linux via pkg-config; macOS uses CoreAudio, so no dep there.
             pkgs.alsa-lib
+            # moq-video `vaapi` feature: cros-libva runs bindgen against the libva
+            # headers at build time (found via pkg-config), even though libva is
+            # dlopen'd at runtime (`vaapi_dlopen`). macOS has no VAAPI.
+            pkgs.libva
           ];
 
         # JavaScript dependencies

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -24,10 +24,24 @@ doctest = false
 # driver, falling back to software (see backend::open). `cuda-12020` pins the CUDA
 # API version so the build needs no CUDA toolkit.
 nvenc = ["dep:nvidia-video-codec-sdk", "nvidia-video-codec-sdk/dynamic-loading", "cudarc/fallback-dynamic-loading", "cudarc/cuda-12020"]
+# Intel/AMD VAAPI hardware encoder (Linux). Off by default; enable for a build
+# that should use VAAPI where present. Everything is dlopen'd at runtime:
+# discord/cros-codecs's `vaapi_dlopen` resolves libva through the cros-libva
+# `dlopen` feature (a fork feature, see the root [patch.crates-io]). So a
+# vaapi-enabled binary still links on a libva-less builder and still loads on
+# machines without libva, falling back to software (see backend::open). The
+# build still needs libva *headers* for bindgen (provided by the nix devShell).
+vaapi = ["dep:cros-codecs"]
 
 [dependencies]
 anyhow = "1"
 bytes = "1"
+# VAAPI H.264 encoder + zero-copy dmabuf import, gated behind `vaapi` + a linux
+# cfg. discord's fork is the maintained one: cros-libva 0.0.13 so it builds
+# against libva >= 2.23 (published cros-codecs pins the broken 0.0.12), plus a
+# hardened H.264 encoder (packed SPS/PPS + slice headers, frame_num, rate
+# control). `vaapi_dlopen` loads libva at runtime.
+cros-codecs = { git = "https://github.com/discord/cros-codecs.git", branch = "discord-0.0.5", optional = true, default-features = false, features = ["vaapi_dlopen"] }
 cudarc = { version = "0.19", optional = true, default-features = false, features = ["driver"] }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }

--- a/rs/moq-video/DESIGN-native-codecs.md
+++ b/rs/moq-video/DESIGN-native-codecs.md
@@ -1,11 +1,11 @@
 # Native H.264 codecs for moq-video (drop ffmpeg)
 
-Status: **phases 2-5 implemented** (openh264, VideoToolbox, NVENC, capture swap +
-ffmpeg removal). Capture is now native on all three platforms (AVFoundation /
-ScreenCaptureKit on macOS, V4L2 on Linux, Media Foundation on Windows), so
-**nokhwa is fully removed**. VAAPI (phase 6) stays parked until cros-codecs
-builds against modern libva. See "As built" at the bottom for where the
-implementation diverged from this plan.
+Status: **phases 2-6 implemented** (openh264, VideoToolbox, NVENC, VAAPI, capture
+swap + ffmpeg removal). Capture is now native on all three platforms (AVFoundation
+/ ScreenCaptureKit on macOS, V4L2 on Linux, Media Foundation on Windows), so
+**nokhwa is fully removed**. VAAPI is back via discord/cros-codecs with an NV12
+surface-upload input path; the zero-copy dmabuf capture is a follow-up. See "As
+built" at the bottom for where the implementation diverged from this plan.
 
 ## Goal
 
@@ -368,26 +368,50 @@ Where the implementation differs from the plan above:
   unpadded NV12 so the I420 deinterleave is correct; (3) the on-demand
   open/`source.Shutdown()` cycle releases the camera (LED off) and reopens cleanly.
 
-### VAAPI removed (cros-codecs is not buildable on modern libva)
+### VAAPI reintroduced via discord/cros-codecs + NV12 surface upload
 
-The VAAPI backend (added behind the `vaapi` feature in #1691) and the V4L2 dmabuf
-capture written to feed it have been **removed**. `cros-codecs 0.0.6` (the latest)
+VAAPI was dropped in #1704 because `cros-codecs 0.0.6` (still the latest release)
 caret-pins `cros-libva 0.0.12`, which does not compile against libva >= 2.23: the
 newer headers add `seg_id_block_size` / `va_reserved8` to
 `VAEncPictureParameterBufferVP9`, and `cros-libva 0.0.12`'s struct literal omits
-them (`cros-libva 0.0.13` fixes it, but `cros-codecs 0.0.6` won't accept it). Since
-modern distros and the nix toolchain ship libva 2.23+, the feature could not build
-or ship, and CI's `--all-features` could not be made green while it existed.
-`cros-codecs` is the only pure-Rust VAAPI H.264 encoder, and reintroducing ffmpeg
-for VAAPI defeats the purpose of this effort, so VAAPI is parked until `cros-codecs`
-releases against `cros-libva >= 0.0.13` (or a better VAAPI path appears). Intel/AMD
-Linux falls back to the openh264 software encoder meanwhile; NVIDIA uses NVENC.
+them. `cros-libva 0.0.13` fixes it, but `cros-codecs 0.0.6`'s `^0.0.12` pin won't
+accept it, and upstream cros-codecs is unmaintained (no release since June 2025).
 
-When it returns: re-add `backend/vaapi.rs`, `capture/v4l2.rs`, the `vaapi` feature
-(+ `cros-codecs`/`v4l`/`libc` deps), `Frame::DmaBuf`, the `requires_dmabuf` capture
-coupling, and `libva` in the nix devShell. See this PR's history for the prior
-implementation; the V4L2 capture (REQBUFS/EXPBUF/QBUF/DQBUF) was compile-verified
-but never runtime-tested.
+The unblock is [discord/cros-codecs](https://github.com/discord/cros-codecs), an
+actively-maintained fork (Discord ships it for Go Live) that bumps to cros-libva
+0.0.13 *and* hardens the H.264 VAAPI encoder (packed SPS/PPS + slice headers,
+`frame_num`, rate control). We consume it as a git dependency, no fork of our own:
+
+- `cros-codecs = { git = discord/cros-codecs, branch = "discord-0.0.5", features = ["vaapi_dlopen"] }`.
+- `vaapi_dlopen` pulls the cros-libva `dlopen` feature, which lives on
+  discord/cros-libva's `discord-0.0.13` branch, so the root `[patch.crates-io]`
+  points `cros-libva` there. Both git URLs are in `deny.toml`'s `allow-git`.
+
+**dlopen, like NVENC.** `dlopen` makes cros-libva load libva at runtime (no
+`cargo:rustc-link-lib`, no `DT_NEEDED libva.so.2`), so a `--features vaapi` binary
+links on a libva-less builder and loads on a libva-less machine, falling back to
+software (see `backend::open`). The build still needs libva *headers* for
+cros-libva's bindgen, so `libva` is in the nix devShell.
+
+**Input is an NV12 surface upload, not zero-copy dmabuf.** The encoder wants an
+NV12 VA surface, but UVC webcams deliver YUYV/MJPEG (decoded to CPU I420); they
+rarely expose NV12 to import zero-copy. So `backend/vaapi.rs` drives
+`new_native_vaapi` with a `VaSurfacePool`: each frame uploads I420 into a pooled
+surface as NV12 (`libva::Image`, honoring plane pitches) and encodes the surface.
+This works with the existing CPU V4L2 capture, no new capture code.
+
+Follow-up (not in this PR): the **zero-copy dmabuf path** for the rare NV12-capable
+V4L2 source. Re-add `Frame::DmaBuf`, a V4L2 `VIDIOC_EXPBUF` capture (the `v4l`
+crate exposes the raw ioctl but no dmabuf stream), and a `requires_dmabuf` capture
+coupling, then import the dmabuf into a VA surface (`MemoryType::DrmPrime2`).
+
+**NOT YET VALIDATED ON HARDWARE.** Compiles on Linux with libva headers; written
+against discord/cros-codecs `discord-0.0.5` with type/field names checked against
+source. Needs a Linux + Intel/AMD GPU to confirm: (1) the `low_power` entrypoint
+(recent Intel iHD often requires the low-power encode entrypoint, AMD the full
+one; we request full and let `Kind::Auto` fall back); (2) the NV12 upload
+pitch/offset handling round-trips; (3) `cargo deny` accepts the new transitive
+licenses (drm, drm-fourcc, etc.) once the vaapi graph resolves.
 
 ### NVENC ships via dlopen (no driver dependency at build or load)
 

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -24,6 +24,9 @@ mod videotoolbox;
 #[cfg(all(target_os = "linux", feature = "nvenc"))]
 mod nvenc;
 
+#[cfg(all(target_os = "linux", feature = "vaapi"))]
+mod vaapi;
+
 /// An opened H.264 encoder. Feed it frames at the configured resolution;
 /// get back zero or more Annex-B H.264 packets.
 pub(crate) trait Backend: Send {
@@ -56,6 +59,11 @@ const HARDWARE: &[Candidate] = &[
 	Candidate {
 		name: nvenc::NAME,
 		open: nvenc::Nvenc::open,
+	},
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	Candidate {
+		name: vaapi::NAME,
+		open: vaapi::Vaapi::open,
 	},
 ];
 

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -1,0 +1,226 @@
+//! Intel/AMD VAAPI hardware backend via `cros-codecs` (Linux, `vaapi` feature).
+//!
+//! VAAPI is a *stateless* encode API: the hardware does the slice coding, but the
+//! application builds the H.264 bitstream (SPS/PPS, DPB, ref lists). cros-codecs
+//! is that bitstream layer; we drive its H.264 VAAPI encoder. Output is an
+//! Annex-B elementary stream with in-band SPS/PPS, matching avc3 mode.
+//!
+//! We consume [discord/cros-codecs](https://github.com/discord/cros-codecs): the
+//! maintained fork that builds against modern libva (cros-libva 0.0.13; the
+//! published cros-codecs pins the broken 0.0.12) and hardens the H.264 encoder
+//! (packed SPS/PPS + slice headers, frame_num, rate control). libva is dlopen'd
+//! at runtime (`vaapi_dlopen`), so this links without libva and the binary loads
+//! on machines without it, falling back to software (see [`backend::open`]).
+//!
+//! Input path: the encoder wants an **NV12** VA surface, but our captures hand us
+//! CPU I420 (webcams deliver YUYV/MJPEG, decoded to I420; the camera rarely
+//! offers NV12 to import zero-copy). So each frame uploads I420 into a pooled VA
+//! surface as NV12, then encodes the surface. A zero-copy dmabuf path (import a
+//! captured NV12 dmabuf straight into a VA surface) is a follow-up for the rare
+//! NV12-capable V4L2 source.
+//!
+//! NOT YET VALIDATED ON HARDWARE. Compiles on Linux with libva headers, but needs
+//! a Linux + Intel/AMD GPU to confirm: (1) the `low_power` entrypoint (recent
+//! Intel iHD often requires the low-power encode entrypoint, AMD the full one; we
+//! request full and let `Kind::Auto` fall back); (2) the NV12 surface upload
+//! (plane pitch/offset handling) round-trips correctly.
+
+use std::borrow::Borrow;
+
+use bytes::Bytes;
+use cros_codecs::backend::vaapi::surface_pool::{PooledVaSurface, VaSurfacePool};
+use cros_codecs::decoder::FramePool;
+use cros_codecs::encoder::h264::EncoderConfig as H264Config;
+use cros_codecs::encoder::stateless::h264::StatelessEncoder;
+use cros_codecs::encoder::{FrameMetadata, RateControl, Tunings, VideoEncoder};
+use cros_codecs::libva::{self, Display, Image, Surface, UsageHint};
+use cros_codecs::{BlockingMode, Fourcc, FrameLayout, PlaneLayout, Resolution};
+
+use super::super::encoder::Config;
+use super::Backend;
+use crate::Error;
+use crate::frame::{Frame, I420};
+
+pub(crate) const NAME: &str = "vaapi";
+
+/// Input surfaces to keep in the pool; a small ring covers frames in flight
+/// under `BlockingMode::Blocking` (reference surfaces are managed separately by
+/// the encoder backend).
+const SURFACE_COUNT: usize = 8;
+
+pub(crate) struct Vaapi {
+	encoder: Box<dyn VideoEncoder<PooledVaSurface<()>>>,
+	pool: VaSurfacePool<()>,
+	/// NV12 image format for surface upload, queried once at open.
+	nv12_format: libva::VAImageFormat,
+	/// Logical NV12 layout handed to the encoder with each frame.
+	layout: FrameLayout,
+	timestamp: u64,
+}
+
+// The encoder, surface pool, and VA `Display` are `!Send` (`Rc` internally) but
+// used only from the single capture/encode thread (see `publish_capture`).
+unsafe impl Send for Vaapi {}
+
+impl Vaapi {
+	pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
+		let display = Display::open().ok_or_else(|| Error::Codec(anyhow::anyhow!("open VAAPI display")))?;
+
+		let size = Resolution {
+			width: config.width,
+			height: config.height,
+		};
+		let h264 = H264Config {
+			resolution: size,
+			initial_tunings: Tunings {
+				rate_control: RateControl::ConstantBitrate(config.resolved_bitrate()),
+				framerate: config.framerate,
+				..Default::default()
+			},
+			..Default::default()
+		};
+
+		let encoder = StatelessEncoder::new_native_vaapi(
+			display.clone(),
+			h264,
+			Fourcc::from(b"NV12"),
+			size,
+			false, // low_power: recent Intel may need true; validate on hardware.
+			BlockingMode::Blocking,
+		)
+		.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI encoder init: {e:?}")))?;
+
+		let mut pool = VaSurfacePool::new(
+			display.clone(),
+			libva::VA_RT_FORMAT_YUV420,
+			Some(UsageHint::USAGE_HINT_ENCODER),
+			size,
+		);
+		pool.add_frames(vec![(); SURFACE_COUNT])
+			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI surface pool: {e}")))?;
+
+		let nv12_format = display
+			.query_image_formats()
+			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI query image formats: {e}")))?
+			.into_iter()
+			.find(|f| f.fourcc == libva::VA_FOURCC_NV12)
+			.ok_or_else(|| Error::Codec(anyhow::anyhow!("VAAPI driver has no NV12 image format")))?;
+
+		// Tightly-packed NV12: Y plane (w*h) then interleaved UV (w*h/2).
+		let layout = FrameLayout {
+			format: (Fourcc::from(b"NV12"), 0),
+			size,
+			planes: vec![
+				PlaneLayout {
+					buffer_index: 0,
+					offset: 0,
+					stride: config.width as usize,
+				},
+				PlaneLayout {
+					buffer_index: 0,
+					offset: (config.width * config.height) as usize,
+					stride: config.width as usize,
+				},
+			],
+		};
+
+		tracing::info!(
+			encoder = NAME,
+			width = config.width,
+			height = config.height,
+			"opened H.264 encoder"
+		);
+		Ok(Box::new(Self {
+			encoder: Box::new(encoder) as Box<dyn VideoEncoder<PooledVaSurface<()>>>,
+			pool,
+			nv12_format,
+			layout,
+			timestamp: 0,
+		}))
+	}
+
+	/// Upload tightly-packed I420 into a VA surface as NV12: copy Y as-is, then
+	/// interleave U and V into the chroma plane, honoring the surface's pitches.
+	fn upload(&self, surface: &Surface<()>, i420: &I420) -> Result<(), Error> {
+		let mut image = Image::create_from(surface, self.nv12_format, surface.size(), surface.size())
+			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI map surface: {e}")))?;
+
+		let va = *image.image();
+		let dst = image.as_mut();
+
+		let (w, h) = (i420.width as usize, i420.height as usize);
+		let (cw, ch) = (w / 2, h / 2);
+
+		let (y_off, y_pitch) = (va.offsets[0] as usize, va.pitches[0] as usize);
+		let y = i420.y();
+		for row in 0..h {
+			let d = y_off + row * y_pitch;
+			dst[d..d + w].copy_from_slice(&y[row * w..row * w + w]);
+		}
+
+		let (uv_off, uv_pitch) = (va.offsets[1] as usize, va.pitches[1] as usize);
+		let (u, v) = (i420.u(), i420.v());
+		for row in 0..ch {
+			let base = uv_off + row * uv_pitch;
+			for col in 0..cw {
+				dst[base + col * 2] = u[row * cw + col];
+				dst[base + col * 2 + 1] = v[row * cw + col];
+			}
+		}
+
+		// Drop the image to flush the upload, then make sure it lands before the
+		// encoder reads the surface.
+		drop(image);
+		surface
+			.sync()
+			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI surface sync: {e}")))
+	}
+
+	/// Drain any ready coded bitstream buffers into Annex-B packets.
+	fn drain_ready(&mut self) -> Result<Vec<Bytes>, Error> {
+		let mut out = Vec::new();
+		while let Some(coded) = self
+			.encoder
+			.poll()
+			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI poll: {e:?}")))?
+		{
+			out.push(Bytes::from(coded.bitstream));
+		}
+		Ok(out)
+	}
+}
+
+impl Backend for Vaapi {
+	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+		let i420 = frame.to_i420()?;
+
+		let surface = self
+			.pool
+			.get_surface()
+			.ok_or_else(|| Error::Codec(anyhow::anyhow!("VAAPI surface pool exhausted")))?;
+		self.upload(surface.borrow(), &i420)?;
+
+		let meta = FrameMetadata {
+			timestamp: self.timestamp,
+			layout: self.layout.clone(),
+			force_keyframe: keyframe,
+		};
+		self.timestamp += 1;
+
+		self.encoder
+			.encode(meta, surface)
+			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI encode: {e:?}")))?;
+		self.drain_ready()
+	}
+
+	fn finish(&mut self) -> Result<Vec<Bytes>, Error> {
+		self.encoder
+			.drain()
+			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI drain: {e:?}")))?;
+		self.drain_ready()
+	}
+
+	fn name(&self) -> &str {
+		NAME
+	}
+}

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -200,10 +200,13 @@ impl Backend for Vaapi {
 			.ok_or_else(|| Error::Codec(anyhow::anyhow!("VAAPI surface pool exhausted")))?;
 		self.upload(surface.borrow(), &i420)?;
 
+		// Force an IDR (not just any keyframe) so a re-subscribing viewer gets a
+		// clean random-access point: references cleared and in-band SPS/PPS.
 		let meta = FrameMetadata {
 			timestamp: self.timestamp,
 			layout: self.layout.clone(),
 			force_keyframe: keyframe,
+			force_idr: keyframe,
 		};
 		self.timestamp += 1;
 

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -22,7 +22,8 @@ pub enum Kind {
 	Hardware,
 	/// Software (openh264) only.
 	Software,
-	/// A specific backend by name, e.g. `"videotoolbox"`, `"nvenc"`, `"openh264"`.
+	/// A specific backend by name, e.g. `"videotoolbox"`, `"nvenc"`, `"vaapi"`,
+	/// `"openh264"`.
 	Named(String),
 }
 


### PR DESCRIPTION
## Summary

Reintroduces the Intel/AMD **VAAPI** H.264 encoder for `moq-video`, dropped in #1704 because `cros-codecs 0.0.6` pins `cros-libva 0.0.12`, which fails to compile against libva >= 2.23.

The unblock is **[discord/cros-codecs](https://github.com/discord/cros-codecs)** (branch `discord-0.0.5`), an actively-maintained fork (Discord ships it for Go Live) that bumps to `cros-libva 0.0.13` **and** hardens the H.264 VAAPI encoder (packed SPS/PPS + slice headers, `frame_num`, rate control). It's consumed as plain git dependencies, with no fork of our own.

- **dlopen, like NVENC.** The `vaapi` feature enables cros-codecs' `vaapi_dlopen`, which loads libva at runtime via the cros-libva `dlopen` feature (`discord/cros-libva#discord-0.0.13`, pulled through a root `[patch.crates-io]`). So a `vaapi`-enabled binary links on a libva-less builder and loads on a libva-less machine, falling back to openh264. The build still needs libva headers for bindgen, so `libva` is back in the nix devShell.
- **Input is an NV12 surface upload, not zero-copy dmabuf.** VAAPI's H.264 encoder wants an NV12 VA surface, but UVC webcams deliver YUYV/MJPEG (decoded to CPU I420) and rarely offer NV12 to import zero-copy. So `backend/vaapi.rs` drives `new_native_vaapi` with a `VaSurfacePool` and uploads each I420 frame into a pooled VA surface as NV12. **This works with the existing CPU V4L2 capture, no new capture code.**

Zero-copy dmabuf (`Frame::DmaBuf` + a `VIDIOC_EXPBUF` capture + `DrmPrime2` surface import) for the rare NV12-capable V4L2 source is a deliberate follow-up.

## Public API

No public API or wire change. The `vaapi` feature is off by default and Linux-gated; the codec-agnostic `moq-video` surface (`Encoder`, `Config`, `Kind`) is untouched. Additive only.

## Test plan

- [x] Default macOS build green (`cargo check -p moq-video`; vaapi is cfg'd out).
- [x] Git deps resolve and lock to the discord forks; the `cros-libva` patch applies (no unused-patch warning).
- [x] `rustfmt` clean (incl. the cfg-gated `vaapi.rs`).
- [x] **Linux `cargo clippy -p moq-video --all-targets --all-features -- -D warnings` green** (nvenc + vaapi both active), verified in a Linux container. Caught one missing field (`FrameMetadata.force_idr`), now fixed.
- [x] `cargo deny check licenses sources` ok (the new transitive licenses are already allow-listed).
- [ ] **Hardware validation on Linux + Intel/AMD GPU** still pending: the `low_power` entrypoint (recent Intel iHD may need `true`), and the NV12 upload pitch handling round-trip.

Targets `dev` because it adds git-patched dependencies and belongs to the native-codecs effort.

(Written by Claude)