### PR TITLE
feat(demo): surface console output on the web demos via <moq-console>

### DIFF
--- a/demo/web/console-overlay.ts
+++ b/demo/web/console-overlay.ts
@@ -1,0 +1,92 @@
+import type { Plugin } from "vite";
+
+// Dev-only overlay that mirrors console.warn/console.error (plus uncaught
+// errors and unhandled rejections) onto the page. The demos are often driven
+// by an AI that can read the DOM but not the browser console, so surfacing
+// failures visually is the only way for it to see what broke.
+export function consoleOverlay(): Plugin {
+	return {
+		name: "moq-console-overlay",
+		apply: "serve",
+		transformIndexHtml() {
+			return [
+				{
+					tag: "script",
+					attrs: { type: "module" },
+					children: OVERLAY_SCRIPT,
+					injectTo: "head",
+				},
+			];
+		},
+	};
+}
+
+const OVERLAY_SCRIPT = `
+const container = document.createElement("div");
+container.id = "moq-console-overlay";
+Object.assign(container.style, {
+	position: "fixed",
+	bottom: "0",
+	left: "0",
+	right: "0",
+	maxHeight: "40vh",
+	overflowY: "auto",
+	zIndex: "2147483647",
+	font: "12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace",
+	background: "rgba(0, 0, 0, 0.85)",
+	color: "#eee",
+	borderTop: "1px solid #444",
+	display: "none",
+	pointerEvents: "auto",
+});
+
+function append(level, args) {
+	const line = document.createElement("div");
+	Object.assign(line.style, {
+		padding: "2px 8px",
+		borderBottom: "1px solid #222",
+		whiteSpace: "pre-wrap",
+		wordBreak: "break-word",
+		color: level === "error" ? "#ff8080" : "#ffd480",
+	});
+	const text = args
+		.map((a) => {
+			if (a instanceof Error) return a.stack || a.message;
+			if (typeof a === "string") return a;
+			try {
+				return JSON.stringify(a);
+			} catch {
+				return String(a);
+			}
+		})
+		.join(" ");
+	line.textContent = "[" + level + "] " + text;
+	container.appendChild(line);
+	container.style.display = "block";
+	container.scrollTop = container.scrollHeight;
+}
+
+function install() {
+	if (!document.body) {
+		document.addEventListener("DOMContentLoaded", install, { once: true });
+		return;
+	}
+	document.body.appendChild(container);
+}
+install();
+
+for (const level of ["warn", "error"]) {
+	const original = console[level].bind(console);
+	console[level] = (...args) => {
+		original(...args);
+		append(level, args);
+	};
+}
+
+window.addEventListener("error", (e) => {
+	append("error", [e.error ?? e.message]);
+});
+window.addEventListener("unhandledrejection", (e) => {
+	append("error", ["Unhandled rejection:", e.reason]);
+});
+`;

--- a/demo/web/console-overlay.ts
+++ b/demo/web/console-overlay.ts
@@ -1,9 +1,15 @@
 import type { Plugin } from "vite";
 
-// Dev-only overlay that mirrors console.warn/console.error (plus uncaught
-// errors and unhandled rejections) onto the page. The demos are often driven
-// by an AI that can read the DOM but not the browser console, so surfacing
-// failures visually is the only way for it to see what broke.
+// Dev-only logger that mirrors the browser console (plus uncaught errors and
+// unhandled rejections) onto the page. The demos are often driven by an AI that
+// can read the DOM but not the browser console, so surfacing output visually is
+// the only way for it to see what happened.
+//
+// The injected script defines a <moq-console> custom element. Drop it anywhere
+// in a page to render the log inline at that spot. Set `level` to choose the
+// minimum severity shown (debug | log | info | warn | error; defaults to warn).
+// If a page doesn't include one, a floating instance is pinned to the bottom as
+// a fallback, so capture is automatic everywhere.
 export function consoleOverlay(): Plugin {
 	return {
 		name: "moq-console-overlay",
@@ -22,34 +28,23 @@ export function consoleOverlay(): Plugin {
 }
 
 const OVERLAY_SCRIPT = `
-const container = document.createElement("div");
-container.id = "moq-console-overlay";
-Object.assign(container.style, {
-	position: "fixed",
-	bottom: "0",
-	left: "0",
-	right: "0",
-	maxHeight: "40vh",
-	overflowY: "auto",
-	zIndex: "2147483647",
-	font: "12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace",
-	background: "rgba(0, 0, 0, 0.85)",
-	color: "#eee",
-	borderTop: "1px solid #444",
-	display: "none",
-	pointerEvents: "auto",
-});
+const LEVELS = ["debug", "log", "info", "warn", "error"];
+const COLORS = {
+	debug: "#999",
+	log: "#ccc",
+	info: "#80c0ff",
+	warn: "#ffd480",
+	error: "#ff8080",
+};
 
-function append(level, args) {
-	const line = document.createElement("div");
-	Object.assign(line.style, {
-		padding: "2px 8px",
-		borderBottom: "1px solid #222",
-		whiteSpace: "pre-wrap",
-		wordBreak: "break-word",
-		color: level === "error" ? "#ff8080" : "#ffd480",
-	});
-	const text = args
+// Buffer messages from the moment this module loads, before any element exists,
+// so an inline <moq-console> added later still shows earlier messages. We patch
+// every level and let each element filter by its own threshold.
+const buffer = [];
+const sinks = new Set();
+
+function format(args) {
+	return args
 		.map((a) => {
 			if (a instanceof Error) return a.stack || a.message;
 			if (typeof a === "string") return a;
@@ -60,33 +55,161 @@ function append(level, args) {
 			}
 		})
 		.join(" ");
-	line.textContent = "[" + level + "] " + text;
-	container.appendChild(line);
-	container.style.display = "block";
-	container.scrollTop = container.scrollHeight;
 }
 
-function install() {
-	if (!document.body) {
-		document.addEventListener("DOMContentLoaded", install, { once: true });
-		return;
-	}
-	document.body.appendChild(container);
+function emit(level, args) {
+	const entry = { level, text: format(args) };
+	buffer.push(entry);
+	for (const sink of sinks) sink(entry);
 }
-install();
 
-for (const level of ["warn", "error"]) {
+for (const level of LEVELS) {
 	const original = console[level].bind(console);
 	console[level] = (...args) => {
 		original(...args);
-		append(level, args);
+		emit(level, args);
 	};
 }
+window.addEventListener("error", (e) => emit("error", [e.error ?? e.message]));
+window.addEventListener("unhandledrejection", (e) => emit("error", ["Unhandled rejection:", e.reason]));
 
-window.addEventListener("error", (e) => {
-	append("error", [e.error ?? e.message]);
-});
-window.addEventListener("unhandledrejection", (e) => {
-	append("error", ["Unhandled rejection:", e.reason]);
+class MoqConsole extends HTMLElement {
+	static observedAttributes = ["level"];
+
+	connectedCallback() {
+		const floating = this.hasAttribute("floating");
+		Object.assign(this.style, {
+			display: "none",
+			flexDirection: "column",
+			maxHeight: floating ? "40vh" : "30vh",
+			overflow: "hidden",
+			font: "12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace",
+			background: "rgba(0, 0, 0, 0.85)",
+			color: "#eee",
+			border: "1px solid #444",
+			borderRadius: "4px",
+		});
+		if (floating) {
+			Object.assign(this.style, {
+				position: "fixed",
+				bottom: "0",
+				left: "0",
+				right: "0",
+				borderRadius: "0",
+				borderLeftWidth: "0",
+				borderRightWidth: "0",
+				borderBottomWidth: "0",
+				zIndex: "2147483647",
+			});
+		}
+
+		// Header bar with the level dropdown pushed to the far right.
+		const header = document.createElement("div");
+		Object.assign(header.style, {
+			display: "flex",
+			alignItems: "center",
+			justifyContent: "space-between",
+			gap: "8px",
+			padding: "2px 8px",
+			borderBottom: "1px solid #333",
+			color: "#888",
+			flex: "0 0 auto",
+		});
+		const label = document.createElement("span");
+		label.textContent = "console";
+		const select = document.createElement("select");
+		Object.assign(select.style, {
+			font: "inherit",
+			background: "#222",
+			color: "#eee",
+			border: "1px solid #444",
+			borderRadius: "3px",
+			padding: "0 2px",
+		});
+		for (const level of LEVELS) {
+			const option = document.createElement("option");
+			option.value = level;
+			option.textContent = level;
+			select.appendChild(option);
+		}
+		select.value = this.levelName();
+		select.addEventListener("change", () => this.setAttribute("level", select.value));
+		this.select = select;
+		header.append(label, select);
+
+		this.body = document.createElement("div");
+		Object.assign(this.body.style, { overflowY: "auto", flex: "1 1 auto" });
+
+		this.replaceChildren(header, this.body);
+
+		this.sink = (entry) => {
+			if (this.shows(entry.level)) this.append(entry);
+		};
+		sinks.add(this.sink);
+		this.render();
+	}
+
+	disconnectedCallback() {
+		sinks.delete(this.sink);
+	}
+
+	attributeChangedCallback() {
+		// Ignore the initial attribute parse; connectedCallback builds the DOM.
+		if (this.body) this.render();
+	}
+
+	levelName() {
+		const name = this.getAttribute("level");
+		return LEVELS.includes(name) ? name : "warn";
+	}
+
+	threshold() {
+		return LEVELS.indexOf(this.levelName());
+	}
+
+	shows(level) {
+		return LEVELS.indexOf(level) >= this.threshold();
+	}
+
+	render() {
+		if (this.select) this.select.value = this.levelName();
+		this.body.replaceChildren();
+		for (const entry of buffer) {
+			if (this.shows(entry.level)) this.append(entry);
+		}
+		this.updateVisibility();
+	}
+
+	updateVisibility() {
+		// A floating fallback stays out of the way until there's something to show;
+		// an explicitly placed inline logger always shows so its dropdown is usable.
+		const hide = this.hasAttribute("floating") && this.body.childElementCount === 0;
+		this.style.display = hide ? "none" : "flex";
+	}
+
+	append(entry) {
+		const line = document.createElement("div");
+		Object.assign(line.style, {
+			padding: "2px 8px",
+			borderTop: this.body.childElementCount ? "1px solid #222" : "none",
+			whiteSpace: "pre-wrap",
+			wordBreak: "break-word",
+			color: COLORS[entry.level] ?? "#eee",
+		});
+		line.textContent = "[" + entry.level + "] " + entry.text;
+		this.body.appendChild(line);
+		this.updateVisibility();
+		this.body.scrollTop = this.body.scrollHeight;
+	}
+}
+customElements.define("moq-console", MoqConsole);
+
+// Fallback: if a page didn't place an inline logger, pin a floating one so
+// output still surfaces automatically.
+window.addEventListener("DOMContentLoaded", () => {
+	if (document.querySelector("moq-console")) return;
+	const el = document.createElement("moq-console");
+	el.setAttribute("floating", "");
+	document.body.appendChild(el);
 });
 `;

--- a/demo/web/console-overlay.ts
+++ b/demo/web/console-overlay.ts
@@ -39,7 +39,9 @@ const COLORS = {
 
 // Buffer messages from the moment this module loads, before any element exists,
 // so an inline <moq-console> added later still shows earlier messages. We patch
-// every level and let each element filter by its own threshold.
+// every level and let each element filter by its own threshold. The buffer is
+// capped so a noisy long-running demo can't grow it without bound.
+const BUFFER_MAX = 1000;
 const buffer = [];
 const sinks = new Set();
 
@@ -48,8 +50,9 @@ function format(args) {
 		.map((a) => {
 			if (a instanceof Error) return a.stack || a.message;
 			if (typeof a === "string") return a;
+			if (a === undefined) return "undefined";
 			try {
-				return JSON.stringify(a);
+				return JSON.stringify(a) ?? String(a);
 			} catch {
 				return String(a);
 			}
@@ -60,7 +63,14 @@ function format(args) {
 function emit(level, args) {
 	const entry = { level, text: format(args) };
 	buffer.push(entry);
-	for (const sink of sinks) sink(entry);
+	if (buffer.length > BUFFER_MAX) buffer.shift();
+	// Never let a misbehaving sink throw out of the patched console method and
+	// break the app's own logging call site.
+	for (const sink of sinks) {
+		try {
+			sink(entry);
+		} catch {}
+	}
 }
 
 for (const level of LEVELS) {

--- a/demo/web/console-overlay.ts
+++ b/demo/web/console-overlay.ts
@@ -36,6 +36,8 @@ const COLORS = {
 	warn: "#ffd480",
 	error: "#ff8080",
 };
+// Max int32: keep the floating overlay above everything else on the page.
+const MAX_Z_INDEX = 2147483647;
 
 // Buffer messages from the moment this module loads, before any element exists,
 // so an inline <moq-console> added later still shows earlier messages. We patch
@@ -109,7 +111,7 @@ class MoqConsole extends HTMLElement {
 				borderLeftWidth: "0",
 				borderRightWidth: "0",
 				borderBottomWidth: "0",
-				zIndex: "2147483647",
+				zIndex: String(MAX_Z_INDEX),
 			});
 		}
 

--- a/demo/web/src/index.html
+++ b/demo/web/src/index.html
@@ -39,6 +39,11 @@
 		</moq-watch-ui>
 	</moq-discover>
 
+	<!-- Dev-only: renders console output inline here. Set `level` to lower the
+	     threshold (debug | log | info | warn | error; defaults to warn). Defined
+	     by the console-overlay Vite plugin; absent from production builds. -->
+	<moq-console></moq-console>
+
 	<h3>Other demos:</h3>
 	<ul>
 		<li><a href="mse.html">Watch a broadcast (MSE).</a></li>

--- a/demo/web/src/manual.html
+++ b/demo/web/src/manual.html
@@ -52,6 +52,11 @@
 		</div>
 	</section>
 
+	<!-- Dev-only: renders console output inline here. Set `level` to lower the
+	     threshold (debug | log | info | warn | error; defaults to warn). Defined
+	     by the console-overlay Vite plugin; absent from production builds. -->
+	<moq-console></moq-console>
+
 	<h3 class="mt-4">Other demos:</h3>
 	<ul>
 		<li><a href="index.html">Watch a broadcast (WebCodecs).</a></li>

--- a/demo/web/src/mse.html
+++ b/demo/web/src/mse.html
@@ -27,6 +27,11 @@
 		</moq-watch-ui>
 	</moq-discover>
 
+	<!-- Dev-only: renders console output inline here. Set `level` to lower the
+	     threshold (debug | log | info | warn | error; defaults to warn). Defined
+	     by the console-overlay Vite plugin; absent from production builds. -->
+	<moq-console></moq-console>
+
 	<h3>Other demos:</h3>
 	<ul>
 		<li><a href="index.html">Watch a broadcast (WebCodecs).</a></li>

--- a/demo/web/src/publish.html
+++ b/demo/web/src/publish.html
@@ -36,6 +36,11 @@
 		</moq-publish>
 	</moq-publish-ui>
 
+	<!-- Dev-only: renders console output inline here. Set `level` to lower the
+	     threshold (debug | log | info | warn | error; defaults to warn). Defined
+	     by the console-overlay Vite plugin; absent from production builds. -->
+	<moq-console></moq-console>
+
 	<h3>Other demos:</h3>
 	<ul>
 		<li><a href="index.html?broadcast=me.hang" target="_blank" rel="noreferrer" id="watch">Watch your broadcast: <span

--- a/demo/web/vite.config.ts
+++ b/demo/web/vite.config.ts
@@ -3,11 +3,12 @@ import { resolve } from "path";
 import { defineConfig } from "vite";
 import solidPlugin from "vite-plugin-solid";
 import { workletInline } from "../../js/common/vite-plugin-worklet";
+import { consoleOverlay } from "./console-overlay";
 
 export default defineConfig({
 	root: "src",
 	envDir: resolve(__dirname),
-	plugins: [tailwindcss(), solidPlugin(), workletInline()],
+	plugins: [tailwindcss(), solidPlugin(), workletInline(), consoleOverlay()],
 	build: {
 		target: "esnext",
 		sourcemap: process.env.NODE_ENV === "production" ? false : "inline",

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -363,7 +363,10 @@ async function connectWebTransport(
 		const fingerprintUrl = new URL(url);
 		fingerprintUrl.pathname = "/certificate.sha256";
 		fingerprintUrl.search = "";
-		console.warn(fingerprintUrl.toString(), "performing an insecure fingerprint fetch; use https:// in production");
+		// Dev-only path: http:// can't be a real WebTransport origin, so we fetch the
+		// self-signed cert's hash over plain HTTP and pin it. Production uses https://
+		// and never reaches here. Keep this at debug so it doesn't read as a problem.
+		console.debug(fingerprintUrl.toString(), "performing an insecure fingerprint fetch; use https:// in production");
 
 		// Fetch the fingerprint from the server.
 		// TODO cancel the request if the effect is cancelled.

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -366,7 +366,10 @@ async function connectWebTransport(
 		// Dev-only path: http:// can't be a real WebTransport origin, so we fetch the
 		// self-signed cert's hash over plain HTTP and pin it. Production uses https://
 		// and never reaches here. Keep this at debug so it doesn't read as a problem.
-		console.debug(fingerprintUrl.toString(), "performing an insecure fingerprint fetch; use https:// in production");
+		console.debug(
+			fingerprintUrl.toString(),
+			"performing an insecure fingerprint fetch; use https:// in production",
+		);
 
 		// Fetch the fingerprint from the server.
 		// TODO cancel the request if the effect is cancelled.


### PR DESCRIPTION
## Summary

Makes the web demos show their `console.warn`/`console.error` (and uncaught errors / unhandled rejections) **on the page**, so an AI driving the demos, that can read the DOM but not the browser console, can see what broke. Humans benefit too.

It's a dev-only Vite plugin, never present in production builds.

## What changed

- **`demo/web/console-overlay.ts`** (new): a `apply: "serve"` Vite plugin that injects a small script into every demo page's `<head>`. The script patches every console level, buffers output from page load, and defines a `<moq-console>` custom element.
- **`<moq-console>` custom element**: drop it anywhere in a page to render captured output inline at that spot. A header bar carries a **level dropdown on the far right** (`debug | log | info | warn | error`) to change verbosity live; the `level` attribute sets the initial threshold and defaults to `warn`. Pages that don't include the element get a **floating fallback** pinned to the bottom (hidden until something logs), so capture stays automatic everywhere.
- **`demo/web/vite.config.ts`**: registers the plugin.
- **`demo/web/src/{index,mse,publish,manual}.html`**: place an inline `<moq-console>` above each page's "Other demos" section.
- **`js/net/src/connection/connect.ts`**: downgrade the insecure-fingerprint-fetch notice from `console.warn` to `console.debug`. That path only runs on `http://` (local dev) and never in production (`https://`), so warning on every connection was pure noise that would trip the overlay on every page load. Comment added explaining the dev-only path.

## Why the `js/net` change

The fingerprint fetch + warning is gated entirely on `url.protocol === "http:"`. Production connects over `https://`, skips the branch, and does normal cert validation. So the warning never fires in production and was only ever dev noise, exactly the kind of false alarm that undermines an "on-page errors" panel.

## Reviewer notes

- **No public API or wire change.** The `js/net` edit is a logging-level change only, so no paired `rs/moq-net` / `doc/concept` update is needed per the Cross-Package Sync table. Targeting `main` accordingly.
- The `<moq-console>` element only exists under the dev server. In a production build the tag is an inert, unstyled, empty inline element (the defining script isn't injected), so it's harmless.
- Verified live in a browser: inline placement renders above "Other demos" in normal flow; the dropdown re-filters output instantly and syncs the `level` attribute; the floating fallback appears only on pages without the element and only once something logs; and the overlay stays empty on a clean load now that the fingerprint notice is `debug`.

(Written by Claude)