### PR TITLE
fix(js): normalize JSR license to a single SPDX id and keep bin shebang on line 1

### DIFF
--- a/js/common/package.ts
+++ b/js/common/package.ts
@@ -154,10 +154,21 @@ function writeJsrConfig() {
 
 	injectSelfTypes();
 
+	// JSR validates the license field as a single recognized SPDX identifier, not
+	// an expression: it rejects "(MIT OR Apache-2.0)". Take the first identifier
+	// from a dual-license expression so the package keeps a valid license field.
+	const license =
+		typeof pkg.license === "string"
+			? pkg.license
+					.replace(/[()]/g, "")
+					.split(/\s+(?:OR|AND)\s+/i)[0]
+					.trim()
+			: undefined;
+
 	const jsr = {
 		name: pkg.name,
 		version: pkg.version,
-		...(pkg.license ? { license: pkg.license } : {}),
+		...(license ? { license } : {}),
 		exports,
 		...(Object.keys(imports).length ? { imports } : {}),
 		// dist is gitignored, so un-ignore it with a "!" negation; JSR honors
@@ -180,6 +191,14 @@ function injectSelfTypes() {
 		const body = readFileSync(js, "utf8");
 		if (body.includes("@ts-self-types")) continue;
 		// Sibling .d.ts (same directory), so just its basename.
-		writeFileSync(js, `/* @ts-self-types="./${basename(dts)}" */\n${body}`);
+		const directive = `/* @ts-self-types="./${basename(dts)}" */\n`;
+		// A shebang (bin entrypoints) must stay on line 1, so insert after it;
+		// otherwise the directive goes first.
+		if (body.startsWith("#!")) {
+			const nl = body.indexOf("\n") + 1;
+			writeFileSync(js, body.slice(0, nl) + directive + body.slice(nl));
+		} else {
+			writeFileSync(js, directive + body);
+		}
 	}
 }


### PR DESCRIPTION
## Problem

The first deno-based **Release JS** run ([run 27508325696](https://github.com/moq-dev/moq/actions/runs/27508325696)) confirmed the download race is gone (`deno publish` ran), but it surfaced two real per-package bugs that `--dry-run` cannot catch:

1. **License rejected on every package.** JSR validates the `license` field server-side with askalono's `is_recognized()`, which matches the whole string against a **single** SPDX identifier/alias - it does **not** parse SPDX expressions. So `(MIT OR Apache-2.0)` (and even `MIT OR Apache-2.0`) is rejected with "license ... was not recognized". Because it's server-side, `deno publish --dry-run` passed locally. (Confirmed by reading [`is_recognized`](https://github.com/jsr-io/jsr/blob/main/api/src/util.rs) in the JSR source.)
2. **`@moq/token` failed to create a tarball.** The `@ts-self-types` directive that `injectSelfTypes` prepends landed **above** the `#!/usr/bin/env node` shebang in `dist/cli.js`, pushing the shebang to line 2 - a syntax error (`Expected ident`).

## Fix

`js/common/package.ts`:

- **License:** emit the first identifier from a dual-license expression, so `(MIT OR Apache-2.0)` → `MIT` (a recognized single SPDX id). The npm `package.json` keeps the full dual expression; only the generated `jsr.json` is normalized, since JSR can't represent an expression.
- **Shebang:** when a built file starts with `#!`, insert the `@ts-self-types` directive **after** the shebang line so it stays on line 1.

## Validation

- `@moq/token`: `dist/cli.js` now has the shebang on line 1, directive on line 2; `deno publish --dry-run` succeeds.
- Generated `jsr.json` `license` is `MIT` for both `token` and `signals`.
- Biome clean.

The license check is server-side so it can't be fully exercised by dry-run, but `MIT` is a standard askalono-recognized identifier, which is exactly what `is_recognized()` requires.

Once merged, the Release JS run should publish all 10 packages.

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)