### PR TITLE
Windows support: dual-stack IPv4/IPv6 sockets, setup.bat, and `just dev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3968,6 +3968,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_with",
+ "socket2",
  "thiserror 2.0.18",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",

--- a/demo/justfile
+++ b/demo/justfile
@@ -31,15 +31,20 @@ default:
     	"just wait $base/certificate.sha256 && just web serve $base/anon"
 
 # Find the first free port at/after `start` (checked on both TCP and UDP).
+# `lsof` isn't available everywhere (e.g. Git Bash on Windows); without it we
+# can't probe, so fall back to `start` and let the relay surface a bind error if
+# it's actually taken.
 [private]
 port start="4443":
     #!/usr/bin/env bash
     set -euo pipefail
     port={{ start }}
-    while lsof -nP -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1 \
-    	|| lsof -nP -iUDP:"$port" -t >/dev/null 2>&1; do
-    	port=$((port + 1))
-    done
+    if command -v lsof >/dev/null 2>&1; then
+    	while lsof -nP -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1 \
+    		|| lsof -nP -iUDP:"$port" -t >/dev/null 2>&1; do
+    		port=$((port + 1))
+    	done
+    fi
     echo "$port"
 
 # Wait for the localhost relay to be ready by repeatedly requesting the cert

--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
 						{ text: "Development", link: "/setup/dev" },
 						{ text: "Production", link: "/setup/prod" },
 						{ text: "Linux Packages", link: "/setup/linux" },
+						{ text: "Windows", link: "/setup/windows" },
 					],
 				},
 				{

--- a/doc/setup/index.md
+++ b/doc/setup/index.md
@@ -44,6 +44,10 @@ just
 
 ## Option 2: Manual Installation
 
+::: tip On Windows?
+See [Windows Setup](/setup/windows) for a `winget`-based `setup.bat` and the `just` PATH caveats.
+:::
+
 If you don't like Nix or enjoy suffering with Windows, then you can manually install the dependencies:
 
 - [Just](https://github.com/casey/just)

--- a/doc/setup/windows.md
+++ b/doc/setup/windows.md
@@ -1,0 +1,107 @@
+---
+title: Windows Setup
+description: Install the MoQ build toolchain on Windows and run a local relay
+---
+
+# Windows Setup
+
+Nix isn't available on Windows, so the toolchain is installed natively with
+[winget](https://learn.microsoft.com/windows/package-manager/winget/). A
+[`setup.bat`](https://github.com/moq-dev/moq/blob/main/setup.bat) script at the
+repo root automates it.
+
+## Quick start
+
+```bat
+git clone https://github.com/moq-dev/moq
+cd moq
+setup.bat
+```
+
+On a fresh machine, run it from an **Administrator** terminal: Git and the
+Visual Studio Build Tools install machine-wide and need elevation. The script
+is safe to re-run; winget skips or upgrades anything already present. It
+installs:
+
+- [Git](https://git-scm.com/), [Rust (rustup)](https://rustup.rs/),
+  [Bun](https://bun.sh/), [Node.js LTS](https://nodejs.org/),
+  [just](https://github.com/casey/just), and [CMake](https://cmake.org/)
+- [GitHub CLI](https://cli.github.com/) and [uv](https://docs.astral.sh/uv/)
+  (for the `py/` workspace)
+- **Visual Studio Build Tools** with the C++ workload, which provides the MSVC
+  linker every Rust MSVC build needs. This step is skipped when the C++ toolset
+  is already installed.
+
+It then runs `rustup update stable` and `bun install`.
+
+::: warning Reopen your terminal after a fresh install
+Tools installed by winget land on `PATH` only for *new* terminals. If the
+script reports that `rustup` or `bun` is "not on PATH yet", close and reopen
+your terminal and run `setup.bat` again. The second run finishes the
+`rustup update` / `bun install` steps.
+:::
+
+## Build and run
+
+```bat
+REM Build the Rust workspace
+cargo build
+
+REM Run a local relay (self-signed cert, anonymous access)
+cargo run --bin moq-relay -- demo/relay/localhost.toml
+```
+
+The relay listens on `[::]:4443` for QUIC and serves its certificate
+fingerprint over HTTP at <http://localhost:4443/certificate.sha256>. Both
+listeners are dual-stack, so IPv4 (`127.0.0.1`) and IPv6 (`[::1]`) both work.
+
+With the relay running, publish and subscribe to a clock in two more terminals:
+
+```bat
+REM Grab the relay's certificate fingerprint
+for /f %f in ('curl -s http://localhost:4443/certificate.sha256') do set FP=%f
+
+REM Publish
+cargo run -p moq-native --example clock -- --url https://localhost:4443/anon --broadcast clock --tls-fingerprint %FP% publish
+
+REM Subscribe (separate terminal)
+cargo run -p moq-native --example clock -- --url https://localhost:4443/anon --broadcast clock --tls-fingerprint %FP% subscribe
+```
+
+The subscriber prints the current time once per second, sourced from the
+publisher through the relay.
+
+## Running the full demo with `just dev`
+
+`just dev` runs the whole demo: a local relay, Big Buck Bunny published through
+it via `ffmpeg`, and the web UI at <http://localhost:5173>.
+
+Run it **from a Git Bash terminal** (installed with Git for Windows), not
+PowerShell or `cmd`:
+
+```bash
+just dev
+```
+
+`just` recipes run through a POSIX shell and need `bash`, `sh`, and `cygpath`.
+Git Bash provides all three plus the `curl`/`sleep`/`seq` the recipes use, and
+inherits `just`/`cargo`/`bun`/`ffmpeg` from your Windows `PATH`. PowerShell and
+`cmd` don't work here: the `bash` they find is the WSL stub, and `cygpath`
+isn't on `PATH`.
+
+::: tip One instance at a time
+The free-port picker uses `lsof`, which Git Bash doesn't ship, so on Windows it
+falls back to port 4443 instead of scanning for a free one. Run a single
+`just dev` at a time.
+:::
+
+::: warning "Access is denied (os error 5)" on rebuild
+Stopping `just dev` can orphan the relay process, and Windows won't let `cargo`
+replace a running `moq-relay.exe`. If a later build fails to remove it, kill the
+leftover process and rebuild:
+
+```bat
+taskkill /IM moq-relay.exe /F
+taskkill /IM moq-cli.exe /F
+```
+:::

--- a/rs/moq-cli/src/web.rs
+++ b/rs/moq-cli/src/web.rs
@@ -53,7 +53,7 @@ pub async fn run_web(
 
 	// Dual-stack so the cert endpoint answers over IPv4 too, even on Windows
 	// where `[::]` is IPv6-only by default.
-	let listener = moq_native::bind_tcp(listen).context("failed to bind web listener")?;
+	let listener = moq_native::bind::tcp(listen).context("failed to bind web listener")?;
 	let server = axum_server::from_tcp(listener)?;
 	server.serve(app.into_make_service()).await?;
 

--- a/rs/moq-cli/src/web.rs
+++ b/rs/moq-cli/src/web.rs
@@ -51,7 +51,10 @@ pub async fn run_web(
 		app = app.fallback_service(handle_404.into_service());
 	}
 
-	let server = axum_server::bind(listen);
+	// Dual-stack so the cert endpoint answers over IPv4 too, even on Windows
+	// where `[::]` is IPv6-only by default.
+	let listener = moq_native::bind_tcp(listen).context("failed to bind web listener")?;
+	let server = axum_server::from_tcp(listener)?;
 	server.serve(app.into_make_service()).await?;
 
 	Ok(())

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -47,6 +47,7 @@ rustls-native-certs = "0.8"
 rustls-webpki = { version = "0.103", features = ["aws-lc-rs"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "3", features = ["hex"] }
+socket2 = "0.6"
 thiserror = "2"
 tikv-jemalloc-ctl = { version = "0.6", optional = true }
 tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"], optional = true }

--- a/rs/moq-native/src/bind.rs
+++ b/rs/moq-native/src/bind.rs
@@ -1,0 +1,78 @@
+//! Dual-stack socket binding.
+//!
+//! Quinn uses a single socket and relies on the OS to route both address
+//! families. On Linux an `[::]` socket accepts IPv4 too, but Windows defaults
+//! `IPV6_V6ONLY` to on, so an IPv6 socket silently drops every IPv4 packet. The
+//! helpers here clear that before binding, so a relay on `[::]` is reachable
+//! over IPv4 and a dual-stack client can dial IPv4 servers (via IPv4-mapped
+//! addresses; the client's address-family matching lives in `util::pick_addr`).
+//! See <https://github.com/moq-dev/moq/issues/1375>.
+
+use socket2::{Domain, Protocol, Socket, Type};
+use std::net::{SocketAddr, TcpListener, UdpSocket};
+
+/// Bind a UDP socket, making an IPv6 socket dual-stack so it also serves IPv4.
+pub fn udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
+	let domain = if addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
+	let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+	make_dual_stack(&socket, addr);
+	socket.bind(&addr.into())?;
+	Ok(socket.into())
+}
+
+/// Bind a TCP listener, making an IPv6 socket dual-stack so it also serves IPv4.
+///
+/// The returned listener is non-blocking, ready for
+/// [`axum_server::from_tcp`](https://docs.rs/axum-server).
+pub fn tcp(addr: SocketAddr) -> std::io::Result<TcpListener> {
+	let domain = if addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
+	let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+	make_dual_stack(&socket, addr);
+	// Match std's TcpListener, which sets SO_REUSEADDR on Unix (not Windows) so a
+	// restarted relay can rebind a port still in TIME_WAIT.
+	#[cfg(not(windows))]
+	socket.set_reuse_address(true)?;
+	socket.bind(&addr.into())?;
+	socket.listen(1024)?;
+	let listener: TcpListener = socket.into();
+	listener.set_nonblocking(true)?;
+	Ok(listener)
+}
+
+/// Clear `IPV6_V6ONLY` so an IPv6 socket also accepts IPv4. Best-effort: a
+/// platform that rejects the option keeps its default rather than failing the
+/// bind. No-op for IPv4 sockets.
+fn make_dual_stack(socket: &Socket, addr: SocketAddr) {
+	if addr.is_ipv6()
+		&& let Err(err) = socket.set_only_v6(false)
+	{
+		tracing::warn!(%err, "failed to enable dual-stack IPv6 socket; IPv4 clients may be unreachable");
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn udp_ipv6_is_dual_stack() {
+		// An IPv6 wildcard bind should come back dual-stack so IPv4 traffic
+		// reaches it. socket2 lets us read the option back to confirm.
+		let socket = udp("[::]:0".parse().unwrap()).unwrap();
+		let socket = Socket::from(socket);
+		assert!(!socket.only_v6().unwrap(), "IPv6 socket should be dual-stack");
+	}
+
+	#[test]
+	fn udp_ipv4_still_binds() {
+		let socket = udp("127.0.0.1:0".parse().unwrap()).unwrap();
+		assert!(socket.local_addr().unwrap().is_ipv4());
+	}
+
+	#[test]
+	fn tcp_ipv6_is_dual_stack() {
+		let listener = tcp("[::]:0".parse().unwrap()).unwrap();
+		let socket = Socket::from(listener);
+		assert!(!socket.only_v6().unwrap(), "IPv6 listener should be dual-stack");
+	}
+}

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -11,6 +11,7 @@
 /// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
 pub(crate) const DEFAULT_MAX_STREAMS: u64 = 1024;
 
+pub mod bind;
 mod client;
 mod connect;
 mod crypto;
@@ -38,7 +39,6 @@ pub use error::{Error, Result};
 pub use log::*;
 pub use reconnect::*;
 pub use server::*;
-pub use util::bind_tcp;
 
 // Re-export these crates.
 pub use moq_net;

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -38,6 +38,7 @@ pub use error::{Error, Result};
 pub use log::*;
 pub use reconnect::*;
 pub use server::*;
+pub use util::bind_tcp;
 
 // Re-export these crates.
 pub use moq_net;

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -121,7 +121,7 @@ pub(crate) struct NoqClient {
 
 impl NoqClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
-		let socket = std::net::UdpSocket::bind(config.bind).map_err(Error::BindSocket)?;
+		let socket = crate::util::bind_udp(config.bind).map_err(Error::BindSocket)?;
 
 		let mut transport = noq::TransportConfig::default();
 		transport.max_idle_timeout(Some(time::Duration::from_secs(30).try_into().unwrap()));
@@ -366,7 +366,7 @@ impl NoqServer {
 			}));
 		}
 
-		let socket = std::net::UdpSocket::bind(listen).map_err(Error::BindSocket)?;
+		let socket = crate::util::bind_udp(listen).map_err(Error::BindSocket)?;
 
 		// Create the generic QUIC endpoint.
 		let quic = noq::Endpoint::new(endpoint_config, Some(tls), socket, runtime).map_err(Error::CreateEndpoint)?;

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -121,7 +121,7 @@ pub(crate) struct NoqClient {
 
 impl NoqClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
-		let socket = crate::util::bind_udp(config.bind).map_err(Error::BindSocket)?;
+		let socket = crate::bind::udp(config.bind).map_err(Error::BindSocket)?;
 
 		let mut transport = noq::TransportConfig::default();
 		transport.max_idle_timeout(Some(time::Duration::from_secs(30).try_into().unwrap()));
@@ -366,7 +366,7 @@ impl NoqServer {
 			}));
 		}
 
-		let socket = crate::util::bind_udp(listen).map_err(Error::BindSocket)?;
+		let socket = crate::bind::udp(listen).map_err(Error::BindSocket)?;
 
 		// Create the generic QUIC endpoint.
 		let quic = noq::Endpoint::new(endpoint_config, Some(tls), socket, runtime).map_err(Error::CreateEndpoint)?;

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -122,7 +122,7 @@ pub(crate) struct QuinnClient {
 
 impl QuinnClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
-		let socket = crate::util::bind_udp(config.bind).map_err(Error::BindSocket)?;
+		let socket = crate::bind::udp(config.bind).map_err(Error::BindSocket)?;
 
 		// TODO Validate the BBR implementation before enabling it
 		let mut transport = quinn::TransportConfig::default();
@@ -386,7 +386,7 @@ impl QuinnServer {
 			endpoint_config.cid_generator(move || Box::new(ServerIdGenerator::new(server_id.clone(), nonce_len)));
 		}
 
-		let socket = crate::util::bind_udp(listen).map_err(Error::BindSocket)?;
+		let socket = crate::bind::udp(listen).map_err(Error::BindSocket)?;
 
 		// Create the generic QUIC endpoint.
 		let quic = quinn::Endpoint::new(endpoint_config, Some(tls), socket, runtime).map_err(Error::CreateEndpoint)?;

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -122,7 +122,7 @@ pub(crate) struct QuinnClient {
 
 impl QuinnClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
-		let socket = std::net::UdpSocket::bind(config.bind).map_err(Error::BindSocket)?;
+		let socket = crate::util::bind_udp(config.bind).map_err(Error::BindSocket)?;
 
 		// TODO Validate the BBR implementation before enabling it
 		let mut transport = quinn::TransportConfig::default();
@@ -386,7 +386,7 @@ impl QuinnServer {
 			endpoint_config.cid_generator(move || Box::new(ServerIdGenerator::new(server_id.clone(), nonce_len)));
 		}
 
-		let socket = std::net::UdpSocket::bind(listen).map_err(Error::BindSocket)?;
+		let socket = crate::util::bind_udp(listen).map_err(Error::BindSocket)?;
 
 		// Create the generic QUIC endpoint.
 		let quic = quinn::Endpoint::new(endpoint_config, Some(tls), socket, runtime).map_err(Error::CreateEndpoint)?;

--- a/rs/moq-native/src/util.rs
+++ b/rs/moq-native/src/util.rs
@@ -1,57 +1,4 @@
-use std::net::{IpAddr, SocketAddr, TcpListener, UdpSocket};
-
-/// Clear `IPV6_V6ONLY` on an IPv6 socket so it also serves IPv4.
-///
-/// On Linux an `[::]` socket accepts IPv4 too, but Windows defaults this option
-/// to on, so an IPv6 socket silently drops every IPv4 packet. Best-effort: a
-/// platform that rejects the option keeps its default rather than failing the
-/// bind. No-op for IPv4 sockets. See <https://github.com/moq-dev/moq/issues/1375>.
-fn make_dual_stack(socket: &socket2::Socket, addr: SocketAddr) {
-	if addr.is_ipv6()
-		&& let Err(err) = socket.set_only_v6(false)
-	{
-		tracing::warn!(%err, "failed to enable dual-stack IPv6 socket; IPv4 clients may be unreachable");
-	}
-}
-
-/// Bind a UDP socket, making IPv6 sockets dual-stack so they also serve IPv4.
-///
-/// Quinn uses a single socket and relies on the OS to route both address
-/// families, so a relay on `[::]` is reachable over IPv4 and a client on `[::]`
-/// can dial IPv4 servers (via IPv4-mapped addresses; see [`pick_addr`]). See
-/// [`make_dual_stack`] for the Windows rationale.
-pub(crate) fn bind_udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
-	use socket2::{Domain, Protocol, Socket, Type};
-
-	let domain = if addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
-	let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
-	make_dual_stack(&socket, addr);
-	socket.bind(&addr.into())?;
-	Ok(socket.into())
-}
-
-/// Bind a TCP listener, making IPv6 sockets dual-stack so they also serve IPv4.
-///
-/// Mirrors [`bind_udp`] for the relay's HTTP/HTTPS listeners (cert fingerprint
-/// and WebSocket fallback), which `axum_server` otherwise binds single-stack and
-/// would leave unreachable over IPv4 on Windows. The returned listener is
-/// non-blocking, ready for [`axum_server::from_tcp`](https://docs.rs/axum-server).
-pub fn bind_tcp(addr: SocketAddr) -> std::io::Result<TcpListener> {
-	use socket2::{Domain, Protocol, Socket, Type};
-
-	let domain = if addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
-	let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
-	make_dual_stack(&socket, addr);
-	// Match std's TcpListener, which sets SO_REUSEADDR on Unix (not Windows) so a
-	// restarted relay can rebind a port still in TIME_WAIT.
-	#[cfg(not(windows))]
-	socket.set_reuse_address(true)?;
-	socket.bind(&addr.into())?;
-	socket.listen(1024)?;
-	let listener: TcpListener = socket.into();
-	listener.set_nonblocking(true)?;
-	Ok(listener)
-}
+use std::net::{IpAddr, SocketAddr};
 
 /// Resolve a `host:port` string to a single [`std::net::SocketAddr`],
 /// falling back to `default` when `addr` is `None`.
@@ -114,21 +61,6 @@ fn normalize_family(addr: SocketAddr, local: SocketAddr) -> SocketAddr {
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	#[test]
-	fn bind_udp_ipv6_is_dual_stack() {
-		// An IPv6 wildcard bind should come back dual-stack so IPv4 traffic
-		// reaches it. socket2 lets us read the option back to confirm.
-		let socket = bind_udp("[::]:0".parse().unwrap()).unwrap();
-		let socket = socket2::Socket::from(socket);
-		assert!(!socket.only_v6().unwrap(), "IPv6 socket should be dual-stack");
-	}
-
-	#[test]
-	fn bind_udp_ipv4_still_binds() {
-		let socket = bind_udp("127.0.0.1:0".parse().unwrap()).unwrap();
-		assert!(socket.local_addr().unwrap().is_ipv4());
-	}
 
 	#[test]
 	fn resolves_socket_literal() {

--- a/rs/moq-native/src/util.rs
+++ b/rs/moq-native/src/util.rs
@@ -1,4 +1,57 @@
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, SocketAddr, TcpListener, UdpSocket};
+
+/// Clear `IPV6_V6ONLY` on an IPv6 socket so it also serves IPv4.
+///
+/// On Linux an `[::]` socket accepts IPv4 too, but Windows defaults this option
+/// to on, so an IPv6 socket silently drops every IPv4 packet. Best-effort: a
+/// platform that rejects the option keeps its default rather than failing the
+/// bind. No-op for IPv4 sockets. See <https://github.com/moq-dev/moq/issues/1375>.
+fn make_dual_stack(socket: &socket2::Socket, addr: SocketAddr) {
+	if addr.is_ipv6()
+		&& let Err(err) = socket.set_only_v6(false)
+	{
+		tracing::warn!(%err, "failed to enable dual-stack IPv6 socket; IPv4 clients may be unreachable");
+	}
+}
+
+/// Bind a UDP socket, making IPv6 sockets dual-stack so they also serve IPv4.
+///
+/// Quinn uses a single socket and relies on the OS to route both address
+/// families, so a relay on `[::]` is reachable over IPv4 and a client on `[::]`
+/// can dial IPv4 servers (via IPv4-mapped addresses; see [`pick_addr`]). See
+/// [`make_dual_stack`] for the Windows rationale.
+pub(crate) fn bind_udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
+	use socket2::{Domain, Protocol, Socket, Type};
+
+	let domain = if addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
+	let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+	make_dual_stack(&socket, addr);
+	socket.bind(&addr.into())?;
+	Ok(socket.into())
+}
+
+/// Bind a TCP listener, making IPv6 sockets dual-stack so they also serve IPv4.
+///
+/// Mirrors [`bind_udp`] for the relay's HTTP/HTTPS listeners (cert fingerprint
+/// and WebSocket fallback), which `axum_server` otherwise binds single-stack and
+/// would leave unreachable over IPv4 on Windows. The returned listener is
+/// non-blocking, ready for [`axum_server::from_tcp`](https://docs.rs/axum-server).
+pub fn bind_tcp(addr: SocketAddr) -> std::io::Result<TcpListener> {
+	use socket2::{Domain, Protocol, Socket, Type};
+
+	let domain = if addr.is_ipv4() { Domain::IPV4 } else { Domain::IPV6 };
+	let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+	make_dual_stack(&socket, addr);
+	// Match std's TcpListener, which sets SO_REUSEADDR on Unix (not Windows) so a
+	// restarted relay can rebind a port still in TIME_WAIT.
+	#[cfg(not(windows))]
+	socket.set_reuse_address(true)?;
+	socket.bind(&addr.into())?;
+	socket.listen(1024)?;
+	let listener: TcpListener = socket.into();
+	listener.set_nonblocking(true)?;
+	Ok(listener)
+}
 
 /// Resolve a `host:port` string to a single [`std::net::SocketAddr`],
 /// falling back to `default` when `addr` is `None`.
@@ -61,6 +114,21 @@ fn normalize_family(addr: SocketAddr, local: SocketAddr) -> SocketAddr {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn bind_udp_ipv6_is_dual_stack() {
+		// An IPv6 wildcard bind should come back dual-stack so IPv4 traffic
+		// reaches it. socket2 lets us read the option back to confirm.
+		let socket = bind_udp("[::]:0".parse().unwrap()).unwrap();
+		let socket = socket2::Socket::from(socket);
+		assert!(!socket.only_v6().unwrap(), "IPv6 socket should be dual-stack");
+	}
+
+	#[test]
+	fn bind_udp_ipv4_still_binds() {
+		let socket = bind_udp("127.0.0.1:0".parse().unwrap()).unwrap();
+		assert!(socket.local_addr().unwrap().is_ipv4());
+	}
 
 	#[test]
 	fn resolves_socket_literal() {

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -154,7 +154,7 @@ impl Web {
 		let http = if let Some(listen) = self.config.http.listen {
 			// Dual-stack so the cert endpoint + WebSocket fallback answer over IPv4
 			// too, even on Windows where `[::]` is IPv6-only by default.
-			let listener = moq_native::bind_tcp(listen).context("failed to bind HTTP listener")?;
+			let listener = moq_native::bind::tcp(listen).context("failed to bind HTTP listener")?;
 			let server = axum_server::from_tcp(listener)?;
 			Some(server.serve(app.clone()))
 		} else {
@@ -178,7 +178,7 @@ impl Web {
 			let acceptor = MtlsAcceptor {
 				inner: RustlsAcceptor::new(rustls_config),
 			};
-			let listener = moq_native::bind_tcp(listen).context("failed to bind HTTPS listener")?;
+			let listener = moq_native::bind::tcp(listen).context("failed to bind HTTPS listener")?;
 			let server = axum_server::from_tcp(listener)?.acceptor(acceptor);
 			Some(server.serve(app))
 		} else {

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -7,6 +7,7 @@ use std::{
 	task::{Context, Poll, ready},
 };
 
+use anyhow::Context as _;
 use axum::{
 	Router,
 	body::Body,
@@ -151,7 +152,10 @@ impl Web {
 			.into_make_service();
 
 		let http = if let Some(listen) = self.config.http.listen {
-			let server = axum_server::bind(listen);
+			// Dual-stack so the cert endpoint + WebSocket fallback answer over IPv4
+			// too, even on Windows where `[::]` is IPv6-only by default.
+			let listener = moq_native::bind_tcp(listen).context("failed to bind HTTP listener")?;
+			let server = axum_server::from_tcp(listener)?;
 			Some(server.serve(app.clone()))
 		} else {
 			None
@@ -174,7 +178,8 @@ impl Web {
 			let acceptor = MtlsAcceptor {
 				inner: RustlsAcceptor::new(rustls_config),
 			};
-			let server = axum_server::bind(listen).acceptor(acceptor);
+			let listener = moq_native::bind_tcp(listen).context("failed to bind HTTPS listener")?;
+			let server = axum_server::from_tcp(listener)?.acceptor(acceptor);
 			Some(server.serve(app))
 		} else {
 			None
@@ -205,7 +210,6 @@ async fn build_https_config(
 	key: &std::path::Path,
 	root: &[PathBuf],
 ) -> anyhow::Result<rustls::ServerConfig> {
-	use anyhow::Context;
 	use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
 	use rustls::server::WebPkiClientVerifier;
 

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,72 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM MoQ developer setup for Windows.
+REM
+REM Installs the toolchain needed to build the Rust workspace and JS packages
+REM using winget. Safe to re-run: winget skips or upgrades anything already
+REM present. See doc/setup/windows.md for the manual steps and known caveats.
+REM ---------------------------------------------------------------------------
+
+echo === MoQ Windows setup ===
+echo.
+echo Tip: on a fresh machine, run this from an Administrator terminal so winget
+echo can install Git and the Visual Studio Build Tools, which need elevation.
+echo.
+
+where winget >nul 2>nul
+if errorlevel 1 (
+	echo ERROR: winget not found.
+	echo Install "App Installer" from the Microsoft Store ^(or Windows Update^), then re-run.
+	exit /b 1
+)
+
+REM No --disable-interactivity: let winget prompt for elevation (UAC) so Git and
+REM the Build Tools can install on a fresh, non-Administrator machine.
+set "WG=winget install -e --source winget --accept-package-agreements --accept-source-agreements"
+
+echo --- Git ---
+%WG% --id Git.Git
+echo --- Rust ^(rustup^) ---
+%WG% --id Rustlang.Rustup
+echo --- Bun ---
+%WG% --id Oven-sh.Bun
+echo --- Node.js LTS ---
+%WG% --id OpenJS.NodeJS.LTS
+echo --- just ---
+%WG% --id Casey.Just
+echo --- CMake ---
+%WG% --id Kitware.CMake
+echo --- FFmpeg ^(CLI, for the `just dev` demo media^) ---
+%WG% --id Gyan.FFmpeg
+echo --- GitHub CLI ---
+%WG% --id GitHub.cli
+echo --- uv ^(Python, for the py/ workspace^) ---
+%WG% --id astral-sh.uv
+
+REM MSVC linker + C++ headers, required for any Rust MSVC build. winget skips
+REM this when it's already installed and current. The --override adds the C++
+REM workload on a fresh install (a bare Build Tools install has no compiler).
+echo --- Visual Studio Build Tools ^(C++ workload^) ---
+%WG% --id Microsoft.VisualStudio.2022.BuildTools --override "--quiet --wait --norestart --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+
+echo.
+echo === Updating the Rust toolchain ^(the workspace needs a recent stable^) ===
+where rustup >nul 2>nul && ( rustup default stable & rustup update stable ) || echo NOTE: rustup not on PATH yet. Reopen your terminal, then run: rustup update stable
+
+echo.
+echo === Installing JS dependencies ^(bun install^) ===
+where bun >nul 2>nul && bun install || echo NOTE: bun not on PATH yet. Reopen your terminal, then run: bun install
+
+echo.
+echo === Done ===
+echo If anything above said "not on PATH yet", CLOSE and REOPEN your terminal so
+echo the freshly installed tools are picked up, then re-run this script.
+echo.
+echo Next steps:
+echo   cargo build                                     ^(build the Rust workspace^)
+echo   cargo run --bin moq-relay -- demo/relay/localhost.toml   ^(run a local relay^)
+echo.
+echo See doc/setup/windows.md for running the demo components and the `just` PATH note.
+
+endlocal


### PR DESCRIPTION
## What

Two related changes that get MoQ building, running, and developing on Windows.

### 1. Dual-stack IPv6 sockets (the bug)

Quinn and the relay's axum HTTP/HTTPS listeners bind a single `[::]` socket and rely on the OS to route both address families. Linux does, but Windows defaults `IPV6_V6ONLY` to **on**, so an IPv6 socket silently drops all IPv4 traffic. The result on Windows:

- a relay on `[::]` is unreachable over `127.0.0.1` (both QUIC/UDP and the cert/WebSocket HTTP listener), and
- a client on `[::]` cannot dial an IPv4 server (the existing `pick_addr` IPv4-mapping only works on a dual-stack socket).

Fix: clear `IPV6_V6ONLY` before binding, via `socket2`. The helpers live in a new `pub mod bind`:

- `bind::udp` backs the quinn and noq client/server sockets (`crate::bind::udp`).
- `bind::tcp` backs the relay and CLI HTTP/HTTPS listeners through `axum_server::from_tcp`.

### 2. Windows onboarding

- `setup.bat` at the repo root: a `winget`-based installer for the Rust + JS toolchain, the MSVC C++ Build Tools, the `ffmpeg` CLI (demo media), and `gh`/`uv`. Idempotent.
- `doc/setup/windows.md` (registered in the sidebar, linked from the setup index).
- The demo free-port picker now guards `lsof` behind `command -v` and falls back to the start port when it is missing (Git Bash ships no `lsof`). This unblocks `just dev`.

## Why

Out of the box on Windows: `cargo build` worked only after `rustup update` (deps need a recent stable), the relay/clients couldn't talk over IPv4, and `just dev` failed on `lsof` + the missing POSIX shell.

## Verification (Windows 11, MSVC toolchain)

- Core workspace builds; `moq-native` + `moq-relay` tests pass (the 16 `auth::tests` failures are pre-existing and reproduce on the base tree: a Windows temp-path-as-URL fixture issue, unrelated to this change).
- `cargo doc` with `-D warnings` is clean on `moq-native`.
- End-to-end over **IPv4** (`127.0.0.1`): HTTP cert fetch and a QUIC publish/subscribe clock round-trip both succeed; the relay logs the client as `::ffff:127.0.0.1`. Both were connection-refused before.
- `just dev` from a Git Bash terminal runs the relay, publishes Big Buck Bunny via ffmpeg, and serves the web UI at `localhost:5173` (playback confirmed).

## Reviewer notes

- **Public API**: adds the `moq_native::bind` module with `bind::tcp` and `bind::udp` (additive, non-breaking). Targets `main` per the branch rules (bug fix + additive).
- `cargo clippy` on this machine flags ~20 pre-existing `result_large_err` lints in `quinn.rs`/`tls.rs`; they come from clippy 1.96 being newer than the Nix-pinned toolchain, not from this change. None are in the new code.
- `setup.bat` was run on a real machine; the `just dev` chain was smoke-tested end to end.

(Written by Claude)