### PR TITLE
fix(js): fix JSR doc-gen for libraries; exclude web-component packages

### DIFF
--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -263,6 +263,6 @@ export default defineConfig({
 	ignoreDeadLinks: [
 		// Localhost URLs are intentional for development examples and aren't
 		// reachable at build time (e.g. the relay on :4443, the dev server on :5173).
-		/^https?:\/\/localhost(:\d+)?(\/|$)/,
+		/^https?:\/\/localhost(:\d+)?(\/|\?|#|$)/,
 	],
 });

--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -261,7 +261,8 @@ export default defineConfig({
 	},
 
 	ignoreDeadLinks: [
-		// Localhost URLs are intentional for development
-		"http://localhost:5173",
+		// Localhost URLs are intentional for development examples and aren't
+		// reachable at build time (e.g. the relay on :4443, the dev server on :5173).
+		/^https?:\/\/localhost(:\d+)?(\/|$)/,
 	],
 });

--- a/js/common/package.ts
+++ b/js/common/package.ts
@@ -14,9 +14,11 @@ const pkg = JSON.parse(readFileSync("package.json", "utf8"));
 // JSR config can map them to the built (.js) entrypoints.
 const srcExports: Record<string, unknown> = structuredClone(pkg.exports ?? {});
 
-// Publish to JSR alongside npm for every package that publishes at all, i.e. one
-// with a release script. Captured before pkg.scripts is cleared below.
-const publishJsr = Boolean(pkg.scripts?.release);
+// Publish to JSR alongside npm for every package that publishes at all (has a
+// release script), unless it opts out with "jsr": false. The web-component
+// packages opt out: JSR forbids the HTMLElementTagNameMap global augmentation
+// every custom element needs. Captured before pkg.scripts/jsr are cleared below.
+const publishJsr = Boolean(pkg.scripts?.release) && pkg.jsr !== false;
 
 function rewritePath(p: string, ext: string): string {
 	return p.replace(/^\.\/src/, ".").replace(/\.ts(x)?$/, `.${ext}`);
@@ -90,6 +92,7 @@ rewriteWorkspaceDependency(pkg.peerDependencies);
 
 pkg.devDependencies = undefined;
 pkg.scripts = undefined;
+pkg.jsr = undefined; // JSR opt-out flag, not part of the npm package
 
 // Write the rewritten package.json
 writeFileSync("dist/package.json", JSON.stringify(pkg, null, 2));
@@ -153,6 +156,7 @@ function writeJsrConfig() {
 	}
 
 	injectSelfTypes();
+	rewriteDtsImports();
 
 	// JSR validates the license field as a single recognized SPDX identifier, not
 	// an expression: it rejects "(MIT OR Apache-2.0)". Take the first identifier
@@ -178,6 +182,22 @@ function writeJsrConfig() {
 
 	writeFileSync("jsr.json", JSON.stringify(jsr, null, 2));
 	console.log("📦 jsr.json written");
+}
+
+function rewriteDtsImports() {
+	// JSR's doc generator resolves the .d.ts import graph and can't handle a
+	// ".ts" extension (the dist ships .js/.d.ts, not .ts) or a bare "." specifier.
+	// Normalize those in the declarations so doc generation resolves. Only the
+	// .d.ts needs this; the .js keeps its own specifiers for npm consumers.
+	const glob = new Bun.Glob("**/*.d.ts");
+	for (const rel of glob.scanSync("dist")) {
+		const file = join("dist", rel);
+		const body = readFileSync(file, "utf8");
+		const next = body
+			.replace(/(from\s+"\.[^"]*?)\.ts"/g, '$1"') // "./x.ts" -> "./x"
+			.replace(/(from\s+")\.(")/g, "$1./index$2"); // "." -> "./index"
+		if (next !== body) writeFileSync(file, next);
+	}
 }
 
 function injectSelfTypes() {

--- a/js/common/release.ts
+++ b/js/common/release.ts
@@ -5,8 +5,10 @@ const dryRun = process.argv.includes("--dry-run") || process.env.DRY_RUN === "tr
 // Read package.json to get name, version, and whether to also publish to JSR.
 const pkg = JSON.parse(await Bun.file("package.json").text());
 const { name, version } = pkg;
-// Anything that publishes to npm (has a release script) also publishes to JSR.
-const publishJsr = Boolean(pkg.scripts?.release);
+// Anything that publishes to npm (this script runs) also publishes to JSR,
+// unless it opts out with "jsr": false (the web-component packages do, since JSR
+// forbids the global type augmentation custom elements need).
+const publishJsr = pkg.jsr !== false;
 
 // Whether this exact version already exists on each registry. The two are
 // checked independently so a package can be onboarded onto JSR even when its
@@ -79,9 +81,9 @@ if (publishJsr) {
 		"--no-check",
 		"--allow-dirty",
 	];
-	// The libs ship explicit .d.ts and have no slow types. The web-component
-	// packages use global type augmentations that fast-check rejects, so opt out
-	// when that env is set (the release workflow sets it).
+	// Only libs publish to JSR now (web components opt out), and their built
+	// .d.ts has explicit types, so slow types shouldn't appear. Keep this as a
+	// safety valve the release workflow can toggle without a code change.
 	if (process.env.JSR_ALLOW_SLOW_TYPES === "true") args.push("--allow-slow-types");
 	if (dryRun) {
 		console.log(`🧪 Publishing ${name}@${version} to JSR (dry-run)...`);

--- a/js/common/release.ts
+++ b/js/common/release.ts
@@ -5,10 +5,12 @@ const dryRun = process.argv.includes("--dry-run") || process.env.DRY_RUN === "tr
 // Read package.json to get name, version, and whether to also publish to JSR.
 const pkg = JSON.parse(await Bun.file("package.json").text());
 const { name, version } = pkg;
-// Anything that publishes to npm (this script runs) also publishes to JSR,
-// unless it opts out with "jsr": false (the web-component packages do, since JSR
-// forbids the global type augmentation custom elements need).
-const publishJsr = pkg.jsr !== false;
+// Publish to JSR alongside npm, unless the package opts out with "jsr": false
+// (the web-component packages do, since JSR forbids the global type augmentation
+// custom elements need). Same predicate as package.ts so the manifest it
+// generates and the publish here stay in lockstep; the release-script clause is
+// always true here (this file is the release script).
+const publishJsr = Boolean(pkg.scripts?.release) && pkg.jsr !== false;
 
 // Whether this exact version already exists on each registry. The two are
 // checked independently so a package can be onboarded onto JSR even when its

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -2,6 +2,7 @@
 	"name": "@moq/boy",
 	"type": "module",
 	"version": "0.2.10",
+	"jsr": false,
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": {

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -2,6 +2,7 @@
 	"name": "@moq/publish",
 	"type": "module",
 	"version": "0.2.14",
+	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -2,6 +2,7 @@
 	"name": "@moq/watch",
 	"type": "module",
 	"version": "0.2.16",
+	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",


### PR DESCRIPTION
## Where we are

The deno-based release ([run 27509033095](https://github.com/moq-dev/moq/actions/runs/27509033095)) **published 5 libraries to JSR**: `token`, `json`, `loc`, `msf`, `hang`. It then exposed two more server-side issues (invisible to `deno publish --dry-run`, but reproducible with `deno doc`):

## Issues fixed

**1. Doc-gen can't resolve `.ts` extensions or bare `.` in the published `.d.ts`.**
JSR generates the API docs by resolving the `.d.ts` import graph. The dist ships `.js`/`.d.ts` (no `.ts`), so:
- `net`'s `export * as Connection from "./connection/index.ts"` → `Failed resolving './connection/index.ts'`
- `signals`' `dom.ts` `import ... from "."` → `Failed resolving './/'`

Fix: normalize the **emitted `.d.ts`** in `package.ts` - strip `.ts` extensions and rewrite bare `"."` → `"./index"`. Only declarations are touched; the `.js` keeps its specifiers for npm consumers. (The successful libs already used extensionless imports, which is why they worked.)

**2. Web components fundamentally can't publish to JSR.**
`watch`/`publish`/`boy` fail with `modifying global types is not allowed` - every custom element augments `HTMLElementTagNameMap`, and JSR prohibits global type modification outright (`--allow-slow-types` only silenced the *warning*). This isn't fixable without dropping the custom-element typing, so these three **opt out** with `"jsr": false`. `publishJsr` now honors that (still defaults on for everything else with a `release` script).

## Validation

All **7 libraries** pass `deno doc` locally - the exact doc generation `deno publish` runs - across every entrypoint in their generated `jsr.json`:

```
net: OK   signals: OK   json: OK   msf: OK   hang: OK   loc: OK   token: OK
```

The 3 web-component packages no longer generate a `jsr.json`. Biome clean.

After merge, the release should skip the 5 already-published libs, publish `net` + `signals`, and skip the 3 web components → green, with all 7 libraries on JSR.

## Note on why this took several rounds

`deno publish --dry-run` validates packaging and slow types, but **license validation and documentation generation only happen server-side at publish**, so each surfaced only on a real run. `deno doc` reproduces the doc-gen step locally and is now part of how these were verified.

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also (folded in from #1734)

The `Check` workflow was failing on a pre-existing docs dead link from #1732 (`http://localhost:4443/certificate.sha256` in `setup/windows.md`). Generalized the VitePress `ignoreDeadLinks` localhost exemption to a regex so dev-example URLs do not break the doc build. Folded here so this PR is green on its own; #1734 closed as superseded.
