### PR TITLE
fix(doc): ignore all localhost URLs in the dead-link check

### DIFF
--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -261,7 +261,8 @@ export default defineConfig({
 	},
 
 	ignoreDeadLinks: [
-		// Localhost URLs are intentional for development
-		"http://localhost:5173",
+		// Localhost URLs are intentional for development examples and aren't
+		// reachable at build time (e.g. the relay on :4443, the dev server on :5173).
+		/^https?:\/\/localhost(:\d+)?(\/|$)/,
 	],
 });


### PR DESCRIPTION
## Problem

The `Check` workflow is failing on **every** PR (including unrelated ones) because the VitePress doc build dies on a dead link:

```
moq-doc build: (!) Found dead link http://localhost:4443/certificate.sha256 in file setup/windows.md
x Build failed
```

[#1732](https://github.com/moq-dev/moq/pull/1732) ("Windows support") added an autolink to `http://localhost:4443/certificate.sha256` in `doc/setup/windows.md`. VitePress can't reach that localhost URL at build time, so the dead-link check fails. The config already exempts `http://localhost:5173`, but not `:4443`.

## Fix

Generalize the existing localhost exemption from a single literal to a regex matching any localhost URL (any port/path), so development-example links don't break the build going forward:

```ts
ignoreDeadLinks: [
  /^https?:\/\/localhost(:\d+)?(\/|$)/,
],
```

## Validation

`cd doc && bun run build` (via `nix develop`) now completes (`✓ building`, `✓ rendering pages`) with no dead-link error. Biome clean.

This unblocks CI for all open PRs.

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)