### PR TITLE
kio: rework Producer::poll/wait to a read-only predicate that returns a Mut

### DIFF
--- a/rs/kio/CHANGELOG.md
+++ b/rs/kio/CHANGELOG.md
@@ -9,15 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replaced the `Mut`-closure poll APIs (`Producer::poll`, `Producer::wait`,
-  `Weak::poll_write`, `Weak::wait`) with `Producer::poll_write_when` and its
-  async sibling `Producer::write_when`. The old variants handed the closure a
-  `Mut` and auto-notified consumers whenever it touched the value via
+- Reworked `Producer::poll` / `Producer::wait`. They previously handed the
+  closure a `Mut` and auto-notified consumers whenever it touched the value via
   `DerefMut`. Since a no-op like `Vec::pop` on an empty queue still trips
   `DerefMut`, a pending poll would wake the polling task's own waiter and spin
-  into an infinite loop. `write_when` evaluates a read-only predicate over a
-  `Ref`, then on `Poll::Ready` hands back a `Mut` (lock still held) so the
-  caller mutates atomically without the footgun.
+  into an infinite loop. They now take a read-only predicate over a `Ref` and,
+  on `Poll::Ready`, hand back a `Mut` with the lock still held so the caller
+  mutates atomically without the footgun. `Weak::poll_write` / `Weak::wait` had
+  no users and are removed.
 
 ## [0.3.0] - 2026-05-29
 

--- a/rs/kio/CHANGELOG.md
+++ b/rs/kio/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced the `Mut`-closure poll APIs (`Producer::poll`, `Producer::wait`,
+  `Weak::poll_write`, `Weak::wait`) with `Producer::poll_drain` /
+  `Weak::poll_drain`. The old variants auto-notified consumers whenever the
+  closure touched the value via `DerefMut`, which could wake the polling task's
+  own waiter and spin into an infinite loop. The replacements hand out plain
+  `&mut T` and never notify. Use `write()` to mutate-and-notify.
+
 ## [0.3.0] - 2026-05-29
 
 ### Other

--- a/rs/kio/CHANGELOG.md
+++ b/rs/kio/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced the `Mut`-closure poll APIs (`Producer::poll`, `Producer::wait`,
-  `Weak::poll_write`, `Weak::wait`) with `Producer::poll_drain` /
-  `Weak::poll_drain`. The old variants auto-notified consumers whenever the
-  closure touched the value via `DerefMut`, which could wake the polling task's
-  own waiter and spin into an infinite loop. The replacements hand out plain
-  `&mut T` and never notify. Use `write()` to mutate-and-notify.
+  `Weak::poll_write`, `Weak::wait`) with `Producer::poll_write_when`. The old
+  variants handed the closure a `Mut` and auto-notified consumers whenever it
+  touched the value via `DerefMut`. Since a no-op like `Vec::pop` on an empty
+  queue still trips `DerefMut`, a pending poll would wake the polling task's own
+  waiter and spin into an infinite loop. `poll_write_when` evaluates a read-only
+  predicate over a `Ref`, then on `Poll::Ready` hands back a `Mut` (lock still
+  held) so the caller mutates atomically without the footgun.
 
 ## [0.3.0] - 2026-05-29
 

--- a/rs/kio/CHANGELOG.md
+++ b/rs/kio/CHANGELOG.md
@@ -10,13 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced the `Mut`-closure poll APIs (`Producer::poll`, `Producer::wait`,
-  `Weak::poll_write`, `Weak::wait`) with `Producer::poll_write`. The old
-  variants handed the closure a `Mut` and auto-notified consumers whenever it
-  touched the value via `DerefMut`. Since a no-op like `Vec::pop` on an empty
-  queue still trips `DerefMut`, a pending poll would wake the polling task's own
-  waiter and spin into an infinite loop. `poll_write` evaluates a read-only
-  predicate over a `Ref`, then on `Poll::Ready` hands back a `Mut` (lock still
-  held) so the caller mutates atomically without the footgun.
+  `Weak::poll_write`, `Weak::wait`) with `Producer::poll_write_when` and its
+  async sibling `Producer::write_when`. The old variants handed the closure a
+  `Mut` and auto-notified consumers whenever it touched the value via
+  `DerefMut`. Since a no-op like `Vec::pop` on an empty queue still trips
+  `DerefMut`, a pending poll would wake the polling task's own waiter and spin
+  into an infinite loop. `write_when` evaluates a read-only predicate over a
+  `Ref`, then on `Poll::Ready` hands back a `Mut` (lock still held) so the
+  caller mutates atomically without the footgun.
 
 ## [0.3.0] - 2026-05-29
 

--- a/rs/kio/CHANGELOG.md
+++ b/rs/kio/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replaced the `Mut`-closure poll APIs (`Producer::poll`, `Producer::wait`,
-  `Weak::poll_write`, `Weak::wait`) with `Producer::poll_write_when`. The old
+  `Weak::poll_write`, `Weak::wait`) with `Producer::poll_write`. The old
   variants handed the closure a `Mut` and auto-notified consumers whenever it
   touched the value via `DerefMut`. Since a no-op like `Vec::pop` on an empty
   queue still trips `DerefMut`, a pending poll would wake the polling task's own
-  waiter and spin into an infinite loop. `poll_write_when` evaluates a read-only
+  waiter and spin into an infinite loop. `poll_write` evaluates a read-only
   predicate over a `Ref`, then on `Poll::Ready` hands back a `Mut` (lock still
   held) so the caller mutates atomically without the footgun.
 

--- a/rs/kio/Cargo.toml
+++ b/rs/kio/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["async", "producer", "consumer", "state", "sync"]
 categories = ["asynchronous", "concurrency"]
 
 [lib]
-test = false
 doctest = false
 
 [dependencies]

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -71,56 +71,31 @@ impl<T> Producer<T> {
 		}
 	}
 
-	/// Poll-based mutable access with waker registration.
+	/// Poll for a condition with mutable access to the value, registering
+	/// `waiter` when `f` returns [`Poll::Pending`].
 	///
-	/// Calls `f` with a [`Mut`] guard. If `f` returns [`Poll::Pending`],
-	/// registers the [`Waiter`] for notification when the state next changes.
+	/// Mutations made through the `&mut T` here do NOT notify consumers, unlike a
+	/// write through [`write`](Self::write). This is meant for a producer draining
+	/// its own queued work: notifying here would wake this producer's own waiter,
+	/// a self-triggering footgun that can spin into an infinite loop. Notify
+	/// consumers explicitly with [`write`](Self::write) when you need to.
+	///
 	/// Returns `Poll::Ready(Err(`[`Ref`]`))` if the channel is closed.
-	pub fn poll<F, R>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<R, Ref<'_, T>>>
+	pub fn poll_drain<F, R>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<R, Ref<'_, T>>>
 	where
-		F: FnMut(&mut Mut<'_, T>) -> Poll<R>,
+		F: FnMut(&mut T) -> Poll<R>,
 	{
-		let mut state = self.write()?;
+		let mut state = self.state.lock();
+		if state.closed {
+			return Poll::Ready(Err(Ref { state }));
+		}
 
-		if let Poll::Ready(res) = f(&mut state) {
+		if let Poll::Ready(res) = f(&mut state.value) {
 			return Poll::Ready(Ok(res));
 		}
 
-		let inner = state.state.as_mut().unwrap();
-
-		// Take existing waiters if f modified the state, so we can notify consumers.
-		let waiters = if state.modified {
-			Some(inner.waiters.take())
-		} else {
-			None
-		};
-
-		// Register ourselves for future notifications.
-		waiter.register(&mut inner.waiters);
-
-		// Prevent Drop from re-waking the waiter we just registered.
-		state.modified = false;
-
-		// Release the lock before waking consumers.
-		drop(state);
-
-		if let Some(mut waiters) = waiters {
-			waiters.wake();
-		}
-
+		waiter.register(&mut state.waiters);
 		Poll::Pending
-	}
-
-	/// Wait for the closure to return [`Poll::Ready`], re-polling on each state change.
-	///
-	/// Returns `Ok(R)` when the closure returns [`Poll::Ready`], or `Err(Ref)` with
-	/// read-only access to the final state if the channel closes first.
-	pub async fn wait<F, R>(&self, mut f: F) -> Result<R, Ref<'_, T>>
-	where
-		F: FnMut(&mut Mut<'_, T>) -> Poll<R> + Unpin,
-		R: Unpin,
-	{
-		crate::wait(move |waiter| self.poll(waiter, &mut f)).await
 	}
 
 	/// Wait until the channel is closed.

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -82,7 +82,7 @@ impl<T> Producer<T> {
 	/// while pending.
 	///
 	/// Returns `Poll::Ready(Err(`[`Ref`]`))` if the channel is closed.
-	pub fn poll_write_when<F>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<Mut<'_, T>, Ref<'_, T>>>
+	pub fn poll_write<F>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<Mut<'_, T>, Ref<'_, T>>>
 	where
 		F: FnMut(&Ref<'_, T>) -> Poll<()>,
 	{

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -82,7 +82,7 @@ impl<T> Producer<T> {
 	/// while pending.
 	///
 	/// Returns `Poll::Ready(Err(`[`Ref`]`))` if the channel is closed.
-	pub fn poll_write<F>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<Mut<'_, T>, Ref<'_, T>>>
+	pub fn poll_write_when<F>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<Mut<'_, T>, Ref<'_, T>>>
 	where
 		F: FnMut(&Ref<'_, T>) -> Poll<()>,
 	{
@@ -100,6 +100,18 @@ impl<T> Producer<T> {
 				Poll::Pending
 			}
 		}
+	}
+
+	/// Wait until the read-only predicate holds, then acquire write access.
+	///
+	/// The async sibling of [`poll_write_when`](Self::poll_write_when): returns
+	/// `Ok(Mut)` once `f` returns [`Poll::Ready`], or `Err(Ref)` if the channel
+	/// closes first.
+	pub async fn write_when<F>(&self, mut f: F) -> Result<Mut<'_, T>, Ref<'_, T>>
+	where
+		F: FnMut(&Ref<'_, T>) -> Poll<()> + Unpin,
+	{
+		crate::wait(move |waiter| self.poll_write_when(waiter, &mut f)).await
 	}
 
 	/// Wait until the channel is closed.

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -74,7 +74,9 @@ impl<T> Producer<T> {
 	/// Poll a read-only predicate; on [`Poll::Ready`] hand back a [`Mut`] with the
 	/// lock still held, so the caller can inspect and mutate atomically.
 	///
-	/// The predicate only sees a [`Ref`], so it can't accidentally flag the state
+	/// Unlike [`Consumer::poll`], the predicate returns `Poll<()>` (it just gates
+	/// readiness) and a satisfied poll yields write access via [`Mut`]. The
+	/// predicate only sees a [`Ref`], so it can't accidentally flag the state
 	/// modified (e.g. via a `&mut`-taking method like `Vec::pop`). That sidesteps
 	/// the footgun where a no-op mutation during a *pending* poll would wake this
 	/// producer's own waiter and spin into an infinite loop. Decide readiness in
@@ -82,7 +84,7 @@ impl<T> Producer<T> {
 	/// while pending.
 	///
 	/// Returns `Poll::Ready(Err(`[`Ref`]`))` if the channel is closed.
-	pub fn poll_write_when<F>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<Mut<'_, T>, Ref<'_, T>>>
+	pub fn poll<F>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<Mut<'_, T>, Ref<'_, T>>>
 	where
 		F: FnMut(&Ref<'_, T>) -> Poll<()>,
 	{
@@ -104,14 +106,13 @@ impl<T> Producer<T> {
 
 	/// Wait until the read-only predicate holds, then acquire write access.
 	///
-	/// The async sibling of [`poll_write_when`](Self::poll_write_when): returns
-	/// `Ok(Mut)` once `f` returns [`Poll::Ready`], or `Err(Ref)` if the channel
-	/// closes first.
-	pub async fn write_when<F>(&self, mut f: F) -> Result<Mut<'_, T>, Ref<'_, T>>
+	/// The async sibling of [`poll`](Self::poll): returns `Ok(Mut)` once `f`
+	/// returns [`Poll::Ready`], or `Err(Ref)` if the channel closes first.
+	pub async fn wait<F>(&self, mut f: F) -> Result<Mut<'_, T>, Ref<'_, T>>
 	where
 		F: FnMut(&Ref<'_, T>) -> Poll<()> + Unpin,
 	{
-		crate::wait(move |waiter| self.poll_write_when(waiter, &mut f)).await
+		crate::wait(move |waiter| self.poll(waiter, &mut f)).await
 	}
 
 	/// Wait until the channel is closed.
@@ -358,5 +359,40 @@ mod test {
 		let _consumer = producer.consume();
 		let _weak = producer.weak();
 		assert!(producer.is_last());
+	}
+
+	#[test]
+	fn poll_gates_on_predicate_then_writes() {
+		let producer = Producer::<Vec<u32>>::default();
+		let waiter = Waiter::noop();
+
+		let predicate = |state: &Ref<'_, Vec<u32>>| {
+			if state.is_empty() {
+				Poll::Pending
+			} else {
+				Poll::Ready(())
+			}
+		};
+
+		// Empty queue: the read-only predicate is pending, so no Mut is handed out
+		// (and crucially nothing flags the state modified to wake our own waiter).
+		assert!(matches!(producer.poll(&waiter, predicate), Poll::Pending));
+
+		let Ok(mut write) = producer.write() else {
+			panic!("channel should be open");
+		};
+		write.push(1);
+		drop(write);
+
+		// Now satisfied: poll upgrades to a Mut with the lock still held.
+		let Poll::Ready(Ok(mut state)) = producer.poll(&waiter, predicate) else {
+			panic!("expected a writable guard");
+		};
+		assert_eq!(state.pop(), Some(1));
+		drop(state);
+
+		// Closed channel reports back through Err.
+		assert!(producer.close().is_ok());
+		assert!(matches!(producer.poll(&waiter, predicate), Poll::Ready(Err(_))));
 	}
 }

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -71,31 +71,35 @@ impl<T> Producer<T> {
 		}
 	}
 
-	/// Poll for a condition with mutable access to the value, registering
-	/// `waiter` when `f` returns [`Poll::Pending`].
+	/// Poll a read-only predicate; on [`Poll::Ready`] hand back a [`Mut`] with the
+	/// lock still held, so the caller can inspect and mutate atomically.
 	///
-	/// Mutations made through the `&mut T` here do NOT notify consumers, unlike a
-	/// write through [`write`](Self::write). This is meant for a producer draining
-	/// its own queued work: notifying here would wake this producer's own waiter,
-	/// a self-triggering footgun that can spin into an infinite loop. Notify
-	/// consumers explicitly with [`write`](Self::write) when you need to.
+	/// The predicate only sees a [`Ref`], so it can't accidentally flag the state
+	/// modified (e.g. via a `&mut`-taking method like `Vec::pop`). That sidesteps
+	/// the footgun where a no-op mutation during a *pending* poll would wake this
+	/// producer's own waiter and spin into an infinite loop. Decide readiness in
+	/// the predicate, then mutate through the returned `Mut`. Registers `waiter`
+	/// while pending.
 	///
 	/// Returns `Poll::Ready(Err(`[`Ref`]`))` if the channel is closed.
-	pub fn poll_drain<F, R>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<R, Ref<'_, T>>>
+	pub fn poll_write_when<F>(&self, waiter: &Waiter, mut f: F) -> Poll<Result<Mut<'_, T>, Ref<'_, T>>>
 	where
-		F: FnMut(&mut T) -> Poll<R>,
+		F: FnMut(&Ref<'_, T>) -> Poll<()>,
 	{
-		let mut state = self.state.lock();
+		let state = self.state.lock();
 		if state.closed {
 			return Poll::Ready(Err(Ref { state }));
 		}
 
-		if let Poll::Ready(res) = f(&mut state.value) {
-			return Poll::Ready(Ok(res));
+		let mut guard = Ref { state };
+		match f(&guard) {
+			// Upgrade the Ref to a Mut, keeping the same lock guard.
+			Poll::Ready(()) => Poll::Ready(Ok(Mut::new(guard.state))),
+			Poll::Pending => {
+				waiter.register(&mut guard.state.waiters);
+				Poll::Pending
+			}
 		}
-
-		waiter.register(&mut state.waiters);
-		Poll::Pending
 	}
 
 	/// Wait until the channel is closed.

--- a/rs/kio/src/weak.rs
+++ b/rs/kio/src/weak.rs
@@ -78,44 +78,31 @@ impl<T> Weak<T> {
 		}
 	}
 
-	/// Poll-based mutable access with waker registration.
+	/// Poll for a condition with mutable access to the value, registering
+	/// `waiter` when `f` returns [`Poll::Pending`].
 	///
-	/// Calls `f` with a [`Mut`] guard. If `f` returns [`Poll::Pending`],
-	/// registers the waiter for notification when the state next changes.
-	/// Returns `None` if the channel is closed.
-	pub fn poll_write<F, R>(&self, waiter: &Waiter, mut f: F) -> Poll<Option<R>>
+	/// Mutations made through the `&mut T` here do NOT notify consumers, unlike a
+	/// write through [`write`](Self::write). This is meant for a producer draining
+	/// its own queued work, where notifying would wake this handle's own waiter,
+	/// a self-triggering footgun that can spin into an infinite loop. Notify
+	/// consumers explicitly with [`write`](Self::write) when you need to.
+	///
+	/// Returns `Poll::Ready(None)` if the channel is closed.
+	pub fn poll_drain<F, R>(&self, waiter: &Waiter, mut f: F) -> Poll<Option<R>>
 	where
-		F: FnMut(&mut Mut<'_, T>) -> Poll<R>,
+		F: FnMut(&mut T) -> Poll<R>,
 	{
-		let Ok(mut state) = self.write() else {
+		let mut state = self.state.lock();
+		if state.closed {
 			return Poll::Ready(None);
-		};
+		}
 
-		if let Poll::Ready(res) = f(&mut state) {
+		if let Poll::Ready(res) = f(&mut state.value) {
 			return Poll::Ready(Some(res));
 		}
 
-		// Reset modified so the drop doesn't immediately wake the waiter we're about to register.
-		state.modified = false;
-
-		let state = state.state.as_mut().unwrap();
 		waiter.register(&mut state.waiters);
 		Poll::Pending
-	}
-
-	/// Wait for the closure to return [`Poll::Ready`], re-polling on each state change.
-	///
-	/// Returns `Ok(R)` when the closure returns [`Poll::Ready`], or `Err(Ref)` with
-	/// read-only access to the final state if the channel closes first.
-	pub async fn wait<F, R>(&self, mut f: F) -> Result<R, Ref<'_, T>>
-	where
-		F: FnMut(&mut Mut<'_, T>) -> Poll<R> + Unpin,
-		R: Unpin,
-	{
-		match crate::wait(move |waiter| self.poll_write(waiter, &mut f)).await {
-			Some(r) => Ok(r),
-			None => Err(self.read()),
-		}
 	}
 
 	/// Returns `true` if the channel has been closed.

--- a/rs/kio/src/weak.rs
+++ b/rs/kio/src/weak.rs
@@ -78,33 +78,6 @@ impl<T> Weak<T> {
 		}
 	}
 
-	/// Poll for a condition with mutable access to the value, registering
-	/// `waiter` when `f` returns [`Poll::Pending`].
-	///
-	/// Mutations made through the `&mut T` here do NOT notify consumers, unlike a
-	/// write through [`write`](Self::write). This is meant for a producer draining
-	/// its own queued work, where notifying would wake this handle's own waiter,
-	/// a self-triggering footgun that can spin into an infinite loop. Notify
-	/// consumers explicitly with [`write`](Self::write) when you need to.
-	///
-	/// Returns `Poll::Ready(None)` if the channel is closed.
-	pub fn poll_drain<F, R>(&self, waiter: &Waiter, mut f: F) -> Poll<Option<R>>
-	where
-		F: FnMut(&mut T) -> Poll<R>,
-	{
-		let mut state = self.state.lock();
-		if state.closed {
-			return Poll::Ready(None);
-		}
-
-		if let Poll::Ready(res) = f(&mut state.value) {
-			return Poll::Ready(Some(res));
-		}
-
-		waiter.register(&mut state.waiters);
-		Poll::Pending
-	}
-
 	/// Returns `true` if the channel has been closed.
 	pub fn is_closed(&self) -> bool {
 		self.state.lock().closed

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -256,9 +256,9 @@ impl BroadcastDynamic {
 	// A helper to automatically apply Dropped if the state is closed without an error.
 	fn poll<F, R>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<R, Error>>
 	where
-		F: FnMut(&mut kio::Mut<'_, State>) -> Poll<R>,
+		F: FnMut(&mut State) -> Poll<R>,
 	{
-		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
+		Poll::Ready(match ready!(self.state.poll_drain(waiter, f)) {
 			Ok(r) => Ok(r),
 			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
 		})

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -254,11 +254,11 @@ impl BroadcastDynamic {
 	}
 
 	// A helper to automatically apply Dropped if the state is closed without an error.
-	fn poll_write_when<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, State>, Error>>
+	fn poll<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, State>, Error>>
 	where
 		F: FnMut(&kio::Ref<'_, State>) -> Poll<()>,
 	{
-		Poll::Ready(match ready!(self.state.poll_write_when(waiter, f)) {
+		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
 			Ok(state) => Ok(state),
 			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
 		})
@@ -267,7 +267,7 @@ impl BroadcastDynamic {
 	/// Poll for the next consumer-requested track, without blocking. The returned producer
 	/// is preconfigured with the requested track's name and priority.
 	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<TrackProducer, Error>> {
-		let mut state = ready!(self.poll_write_when(waiter, |state| {
+		let mut state = ready!(self.poll(waiter, |state| {
 			if state.requests.is_empty() {
 				Poll::Pending
 			} else {

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -254,11 +254,11 @@ impl BroadcastDynamic {
 	}
 
 	// A helper to automatically apply Dropped if the state is closed without an error.
-	fn poll_write_when<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, State>, Error>>
+	fn poll_write<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, State>, Error>>
 	where
 		F: FnMut(&kio::Ref<'_, State>) -> Poll<()>,
 	{
-		Poll::Ready(match ready!(self.state.poll_write_when(waiter, f)) {
+		Poll::Ready(match ready!(self.state.poll_write(waiter, f)) {
 			Ok(state) => Ok(state),
 			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
 		})
@@ -267,7 +267,7 @@ impl BroadcastDynamic {
 	/// Poll for the next consumer-requested track, without blocking. The returned producer
 	/// is preconfigured with the requested track's name and priority.
 	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<TrackProducer, Error>> {
-		let mut state = ready!(self.poll_write_when(waiter, |state| {
+		let mut state = ready!(self.poll_write(waiter, |state| {
 			if state.requests.is_empty() {
 				Poll::Pending
 			} else {

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -254,12 +254,12 @@ impl BroadcastDynamic {
 	}
 
 	// A helper to automatically apply Dropped if the state is closed without an error.
-	fn poll<F, R>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<R, Error>>
+	fn poll_write_when<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, State>, Error>>
 	where
-		F: FnMut(&mut State) -> Poll<R>,
+		F: FnMut(&kio::Ref<'_, State>) -> Poll<()>,
 	{
-		Poll::Ready(match ready!(self.state.poll_drain(waiter, f)) {
-			Ok(r) => Ok(r),
+		Poll::Ready(match ready!(self.state.poll_write_when(waiter, f)) {
+			Ok(state) => Ok(state),
 			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
 		})
 	}
@@ -267,10 +267,14 @@ impl BroadcastDynamic {
 	/// Poll for the next consumer-requested track, without blocking. The returned producer
 	/// is preconfigured with the requested track's name and priority.
 	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<TrackProducer, Error>> {
-		self.poll(waiter, |state| match state.requests.pop() {
-			Some(producer) => Poll::Ready(producer),
-			None => Poll::Pending,
-		})
+		let mut state = ready!(self.poll_write_when(waiter, |state| {
+			if state.requests.is_empty() {
+				Poll::Pending
+			} else {
+				Poll::Ready(())
+			}
+		}))?;
+		Poll::Ready(Ok(state.requests.pop().expect("predicate guaranteed a request")))
 	}
 
 	/// Block until a consumer requests a track, returning its producer.

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -254,11 +254,11 @@ impl BroadcastDynamic {
 	}
 
 	// A helper to automatically apply Dropped if the state is closed without an error.
-	fn poll_write<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, State>, Error>>
+	fn poll_write_when<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, State>, Error>>
 	where
 		F: FnMut(&kio::Ref<'_, State>) -> Poll<()>,
 	{
-		Poll::Ready(match ready!(self.state.poll_write(waiter, f)) {
+		Poll::Ready(match ready!(self.state.poll_write_when(waiter, f)) {
 			Ok(state) => Ok(state),
 			Err(state) => Err(state.abort.clone().unwrap_or(Error::Dropped)),
 		})
@@ -267,7 +267,7 @@ impl BroadcastDynamic {
 	/// Poll for the next consumer-requested track, without blocking. The returned producer
 	/// is preconfigured with the requested track's name and priority.
 	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<TrackProducer, Error>> {
-		let mut state = ready!(self.poll_write(waiter, |state| {
+		let mut state = ready!(self.poll_write_when(waiter, |state| {
 			if state.requests.is_empty() {
 				Poll::Pending
 			} else {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -879,11 +879,15 @@ impl OriginConsumer {
 	/// consumer is closed, or `Poll::Pending` after registering `waiter` to be
 	/// notified when the next update arrives.
 	pub fn poll_announced(&mut self, waiter: &kio::Waiter) -> Poll<Option<OriginAnnounce>> {
-		match self.state.poll_drain(waiter, |state| match state.take() {
-			Some(item) => Poll::Ready(item),
-			None => Poll::Pending,
-		}) {
-			Poll::Ready(Ok(item)) => Poll::Ready(Some(item)),
+		let res = self.state.poll_write_when(waiter, |state| {
+			if state.pending.is_empty() {
+				Poll::Pending
+			} else {
+				Poll::Ready(())
+			}
+		});
+		match res {
+			Poll::Ready(Ok(mut state)) => Poll::Ready(Some(state.take().expect("predicate guaranteed an update"))),
 			// Closed: discard the Ref so its MutexGuard doesn't escape this call.
 			Poll::Ready(Err(_)) => Poll::Ready(None),
 			Poll::Pending => Poll::Pending,

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -2,7 +2,7 @@ use std::{
 	collections::{BTreeMap, HashMap, VecDeque},
 	fmt,
 	sync::atomic::{AtomicU64, Ordering},
-	task::Poll,
+	task::{Poll, ready},
 };
 
 use rand::RngExt;
@@ -879,19 +879,18 @@ impl OriginConsumer {
 	/// consumer is closed, or `Poll::Pending` after registering `waiter` to be
 	/// notified when the next update arrives.
 	pub fn poll_announced(&mut self, waiter: &kio::Waiter) -> Poll<Option<OriginAnnounce>> {
-		let res = self.state.poll_write_when(waiter, |state| {
+		let mut state = match ready!(self.state.poll(waiter, |state| {
 			if state.pending.is_empty() {
 				Poll::Pending
 			} else {
 				Poll::Ready(())
 			}
-		});
-		match res {
-			Poll::Ready(Ok(mut state)) => Poll::Ready(Some(state.take().expect("predicate guaranteed an update"))),
+		})) {
+			Ok(state) => state,
 			// Closed: discard the Ref so its MutexGuard doesn't escape this call.
-			Poll::Ready(Err(_)) => Poll::Ready(None),
-			Poll::Pending => Poll::Pending,
-		}
+			Err(_) => return Poll::Ready(None),
+		};
+		Poll::Ready(Some(state.take().expect("predicate guaranteed an update")))
 	}
 
 	/// Returns the next (un)announced broadcast and the absolute path without blocking.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -879,7 +879,7 @@ impl OriginConsumer {
 	/// consumer is closed, or `Poll::Pending` after registering `waiter` to be
 	/// notified when the next update arrives.
 	pub fn poll_announced(&mut self, waiter: &kio::Waiter) -> Poll<Option<OriginAnnounce>> {
-		match self.state.poll(waiter, |state| match state.take() {
+		match self.state.poll_drain(waiter, |state| match state.take() {
 			Some(item) => Poll::Ready(item),
 			None => Poll::Pending,
 		}) {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -879,7 +879,7 @@ impl OriginConsumer {
 	/// consumer is closed, or `Poll::Pending` after registering `waiter` to be
 	/// notified when the next update arrives.
 	pub fn poll_announced(&mut self, waiter: &kio::Waiter) -> Poll<Option<OriginAnnounce>> {
-		let res = self.state.poll_write_when(waiter, |state| {
+		let res = self.state.poll_write(waiter, |state| {
 			if state.pending.is_empty() {
 				Poll::Pending
 			} else {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -879,7 +879,7 @@ impl OriginConsumer {
 	/// consumer is closed, or `Poll::Pending` after registering `waiter` to be
 	/// notified when the next update arrives.
 	pub fn poll_announced(&mut self, waiter: &kio::Waiter) -> Poll<Option<OriginAnnounce>> {
-		let res = self.state.poll_write(waiter, |state| {
+		let res = self.state.poll_write_when(waiter, |state| {
 			if state.pending.is_empty() {
 				Poll::Pending
 			} else {


### PR DESCRIPTION
## Summary

`Producer::poll` / `Producer::wait` were a self-triggering footgun. This reworks them so the closure is a read-only predicate and a satisfied poll hands back a `Mut`.

The old versions handed the closure a `&mut Mut<T>` and tracked a `modified` flag via `DerefMut`. On a `Poll::Pending`, the poll woke the consumer waiters. The trap: merely *reading through a mutable path* trips `DerefMut`. The canonical case is `requests.pop()` on an empty `Vec` — `pop()` takes `&mut`, so an empty (no-op) poll still flags the state modified, wakes a waiter in the very list the poller just registered itself into, re-polls, and spins into an infinite busy loop.

## Approach

`Producer::poll` (and its async sibling `Producer::wait`) now evaluates a **read-only** predicate over a `Ref`. While the predicate returns `Poll::Pending` nothing is mutated, so it can't spuriously flag the state modified. On `Poll::Ready` it upgrades the held lock guard to a `Mut` and hands it back, so the caller mutates atomically — the lock is never dropped between the predicate and the mutation, so there's no TOCTOU even with multiple drainers.

```rust
let mut state = ready!(self.poll(waiter, |state| {
    if state.requests.is_empty() { Poll::Pending } else { Poll::Ready(()) }
}))?;
Poll::Ready(Ok(state.requests.pop().expect("predicate guaranteed a request")))
```

Naming: both channel sides now expose a `poll()`/`wait()` pair. They differ in contract by design — `Consumer::poll`'s closure returns the value (`Poll<R>`), while `Producer::poll`'s closure is a bare `Poll<()>` predicate that gates handing back a `Mut`.

## Changes

- **`kio`**: `Producer::poll` / `Producer::wait` reworked to the read-only-predicate-returns-`Mut` shape. `Weak::poll_write` / `Weak::wait` had no users and are removed. The read-only `Consumer::poll` / `Consumer::wait` are unchanged. Dropped `test = false` from the `[lib]` so unit tests run, and added a test for the new `Producer::poll`.
- **`moq-net`**: the two callers, `BroadcastDynamic::poll_requested_track` and `OriginConsumer::poll_announced`, now check "queue non-empty" read-only, then pop/take through the returned `Mut` (the latter tidied to use `ready!`).

## API note

This is a breaking change to the published `kio` crate's surface (`Producer::poll`/`wait` change signature; the `Weak` methods are removed). No other workspace crate used the removed/changed APIs, and `moq-net`'s public surface is unchanged — the affected helpers are private. Targeting `main` per request.

## Test plan

- [x] `cargo test -p kio` (2 passed, incl. the new `poll_gates_on_predicate_then_writes`)
- [x] `cargo test -p kio -p moq-net` (346 passed; incl. `broadcast::test::requests`, `requested_unused`, origin announce tests)
- [x] `cargo clippy -p kio -p moq-net -p moq-native` clean
- [x] `cargo build` for kio-dependent crates (moq-net, moq-native, hang, moq-mux, moq-cli, moq-bench)

(Written by Claude)