### PR TITLE
docs(js): document exported symbols for JSR and require it going forward

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,8 @@ match version {
 
 ## Comment Conventions
 
-- Keep things brief and avoid comments if the code is self-explanatory. Reserve comments for the non-obvious WHY: a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise a reader.
+- Keep things brief and avoid comments if the code is self-explanatory. Reserve comments for the non-obvious WHY: a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise a reader. This is about *implementation* comments inside function bodies and on private items.
+- **Public API symbols are the exception: document every exported symbol.** Each `pub` Rust item and each exported JS/TS symbol (function, class, interface, type, const, enum, plus their notable public members) gets a doc comment (`///` / `/** */`), even when it looks self-explanatory. These render on the published docs (JSR builds API docs from the `.d.ts`; docs.rs from `///`), so a missing doc is a hole a consumer hits, not a self-evident line of code. Add a module-level doc to every entrypoint too (a `/** ... @module */` block at the top of each JS entrypoint file; a `//!` block on each Rust module root). Keep these one line where possible and say what a *consumer* needs (units, ownership, lifecycle, what it wraps), not throat-clearing.
 - Write the way you'd say it out loud, not the way a doc generator would. One short line is almost always enough. Skip throat-clearing like "This function is responsible for...".
 - Comments must reflect the **current** state of the code, not its history. Don't write "X no longer does Y" or "this used to cascade". Describe what the code does today, or delete the comment. Migration context belongs in commit messages and PR descriptions, where it ages with the change rather than rotting in the source.
 

--- a/js/common/package.ts
+++ b/js/common/package.ts
@@ -172,6 +172,9 @@ function writeJsrConfig() {
 	const jsr = {
 		name: pkg.name,
 		version: pkg.version,
+		// JSR reads this for the package description and the "has a description"
+		// score check; it isn't pulled from the npm package.json automatically.
+		...(pkg.description ? { description: pkg.description } : {}),
 		...(license ? { license } : {}),
 		exports,
 		...(Object.keys(imports).length ? { imports } : {}),

--- a/js/hang/src/catalog/audio.ts
+++ b/js/hang/src/catalog/audio.ts
@@ -7,8 +7,10 @@ const TrackSchema = z.object({
 	name: z.string(),
 });
 
-// Mirrors AudioDecoderConfig
-// https://w3c.github.io/webcodecs/#audio-decoder-config
+/**
+ * Schema for a single audio rendition's decoder config.
+ * Mirrors WebCodecs AudioDecoderConfig (https://w3c.github.io/webcodecs/#audio-decoder-config).
+ */
 export const AudioConfigSchema = z.object({
 	// See: https://w3c.github.io/webcodecs/codec_registry.html
 	codec: z.string(),
@@ -40,6 +42,7 @@ export const AudioConfigSchema = z.object({
 	jitter: z.optional(u53Schema),
 });
 
+/** Schema for the catalog audio section: a map of track name to rendition config. */
 export const AudioSchema = z.union([
 	z.object({
 		// A map of track name to rendition configuration.
@@ -58,5 +61,7 @@ export const AudioSchema = z.union([
 	),
 ]);
 
+/** The catalog audio section: renditions keyed by track name. */
 export type Audio = z.infer<typeof AudioSchema>;
+/** Decoder config for a single audio rendition. */
 export type AudioConfig = z.infer<typeof AudioConfigSchema>;

--- a/js/hang/src/catalog/container.ts
+++ b/js/hang/src/catalog/container.ts
@@ -31,4 +31,5 @@ export const ContainerSchema = z._default(
 	{ kind: "legacy" },
 );
 
+/** The per-frame container format declared in the catalog. */
 export type Container = z.infer<typeof ContainerSchema>;

--- a/js/hang/src/catalog/format.ts
+++ b/js/hang/src/catalog/format.ts
@@ -5,9 +5,12 @@
 // catalog track without explicit configuration; publishers should include the
 // suffix in the name they publish so consumers can detect it.
 
+/** Recognized catalog format suffixes used in broadcast names. */
 export const FORMATS = ["hang", "msf"] as const;
+/** A catalog format advertised by a broadcast name suffix. */
 export type Format = (typeof FORMATS)[number];
 
+/** The catalog format assumed when a broadcast name has no recognized suffix. */
 export const DEFAULT_FORMAT: Format = "hang";
 
 /** Detect the catalog format from a broadcast name suffix, or `undefined` if the name has no recognized extension. */

--- a/js/hang/src/catalog/index.ts
+++ b/js/hang/src/catalog/index.ts
@@ -1,3 +1,10 @@
+/**
+ * JSON catalog schema and types describing a broadcast's tracks for WebCodecs:
+ * audio/video decoder configs, container format, and rendition layout.
+ *
+ * @module
+ */
+
 export * from "./audio";
 export * from "./container";
 export * from "./format";

--- a/js/hang/src/catalog/integers.ts
+++ b/js/hang/src/catalog/integers.ts
@@ -5,6 +5,7 @@ import * as z from "zod/mini";
  */
 export const u8Schema = z.number().check(z.int(), z.nonnegative(), z.lte(255)).brand("u8");
 
+/** Branded 8-bit unsigned integer (0-255). */
 export type U8 = z.infer<typeof u8Schema>;
 
 /**
@@ -13,6 +14,7 @@ export type U8 = z.infer<typeof u8Schema>;
  */
 export const u53Schema = z.number().check(z.int(), z.nonnegative(), z.lte(Number.MAX_SAFE_INTEGER)).brand("u53");
 
+/** Branded unsigned integer up to JavaScript's MAX_SAFE_INTEGER (2^53 - 1). */
 export type U53 = z.infer<typeof u53Schema>;
 
 /**

--- a/js/hang/src/catalog/priority.ts
+++ b/js/hang/src/catalog/priority.ts
@@ -1,5 +1,5 @@
-// We define all of the priorities for tracks here.
-// That way it's easier to make sure they are in the right order.
+// Defined in one place so the relative ordering stays consistent.
+/** Delivery priority per track kind; higher is sent first. */
 export const PRIORITY = {
 	catalog: 100,
 	audio: 80,

--- a/js/hang/src/catalog/root.ts
+++ b/js/hang/src/catalog/root.ts
@@ -16,4 +16,5 @@ export const RootSchema = z.looseObject({
 	audio: z.optional(AudioSchema),
 });
 
+/** The root catalog object, with optional video and audio sections plus any app extensions. */
 export type Root = z.infer<typeof RootSchema>;

--- a/js/hang/src/catalog/track.ts
+++ b/js/hang/src/catalog/track.ts
@@ -1,6 +1,8 @@
 import * as z from "zod/mini";
 
+/** Schema for a catalog track reference, identified by name. */
 export const TrackSchema = z.object({
 	name: z.string(),
 });
+/** A catalog track reference, identified by name. */
 export type Track = z.infer<typeof TrackSchema>;

--- a/js/hang/src/catalog/video.ts
+++ b/js/hang/src/catalog/video.ts
@@ -7,7 +7,7 @@ const TrackSchema = z.object({
 	name: z.string(),
 });
 
-// Based on VideoDecoderConfig
+/** Schema for a single video rendition's decoder config. Mirrors WebCodecs VideoDecoderConfig. */
 export const VideoConfigSchema = z.object({
 	// See: https://w3c.github.io/webcodecs/codec_registry.html
 	codec: z.string(),
@@ -53,8 +53,10 @@ export const VideoConfigSchema = z.object({
 	jitter: z.optional(u53Schema),
 });
 
-// Mirrors VideoDecoderConfig
-// https://w3c.github.io/webcodecs/#video-decoder-config
+/**
+ * Schema for the catalog video section: renditions plus display size, rotation, and flip.
+ * Renditions mirror WebCodecs VideoDecoderConfig (https://w3c.github.io/webcodecs/#video-decoder-config).
+ */
 export const VideoSchema = z.union([
 	z.object({
 		// A map of track name to rendition configuration.
@@ -101,5 +103,7 @@ export const VideoSchema = z.union([
 	),
 ]);
 
+/** The catalog video section: renditions keyed by track name plus display options. */
 export type Video = z.infer<typeof VideoSchema>;
+/** Decoder config for a single video rendition. */
 export type VideoConfig = z.infer<typeof VideoConfigSchema>;

--- a/js/hang/src/container/cmaf/format.ts
+++ b/js/hang/src/container/cmaf/format.ts
@@ -3,13 +3,16 @@ import type { Format as ContainerFormat } from "../format";
 import type { Frame } from "../types";
 import { decodeDataSegment, type InitSegment } from "./decode";
 
+/** CMAF container format: decodes each MoQ frame as a moof+mdat fragment using the parsed init segment. */
 export class Format implements ContainerFormat {
 	#init: InitSegment;
 
+	/** Create a format bound to the given parsed init segment (timescale, codec defaults). */
 	constructor(init: InitSegment) {
 		this.#init = init;
 	}
 
+	/** Decode one CMAF fragment into its media frames. */
 	decode(frame: Uint8Array): Frame[] {
 		return decodeDataSegment(frame, this.#init).map((s) => ({
 			data: s.data,

--- a/js/hang/src/container/cmaf/index.ts
+++ b/js/hang/src/container/cmaf/index.ts
@@ -1,5 +1,7 @@
 /**
- * CMAF (fMP4) container utilities for encoding and decoding segments.
+ * CMAF (fMP4) container utilities for encoding and decoding init and media segments.
+ *
+ * @module
  */
 
 export * from "./decode";

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -5,9 +5,11 @@ import { Effect, type Getter, Signal } from "@moq/signals";
 import type { Format } from "./format";
 import type { BufferedRanges, Frame } from "./types";
 
+/** Options for constructing a {@link Consumer}. */
 export interface ConsumerProps {
+	/** The container format used to decode each MoQ frame. */
 	format: Format;
-	// Target latency in milliseconds (default: 0)
+	/** Target latency in milliseconds, controlling how aggressively slow groups are skipped (default: 0). */
 	latency?: Signal<Time.Milli> | Time.Milli;
 }
 
@@ -18,6 +20,7 @@ interface Group {
 	done?: boolean; // Set when #runGroup finishes reading all frames
 }
 
+/** Reads frames from a MoQ track in order, buffering groups and skipping slow ones to meet the latency target. */
 export class Consumer {
 	#track: Moq.Track;
 	#format: Format;
@@ -29,10 +32,12 @@ export class Consumer {
 	#notify?: () => void;
 
 	#buffered = new Signal<BufferedRanges>([]);
+	/** The time ranges currently buffered and ready to play. */
 	readonly buffered: Getter<BufferedRanges> = this.#buffered;
 
 	#signals = new Effect();
 
+	/** Start consuming the given track, decoding frames with `props.format`. */
 	constructor(track: Moq.Track, props: ConsumerProps) {
 		this.#track = track;
 		this.#format = props.format;
@@ -193,8 +198,10 @@ export class Consumer {
 		}
 	}
 
-	// Returns the next frame in order, along with the group number.
-	// If frame is undefined, the group is done.
+	/**
+	 * Returns the next frame in order along with its group number, awaiting one if needed.
+	 * A `frame` of undefined signals the end of that group; the overall result is undefined once closed.
+	 */
 	async next(): Promise<{ frame: Frame | undefined; group: number } | undefined> {
 		for (;;) {
 			if (
@@ -273,6 +280,7 @@ export class Consumer {
 		this.#buffered.set(ranges);
 	}
 
+	/** Stop consuming and release the track and all buffered groups. */
 	close(): void {
 		this.#signals.close();
 	}

--- a/js/hang/src/container/format.ts
+++ b/js/hang/src/container/format.ts
@@ -1,5 +1,6 @@
 import type { Frame } from "./types";
 
+/** A container format that decodes raw MoQ frames into media frames. */
 export interface Format {
 	/** Parse one MoQ frame (raw bytes) into decoded media frames. */
 	decode(frame: Uint8Array): Frame[];

--- a/js/hang/src/container/index.ts
+++ b/js/hang/src/container/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Per-frame container formats (timestamp plus codec bitstream): the legacy varint
+ * container, CMAF (fMP4), and LOC, with consumers and producers to read/write them.
+ *
+ * @module
+ */
+
 export * as Loc from "@moq/loc";
 export * as Cmaf from "./cmaf";
 export { Consumer, type ConsumerProps } from "./consumer";

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -6,19 +6,24 @@ export type { BufferedRange, BufferedRanges, Frame } from "./types";
 import type { Format as ContainerFormat } from "./format";
 import type { Frame } from "./types";
 
+/** The legacy hang container: a microsecond timestamp varint followed by the raw codec payload. */
 export class Format implements ContainerFormat {
+	/** Decode one legacy frame into a single media frame. */
 	decode(frame: Uint8Array): Frame[] {
 		const [timestamp, data] = Moq.Varint.decode(frame);
 		return [{ data, timestamp: timestamp as Time.Micro, keyframe: false }];
 	}
 }
 
+/** A byte source that can be copied into a buffer, e.g. a WebCodecs EncodedChunk. */
 export interface Source {
+	/** Number of bytes the source will copy. */
 	byteLength: number;
+	/** Copy the source bytes into the given buffer. */
 	copyTo(buffer: Uint8Array): void;
 }
 
-// Encode a frame as a timestamp varint followed by the payload bytes.
+/** Encode a frame as a timestamp varint followed by the payload bytes. */
 export function encodeFrame(source: Uint8Array | Source, timestamp: Time.Micro): Uint8Array {
 	const timestampBytes = Moq.Varint.encode(timestamp);
 	const data = new Uint8Array(timestampBytes.byteLength + source.byteLength);
@@ -33,15 +38,17 @@ export function encodeFrame(source: Uint8Array | Source, timestamp: Time.Micro):
 	return data;
 }
 
-// A Helper class to encode frames into a track.
+/** Writes legacy-container frames into a MoQ track, starting a new group on each keyframe. */
 export class Producer {
 	#track: Moq.Track;
 	#group?: Moq.Group;
 
+	/** Wrap a track to publish legacy-container frames into it. */
 	constructor(track: Moq.Track) {
 		this.#track = track;
 	}
 
+	/** Encode and append a frame; a keyframe starts a new group. Throws if the first frame is not a keyframe. */
 	encode(data: Uint8Array | Source, timestamp: Time.Micro, keyframe: boolean) {
 		if (keyframe) {
 			this.#group?.close();
@@ -53,6 +60,7 @@ export class Producer {
 		this.#group?.writeFrame(encodeFrame(data, timestamp));
 	}
 
+	/** Close the track and current group, optionally with an error. */
 	close(err?: Error) {
 		this.#track.close(err);
 		this.#group?.close();

--- a/js/hang/src/container/types.ts
+++ b/js/hang/src/container/types.ts
@@ -1,18 +1,27 @@
 import { Time } from "@moq/net";
 
+/** A decoded media frame: codec payload plus its presentation timestamp and keyframe flag. */
 export interface Frame {
+	/** The codec bitstream payload. */
 	data: Uint8Array;
+	/** Presentation timestamp in microseconds. */
 	timestamp: Time.Micro;
+	/** Whether this frame is a keyframe (can be decoded standalone). */
 	keyframe: boolean;
 }
 
+/** A contiguous span of buffered media, in milliseconds. */
 export interface BufferedRange {
+	/** Start of the range in milliseconds. */
 	start: Time.Milli;
+	/** End of the range in milliseconds. */
 	end: Time.Milli;
 }
 
+/** An ordered list of buffered time ranges. */
 export type BufferedRanges = BufferedRange[];
 
+/** Merge two sets of buffered ranges into a single sorted, non-overlapping list. */
 export function mergeBufferedRanges(a: BufferedRanges, b: BufferedRanges): BufferedRanges {
 	if (a.length === 0) return b;
 	if (b.length === 0) return a;

--- a/js/hang/src/index.ts
+++ b/js/hang/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * WebCodecs-based media layer on top of `@moq/net`: catalog, container, and helpers
+ * for publishing and consuming live audio/video over MoQ.
+ *
+ * @module
+ */
+
 export * as Net from "@moq/net";
 /** @deprecated Use `Net` instead. */
 export * as Moq from "@moq/net";

--- a/js/hang/src/util/aac.ts
+++ b/js/hang/src/util/aac.ts
@@ -26,10 +26,12 @@ function channelConfig(channelCount: number): number {
 	return 2;
 }
 
-// Build the AudioSpecificConfig for AAC-LC, which decoders need to initialize when frames are raw (no
-// ADTS header). Standard sample rates produce the 2-byte form; non-table rates fall back to the
-// 5-byte form with an explicit 24-bit frequency. This mirrors Config::encode() in the Rust muxer so
-// the JS and Rust sides agree on the bytes.
+/**
+ * Build the AAC-LC AudioSpecificConfig that decoders need when frames are raw (no ADTS header).
+ *
+ * Standard sample rates produce the 2-byte form; non-table rates fall back to the 5-byte form
+ * with an explicit 24-bit frequency. Mirrors the Rust muxer so JS and Rust agree on the bytes.
+ */
 export function audioSpecificConfig(sampleRate: number, channelCount: number): Uint8Array {
 	const config = channelConfig(channelCount);
 	const freqIndex = SAMPLE_RATE_INDEX[sampleRate];

--- a/js/hang/src/util/hacks.ts
+++ b/js/hang/src/util/hacks.ts
@@ -1,5 +1,5 @@
-// https://issues.chromium.org/issues/40504498
+/** True when running in Chrome, used to work around https://issues.chromium.org/issues/40504498. */
 export const isChrome = navigator.userAgent.toLowerCase().includes("chrome");
 
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
+/** True when running in Firefox, used to work around https://bugzilla.mozilla.org/show_bug.cgi?id=1967793. */
 export const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");

--- a/js/hang/src/util/hex.ts
+++ b/js/hang/src/util/hex.ts
@@ -1,3 +1,4 @@
+/** Decode a hex string (with optional `0x` prefix) into bytes. */
 export function toBytes(hex: string) {
 	hex = hex.startsWith("0x") ? hex.slice(2) : hex;
 	if (hex.length % 2) {
@@ -12,6 +13,7 @@ export function toBytes(hex: string) {
 	return new Uint8Array(matches.map((byte) => parseInt(byte, 16)));
 }
 
+/** Encode bytes as a lowercase hex string. */
 export function fromBytes(bytes: Uint8Array) {
 	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }

--- a/js/hang/src/util/index.ts
+++ b/js/hang/src/util/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Miscellaneous helpers for the hang media layer: AAC config, hex encoding,
+ * latency tracking, and the libav/WebCodecs polyfill.
+ *
+ * @module
+ */
+
 export * as Aac from "./aac";
 export * as Hacks from "./hacks";
 export * as Hex from "./hex";

--- a/js/hang/src/util/latency.ts
+++ b/js/hang/src/util/latency.ts
@@ -4,8 +4,11 @@ import { Effect, type Getter, Signal } from "@moq/signals";
 
 type ConfigWithJitter = { jitter?: number; framerate?: number };
 
+/** Options for constructing a {@link Latency}. */
 export interface LatencyProps {
+	/** The user-configured buffer, added on top of the catalog jitter. */
 	buffer: Signal<Moq.Time.Milli>;
+	/** The track config supplying jitter and framerate, or undefined until known. */
 	config: Getter<ConfigWithJitter | undefined>;
 }
 
@@ -16,14 +19,19 @@ export interface LatencyProps {
  * Effective latency = catalog.jitter + buffer
  */
 export class Latency {
+	/** The user-configured buffer, added on top of the catalog jitter. */
 	buffer: Signal<Moq.Time.Milli>;
+	/** The track config supplying jitter and framerate. */
 	config: Getter<ConfigWithJitter | undefined>;
 
+	/** The reactive effect recomputing the combined latency. */
 	signals = new Effect();
 
 	#combined = new Signal<Moq.Time.Milli>(0 as Moq.Time.Milli);
+	/** The effective latency in milliseconds (catalog jitter plus buffer). */
 	readonly combined: Signal<Moq.Time.Milli> = this.#combined;
 
+	/** Start tracking latency from the given buffer and config signals. */
 	constructor(props: LatencyProps) {
 		this.buffer = props.buffer;
 		this.config = props.config;
@@ -49,10 +57,12 @@ export class Latency {
 		this.#combined.set(latency);
 	}
 
+	/** Read the current effective latency without subscribing. */
 	peek(): Moq.Time.Milli {
 		return this.#combined.peek();
 	}
 
+	/** Stop tracking and release the effect. */
 	close(): void {
 		this.signals.close();
 	}

--- a/js/hang/src/util/libav.ts
+++ b/js/hang/src/util/libav.ts
@@ -1,6 +1,6 @@
 let loading: Promise<boolean> | undefined;
 
-// Returns true when the polyfill is loaded.
+/** Load the libav WebCodecs polyfill (Opus) if AudioEncoder/AudioDecoder are missing. Resolves true once available. */
 export async function polyfill(): Promise<boolean> {
 	if (globalThis.AudioEncoder && globalThis.AudioDecoder) {
 		return true;

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -1,9 +1,13 @@
 import type { Time } from "@moq/net";
 import * as Moq from "@moq/net";
 
+/** A decoded LOC frame: the codec bitstream plus its timing metadata. */
 export interface Frame {
+	/** The codec bitstream payload, with the LOC property block stripped. */
 	data: Uint8Array;
+	/** Presentation timestamp in microseconds. */
 	timestamp: Time.Micro;
+	/** True if this frame can be decoded without any preceding frames. */
 	keyframe: boolean;
 }
 
@@ -21,6 +25,7 @@ const DEFAULT_TIMESCALE = 1_000_000;
  * timescale property are interpreted as microseconds.
  */
 export class Format {
+	/** Decode one moq-net frame into its LOC frames. Throws on malformed input. */
 	decode(frame: Uint8Array): Frame[] {
 		const [propsLen, afterLen] = Moq.Varint.decode(frame);
 		if (afterLen.byteLength < propsLen) {
@@ -73,8 +78,11 @@ export class Format {
 	}
 }
 
+/** A payload that can be copied into a buffer without first materializing a Uint8Array. */
 export interface Source {
+	/** Size in bytes of the payload. */
 	byteLength: number;
+	/** Copy the payload into the provided buffer. */
 	copyTo(buffer: Uint8Array): void;
 }
 
@@ -93,6 +101,7 @@ export class Producer {
 		this.#track = track;
 	}
 
+	/** Encode one frame and write it to the track. Keyframes start a new group. */
 	encode(data: Uint8Array | Source, timestamp: Time.Micro, keyframe: boolean) {
 		if (keyframe) {
 			this.#group?.close();
@@ -133,6 +142,7 @@ export class Producer {
 		return out;
 	}
 
+	/** Close the current group and the underlying track, optionally with an error. */
 	close(err?: Error) {
 		this.#group?.close();
 		this.#track.close(err);

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Low Overhead Container (LOC): encode and decode codec bitstreams framed with
+ * per-frame timestamp and timescale metadata for MoQ.
+ *
+ * @module
+ */
 import type { Time } from "@moq/net";
 import * as Moq from "@moq/net";
 

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -1,20 +1,25 @@
 import type * as Moq from "@moq/net";
 import * as z from "zod/mini";
 
+/** Zod schema for a track's wire packaging. Accepts known values or any future string. */
 export const PackagingSchema = z.union([
 	z.enum(["loc", "cmaf", "legacy", "mediatimeline", "eventtimeline"]),
 	z.string(),
 ]);
 
+/** How a track's frames are packaged on the wire (e.g. "loc" or "cmaf"). */
 export type Packaging = z.infer<typeof PackagingSchema>;
 
+/** Zod schema for a track's role. Accepts known values or any future string. */
 export const RoleSchema = z.union([
 	z.enum(["video", "audio", "audiodescription", "caption", "subtitle", "signlanguage"]),
 	z.string(),
 ]);
 
+/** The semantic role a track plays in the presentation (e.g. "video", "audio", "caption"). */
 export type Role = z.infer<typeof RoleSchema>;
 
+/** Zod schema describing a single track entry in an MSF catalog. */
 export const TrackSchema = z.object({
 	name: z.string(),
 	packaging: PackagingSchema,
@@ -37,20 +42,25 @@ export const TrackSchema = z.object({
 	jitter: z.optional(z.number()),
 });
 
+/** A single track in an MSF catalog, including its codec and media properties. */
 export type Track = z.infer<typeof TrackSchema>;
 
+/** Zod schema for the top-level MSF catalog (version 1). */
 export const CatalogSchema = z.object({
 	version: z.literal(1),
 	tracks: z.array(TrackSchema),
 });
 
+/** The MSF catalog: a versioned list of available tracks. */
 export type Catalog = z.infer<typeof CatalogSchema>;
 
+/** Serialize a catalog to its JSON wire representation. */
 export function encode(catalog: Catalog): Uint8Array {
 	const encoder = new TextEncoder();
 	return encoder.encode(JSON.stringify(catalog));
 }
 
+/** Parse and validate a catalog from its JSON wire representation. Throws if invalid. */
 export function decode(raw: Uint8Array): Catalog {
 	const decoder = new TextDecoder();
 	const str = decoder.decode(raw);
@@ -63,6 +73,7 @@ export function decode(raw: Uint8Array): Catalog {
 	}
 }
 
+/** Read and decode the next catalog frame from a track, or undefined if the track ended. */
 export async function fetch(track: Moq.Track): Promise<Catalog | undefined> {
 	const frame = await track.readFrame();
 	if (!frame) return undefined;

--- a/js/msf/src/index.ts
+++ b/js/msf/src/index.ts
@@ -1,1 +1,7 @@
+/**
+ * MSF (MOQT Streaming Format) catalog: Zod schemas and types describing the
+ * tracks in a broadcast (packaging, role, codec, and media properties).
+ *
+ * @module
+ */
 export * from "./catalog";

--- a/js/net/src/announced.ts
+++ b/js/net/src/announced.ts
@@ -11,6 +11,7 @@ export interface AnnouncedEntry {
 	active: boolean;
 }
 
+/** Reactive backing state for an {@link Announced}: the pending queue plus a closed flag. */
 export class AnnouncedState {
 	queue = new Signal<AnnouncedEntry[]>([]);
 	closed = new Signal<boolean | Error>(false);
@@ -22,9 +23,13 @@ export class AnnouncedState {
  * @public
  */
 export class Announced {
+	/** Reactive backing state. */
 	state = new AnnouncedState();
+
+	/** Path prefix this stream is scoped to. */
 	prefix: Path.Valid;
 
+	/** Resolves with the abort error (or undefined) once closed. */
 	readonly closed: Promise<Error | undefined>;
 
 	constructor(prefix = Path.empty()) {

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -1,11 +1,13 @@
 import { Signal } from "@moq/signals";
 import { Track } from "./track.ts";
 
+/** A track a subscriber asked for, along with its requested delivery priority. */
 export interface TrackRequest {
 	track: Track;
 	priority: number;
 }
 
+/** Reactive backing state for a {@link Broadcast}: requested tracks plus a closed flag. */
 export class BroadcastState {
 	requested = new Signal<TrackRequest[]>([]);
 	closed = new Signal<boolean | Error>(false);
@@ -17,8 +19,10 @@ export class BroadcastState {
  * @public
  */
 export class Broadcast {
+	/** Reactive backing state. */
 	state = new BroadcastState();
 
+	/** Resolves with the abort error (or undefined) once closed. */
 	readonly closed: Promise<Error | undefined>;
 
 	constructor() {

--- a/js/net/src/connection/accept.ts
+++ b/js/net/src/connection/accept.ts
@@ -4,6 +4,7 @@ import { Stream } from "../stream.ts";
 import type { Established } from "./established.ts";
 import { exchangeSetup } from "./handshake.ts";
 
+/** Options for {@link accept}. */
 export interface AcceptProps {
 	// Version to select during SETUP negotiation (for non-ALPN paths).
 	version?: number;

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -9,6 +9,7 @@ import { exchangeSetup } from "./handshake.ts";
 // Default head start for WebTransport before attempting the WebSocket fallback.
 const DEFAULT_WEBSOCKET_DELAY_MS = 500;
 
+/** Tuning for the WebSocket fallback used when WebTransport is unavailable or loses the connect race. */
 export interface WebSocketOptions {
 	// If true (default), enable the WebSocket fallback.
 	enabled?: boolean;
@@ -25,12 +26,14 @@ export interface WebSocketOptions {
 // One entry of `serverCertificateHashes`, used to pin a self-signed server.
 // Unlike the DOM type, `value` also accepts a hex string (the format moq
 // servers report via their certificate fingerprints), decoded automatically.
+/** A server certificate hash used to pin a self-signed server. `value` accepts raw bytes or a hex string. */
 export interface CertificateHash {
 	algorithm?: "sha-256";
 	value: BufferSource | string;
 }
 
 // WebTransport options, extended with friendlier certificate pinning.
+/** WebTransport options extended with friendlier certificate pinning (hex hashes or a raw certificate). */
 export interface WebTransportProps extends Omit<WebTransportOptions, "serverCertificateHashes"> {
 	// Pin the server to one or more certificate hashes. Each `value` may be raw
 	// bytes or a hex string; the algorithm defaults to `sha-256`.
@@ -42,6 +45,7 @@ export interface WebTransportProps extends Omit<WebTransportOptions, "serverCert
 	serverCertificate?: string | BufferSource;
 }
 
+/** Options for {@link connect}. */
 export interface ConnectProps {
 	// WebTransport options.
 	webtransport?: WebTransportProps;

--- a/js/net/src/connection/established.ts
+++ b/js/net/src/connection/established.ts
@@ -5,9 +5,12 @@ import type { Broadcast } from "../broadcast.ts";
 import type * as Path from "../path.ts";
 import type * as Time from "../time.ts";
 
-// Both moq-lite and moq-ietf implement this.
+/** An established MoQ session, implemented by both the moq-lite and moq-ietf protocols. */
 export interface Established {
+	/** URL of the connected server. */
 	readonly url: URL;
+
+	/** Negotiated wire protocol version. */
 	readonly version: string;
 
 	/** Estimated send bitrate from the congestion controller (if supported). */
@@ -19,9 +22,18 @@ export interface Established {
 	/** RTT in milliseconds from PROBE (moq-lite-04+ only). */
 	readonly rtt?: Signal<Time.Milli | undefined>;
 
+	/** Subscribe to broadcast announcements under an optional path prefix. */
 	announced(prefix?: Path.Valid): Announced;
+
+	/** Publish a broadcast at the given path. */
 	publish(path: Path.Valid, broadcast: Broadcast): void;
+
+	/** Consume the broadcast at the given path. */
 	consume(broadcast: Path.Valid): Broadcast;
+
+	/** Close the session. */
 	close(): void;
+
+	/** Resolves when the session closes. */
 	closed: Promise<void>;
 }

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -4,6 +4,7 @@ import { empty as emptyPath } from "../path.ts";
 import { type ConnectProps, connect, type WebSocketOptions, type WebTransportProps } from "./connect.ts";
 import type { Established } from "./established.ts";
 
+/** Exponential backoff settings for {@link Reload}'s reconnect loop. */
 export type ReloadDelay = {
 	// The delay in milliseconds before reconnecting.
 	// default: 1000
@@ -23,6 +24,7 @@ export type ReloadDelay = {
 	timeout?: DOMHighResTimeStamp;
 };
 
+/** Options for {@link Reload}: connect options plus reactive URL/enabled signals and backoff tuning. */
 export type ReloadProps = ConnectProps & {
 	// Whether to reload the connection when it disconnects.
 	// default: true
@@ -35,31 +37,42 @@ export type ReloadProps = ConnectProps & {
 	delay?: ReloadDelay;
 };
 
+/** Current state of a {@link Reload} connection. */
 export type ReloadStatus = "connecting" | "connected" | "disconnected";
 
+/** Maintains a MoQ connection, reconnecting with exponential backoff when it drops. */
 export class Reload {
+	/** Relay URL to connect to; updating it triggers a reconnect. */
 	url: Signal<URL | undefined>;
+
+	/** Whether reconnecting is active. */
 	enabled: Signal<boolean>;
 
+	/** Current connection status. */
 	status = new Signal<ReloadStatus>("disconnected");
+
+	/** The currently established session, or undefined while disconnected. */
 	established = new Signal<Established | undefined>(undefined);
 
 	// All actively announced broadcast paths, updated reactively.
 	#announced = new Signal<Set<Path.Valid>>(new Set());
+
+	/** The set of broadcast paths currently announced by the server, updated reactively. */
 	readonly announced: Getter<Set<Path.Valid>> = this.#announced;
 
-	// WebTransport options (not reactive).
+	/** WebTransport options applied to each connection attempt (not reactive). */
 	webtransport?: WebTransportProps;
 
-	// WebSocket (fallback) options (not reactive).
+	/** WebSocket fallback options applied to each connection attempt (not reactive). */
 	websocket: WebSocketOptions | undefined;
 
-	// Not reactive, but can be updated.
+	/** Backoff settings for the reconnect loop. */
 	delay: ReloadDelay;
 
+	/** The reactive effect scope driving the connect loop; closed by {@link Reload.close}. */
 	signals = new Effect();
 
-	// Resolves when the reconnect loop stops (close() or timeout).
+	/** Resolves when the reconnect loop stops via {@link Reload.close} or the retry timeout. */
 	closed: Promise<void>;
 	#closedResolve!: () => void;
 	#closedReject!: (err: Error) => void;
@@ -185,6 +198,7 @@ export class Reload {
 		});
 	}
 
+	/** Stop reconnecting, close the current connection, and resolve {@link Reload.closed}. */
 	close() {
 		this.signals.close();
 		this.#closedResolve();

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -1,15 +1,21 @@
 import { Signal } from "@moq/signals";
 
+/** Reactive backing state for a {@link Group}: buffered frames, a closed flag, and the running frame count. */
 export class GroupState {
 	frames = new Signal<Uint8Array[]>([]);
 	closed = new Signal<boolean | Error>(false);
 	total = new Signal<number>(0); // The total number of frames in the group thus far
 }
 
+/** An ordered stream of frames within a track, delivered over a single QUIC stream. */
 export class Group {
+	/** Sequence number of this group within its track. */
 	readonly sequence: number;
 
+	/** Reactive backing state. */
 	state = new GroupState();
+
+	/** Resolves with the abort error (or undefined) once closed. */
 	readonly closed: Promise<Error | undefined>;
 
 	constructor(sequence: number) {
@@ -39,14 +45,17 @@ export class Group {
 		this.state.total.update((total) => total + 1);
 	}
 
+	/** Write a string as a single UTF-8 encoded frame. */
 	writeString(str: string) {
 		this.writeFrame(new TextEncoder().encode(str));
 	}
 
+	/** Write a value as a single JSON-encoded frame. */
 	writeJson(json: unknown) {
 		this.writeString(JSON.stringify(json));
 	}
 
+	/** Write a boolean as a single one-byte frame. */
 	writeBool(bool: boolean) {
 		this.writeFrame(new Uint8Array([bool ? 1 : 0]));
 	}
@@ -69,6 +78,7 @@ export class Group {
 		}
 	}
 
+	/** Reads the next frame along with its sequence number within the group. */
 	async readFrameSequence(): Promise<{ sequence: number; data: Uint8Array } | undefined> {
 		for (;;) {
 			const frames = this.state.frames.peek();
@@ -83,21 +93,25 @@ export class Group {
 		}
 	}
 
+	/** Reads the next frame and decodes it as a UTF-8 string. */
 	async readString(): Promise<string | undefined> {
 		const frame = await this.readFrame();
 		return frame ? new TextDecoder().decode(frame) : undefined;
 	}
 
+	/** Reads the next frame and parses it as JSON. */
 	async readJson(): Promise<unknown | undefined> {
 		const frame = await this.readString();
 		return frame ? JSON.parse(frame) : undefined;
 	}
 
+	/** Reads the next frame and decodes it as a one-byte boolean. */
 	async readBool(): Promise<boolean | undefined> {
 		const frame = await this.readFrame();
 		return frame ? frame[0] === 1 : undefined;
 	}
 
+	/** Closes the group, optionally with an error to abort readers. */
 	close(abort?: Error) {
 		this.state.closed.set(abort ?? true);
 	}

--- a/js/net/src/index.ts
+++ b/js/net/src/index.ts
@@ -1,10 +1,22 @@
+/**
+ * MoQ networking layer for browsers: connect to a relay, then publish and consume
+ * broadcasts, tracks, groups, and frames over WebTransport (or a WebSocket fallback).
+ *
+ * @module
+ */
+
+/** Re-export of {@link https://jsr.io/@moq/signals | @moq/signals}, the reactive primitives used throughout this package. */
 export * as Signals from "@moq/signals";
 export * from "./announced.ts";
 export * from "./bandwidth.ts";
 export * from "./broadcast.ts";
+/** Connection helpers: connect to or accept a MoQ session and reconnect on failure. */
 export * as Connection from "./connection/index.ts";
 export * from "./group.ts";
+/** Broadcast path utilities with delimiter-aware prefix matching. */
 export * as Path from "./path.ts";
+/** Branded time types (nanoseconds, microseconds, milliseconds, seconds) with conversions. */
 export * as Time from "./time.ts";
 export * from "./track.ts";
+/** QUIC variable-length integer encoding and decoding. */
 export * as Varint from "./varint.ts";

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -30,6 +30,7 @@
  */
 export type Valid = string & { __brand: "Name" };
 
+/** Build a path from one or more components, joining with "/" and trimming redundant slashes. */
 export function from(...paths: string[]): Valid {
 	// Join paths with "/" and then remove leading and trailing slashes, and collapse multiple slashes into one.
 	const joined = paths.join("/");
@@ -132,6 +133,7 @@ export function join(path: Valid, other: Valid): Valid {
 	}
 }
 
+/** The empty path, which is a prefix of every path. */
 export function empty(): Valid {
 	return "" as Valid;
 }

--- a/js/net/src/time.ts
+++ b/js/net/src/time.ts
@@ -1,5 +1,7 @@
+/** A duration in nanoseconds, branded so it can't be mixed with other units. */
 export type Nano = number & { readonly _brand: "nano" };
 
+/** Constructors, conversions, and arithmetic for {@link Nano} values. */
 export const Nano = {
 	zero: 0 as Nano,
 	fromMicro: (us: Micro): Nano => (us * 1_000) as Nano,
@@ -17,8 +19,10 @@ export const Nano = {
 	min: (a: Nano, b: Nano): Nano => Math.min(a, b) as Nano,
 } as const;
 
+/** A duration in microseconds, branded so it can't be mixed with other units. */
 export type Micro = number & { readonly _brand: "micro" };
 
+/** Constructors, conversions, and arithmetic for {@link Micro} values. */
 export const Micro = {
 	zero: 0 as Micro,
 	fromNano: (ns: Nano): Micro => (ns / 1_000) as Micro,
@@ -36,8 +40,10 @@ export const Micro = {
 	min: (a: Micro, b: Micro): Micro => Math.min(a, b) as Micro,
 } as const;
 
+/** A duration in milliseconds, branded so it can't be mixed with other units. */
 export type Milli = number & { readonly _brand: "milli" };
 
+/** Constructors, conversions, and arithmetic for {@link Milli} values. */
 export const Milli = {
 	zero: 0 as Milli,
 	fromNano: (ns: Nano): Milli => (ns / 1_000_000) as Milli,
@@ -55,8 +61,10 @@ export const Milli = {
 	min: (a: Milli, b: Milli): Milli => Math.min(a, b) as Milli,
 } as const;
 
+/** A duration in seconds, branded so it can't be mixed with other units. */
 export type Second = number & { readonly _brand: "second" };
 
+/** Constructors, conversions, and arithmetic for {@link Second} values. */
 export const Second = {
 	zero: 0 as Second,
 	fromNano: (ns: Nano): Second => (ns / 1_000_000_000) as Second,

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1,19 +1,24 @@
 import { Signal } from "@moq/signals";
 import { Group } from "./group.ts";
 
+/** Reactive backing state for a {@link Track}: buffered groups, a closed flag, and the subscription priority. */
 export class TrackState {
 	groups = new Signal<Group[]>([]);
 	closed = new Signal<boolean | Error>(false);
 	priority = new Signal<number | undefined>(undefined);
 }
 
+/** A live stream of groups within a broadcast, identified by name. */
 export class Track {
+	/** Name of this track within its broadcast. */
 	readonly name: string;
 
+	/** Reactive backing state. */
 	state = new TrackState();
 	#next?: number;
 	#nextSequence = 0;
 
+	/** Resolves with the abort error (or undefined) once closed. */
 	readonly closed: Promise<Error | undefined>;
 
 	constructor(name: string) {
@@ -75,18 +80,21 @@ export class Track {
 		group.close();
 	}
 
+	/** Appends a string to the track as its own single-frame group. */
 	writeString(str: string) {
 		const group = this.appendGroup();
 		group.writeString(str);
 		group.close();
 	}
 
+	/** Appends a JSON value to the track as its own single-frame group. */
 	writeJson(json: unknown) {
 		const group = this.appendGroup();
 		group.writeJson(json);
 		group.close();
 	}
 
+	/** Appends a boolean to the track as its own single-frame group. */
 	writeBool(bool: boolean) {
 		const group = this.appendGroup();
 		group.writeBool(bool);
@@ -142,11 +150,12 @@ export class Track {
 		}
 	}
 
+	/** Reads the next frame across all groups, discarding older groups. */
 	async readFrame(): Promise<Uint8Array | undefined> {
 		return (await this.readFrameSequence())?.data;
 	}
 
-	// Returns the sequence number of the group and frame, not just the data.
+	/** Reads the next frame along with its group and frame sequence numbers. */
 	async readFrameSequence(): Promise<{ group: number; frame: number; data: Uint8Array } | undefined> {
 		for (;;) {
 			const groups = this.state.groups.peek();
@@ -193,18 +202,21 @@ export class Track {
 		}
 	}
 
+	/** Reads the next frame and decodes it as a UTF-8 string. */
 	async readString(): Promise<string | undefined> {
 		const next = await this.readFrame();
 		if (!next) return undefined;
 		return new TextDecoder().decode(next);
 	}
 
+	/** Reads the next frame and parses it as JSON. */
 	async readJson(): Promise<unknown | undefined> {
 		const next = await this.readString();
 		if (!next) return undefined;
 		return JSON.parse(next);
 	}
 
+	/** Reads the next frame and decodes it as a one-byte boolean, throwing on a malformed frame. */
 	async readBool(): Promise<boolean | undefined> {
 		const next = await this.readFrame();
 		if (!next) return undefined;

--- a/js/net/src/varint.ts
+++ b/js/net/src/varint.ts
@@ -1,9 +1,13 @@
 // QUIC variable-length integer encoding/decoding
 // https://www.rfc-editor.org/rfc/rfc9000#section-16
 
+/** Largest value that fits in a 1-byte varint (6 bits). */
 export const MAX_U6 = 2 ** 6 - 1;
+/** Largest value that fits in a 2-byte varint (14 bits). */
 export const MAX_U14 = 2 ** 14 - 1;
+/** Largest value that fits in a 4-byte varint (30 bits). */
 export const MAX_U30 = 2 ** 30 - 1;
+/** Largest value representable without precision loss (`Number.MAX_SAFE_INTEGER`, 53 bits). */
 export const MAX_U53 = Number.MAX_SAFE_INTEGER;
 
 // Leading-ones varint encoding/decoding (draft-17 Section 1.4.1)
@@ -20,6 +24,7 @@ export const MAX_U53 = Number.MAX_SAFE_INTEGER;
 
 const MAX_U64 = (1n << 64n) - 1n;
 
+/** Number of bytes needed to encode a value in the leading-ones varint format. */
 export function sizeLeadingOnes(v: number | bigint): number {
 	const b = BigInt(v);
 	if (b < 0n) throw new RangeError(`value is negative: ${v}`);
@@ -34,6 +39,7 @@ export function sizeLeadingOnes(v: number | bigint): number {
 	return 9;
 }
 
+/** Encode a value in leading-ones varint format into the provided buffer, returning the written subarray. */
 export function encodeLeadingOnesTo(dst: ArrayBuffer, v: number | bigint): Uint8Array {
 	const x = BigInt(v);
 	if (x < 0n) throw new RangeError(`underflow, value is negative: ${v}`);
@@ -86,10 +92,12 @@ export function encodeLeadingOnesTo(dst: ArrayBuffer, v: number | bigint): Uint8
 	return new Uint8Array(dst, 0, 9);
 }
 
+/** Encode a value in leading-ones varint format into a freshly allocated buffer. */
 export function encodeLeadingOnes(v: number | bigint): Uint8Array {
 	return encodeLeadingOnesTo(new ArrayBuffer(9), v);
 }
 
+/** Decode a leading-ones varint, returning the value and the remaining buffer. */
 export function decodeLeadingOnes(buf: Uint8Array): [bigint, Uint8Array] {
 	if (buf.length === 0) throw new Error("buffer is empty");
 

--- a/js/net/src/zod.ts
+++ b/js/net/src/zod.ts
@@ -1,15 +1,21 @@
-// Helper containers for Zod-validated track encoding/decoding.
+/**
+ * Helpers for reading and writing Zod-validated JSON frames on a track or group.
+ *
+ * @module
+ */
 
 import type * as z from "zod/mini";
 import type { Group } from "./group.ts";
 import type { Track } from "./track.ts";
 
+/** Read the next JSON frame and validate it against the schema. Returns undefined at end of stream. */
 export async function read<T = unknown>(source: Track | Group, schema: z.ZodMiniType<T>): Promise<T | undefined> {
 	const next = await source.readJson();
 	if (next === undefined) return undefined; // only treat undefined as EOF, not other falsy values
 	return schema.parse(next);
 }
 
+/** Validate a value against the schema, then write it as a JSON frame. */
 export function write<T = unknown>(source: Track | Group, value: T, schema: z.ZodMiniType<T>) {
 	const valid = schema.parse(value);
 	source.writeJson(valid);

--- a/js/signals/src/dom.ts
+++ b/js/signals/src/dom.ts
@@ -1,5 +1,13 @@
+/**
+ * DOM helpers built on Effects: create elements, render reactive content, and
+ * toggle classes with automatic cleanup when the owning effect tears down.
+ *
+ * @module
+ */
+
 import type { Effect } from ".";
 
+/** Options for {@link create}: styles, classes, dataset, attributes, plus any element properties. */
 export type CreateOptions<T extends HTMLElement> = {
 	style?: Partial<CSSStyleDeclaration>;
 	className?: string;
@@ -9,6 +17,7 @@ export type CreateOptions<T extends HTMLElement> = {
 	attributes?: Record<string, string>;
 } & Partial<Omit<T, "style" | "dataset">>;
 
+/** Creates an HTML element, applying the given options and appending the given children. */
 export function create<K extends keyof HTMLElementTagNameMap>(
 	tagName: K,
 	options?: CreateOptions<HTMLElementTagNameMap[K] & HTMLElement>,
@@ -61,10 +70,11 @@ export function create<K extends keyof HTMLElementTagNameMap>(
 	return element;
 }
 
-// Matches solid.js's JSX.Element type.
+/** Renderable content: a node, array of nodes, primitive, or nullish. Matches solid.js's JSX.Element. */
 export type Element = Node | ArrayElement | (string & {}) | number | boolean | null | undefined;
 interface ArrayElement extends Array<Element> {}
 
+/** Renders `element` into `parent`, removing it again when the effect reruns or closes. */
 export function render(effect: Effect, parent: Node, element: Element | ((effect: Effect) => Element)) {
 	const e = typeof element === "function" ? element(effect) : element;
 	if (e === undefined || e === null) return;
@@ -88,6 +98,7 @@ export function render(effect: Effect, parent: Node, element: Element | ((effect
 	effect.cleanup(() => parent.removeChild(node));
 }
 
+/** Adds the given classes to `element`, removing them again when the effect reruns or closes. */
 export function setClass(effect: Effect, element: HTMLElement, ...classNames: string[]) {
 	for (const className of classNames) {
 		element.classList.add(className);

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Reactive, safe signals: observable values, derived computeds, and effects
+ * that track their dependencies and clean up automatically.
+ *
+ * @module
+ */
+
+/** Cancels a subscription, effect, or other registration when called. */
 export type Dispose = () => void;
 
 type Subscriber<T> = (value: T) => void;
@@ -8,22 +16,27 @@ const DEV = typeof import.meta.env !== "undefined" && import.meta.env?.MODE !== 
 // Symbol to identify Signal instances across different package versions
 const SIGNAL_BRAND = Symbol.for("@moq/signals");
 
+/** Read side of a signal: peek the current value and subscribe to changes. */
 export interface Getter<T> {
-	// Get the current value.
+	/** Returns the current value without subscribing. */
 	peek(): T;
 
-	// Receive a notification once when the value changes.
+	/** Calls `fn` once the next time the value changes. */
 	changed(fn: Subscriber<T>): Dispose;
 
-	// Receive a notification each time the value changes.
+	/** Calls `fn` every time the value changes. */
 	subscribe(fn: Subscriber<T>): Dispose;
 }
 
+/** Write side of a signal: replace or transform the current value. */
 export interface Setter<T> {
+	/** Replaces the value, or transforms it via a function of the previous value. */
 	set(value: T | ((prev: T) => T)): void;
+	/** Transforms the value via a function of the previous value. */
 	update(fn: (prev: T) => T): void;
 }
 
+/** A mutable observable value. Writes are coalesced per microtask and only notify subscribers when the value actually changes. */
 export class Signal<T> implements Getter<T>, Setter<T> {
 	#value: T;
 
@@ -43,6 +56,7 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 		this.#value = value;
 	}
 
+	/** Returns the value if it's already a Signal, otherwise wraps it in a new Signal. */
 	static from<T>(value: T | Signal<T>): Signal<T> {
 		// Use brand check instead of instanceof to work across package instances
 		if (typeof value === "object" && value !== null && SIGNAL_BRAND in value) {
@@ -51,17 +65,21 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 		return new Signal(value);
 	}
 
+	/** Returns the current value without subscribing. */
 	get(): T {
 		return this.#value;
 	}
 
+	/** Returns the current value without subscribing. */
 	// TODO rename to `get` once we've ported everything
 	peek(): T {
 		return this.#value;
 	}
 
-	// Set the current value, by default notifying subscribers if the value is different.
-	// If notify is undefined, we'll check if the value has changed after the microtask.
+	/**
+	 * Sets the current value, notifying subscribers if it changed.
+	 * Pass `notify` true to always notify or false to never notify.
+	 */
 	set(value: T, notify?: boolean): void {
 		// Capture old value before the first set in this microtask.
 		if (!this.#hasCapturedOldValue) {
@@ -126,21 +144,23 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 		}
 	}
 
-	// Mutate the current value and notify subscribers unless notify is false.
-	// Unlike set, we can't use a dequal check because the function may mutate the value.
+	/** Sets the value to the result of `fn(prev)`, notifying subscribers unless `notify` is false. */
 	update(fn: (prev: T) => T, notify = true): void {
 		const value = fn(this.#value);
 		this.set(value, notify);
 	}
 
-	// Mutate the current value and notify subscribers unless notify is false.
+	/**
+	 * Mutates the current value in place via `fn`, returning `fn`'s result and
+	 * notifying subscribers unless `notify` is false.
+	 */
 	mutate<R>(fn: (value: T) => R, notify = true): R {
 		const r = fn(this.#value);
 		this.set(this.#value, notify);
 		return r;
 	}
 
-	// Receive a notification each time the value changes.
+	/** Calls `fn` every time the value changes. Returns a function to unsubscribe. */
 	subscribe(fn: Subscriber<T>): Dispose {
 		this.#subscribers.add(fn);
 		if (DEV && this.#subscribers.size >= 100 && Number.isInteger(Math.log10(this.#subscribers.size))) {
@@ -149,26 +169,27 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 		return () => this.#subscribers.delete(fn);
 	}
 
-	// Receive a notification when the value changes.
+	/** Calls `fn` once the next time the value changes. Returns a function to cancel. */
 	changed(fn: (value: T) => void): Dispose {
 		this.#changed.add(fn);
 		return () => this.#changed.delete(fn);
 	}
 
-	// Resolve with the next value, once the signal changes.
+	/** Resolves with the next value, once the signal changes. */
 	next(): Promise<T> {
 		return new Promise<T>((resolve) => {
 			this.changed(resolve);
 		});
 	}
 
-	// Receive a notification when the value changes AND with the initial value.
+	/** Calls `fn` with the current value now, and again every time it changes. */
 	watch(fn: Subscriber<T>): Dispose {
 		const dispose = this.subscribe(fn);
 		queueMicrotask(() => fn(this.#value));
 		return dispose;
 	}
 
+	/** Resolves with the next value from whichever of the given signals changes first. */
 	static async race<T extends readonly unknown[]>(
 		...sigs: { [K in keyof T]: Signal<T[K]> }
 	): Promise<Awaited<T[number]>> {
@@ -192,6 +213,11 @@ type GetterType<G> = G extends Getter<infer T> ? T : never;
 type Falsy = false | 0 | "" | null | undefined;
 type Truthy<T> = Exclude<T, Falsy>;
 
+/**
+ * Runs a function that reads signals via `effect.get(...)` and reruns whenever
+ * any of them change. Registers cleanup, timers, and event listeners that are
+ * torn down automatically on each rerun and when the effect is closed.
+ */
 // TODO Make this a single instance of an Effect, so close() can work correctly from async code.
 export class Effect {
 	// Sanity check to make sure roots are being disposed on dev.
@@ -212,7 +238,7 @@ export class Effect {
 
 	#abort: AbortController = new AbortController();
 
-	// If a function is provided, it will be run with the effect as an argument.
+	/** If a function is provided, it runs immediately and reruns whenever a tracked signal changes. */
 	constructor(fn?: (effect: Effect) => void) {
 		if (DEV) {
 			const debug = new Error("created here:").stack ?? "No stack";
@@ -308,7 +334,7 @@ export class Effect {
 		}
 	}
 
-	// Get the current value of a signal, monitoring it for changes (via ===) and rerunning on change.
+	/** Reads a signal and tracks it, rerunning the effect whenever it changes. */
 	get<T>(signal: Getter<T>): T {
 		if (this.#dispose === undefined) {
 			if (DEV) {
@@ -327,9 +353,10 @@ export class Effect {
 		return value;
 	}
 
-	// Temporarily set the value of a signal, unsetting it on cleanup.
-	// The last argument is the cleanup value, set before the effect is rerun.
-	// It's optional only if T can be undefined.
+	/**
+	 * Sets a signal for the duration of this run, restoring `cleanup` on rerun or close.
+	 * The cleanup value is optional only when the signal type includes `undefined`.
+	 */
 	set<S extends Setter<unknown>>(
 		signal: S,
 		value: SetterType<S>,
@@ -348,8 +375,10 @@ export class Effect {
 		this.cleanup(() => signal.set(cleanupValue));
 	}
 
-	// Spawn an async effect that blocks the effect being reloaded until it completes.
-	// Use this.cancel if you need to detect when the effect is reloading to terminate.
+	/**
+	 * Runs an async task that blocks the effect from rerunning until it resolves.
+	 * Await `cancel` inside the task to detect a pending rerun and bail out early.
+	 */
 	// TODO: Add effect for another layer of nesting
 	spawn(fn: () => Promise<void>) {
 		const promise = fn().catch((error) => {
@@ -367,7 +396,7 @@ export class Effect {
 		this.#async.push(promise);
 	}
 
-	// Run the function after the given delay in milliseconds UNLESS the effect is cleaned up first.
+	/** Runs `fn` after `ms` milliseconds, unless the effect reruns or closes first. */
 	timer(fn: () => void, ms: DOMHighResTimeStamp) {
 		if (this.#dispose === undefined) {
 			if (DEV) {
@@ -384,7 +413,7 @@ export class Effect {
 		this.cleanup(() => timeout && clearTimeout(timeout));
 	}
 
-	// Run the function, and clean up the nested effect after the given delay.
+	/** Runs `fn` as a nested effect, then closes that effect after `ms` milliseconds. */
 	timeout(fn: (effect: Effect) => void, ms: DOMHighResTimeStamp) {
 		if (this.#dispose === undefined) {
 			if (DEV) {
@@ -408,7 +437,7 @@ export class Effect {
 		});
 	}
 
-	// Run the callback on the next animation frame, unless the effect is cleaned up first.
+	/** Runs `fn` on the next animation frame, unless the effect reruns or closes first. */
 	animate(fn: (now: DOMHighResTimeStamp) => void) {
 		if (this.#dispose === undefined) {
 			if (DEV) {
@@ -426,6 +455,7 @@ export class Effect {
 		});
 	}
 
+	/** Runs `fn` every `ms` milliseconds until the effect reruns or closes. */
 	interval(fn: () => void, ms: DOMHighResTimeStamp) {
 		if (this.#dispose === undefined) {
 			if (DEV) {
@@ -440,7 +470,7 @@ export class Effect {
 		this.cleanup(() => clearInterval(interval));
 	}
 
-	// Create a nested effect that can be rerun independently.
+	/** Creates a nested effect that reruns independently and is closed with its parent. */
 	run(fn: (effect: Effect) => void) {
 		if (this.#dispose === undefined) {
 			if (DEV) {
@@ -453,20 +483,19 @@ export class Effect {
 		this.#dispose.push(() => effect.close());
 	}
 
-	// Backwards compatibility with the old name.
+	/** Alias for {@link run}, kept for backwards compatibility. */
 	effect(fn: (effect: Effect) => void) {
 		return this.run(fn);
 	}
 
-	// Create a derived signal whose lifetime is tied to this effect.
-	// It's closed (unsubscribing from its dependencies) when the effect reruns or closes.
+	/** Creates a derived signal scoped to this effect, closed when the effect reruns or closes. */
 	computed<T>(fn: (effect: Effect) => T): Computed<T> {
 		const computed = new Computed(fn);
 		this.cleanup(() => computed.close());
 		return computed;
 	}
 
-	// Get the values of multiple signals, returning undefined if any are falsy.
+	/** Reads and tracks several signals, returning their values or `undefined` if any is falsy. */
 	getAll<S extends readonly Getter<unknown>[]>(
 		signals: [...S],
 	): { [K in keyof S]: Truthy<GetterType<S[K]>> } | undefined {
@@ -479,7 +508,7 @@ export class Effect {
 		return values as { [K in keyof S]: Truthy<GetterType<S[K]>> };
 	}
 
-	// A helper to call a function when a signal changes.
+	/** Runs `fn` with the signal's value now and again whenever it changes, scoped to this effect. */
 	subscribe<T>(signal: Getter<T>, fn: (value: T) => void) {
 		if (this.#dispose === undefined) {
 			if (DEV) {
@@ -495,7 +524,7 @@ export class Effect {
 		});
 	}
 
-	// Add an event listener that automatically removes on cleanup.
+	/** Adds an event listener that is removed automatically when the effect reruns or closes. */
 	event<K extends keyof HTMLElementEventMap>(
 		target: HTMLElement,
 		type: K,
@@ -580,7 +609,7 @@ export class Effect {
 		target.addEventListener(type, listener, merged);
 	}
 
-	// Register a cleanup function.
+	/** Registers a function to run when the effect reruns or closes. */
 	cleanup(fn: Dispose): void {
 		if (this.#dispose === undefined) {
 			if (DEV) {
@@ -594,6 +623,7 @@ export class Effect {
 		this.#dispose.push(fn);
 	}
 
+	/** Stops the effect permanently, running all cleanup and unsubscribing from every signal. */
 	close(): void {
 		if (this.#dispose === undefined) {
 			return;
@@ -616,57 +646,69 @@ export class Effect {
 		}
 	}
 
+	/** Resolves when the effect is closed. */
 	get closed(): Promise<void> {
 		return this.#closed.promise;
 	}
 
+	/** Resolves when the current run is about to be torn down, by a rerun or close. */
 	get cancel(): Promise<void> {
 		return this.#stopped.promise;
 	}
 
+	/** An AbortSignal that fires when the current run is torn down. */
 	get abort(): AbortSignal {
 		return this.#abort.signal;
 	}
 
+	/** Copies `src` into `dst` and keeps `dst` in sync as `src` changes. */
 	proxy<T>(dst: Setter<T>, src: Getter<T>): void {
 		this.subscribe(src, (value) => dst.update(() => value));
 	}
 }
 
-// A read-only signal derived from other signals.
-//
-// The compute function reads its dependencies with `effect.get(...)`, exactly
-// like an effect, and returns the derived value. It reruns whenever a
-// dependency changes. Keep it pure: derive a value, don't perform side effects.
-//
-// Like every signal, updates are asynchronous: the value is `undefined` until
-// the first run completes (and after close()), and recomputes propagate on a
-// microtask. Read it inside an effect and handle the `undefined` case, the same
-// way you would any other signal that starts empty.
+/**
+ * A read-only signal derived from other signals.
+ *
+ * The compute function reads its dependencies with `effect.get(...)`, exactly
+ * like an effect, and returns the derived value. It reruns whenever a
+ * dependency changes. Keep it pure: derive a value, don't perform side effects.
+ *
+ * Like every signal, updates are asynchronous: the value is `undefined` until
+ * the first run completes (and after close()), and recomputes propagate on a
+ * microtask. Read it inside an effect and handle the `undefined` case, the same
+ * way you would any other signal that starts empty.
+ */
 export class Computed<T> implements Getter<T | undefined> {
 	#signal = new Signal<T | undefined>(undefined);
 	#effect: Effect;
 
+	/** Creates a computed that derives its value from `fn`, rerunning when dependencies change. */
 	constructor(fn: (effect: Effect) => T) {
 		this.#effect = new Effect((effect) => {
 			this.#signal.set(fn(effect));
 		});
 	}
 
+	/** Returns the current derived value without subscribing (`undefined` until the first run). */
 	peek(): T | undefined {
 		return this.#signal.peek();
 	}
 
+	/** Calls `fn` once the next time the derived value changes. */
 	changed(fn: Subscriber<T | undefined>): Dispose {
 		return this.#signal.changed(fn);
 	}
 
+	/** Calls `fn` every time the derived value changes. */
 	subscribe(fn: Subscriber<T | undefined>): Dispose {
 		return this.#signal.subscribe(fn);
 	}
 
-	// Stop recomputing and tracking dependencies. Required for standalone computeds;
-	// an effect.computed() is closed automatically with its parent effect.
+	/**
+	 * Stops recomputing and tracking dependencies. Required for standalone computeds;
+	 * an `effect.computed()` is closed automatically with its parent effect.
+	 */
 	close(): void {
 		this.#effect.close();
 	}

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -376,8 +376,7 @@ export class Effect {
 	}
 
 	/**
-	 * Runs an async task that blocks the effect from rerunning until it resolves.
-	 * Await `cancel` inside the task to detect a pending rerun and bail out early.
+	 * Runs an async task. The effect will not rerun until the task's promise settles.
 	 */
 	// TODO: Add effect for another layer of nesting
 	spawn(fn: () => Promise<void>) {

--- a/js/signals/src/react.ts
+++ b/js/signals/src/react.ts
@@ -1,7 +1,13 @@
+/**
+ * React hooks for reading and writing signals from components.
+ *
+ * @module
+ */
+
 import { useCallback, useSyncExternalStore } from "react";
 import type { Getter, Signal } from "./index";
 
-// A helper to read a signal's value in React.
+/** Subscribes a component to a signal and returns its current value. */
 export function useValue<T>(signal: Getter<T>): T {
 	return useSyncExternalStore(
 		(callback) => signal.subscribe(callback),
@@ -10,7 +16,7 @@ export function useValue<T>(signal: Getter<T>): T {
 	);
 }
 
-// A helper to read and write a signal in React, like useState.
+/** Reads and writes a signal as a `[value, setValue]` pair, like `useState`. */
 export function useSignal<T>(signal: Signal<T>): [T, (value: T | ((prev: T) => T)) => void] {
 	const value = useValue(signal);
 	const setter = useCallback(

--- a/js/signals/src/solid.ts
+++ b/js/signals/src/solid.ts
@@ -1,3 +1,9 @@
+/**
+ * SolidJS adapters that bridge signals to Solid accessors and setters.
+ *
+ * @module
+ */
+
 import {
 	createSignal,
 	onCleanup,
@@ -7,7 +13,7 @@ import {
 } from "solid-js";
 import type { Getter, Signal } from "./index";
 
-// A helper to create a Solid accessor from a signal.
+/** Creates a Solid accessor that tracks the given signal, unsubscribing on cleanup. */
 export function createAccessor<T>(signal: Getter<T>): SolidAccessor<T> {
 	// Disable the equals check because we do it ourselves.
 	const [get, set] = createSignal(signal.peek(), { equals: false });
@@ -16,7 +22,7 @@ export function createAccessor<T>(signal: Getter<T>): SolidAccessor<T> {
 	return get;
 }
 
-// A helper to create a Solid setter that writes to a signal.
+/** Creates a Solid setter that writes through to the given signal. */
 export function createSetter<T>(signal: Signal<T>): SolidSetter<T> {
 	const setter = (value: T | ((prev: T) => T)) => {
 		if (typeof value === "function") {
@@ -29,7 +35,7 @@ export function createSetter<T>(signal: Signal<T>): SolidSetter<T> {
 	return setter as SolidSetter<T>;
 }
 
-// A helper to create a Solid [get, set] pair from a signal.
+/** Creates a Solid `[accessor, setter]` pair backed by the given signal. */
 export function createPair<T>(signal: Signal<T>): SolidSignal<T> {
 	return [createAccessor(signal), createSetter(signal)];
 }


### PR DESCRIPTION
## Summary

We just published all the JS packages to [JSR](https://jsr.io/@moq). This raises the JSR documentation score across the board and adds a CLAUDE.md rule so it doesn't regress.

JSR scores packages partly on documentation. Before this PR, most exported symbols had no doc comments and the generated `jsr.json` silently dropped the `description` field, so every package scored 0/1 on "has a description" and the libraries sat at 52-58%.

### Changes

- **`js/common/package.ts`**: carry the `package.json` `description` into the generated `jsr.json`. JSR reads it for the package description and the score's "has a description" check; it isn't pulled from the npm `package.json` automatically. This fixes all 7 published packages at once.
- **Module docs**: added `@module` doc blocks to every entrypoint of `@moq/net`, `@moq/hang`, and `@moq/signals`. Their *secondary* entrypoints (`./zod`, `./catalog`, `./container`, `./util`, `./solid`, `./react`, `./dom`) lacked module docs; single-entrypoint packages already pass via their README.
- **Symbol docs**: documented the exported surface of `@moq/net`, `@moq/hang`, `@moq/signals`, `@moq/loc`, and `@moq/msf` (roughly 26 / 17 / 11 / 50 / 0% → ~100% coverage), matching the terse `@moq/json` / `@moq/token` style that already scores 100%.
- **`CLAUDE.md`**: scoped the "avoid comments if self-explanatory" rule to *implementation* comments, and added a rule requiring a doc comment on every exported symbol and module entrypoint (these render on JSR for JS and docs.rs for Rust, so a missing doc is a hole a consumer hits).

Comments-only; no code, type, or wire changes, so this targets `main`.

### Public API changes

None. This PR adds doc comments and a build-script tweak only. No `pub` / exported items were added, removed, renamed, or had signatures changed.

### Notes

- The score changes land on the next publish (JSR scores the published `.d.ts`, where `tsc` preserves the JSDoc).
- One remaining lever, **"at least one runtime is marked compatible"**, is a per-package JSR **web-UI** setting (Settings → Runtime Compat) and can't be set from the repo.

### Test plan

- [x] `bun biome check` clean on the touched packages
- [x] `bun run --filter=... check` (tsc) passes for net, hang, signals, loc, msf
- [x] Downstream consumers `@moq/watch` and `@moq/publish` still type-check
- [x] Built `@moq/token` and confirmed the generated `jsr.json` now includes `description`

(Written by Claude)