### PR TITLE
fix(kio): split waiters by condition so writes don't churn closed/consumer waiters

### DIFF
--- a/rs/kio/CHANGELOG.md
+++ b/rs/kio/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Split the internal waiter list into separate value / closed / consumer lists,
+  so an event only wakes the waiters that care about it. Previously every value
+  modification (the hot path) also woke parked `closed()` and `used`/`unused`
+  waiters, which re-registered and ping-ponged. No public API change.
+
 ### Changed
 
 - Reworked `Producer::poll` / `Producer::wait`. They previously handed the

--- a/rs/kio/src/consumer.rs
+++ b/rs/kio/src/consumer.rs
@@ -14,8 +14,8 @@ use crate::{
 ///
 /// Consumers have read-only access to the shared value and are notified when
 /// a producer modifies it. Cloning a consumer increments the consumer reference
-/// count. When the last consumer is dropped, all waiters (e.g. [`Producer::unused`])
-/// are notified.
+/// count. When the last consumer is dropped, the consumer-count waiters
+/// (e.g. [`Producer::unused`]) are notified.
 #[derive(Debug)]
 pub struct Consumer<T> {
 	pub(crate) state: Lock<State<T>>,
@@ -46,7 +46,7 @@ impl<T> Consumer<T> {
 
 		// Re-extract state from consumer_state to register
 		let mut state = consumer_state.state;
-		waiter.register(&mut state.waiters);
+		waiter.register(&mut state.waiters_value);
 
 		Poll::Pending
 	}
@@ -58,7 +58,7 @@ impl<T> Consumer<T> {
 			return Poll::Ready(());
 		}
 
-		waiter.register(&mut state.waiters);
+		waiter.register(&mut state.waiters_closed);
 		Poll::Pending
 	}
 
@@ -131,10 +131,12 @@ impl<T> Drop for Consumer<T> {
 			return;
 		}
 
-		// We were the last consumer, need to wake waiters
+		// We were the last consumer, so wake the `unused()` waiters. The value
+		// and closed waiters don't care about the consumer count, so leave
+		// them alone.
 		let mut waiters = {
 			let mut state = self.state.lock();
-			state.waiters.take()
+			state.waiters_consumer.take()
 		};
 
 		waiters.wake();

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -17,15 +17,28 @@ mod consumer;
 mod producer;
 mod weak;
 
+#[cfg(test)]
+mod tests;
+
 pub use consumer::Consumer;
 pub use producer::{Mut, Producer, Ref};
 pub use waiter::{Waiter, WaiterList, wait};
 pub use weak::Weak;
 
+/// Waiters split by what they're waiting on, so an event only wakes the
+/// waiters that care about it. The big win is per-modification writes (the hot
+/// path) waking only `value`, leaving the long-lived `closed` and `consumer`
+/// waiters untouched.
 #[derive(Debug)]
 pub(crate) struct State<T> {
 	pub value: T,
-	pub waiters: waiter::WaiterList,
+	/// Value changes (`poll`/`wait`). Woken on every modification.
+	pub waiters_value: waiter::WaiterList,
+	/// Closure (`closed`). Woken only when the channel closes.
+	pub waiters_closed: waiter::WaiterList,
+	/// Consumer-count changes (`used`/`unused`). `used`/`unused` are used
+	/// sequentially in practice, so they share one list.
+	pub waiters_consumer: waiter::WaiterList,
 	pub closed: bool,
 }
 
@@ -40,8 +53,20 @@ impl<T> State<T> {
 		Self {
 			value,
 			closed: false,
-			waiters: waiter::WaiterList::new(),
+			waiters_value: waiter::WaiterList::new(),
+			waiters_closed: waiter::WaiterList::new(),
+			waiters_consumer: waiter::WaiterList::new(),
 		}
+	}
+
+	/// Drain every waiter list. Used on close, which all waiters react to.
+	/// Caller wakes the returned lists after releasing the lock.
+	pub fn take_close_waiters(&mut self) -> [waiter::WaiterList; 3] {
+		[
+			self.waiters_value.take(),
+			self.waiters_closed.take(),
+			self.waiters_consumer.take(),
+		]
 	}
 }
 

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -40,9 +40,9 @@ impl<T> Producer<T> {
 	pub fn consume(&self) -> Consumer<T> {
 		let prev = self.counts.consumers.fetch_add(1, Ordering::AcqRel);
 
-		// Wake waiters (e.g. `used()`) when the first consumer appears.
+		// Wake `used()` waiters when the first consumer appears.
 		if prev == 0 {
-			let mut waiters = self.state.lock().waiters.take();
+			let mut waiters = self.state.lock().waiters_consumer.take();
 			waiters.wake();
 		}
 
@@ -98,7 +98,7 @@ impl<T> Producer<T> {
 			// Upgrade the Ref to a Mut, keeping the same lock guard.
 			Poll::Ready(()) => Poll::Ready(Ok(Mut::new(guard.state))),
 			Poll::Pending => {
-				waiter.register(&mut guard.state.waiters);
+				waiter.register(&mut guard.state.waiters_value);
 				Poll::Pending
 			}
 		}
@@ -126,7 +126,7 @@ impl<T> Producer<T> {
 			return Poll::Ready(());
 		}
 
-		waiter.register(&mut state.waiters);
+		waiter.register(&mut state.waiters_closed);
 		Poll::Pending
 	}
 
@@ -150,7 +150,7 @@ impl<T> Producer<T> {
 			return Poll::Ready(Some(()));
 		}
 
-		waiter.register(&mut state.waiters);
+		waiter.register(&mut state.waiters_consumer);
 
 		// Re-check after registration to avoid TOCTOU race where the last
 		// consumer drops between the initial check and waiter registration.
@@ -181,7 +181,7 @@ impl<T> Producer<T> {
 			return Poll::Ready(Some(()));
 		}
 
-		waiter.register(&mut state.waiters);
+		waiter.register(&mut state.waiters_consumer);
 
 		// Re-check after registration to avoid TOCTOU race where a consumer
 		// is created between the initial check and waiter registration.
@@ -242,7 +242,9 @@ impl<T> Drop for Producer<T> {
 			return;
 		}
 
-		// We were the last producer, need to close
+		// We were the last producer, need to close. Every waiter reacts to
+		// closure (value/closed resolve, `used`/`unused` resolve to `None`),
+		// so wake all the lists.
 		let mut waiters = {
 			let mut state = self.state.lock();
 			if state.closed {
@@ -250,10 +252,12 @@ impl<T> Drop for Producer<T> {
 			}
 
 			state.closed = true;
-			state.waiters.take()
+			state.take_close_waiters()
 		};
 
-		waiters.wake();
+		for list in &mut waiters {
+			list.wake();
+		}
 	}
 }
 
@@ -309,11 +313,22 @@ impl<T> Drop for Mut<'_, T> {
 			return;
 		}
 
-		// Drain wakers while holding lock, then wake after releasing
-		let mut waiters = state.waiters.take();
+		// Drain wakers while holding lock, then wake after releasing.
+		// A modification that also closed the channel (e.g. `close()`) must
+		// wake the closed and consumer-count waiters too, since they resolve
+		// on closure. A plain modification touches only the value waiters.
+		let mut waiters_value = state.waiters_value.take();
+		let extra = state
+			.closed
+			.then(|| [state.waiters_closed.take(), state.waiters_consumer.take()]);
 		drop(state); // Release Mutex BEFORE waking
 
-		waiters.wake();
+		waiters_value.wake();
+		if let Some(mut extra) = extra {
+			for list in &mut extra {
+				list.wake();
+			}
+		}
 	}
 }
 

--- a/rs/kio/src/tests.rs
+++ b/rs/kio/src/tests.rs
@@ -1,0 +1,165 @@
+//! Regression tests for the value/closed/consumer waiter split.
+//!
+//! Each non-close event must wake only the waiters that care about it: a value
+//! modification wakes neither `closed()` nor `used`/`unused`, and consumer
+//! create/drop wakes neither value nor `closed()` waiters. We drive the public
+//! async futures by hand with a counting waker so we can assert that a waiter
+//! was *not* notified.
+
+use std::{
+	future::Future,
+	sync::{
+		Arc,
+		atomic::{AtomicUsize, Ordering},
+	},
+	task::{Context, Poll, Wake, Waker},
+};
+
+use crate::Producer;
+
+/// A waker that counts how many times it was woken.
+struct CountWaker(AtomicUsize);
+
+impl CountWaker {
+	fn new() -> Arc<Self> {
+		Arc::new(Self(AtomicUsize::new(0)))
+	}
+
+	fn count(&self) -> usize {
+		self.0.load(Ordering::SeqCst)
+	}
+}
+
+impl Wake for CountWaker {
+	fn wake(self: Arc<Self>) {
+		self.0.fetch_add(1, Ordering::SeqCst);
+	}
+
+	fn wake_by_ref(self: &Arc<Self>) {
+		self.0.fetch_add(1, Ordering::SeqCst);
+	}
+}
+
+/// Bundle a counting waker with a `Context` borrowing it.
+fn counting() -> (Arc<CountWaker>, Waker) {
+	let waker = CountWaker::new();
+	let w = Waker::from(waker.clone());
+	(waker, w)
+}
+
+#[test]
+fn value_modification_does_not_wake_consumer() {
+	let producer = Producer::new(0u32);
+	let consumer = producer.consume();
+
+	let (waker, w) = counting();
+	let mut cx = Context::from_waker(&w);
+
+	let mut fut = Box::pin(producer.unused());
+	assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
+
+	// `unused()` only cares about the consumer count, so value churn shouldn't wake it.
+	for i in 1..=100 {
+		*producer.write().ok().expect("open") = i;
+	}
+	assert_eq!(waker.count(), 0, "value modification spuriously woke unused()");
+	assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
+
+	// Dropping the last consumer is what should wake it.
+	drop(consumer);
+	assert!(waker.count() >= 1, "dropping the last consumer did not wake unused()");
+	assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Ready(Ok(()))));
+}
+
+#[test]
+fn value_modification_does_not_wake_closed() {
+	let producer = Producer::new(0u32);
+	let _consumer = producer.consume();
+
+	let (waker, w) = counting();
+	let mut cx = Context::from_waker(&w);
+
+	let mut fut = Box::pin(producer.closed());
+	assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
+
+	// The hot path: a parked `closed()` must survive per-modification churn untouched.
+	for i in 1..=100 {
+		*producer.write().ok().expect("open") = i;
+	}
+	assert_eq!(waker.count(), 0, "value modification spuriously woke closed()");
+	assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
+
+	// Closing is what should wake it.
+	producer.close().ok().expect("open");
+	assert!(waker.count() >= 1, "close did not wake closed()");
+	assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Ready(())));
+}
+
+#[test]
+fn consumer_churn_does_not_wake_value_or_closed() {
+	let producer = Producer::new(0u32);
+
+	let (value_waker, vw) = counting();
+	let mut value_cx = Context::from_waker(&vw);
+	let (closed_waker, cw) = counting();
+	let mut closed_cx = Context::from_waker(&cw);
+
+	// Wait for a value we never set, so the future stays pending throughout.
+	let mut value_fut = Box::pin(producer.wait(|m| if **m == 99 { Poll::Ready(()) } else { Poll::Pending }));
+	let mut closed_fut = Box::pin(producer.closed());
+	assert!(matches!(value_fut.as_mut().poll(&mut value_cx), Poll::Pending));
+	assert!(matches!(closed_fut.as_mut().poll(&mut closed_cx), Poll::Pending));
+
+	// Cross the 0<->1 consumer boundary repeatedly. Each transition wakes the
+	// consumer-count waiters, but must leave the value and closed waiters alone.
+	for _ in 0..100 {
+		let consumer = producer.consume();
+		drop(consumer);
+	}
+	assert_eq!(value_waker.count(), 0, "consumer churn spuriously woke a value waiter");
+	assert_eq!(
+		closed_waker.count(),
+		0,
+		"consumer churn spuriously woke a closed waiter"
+	);
+	assert!(matches!(value_fut.as_mut().poll(&mut value_cx), Poll::Pending));
+	assert!(matches!(closed_fut.as_mut().poll(&mut closed_cx), Poll::Pending));
+
+	// A real value change still wakes the value waiter. `wait` now hands back a
+	// writable `Mut` on success, so just match `Ok(_)`.
+	*producer.write().ok().expect("open") = 99;
+	assert!(value_waker.count() >= 1, "value change did not wake the value waiter");
+	assert!(matches!(value_fut.as_mut().poll(&mut value_cx), Poll::Ready(Ok(_))));
+}
+
+#[test]
+fn close_wakes_value_closed_and_consumer() {
+	let producer = Producer::new(0u32);
+	let _consumer = producer.consume();
+
+	let (value_waker, vw) = counting();
+	let mut value_cx = Context::from_waker(&vw);
+	let (closed_waker, cw) = counting();
+	let mut closed_cx = Context::from_waker(&cw);
+	let (unused_waker, uw) = counting();
+	let mut unused_cx = Context::from_waker(&uw);
+
+	let mut value_fut = Box::pin(producer.wait(|m| if **m == 99 { Poll::Ready(()) } else { Poll::Pending }));
+	let mut closed_fut = Box::pin(producer.closed());
+	let mut unused_fut = Box::pin(producer.unused());
+	assert!(matches!(value_fut.as_mut().poll(&mut value_cx), Poll::Pending));
+	assert!(matches!(closed_fut.as_mut().poll(&mut closed_cx), Poll::Pending));
+	assert!(matches!(unused_fut.as_mut().poll(&mut unused_cx), Poll::Pending));
+
+	// Closing resolves all three: value/unused with `Err`, closed with `()`.
+	producer.close().ok().expect("open");
+	assert!(value_waker.count() >= 1, "close did not wake the value waiter");
+	assert!(closed_waker.count() >= 1, "close did not wake the closed waiter");
+	assert!(
+		unused_waker.count() >= 1,
+		"close did not wake the consumer-count waiter"
+	);
+	assert!(matches!(value_fut.as_mut().poll(&mut value_cx), Poll::Ready(Err(_))));
+	assert!(matches!(closed_fut.as_mut().poll(&mut closed_cx), Poll::Ready(())));
+	assert!(matches!(unused_fut.as_mut().poll(&mut unused_cx), Poll::Ready(Err(_))));
+}

--- a/rs/kio/src/weak.rs
+++ b/rs/kio/src/weak.rs
@@ -46,9 +46,9 @@ impl<T> Weak<T> {
 	pub fn consume(&self) -> Consumer<T> {
 		let prev = self.counts.consumers.fetch_add(1, Ordering::AcqRel);
 
-		// Wake waiters (e.g. `used()`) when the first consumer appears.
+		// Wake `used()` waiters when the first consumer appears.
 		if prev == 0 {
-			let mut waiters = self.state.lock().waiters.take();
+			let mut waiters = self.state.lock().waiters_consumer.take();
 			waiters.wake();
 		}
 
@@ -103,7 +103,7 @@ impl<T> Weak<T> {
 			return Poll::Ready(None);
 		}
 
-		waiter.register(&mut state.waiters);
+		waiter.register(&mut state.waiters_consumer);
 
 		// Re-check after registration to avoid TOCTOU race where the last
 		// consumer drops between the initial check and waiter registration.
@@ -134,7 +134,7 @@ impl<T> Weak<T> {
 			return Poll::Ready(None);
 		}
 
-		waiter.register(&mut state.waiters);
+		waiter.register(&mut state.waiters_consumer);
 
 		// Re-check after registration to avoid TOCTOU race.
 		if self.counts.consumers.load(Ordering::Relaxed) > 0 {


### PR DESCRIPTION
## Summary

kio used a single waiter list, so every event woke every parked waiter. The expensive case is a per-modification write (the hot path): it woke `closed()`, `used()`, and `unused()` waiters that don't care about value changes, and conversely consumer create/drop woke the value waiters. Those spurious wakes just re-register and ping-pong, which is the root cause behind the per-poll `consume()` churn.

This splits `State` into three lists, keyed by what each waiter actually waits on:

| List | Waiters | Woken by |
|---|---|---|
| `waiters_value` | `poll`/`wait` | every modification (hot path) + close |
| `waiters_closed` | `closed()` | close only |
| `waiters_consumer` | `used()`/`unused()` | consumer 0↔1 + close |

Close still wakes all three, since every waiter resolves on close. No other event over-wakes.

### Why these groupings

- **`used`/`unused` share one list.** Every call site uses them sequentially (`used().await`, then a loop selecting on `unused()`), so they're never parked on the same channel simultaneously and a combined list never cross-wakes in practice. A separate `unused` list would add cost for no benefit.
- **`closed()` gets its own list.** It's heavily used (87 call sites) and parked long-term in `select!` blocks. Sharing the value list meant it ate a spurious wake on *every frame write* — a bigger churn source than used/unused.

### Also

- Added a `[Unreleased]` CHANGELOG entry.
- Added waker-counting regression tests asserting each event wakes only the waiters that care: value writes don't wake `closed()`/`unused()`, consumer churn doesn't wake value/`closed()` waiters, and close wakes all three.

## Relation to #1735

Rebased on top of #1735 (read-only-predicate `poll`/`wait` rework). That PR fixed the *"a no-op mutation during a pending poll wakes the poller's own waiter"* footgun by making the predicate read-only; this PR fixes the orthogonal *"every event wakes every waiter"* problem by splitting the list. The two compose: `poll`/`wait` now register in `waiters_value`, and a write through the returned `Mut` wakes only that list (plus closed/consumer on close).

## Public API

No public API change — `State` and its waiter lists are `pub(crate)`. Internal behavior-preserving fix, hence targeting `main`.

## Tradeoff

`State` now holds three `WaiterList`s (each ~256 B inline via `INLINE_WAITERS = 32`), so it grows ~512 B vs. the single-list original. `waiters_value`/`waiters_closed` both scale with subscriber count, but `waiters_consumer` is almost always 0–1 waiters, where inline-32 is waste. A clean follow-up is making `WaiterList` generic over its inline size and giving the consumer list a tiny one; left out here to keep the change focused.

## Test plan

- [x] `cargo test -p kio` — 6 passed (4 new + `is_last` + #1735's `poll_gates`)
- [x] clippy (nix) + fmt clean
- [x] `moq-net` builds; its 143 model tests pass (exercise the `unused()` path)

(Written by Claude)