### PR TITLE
feat(moq-native): mTLS + preferred_address on the noq backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3967,6 +3967,7 @@ dependencies = [
  "serde",
  "serde_with",
  "socket2",
+ "tempfile",
  "thiserror 2.0.18",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -231,8 +231,8 @@ advertises its own identity by setting `--cluster-mesh` to its
 externally-reachable URL, which it publishes on the cluster origin for other
 peers to discover and dial.
 
-Only the `quinn` QUIC backend supports mTLS; configuring `tls.root` with any
-other backend is a startup error.
+The `quinn` and `noq` QUIC backends support mTLS; configuring `tls.root` with a
+backend that does not (e.g. `quiche`) is a startup error.
 
 ## Example Configurations
 

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -63,7 +63,7 @@ generate = ["localhost", "127.0.0.1"]
 # Optional: root CAs to accept for mTLS peer authentication.
 # Clients that present a cert signed by one of these CAs are granted
 # full access (publish/subscribe/cluster). Intended for relay clustering.
-# Quinn backend only.
+# Supported by the quinn and noq backends.
 root = ["/path/to/peer-ca.pem"]
 ```
 

--- a/rs/moq-native/CHANGELOG.md
+++ b/rs/moq-native/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(moq-native)* support mTLS client certificates and `preferred_address` on the noq backend, bringing it to parity with quinn.
+
+### Changed
+
+- *(moq-native)* rename `Error::MtlsQuinnOnly` to `Error::MtlsUnsupported`; mTLS now works on both the quinn and noq backends.
+
 ## [0.17.0](https://github.com/moq-dev/moq/compare/moq-native-v0.16.3...moq-native-v0.17.0) - 2026-06-10
 
 ### Added

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -70,5 +70,7 @@ tracing-android = { version = "0.2", optional = true }
 anyhow = "1"
 bytes = "1"
 chrono = "0.4"
+rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs"] }
+tempfile = "3"
 toml = "1.1"
 tracing-test = "0.2"

--- a/rs/moq-native/src/error.rs
+++ b/rs/moq-native/src/error.rs
@@ -40,8 +40,8 @@ pub enum Error {
 	#[error("Iroh support is not enabled")]
 	IrohDisabled,
 
-	#[error("tls.root (mTLS) is only supported by the quinn backend")]
-	MtlsQuinnOnly,
+	#[error("tls.root (mTLS) is not supported by the selected QUIC backend")]
+	MtlsUnsupported,
 
 	#[error("invalid status code")]
 	InvalidStatusCode,

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -80,6 +80,9 @@ pub enum Error {
 	#[error("connection ID length ({0}) exceeds maximum of 20")]
 	QuicLbCidTooLong(usize),
 
+	#[error("failed to build client certificate verifier")]
+	ClientVerifier(#[source] rustls::server::VerifierBuilderError),
+
 	#[error(transparent)]
 	NoInitialCipherSuite(#[from] noq::crypto::rustls::NoInitialCipherSuite),
 
@@ -315,11 +318,22 @@ impl NoqServer {
 		certs.load_certs(&config.tls)?;
 		let certs = Arc::new(certs);
 
-		let mut tls = rustls::ServerConfig::builder_with_provider(provider)
+		let tls_builder = rustls::ServerConfig::builder_with_provider(provider.clone())
 			.with_protocol_versions(&[&rustls::version::TLS13])
-			.map_err(crate::tls::Error::from)?
-			.with_no_client_auth()
-			.with_cert_resolver(certs.clone());
+			.map_err(crate::tls::Error::from)?;
+
+		let mut tls = if config.tls.root.is_empty() {
+			tls_builder.with_no_client_auth().with_cert_resolver(certs.clone())
+		} else {
+			let roots = config.tls.load_roots()?;
+			let verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(Arc::new(roots), provider)
+				.allow_unauthenticated()
+				.build()
+				.map_err(Error::ClientVerifier)?;
+			tls_builder
+				.with_client_cert_verifier(verifier)
+				.with_cert_resolver(certs.clone())
+		};
 
 		// H3 is last because it requires WebTransport framing which not all H3 endpoints support.
 		let mut alpns: Vec<Vec<u8>> = config
@@ -336,6 +350,15 @@ impl NoqServer {
 		let tls: noq::crypto::rustls::QuicServerConfig = tls.try_into()?;
 		let mut tls = noq::ServerConfig::with_crypto(Arc::new(tls));
 		tls.transport_config(transport);
+
+		// Advertise the preferred_address transport parameter (RFC 9000 §9.6).
+		// noq allocates a fresh CID + reset token for the address during the handshake.
+		if let Some(addr) = config.preferred_v4 {
+			tls.preferred_address_v4(Some(addr));
+		}
+		if let Some(addr) = config.preferred_v6 {
+			tls.preferred_address_v6(Some(addr));
+		}
 
 		// There's a bit more boilerplate to make a generic endpoint.
 		let runtime = noq::default_runtime().ok_or(Error::NoRuntime)?;
@@ -490,6 +513,16 @@ impl NoqRequest {
 			NoqRequest::Raw { .. } => None,
 			NoqRequest::WebTransport { request, .. } => Some(&request.url),
 		}
+	}
+
+	/// Whether the peer presented a client certificate that rustls validated
+	/// against the configured `tls.root` during the handshake.
+	pub fn has_peer_certificate(&self) -> bool {
+		let conn = match self {
+			NoqRequest::Raw { connection, .. } => connection,
+			NoqRequest::WebTransport { request, .. } => request.conn(),
+		};
+		conn.peer_identity().is_some()
 	}
 
 	/// Reject the session with a status code.

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -58,7 +58,7 @@ pub struct ServerConfig {
 	/// shortly after the handshake completes. Typical use: handshake on an
 	/// anycast IP, steady-state on this host's unicast IP.
 	///
-	/// Only honored by the Quinn backend.
+	/// Honored by the Quinn and noq backends.
 	#[arg(
 		id = "server-preferred-v4",
 		long = "server-preferred-v4",
@@ -162,12 +162,16 @@ impl Server {
 		let versions = config.versions();
 
 		if !config.tls.root.is_empty() {
-			#[cfg(feature = "quinn")]
-			let quinn_backend = matches!(backend, QuicBackend::Quinn);
-			#[cfg(not(feature = "quinn"))]
-			let quinn_backend = false;
-			if !quinn_backend {
-				return Err(Error::MtlsQuinnOnly);
+			let mtls_supported = match backend {
+				#[cfg(feature = "quinn")]
+				QuicBackend::Quinn => true,
+				#[cfg(feature = "noq")]
+				QuicBackend::Noq => true,
+				#[allow(unreachable_patterns)]
+				_ => false,
+			};
+			if !mtls_supported {
+				return Err(Error::MtlsUnsupported);
 			}
 		}
 
@@ -611,13 +615,13 @@ impl Request {
 	/// Whether the peer presented a client certificate during the handshake
 	/// that chained to a configured [`crate::tls::Server::root`].
 	///
-	/// Only the Quinn backend supports mTLS; other backends always return `false`.
+	/// Only the Quinn and noq backends support mTLS; other backends always return `false`.
 	pub fn has_peer_certificate(&self) -> bool {
 		match self.kind {
 			#[cfg(feature = "quinn")]
 			RequestKind::Quinn(ref request) => request.has_peer_certificate(),
 			#[cfg(feature = "noq")]
-			RequestKind::Noq(_) => false,
+			RequestKind::Noq(ref request) => request.has_peer_certificate(),
 			#[cfg(feature = "quiche")]
 			RequestKind::Quiche(_) => false,
 			#[cfg(feature = "iroh")]

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -315,7 +315,7 @@ pub struct Server {
 	/// and can be used by the application to grant elevated access. Clients that
 	/// do not present a certificate are unaffected.
 	///
-	/// Only supported by the Quinn backend.
+	/// Only supported by the Quinn and noq backends.
 	#[arg(
 		long = "server-tls-root",
 		id = "server-tls-root",

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -94,6 +94,111 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 		.expect("server task failed");
 }
 
+/// Generate a CA, a server cert + key, and a client cert + key (all PEM, the
+/// leaf certs signed by the CA) written to a tempdir. Returns the dir plus the
+/// five paths so the caller can wire them into the TLS configs.
+#[cfg(any(feature = "quinn", feature = "noq"))]
+fn generate_mtls_certs() -> (tempfile::TempDir, MtlsPaths) {
+	use rcgen::{BasicConstraints, CertificateParams, IsCa, Issuer, KeyPair};
+	use std::io::Write;
+
+	let dir = tempfile::tempdir().expect("failed to create tempdir");
+
+	// Self-signed CA that signs both the server and client leaf certs.
+	let ca_key = KeyPair::generate().expect("ca key");
+	let mut ca_params = CertificateParams::new(Vec::new()).expect("ca params");
+	ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+	let ca_cert = ca_params.self_signed(&ca_key).expect("ca cert");
+	let issuer = Issuer::from_params(&ca_params, &ca_key);
+
+	// Server leaf with a localhost SAN so the client can verify the name.
+	let server_key = KeyPair::generate().expect("server key");
+	let server_params = CertificateParams::new(vec!["localhost".to_string()]).expect("server params");
+	let server_cert = server_params.signed_by(&server_key, &issuer).expect("server cert");
+
+	// Client leaf presented during the handshake for mTLS.
+	let client_key = KeyPair::generate().expect("client key");
+	let client_params = CertificateParams::new(Vec::new()).expect("client params");
+	let client_cert = client_params.signed_by(&client_key, &issuer).expect("client cert");
+
+	let write = |name: &str, contents: String| {
+		let path = dir.path().join(name);
+		let mut file = std::fs::File::create(&path).expect("create pem file");
+		file.write_all(contents.as_bytes()).expect("write pem file");
+		path
+	};
+
+	let paths = MtlsPaths {
+		ca: write("ca.pem", ca_cert.pem()),
+		server_cert: write("server.pem", server_cert.pem()),
+		server_key: write("server.key", server_key.serialize_pem()),
+		client_cert: write("client.pem", client_cert.pem()),
+		client_key: write("client.key", client_key.serialize_pem()),
+	};
+
+	(dir, paths)
+}
+
+/// Filesystem paths to the PEM material produced by [`generate_mtls_certs`].
+#[cfg(any(feature = "quinn", feature = "noq"))]
+struct MtlsPaths {
+	ca: std::path::PathBuf,
+	server_cert: std::path::PathBuf,
+	server_key: std::path::PathBuf,
+	client_cert: std::path::PathBuf,
+	client_key: std::path::PathBuf,
+}
+
+/// Connect with a client certificate signed by a CA the server trusts, and
+/// assert the server observes the validated peer certificate via mTLS.
+#[cfg(any(feature = "quinn", feature = "noq"))]
+async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend) {
+	let (_dir, paths) = generate_mtls_certs();
+
+	let pub_origin = Origin::random().produce();
+
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some("[::]:0".to_string());
+	server_config.tls.cert = vec![paths.server_cert.clone()];
+	server_config.tls.key = vec![paths.server_key.clone()];
+	server_config.tls.root = vec![paths.ca.clone()];
+	server_config.backend = Some(backend.clone());
+
+	let mut server = server_config.init().expect("failed to init server");
+	let addr = server.local_addr().expect("failed to get local addr");
+
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.root = vec![paths.ca.clone()];
+	client_config.tls.system_roots = Some(false);
+	client_config.tls.cert = Some(paths.client_cert.clone());
+	client_config.tls.key = Some(paths.client_key.clone());
+	client_config.backend = Some(backend);
+
+	let client = client_config.init().expect("failed to init client");
+	let url: url::Url = format!("{scheme}://localhost:{}", addr.port()).parse().unwrap();
+
+	let server_handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("no incoming connection");
+		// The peer cert must be visible before we accept the session.
+		let has_cert = request.has_peer_certificate();
+		let session = request.with_publish(pub_origin.consume()).ok().await?;
+		let _ = session.closed().await;
+		Ok::<_, anyhow::Error>(has_cert)
+	});
+
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+		.await
+		.expect("client connect timed out")
+		.expect("client connect failed");
+
+	drop(session);
+	let has_cert = server_handle
+		.await
+		.expect("server task panicked")
+		.expect("server task failed");
+	assert!(has_cert, "server did not observe the client certificate");
+}
+
 // ── Quinn backend ───────────────────────────────────────────────────
 
 #[cfg(feature = "quinn")]
@@ -101,6 +206,13 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 #[tokio::test]
 async fn quinn_raw_quic() {
 	backend_test("moqt", moq_native::QuicBackend::Quinn).await;
+}
+
+#[cfg(feature = "quinn")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn quinn_mtls() {
+	mtls_test("https", moq_native::QuicBackend::Quinn).await;
 }
 
 #[cfg(feature = "quinn")]
@@ -260,4 +372,11 @@ async fn noq_raw_quic() {
 #[tokio::test]
 async fn noq_webtransport() {
 	backend_test("https", moq_native::QuicBackend::Noq).await;
+}
+
+#[cfg(feature = "noq")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn noq_mtls() {
+	mtls_test("https", moq_native::QuicBackend::Noq).await;
 }


### PR DESCRIPTION
## Summary

Closes the two remaining feature gaps between the `noq` QUIC backend and `quinn` in `moq-native`, so noq is a viable candidate to become the default backend.

Before this, two quinn-only features blocked the switch:

1. **mTLS / client certificate auth** was hard-rejected for noq (`Error::MtlsQuinnOnly`), `NoqServer` always used `with_no_client_auth()`, and `has_peer_certificate()` was hardcoded to `false`. This is what moq-relay's cluster auth keys off of, so noq silently degraded to JWT-only.
2. **`preferred_address`** (anycast-handshake → unicast-steady-state migration) was ignored by the noq backend.

Both turned out to be wirable: noq exposes `Connection::peer_identity()`, and `preferred_address_v4/v6` live in `noq-proto` and are re-exported as `noq::ServerConfig` (already used here).

## Changes

- **mTLS**: `NoqServer::new` builds a `WebPkiClientVerifier` when `tls.root` is set (mirrors `quinn.rs`), and `NoqRequest::has_peer_certificate()` reports the validated peer via `peer_identity()`. New `noq::Error::ClientVerifier` variant.
- **preferred_address**: advertise `preferred_v4`/`preferred_v6` via `noq::ServerConfig`, matching the quinn path.
- **Gate**: `Server::new` now allows mTLS on `quinn` *or* `noq` (still a startup error on `quiche`). Renamed `Error::MtlsQuinnOnly` → `Error::MtlsUnsupported`.
- **Tests**: new generic `mtls_test` (CA-signed server + client certs via `rcgen`/`tempfile`) run against both `quinn_mtls` and `noq_mtls`.
- **Docs**: refreshed the relay auth/config docs and doc-comments that described mTLS and `preferred_address` as quinn-only.

This PR does **not** flip the `default` feature in `moq-native`'s `Cargo.toml` — that's a separate decision; this just removes the blockers. moq-relay still defaults to quinn.

## Breaking change

`Error::MtlsQuinnOnly` → `Error::MtlsUnsupported` is a source-breaking rename on the public `#[non_exhaustive]` `moq_native::Error` enum. Per the branch-targeting rules this would normally go to `dev`; targeting `main` here at your request. Happy to keep the old name as a deprecated alias instead if you'd prefer to keep it strictly additive.

## Test plan

- [x] `quinn_mtls` and `noq_mtls` pass (validated over IPv4 loopback; the sandbox lacks IPv6 so the existing `[::]:0` tests can't run here, but they're unchanged in convention)
- [x] `cargo clippy` clean for `noq`, `noq+websocket`, and all backends together (`quinn,noq,quiche,websocket,iroh`)
- [x] `cargo test -p moq-native --lib` passes (the only 2 failures are the pre-existing `*_ipv6_is_dual_stack` bind tests, which fail solely due to the sandbox having no IPv6)
- [x] `cargo fmt --check` clean

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATBbyYYezhd4YiMuuC9Mcj)_