### PR TITLE
feat(watch): add `visible` attribute to control video download distance

### DIFF
--- a/demo/web/src/index.html
+++ b/demo/web/src/index.html
@@ -24,7 +24,7 @@
 				- `name`: The broadcast name, otherwise we use the last part of the URL.
 				- `paused`: Video and audio are paused.
 				- `muted`: Audio is muted.
-				- `visible`: When to download video: `never`, a distance like `200px` from the viewport, or `always` (default `0px`, on screen only).
+				- `visible`: When to download video: `never`, a distance like `200px` from the viewport (suspended while the tab is hidden), or `always` (default `0px`, on screen only).
 				- `volume`: The audio volume (0-1).
 				- `latency`: The target jitter buffer size in milliseconds, or "real-time" to use the RTT.
 				- `reload`: Whether to automatically reconnect when the broadcast goes offline/online.
@@ -90,8 +90,7 @@
 		wowee the bandwidth savings!
 	</p>
 	<p>
-		Use <code>visible="200px"</code> to pre-warm video before it scrolls into view, or <code>visible="always"</code> to download it regardless of scroll position.
-		Either way video is still suspended while the tab is hidden.
+		Use <code>visible="200px"</code> to pre-warm video before it scrolls into view (still suspended while the tab is hidden), or <code>visible="always"</code> to download it regardless of scroll position or tab visibility.
 	</p>
 	<p>
 		Audio may start muted because the browser can require user interaction before autoplaying.

--- a/demo/web/src/index.html
+++ b/demo/web/src/index.html
@@ -24,6 +24,7 @@
 				- `name`: The broadcast name, otherwise we use the last part of the URL.
 				- `paused`: Video and audio are paused.
 				- `muted`: Audio is muted.
+				- `visible`: When to download video: `never`, a distance like `200px` from the viewport, or `always` (default `0px`, on screen only).
 				- `volume`: The audio volume (0-1).
 				- `latency`: The target jitter buffer size in milliseconds, or "real-time" to use the RTT.
 				- `reload`: Whether to automatically reconnect when the broadcast goes offline/online.
@@ -87,6 +88,10 @@
 		It won't be downloaded, decoded, or rendered.
 		This includes when the video is paused, minimized, not in the DOM, or scrolled out of view.
 		wowee the bandwidth savings!
+	</p>
+	<p>
+		Use <code>visible="200px"</code> to pre-warm video before it scrolls into view, or <code>visible="always"</code> to download it regardless of scroll position.
+		Either way video is still suspended while the tab is hidden.
 	</p>
 	<p>
 		Audio may start muted because the browser can require user interaction before autoplaying.

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -64,13 +64,25 @@ The simplest way to watch a stream:
 
 ### Attributes
 
-| Attribute | Type    | Default  | Description           |
-|-----------|---------|----------|-----------------------|
-| `url`     | string  | required | Relay server URL      |
-| `path`    | string  | required | Broadcast path        |
-| `paused`  | boolean | false    | Pause playback        |
-| `muted`   | boolean | false    | Mute audio            |
-| `volume`  | number  | 1        | Audio volume (0-1)    |
+| Attribute | Type                                | Default  | Description                              |
+|-----------|-------------------------------------|----------|------------------------------------------|
+| `url`     | string                              | required | Relay server URL                         |
+| `path`    | string                              | required | Broadcast path                           |
+| `paused`  | boolean                             | false    | Pause playback                           |
+| `muted`   | boolean                             | false    | Mute audio                               |
+| `visible` | `never` \| distance \| `always`     | `0px`    | When to download video (see below)       |
+| `volume`  | number                              | 1        | Audio volume (0-1)                       |
+
+The `visible` attribute controls when the video track is downloaded, based on the canvas
+position relative to the viewport:
+
+- `never`: never download video.
+- a distance (`0px`, `200px`, `100%`, ...): download while the canvas is within that distance
+  of the viewport. `0px` (the default) means strictly on screen; a larger distance pre-warms
+  the video before it scrolls into view.
+- `always`: always download video, even when the canvas is scrolled out of view.
+
+In all cases video is still suspended while the tab is hidden.
 
 ## JavaScript API
 

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -78,11 +78,11 @@ position relative to the viewport:
 
 - `never`: never download video.
 - a distance (`0px`, `200px`, `100%`, ...): download while the canvas is within that distance
-  of the viewport. `0px` (the default) means strictly on screen; a larger distance pre-warms
-  the video before it scrolls into view.
-- `always`: always download video, even when the canvas is scrolled out of view.
+  of the viewport **and** the tab is visible. `0px` (the default) means strictly on screen; a
+  larger distance pre-warms the video before it scrolls into view.
+- `always`: always download video, regardless of the canvas position or tab visibility.
 
-In all cases video is still suspended while the tab is hidden.
+Only the distance mode suspends video while the tab is hidden; `always` keeps downloading.
 
 ## JavaScript API
 

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -56,7 +56,7 @@ The simplest way to watch a stream:
 
 <moq-watch
     url="https://relay.example.com/anon"
-    path="room/alice.hang"
+    name="room/alice.hang"
     controls>
     <canvas></canvas>
 </moq-watch>
@@ -67,11 +67,11 @@ The simplest way to watch a stream:
 | Attribute | Type                                | Default  | Description                              |
 |-----------|-------------------------------------|----------|------------------------------------------|
 | `url`     | string                              | required | Relay server URL                         |
-| `path`    | string                              | required | Broadcast path                           |
+| `name`    | string                              | required | Broadcast name/path                      |
 | `paused`  | boolean                             | false    | Pause playback                           |
 | `muted`   | boolean                             | false    | Mute audio                               |
 | `visible` | `never` \| distance \| `always`     | `0px`    | When to download video (see below)       |
-| `volume`  | number                              | 1        | Audio volume (0-1)                       |
+| `volume`  | number                              | 0.5      | Audio volume (0-1)                       |
 
 The `visible` attribute controls when the video track is downloaded, based on the canvas
 position relative to the viewport:
@@ -117,7 +117,7 @@ watch.video.media.subscribe((stream) => {
 </script>
 
 <moq-watch-ui>
-    <moq-watch url="https://relay.example.com/anon" path="room/alice.hang">
+    <moq-watch url="https://relay.example.com/anon" name="room/alice.hang">
         <canvas></canvas>
     </moq-watch>
 </moq-watch-ui>

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -54,6 +54,9 @@ export interface MultiBackendProps {
 	connection?: Signal<Moq.Connection.Established | undefined>;
 
 	paused?: boolean | Signal<boolean>;
+
+	// When video is downloaded relative to the canvas position. See {@link Video.Visible}.
+	visible?: Video.Visible | Signal<Video.Visible>;
 }
 
 // We have to proxy some of these signals because we support both the MSE and WebCodecs.
@@ -112,6 +115,9 @@ export class MultiBackend implements Backend {
 	jitter: Signal<Moq.Time.Milli>;
 	paused: Signal<boolean>;
 
+	// When video is downloaded relative to the canvas position. See {@link Video.Visible}.
+	visible: Signal<Video.Visible>;
+
 	video: VideoBackend;
 	#videoSource: Video.Source;
 
@@ -141,6 +147,7 @@ export class MultiBackend implements Backend {
 		this.audio = new AudioBackend(this.#audioSource);
 
 		this.paused = Signal.from(props?.paused ?? false);
+		this.visible = Signal.from(props?.visible ?? "0px");
 
 		this.signals.run(this.#runElement.bind(this));
 	}
@@ -169,6 +176,7 @@ export class MultiBackend implements Backend {
 		const videoRenderer = new Video.Renderer(videoSource, {
 			canvas: element,
 			paused: this.paused,
+			visible: this.visible,
 		});
 
 		effect.cleanup(() => {

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -5,9 +5,34 @@ import { Effect, Signal } from "@moq/signals";
 import { MultiBackend } from "./backend";
 import { Broadcast, type CatalogFormat, parseCatalogFormat } from "./broadcast";
 import type { Latency } from "./sync";
+import type { Visible } from "./video";
 
-const OBSERVED = ["url", "name", "paused", "volume", "muted", "reload", "latency", "jitter", "catalog-format"] as const;
+const OBSERVED = [
+	"url",
+	"name",
+	"paused",
+	"volume",
+	"muted",
+	"visible",
+	"reload",
+	"latency",
+	"jitter",
+	"catalog-format",
+] as const;
 type Observed = (typeof OBSERVED)[number];
+
+// Parse the `visible` attribute into a Visible value, falling back to "0px" (on screen only).
+function parseVisible(value: string | null): Visible {
+	const trimmed = value?.trim();
+	if (!trimmed) return "0px";
+	if (trimmed === "never" || trimmed === "always") return trimmed;
+	// A CSS length usable as an IntersectionObserver rootMargin (px or %).
+	if (/^-?\d+(\.\d+)?(px|%)$/.test(trimmed)) return trimmed;
+	// Allow a bare number as a px convenience (e.g. visible="200").
+	if (/^-?\d+(\.\d+)?$/.test(trimmed)) return `${trimmed}px`;
+	console.warn(`moq-watch: invalid visible="${value}", expected "never", "always", or a CSS length like "200px"`);
+	return "0px";
+}
 
 // Close everything when this element is garbage collected.
 // This is primarily to avoid a console.warn that we didn't close() before GC.
@@ -108,6 +133,11 @@ export default class MoqWatch extends HTMLElement {
 		});
 
 		this.signals.run((effect) => {
+			const visible = effect.get(this.backend.visible);
+			this.setAttribute("visible", visible);
+		});
+
+		this.signals.run((effect) => {
 			const volume = effect.get(this.backend.audio.volume);
 			this.setAttribute("volume", volume.toString());
 		});
@@ -182,6 +212,8 @@ export default class MoqWatch extends HTMLElement {
 			this.backend.audio.volume.set(volume);
 		} else if (name === "muted") {
 			this.backend.audio.muted.set(newValue !== null);
+		} else if (name === "visible") {
+			this.backend.visible.set(parseVisible(newValue));
 		} else if (name === "reload") {
 			this.broadcast.reload.set(newValue !== null);
 		} else if (name === "latency") {
@@ -239,6 +271,15 @@ export default class MoqWatch extends HTMLElement {
 
 	set muted(value: boolean) {
 		this.backend.audio.muted.set(value);
+	}
+
+	/** When video is downloaded relative to the canvas position. See {@link Visible}. */
+	get visible(): Visible {
+		return this.backend.visible.peek();
+	}
+
+	set visible(value: Visible) {
+		this.backend.visible.set(value);
 	}
 
 	get reload(): boolean {

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -2,6 +2,9 @@ import { Time } from "@moq/net";
 import { Effect, Signal } from "@moq/signals";
 import type { Decoder } from "./decoder";
 
+// Fraction of the canvas that must intersect the viewport before it counts as visible.
+const INTERSECTION_THRESHOLD = 0.01;
+
 /**
  * Controls when video is downloaded relative to the canvas position.
  *
@@ -14,13 +17,17 @@ import type { Decoder } from "./decoder";
  */
 export type Visible = "never" | "always" | (string & {});
 
+/** Options for {@link Renderer}. */
 export type RendererProps = {
+	/** The canvas to render decoded frames to. */
 	canvas?: HTMLCanvasElement | Signal<HTMLCanvasElement | undefined>;
+	/** Whether playback is paused; when paused only a single preview frame is fetched. */
 	paused?: boolean | Signal<boolean>;
+	/** When video is downloaded relative to the canvas position. See {@link Visible}. Defaults to `"0px"`. */
 	visible?: Visible | Signal<Visible>;
 };
 
-// An component to render a video to a canvas.
+/** Decodes a video track and paints it to a canvas, gating downloads on canvas visibility. */
 export class Renderer {
 	decoder: Decoder;
 
@@ -113,10 +120,10 @@ export class Renderer {
 		// invalid rootMargin throws a SyntaxError, so fall back to the default margin.
 		let observer: IntersectionObserver;
 		try {
-			observer = new IntersectionObserver(callback, { threshold: 0.01, rootMargin: visible });
+			observer = new IntersectionObserver(callback, { threshold: INTERSECTION_THRESHOLD, rootMargin: visible });
 		} catch {
 			console.warn(`moq-watch: invalid visible margin "${visible}", using "0px"`);
-			observer = new IntersectionObserver(callback, { threshold: 0.01 });
+			observer = new IntersectionObserver(callback, { threshold: INTERSECTION_THRESHOLD });
 		}
 
 		update();

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -5,14 +5,12 @@ import type { Decoder } from "./decoder";
 /**
  * Controls when video is downloaded relative to the canvas position.
  *
- * - `"never"`: never download video (forces the visibility check off).
- * - `"always"`: always download video, even when the canvas is scrolled out of view (forces
- *   the visibility check on).
+ * - `"never"`: never download video.
+ * - `"always"`: always download video, regardless of the canvas position or tab visibility.
  * - a CSS length (`"0px"`, `"200px"`, `"100%"`, ...): download while the canvas is within
- *   that distance of the viewport, used as the {@link IntersectionObserver} `rootMargin`.
- *   `"0px"` means strictly on screen; larger values pre-warm the video before it scrolls in.
- *
- * In all cases video is still suspended while the tab is hidden.
+ *   that distance of the viewport (used as the {@link IntersectionObserver} `rootMargin`) and
+ *   the tab is visible. `"0px"` means strictly on screen; larger values pre-warm the video
+ *   before it scrolls in.
  */
 export type Visible = "never" | "always" | (string & {});
 
@@ -42,7 +40,7 @@ export class Renderer {
 	readonly timestamp = new Signal<Time.Milli | undefined>(undefined);
 
 	#ctx = new Signal<CanvasRenderingContext2D | undefined>(undefined);
-	// Whether the canvas is within the configured visible margin and the tab is focused.
+	// Whether video should currently download (within the configured margin and tab visible, or forced via "always").
 	#visible = new Signal(false);
 	#signals = new Effect();
 
@@ -76,53 +74,55 @@ export class Renderer {
 		}
 	}
 
-	// Track whether the canvas is within the configured visible margin and the tab is focused.
+	// Track whether video should currently download.
 	#runVisible(effect: Effect): void {
 		const visible = effect.get(this.visible);
 
-		// "never" forces the visibility check off regardless of position or tab state.
+		// "never" forces the check off; "always" forces it on regardless of viewport or tab state.
 		if (visible === "never") {
 			this.#visible.set(false);
 			return;
 		}
 
-		// "always" overrides the IntersectionObserver result to true; a distance is its rootMargin.
-		let intersecting = visible === "always";
+		if (visible === "always") {
+			this.#visible.set(true);
+			effect.cleanup(() => this.#visible.set(false));
+			return;
+		}
 
+		// A distance gates on the viewport (used as the rootMargin) and the tab being visible.
+		const canvas = effect.get(this.canvas);
+		if (!canvas) {
+			this.#visible.set(false);
+			return;
+		}
+
+		let intersecting = false;
 		const update = () => {
 			this.#visible.set(intersecting && !document.hidden);
 		};
 
-		if (visible !== "always") {
-			const canvas = effect.get(this.canvas);
-			if (!canvas) {
-				this.#visible.set(false);
-				return;
+		const callback = (entries: IntersectionObserverEntry[]) => {
+			for (const entry of entries) {
+				intersecting = entry.isIntersecting;
+				update();
 			}
+		};
 
-			const callback = (entries: IntersectionObserverEntry[]) => {
-				for (const entry of entries) {
-					intersecting = entry.isIntersecting;
-					update();
-				}
-			};
-
-			// `visible` is a CSS length, but the programmatic API accepts arbitrary strings. An
-			// invalid rootMargin throws a SyntaxError, so fall back to the default margin.
-			let observer: IntersectionObserver;
-			try {
-				observer = new IntersectionObserver(callback, { threshold: 0.01, rootMargin: visible });
-			} catch {
-				console.warn(`moq-watch: invalid visible margin "${visible}", using "0px"`);
-				observer = new IntersectionObserver(callback, { threshold: 0.01 });
-			}
-
-			observer.observe(canvas);
-			effect.cleanup(() => observer.disconnect());
+		// `visible` is a CSS length, but the programmatic API accepts arbitrary strings. An
+		// invalid rootMargin throws a SyntaxError, so fall back to the default margin.
+		let observer: IntersectionObserver;
+		try {
+			observer = new IntersectionObserver(callback, { threshold: 0.01, rootMargin: visible });
+		} catch {
+			console.warn(`moq-watch: invalid visible margin "${visible}", using "0px"`);
+			observer = new IntersectionObserver(callback, { threshold: 0.01 });
 		}
 
 		update();
 		effect.event(document, "visibilitychange", update);
+		observer.observe(canvas);
+		effect.cleanup(() => observer.disconnect());
 		effect.cleanup(() => this.#visible.set(false));
 	}
 

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -2,9 +2,24 @@ import { Time } from "@moq/net";
 import { Effect, Signal } from "@moq/signals";
 import type { Decoder } from "./decoder";
 
+/**
+ * Controls when video is downloaded relative to the canvas position.
+ *
+ * - `"never"`: never download video (forces the visibility check off).
+ * - `"always"`: always download video, even when the canvas is scrolled out of view (forces
+ *   the visibility check on).
+ * - a CSS length (`"0px"`, `"200px"`, `"100%"`, ...): download while the canvas is within
+ *   that distance of the viewport, used as the {@link IntersectionObserver} `rootMargin`.
+ *   `"0px"` means strictly on screen; larger values pre-warm the video before it scrolls in.
+ *
+ * In all cases video is still suspended while the tab is hidden.
+ */
+export type Visible = "never" | "always" | (string & {});
+
 export type RendererProps = {
 	canvas?: HTMLCanvasElement | Signal<HTMLCanvasElement | undefined>;
 	paused?: boolean | Signal<boolean>;
+	visible?: Visible | Signal<Visible>;
 };
 
 // An component to render a video to a canvas.
@@ -17,6 +32,9 @@ export class Renderer {
 	// Whether the video is paused.
 	paused: Signal<boolean>;
 
+	// When video is downloaded relative to the canvas position. See {@link Visible}.
+	visible: Signal<Visible>;
+
 	// The most recently rendered frame, updated after each rAF paint.
 	readonly frame = new Signal<VideoFrame | undefined>(undefined);
 
@@ -24,6 +42,7 @@ export class Renderer {
 	readonly timestamp = new Signal<Time.Milli | undefined>(undefined);
 
 	#ctx = new Signal<CanvasRenderingContext2D | undefined>(undefined);
+	// Whether the canvas is within the configured visible margin and the tab is focused.
 	#visible = new Signal(false);
 	#signals = new Effect();
 
@@ -31,6 +50,7 @@ export class Renderer {
 		this.decoder = decoder;
 		this.canvas = Signal.from(props?.canvas);
 		this.paused = Signal.from(props?.paused ?? false);
+		this.visible = Signal.from(props?.visible ?? "0px");
 
 		this.#signals.run((effect) => {
 			const canvas = effect.get(this.canvas);
@@ -56,34 +76,46 @@ export class Renderer {
 		}
 	}
 
-	// Track whether the canvas is visible in the viewport and the tab is focused.
+	// Track whether the canvas is within the configured visible margin and the tab is focused.
 	#runVisible(effect: Effect): void {
-		const canvas = effect.get(this.canvas);
-		if (!canvas) {
+		const visible = effect.get(this.visible);
+
+		// "never" forces the visibility check off regardless of position or tab state.
+		if (visible === "never") {
 			this.#visible.set(false);
 			return;
 		}
 
-		let intersecting = false;
+		// "always" overrides the IntersectionObserver result to true; a distance is its rootMargin.
+		let intersecting = visible === "always";
 
 		const update = () => {
 			this.#visible.set(intersecting && !document.hidden);
 		};
 
-		const observer = new IntersectionObserver(
-			(entries) => {
-				for (const entry of entries) {
-					intersecting = entry.isIntersecting;
-					update();
-				}
-			},
-			{ threshold: 0.01 },
-		);
+		if (visible !== "always") {
+			const canvas = effect.get(this.canvas);
+			if (!canvas) {
+				this.#visible.set(false);
+				return;
+			}
 
+			const observer = new IntersectionObserver(
+				(entries) => {
+					for (const entry of entries) {
+						intersecting = entry.isIntersecting;
+						update();
+					}
+				},
+				{ threshold: 0.01, rootMargin: visible },
+			);
+
+			observer.observe(canvas);
+			effect.cleanup(() => observer.disconnect());
+		}
+
+		update();
 		effect.event(document, "visibilitychange", update);
-
-		observer.observe(canvas);
-		effect.cleanup(() => observer.disconnect());
 		effect.cleanup(() => this.#visible.set(false));
 	}
 

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -100,15 +100,22 @@ export class Renderer {
 				return;
 			}
 
-			const observer = new IntersectionObserver(
-				(entries) => {
-					for (const entry of entries) {
-						intersecting = entry.isIntersecting;
-						update();
-					}
-				},
-				{ threshold: 0.01, rootMargin: visible },
-			);
+			const callback = (entries: IntersectionObserverEntry[]) => {
+				for (const entry of entries) {
+					intersecting = entry.isIntersecting;
+					update();
+				}
+			};
+
+			// `visible` is a CSS length, but the programmatic API accepts arbitrary strings. An
+			// invalid rootMargin throws a SyntaxError, so fall back to the default margin.
+			let observer: IntersectionObserver;
+			try {
+				observer = new IntersectionObserver(callback, { threshold: 0.01, rootMargin: visible });
+			} catch {
+				console.warn(`moq-watch: invalid visible margin "${visible}", using "0px"`);
+				observer = new IntersectionObserver(callback, { threshold: 0.01 });
+			}
 
 			observer.observe(canvas);
 			effect.cleanup(() => observer.disconnect());


### PR DESCRIPTION
## Summary

Reworks the hidden-tab/video-download option from #1666 into a single `visible` setting on `<moq-watch>` (plus `RendererProps` / `MultiBackendProps` / the `visible` element property). This came out of a naming brainstorm: rather than a `background-playback` boolean, the setting is a small value space that doubles as a configurable prefetch distance.

`visible` accepts:

- **`never`** &mdash; never download video.
- **a distance** (`0px`, `200px`, `100%`, ...) &mdash; download while the canvas is within that distance of the viewport (used directly as the `IntersectionObserver` `rootMargin`) **and** the tab is visible. `0px` (the default) means strictly on screen; a larger distance pre-warms the video before it scrolls into view.
- **`always`** &mdash; always download video, regardless of the canvas position or tab visibility.

Mechanically, `never`/`always` short-circuit the visibility check and a distance drives the observer's `rootMargin`. The `document.hidden` gate applies **only** to the distance mode: a distance suspends video while the tab is hidden, whereas `always` keeps downloading. The default `0px` reproduces today's behavior (on screen + tab visible), so this is additive and non-breaking.

## Changes

- `js/watch/src/video/renderer.ts`: new exported `Visible` type and `visible` signal; `#runVisible` short-circuits for `never`/`always` and otherwise drives the observer's `rootMargin` (with a try/catch fallback to the default margin, since the programmatic API accepts arbitrary strings).
- `js/watch/src/backend.ts`: thread `visible` through `MultiBackend` to the renderer.
- `js/watch/src/element.ts`: observe/parse/reflect the `visible` attribute, validate it as `never` / `always` / a CSS length (bare numbers coerced to `px`), and expose the `visible` property.
- Docs: `js/watch/README.md` attribute table + explanation (also fixed a stale `path`→`name` and the `0.5` volume default), and the `demo/web` attribute list and tips.

## Cross-Package Sync

`js/watch` API/UI changed. `demo/web` consumes the component and is updated. No `rs/` counterpart (this is a browser-only rendering concern).

## Test plan

- [x] `bun run check` (tsc) passes for `@moq/watch`
- [x] `biome check` clean on the changed files
- [ ] Manual: `visible="200px"` pre-warms before scroll-in and suspends when the tab is hidden; `visible="always"` keeps downloading regardless of scroll or tab visibility; `visible="never"` never downloads; default unchanged

Refines the naming discussed on #1666.

(Written by Claude)