### PR TITLE
Add FLV (Flash Video / RTMP) container support to moq-mux

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -129,6 +129,7 @@ Publish (read from stdin unless noted):
 - `avc3` - raw H.264 Annex-B
 - `fmp4` - fragmented MP4 / CMAF
 - `ts` - MPEG-TS (H.264 / H.265 video; AAC, MP2, AC-3, or E-AC-3 audio)
+- `flv` - FLV / RTMP (H.264 video, AAC audio)
 - `hls --playlist <url>` - HLS playlist ingest
 - `capture` - capture local devices directly (camera H.264 + microphone Opus; requires the `capture` build feature; does not read stdin)
 
@@ -137,6 +138,7 @@ Subscribe (`--format`):
 - `fmp4` - fragmented MP4 / CMAF
 - `mkv` - Matroska / WebM
 - `ts` - MPEG-TS
+- `flv` - FLV / RTMP (H.264 video, AAC audio)
 
 ### MPEG-TS
 
@@ -161,6 +163,25 @@ frames pass through byte-exact, never transcoded; malformed input is rejected
 rather than mis-described. The catalog describes the codec honestly so a
 subscriber that can decode it (typically TS gear) picks it up; browsers cannot
 play these codecs and should skip the rendition.
+
+### FLV
+
+Ingest an FLV stream from FFmpeg and play one back out:
+
+```bash
+# Publish: remux a file to FLV and pipe it in
+ffmpeg -i input.mp4 -c copy -f flv - | \
+    moq-cli publish --url https://relay.example.com --broadcast my-stream flv
+
+# Subscribe: pull FLV back out and play it
+moq-cli subscribe --url https://relay.example.com --broadcast my-stream --format flv | ffplay -
+```
+
+FLV is the classic RTMP container: H.264 video carried as length-prefixed NALU
+with an out-of-band avcC, and AAC audio carried raw with an out-of-band
+AudioSpecificConfig. Both pass straight through to the catalog `description`. The
+enhanced E-RTMP FourCC payloads (HEVC, AV1, Opus) and the older codecs (VP6, MP3)
+are not supported.
 
 ## Authentication
 

--- a/doc/lib/rs/crate/moq-mux.md
+++ b/doc/lib/rs/crate/moq-mux.md
@@ -13,9 +13,12 @@ Media muxers and demuxers for converting existing media formats into MoQ broadca
 
 ## Overview
 
-`moq-mux` provides tools for importing media from various container formats:
+`moq-mux` provides tools for importing media from (and exporting it back to) various container formats:
 
 - **fMP4/CMAF** - Fragmented MP4 and Common Media Application Format
+- **MPEG-TS** - Transport stream (import and export)
+- **Matroska / WebM** - EBML container (import and export)
+- **FLV** - Flash Video / RTMP container (H.264 + AAC; import and export)
 - **HLS** - HTTP Live Streaming playlists
 - **Annex B** - H.264/H.265 raw NAL unit streams
 

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -1,6 +1,6 @@
 use clap::Subcommand;
 use hang::moq_net;
-use moq_mux::container::{fmp4, hls, ts};
+use moq_mux::container::{flv, fmp4, hls, ts};
 
 #[derive(Subcommand, Clone)]
 pub enum PublishFormat {
@@ -8,6 +8,8 @@ pub enum PublishFormat {
 	Fmp4,
 	/// MPEG-TS (transport stream) read from stdin.
 	Ts,
+	/// FLV (Flash Video / RTMP) read from stdin.
+	Flv,
 	// NOTE: No aac support because it needs framing.
 	Hls {
 		/// URL or file path of an HLS playlist to ingest.
@@ -20,16 +22,18 @@ enum PublishDecoder {
 	Avc3(Box<moq_mux::codec::h264::Import>),
 	Fmp4(Box<fmp4::Import>),
 	Ts(Box<ts::Import>),
+	Flv(Box<flv::Import>),
 	Hls(Box<hls::Import>),
 }
 
 impl PublishDecoder {
-	/// Decode a chunk of bytes from stdin (Avc3, Fmp4, or Ts).
+	/// Decode a chunk of bytes from stdin (Avc3, Fmp4, Ts, or Flv).
 	fn decode_buf(&mut self, buffer: &mut bytes::BytesMut) -> anyhow::Result<()> {
 		match self {
 			Self::Avc3(d) => d.decode_stream(buffer, None),
 			Self::Fmp4(d) => d.decode(buffer),
 			Self::Ts(d) => d.decode(buffer),
+			Self::Flv(d) => d.decode(buffer),
 			Self::Hls(_) => unreachable!(),
 		}
 	}
@@ -58,6 +62,10 @@ impl Publish {
 			PublishFormat::Ts => {
 				let ts = ts::Import::new(broadcast.clone(), catalog.clone());
 				PublishDecoder::Ts(Box::new(ts))
+			}
+			PublishFormat::Flv => {
+				let flv = flv::Import::new(broadcast.clone(), catalog.clone());
+				PublishDecoder::Flv(Box::new(flv))
 			}
 			PublishFormat::Hls { playlist } => {
 				let hls = hls::Import::new(broadcast.clone(), catalog.clone(), hls::Config::new(playlist.clone()))?;

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -10,6 +10,7 @@ pub enum SubscribeFormat {
 	Fmp4,
 	Mkv,
 	Ts,
+	Flv,
 }
 
 /// `clap` adapter for [`CatalogFormat`] (which is `#[non_exhaustive]` and so
@@ -86,6 +87,7 @@ impl Subscribe {
 			SubscribeFormat::Fmp4 => self.run_fmp4().await,
 			SubscribeFormat::Mkv => self.run_mkv().await,
 			SubscribeFormat::Ts => self.run_ts().await,
+			SubscribeFormat::Flv => self.run_flv().await,
 		}
 	}
 
@@ -135,6 +137,24 @@ impl Subscribe {
 			.with_latency(self.args.max_latency);
 
 		while let Some(chunk) = ts.next().await? {
+			stdout.write_all(&chunk).await?;
+			stdout.flush().await?;
+		}
+
+		Ok(())
+	}
+
+	async fn run_flv(self) -> anyhow::Result<()> {
+		let mut stdout = tokio::io::stdout();
+
+		// FLV emits the file header plus AVC/AAC sequence headers, then one tag per
+		// frame interleaved by timestamp. Avc3 sources are transcoded to avc1 shape
+		// internally (synthesizing avcC from inline parameter sets). Only H.264 video
+		// and AAC audio are supported; `fragment_duration` does not apply to FLV.
+		let mut flv = moq_mux::container::flv::Export::with_catalog_format(self.broadcast, self.catalog)?
+			.with_latency(self.args.max_latency);
+
+		while let Some(chunk) = flv.next().await? {
 			stdout.write_all(&chunk).await?;
 			stdout.flush().await?;
 		}

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -35,7 +35,7 @@ use crate::container::{CatalogSource, ExportSource, Frame};
 /// [`Avc1`](crate::codec::h264::Avc1) transform caches the inline SPS/PPS, builds
 /// the avcC for the sequence-header tag, and length-prefixes each sample. The
 /// header is deferred until that codec config is available (typically the first
-/// keyframe). Only [`Legacy`](crate::catalog::hang::Container) tracks are
+/// keyframe). Only Legacy and LOC container tracks (raw codec payloads) are
 /// supported; CMAF tracks are rejected.
 pub struct Export {
 	broadcast: moq_net::BroadcastConsumer,
@@ -271,7 +271,7 @@ impl Export {
 			body.put_u8(AVC_SEQUENCE_HEADER);
 			body.put_slice(&[0, 0, 0]); // composition time
 			body.put_slice(avcc);
-			write_tag(&mut out, TAG_VIDEO, 0, &body);
+			write_tag(&mut out, TAG_VIDEO, 0, &body)?;
 		}
 		if let Some(track) = &self.audio {
 			let asc = track
@@ -282,7 +282,7 @@ impl Export {
 			body.put_u8(AAC_AUDIO_TAG_HEADER);
 			body.put_u8(AAC_SEQUENCE_HEADER);
 			body.put_slice(asc);
-			write_tag(&mut out, TAG_AUDIO, 0, &body);
+			write_tag(&mut out, TAG_AUDIO, 0, &body)?;
 		}
 
 		Ok(out.freeze())
@@ -328,21 +328,29 @@ impl Export {
 			// We carry PTS in the tag timestamp, so the composition offset is zero.
 			body.put_slice(&[0, 0, 0]);
 			body.put_slice(&frame.payload);
-			write_tag(&mut out, TAG_VIDEO, timestamp_ms, &body);
+			write_tag(&mut out, TAG_VIDEO, timestamp_ms, &body)?;
 		} else {
 			let mut body = BytesMut::with_capacity(2 + frame.payload.len());
 			body.put_u8(AAC_AUDIO_TAG_HEADER);
 			body.put_u8(AAC_RAW);
 			body.put_slice(&frame.payload);
-			write_tag(&mut out, TAG_AUDIO, timestamp_ms, &body);
+			write_tag(&mut out, TAG_AUDIO, timestamp_ms, &body)?;
 		}
 		Ok(out.freeze())
 	}
 }
 
 /// Append one FLV tag (header + body + trailing `PreviousTagSize`) to `out`.
-fn write_tag(out: &mut BytesMut, tag_type: u8, timestamp_ms: u32, body: &[u8]) {
-	let size = body.len() as u32;
+///
+/// Errors if `body` exceeds FLV's 24-bit `DataSize` field (16 MiB), which would
+/// otherwise be silently truncated into a corrupt header.
+fn write_tag(out: &mut BytesMut, tag_type: u8, timestamp_ms: u32, body: &[u8]) -> anyhow::Result<()> {
+	let size: u32 = body
+		.len()
+		.try_into()
+		.ok()
+		.filter(|n| *n <= 0x00FF_FFFF)
+		.context("FLV tag body exceeds the 24-bit DataSize limit")?;
 	out.put_u8(tag_type);
 	out.put_slice(&size.to_be_bytes()[1..]); // 24-bit data size
 	out.put_slice(&timestamp_ms.to_be_bytes()[1..]); // 24-bit timestamp (low)
@@ -350,6 +358,7 @@ fn write_tag(out: &mut BytesMut, tag_type: u8, timestamp_ms: u32, body: &[u8]) {
 	out.put_slice(&[0, 0, 0]); // stream id
 	out.put_slice(body);
 	out.put_u32(TAG_HEADER_LEN as u32 + size);
+	Ok(())
 }
 
 fn ensure_legacy(container: &Container, kind: &str, name: &str) -> anyhow::Result<()> {

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -1,0 +1,374 @@
+//! FLV muxer.
+//!
+//! [`Export`] subscribes to a MoQ broadcast and produces a single FLV byte
+//! stream: the file header, an AVC and/or AAC sequence header, then one tag per
+//! media frame interleaved by timestamp. Frames flow through [`ExportSource`],
+//! which normalizes H.264 to length-prefixed NALU plus a resolved avcC (parsing
+//! inline avc3 parameter sets when needed) and hands audio through with its
+//! `AudioSpecificConfig`. FLV carries a single video and a single audio stream,
+//! so only the first rendition of each kind is muxed; extra renditions and any
+//! non-AVC/AAC codec are rejected.
+
+use std::task::Poll;
+use std::time::Duration;
+
+use anyhow::Context;
+use bytes::{BufMut, Bytes, BytesMut};
+use hang::catalog::{AudioCodec, Catalog, Container, VideoCodec};
+
+use super::{
+	AAC_AUDIO_TAG_HEADER, AAC_RAW, AAC_SEQUENCE_HEADER, AVC_NALU, AVC_SEQUENCE_HEADER, FRAME_TYPE_INTER,
+	FRAME_TYPE_KEY, TAG_AUDIO, TAG_HEADER_LEN, TAG_VIDEO, VIDEO_CODEC_AVC,
+};
+use crate::catalog::CatalogFormat;
+use crate::container::{CatalogSource, ExportSource, Frame};
+
+/// Subscribe to a broadcast and produce an FLV byte stream.
+///
+/// Use [`next`](Self::next) to pull byte chunks. The first chunk is the FLV file
+/// header followed by the AVC/AAC sequence headers; each subsequent chunk is the
+/// tag for one media frame. Returns `None` when the broadcast ends.
+///
+/// ## Avc3 sources
+///
+/// Annex-B H.264 (`H264 { inline: true }`, empty `description`) is accepted: an
+/// [`Avc1`](crate::codec::h264::Avc1) transform caches the inline SPS/PPS, builds
+/// the avcC for the sequence-header tag, and length-prefixes each sample. The
+/// header is deferred until that codec config is available (typically the first
+/// keyframe). Only [`Legacy`](crate::catalog::hang::Container) tracks are
+/// supported; CMAF tracks are rejected.
+pub struct Export {
+	broadcast: moq_net::BroadcastConsumer,
+	catalog: Option<CatalogSource>,
+	latency: Duration,
+
+	video: Option<FlvTrack>,
+	audio: Option<FlvTrack>,
+
+	/// True once the file header and sequence headers have been emitted.
+	header_emitted: bool,
+}
+
+/// A subscribed rendition feeding the muxer.
+struct FlvTrack {
+	name: String,
+	source: ExportSource,
+	pending: Option<Frame>,
+	finished: bool,
+}
+
+impl Export {
+	/// Subscribe to `broadcast` and produce FLV byte chunks, using the default
+	/// catalog format ([`CatalogFormat::Hang`]).
+	pub fn new(broadcast: moq_net::BroadcastConsumer) -> Result<Self, crate::Error> {
+		Self::with_catalog_format(broadcast, CatalogFormat::default())
+	}
+
+	/// Subscribe to `broadcast` and produce FLV byte chunks, selecting an explicit
+	/// `catalog_format` for track discovery.
+	pub fn with_catalog_format(
+		broadcast: moq_net::BroadcastConsumer,
+		catalog_format: CatalogFormat,
+	) -> Result<Self, crate::Error> {
+		let catalog = CatalogSource::new(&broadcast, catalog_format)?;
+		Ok(Self {
+			broadcast,
+			catalog: Some(catalog),
+			latency: Duration::ZERO,
+			video: None,
+			audio: None,
+			header_emitted: false,
+		})
+	}
+
+	/// Set the maximum buffering latency for each per-track source.
+	pub fn with_latency(mut self, latency: Duration) -> Self {
+		self.latency = latency;
+		self
+	}
+
+	/// Get the next byte chunk.
+	pub async fn next(&mut self) -> anyhow::Result<Option<Bytes>> {
+		kio::wait(|waiter| self.poll_next(waiter)).await
+	}
+
+	/// Poll for the next byte chunk.
+	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<anyhow::Result<Option<Bytes>>> {
+		// 1. Drain catalog updates to discover the track layout.
+		while let Some(catalog) = self.catalog.as_mut() {
+			match catalog.poll_next(waiter)? {
+				Poll::Ready(Some(snapshot)) => self.update_catalog(snapshot.media())?,
+				Poll::Ready(None) => {
+					self.catalog = None;
+					break;
+				}
+				Poll::Pending => break,
+			}
+		}
+
+		// 2. Pull frames from each track into `pending`. Pre-header, drop slices
+		// that arrived before the track's codec config is ready: a mid-GOP joiner
+		// can't render them, and parking would block polling for the next SPS/PPS.
+		let waiting_for_header = !self.header_emitted;
+		for track in [self.video.as_mut(), self.audio.as_mut()].into_iter().flatten() {
+			if track.pending.is_some() || track.finished {
+				continue;
+			}
+			loop {
+				match track.source.poll_read(waiter) {
+					Poll::Ready(Ok(Some(frame))) => {
+						if waiting_for_header && !track.source.header_ready() {
+							continue;
+						}
+						track.pending = Some(frame);
+						break;
+					}
+					Poll::Ready(Ok(None)) => {
+						track.finished = true;
+						break;
+					}
+					Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+					Poll::Pending => break,
+				}
+			}
+		}
+
+		// 3. Emit the header once every track's codec config has resolved.
+		if !self.header_emitted {
+			if self.header_ready() {
+				let header = self.build_header()?;
+				self.header_emitted = true;
+				return Poll::Ready(Ok(Some(header)));
+			}
+			// The catalog closed and nothing more can resolve a codec config (no
+			// tracks arrived, or every bound track ended first): there's no header.
+			if self.catalog.is_none() && (!self.has_tracks() || self.tracks().all(|t| t.finished)) {
+				return Poll::Ready(Ok(None));
+			}
+			return Poll::Pending;
+		}
+
+		// 4. Emit the smallest-timestamp pending frame as one tag.
+		if let Some(is_video) = self.pick_next_track() {
+			let track = if is_video {
+				self.video.as_mut()
+			} else {
+				self.audio.as_mut()
+			};
+			let track = track.unwrap();
+			let frame = track.pending.take().unwrap();
+			let chunk = self.encode_frame(is_video, frame)?;
+			return Poll::Ready(Ok(Some(chunk)));
+		}
+
+		// 5. End-of-stream once every subscribed track is drained.
+		if self.has_tracks() && self.tracks().all(|t| t.finished && t.pending.is_none()) {
+			if self.catalog.is_none() {
+				return Poll::Ready(Ok(None));
+			}
+		} else if self.catalog.is_none() && !self.has_tracks() {
+			return Poll::Ready(Ok(None));
+		}
+
+		Poll::Pending
+	}
+
+	/// Iterate the subscribed tracks (video first, then audio).
+	fn tracks(&self) -> impl Iterator<Item = &FlvTrack> {
+		[self.video.as_ref(), self.audio.as_ref()].into_iter().flatten()
+	}
+
+	fn has_tracks(&self) -> bool {
+		self.video.is_some() || self.audio.is_some()
+	}
+
+	fn update_catalog(&mut self, catalog: Catalog) -> anyhow::Result<()> {
+		// FLV carries one video and one audio stream. Bind to the first rendition of
+		// each kind and ignore the rest; a layout change once bound is rejected.
+		if self.video.is_none()
+			&& let Some((name, config)) = catalog.video.renditions.iter().next()
+		{
+			ensure_supported_video(config)?;
+			ensure_legacy(&config.container, "video", name)?;
+			let source = ExportSource::for_video(&self.broadcast, name, config, self.latency)?;
+			self.video = Some(FlvTrack {
+				name: name.clone(),
+				source,
+				pending: None,
+				finished: false,
+			});
+		}
+		if catalog.video.renditions.len() > 1 {
+			tracing::warn!("FLV export only supports one video track; ignoring the rest");
+		}
+
+		if self.audio.is_none()
+			&& let Some((name, config)) = catalog.audio.renditions.iter().next()
+		{
+			ensure_supported_audio(config)?;
+			ensure_legacy(&config.container, "audio", name)?;
+			let source = ExportSource::for_audio(&self.broadcast, name, config, self.latency)?;
+			self.audio = Some(FlvTrack {
+				name: name.clone(),
+				source,
+				pending: None,
+				finished: false,
+			});
+		}
+		if catalog.audio.renditions.len() > 1 {
+			tracing::warn!("FLV export only supports one audio track; ignoring the rest");
+		}
+
+		// A bound track vanishing from the catalog is a layout change FLV can't express.
+		if let Some(track) = &self.video {
+			anyhow::ensure!(
+				catalog.video.renditions.contains_key(&track.name),
+				"FLV video track '{}' removed mid-stream",
+				track.name
+			);
+		}
+		if let Some(track) = &self.audio {
+			anyhow::ensure!(
+				catalog.audio.renditions.contains_key(&track.name),
+				"FLV audio track '{}' removed mid-stream",
+				track.name
+			);
+		}
+
+		Ok(())
+	}
+
+	/// Header is ready once at least one track is bound and every bound track's
+	/// [`ExportSource`] has resolved its codec config (from the catalog
+	/// `description` or synthesized by the Avc3 transform).
+	fn header_ready(&self) -> bool {
+		self.has_tracks() && self.tracks().all(|t| t.source.header_ready())
+	}
+
+	/// Build the FLV file header plus the AVC/AAC sequence-header tags.
+	fn build_header(&self) -> anyhow::Result<Bytes> {
+		let mut out = BytesMut::new();
+
+		// FLV file header: signature, version 1, type flags, data offset = 9.
+		out.put_slice(b"FLV");
+		out.put_u8(1);
+		let mut flags = 0u8;
+		if self.video.is_some() {
+			flags |= 0x01;
+		}
+		if self.audio.is_some() {
+			flags |= 0x04;
+		}
+		out.put_u8(flags);
+		out.put_u32(9);
+		// PreviousTagSize0 is always zero.
+		out.put_u32(0);
+
+		if let Some(track) = &self.video {
+			let avcc = track.source.description().context("H.264 track missing avcC")?;
+			let mut body = BytesMut::with_capacity(5 + avcc.len());
+			body.put_u8((FRAME_TYPE_KEY << 4) | VIDEO_CODEC_AVC);
+			body.put_u8(AVC_SEQUENCE_HEADER);
+			body.put_slice(&[0, 0, 0]); // composition time
+			body.put_slice(avcc);
+			write_tag(&mut out, TAG_VIDEO, 0, &body);
+		}
+		if let Some(track) = &self.audio {
+			let asc = track
+				.source
+				.description()
+				.context("AAC track missing AudioSpecificConfig")?;
+			let mut body = BytesMut::with_capacity(2 + asc.len());
+			body.put_u8(AAC_AUDIO_TAG_HEADER);
+			body.put_u8(AAC_SEQUENCE_HEADER);
+			body.put_slice(asc);
+			write_tag(&mut out, TAG_AUDIO, 0, &body);
+		}
+
+		Ok(out.freeze())
+	}
+
+	/// Pick the track with the smallest pending timestamp. Returns whether it's the
+	/// video track, or `None` if no frame is pending.
+	fn pick_next_track(&self) -> Option<bool> {
+		let video = self
+			.video
+			.as_ref()
+			.and_then(|t| t.pending.as_ref())
+			.map(|f| f.timestamp);
+		let audio = self
+			.audio
+			.as_ref()
+			.and_then(|t| t.pending.as_ref())
+			.map(|f| f.timestamp);
+		match (video, audio) {
+			(Some(v), Some(a)) => Some(v <= a),
+			(Some(_), None) => Some(true),
+			(None, Some(_)) => Some(false),
+			(None, None) => None,
+		}
+	}
+
+	/// Encode one frame as a single FLV tag.
+	fn encode_frame(&self, is_video: bool, frame: Frame) -> anyhow::Result<Bytes> {
+		let timestamp_ms: u32 = (frame.timestamp.as_millis())
+			.try_into()
+			.context("FLV timestamp exceeds 32 bits")?;
+
+		let mut out = BytesMut::with_capacity(TAG_HEADER_LEN + frame.payload.len() + 8);
+		if is_video {
+			let mut body = BytesMut::with_capacity(5 + frame.payload.len());
+			let frame_type = if frame.keyframe {
+				FRAME_TYPE_KEY
+			} else {
+				FRAME_TYPE_INTER
+			};
+			body.put_u8((frame_type << 4) | VIDEO_CODEC_AVC);
+			body.put_u8(AVC_NALU);
+			// We carry PTS in the tag timestamp, so the composition offset is zero.
+			body.put_slice(&[0, 0, 0]);
+			body.put_slice(&frame.payload);
+			write_tag(&mut out, TAG_VIDEO, timestamp_ms, &body);
+		} else {
+			let mut body = BytesMut::with_capacity(2 + frame.payload.len());
+			body.put_u8(AAC_AUDIO_TAG_HEADER);
+			body.put_u8(AAC_RAW);
+			body.put_slice(&frame.payload);
+			write_tag(&mut out, TAG_AUDIO, timestamp_ms, &body);
+		}
+		Ok(out.freeze())
+	}
+}
+
+/// Append one FLV tag (header + body + trailing `PreviousTagSize`) to `out`.
+fn write_tag(out: &mut BytesMut, tag_type: u8, timestamp_ms: u32, body: &[u8]) {
+	let size = body.len() as u32;
+	out.put_u8(tag_type);
+	out.put_slice(&size.to_be_bytes()[1..]); // 24-bit data size
+	out.put_slice(&timestamp_ms.to_be_bytes()[1..]); // 24-bit timestamp (low)
+	out.put_u8((timestamp_ms >> 24) as u8); // timestamp extension (high)
+	out.put_slice(&[0, 0, 0]); // stream id
+	out.put_slice(body);
+	out.put_u32(TAG_HEADER_LEN as u32 + size);
+}
+
+fn ensure_legacy(container: &Container, kind: &str, name: &str) -> anyhow::Result<()> {
+	match container {
+		Container::Legacy | Container::Loc => Ok(()),
+		Container::Cmaf { .. } => anyhow::bail!("FLV export does not support CMAF {kind} track '{name}'"),
+	}
+}
+
+fn ensure_supported_video(config: &hang::catalog::VideoConfig) -> anyhow::Result<()> {
+	match &config.codec {
+		VideoCodec::H264(_) => Ok(()),
+		other => anyhow::bail!("FLV export only supports H.264 video, got {other:?}"),
+	}
+}
+
+fn ensure_supported_audio(config: &hang::catalog::AudioConfig) -> anyhow::Result<()> {
+	match &config.codec {
+		AudioCodec::AAC(_) => Ok(()),
+		other => anyhow::bail!("FLV export only supports AAC audio, got {other:?}"),
+	}
+}

--- a/rs/moq-mux/src/container/flv/export_test.rs
+++ b/rs/moq-mux/src/container/flv/export_test.rs
@@ -1,0 +1,247 @@
+//! Tests for the FLV muxer.
+//!
+//! Round-trip: ingest a synthetic FLV via the importer, re-export via the
+//! exporter, and assert the bytes parse back into the same catalog shape.
+
+use std::time::Duration;
+
+use hang::catalog::{AudioCodec, VideoCodec};
+
+use super::{Export, Import};
+
+/// A minimal `AVCDecoderConfigurationRecord` (profile 0x42, level 0x1f, one SPS + PPS).
+fn avcc() -> Vec<u8> {
+	let sps = [0x67u8, 0x42, 0xc0, 0x1f];
+	let mut out = vec![0x01, 0x42, 0xc0, 0x1f, 0xff, 0xe1, 0x00, sps.len() as u8];
+	out.extend_from_slice(&sps);
+	out.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]);
+	out
+}
+
+/// AudioSpecificConfig for AAC-LC, 44100 Hz, stereo.
+const ASC: [u8; 2] = [0x12, 0x10];
+
+fn write_tag(out: &mut Vec<u8>, tag_type: u8, timestamp: u32, body: &[u8]) {
+	out.push(tag_type);
+	out.extend_from_slice(&(body.len() as u32).to_be_bytes()[1..]);
+	out.extend_from_slice(&timestamp.to_be_bytes()[1..]);
+	out.push((timestamp >> 24) as u8);
+	out.extend_from_slice(&[0, 0, 0]);
+	out.extend_from_slice(body);
+	out.extend_from_slice(&(11 + body.len() as u32).to_be_bytes());
+}
+
+/// Build an FLV with AVC + AAC sequence headers and a couple of frames each.
+fn synth_flv() -> Vec<u8> {
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1);
+	out.push(0x05);
+	out.extend_from_slice(&9u32.to_be_bytes());
+	out.extend_from_slice(&0u32.to_be_bytes());
+
+	let mut vseq = vec![
+		(super::FRAME_TYPE_KEY << 4) | super::VIDEO_CODEC_AVC,
+		super::AVC_SEQUENCE_HEADER,
+		0,
+		0,
+		0,
+	];
+	vseq.extend_from_slice(&avcc());
+	write_tag(&mut out, super::TAG_VIDEO, 0, &vseq);
+
+	let mut aseq = vec![super::AAC_AUDIO_TAG_HEADER, super::AAC_SEQUENCE_HEADER];
+	aseq.extend_from_slice(&ASC);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &aseq);
+
+	// Video keyframe at t=0, inter frame at t=33ms.
+	let idr = [0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00];
+	let mut vkey = vec![
+		(super::FRAME_TYPE_KEY << 4) | super::VIDEO_CODEC_AVC,
+		super::AVC_NALU,
+		0,
+		0,
+		0,
+	];
+	vkey.extend_from_slice(&idr);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &vkey);
+
+	let p = [0, 0, 0, 4, 0x41, 0xe0, 0x12, 0x34];
+	let mut vinter = vec![
+		(super::FRAME_TYPE_INTER << 4) | super::VIDEO_CODEC_AVC,
+		super::AVC_NALU,
+		0,
+		0,
+		0,
+	];
+	vinter.extend_from_slice(&p);
+	write_tag(&mut out, super::TAG_VIDEO, 33, &vinter);
+
+	// Audio frames at t=0 and t=23ms.
+	let mut a0 = vec![super::AAC_AUDIO_TAG_HEADER, super::AAC_RAW];
+	a0.extend_from_slice(&[0xde, 0xad]);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &a0);
+
+	let mut a1 = vec![super::AAC_AUDIO_TAG_HEADER, super::AAC_RAW];
+	a1.extend_from_slice(&[0xbe, 0xef]);
+	write_tag(&mut out, super::TAG_AUDIO, 23, &a1);
+
+	out
+}
+
+/// Drive the exporter to completion, dropping the importer to signal EOS.
+async fn drain_export(mut exporter: Export, mut importer: Import) -> Vec<u8> {
+	// Finish the tracks cleanly so the exporter can reach end-of-stream instead of
+	// seeing the producer dropped out from under it.
+	importer.finish().unwrap();
+	let mut exported = Vec::new();
+	let mut importer = Some(importer);
+	for _ in 0..64 {
+		match tokio::time::timeout(Duration::from_millis(100), exporter.next()).await {
+			Ok(Ok(Some(chunk))) => exported.extend_from_slice(&chunk),
+			Ok(Ok(None)) => break,
+			Ok(Err(e)) => panic!("exporter error: {e}"),
+			Err(_) => importer = None, // close the broadcast so the exporter can EOS
+		}
+	}
+	drop(importer);
+	exported
+}
+
+#[tokio::test(start_paused = true)]
+async fn export_roundtrips_through_import() {
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	importer
+		.decode(&mut bytes::BytesMut::from(synth_flv().as_slice()))
+		.unwrap();
+	catalog.finish().unwrap();
+
+	let exporter = Export::new(consumer).unwrap();
+	let exported = drain_export(exporter, importer).await;
+
+	// The export must be a real FLV stream.
+	assert_eq!(&exported[0..3], b"FLV");
+
+	// Re-import the exported bytes and confirm the catalog rebuilds identically.
+	let mut bcast2 = moq_net::Broadcast::new().produce();
+	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
+	let mut imp2 = Import::new(bcast2, cat2.clone());
+	imp2.decode(&mut bytes::BytesMut::from(exported.as_slice())).unwrap();
+	imp2.finish().unwrap();
+
+	let snap = cat2.snapshot();
+	assert_eq!(snap.video.renditions.len(), 1);
+	assert_eq!(snap.audio.renditions.len(), 1);
+
+	let v = snap.video.renditions.values().next().unwrap();
+	assert!(matches!(v.codec, VideoCodec::H264(_)));
+	assert_eq!(v.description.as_ref().map(|b| b.as_ref()), Some(avcc().as_slice()));
+
+	let a = snap.audio.renditions.values().next().unwrap();
+	assert!(matches!(a.codec, AudioCodec::AAC(_)));
+	assert_eq!(a.sample_rate, 44100);
+	assert_eq!(a.description.as_ref().map(|b| b.as_ref()), Some(&ASC[..]));
+}
+
+#[tokio::test(start_paused = true)]
+async fn export_emits_sequence_headers_and_frames() {
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	importer
+		.decode(&mut bytes::BytesMut::from(synth_flv().as_slice()))
+		.unwrap();
+	catalog.finish().unwrap();
+
+	let exporter = Export::new(consumer).unwrap();
+	let exported = drain_export(exporter, importer).await;
+
+	let tags = parse_tags(&exported);
+
+	// One AVC sequence header, one AAC sequence header.
+	let avc_seq = tags
+		.iter()
+		.filter(|t| t.tag_type == super::TAG_VIDEO && t.body[1] == super::AVC_SEQUENCE_HEADER)
+		.count();
+	let aac_seq = tags
+		.iter()
+		.filter(|t| t.tag_type == super::TAG_AUDIO && t.body[1] == super::AAC_SEQUENCE_HEADER)
+		.count();
+	assert_eq!(avc_seq, 1, "expected one AVC sequence header");
+	assert_eq!(aac_seq, 1, "expected one AAC sequence header");
+
+	// Two video NALU frames and two raw AAC frames.
+	let video_frames = tags
+		.iter()
+		.filter(|t| t.tag_type == super::TAG_VIDEO && t.body[1] == super::AVC_NALU)
+		.count();
+	let audio_frames = tags
+		.iter()
+		.filter(|t| t.tag_type == super::TAG_AUDIO && t.body[1] == super::AAC_RAW)
+		.count();
+	assert_eq!(video_frames, 2, "expected two video frames");
+	assert_eq!(audio_frames, 2, "expected two audio frames");
+}
+
+struct ParsedTag {
+	tag_type: u8,
+	timestamp: u32,
+	body: Vec<u8>,
+}
+
+/// Parse an FLV byte stream into its tags (skipping the 9-byte file header and
+/// every `PreviousTagSize`).
+fn parse_tags(flv: &[u8]) -> Vec<ParsedTag> {
+	let mut tags = Vec::new();
+	let mut off = 9 + 4; // file header + PreviousTagSize0
+	while off + 11 <= flv.len() {
+		let tag_type = flv[off];
+		let size = super::read_u24(&flv[off + 1..off + 4]) as usize;
+		let timestamp = super::read_u24(&flv[off + 4..off + 7]) | ((flv[off + 7] as u32) << 24);
+		let body_start = off + 11;
+		if body_start + size + 4 > flv.len() {
+			break;
+		}
+		tags.push(ParsedTag {
+			tag_type,
+			timestamp,
+			body: flv[body_start..body_start + size].to_vec(),
+		});
+		off = body_start + size + 4;
+	}
+	tags
+}
+
+/// A frame's tag timestamp must survive the round trip (PTS in milliseconds).
+#[tokio::test(start_paused = true)]
+async fn export_preserves_timestamps() {
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	importer
+		.decode(&mut bytes::BytesMut::from(synth_flv().as_slice()))
+		.unwrap();
+	catalog.finish().unwrap();
+
+	let exporter = Export::new(consumer).unwrap();
+	let exported = drain_export(exporter, importer).await;
+
+	let tags = parse_tags(&exported);
+	let video_ts: Vec<u32> = tags
+		.iter()
+		.filter(|t| t.tag_type == super::TAG_VIDEO && t.body[1] == super::AVC_NALU)
+		.map(|t| t.timestamp)
+		.collect();
+	assert_eq!(video_ts, vec![0, 33]);
+}

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -19,6 +19,10 @@ use super::{
 };
 use crate::container::{Frame, Timestamp};
 
+/// Upper bound on the FLV header's `data_offset`. The header is 9 bytes in
+/// practice; this cap stops a crafted offset from forcing unbounded buffering.
+const MAX_DATA_OFFSET: usize = 64 * 1024;
+
 /// Demuxes an FLV byte stream into a MoQ broadcast.
 ///
 /// Supports H.264 (CodecID 7) video and AAC (SoundFormat 10) audio, the modern
@@ -104,6 +108,9 @@ impl Import {
 			let data_offset =
 				u32::from_be_bytes([self.buffer[5], self.buffer[6], self.buffer[7], self.buffer[8]]) as usize;
 			anyhow::ensure!(data_offset >= FILE_HEADER_LEN, "invalid FLV data offset");
+			// The header is tiny in practice (9 bytes). Cap it so a crafted offset
+			// can't force unbounded buffering before the first tag is reached.
+			anyhow::ensure!(data_offset <= MAX_DATA_OFFSET, "FLV data offset too large");
 			if self.buffer.len() < data_offset + PREV_TAG_SIZE_LEN {
 				return Ok(());
 			}

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -1,0 +1,330 @@
+//! FLV demuxer.
+//!
+//! [`Import`] reads an FLV byte stream, splits it into tags, and routes the
+//! H.264 (AVC) video and AAC audio onto MoQ tracks. FLV carries codec config
+//! out of band: the AVC sequence header is an `AVCDecoderConfigurationRecord`
+//! (avcC) and the AAC sequence header is an `AudioSpecificConfig`, both reused
+//! verbatim as the catalog `description`. Video access units are already
+//! length-prefixed NALU (the avc1 shape) and audio frames are raw AAC, so the
+//! sample bytes pass through to the [`Legacy`](crate::catalog::hang::Container)
+//! container unchanged.
+
+use bytes::{Buf, Bytes, BytesMut};
+use hang::catalog::{AAC, AudioConfig, Container, H264, VideoConfig};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use super::{
+	AAC_RAW, AAC_SEQUENCE_HEADER, AUDIO_FORMAT_AAC, AVC_NALU, AVC_SEQUENCE_HEADER, FILE_HEADER_LEN, FRAME_TYPE_KEY,
+	PREV_TAG_SIZE_LEN, TAG_AUDIO, TAG_HEADER_LEN, TAG_SCRIPT, TAG_VIDEO, VIDEO_CODEC_AVC, read_i24, read_u24,
+};
+use crate::container::{Frame, Timestamp};
+
+/// Demuxes an FLV byte stream into a MoQ broadcast.
+///
+/// Supports H.264 (CodecID 7) video and AAC (SoundFormat 10) audio, the modern
+/// FLV payload produced by RTMP encoders and `ffmpeg -f flv`. Every other codec,
+/// plus the enhanced E-RTMP FourCC tags and `onMetaData` script tags, is logged
+/// and dropped. A single FLV stream carries at most one video and one audio
+/// track; a new sequence header replaces the previous configuration.
+pub struct Import {
+	broadcast: moq_net::BroadcastProducer,
+	catalog: crate::catalog::Producer,
+
+	/// Accumulated unparsed input. Whole tags are drained out; a trailing partial
+	/// tag is retained for the next [`decode`](Self::decode) call.
+	buffer: BytesMut,
+	/// True once the 9-byte FLV file header and its `PreviousTagSize0` have been consumed.
+	header_seen: bool,
+
+	video: Option<Stream>,
+	audio: Option<Stream>,
+}
+
+/// One demuxed track: its producer plus the sequence-header bytes last seen, so a
+/// repeated (identical) sequence header is a no-op rather than a track rebuild.
+struct Stream {
+	track: crate::container::Producer<crate::catalog::hang::Container>,
+	description: Bytes,
+}
+
+impl Import {
+	/// Create a demuxer publishing into `broadcast` with renditions announced on `catalog`.
+	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer) -> Self {
+		Self {
+			broadcast,
+			catalog,
+			buffer: BytesMut::new(),
+			header_seen: false,
+			video: None,
+			audio: None,
+		}
+	}
+
+	/// True once at least one stream's sequence header has been parsed.
+	pub fn is_initialized(&self) -> bool {
+		self.video.is_some() || self.audio.is_some()
+	}
+
+	/// Decode from an asynchronous reader, driving [`Self::decode`] in a loop.
+	pub async fn decode_from<T: AsyncRead + Unpin>(&mut self, reader: &mut T) -> anyhow::Result<()> {
+		let mut chunk = BytesMut::with_capacity(64 * 1024);
+		loop {
+			chunk.clear();
+			let n = reader.read_buf(&mut chunk).await?;
+			if n == 0 {
+				break;
+			}
+			self.decode(&mut chunk)?;
+		}
+		Ok(())
+	}
+
+	/// Append `buf` to the internal scratch and demux every whole tag it now
+	/// completes. The buffer is fully consumed; a trailing partial tag is retained
+	/// for the next call.
+	pub fn decode<T: Buf + AsRef<[u8]>>(&mut self, buf: &mut T) -> anyhow::Result<()> {
+		while buf.has_remaining() {
+			let chunk = buf.chunk();
+			self.buffer.extend_from_slice(chunk);
+			let len = chunk.len();
+			buf.advance(len);
+		}
+
+		self.drain()
+	}
+
+	fn drain(&mut self) -> anyhow::Result<()> {
+		if !self.header_seen {
+			if self.buffer.len() < FILE_HEADER_LEN {
+				return Ok(());
+			}
+			anyhow::ensure!(&self.buffer[0..3] == b"FLV", "not an FLV stream");
+			// data_offset is where the body starts (>= 9). It's followed by the
+			// 4-byte PreviousTagSize0 before the first tag.
+			let data_offset =
+				u32::from_be_bytes([self.buffer[5], self.buffer[6], self.buffer[7], self.buffer[8]]) as usize;
+			anyhow::ensure!(data_offset >= FILE_HEADER_LEN, "invalid FLV data offset");
+			if self.buffer.len() < data_offset + PREV_TAG_SIZE_LEN {
+				return Ok(());
+			}
+			self.buffer.advance(data_offset + PREV_TAG_SIZE_LEN);
+			self.header_seen = true;
+		}
+
+		while self.buffer.len() >= TAG_HEADER_LEN {
+			let tag_type = self.buffer[0];
+			let data_size = read_u24(&self.buffer[1..4]) as usize;
+			// Header + body + the trailing PreviousTagSize that follows every tag.
+			let total = TAG_HEADER_LEN + data_size + PREV_TAG_SIZE_LEN;
+			if self.buffer.len() < total {
+				break;
+			}
+
+			// FLV timestamps are milliseconds: a 24-bit field plus an 8-bit
+			// most-significant extension byte.
+			let timestamp = (read_u24(&self.buffer[4..7]) as u64) | ((self.buffer[7] as u64) << 24);
+			let body = Bytes::copy_from_slice(&self.buffer[TAG_HEADER_LEN..TAG_HEADER_LEN + data_size]);
+			self.buffer.advance(total);
+
+			match tag_type {
+				TAG_VIDEO => self.handle_video(&body, timestamp)?,
+				TAG_AUDIO => self.handle_audio(&body, timestamp)?,
+				TAG_SCRIPT => {} // onMetaData and friends: nothing we need.
+				other => tracing::debug!(tag_type = other, "ignoring unknown FLV tag"),
+			}
+		}
+
+		Ok(())
+	}
+
+	fn handle_video(&mut self, body: &[u8], timestamp: u64) -> anyhow::Result<()> {
+		let Some(&first) = body.first() else {
+			return Ok(());
+		};
+		// The enhanced E-RTMP signaling sets the high bit and switches to FourCC
+		// codec identification; we only speak classic AVC.
+		if first & 0x80 != 0 {
+			tracing::warn!("enhanced FLV (FourCC) video not supported, dropping");
+			return Ok(());
+		}
+		let frame_type = first >> 4;
+		let codec_id = first & 0x0f;
+		if codec_id != VIDEO_CODEC_AVC {
+			tracing::warn!(codec_id, "unsupported FLV video codec, dropping");
+			return Ok(());
+		}
+
+		anyhow::ensure!(body.len() >= 5, "AVC video tag too short");
+		let avc_packet_type = body[1];
+		let composition_time = read_i24(&body[2..5]);
+		let data = &body[5..];
+
+		match avc_packet_type {
+			AVC_SEQUENCE_HEADER => self.init_video(data),
+			AVC_NALU => {
+				let Some(stream) = self.video.as_mut() else {
+					tracing::debug!("AVC NALU before sequence header, dropping");
+					return Ok(());
+				};
+				// FLV stores DTS in the tag; PTS is DTS plus the composition offset.
+				let pts_ms = (timestamp as i64) + (composition_time as i64);
+				anyhow::ensure!(pts_ms >= 0, "negative AVC presentation timestamp");
+				stream.track.write(Frame {
+					timestamp: Timestamp::from_millis(pts_ms as u64)?,
+					payload: Bytes::copy_from_slice(data),
+					keyframe: frame_type == FRAME_TYPE_KEY,
+				})?;
+				Ok(())
+			}
+			// AVCPacketType 2 is "end of sequence"; nothing to emit.
+			_ => Ok(()),
+		}
+	}
+
+	fn handle_audio(&mut self, body: &[u8], timestamp: u64) -> anyhow::Result<()> {
+		let Some(&first) = body.first() else {
+			return Ok(());
+		};
+		let sound_format = first >> 4;
+		if sound_format != AUDIO_FORMAT_AAC {
+			tracing::warn!(sound_format, "unsupported FLV audio format, dropping");
+			return Ok(());
+		}
+
+		anyhow::ensure!(body.len() >= 2, "AAC audio tag too short");
+		let aac_packet_type = body[1];
+		let data = &body[2..];
+
+		match aac_packet_type {
+			AAC_SEQUENCE_HEADER => self.init_audio(data),
+			AAC_RAW => {
+				let Some(stream) = self.audio.as_mut() else {
+					tracing::debug!("AAC frame before sequence header, dropping");
+					return Ok(());
+				};
+				// Each frame is its own group so the relay can forward it immediately.
+				stream.track.write(Frame {
+					timestamp: Timestamp::from_millis(timestamp)?,
+					payload: Bytes::copy_from_slice(data),
+					keyframe: true,
+				})?;
+				stream.track.finish_group()?;
+				Ok(())
+			}
+			_ => Ok(()),
+		}
+	}
+
+	/// Handle an AVC sequence header (an `AVCDecoderConfigurationRecord`). On the
+	/// first one, or whenever the bytes change, (re)build the video track.
+	fn init_video(&mut self, avcc_bytes: &[u8]) -> anyhow::Result<()> {
+		if self.video.as_ref().is_some_and(|s| s.description == avcc_bytes) {
+			return Ok(());
+		}
+
+		let avcc = crate::codec::h264::Avcc::parse(avcc_bytes)?;
+		let mut config = VideoConfig::new(H264 {
+			profile: avcc.profile,
+			constraints: avcc.constraints,
+			level: avcc.level,
+			inline: false,
+		});
+		config.description = Some(Bytes::copy_from_slice(avcc_bytes));
+		config.coded_width = avcc.coded_width;
+		config.coded_height = avcc.coded_height;
+		config.container = Container::Legacy;
+
+		let net_track = self.replace_video()?;
+		self.catalog
+			.lock()
+			.video
+			.renditions
+			.insert(net_track.name.clone(), config);
+		self.video = Some(Stream {
+			// Live FLV can join mid-GOP; tolerate leading deltas before the first keyframe.
+			track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy)
+				.with_lenient_start(),
+			description: Bytes::copy_from_slice(avcc_bytes),
+		});
+		Ok(())
+	}
+
+	/// Handle an AAC sequence header (an `AudioSpecificConfig`).
+	fn init_audio(&mut self, asc_bytes: &[u8]) -> anyhow::Result<()> {
+		if self.audio.as_ref().is_some_and(|s| s.description == asc_bytes) {
+			return Ok(());
+		}
+
+		let mut cursor = asc_bytes;
+		let cfg = crate::codec::aac::Config::parse(&mut cursor)?;
+		let mut config = AudioConfig::new(AAC { profile: cfg.profile }, cfg.sample_rate, cfg.channel_count);
+		config.description = Some(Bytes::copy_from_slice(asc_bytes));
+		config.container = Container::Legacy;
+
+		let net_track = self.replace_audio()?;
+		self.catalog
+			.lock()
+			.audio
+			.renditions
+			.insert(net_track.name.clone(), config);
+		self.audio = Some(Stream {
+			track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy),
+			description: Bytes::copy_from_slice(asc_bytes),
+		});
+		Ok(())
+	}
+
+	/// Drop any existing video track (finishing it and clearing its catalog
+	/// rendition) and allocate a fresh one.
+	fn replace_video(&mut self) -> anyhow::Result<moq_net::TrackProducer> {
+		if let Some(mut old) = self.video.take() {
+			old.track.finish()?;
+			self.catalog.lock().video.renditions.remove(&old.track.name);
+		}
+		Ok(self.broadcast.unique_track(".flv-v")?)
+	}
+
+	/// Drop any existing audio track (finishing it and clearing its catalog
+	/// rendition) and allocate a fresh one.
+	fn replace_audio(&mut self) -> anyhow::Result<moq_net::TrackProducer> {
+		if let Some(mut old) = self.audio.take() {
+			old.track.finish()?;
+			self.catalog.lock().audio.renditions.remove(&old.track.name);
+		}
+		Ok(self.broadcast.unique_track(".flv-a")?)
+	}
+
+	/// Close the current group on every track and reopen at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+		if let Some(stream) = self.video.as_mut() {
+			stream.track.seek(sequence)?;
+		}
+		if let Some(stream) = self.audio.as_mut() {
+			stream.track.seek(sequence)?;
+		}
+		Ok(())
+	}
+
+	/// Finish every track, flushing the current group.
+	pub fn finish(&mut self) -> anyhow::Result<()> {
+		if let Some(stream) = self.video.as_mut() {
+			stream.track.finish()?;
+		}
+		if let Some(stream) = self.audio.as_mut() {
+			stream.track.finish()?;
+		}
+		Ok(())
+	}
+}
+
+impl Drop for Import {
+	fn drop(&mut self) {
+		let mut catalog = self.catalog.lock();
+		if let Some(stream) = &self.video {
+			catalog.video.renditions.remove(&stream.track.name);
+		}
+		if let Some(stream) = &self.audio {
+			catalog.audio.renditions.remove(&stream.track.name);
+		}
+	}
+}

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -1,0 +1,158 @@
+//! Tests for the FLV demuxer.
+
+use hang::catalog::{AudioCodec, VideoCodec};
+
+use super::Import;
+
+/// A minimal `AVCDecoderConfigurationRecord`: AVC-LC baseline (profile 0x42,
+/// level 0x1f) with one SPS and one PPS.
+fn avcc() -> Vec<u8> {
+	let sps = [0x67u8, 0x42, 0xc0, 0x1f];
+	let mut out = vec![0x01, 0x42, 0xc0, 0x1f, 0xff, 0xe1, 0x00, sps.len() as u8];
+	out.extend_from_slice(&sps);
+	out.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]); // numPPS, PPS len, PPS
+	out
+}
+
+/// AudioSpecificConfig for AAC-LC, 44100 Hz, stereo.
+const ASC: [u8; 2] = [0x12, 0x10];
+
+/// Append an FLV tag (header + body + trailing PreviousTagSize) to `out`.
+fn write_tag(out: &mut Vec<u8>, tag_type: u8, timestamp: u32, body: &[u8]) {
+	out.push(tag_type);
+	out.extend_from_slice(&(body.len() as u32).to_be_bytes()[1..]); // 24-bit data size
+	out.extend_from_slice(&timestamp.to_be_bytes()[1..]); // 24-bit timestamp (low)
+	out.push((timestamp >> 24) as u8); // timestamp extension
+	out.extend_from_slice(&[0, 0, 0]); // stream id
+	out.extend_from_slice(body);
+	out.extend_from_slice(&(11 + body.len() as u32).to_be_bytes());
+}
+
+/// Build a tiny FLV: header, AVC + AAC sequence headers, one keyframe, one audio frame.
+fn synth_flv() -> Vec<u8> {
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1); // version
+	out.push(0x05); // flags: audio | video
+	out.extend_from_slice(&9u32.to_be_bytes()); // data offset
+	out.extend_from_slice(&0u32.to_be_bytes()); // PreviousTagSize0
+
+	// AVC sequence header.
+	let mut vseq = vec![
+		(super::FRAME_TYPE_KEY << 4) | super::VIDEO_CODEC_AVC,
+		super::AVC_SEQUENCE_HEADER,
+		0,
+		0,
+		0,
+	];
+	vseq.extend_from_slice(&avcc());
+	write_tag(&mut out, super::TAG_VIDEO, 0, &vseq);
+
+	// AAC sequence header.
+	let mut aseq = vec![super::AAC_AUDIO_TAG_HEADER, super::AAC_SEQUENCE_HEADER];
+	aseq.extend_from_slice(&ASC);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &aseq);
+
+	// One keyframe NALU (length-prefixed IDR).
+	let nalu = [0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00];
+	let mut vframe = vec![
+		(super::FRAME_TYPE_KEY << 4) | super::VIDEO_CODEC_AVC,
+		super::AVC_NALU,
+		0,
+		0,
+		0,
+	];
+	vframe.extend_from_slice(&nalu);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &vframe);
+
+	// One raw AAC frame.
+	let mut aframe = vec![super::AAC_AUDIO_TAG_HEADER, super::AAC_RAW];
+	aframe.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &aframe);
+
+	out
+}
+
+#[tokio::test(start_paused = true)]
+async fn import_populates_catalog() {
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	let mut buf = bytes::BytesMut::from(synth_flv().as_slice());
+	importer.decode(&mut buf).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	assert_eq!(snap.video.renditions.len(), 1);
+	assert_eq!(snap.audio.renditions.len(), 1);
+
+	let v = snap.video.renditions.values().next().unwrap();
+	assert!(matches!(v.codec, VideoCodec::H264(_)));
+	assert_eq!(v.description.as_ref().map(|b| b.as_ref()), Some(avcc().as_slice()));
+
+	let a = snap.audio.renditions.values().next().unwrap();
+	assert!(matches!(a.codec, AudioCodec::AAC(_)));
+	assert_eq!(a.sample_rate, 44100);
+	assert_eq!(a.channel_count, 2);
+	assert_eq!(a.description.as_ref().map(|b| b.as_ref()), Some(&ASC[..]));
+}
+
+#[tokio::test(start_paused = true)]
+async fn import_emits_frames() {
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	let mut buf = bytes::BytesMut::from(synth_flv().as_slice());
+	importer.decode(&mut buf).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	let video_name = snap.video.renditions.keys().next().unwrap().clone();
+
+	// Decode the video track back through the Legacy container.
+	let track = consumer.subscribe_track(&moq_net::Track::new(video_name)).unwrap();
+	let mut decoder = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy)
+		.with_latency(std::time::Duration::from_secs(1));
+	let frame = decoder.read().await.unwrap().expect("a video frame");
+	assert!(frame.keyframe);
+	// The payload is the length-prefixed NALU, carried through verbatim.
+	assert_eq!(frame.payload.as_ref(), &[0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00]);
+
+	drop(importer);
+}
+
+/// Bytes split across two `decode` calls still reassemble into whole tags.
+#[tokio::test(start_paused = true)]
+async fn import_handles_split_input() {
+	let flv = synth_flv();
+	let (head, tail) = flv.split_at(flv.len() / 2);
+
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&mut bytes::BytesMut::from(head)).unwrap();
+	importer.decode(&mut bytes::BytesMut::from(tail)).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	assert_eq!(snap.video.renditions.len(), 1);
+	assert_eq!(snap.audio.renditions.len(), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn import_rejects_non_flv() {
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog);
+	let mut buf = bytes::BytesMut::from(&b"NOTFLV\x00\x00\x00"[..]);
+	assert!(importer.decode(&mut buf).is_err());
+}

--- a/rs/moq-mux/src/container/flv/mod.rs
+++ b/rs/moq-mux/src/container/flv/mod.rs
@@ -1,0 +1,73 @@
+//! FLV (Flash Video / RTMP container).
+//!
+//! An interchange format only, not a wire format: [`Import`] demuxes an FLV byte
+//! stream into a broadcast and [`Export`] muxes a broadcast back into FLV. Only
+//! the modern FLV payload is handled: H.264 (AVC) video carried as
+//! length-prefixed NALU with an out-of-band `AVCDecoderConfigurationRecord`
+//! (avcC), and AAC audio carried raw with an out-of-band `AudioSpecificConfig`.
+//! Both records pass straight through as the catalog `description`, and the
+//! sample bytes already match the [`Legacy`](crate::catalog::hang::Container)
+//! container, so no codec transform is needed. Other legacy codecs (VP6, MP3,
+//! Speex, …) and the enhanced E-RTMP FourCC payloads are logged and dropped on
+//! import, and rejected on export.
+
+mod export;
+mod import;
+
+pub use export::*;
+pub use import::*;
+
+#[cfg(test)]
+mod export_test;
+#[cfg(test)]
+mod import_test;
+
+/// FLV tag type: audio.
+const TAG_AUDIO: u8 = 8;
+/// FLV tag type: video.
+const TAG_VIDEO: u8 = 9;
+/// FLV tag type: script data (`onMetaData`, etc.).
+const TAG_SCRIPT: u8 = 18;
+
+/// Bytes in an FLV tag header (type, data size, timestamp, stream id).
+const TAG_HEADER_LEN: usize = 11;
+/// Bytes in the `PreviousTagSize` field that trails every tag.
+const PREV_TAG_SIZE_LEN: usize = 4;
+/// Bytes in the FLV file header preceding the first `PreviousTagSize`.
+const FILE_HEADER_LEN: usize = 9;
+
+/// Video CodecID for H.264 (low nibble of a video tag's first byte).
+const VIDEO_CODEC_AVC: u8 = 7;
+/// SoundFormat for AAC (high nibble of an audio tag's first byte).
+const AUDIO_FORMAT_AAC: u8 = 10;
+
+/// Video FrameType for a keyframe.
+const FRAME_TYPE_KEY: u8 = 1;
+/// Video FrameType for an inter frame.
+const FRAME_TYPE_INTER: u8 = 2;
+
+/// AVCPacketType for the `AVCDecoderConfigurationRecord`.
+const AVC_SEQUENCE_HEADER: u8 = 0;
+/// AVCPacketType for a length-prefixed NALU access unit.
+const AVC_NALU: u8 = 1;
+
+/// AACPacketType for the `AudioSpecificConfig`.
+const AAC_SEQUENCE_HEADER: u8 = 0;
+/// AACPacketType for a raw AAC frame.
+const AAC_RAW: u8 = 1;
+
+/// Standard first byte of an AAC audio tag: SoundFormat 10, SoundRate 3
+/// (44 kHz flag), SoundSize 1 (16-bit), SoundType 1 (stereo). The real rate and
+/// channel layout live in the `AudioSpecificConfig`, so these bits are nominal.
+const AAC_AUDIO_TAG_HEADER: u8 = (AUDIO_FORMAT_AAC << 4) | (3 << 2) | (1 << 1) | 1;
+
+/// Read a 24-bit big-endian unsigned integer.
+fn read_u24(b: &[u8]) -> u32 {
+	((b[0] as u32) << 16) | ((b[1] as u32) << 8) | (b[2] as u32)
+}
+
+/// Read a 24-bit big-endian signed integer (FLV composition time offset).
+fn read_i24(b: &[u8]) -> i32 {
+	let v = read_u24(b) as i32;
+	if v & 0x80_0000 != 0 { v - 0x100_0000 } else { v }
+}

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod jitter;
 mod producer;
 mod source;
 
+pub mod flv;
 pub mod fmp4;
 pub mod hls;
 pub mod legacy;

--- a/rs/moq-mux/src/import.rs
+++ b/rs/moq-mux/src/import.rs
@@ -257,7 +257,7 @@ impl Framed {
 				let config = crate::codec::opus::Config::parse(buf)?;
 				FramedKind::Opus(crate::codec::opus::Import::new_with_track(track, catalog, config)?)
 			}
-			FramedFormat::Fmp4 | FramedFormat::Mkv | FramedFormat::Ts => {
+			FramedFormat::Fmp4 | FramedFormat::Mkv | FramedFormat::Ts | FramedFormat::Flv => {
 				anyhow::bail!("{format} can publish multiple tracks")
 			}
 		};

--- a/rs/moq-mux/src/import.rs
+++ b/rs/moq-mux/src/import.rs
@@ -42,6 +42,8 @@ pub enum FramedFormat {
 	Vp8,
 	/// VP9 (one frame per buffer; not self-delimiting).
 	Vp9,
+	/// FLV (Flash Video / RTMP) container.
+	Flv,
 }
 
 impl FromStr for FramedFormat {
@@ -60,6 +62,7 @@ impl FromStr for FramedFormat {
 			"ts" | "mpegts" | "mpeg2ts" | "m2ts" => Ok(FramedFormat::Ts),
 			"vp8" | "vp08" => Ok(FramedFormat::Vp8),
 			"vp9" | "vp09" => Ok(FramedFormat::Vp9),
+			"flv" => Ok(FramedFormat::Flv),
 			_ => Err(Error::UnknownFormat(s.to_string())),
 		}
 	}
@@ -79,6 +82,7 @@ impl fmt::Display for FramedFormat {
 			FramedFormat::Ts => write!(f, "ts"),
 			FramedFormat::Vp8 => write!(f, "vp8"),
 			FramedFormat::Vp9 => write!(f, "vp9"),
+			FramedFormat::Flv => write!(f, "flv"),
 		}
 	}
 }
@@ -92,6 +96,7 @@ impl From<StreamFormat> for FramedFormat {
 			StreamFormat::Av01 => FramedFormat::Av01,
 			StreamFormat::Mkv => FramedFormat::Mkv,
 			StreamFormat::Ts => FramedFormat::Ts,
+			StreamFormat::Flv => FramedFormat::Flv,
 		}
 	}
 }
@@ -112,6 +117,8 @@ enum FramedKind {
 	Mkv(Box<crate::container::mkv::Import>),
 	// Boxed for the same reason as Fmp4.
 	Ts(Box<crate::container::ts::Import>),
+	// Boxed for the same reason as Fmp4.
+	Flv(Box<crate::container::flv::Import>),
 }
 
 /// An importer for formats with known frame boundaries.
@@ -186,6 +193,11 @@ impl Framed {
 				decoder.decode(buf)?;
 				FramedKind::Ts(decoder)
 			}
+			FramedFormat::Flv => {
+				let mut decoder = Box::new(crate::container::flv::Import::new(broadcast, catalog));
+				decoder.decode(buf)?;
+				FramedKind::Flv(decoder)
+			}
 		};
 
 		anyhow::ensure!(!buf.has_remaining(), "buffer was not fully consumed");
@@ -206,6 +218,7 @@ impl Framed {
 			FramedKind::Opus(ref mut decoder) => decoder.finish(),
 			FramedKind::Mkv(ref mut decoder) => decoder.finish(),
 			FramedKind::Ts(ref mut decoder) => decoder.finish(),
+			FramedKind::Flv(ref mut decoder) => decoder.finish(),
 		}
 	}
 
@@ -222,6 +235,7 @@ impl Framed {
 			FramedKind::Opus(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Mkv(ref mut decoder) => decoder.seek(sequence),
 			FramedKind::Ts(ref mut decoder) => decoder.seek(sequence),
+			FramedKind::Flv(ref mut decoder) => decoder.seek(sequence),
 		}
 	}
 
@@ -238,6 +252,7 @@ impl Framed {
 			FramedKind::Opus(ref decoder) => Ok(decoder.track()),
 			FramedKind::Mkv(_) => anyhow::bail!("mkv can contain multiple tracks"),
 			FramedKind::Ts(_) => anyhow::bail!("ts can contain multiple tracks"),
+			FramedKind::Flv(_) => anyhow::bail!("flv can contain multiple tracks"),
 		}
 	}
 
@@ -261,6 +276,10 @@ impl Framed {
 				decoder.decode(buf)?;
 			}
 			FramedKind::Ts(ref mut decoder) => {
+				let _ = pts;
+				decoder.decode(buf)?;
+			}
+			FramedKind::Flv(ref mut decoder) => {
 				let _ = pts;
 				decoder.decode(buf)?;
 			}
@@ -309,6 +328,8 @@ pub enum StreamFormat {
 	Mkv,
 	/// MPEG-TS (transport stream) container.
 	Ts,
+	/// FLV (Flash Video / RTMP) container.
+	Flv,
 }
 
 impl FromStr for StreamFormat {
@@ -322,6 +343,7 @@ impl FromStr for StreamFormat {
 			"av01" | "av1" | "av1c" | "av1C" => Ok(StreamFormat::Av01),
 			"mkv" | "webm" | "matroska" => Ok(StreamFormat::Mkv),
 			"ts" | "mpegts" | "mpeg2ts" | "m2ts" => Ok(StreamFormat::Ts),
+			"flv" => Ok(StreamFormat::Flv),
 			_ => Err(Error::UnknownFormat(s.to_string())),
 		}
 	}
@@ -336,6 +358,7 @@ impl fmt::Display for StreamFormat {
 			StreamFormat::Av01 => write!(f, "av01"),
 			StreamFormat::Mkv => write!(f, "mkv"),
 			StreamFormat::Ts => write!(f, "ts"),
+			StreamFormat::Flv => write!(f, "flv"),
 		}
 	}
 }
@@ -351,6 +374,8 @@ enum StreamKind {
 	Mkv(Box<crate::container::mkv::Import>),
 	// Boxed for the same reason as Fmp4.
 	Ts(Box<crate::container::ts::Import>),
+	// Boxed for the same reason as Fmp4.
+	Flv(Box<crate::container::flv::Import>),
 }
 
 /// An importer for formats that support stream decoding (unknown frame boundaries).
@@ -378,6 +403,7 @@ impl Stream {
 			StreamFormat::Av01 => StreamKind::Av01(crate::codec::av1::Import::new(broadcast, catalog)),
 			StreamFormat::Mkv => StreamKind::Mkv(Box::new(crate::container::mkv::Import::new(broadcast, catalog))),
 			StreamFormat::Ts => StreamKind::Ts(Box::new(crate::container::ts::Import::new(broadcast, catalog))),
+			StreamFormat::Flv => StreamKind::Flv(Box::new(crate::container::flv::Import::new(broadcast, catalog))),
 		};
 
 		Ok(Self { decoder })
@@ -396,6 +422,7 @@ impl Stream {
 			StreamKind::Av01(ref mut decoder) => decoder.initialize(buf)?,
 			StreamKind::Mkv(ref mut decoder) => decoder.decode(buf)?,
 			StreamKind::Ts(ref mut decoder) => decoder.decode(buf)?,
+			StreamKind::Flv(ref mut decoder) => decoder.decode(buf)?,
 		}
 
 		anyhow::ensure!(!buf.has_remaining(), "buffer was not fully consumed");
@@ -412,6 +439,7 @@ impl Stream {
 			StreamKind::Av01(ref mut decoder) => decoder.decode_stream(buf, None),
 			StreamKind::Mkv(ref mut decoder) => decoder.decode(buf),
 			StreamKind::Ts(ref mut decoder) => decoder.decode(buf),
+			StreamKind::Flv(ref mut decoder) => decoder.decode(buf),
 		}
 	}
 
@@ -424,6 +452,7 @@ impl Stream {
 			StreamKind::Av01(ref mut decoder) => decoder.finish(),
 			StreamKind::Mkv(ref mut decoder) => decoder.finish(),
 			StreamKind::Ts(ref mut decoder) => decoder.finish(),
+			StreamKind::Flv(ref mut decoder) => decoder.finish(),
 		}
 	}
 
@@ -436,6 +465,7 @@ impl Stream {
 			StreamKind::Av01(ref mut decoder) => decoder.seek(sequence),
 			StreamKind::Mkv(ref mut decoder) => decoder.seek(sequence),
 			StreamKind::Ts(ref mut decoder) => decoder.seek(sequence),
+			StreamKind::Flv(ref mut decoder) => decoder.seek(sequence),
 		}
 	}
 
@@ -448,6 +478,7 @@ impl Stream {
 			StreamKind::Av01(ref decoder) => decoder.is_initialized(),
 			StreamKind::Mkv(ref decoder) => decoder.is_initialized(),
 			StreamKind::Ts(ref decoder) => decoder.is_initialized(),
+			StreamKind::Flv(ref decoder) => decoder.is_initialized(),
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds an FLV import (demuxer) and export (muxer) to `moq-mux`, alongside the existing fMP4, MKV, and MPEG-TS containers.

FLV is the classic RTMP container. It carries H.264 video as length-prefixed NALU with an out-of-band `AVCDecoderConfigurationRecord` (avcC), and AAC audio raw with an out-of-band `AudioSpecificConfig`. Both records map directly onto the `Legacy` container and the existing `Avcc` / `aac::Config` parsers, and the sample bytes pass straight through, so no codec transform is needed. Only the trivial tag framing is hand-rolled (wire-level framing, which the repo guidelines reserve bespoke code for).

### What's included

- **`container::flv::Import`** — demuxes an FLV byte stream into a broadcast. Supports incremental/streaming input (buffers partial tags across `decode` calls), composition-time → PTS, and a sequence-header change rebuilding the track. The header `data_offset` is bounded to avoid unbounded buffering on crafted input.
- **`container::flv::Export`** — muxes a broadcast back into FLV: file header, AVC/AAC sequence headers, then one tag per frame interleaved by timestamp. Accepts Avc3 (Annex-B) sources via the shared `Avc1` transform, deferring the header until the codec config resolves. Rejects tag bodies larger than FLV's 24-bit `DataSize` instead of silently truncating.
- Wired `Flv` into the `FramedFormat` / `StreamFormat` dispatchers (string `"flv"`), including the multi-track guard in `Framed::new_with_track`.
- Wired `flv` into `moq-cli` `publish` (stdin demux) and `subscribe` (`--format flv`).
- Docs: FLV section in `doc/bin/cli.md` and the supported-format list in `doc/lib/rs/crate/moq-mux.md`.

Enhanced E-RTMP FourCC payloads (HEVC, AV1, Opus) and the older codecs (VP6, MP3) are logged and dropped on import, and rejected on export.

### Public API changes (all additive)

- New module `moq_mux::container::flv` with `Import` and `Export`.
- New `#[non_exhaustive]` enum variants: `FramedFormat::Flv`, `StreamFormat::Flv`.
- New `moq-cli` subcommand `publish flv` and `--format flv`.

No wire-protocol or breaking API changes, so this targets `main`.

### Cross-package sync

This is a `rs/moq-mux` container addition. The sync table doesn't list a JS counterpart for new containers (FLV is a native ingest/egress format), and the `moq-cli` + doc rows are updated here.

### Test plan

- [x] `cargo test -p moq-mux` — 234 pass, incl. 7 new FLV tests (catalog population, frame decode, split input, non-FLV rejection, export round-trip through import, sequence-header/frame counts, timestamp preservation)
- [x] `cargo clippy -p moq-mux -p moq-cli --all-targets` clean
- [x] Merged latest `main`; `Framed::new_with_track` (added by #1684) now covers `FramedFormat::Flv`

(Written by Claude)