### PR TITLE
fix(moq-native): watch current dir for bare-filename certs

### DIFF
--- a/rs/moq-native/src/watch.rs
+++ b/rs/moq-native/src/watch.rs
@@ -36,8 +36,15 @@ impl FileWatcher {
 			let _ = tx.try_send(());
 		})?;
 
-		// Watch each distinct parent directory once.
-		let mut dirs: Vec<&Path> = paths.iter().filter_map(|p| p.parent()).collect();
+		// Watch each distinct parent directory once. A bare filename like
+		// `cert.pem` has an empty-string parent (`Some("")`, not `None`), which the
+		// OS watcher rejects with "No path was found", so map that to the current
+		// directory.
+		let mut dirs: Vec<&Path> = paths
+			.iter()
+			.filter_map(|p| p.parent())
+			.map(|p| if p.as_os_str().is_empty() { Path::new(".") } else { p })
+			.collect();
 		dirs.sort_unstable();
 		dirs.dedup();
 		for dir in dirs {
@@ -60,5 +67,18 @@ impl FileWatcher {
 			.recv()
 			.await
 			.expect("file watcher channel closed unexpectedly");
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// A bare filename has a `Some("")` parent; watching "" is rejected by the OS
+	// watcher, so `new` must fall back to the current directory rather than error.
+	#[test]
+	fn bare_filename_watches_current_dir() {
+		FileWatcher::new(&[PathBuf::from("cert.pem"), PathBuf::from("key.pem")])
+			.expect("bare filenames should watch the current directory");
 	}
 }


### PR DESCRIPTION
## Summary

A relay configured with cert/key paths as bare filenames (e.g. `cert.pem`, no directory component) logged this on startup and then never hot-reloaded its certificates:

```
ERROR moq_native::tls: failed to watch certificate files; hot reload disabled err=No path was found. about [""]
```

The `about [""]` is the tell: the file watcher was trying to watch an **empty-string directory**.

## Root cause

`FileWatcher::new` in `rs/moq-native/src/watch.rs` watches each cert/key file's *parent directory* (so atomic renames and K8s secret-mount symlink swaps still fire a change event). For a bare filename like `cert.pem`, `Path::parent()` returns `Some("")` — an empty path, not `None` — so `filter_map(|p| p.parent())` keeps it, and the OS watcher rejects `""` with "No path was found".

The error was swallowed by the `reload_certs` path: cert *serving* still worked, but reload-on-change was silently disabled. Rotating a relative-path cert never took effect until restart.

## Fix

Map an empty parent to `.` (current directory):

```rust
let mut dirs: Vec<&Path> = paths
    .iter()
    .filter_map(|p| p.parent())
    .map(|p| if p.as_os_str().is_empty() { Path::new(".") } else { p })
    .collect();
```

Plus a regression test (`bare_filename_watches_current_dir`) that constructs a `FileWatcher` from bare filenames and asserts it doesn't error.

## Test plan

- [x] `cargo build -p moq-native`
- [x] `cargo test -p moq-native --lib bare_filename` — passes
- [x] `cargo fmt -p moq-native -- --check` (via nix) — clean
- [x] `cargo clippy -p moq-native` (via nix) — clean

(Written by Claude)