### PR TITLE
chore(js): bump JS package versions to publish pending changes

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/json",
 	"type": "module",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"description": "Snapshot/delta JSON publishing over MoQ tracks using RFC 7396 JSON Merge Patch.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/loc/package.json
+++ b/js/loc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/loc",
 	"type": "module",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Low Overhead Container (LOC) frame encoding for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/msf",
 	"type": "module",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "MSF (MOQT Streaming Format) catalog types for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.14",
+	"version": "0.2.15",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/signals",
 	"type": "module",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "Reactive and safe signals",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.16",
+	"version": "0.2.17",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

The local `package.json` versions all matched what's published on npm, so source changes merged to `main` since the last bump were sitting unpublished. The release workflow (`release-js.yml`) only publishes a package when its version differs from npm, so a bump is required to ship them.

This patch-bumps each JS package with **unreleased source changes**:

| Package | Bump | Pending changes |
|---|---|---|
| `@moq/net` | 0.1.4 → 0.1.5 | connection reload/connect, group, time additions |
| `@moq/hang` | 0.2.9 → 0.2.10 | exported-symbol docs for JSR (#1738) |
| `@moq/json` | 0.0.2 → 0.0.3 | producer set/delta changes (#1748) |
| `@moq/loc` | 0.1.0 → 0.1.1 | exported-symbol docs (#1738) |
| `@moq/msf` | 0.1.1 → 0.1.2 | catalog/index additions (#1738) |
| `@moq/publish` | 0.2.14 → 0.2.15 | simulcast attr, custom tracks, encoder (#1679, #1748) |
| `@moq/signals` | 0.1.8 → 0.1.9 | index/dom/react/solid rework, JSR (#1725) |
| `@moq/watch` | 0.2.16 → 0.2.17 | `visible` attr, custom tracks, renderer (#1744, #1748) |

## Skipped

- `@moq/clock` — intentionally unpublished (#1488).
- `@moq/token` and `@moq/boy` — only dependency-range bumps in `package.json`, no shipped source change (existing `^` ranges already resolve to the newer deps).

## Notes for reviewer

- Only the `version` line changed in each file (8 files, 1 line each).
- `bun.lock` is unaffected: it references workspace packages by path (`@moq/net@workspace:js/net`) and `workspace:^` range, not concrete version, so `--frozen-lockfile` still passes.
- On merge, the release script skips any package already matching npm, so exactly these 8 publish.

(Written by Claude)