### PR TITLE
chore(moq-native): bump to 0.17.1 to unblock moq-relay release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "moq-native"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary

The `Release RS` workflow ([run 27593759846](https://github.com/moq-dev/moq/actions/runs/27593759846)) fails publishing `moq-relay 0.12.10` to crates.io with a `noq-proto` version conflict:

- `web-transport-iroh 0.5` → `iroh 1.0.0-rc.0` → `noq-proto =1.0.0-rc.0` (exact pin)
- `web-transport-noq 0.1.1` → `noq 1.0.0-rc.0` → `noq-proto ^1.0.0-rc.0`

Now that `noq-proto 1.0.0` is published, release-plz's `dependencies_update = true` runs `cargo update`, which bumps `noq-proto` to `1.0.0` on the `noq` path and breaks iroh's exact `rc.0` pin.

`main` already fixed the source by bumping the workspace transports to `web-transport-iroh 0.6` / `web-transport-noq 0.2.0`, which ride the stable `iroh 1.0.0` / `noq 1.0.0` line and use `noq-proto ^1.0.0` consistently. But `moq-native 0.17.0` was already published with the old constraints, and `moq-relay` depends on that published version, so the release keeps failing.

This bumps `moq-native` `0.17.0` → `0.17.1` (patch) so release-plz publishes a fresh `moq-native` carrying the corrected transport constraints, which `moq-relay` then resolves against.

## Changes

- `rs/moq-native/Cargo.toml`: `version = "0.17.1"`
- `Cargo.lock`: synced

## Verification

- `cargo update --dry-run` runs clean — `noq-proto` and `iroh` both resolve to `1.0.0`, no conflict.
- `cargo check -p moq-relay --features noq` (exercises both the default `iroh` backend and `noq`) builds green against `moq-native 0.17.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)