### PR TITLE
fix(libmoq)!: standardise the pkg-config paths

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -27,6 +27,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
+		"@moq/json": "workspace:^",
 		"@types/audioworklet": "^0.0.100",
 		"@types/bun": "^1.3.14",
 		"@typescript/lib-dom": "npm:@types/web@^0.0.350",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -27,7 +27,6 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@moq/json": "workspace:^",
 		"@types/audioworklet": "^0.0.100",
 		"@types/bun": "^1.3.14",
 		"@typescript/lib-dom": "npm:@types/web@^0.0.350",

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -92,13 +92,20 @@ let
       mkdir -p $out/lib/pkgconfig $out/include $out/lib/cmake/moq
 
       # build.rs derives its output dir from OUT_DIR, so a cross --target
-      # build puts the staticlib, header and pkgconfig under target/<triple>/.
-      # Keep the prefix target-aware so the native and cross outputs share
-      # one installPhase.
+      # build puts the staticlib, header and pkgconfig (under lib/) below
+      # target/<triple>/. Keep the prefix target-aware so the native and
+      # cross outputs share one installPhase.
       tdir="target''${CARGO_BUILD_TARGET:+/$CARGO_BUILD_TARGET}"
       cp "$tdir/release/libmoq.a" $out/lib/
       cp "$tdir/include/moq.h" $out/include/
-      cp "$tdir/pkgconfig/moq.pc" $out/lib/pkgconfig/
+      cp "$tdir/lib/pkgconfig/moq.pc" $out/lib/pkgconfig/
+
+      # build.rs writes libdir relative to the raw cargo target tree
+      # (../../release). Here the staticlib sits in $out/lib alongside
+      # pkgconfig/, so point libdir one level up. Stays relocatable; no
+      # build-time path leaks into the store.
+      substituteInPlace $out/lib/pkgconfig/moq.pc \
+        --replace-fail 'libdir=''${pcfiledir}/../../release' 'libdir=''${pcfiledir}/..'
 
       major_version="$(echo "${libmoqInfo.version}" | cut -d. -f1)"
       substitute ${../rs/libmoq/cmake/moq-config.cmake.in} \

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -100,12 +100,12 @@ let
       cp "$tdir/include/moq.h" $out/include/
       cp "$tdir/lib/pkgconfig/moq.pc" $out/lib/pkgconfig/
 
-      # build.rs writes libdir relative to the raw cargo target tree
-      # (../../release). Here the staticlib sits in $out/lib alongside
-      # pkgconfig/, so point libdir one level up. Stays relocatable; no
-      # build-time path leaks into the store.
-      substituteInPlace $out/lib/pkgconfig/moq.pc \
-        --replace-fail 'libdir=''${pcfiledir}/../../release' 'libdir=''${pcfiledir}/..'
+      # build.rs points libdir at the raw cargo target tree's profile dir
+      # (../../<profile>). The installPhase puts the staticlib in $out/lib
+      # alongside pkgconfig/, so rewrite libdir one level up. Match the whole
+      # line so this is independent of the profile name and the exact .pc
+      # template. Stays relocatable; no build-time path leaks into the store.
+      sed -i 's#^libdir=.*#libdir=''${pcfiledir}/..#' $out/lib/pkgconfig/moq.pc
 
       major_version="$(echo "${libmoqInfo.version}" | cut -d. -f1)"
       substitute ${../rs/libmoq/cmake/moq-config.cmake.in} \

--- a/rs/libmoq/README.md
+++ b/rs/libmoq/README.md
@@ -12,7 +12,7 @@ This will:
 
 - Build the static library (`libmoq.a` on Unix-like systems, `moq.lib` on Windows)
 - Generate the C header file at `target/include/moq.h`
-- Generate the pkg-config file at `target/moq.pc`
+- Generate the pkg-config file at `target/lib/pkgconfig/moq.pc`
 
 There's also a [CMakeLists.txt](CMakeLists.txt) file that can be used to import/build the library.
 

--- a/rs/libmoq/build.rs
+++ b/rs/libmoq/build.rs
@@ -20,15 +20,17 @@ fn main() {
 		.expect("Unable to generate bindings")
 		.write_to_file(&header);
 
-	// Generate pkg-config file into target/pkgconfig/
+	// Generate pkg-config file into target/lib/pkgconfig/
 	let pc_in = PathBuf::from(&crate_dir).join(format!("{}.pc.in", LIB_NAME));
-	let pkgconfig_dir = target_dir.join("pkgconfig");
+	let pkgconfig_dir = target_dir.join("lib").join("pkgconfig");
 	fs::create_dir_all(&pkgconfig_dir).expect("Failed to create pkgconfig directory");
 	let pc_out = pkgconfig_dir.join(format!("{}.pc", LIB_NAME));
 	if let Ok(template) = fs::read_to_string(&pc_in) {
 		let target = env::var("TARGET").unwrap();
+		let profile = env::var("PROFILE").unwrap();
+		let lib_dir = target_dir.join(&profile);
 		let libs_private = if target.contains("apple") {
-			"-framework CoreFoundation -framework Security"
+			"-framework CoreFoundation -framework Security -framework CoreServices"
 		} else if target.contains("windows") {
 			"-lws2_32 -lbcrypt -luserenv -lntdll"
 		} else {
@@ -37,7 +39,9 @@ fn main() {
 
 		let content = template
 			.replace("@VERSION@", &version)
-			.replace("@LIBS_PRIVATE@", libs_private);
+			.replace("@LIBS_PRIVATE@", libs_private)
+			.replace("@LIB_DIR@", lib_dir.to_str().unwrap())
+			.replace("@INCLUDE_DIR@", include_dir.to_str().unwrap());
 		fs::write(&pc_out, content).expect("Failed to write pkg-config file");
 	}
 }

--- a/rs/libmoq/build.rs
+++ b/rs/libmoq/build.rs
@@ -20,7 +20,8 @@ fn main() {
 		.expect("Unable to generate bindings")
 		.write_to_file(&header);
 
-	// Generate pkg-config file into target/lib/pkgconfig/
+	// Generate pkg-config file into target/lib/pkgconfig/ so the raw cargo
+	// target tree matches the conventional lib/ layout consumers expect.
 	let pc_in = PathBuf::from(&crate_dir).join(format!("{}.pc.in", LIB_NAME));
 	let pkgconfig_dir = target_dir.join("lib").join("pkgconfig");
 	fs::create_dir_all(&pkgconfig_dir).expect("Failed to create pkgconfig directory");
@@ -28,7 +29,6 @@ fn main() {
 	if let Ok(template) = fs::read_to_string(&pc_in) {
 		let target = env::var("TARGET").unwrap();
 		let profile = env::var("PROFILE").unwrap();
-		let lib_dir = target_dir.join(&profile);
 		let libs_private = if target.contains("apple") {
 			"-framework CoreFoundation -framework Security -framework CoreServices"
 		} else if target.contains("windows") {
@@ -40,8 +40,7 @@ fn main() {
 		let content = template
 			.replace("@VERSION@", &version)
 			.replace("@LIBS_PRIVATE@", libs_private)
-			.replace("@LIB_DIR@", lib_dir.to_str().unwrap())
-			.replace("@INCLUDE_DIR@", include_dir.to_str().unwrap());
+			.replace("@PROFILE@", &profile);
 		fs::write(&pc_out, content).expect("Failed to write pkg-config file");
 	}
 }

--- a/rs/libmoq/moq.pc.in
+++ b/rs/libmoq/moq.pc.in
@@ -1,5 +1,10 @@
-libdir=@LIB_DIR@
-includedir=@INCLUDE_DIR@
+# Paths are relative to this .pc file so the raw `cargo build` target tree is
+# usable directly (e.g. PKG_CONFIG_PATH=target/lib/pkgconfig). The staticlib
+# lives in the profile dir (target/<profile>/), the header in target/include/.
+# Packagers that relocate into a conventional lib/+include/ layout rewrite
+# libdir; see nix/overlay.nix.
+libdir=${pcfiledir}/../../@PROFILE@
+includedir=${pcfiledir}/../../include
 
 Name: moq
 Description: Media over QUIC C Interface

--- a/rs/libmoq/moq.pc.in
+++ b/rs/libmoq/moq.pc.in
@@ -1,11 +1,9 @@
-prefix=${pcfiledir}/../..
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+libdir=@LIB_DIR@
+includedir=@INCLUDE_DIR@
 
 Name: moq
 Description: Media over QUIC C Interface
 Version: @VERSION@
 Libs: -L${libdir} -lmoq
-Libs.private: -framework CoreFoundation -framework Security
+Libs.private: @LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
Standardise the pkg-config paths, noticed this issue when trying to build FFmpeg with support for `libmoq`:
```bash
PKG_CONFIG_PATH=/moq/target/lib/pkgconfig ./configure ... --enable-libmoq
```
as seen in my pull request for FFmpeg: https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/23263.

This should produce a more standard directory structure for the `.pc` file, library files and headers:
```bash
target/{target}/
├── include/moq.h
├── lib/
│   ├── libmoq.a
│   └── pkgconfig/moq.pc
└── release/
    └── libmoq.a
```

Marked as breaking, since it might break builds that depend on the old directory structure, but the previous `moq.pc` file also pointed at the wrong include directory, so not sure if this ever worked properly?

I was also not able to link on Mac OS without `-framework CoreServices`, so that was added. Target for `windows` and fallback (linux etc.) is untouched.

Added a small chore to add the `@moq/json` to the `devDependencies`, not sure why they were removed but `just web` gives me a broken frontend without it.