### PR TITLE
feat(js/publish): default `announce` to "source", restyle modes as strings

### DIFF
--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -71,7 +71,7 @@ a real bundler (the examples below).
 - `invisible` - Disable video capture (boolean)
 - `simulcast` - Also publish a lower-resolution `video/sd` rendition (a fraction of the source resolution) alongside `video/hd` (boolean)
 - `preview` - What the preview renders: `"source"` (default), `"encoded"`, or `"none"` to disable it (see [Preview element](#preview-element))
-- `announce` - When to publish the broadcast: `"true"` (default, announce as soon as the element connects), `"false"` (never announce), or `"source"` (hold off until a `source` is selected). The JS property takes a real boolean or `"source"` (`el.announce = false`)
+- `announce` - When to publish the broadcast: `"source"` (default, hold off until a `source` is selected), `"always"` (announce as soon as the element connects), or `"never"`. The JS property takes the same string values (`el.announce = "always"`)
 
 ## Preview element
 

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -72,7 +72,7 @@ The simplest way to publish a stream:
 | `muted`     | boolean | false    | Mute audio capture              |
 | `invisible` | boolean | false    | Disable video capture           |
 | `preview`   | string  | `"source"` | What the preview renders: `"source"`, `"encoded"`, `"none"` |
-| `announce`  | string  | `"true"` | When to publish: `"true"` (always), `"false"` (never), `"source"` (once a source is selected) |
+| `announce`  | string  | `"source"` | When to publish: `"always"`, `"never"`, `"source"` (once a source is selected) |
 
 ## JavaScript API
 

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -9,8 +9,9 @@ type Observed = (typeof OBSERVED)[number];
 
 type SourceType = "camera" | "screen" | "file";
 
-// `true` announces immediately, `false` never announces, "source" waits until a source is selected.
-type AnnounceMode = boolean | "source";
+// "always" announces immediately, "never" never announces, "source" waits until a source is selected.
+// Defaults to "source" so we don't announce an empty broadcast with no audio/video.
+type AnnounceMode = "always" | "source" | "never";
 
 // Close everything when this element is garbage collected.
 // This is primarily to avoid a console.warn that we didn't close() before GC.
@@ -30,7 +31,7 @@ export default class MoqPublish extends HTMLElement {
 		// What a <canvas> preview renders: the raw capture, or a decoded copy of the encoded video.
 		preview: new Signal<Preview.Mode>("source"),
 		// When to announce/publish the broadcast: always, never, or only once a source is selected.
-		announce: new Signal<AnnounceMode>(true),
+		announce: new Signal<AnnounceMode>("source"),
 	};
 
 	connection: Moq.Connection.Reload;
@@ -90,7 +91,7 @@ export default class MoqPublish extends HTMLElement {
 			const enabled = effect.get(this.#enabled);
 			const announce = effect.get(this.state.announce);
 			const hasSource = effect.get(this.state.source) !== undefined;
-			const announcing = announce === true || (announce === "source" && hasSource);
+			const announcing = announce === "always" || (announce === "source" && hasSource);
 			this.#publishEnabled.set(enabled && announcing);
 		});
 
@@ -190,12 +191,12 @@ export default class MoqPublish extends HTMLElement {
 				throw new Error(`Invalid source: ${newValue}`);
 			}
 		} else if (name === "announce") {
-			if (newValue === "true" || newValue === null) {
-				this.state.announce.set(true);
-			} else if (newValue === "false") {
-				this.state.announce.set(false);
-			} else if (newValue === "source") {
+			if (newValue === "source" || newValue === null) {
 				this.state.announce.set("source");
+			} else if (newValue === "always") {
+				this.state.announce.set("always");
+			} else if (newValue === "never") {
+				this.state.announce.set("never");
 			} else {
 				throw new Error(`Invalid announce: ${newValue}`);
 			}


### PR DESCRIPTION
## Summary

The `<moq-publish>` element announced (published) its broadcast the moment it connected to the DOM, regardless of whether a source was selected. That publishes an empty broadcast (no audio/video) that consumers can subscribe to but get nothing from, which is surprising. This makes the element hold off until a source is actually selected by default.

While here, the `announce` mode values are reshaped from `true | false | "source"` into a plain string union: `"always" | "source" | "never"`. The boolean form only just landed, so this is a safe rename of a brand-new API (no semver concern, per the author).

## Behavior

- `announce="source"` (now the **default**) - hold off until a `source` is selected, then publish; stop announcing if the source is cleared.
- `announce="always"` - publish as soon as the element connects (the old default).
- `announce="never"` - never publish.

The JS property takes the same string values: `el.announce = "always"`.

## Changes

- `js/publish/src/element.ts` - `AnnounceMode` is now `"always" | "source" | "never"`; default signal value is `"source"`; publish gate and attribute parsing updated; absent/removed attribute falls back to `"source"`.
- `js/publish/README.md`, `doc/lib/js/@moq/publish.md` - documented the new values and default.

## Reviewer notes

- This is a public-API change to `js/publish`. The `announce` attribute itself shipped very recently, so flipping its default and renaming the mode values is a breaking change in the strict sense, but on a brand-new surface with no real consumers yet. Targeting `main` since the feature already lives there; happy to retarget `dev` if preferred.
- `just check`-level typecheck of `js/publish` passes (`tsc --noEmit` clean aside from the known worktree `audioworklet`/`bun` lib-resolution noise).

(Written by Claude)