### PR TITLE
fix(publish): open a file picker for the `file` source

### DIFF
--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -273,10 +273,17 @@ export default class MoqPublish extends HTMLElement {
 		if (source === "file" || source instanceof File) {
 			const fileSource = new Source.File({
 				// If a File is provided, use it directly.
-				// TODO: Show a file picker otherwise.
 				file: source instanceof File ? source : undefined,
 				enabled: this.#eitherEnabled,
 			});
+
+			// Otherwise prompt the user to pick one. The selection click is still the
+			// active user gesture (effects run a microtask later, which preserves it).
+			if (!(source instanceof File)) {
+				fileSource.prompt();
+			}
+
+			effect.set(this.file, fileSource);
 
 			this.signals.run((effect) => {
 				const source = effect.get(fileSource.source);

--- a/js/publish/src/source/file.ts
+++ b/js/publish/src/source/file.ts
@@ -7,6 +7,9 @@ export interface FileSourceConfig {
 	file?: globalThis.File | Signal<globalThis.File | undefined>;
 }
 
+// Image, video, and audio files we know how to decode (see #decode).
+const ACCEPT = "image/*,video/*,audio/*";
+
 export class File {
 	file = new Signal<globalThis.File | undefined>(undefined);
 	signals = new Effect();
@@ -27,6 +30,21 @@ export class File {
 				console.error("Failed to decode file:", err);
 			});
 		});
+	}
+
+	/**
+	 * Open a native file picker and use the chosen file as the source.
+	 * Must be called from within a user gesture (e.g. a click handler), otherwise the browser blocks the dialog.
+	 */
+	prompt() {
+		const input = document.createElement("input");
+		input.type = "file";
+		input.accept = ACCEPT;
+		input.addEventListener("change", () => {
+			const file = input.files?.[0];
+			if (file) this.file.set(file);
+		});
+		input.click();
 	}
 
 	async #decode(file: globalThis.File, effect: Effect) {

--- a/js/publish/src/ui/components/source-tab.ts
+++ b/js/publish/src/ui/components/source-tab.ts
@@ -13,6 +13,12 @@ interface DeviceLike {
 	preferred: Signal<string | undefined>;
 }
 
+// Structural view of source/file.ts File, avoiding a cross-module import.
+interface FileLike {
+	file: Getter<File | undefined>;
+	prompt(): void;
+}
+
 const OPTIONS: { id: SourceValue; label: string; svg: string }[] = [
 	{ id: "camera", label: "Camera", svg: camera },
 	{ id: "screen", label: "Screen", svg: screen },
@@ -106,6 +112,42 @@ export function sourceTab(parent: Effect, publish: MoqPublish): HTMLElement {
 		DOM.render(effect, devices, section);
 	});
 
-	container.appendChild(devices);
+	// File selection only applies to the file source.
+	const filePicker = DOM.create("div");
+	parent.run((effect) => {
+		const source = effect.get(publish.state.source);
+		if (source !== "file" && !(source instanceof File)) return;
+
+		const fileSource = effect.get(publish.file);
+		if (!fileSource) return;
+
+		DOM.render(effect, filePicker, fileField(effect, fileSource));
+	});
+
+	container.appendChild(filePicker);
 	return container;
+}
+
+function fileField(parent: Effect, source: FileLike): HTMLElement {
+	const section = DOM.create("div");
+	section.appendChild(DOM.create("div", { className: "tab-section-label" }, "File"));
+
+	const field = DOM.create("div", { className: "device-field" });
+	const labelEl = DOM.create("div", { className: "device-field-label" });
+	const name = DOM.create("span", {}, "No file");
+	labelEl.append(icon(file), name);
+
+	const button = DOM.create("button", { className: "source-opt", type: "button" }, "Choose");
+	field.append(labelEl, button);
+	section.appendChild(field);
+
+	parent.run((effect) => {
+		const picked = effect.get(source.file);
+		name.textContent = picked?.name ?? "No file";
+	});
+
+	// A click is a user gesture, so the picker can open synchronously.
+	parent.event(button, "click", () => source.prompt());
+
+	return section;
 }


### PR DESCRIPTION
## Summary

Selecting the **File** source in `<moq-publish>` (or the publish UI) never prompted for a file. The only code path that supplied a file was passing a `File` instance directly; choosing the string `"file"` constructed a `Source.File` with `file: undefined` and stopped at a `// TODO: Show a file picker otherwise.`, so no picker ever opened.

This adds the missing file picker.

## What changed

- **`source/file.ts`**: new `Source.File.prompt()` method that opens a native `<input type="file" accept="image/*,video/*,audio/*">` picker and sets the chosen file on its `file` signal. The `accept` list matches the formats `#decode` already handles.
- **`element.ts`**: when the source is `"file"` (and not an already-provided `File`), call `fileSource.prompt()`. Also wires the live `Source.File` into the element's previously-unused `file` signal so the UI can observe it.
- **`ui/components/source-tab.ts`**: adds a "File" section (mirroring the existing camera "Devices" section) that shows the chosen filename and a **Choose** button to (re-)pick, plus a `FileLike` structural interface matching the existing `DeviceLike` pattern.

## Notes for reviewers

- **User gesture**: `@moq/signals` flushes effects on a `queueMicrotask`, so `#runSource` runs a couple of microtasks after the click. Transient user activation survives microtasks (multi-second window, not consumed by them), so the picker opening from that effect still counts as a gesture. The UI **Choose** button calls `prompt()` synchronously in its own click handler regardless.
- **Behavior**: selecting **File** opens the picker once; re-picking is done via the **Choose** button (re-clicking the already-active File tile doesn't re-fire, since `source` is unchanged). This matches how camera/screen behave.
- **Public API**: adds `Source.File.prompt()` (additive, non-breaking) — targeting `main` per the branch-targeting rules.
- **Cross-package sync**: `demo/web` only embeds `<moq-publish>` and doesn't touch the file API, so no demo change is needed.

## Test plan

- [x] `tsc --noEmit` passes for `js/publish`
- [x] `biome check` clean on changed files
- [ ] Manually verify in the web demo that choosing **File** opens a picker and the selected media publishes

(Written by Claude)