### PR TITLE
chore(hang): add @moq/json devDependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.8.8",
@@ -90,6 +90,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@moq/json": "workspace:^",
         "@types/audioworklet": "^0.0.100",
         "@types/bun": "^1.3.14",
         "@typescript/lib-dom": "npm:@types/web@^0.0.350",
@@ -100,7 +101,7 @@
     },
     "js/json": {
       "name": "@moq/json",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@moq/net": "workspace:^",
         "@moq/signals": "workspace:^",
@@ -116,7 +117,7 @@
     },
     "js/loc": {
       "name": "@moq/loc",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@moq/net": "workspace:^",
       },
@@ -147,7 +148,7 @@
     },
     "js/msf": {
       "name": "@moq/msf",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@moq/net": "workspace:^",
         "zod": "^4.4.3",
@@ -159,7 +160,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@moq/qmux": "^0.0.6",
         "@moq/signals": "workspace:*",
@@ -179,7 +180,7 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",
@@ -198,7 +199,7 @@
     },
     "js/signals": {
       "name": "@moq/signals",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "devDependencies": {
         "@types/bun": "^1.3.11",
         "@types/react": "^19.2.15",
@@ -239,7 +240,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -27,6 +27,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
+		"@moq/json": "workspace:^",
 		"@types/audioworklet": "^0.0.100",
 		"@types/bun": "^1.3.14",
 		"@typescript/lib-dom": "npm:@types/web@^0.0.350",


### PR DESCRIPTION
## Summary

Adds `@moq/json` (the `js/json` workspace package) as a devDependency of `js/hang`. Without it, `just web` produces a broken frontend.

```diff
 "devDependencies": {
+    "@moq/json": "workspace:^",
     "@types/audioworklet": "^0.0.100",
```

## Note on `bun.lock`

Running `bun install` to add the dependency also reconciled some pre-existing lockfile drift (stale workspace version fields for `js/hang`, `js/json`, `js/watch`, `js/publish` that were already out of sync with their `package.json` versions on `main`). Those version bumps are not introduced by this change; bun just brought the lockfile back in sync. Keeping them avoids a `--frozen-lockfile` mismatch in CI.

## Test plan

- [ ] `bun install` is clean (no further lockfile changes)
- [ ] `just web` builds the frontend

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DnuU365GhxnHA1WL21zGuS)_