### PR TITLE
chore(demo): drop dashed border around the watch player

### DIFF
--- a/demo/web/src/index.html
+++ b/demo/web/src/index.html
@@ -15,7 +15,7 @@
 	<moq-watch-support show="always"></moq-watch-support>
 
 	<!-- Drag the handle on the right edge to resize the player. -->
-	<div style="resize: horizontal; overflow: hidden; min-width: 240px; padding: 4px; border: 1px dashed #525252; border-radius: 4px;">
+	<div style="resize: horizontal; overflow: hidden; min-width: 240px;">
 	<!-- Live discovers new broadcasts available at the given URL. -->
 	<moq-discover>
 		<!-- This optional component shows some simple controls for the inner <moq-watch> component. -->


### PR DESCRIPTION
## Summary

Removes the dashed border around the `<moq-watch>` player in the web demo.

The resize wrapper was given a `1px dashed #525252` border (plus `padding` and `border-radius` to frame it) in the simulcast demo commit ([#1679](https://github.com/moq-dev/moq/pull/1679)) to highlight the drag-to-resize handle. The dotted outline is visually noisy, so this drops the border styling while keeping `resize: horizontal` so you can still drag the player width to exercise simulcast layer switching.

## Test plan

- [ ] Open the web demo and confirm the player no longer has a dotted outline and still resizes via the right-edge handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)