### PR TITLE
feat(json): default delta_ratio to 8, count only delta bytes

### DIFF
--- a/js/json/src/json.test.ts
+++ b/js/json/src/json.test.ts
@@ -29,7 +29,7 @@ async function structure(track: Track): Promise<number[]> {
 
 test("deltas off: a snapshot group per change", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track);
+	const producer = new Producer<Value>(track, { deltaRatio: 0 });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
 	producer.finish();
@@ -139,14 +139,28 @@ test("mutate removes a section", async () => {
 
 test("tight ratio rolls snapshots", async () => {
 	const track = new Track("test");
-	// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
-	const producer = new Producer<Value>(track, { deltaRatio: 1.0 });
-	producer.update({ a: 1 });
-	producer.update({ a: 2 });
-	producer.update({ a: 3 });
+	// A ratio of 1 admits deltas only up to the snapshot size: with equal 7-byte frames that is a
+	// single delta per group, so it rolls every other update.
+	const producer = new Producer<Value>(track, { deltaRatio: 1 });
+	producer.update({ a: 1 }); // snapshot, group 0
+	producer.update({ a: 2 }); // delta, group 0
+	producer.update({ a: 3 }); // exceeds budget, rolls group 1
+	producer.update({ a: 4 }); // delta, group 1
 	producer.finish();
 
-	expect(await structure(track)).toEqual([1, 1, 1]);
+	expect(await structure(track)).toEqual([2, 2]);
+});
+
+test("deltas stay within ratio times snapshot", async () => {
+	const track = new Track("test");
+	// The budget covers only the deltas, not the snapshot frame, measured against the current
+	// snapshot size. Single-digit values keep every frame at a constant 7 bytes (`{"n":N}`), so a
+	// ratio of 8 admits 8 deltas (8x the snapshot) on top of the snapshot before the 9th rolls.
+	const producer = new Producer<Value>(track, { deltaRatio: 8 });
+	for (let n = 0; n <= 9; n++) producer.update({ n });
+	producer.finish();
+
+	expect(await structure(track)).toEqual([9, 1]);
 });
 
 test("array change is a wholesale delta", async () => {

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -8,14 +8,20 @@ import { deepEqual, diff } from "./diff.ts";
 // well below the per-group frame cap so a late joiner can always read the snapshot at frame 0.
 const MAX_DELTA_FRAMES = 256;
 
+// Delta ratio used when {@link Config.deltaRatio} is left unset.
+const DEFAULT_DELTA_RATIO = 8;
+
 export interface Config<T> {
-	// Controls whether the producer emits deltas (merge patches) instead of full snapshots.
+	// Controls how aggressively the producer emits deltas (merge patches) instead of full snapshots.
 	//
-	// `undefined` disables deltas: every change is published as a new snapshot group.
+	// `0` disables deltas: every change is published as a new snapshot group.
 	//
-	// A number enables deltas: a delta is appended to the current group as long as the group's
-	// total size stays within `deltaRatio` times the size of a fresh snapshot; otherwise a new
-	// snapshot group is started.
+	// A positive number enables deltas: a delta is appended to the current group as long as the
+	// accumulated deltas (excluding the snapshot frame) stay within `deltaRatio` times the size of a
+	// fresh snapshot; otherwise a new snapshot group is started. So `1` allows deltas totalling up to
+	// one snapshot before rolling.
+	//
+	// Defaults to `8` when unset.
 	deltaRatio?: number;
 
 	// Optional zod schema used to validate each value before publishing.
@@ -43,7 +49,8 @@ export class Producer<T> {
 	#track?: Moq.Track;
 	#group?: Moq.Group;
 	#last?: unknown;
-	#groupBytes = 0;
+	// Bytes of deltas accumulated in the current group, excluding the snapshot frame.
+	#deltaBytes = 0;
 	#groupFrames = 0;
 
 	// Fan-out mode: retains the value and serves a child (leaf) Producer per subscriber.
@@ -104,7 +111,7 @@ export class Producer<T> {
 		const delta = this.#delta(json, snapshot.length);
 		if (delta && this.#group) {
 			this.#group.writeFrame(delta);
-			this.#groupBytes += delta.length;
+			this.#deltaBytes += delta.length;
 			this.#groupFrames += 1;
 		} else {
 			this.#snapshot(this.#track, snapshot);
@@ -177,9 +184,14 @@ export class Producer<T> {
 		this.#track.close();
 	}
 
+	// Resolved delta ratio: the configured value, or the default when unset. `0` disables deltas.
+	get #deltaRatio(): number {
+		return this.#config.deltaRatio ?? DEFAULT_DELTA_RATIO;
+	}
+
 	#delta(json: unknown, snapshotLen: number): Uint8Array | undefined {
-		const ratio = this.#config.deltaRatio;
-		if (ratio === undefined) return undefined;
+		const ratio = this.#deltaRatio;
+		if (ratio === 0) return undefined;
 		if (this.#last === undefined) return undefined;
 		if (!this.#group || this.#groupFrames >= MAX_DELTA_FRAMES) return undefined;
 
@@ -188,8 +200,8 @@ export class Producer<T> {
 
 		const delta = new TextEncoder().encode(JSON.stringify(result.patch));
 
-		// Roll a snapshot if appending the delta would bloat the group past the budget.
-		if (this.#groupBytes + delta.length > ratio * snapshotLen) return undefined;
+		// Roll a snapshot once the deltas would outgrow the budget (snapshot frame excluded).
+		if (this.#deltaBytes + delta.length > ratio * snapshotLen) return undefined;
 
 		return delta;
 	}
@@ -200,10 +212,10 @@ export class Producer<T> {
 
 		const group = track.appendGroup();
 		group.writeFrame(snapshot);
-		this.#groupBytes = snapshot.length;
+		this.#deltaBytes = 0;
 		this.#groupFrames = 1;
 
-		if (this.#config.deltaRatio !== undefined) {
+		if (this.#deltaRatio !== 0) {
 			// Keep the group open so future deltas can be appended.
 			this.#group = group;
 		} else {

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -30,7 +30,8 @@ export class Broadcast {
 	// The catalog, editable at any time regardless of whether anyone is subscribed. The base
 	// `video`/`audio` sections are kept in sync from the encoders; an application adds its own root
 	// sections (e.g. `scte35`) by mutating it too.
-	readonly catalog: CatalogProducer = new Producer<Catalog.Root>({ initial: {} });
+	// Deltas are disabled for now (`deltaRatio: 0`) to stay byte-compatible with consumers that only read snapshots.
+	readonly catalog: CatalogProducer = new Producer<Catalog.Root>({ initial: {}, deltaRatio: 0 });
 
 	// Handlers for custom tracks registered via `publishTrack`, keyed by track name. Persists across
 	// reconnects so a new `Moq.Broadcast` still serves them.

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -6,8 +6,8 @@
 //! order. A consumer jumps to the newest group, reads the snapshot, and applies the deltas, so
 //! a late joiner never needs older groups.
 //!
-//! Deltas are opt-in via [`Config::delta_ratio`]. With deltas disabled (the default)
-//! every change is a fresh snapshot group, matching a plain "one JSON blob per group" track.
+//! Deltas are controlled by [`Config::delta_ratio`]. A ratio of `0` disables them, so every
+//! change is a fresh snapshot group, matching a plain "one JSON blob per group" track.
 
 mod diff;
 
@@ -53,16 +53,25 @@ impl From<serde_json::Error> for Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Configuration for a [`Producer`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Config {
-	/// Controls whether the producer emits deltas (merge patches) instead of full snapshots.
+	/// Controls how aggressively the producer emits deltas (merge patches) instead of full snapshots.
 	///
-	/// `None` disables deltas: every change is published as a new snapshot group.
+	/// A ratio of `0` disables deltas: every change is published as a new snapshot group.
 	///
-	/// `Some(ratio)` enables deltas. A delta is appended to the current group as long as the
-	/// group's total size stays within `ratio` times the size of a fresh snapshot; otherwise a
-	/// new snapshot group is started. A larger ratio tolerates bigger groups before snapshotting.
-	pub delta_ratio: Option<f64>,
+	/// A positive ratio enables deltas. A delta is appended to the current group as long as the
+	/// accumulated deltas (excluding the snapshot frame) stay within `ratio` times the size of a
+	/// fresh snapshot; otherwise a new snapshot group is started. So `1` allows deltas totalling up
+	/// to one snapshot before rolling, and a larger ratio tolerates more deltas per snapshot.
+	///
+	/// Defaults to `8`.
+	pub delta_ratio: u32,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self { delta_ratio: 8 }
+	}
 }
 
 /// Publishes a JSON value over a track, choosing snapshots and deltas automatically.
@@ -98,7 +107,7 @@ impl<T: Serialize> Producer<T> {
 				track,
 				group: None,
 				last: None,
-				group_bytes: 0,
+				delta_bytes: 0,
 				group_frames: 0,
 				config,
 			})),
@@ -199,7 +208,8 @@ struct Inner {
 	track: moq_net::TrackProducer,
 	group: Option<moq_net::GroupProducer>,
 	last: Option<Value>,
-	group_bytes: u64,
+	// Bytes of deltas accumulated in the current group, excluding the snapshot frame.
+	delta_bytes: u64,
 	group_frames: usize,
 	config: Config,
 }
@@ -215,7 +225,7 @@ impl Inner {
 				let group = self.group.as_mut().expect("delta requires an open group");
 				let len = delta.len() as u64;
 				group.write_frame(delta)?;
-				self.group_bytes += len;
+				self.delta_bytes += len;
 				self.group_frames += 1;
 			}
 			None => self.snapshot(snapshot)?,
@@ -228,9 +238,10 @@ impl Inner {
 	/// Serialize a delta if deltas are enabled and appending one keeps the group within budget;
 	/// otherwise `None`, signalling that a fresh snapshot should be published instead.
 	fn delta(&self, value: &Value, snapshot_len: usize) -> Result<Option<Vec<u8>>> {
-		let Some(ratio) = self.config.delta_ratio else {
+		let ratio = self.config.delta_ratio;
+		if ratio == 0 {
 			return Ok(None);
-		};
+		}
 		let Some(last) = &self.last else {
 			return Ok(None);
 		};
@@ -245,9 +256,9 @@ impl Inner {
 
 		let delta = serde_json::to_vec(&diff.patch)?;
 
-		// Roll a snapshot if appending the delta would bloat the group past the budget.
-		let projected = (self.group_bytes + delta.len() as u64) as f64;
-		if projected > ratio * snapshot_len as f64 {
+		// Roll a snapshot once the deltas would outgrow the budget (snapshot frame excluded).
+		let projected = self.delta_bytes + delta.len() as u64;
+		if projected > ratio as u64 * snapshot_len as u64 {
 			return Ok(None);
 		}
 
@@ -261,13 +272,12 @@ impl Inner {
 			group.finish()?;
 		}
 
-		let len = snapshot.len() as u64;
 		let mut group = self.track.append_group()?;
 		group.write_frame(snapshot)?;
-		self.group_bytes = len;
+		self.delta_bytes = 0;
 		self.group_frames = 1;
 
-		if self.config.delta_ratio.is_some() {
+		if self.config.delta_ratio != 0 {
 			// Keep the group open so future deltas can be appended.
 			self.group = Some(group);
 		} else {
@@ -407,7 +417,7 @@ mod test {
 
 	#[test]
 	fn deltas_off_snapshot_per_group() {
-		let (mut producer, track) = producer(Config::default());
+		let (mut producer, track) = producer(Config { delta_ratio: 0 });
 		producer.update(&json!({ "a": 1 })).unwrap();
 		producer.update(&json!({ "a": 2 })).unwrap();
 		producer.finish().unwrap();
@@ -446,9 +456,7 @@ mod test {
 
 	#[test]
 	fn deltas_share_one_group() {
-		let config = Config {
-			delta_ratio: Some(100.0),
-		};
+		let config = Config { delta_ratio: 100 };
 		let (mut producer, track) = producer(config);
 		producer.update(&json!({ "a": 1, "b": 1 })).unwrap();
 		producer.update(&json!({ "a": 1, "b": 2 })).unwrap();
@@ -463,22 +471,41 @@ mod test {
 
 	#[test]
 	fn tight_ratio_rolls_snapshots() {
-		// A ratio of 1.0 leaves no room for any delta past the snapshot, so every change rolls.
-		let config = Config { delta_ratio: Some(1.0) };
+		// A ratio of 1 admits deltas only up to the snapshot size: with equal 7-byte frames that is a
+		// single delta per group, so it rolls every other update. (Still distinct from 0, which would
+		// disable deltas entirely and never produce the group-0 delta below.)
+		let config = Config { delta_ratio: 1 };
 		let (mut producer, track) = producer(config);
-		producer.update(&json!({ "a": 1 })).unwrap();
-		producer.update(&json!({ "a": 2 })).unwrap();
-		producer.update(&json!({ "a": 3 })).unwrap();
+		producer.update(&json!({ "a": 1 })).unwrap(); // snapshot, group 0
+		producer.update(&json!({ "a": 2 })).unwrap(); // delta, group 0
+		producer.update(&json!({ "a": 3 })).unwrap(); // exceeds budget, rolls group 1
+		producer.update(&json!({ "a": 4 })).unwrap(); // delta, group 1
 		producer.finish().unwrap();
 
-		assert_eq!(track.latest(), Some(2));
+		assert_eq!(track.latest(), Some(1));
+	}
+
+	#[test]
+	fn deltas_stay_within_ratio_times_snapshot() {
+		// The budget covers only the deltas, not the snapshot frame, measured against the current
+		// snapshot size. Single-digit values keep every frame at a constant 7 bytes (`{"n":N}`), so a
+		// `ratio = 8` admits 8 deltas (8x the snapshot, the inclusive limit) on top of the snapshot
+		// before the 9th delta rolls.
+		let config = Config { delta_ratio: 8 };
+		let (mut producer, track) = producer(config);
+		for n in 0..=9 {
+			producer.update(&json!({ "n": n })).unwrap();
+		}
+		producer.finish().unwrap();
+
+		// Group 0 carries the snapshot plus 8 deltas (9 frames); the 9th delta opens group 1.
+		assert_eq!(track.latest(), Some(1));
+		assert_eq!(drain(track).last().unwrap(), &json!({ "n": 9 }));
 	}
 
 	#[test]
 	fn array_change_is_delta() {
-		let config = Config {
-			delta_ratio: Some(100.0),
-		};
+		let config = Config { delta_ratio: 100 };
 		let (mut producer, track) = producer(config);
 		producer.update(&json!({ "list": [1, 2] })).unwrap();
 		producer.update(&json!({ "list": [1, 2, 3] })).unwrap();
@@ -491,9 +518,7 @@ mod test {
 
 	#[test]
 	fn frame_cap_rolls_snapshot() {
-		let config = Config {
-			delta_ratio: Some(1_000_000.0),
-		};
+		let config = Config { delta_ratio: 1_000_000 };
 		let (mut producer, track) = producer(config);
 		// First update is the snapshot (frame 0); then MAX_DELTA_FRAMES - 1 deltas fill the group.
 		for i in 0..=MAX_DELTA_FRAMES {
@@ -508,9 +533,7 @@ mod test {
 
 	#[test]
 	fn late_joiner_reconstructs_from_deltas() {
-		let config = Config {
-			delta_ratio: Some(100.0),
-		};
+		let config = Config { delta_ratio: 100 };
 		let (mut producer, track) = producer(config);
 		producer.update(&json!({ "a": 1, "b": 1 })).unwrap();
 		producer.update(&json!({ "a": 1, "b": 2 })).unwrap();
@@ -565,7 +588,7 @@ mod test {
 	#[test]
 	fn newer_group_supersedes_in_progress_reconstruction() {
 		// A tight ratio lets one delta fit, then forces the next update into a new snapshot group.
-		let config = Config { delta_ratio: Some(2.0) };
+		let config = Config { delta_ratio: 1 };
 		let (mut producer, track) = producer(config);
 		let observer = producer.consume();
 		let mut consumer = Consumer::<Value>::new(track);
@@ -593,9 +616,7 @@ mod test {
 	#[test]
 	fn cloned_consumer_reconstructs_independently() {
 		// Deltas share one group, so a clone taken mid-group carries in-progress reconstruction state.
-		let config = Config {
-			delta_ratio: Some(100.0),
-		};
+		let config = Config { delta_ratio: 100 };
 		let (mut producer, track) = producer(config);
 		let mut consumer = Consumer::<Value>::new(track);
 		let waiter = kio::Waiter::noop();

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -56,7 +56,8 @@ impl<E: CatalogExt> Producer<E> {
 		let hang_track = broadcast.create_track(hang::Catalog::default_track())?;
 		let msf_track = broadcast.create_track(moq_net::Track::new(moq_msf::DEFAULT_NAME))?;
 
-		let hang = moq_json::Producer::new(hang_track, moq_json::Config::default());
+		// Disable deltas for now to stay byte-compatible with consumers that only read snapshots.
+		let hang = moq_json::Producer::new(hang_track, moq_json::Config { delta_ratio: 0 });
 
 		Ok(Self {
 			hang,


### PR DESCRIPTION
## Summary

Make the snapshot/delta JSON producer (`rs/moq-json` and `@moq/json`) emit deltas **by default** instead of requiring an explicit opt-in, and fix the budget so it counts only the delta bytes.

- **`delta_ratio` default is now `8`** (was disabled). The config changes from `Option<f64>` / `number | undefined` (default disabled) to a plain number defaulting to `8`, where **`0` now means disabled**. Rust uses `u32` (the ratio is a coarse knob with no need for fractional precision); JS keeps `number`. Deltas are never even encoded when the ratio is `0`.
- **Budget counts only the deltas**, not the snapshot frame. The check is now `accumulated_delta_bytes + new_delta > ratio × snapshot_size`. Previously the snapshot counted toward the budget, which made a ratio of `1` behave identically to `0` (the snapshot alone filled the budget, so no delta ever fit). Now `1` means "deltas may total up to one snapshot before rolling", genuinely distinct from disabled.
- **Catalog producers pin `delta_ratio: 0` for now** ([`rs/moq-mux/src/catalog/producer.rs`](rs/moq-mux/src/catalog/producer.rs) and [`js/publish/src/broadcast.ts`](js/publish/src/broadcast.ts)) to stay byte-compatible with consumers that only read snapshots. Turning deltas on for the catalog is a follow-up.

## Semantics

With default `8`: a group keeps appending deltas until they total more than 8× the current snapshot size, then it rolls a fresh snapshot. A late joiner reads the snapshot at frame 0 plus the deltas (still also bounded by the existing 256-frame cap).

## Public API

- `moq_json::Config::delta_ratio`: `Option<f64>` → `u32` (breaking, but `moq-json` has no external consumers yet).
- `@moq/json` `Config.deltaRatio`: still `number?`, semantics changed (`0` disables, default `8`).

## Tests

- Added `deltas_stay_within_ratio_times_snapshot` (Rust) / "deltas stay within ratio times snapshot" (JS) documenting the exact byte-budget threshold: with 7-byte frames, ratio 8 admits 8 deltas on top of the snapshot (group 0 = 9 frames) before the 9th delta rolls.
- Updated `tight_ratio_rolls_snapshots` to show ratio 1 now lands one delta per group then rolls (distinct from 0), and the deltas-off tests to pass `0` explicitly.

## Test plan

- [x] `cargo test -p moq-json` (23 pass)
- [x] `cargo build -p moq-mux`, clippy + fmt clean (via nix)
- [x] `bun test` in `js/json` (37 pass), biome clean

(Written by Claude)