### PR TITLE
fix(moq-mux): reject frames before the first keyframe instead of dropping

### DIFF
--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -267,12 +267,8 @@ impl<E: CatalogExt> Import<E> {
 			.as_mut()
 			.context("not initialized; call initialize() first")?;
 
-		// A delta with no open group can't anchor a group (which must start with a
-		// keyframe). Reject it; importers that join mid-stream ignore MissingKeyframe.
-		if !keyframe && !track.has_group() {
-			return Err(crate::Error::MissingKeyframe.into());
-		}
-
+		// A delta before the first keyframe is rejected by the producer with
+		// MissingKeyframe; importers that join mid-stream ignore that error.
 		track.write(crate::container::Frame {
 			timestamp: pts,
 			payload: data.to_vec().into(),
@@ -441,12 +437,9 @@ impl<E: CatalogExt> Import<E> {
 
 		let track = self.track.as_mut().context("avc3 track not created")?;
 
-		// A delta with no open group can't anchor a group (which must start with a
-		// keyframe). Reject it; importers that join mid-stream ignore MissingKeyframe.
-		if !keyframe && !track.has_group() {
-			return Err(crate::Error::MissingKeyframe.into());
-		}
-
+		// Per-frame state is reset above, so a delta before the first keyframe (which
+		// the producer rejects with MissingKeyframe) leaves the importer ready for the
+		// next access unit. Importers that join mid-stream ignore that error.
 		track.write(crate::container::Frame {
 			timestamp: pts,
 			payload,

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -102,10 +102,10 @@ impl<E: CatalogExt> Import<E> {
 			Mode::Avc3 => {
 				self.tracks.set_suffix(".avc3");
 				let track = self.tracks.create()?;
-				self.track = Some(
-					crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy)
-						.with_lenient_start(),
-				);
+				self.track = Some(crate::container::Producer::new(
+					track,
+					crate::catalog::hang::Container::Legacy,
+				));
 				self.state = State::Avc3 {
 					current: Avc3Frame::default(),
 					sps: None,
@@ -185,10 +185,10 @@ impl<E: CatalogExt> Import<E> {
 			if self.track.is_none() {
 				self.tracks.set_suffix(".avc3");
 				let track = self.tracks.create()?;
-				self.track = Some(
-					crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy)
-						.with_lenient_start(),
-				);
+				self.track = Some(crate::container::Producer::new(
+					track,
+					crate::catalog::hang::Container::Legacy,
+				));
 			}
 		}
 
@@ -266,6 +266,12 @@ impl<E: CatalogExt> Import<E> {
 			.track
 			.as_mut()
 			.context("not initialized; call initialize() first")?;
+
+		// A delta with no open group can't anchor a group (which must start with a
+		// keyframe). Reject it; importers that join mid-stream ignore MissingKeyframe.
+		if !keyframe && !track.has_group() {
+			return Err(crate::Error::MissingKeyframe.into());
+		}
 
 		track.write(crate::container::Frame {
 			timestamp: pts,
@@ -427,7 +433,20 @@ impl<E: CatalogExt> Import<E> {
 		current.contains_sps = false;
 		current.contains_pps = false;
 
+		// A keyframe with no SPS (none inline, none cached) is genuinely undecodable:
+		// the group it would anchor could never be played. Reject it loudly.
+		if keyframe && self.config.is_none() {
+			anyhow::bail!("H.264 keyframe arrived before any SPS; cannot configure the decoder");
+		}
+
 		let track = self.track.as_mut().context("avc3 track not created")?;
+
+		// A delta with no open group can't anchor a group (which must start with a
+		// keyframe). Reject it; importers that join mid-stream ignore MissingKeyframe.
+		if !keyframe && !track.has_group() {
+			return Err(crate::Error::MissingKeyframe.into());
+		}
+
 		track.write(crate::container::Frame {
 			timestamp: pts,
 			payload,
@@ -465,8 +484,10 @@ impl<E: CatalogExt> Import<E> {
 		catalog.video.renditions.insert(track.name.clone(), config.clone());
 
 		self.config = Some(config);
-		self.track =
-			Some(crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy).with_lenient_start());
+		self.track = Some(crate::container::Producer::new(
+			track,
+			crate::catalog::hang::Container::Legacy,
+		));
 		Ok(())
 	}
 
@@ -631,6 +652,42 @@ mod tests {
 		assert!(cfg.description.is_none(), "avc3 has no out-of-band description");
 		assert_eq!(h264.profile, sps[1]);
 		assert_eq!(h264.level, sps[3]);
+	}
+
+	/// An avc3 IDR that arrives before any SPS can't configure the decoder, so the
+	/// importer rejects it rather than anchoring an undecodable group.
+	#[tokio::test(start_paused = true)]
+	async fn keyframe_without_sps_errors() {
+		let mut producer = moq_net::Broadcast::new().produce();
+		let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+		let mut importer = Import::new(producer, catalog).with_mode(Mode::Avc3).unwrap();
+
+		// Annex-B IDR slice (NAL type 5) with no preceding SPS.
+		let mut annexb = bytes::BytesMut::new();
+		annexb.extend_from_slice(&[0, 0, 0, 1]);
+		annexb.extend_from_slice(&[0x65, 0x88, 0x80, 0x00]);
+
+		let err = importer.decode_frame(&mut annexb, None).unwrap_err();
+		assert!(err.to_string().contains("SPS"), "unexpected error: {err}");
+	}
+
+	/// An avc3 delta that arrives before the first keyframe (a mid-stream join) is
+	/// rejected with `MissingKeyframe`: a MoQ group must start with a keyframe.
+	/// Container importers that can join mid-stream ignore this error.
+	#[tokio::test(start_paused = true)]
+	async fn delta_before_init_returns_missing_keyframe() {
+		let mut producer = moq_net::Broadcast::new().produce();
+		let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+		let mut importer = Import::new(producer, catalog).with_mode(Mode::Avc3).unwrap();
+
+		// Annex-B non-IDR slice (NAL type 1) with the slice-header high bit set so it
+		// is treated as a frame boundary.
+		let mut annexb = bytes::BytesMut::new();
+		annexb.extend_from_slice(&[0, 0, 0, 1]);
+		annexb.extend_from_slice(&[0x41, 0x9a, 0x00, 0x00]);
+
+		let err = importer.decode_frame(&mut annexb, None).unwrap_err();
+		assert!(crate::Error::is_missing_keyframe(&err), "unexpected error: {err}");
 	}
 }
 

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -110,8 +110,10 @@ impl<E: CatalogExt> Import<E> {
 		catalog.video.renditions.insert(track.name.clone(), config.clone());
 
 		self.config = Some(config);
-		self.track =
-			Some(crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy).with_lenient_start());
+		self.track = Some(crate::container::Producer::new(
+			track,
+			crate::catalog::hang::Container::Legacy,
+		));
 
 		Ok(())
 	}
@@ -314,11 +316,23 @@ impl<E: CatalogExt> Import<E> {
 		let pts = pts.context("missing timestamp")?;
 
 		let payload = std::mem::take(&mut self.current.chunks).freeze();
+		let keyframe = self.current.contains_idr;
+
+		// A delta with no open group can't anchor a group (which must start with a
+		// keyframe). Reject it; importers that join mid-stream ignore MissingKeyframe.
+		if !keyframe && !track.has_group() {
+			self.current.contains_idr = false;
+			self.current.contains_slice = false;
+			self.current.contains_vps = false;
+			self.current.contains_sps = false;
+			self.current.contains_pps = false;
+			return Err(crate::Error::MissingKeyframe.into());
+		}
 
 		let frame = crate::container::Frame {
 			timestamp: pts,
 			payload,
-			keyframe: self.current.contains_idr,
+			keyframe,
 		};
 
 		track.write(frame)?;

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -318,36 +318,26 @@ impl<E: CatalogExt> Import<E> {
 		let payload = std::mem::take(&mut self.current.chunks).freeze();
 		let keyframe = self.current.contains_idr;
 
-		// A delta with no open group can't anchor a group (which must start with a
-		// keyframe). Reject it; importers that join mid-stream ignore MissingKeyframe.
-		if !keyframe && !track.has_group() {
-			self.current.contains_idr = false;
-			self.current.contains_slice = false;
-			self.current.contains_vps = false;
-			self.current.contains_sps = false;
-			self.current.contains_pps = false;
-			return Err(crate::Error::MissingKeyframe.into());
-		}
+		// Reset per-frame state up front so a delta before the first keyframe (which
+		// the producer rejects with MissingKeyframe) leaves the importer ready for the
+		// next access unit. Importers that join mid-stream ignore that error.
+		self.current.contains_idr = false;
+		self.current.contains_slice = false;
+		self.current.contains_vps = false;
+		self.current.contains_sps = false;
+		self.current.contains_pps = false;
 
-		let frame = crate::container::Frame {
+		track.write(crate::container::Frame {
 			timestamp: pts,
 			payload,
 			keyframe,
-		};
-
-		track.write(frame)?;
+		})?;
 
 		if let Some(jitter) = self.jitter.observe(pts)
 			&& let Some(c) = self.catalog.lock().video.renditions.get_mut(&track.name)
 		{
 			c.jitter = Some(jitter);
 		}
-
-		self.current.contains_idr = false;
-		self.current.contains_slice = false;
-		self.current.contains_vps = false;
-		self.current.contains_sps = false;
-		self.current.contains_pps = false;
 
 		Ok(())
 	}

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -176,10 +176,18 @@ impl Import {
 				// FLV stores DTS in the tag; PTS is DTS plus the composition offset.
 				let pts_ms = (timestamp as i64) + (composition_time as i64);
 				anyhow::ensure!(pts_ms >= 0, "negative AVC presentation timestamp");
+
+				// A group must start with a keyframe. A valid FLV opens on one, so a
+				// leading delta means a malformed/mid-GOP stream: reject it outright.
+				let keyframe = frame_type == FRAME_TYPE_KEY;
+				if !keyframe && !stream.track.has_group() {
+					return Err(crate::Error::MissingKeyframe.into());
+				}
+
 				stream.track.write(Frame {
 					timestamp: Timestamp::from_millis(pts_ms as u64)?,
 					payload: Bytes::copy_from_slice(data),
-					keyframe: frame_type == FRAME_TYPE_KEY,
+					keyframe,
 				})?;
 				Ok(())
 			}
@@ -248,9 +256,7 @@ impl Import {
 			.renditions
 			.insert(net_track.name.clone(), config);
 		self.video = Some(Stream {
-			// Live FLV can join mid-GOP; tolerate leading deltas before the first keyframe.
-			track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy)
-				.with_lenient_start(),
+			track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy),
 			description: Bytes::copy_from_slice(avcc_bytes),
 		});
 		Ok(())

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -178,16 +178,13 @@ impl Import {
 				anyhow::ensure!(pts_ms >= 0, "negative AVC presentation timestamp");
 
 				// A group must start with a keyframe. A valid FLV opens on one, so a
-				// leading delta means a malformed/mid-GOP stream: reject it outright.
-				let keyframe = frame_type == FRAME_TYPE_KEY;
-				if !keyframe && !stream.track.has_group() {
-					return Err(crate::Error::MissingKeyframe.into());
-				}
-
+				// leading delta is rejected by the producer with MissingKeyframe and
+				// propagates as a malformed-stream error (unlike TS, FLV doesn't join
+				// mid-GOP).
 				stream.track.write(Frame {
 					timestamp: Timestamp::from_millis(pts_ms as u64)?,
 					payload: Bytes::copy_from_slice(data),
-					keyframe,
+					keyframe: frame_type == FRAME_TYPE_KEY,
 				})?;
 				Ok(())
 			}

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -39,7 +39,10 @@ pub struct Producer<C: Container> {
 	pending_sequence: Option<u64>,
 }
 
-impl<C: Container> Producer<C> {
+impl<C: Container> Producer<C>
+where
+	crate::Error: From<C::Error>,
+{
 	/// Create a new Producer wrapping the given moq-lite producer.
 	pub fn new(track: moq_net::TrackProducer, container: C) -> Self {
 		Self {
@@ -50,14 +53,6 @@ impl<C: Container> Producer<C> {
 			latency: std::time::Duration::ZERO,
 			pending_sequence: None,
 		}
-	}
-
-	/// Whether a group is currently open (the last frame written was a keyframe or
-	/// extended an open group). Importers check this before writing a non-keyframe:
-	/// a group must always start with a keyframe, so a delta with no open group has
-	/// nowhere to go and is rejected rather than written.
-	pub fn has_group(&self) -> bool {
-		self.group.is_some()
 	}
 
 	/// The underlying moq-lite track producer. Read-only; mutating it directly
@@ -81,10 +76,10 @@ impl<C: Container> Producer<C> {
 	/// Write a frame to the track.
 	///
 	/// A keyframe closes any open group and starts a new one. A non-keyframe extends
-	/// the current group; if no group is open it's a protocol violation. A group must
-	/// always start with a keyframe, so callers joining mid-stream must drop leading
-	/// deltas themselves (see [`has_group`](Self::has_group)) rather than write them.
-	pub fn write(&mut self, frame: Frame) -> Result<(), C::Error> {
+	/// the current group; if no group is open it's rejected with
+	/// [`MissingKeyframe`](crate::Error::MissingKeyframe), since a group must always
+	/// start with a keyframe. Importers that can join mid-stream ignore that error.
+	pub fn write(&mut self, frame: Frame) -> Result<(), crate::Error> {
 		// Close the current group on an explicit keyframe.
 		if frame.keyframe {
 			self.finish_group()?;
@@ -93,9 +88,9 @@ impl<C: Container> Producer<C> {
 		// Start a new group if needed; the first frame of a group must be a keyframe.
 		if self.group.is_none() {
 			if !frame.keyframe {
-				// No group yet and this delta can't anchor one. A caller joining
-				// mid-stream must drop leading deltas before they reach here.
-				return Err(moq_net::Error::ProtocolViolation.into());
+				// No group yet and this delta can't anchor one (a group must start
+				// with a keyframe). Importers joining mid-stream ignore this.
+				return Err(crate::Error::MissingKeyframe);
 			}
 			self.group = Some(match self.pending_sequence.take() {
 				Some(sequence) => self.inner.create_group(moq_net::Group { sequence })?,
@@ -127,7 +122,7 @@ impl<C: Container> Producer<C> {
 	/// Close the current group early, flushing any buffered frames.
 	///
 	/// The next [`write`](Self::write) must be a keyframe.
-	pub fn finish_group(&mut self) -> Result<(), C::Error> {
+	pub fn finish_group(&mut self) -> Result<(), crate::Error> {
 		self.flush()?;
 		if let Some(mut group) = self.group.take() {
 			group.finish()?;
@@ -139,14 +134,14 @@ impl<C: Container> Producer<C> {
 	///
 	/// The next [`write`](Self::write) must be a keyframe and will land in a group with
 	/// `sequence`. Useful for joining mid-stream or signalling a discontinuity.
-	pub fn seek(&mut self, sequence: u64) -> Result<(), C::Error> {
+	pub fn seek(&mut self, sequence: u64) -> Result<(), crate::Error> {
 		self.finish_group()?;
 		self.pending_sequence = Some(sequence);
 		Ok(())
 	}
 
 	/// Flush any buffered frames into the current group without closing it.
-	fn flush(&mut self) -> Result<(), C::Error> {
+	fn flush(&mut self) -> Result<(), crate::Error> {
 		if self.buffer.is_empty() {
 			return Ok(());
 		}
@@ -163,7 +158,7 @@ impl<C: Container> Producer<C> {
 	}
 
 	/// Finish the track, flushing any buffered frames and closing any open group.
-	pub fn finish(&mut self) -> Result<(), C::Error> {
+	pub fn finish(&mut self) -> Result<(), crate::Error> {
 		self.finish_group()?;
 		self.inner.finish()?;
 		Ok(())
@@ -251,7 +246,7 @@ mod tests {
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		let err = producer.write(frame(0, false)).unwrap_err();
-		assert!(matches!(err, crate::Error::Moq(moq_net::Error::ProtocolViolation)));
+		assert!(matches!(err, crate::Error::MissingKeyframe));
 	}
 
 	/// Drain all groups from a finished track, returning their sequence numbers.

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -37,12 +37,6 @@ pub struct Producer<C: Container> {
 	/// Sequence to use for the next group opened by [`Self::write`].
 	/// Set by [`Self::seek`] and consumed on the next group creation.
 	pending_sequence: Option<u64>,
-
-	/// When set, a non-keyframe arriving with no open group is dropped instead of
-	/// erroring. Lets a track join mid-stream (the leading deltas before the first
-	/// keyframe have no group to anchor) without a protocol violation. Off by
-	/// default so a producer that simply never marks keyframes still fails loudly.
-	lenient_start: bool,
 }
 
 impl<C: Container> Producer<C> {
@@ -55,16 +49,15 @@ impl<C: Container> Producer<C> {
 			buffer: Vec::new(),
 			latency: std::time::Duration::ZERO,
 			pending_sequence: None,
-			lenient_start: false,
 		}
 	}
 
-	/// Tolerate joining a stream mid-flight: drop non-keyframes that arrive before
-	/// the first keyframe (which has no group to anchor) instead of erroring. Use
-	/// for live ingest, where the input may start mid-GOP.
-	pub fn with_lenient_start(mut self) -> Self {
-		self.lenient_start = true;
-		self
+	/// Whether a group is currently open (the last frame written was a keyframe or
+	/// extended an open group). Importers check this before writing a non-keyframe:
+	/// a group must always start with a keyframe, so a delta with no open group has
+	/// nowhere to go and is rejected rather than written.
+	pub fn has_group(&self) -> bool {
+		self.group.is_some()
 	}
 
 	/// The underlying moq-lite track producer. Read-only; mutating it directly
@@ -88,8 +81,9 @@ impl<C: Container> Producer<C> {
 	/// Write a frame to the track.
 	///
 	/// A keyframe closes any open group and starts a new one. A non-keyframe extends
-	/// the current group; if no group is open it's a protocol violation, unless
-	/// [`with_lenient_start`](Self::with_lenient_start) was set (then it's dropped).
+	/// the current group; if no group is open it's a protocol violation. A group must
+	/// always start with a keyframe, so callers joining mid-stream must drop leading
+	/// deltas themselves (see [`has_group`](Self::has_group)) rather than write them.
 	pub fn write(&mut self, frame: Frame) -> Result<(), C::Error> {
 		// Close the current group on an explicit keyframe.
 		if frame.keyframe {
@@ -99,11 +93,8 @@ impl<C: Container> Producer<C> {
 		// Start a new group if needed; the first frame of a group must be a keyframe.
 		if self.group.is_none() {
 			if !frame.keyframe {
-				// Mid-stream join: no group yet and this delta can't anchor one. Drop it
-				// (wait for the first keyframe) when lenient; otherwise it's a violation.
-				if self.lenient_start {
-					return Ok(());
-				}
+				// No group yet and this delta can't anchor one. A caller joining
+				// mid-stream must drop leading deltas before they reach here.
 				return Err(moq_net::Error::ProtocolViolation.into());
 			}
 			self.group = Some(match self.pending_sequence.take() {

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -723,7 +723,7 @@ enum Stream<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Stream<E> {
 	fn write(&mut self, pending: Pending, burst: Option<u64>) -> anyhow::Result<()> {
-		match self {
+		let result = match self {
 			Stream::H264 { import, unwrap } => {
 				let pts = unwrap_pts(unwrap, pending.pts)?;
 				import.decode_frame(&mut pending.data.as_slice(), pts)
@@ -735,6 +735,13 @@ impl<E: CatalogExt> Stream<E> {
 			Stream::Aac(stream) => stream.write(pending, burst),
 			Stream::Legacy(stream) => stream.write(pending),
 			Stream::Clock | Stream::Ignored => Ok(()),
+		};
+
+		// A TS stream can join mid-GOP: the codec importer rejects deltas until a
+		// keyframe anchors the first group. Drop those, but surface any other error.
+		match result {
+			Err(err) if crate::Error::is_missing_keyframe(&err) => Ok(()),
+			result => result,
 		}
 	}
 

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -25,6 +25,25 @@ pub enum Error {
 	/// Error parsing or building LOC frames.
 	#[error("loc: {0}")]
 	Loc(#[from] moq_loc::Error),
+
+	/// A frame arrived with no open group to anchor it, i.e. before the first
+	/// keyframe. A MoQ group must start with a keyframe, so importers reject such
+	/// frames. A stream that can legitimately join mid-GOP (TS) ignores this via
+	/// [`is_missing_keyframe`](Self::is_missing_keyframe); formats that must open on
+	/// a keyframe (FLV) let it propagate as a malformed-stream error.
+	#[error("frame received before the first keyframe")]
+	MissingKeyframe,
+}
+
+impl Error {
+	/// Whether `err` (possibly wrapped by anyhow) is [`Error::MissingKeyframe`].
+	///
+	/// Container importers that join mid-stream use this to drop the leading deltas
+	/// a codec importer rejects before a keyframe anchors the first group.
+	pub fn is_missing_keyframe(err: &anyhow::Error) -> bool {
+		err.downcast_ref::<Error>()
+			.is_some_and(|e| matches!(e, Error::MissingKeyframe))
+	}
 }
 
 /// A Result type alias for moq-mux operations.


### PR DESCRIPTION
## Summary

A MoQ group must start with a keyframe. The container `Producer` papered over this with a `with_lenient_start` opt-in that **silently dropped** non-keyframes arriving before the first group. That let a malformed stream produce an undecodable group with no signal, and the leniency was load-bearing in ways that weren't obvious at the call sites.

This removes `with_lenient_start` and makes the invariant explicit, with a single legitimate exception (MPEG-TS, which can join mid-GOP).

## What changed

- **`Producer` owns and enforces the invariant** ([producer.rs](rs/moq-mux/src/container/producer.rs)): a non-keyframe with no open group is rejected with a new typed `Error::MissingKeyframe`. `write` now returns `crate::Error` directly (the bound `crate::Error: From<C::Error>` holds for every container error, incl. `fmp4::Error` via the `Cmaf` variant), so importers just `?`-propagate the error rather than re-deriving the decision. Removed `with_lenient_start`.
- **New typed error** ([error.rs](rs/moq-mux/src/error.rs)): `Error::MissingKeyframe` plus `Error::is_missing_keyframe(&anyhow::Error)` to detect it through an anyhow chain.
- **Codec importers** ([h264](rs/moq-mux/src/codec/h264/import.rs), [h265](rs/moq-mux/src/codec/h265/import.rs)) reset per-frame state before writing, so a propagated `MissingKeyframe` leaves them ready for the next access unit. The h264 avc3 path additionally errors on a keyframe it **cannot configure** (no inline SPS, no avcC seed) — the genuinely undecodable case, kept distinct from `MissingKeyframe` so it is never swallowed.
- **TS is the sole exception** ([ts/import.rs](rs/moq-mux/src/container/ts/import.rs)): a transport stream legitimately joins mid-GOP, so `Stream::write` ignores `MissingKeyframe`. This is the single choke point, so it also covers the post-`seek` discontinuity case.
- **FLV propagates it** ([flv/import.rs](rs/moq-mux/src/container/flv/import.rs)): a valid FLV is expected to open on a keyframe, so a leading delta surfaces as a malformed-stream error to the caller.

## Why

The old behavior silently swallowed a real protocol violation. Making it a typed error that the `Producer` returns by default — with mid-stream tolerance opt-in at exactly one importer — means a group can never start without a keyframe, the one format where mid-GOP join is normal (TS) is explicitly the special case, and the keyframe decision lives in one place instead of being re-derived at every call site.

## Public API note

Removing `pub fn with_lenient_start` from `moq-mux`'s container `Producer` is technically a breaking change, but the only callers were internal to the crate. `Producer::write`/`finish`/`seek`/`finish_group` now return `crate::Error` instead of the (always-`crate::Error` in practice) associated `C::Error`. `Error::MissingKeyframe` (a `#[non_exhaustive]` enum) and `Error::is_missing_keyframe` are additive. moq-mux isn't in the explicit breaking-change list, so this targets `main` — happy to retarget `dev` if reviewers prefer.

## Test plan

- [x] `cargo test -p moq-mux` — 236 passed, incl. `survives_midstream_join` and `kyrion_dirtystart_extracts_real_cues`
- [x] New: `keyframe_without_sps_errors`, `delta_before_init_returns_missing_keyframe`; updated `first_frame_must_be_keyframe` to expect `MissingKeyframe`
- [x] `cargo clippy -p moq-mux --all-targets` clean
- [x] `cargo fmt --check` clean (via nix toolchain)
- [x] Dependents compile (`hang`, `moq-cli`, `moq-native`)

No cross-package sync needed: the JS side (`js/hang`) has no equivalent leniency concept.

(Written by Claude)