### PR TITLE
chore(libmoq): bump patch version to 0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,7 +3544,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmoq"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "bytes",

--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>", "Brian Medley <bpm@bmedley.org>"
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary

Bump `libmoq` from `0.3.5` to `0.3.6`.

The `build.rs` was changed in [#1758](https://github.com/moq-dev/moq/pull/1758) (standardised the pkg-config paths), so a patch bump is needed to ship a new libmoq release.

## Changes

- `rs/libmoq/Cargo.toml`: `0.3.5` → `0.3.6`
- `Cargo.lock`: updated accordingly

(Written by Claude)