### PR TITLE
ci: drop magic-nix-cache-action

### DIFF
--- a/.github/actions/setup-packaging/action.yml
+++ b/.github/actions/setup-packaging/action.yml
@@ -7,7 +7,6 @@ runs:
     - uses: DeterminateSystems/nix-installer-action@00199f951aeb9404028a6e4b95ad42546f73296a # main
       with:
         determinate: false
-    - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
     - name: Build packaging tools from flake
       shell: bash

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -48,7 +48,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
       - uses: DeterminateSystems/flake-checker-action@9ee1c5473f1abdfb299f6c4f0fab813147c97fe3 # main
 
       # Cache Rust dependencies and build artifacts

--- a/.github/workflows/libmoq.yml
+++ b/.github/workflows/libmoq.yml
@@ -50,7 +50,6 @@ jobs:
           determinate: false
       - name: Configure Nix cache
         if: matrix.use_nix
-        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - name: Install Rust (Windows)
         if: '!matrix.use_nix'

--- a/.github/workflows/libmoq.yml
+++ b/.github/workflows/libmoq.yml
@@ -48,8 +48,6 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - name: Configure Nix cache
-        if: matrix.use_nix
 
       - name: Install Rust (Windows)
         if: '!matrix.use_nix'

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -148,7 +148,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       # The cross build links system libs only, but its dyld smoke test must
       # actually run the x86_64 binary on this arm host. Idempotent no-op when

--- a/.github/workflows/moq-gst.yml
+++ b/.github/workflows/moq-gst.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - name: Parse version
         id: parse

--- a/.github/workflows/moq-relay.yml
+++ b/.github/workflows/moq-relay.yml
@@ -137,7 +137,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       # The cross build links system libs only, but its dyld smoke test must
       # actually run the x86_64 binary on this arm host. Idempotent no-op when

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -134,7 +134,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       # The cross build links system libs only, but its dyld smoke test must
       # actually run the x86_64 binary on this arm host. Idempotent no-op when

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - name: Setup npm registry
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/release-py.yml
+++ b/.github/workflows/release-py.yml
@@ -59,7 +59,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - name: Build
         run: nix develop --command just py package

--- a/.github/workflows/release-rs.yml
+++ b/.github/workflows/release-rs.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       - name: Release
         run: nix develop --command just rs release


### PR DESCRIPTION
## Summary

Determinate Systems sunset `magic-nix-cache` and now gates it behind FlakeHub registration, so every Nix CI job fails an annotation check nagging us to register:

> FlakeHub registration required. Unable to authenticate to FlakeHub.

We never deliberately used FlakeHub. The `magic-nix-cache-action` only ever served as a GitHub-Actions-backed Nix store cache, and in this repo it adds near-zero value:

- The devShell is **entirely stock nixpkgs + rust-overlay prebuilt binaries** (nothing compiles from source), so `cache.nixos.org` already covers it.
- Rust compilation is cached separately by `Swatinem/rust-cache`.
- The crane packages in `nix/overlay.nix` are the only from-source builds, and they're only built in the release/Cachix flows.
- The durable cache for released artifacts is **Cachix (`kixelated`)**, which this PR leaves untouched.

So the only thing CI loses is a GHA-backed Nix store cache across runs that was barely doing anything, in exchange for dropping a now-failing dependency.

## Changes

Removed `DeterminateSystems/magic-nix-cache-action` from all 10 workflows and the `setup-packaging` composite action. The removed steps had no `with:` blocks, so the surrounding `nix-installer-action` setup is unchanged.

## Notes for reviewers

- No `main`-push cache-warming job was added here; this is purely the removal. If `nixpkgs-unstable` churn ever causes a cold source build in CI, warming Cachix on `main` is the natural follow-up.
- Cachix push/pin on release tags (`.github/workflows/cachix.yml`) is unaffected.

(Written by Claude)