### PR TITLE
feat(moq-net): add OriginDynamic for unannounced fallback broadcasts

### DIFF
--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -92,6 +92,8 @@ Any function that registers a callback (`moq_session_connect`, `moq_origin_annou
 - **`0`** — closed cleanly. **Terminal.**
 - **`< 0`** — closed with an error. **Terminal.**
 
+A positive result that is itself a handle must be freed once you're done with it (e.g. broadcasts from `moq_origin_consume` / `moq_origin_request` via `moq_consume_close`). `moq_origin_announced` is the notable repeat case: it delivers a fresh announce ID for *every* announce / unannounce event, so free each one with `moq_origin_announced_free` after reading it with `moq_origin_announced_info`, or they accumulate for the life of the listener.
+
 Once a callback fires with any non-positive (`<= 0`) code, libmoq will never invoke it again and never touch `user_data` again. Release `user_data` in response to that final callback.
 
 The matching `*_close` function only *requests* shutdown: it returns immediately, does **not** free `user_data`, and does **not** cancel the final callback. The terminal callback still fires (on libmoq's internal thread) once the background task stops, and that is the one safe point to free `user_data`. This means you never have to guess whether an in-flight callback is still running after `close`, and you don't need an external weak-reference or refcount around `user_data`.

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -86,7 +86,7 @@ generated header at `../../target/release/moq.h`.
 
 ## Callback lifetime
 
-Any function that registers a callback (`moq_session_connect`, `moq_origin_announced`, `moq_consume_catalog`, `moq_consume_video_ordered`, `moq_consume_audio_ordered`, `moq_consume_track`, `moq_consume_audio_raw`) takes a `void *user_data` pointer that libmoq passes back to every callback invocation. The status code carries the lifecycle:
+Any function that registers a callback (`moq_session_connect`, `moq_origin_announced`, `moq_origin_consume_announced`, `moq_origin_request`, `moq_consume_catalog`, `moq_consume_video_ordered`, `moq_consume_audio_ordered`, `moq_consume_track`, `moq_consume_audio_raw`) takes a `void *user_data` pointer that libmoq passes back to every callback invocation. The status code carries the lifecycle:
 
 - **`> 0`** — a live result you can use: a frame, catalog, or announce ID (or `1` to mean "session connected"). May fire any number of times.
 - **`0`** — closed cleanly. **Terminal.**

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -92,7 +92,7 @@ Any function that registers a callback (`moq_session_connect`, `moq_origin_annou
 - **`0`** — closed cleanly. **Terminal.**
 - **`< 0`** — closed with an error. **Terminal.**
 
-A positive result that is itself a handle must be freed once you're done with it (e.g. broadcasts from `moq_origin_consume` / `moq_origin_request` via `moq_consume_close`). `moq_origin_announced` is the notable repeat case: it delivers a fresh announce ID for *every* announce / unannounce event, so free each one with `moq_origin_announced_free` after reading it with `moq_origin_announced_info`, or they accumulate for the life of the listener.
+A positive result that is itself a handle must be freed once you're done with it (e.g. a broadcast from `moq_origin_request` via `moq_consume_close`). `moq_origin_announced` is the notable repeat case: it delivers a fresh announce ID for *every* announce / unannounce event, so free each one with `moq_origin_announced_free` after reading it with `moq_origin_announced_info`, or they accumulate for the life of the listener.
 
 Once a callback fires with any non-positive (`<= 0`) code, libmoq will never invoke it again and never touch `user_data` again. Release `user_data` in response to that final callback.
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -103,8 +103,12 @@ async for announcement in client.announced("live/"):
     print(announcement.path)
     ...
 
-# Or wait for a specific path:
+# Or wait for a specific path to be announced:
 broadcast = await client.announced_broadcast("live/cam1")
+
+# Or request a path: resolves to the announced broadcast, falls back to a dynamic
+# handler if the origin has one, else raises. Does not wait for a future announce.
+broadcast = await client.request_broadcast("live/cam1")
 ```
 
 ## Examples

--- a/go/wrapper/moq/client.go
+++ b/go/wrapper/moq/client.go
@@ -130,6 +130,16 @@ func (c *Client) AnnouncedBroadcast(path string) (*AnnouncedBroadcast, error) {
 	return c.consumer.AnnouncedBroadcast(path)
 }
 
+// RequestBroadcast resolves a broadcast at path as soon as it can be served: the
+// announced broadcast if present, otherwise a dynamic fallback on the origin, or an
+// error. Unlike AnnouncedBroadcast, it does not wait for a future announcement.
+func (c *Client) RequestBroadcast(path string) (*BroadcastConsumer, error) {
+	if c.consumer == nil {
+		return nil, ErrNoConsumeOrigin
+	}
+	return c.consumer.RequestBroadcast(path)
+}
+
 // Session returns the underlying session. Hold the client (or session) to keep
 // the connection alive.
 func (c *Client) Session() *Session {

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -56,6 +56,18 @@ func (o *OriginConsumer) AnnouncedBroadcast(path string) (*AnnouncedBroadcast, e
 	return &AnnouncedBroadcast{inner: inner}, nil
 }
 
+// RequestBroadcast resolves a broadcast at path as soon as it can be served: the
+// announced broadcast if present, otherwise a dynamic fallback on the origin, or an
+// error if neither can serve it. Unlike AnnouncedBroadcast, it does not wait for a
+// future announcement. Blocks until resolved.
+func (o *OriginConsumer) RequestBroadcast(path string) (*BroadcastConsumer, error) {
+	inner, err := o.inner.RequestBroadcast(path)
+	if err != nil {
+		return nil, err
+	}
+	return &BroadcastConsumer{inner: inner}, nil
+}
+
 // Announcement is a discovered broadcast.
 type Announcement struct {
 	inner *ffi.MoqAnnouncement

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -151,7 +151,8 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
   - `.publish(path, broadcast)`
 - **`OriginConsumer`**. Discover broadcasts.
   - `.announced(prefix) → Announced` (async iterator)
-  - `.announced_broadcast(path) → AnnouncedBroadcast` (awaitable)
+  - `.announced_broadcast(path) → AnnouncedBroadcast` (awaitable, waits for a future announcement)
+  - `.request_broadcast(path) → BroadcastConsumer` (awaitable; announced now or a dynamic fallback, else raises)
 
 ### Types
 

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -7,6 +7,7 @@ from moq_ffi import MoqClient
 from .origin import Announced, AnnouncedBroadcast, OriginConsumer, OriginProducer
 from .publish import BroadcastProducer
 from .session import Session
+from .subscribe import BroadcastConsumer
 
 
 class Client:
@@ -103,6 +104,11 @@ class Client:
         if self._consumer is None:
             raise RuntimeError("no consume origin configured")
         return self._consumer.announced_broadcast(path)
+
+    async def request_broadcast(self, path: str) -> BroadcastConsumer:
+        if self._consumer is None:
+            raise RuntimeError("no consume origin configured")
+        return await self._consumer.request_broadcast(path)
 
     @property
     def session(self) -> Session | None:

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -82,6 +82,16 @@ class OriginConsumer:
     def announced_broadcast(self, path: str) -> AnnouncedBroadcast:
         return AnnouncedBroadcast(self._inner.announced_broadcast(path))
 
+    async def request_broadcast(self, path: str) -> BroadcastConsumer:
+        """Request a broadcast by path, resolving as soon as it can be served.
+
+        Returns the announced broadcast immediately if one exists, otherwise falls
+        back to a dynamic handler on the origin (if any), or raises if neither can
+        serve it. Unlike `announced_broadcast`, this does not wait indefinitely for a
+        future announcement.
+        """
+        return BroadcastConsumer(await self._inner.request_broadcast(path))
+
 
 class OriginProducer:
     """Wraps MoqOriginProducer for publishing broadcasts."""

--- a/rs/libmoq/README.md
+++ b/rs/libmoq/README.md
@@ -32,11 +32,13 @@ int32_t moq_session_close(uint32_t session);
 int32_t moq_origin_create(void);
 int32_t moq_origin_close(uint32_t origin);
 int32_t moq_origin_publish(uint32_t origin, const char *path, uintptr_t path_len, uint32_t broadcast);
-int32_t moq_origin_consume(uint32_t origin, const char *path, uintptr_t path_len);
+int32_t moq_origin_request(uint32_t origin, const char *path, uintptr_t path_len, void (*on_broadcast)(void *user_data, int32_t broadcast), void *user_data);
+int32_t moq_origin_request_close(uint32_t task);
 int32_t moq_origin_consume_announced(uint32_t origin, const char *path, uintptr_t path_len, void (*on_broadcast)(void *user_data, int32_t broadcast), void *user_data);
 int32_t moq_origin_consume_announced_close(uint32_t task);
 int32_t moq_origin_announced(uint32_t origin, void (*on_announce)(void *user_data, int32_t announced), void *user_data);
 int32_t moq_origin_announced_info(uint32_t announced, moq_announced *dst);
+int32_t moq_origin_announced_free(uint32_t announced);
 int32_t moq_origin_announced_close(uint32_t announced);
 
 // Publishing

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -253,6 +253,7 @@ pub extern "C" fn moq_origin_unpublish(publish: u32) -> i32 {
 /// there. The terminal callback fires even after [moq_origin_announced_close].
 ///
 /// - [moq_origin_announced_info] is used to query information about the broadcast.
+/// - [moq_origin_announced_free] releases each delivered announced ID once read.
 /// - [moq_origin_announced_close] is used to stop receiving announcements.
 ///
 /// Returns a non-zero handle on success, or a negative code on failure.
@@ -274,7 +275,9 @@ pub unsafe extern "C" fn moq_origin_announced(
 
 /// Query information about a broadcast discovered by [moq_origin_announced].
 ///
-/// The destination is filled with the broadcast information.
+/// The destination is filled with the broadcast information. The `path` pointer borrows
+/// the announcement's storage: copy it out before calling [moq_origin_announced_free], which
+/// invalidates it.
 ///
 /// Returns a zero on success, or a negative code on failure.
 ///
@@ -286,6 +289,23 @@ pub unsafe extern "C" fn moq_origin_announced_info(announced: u32, dst: *mut moq
 		let announced = ffi::parse_id(announced)?;
 		let dst = unsafe { dst.as_mut() }.ok_or(Error::InvalidPointer)?;
 		State::lock().origin.announced_info(announced, dst)
+	})
+}
+
+/// Free a single announcement delivered to a [moq_origin_announced] `on_announce` callback.
+///
+/// Each announce / unannounce event hands the callback a distinct announcement handle (read
+/// with [moq_origin_announced_info]); release it here once done to avoid leaking one per event
+/// over the life of the listener. This is per-announcement and distinct from
+/// [moq_origin_announced_close], which stops the listener itself. After freeing, any `path`
+/// pointer obtained from [moq_origin_announced_info] for this handle is dangling.
+///
+/// Returns zero on success, or a negative code if the handle is unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_origin_announced_free(announced: u32) -> i32 {
+	ffi::enter(move || {
+		let announced = ffi::parse_id(announced)?;
+		State::lock().origin.announced_free(announced)
 	})
 }
 

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -201,7 +201,7 @@ pub extern "C" fn moq_session_close(session: u32) -> i32 {
 /// The same broadcast can be published to multiple origins under different paths.
 ///
 /// [moq_origin_announced] can be used to discover broadcasts published to this origin.
-/// This is extremely useful for discovering what is available on the server to [moq_origin_consume].
+/// This is extremely useful for discovering what is available on the server to [moq_origin_request].
 ///
 /// Returns a non-zero handle to the origin on success.
 #[unsafe(no_mangle)]
@@ -323,30 +323,12 @@ pub extern "C" fn moq_origin_announced_close(announced: u32) -> i32 {
 	})
 }
 
-/// Consume a broadcast from an origin by path.
-///
-/// Returns a non-zero handle to the broadcast on success, or a negative code on failure.
-///
-/// # Safety
-/// - The caller must ensure that path is a valid pointer to path_len bytes of data.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_origin_consume(origin: u32, path: *const c_char, path_len: usize) -> i32 {
-	ffi::enter(move || {
-		let origin = ffi::parse_id(origin)?;
-		let path = unsafe { ffi::parse_str(path, path_len)? };
-
-		let mut state = State::lock();
-		let broadcast = state.origin.consume(origin, path)?;
-		state.consume.start(broadcast)
-	})
-}
-
 /// Consume a broadcast from an origin by path, waiting until it is announced.
 ///
-/// Unlike [moq_origin_consume], which fails immediately with a not-found code when the broadcast
-/// has not been announced yet, this waits for the announcement to arrive (e.g. over the network)
-/// and then delivers the broadcast handle via `on_broadcast`. Use it right after [moq_session_connect]
-/// to avoid racing announcement gossip, instead of polling [moq_origin_consume] in a retry loop.
+/// Resolves against future announcements: it waits for the announcement to arrive (e.g. over the
+/// network) and then delivers the broadcast handle via `on_broadcast`. Use it right after
+/// [moq_session_connect] to avoid racing announcement gossip. To resolve against only what is
+/// announced now (plus any dynamic fallback), use [moq_origin_request] instead.
 ///
 /// `on_broadcast` is invoked with a positive broadcast handle once announced, then exactly once
 /// more with a terminal code: `0` (the wait finished, including after
@@ -393,8 +375,8 @@ pub extern "C" fn moq_origin_consume_announced_close(task: u32) -> i32 {
 
 /// Request a broadcast from an origin by path, resolving as soon as it can be served.
 ///
-/// Sits between [moq_origin_consume] (announced-only, fails immediately) and
-/// [moq_origin_consume_announced] (waits indefinitely for a future announcement): it returns an
+/// Resolves against what is announced *now* plus any dynamic fallback, where
+/// [moq_origin_consume_announced] waits indefinitely for a future announcement: it returns an
 /// already-announced broadcast at once, otherwise falls back to a dynamic handler on the origin
 /// (if any), and fails when neither can serve the path. It does NOT wait for a later
 /// announcement.

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -371,6 +371,55 @@ pub extern "C" fn moq_origin_consume_announced_close(task: u32) -> i32 {
 	})
 }
 
+/// Request a broadcast from an origin by path, resolving as soon as it can be served.
+///
+/// Sits between [moq_origin_consume] (announced-only, fails immediately) and
+/// [moq_origin_consume_announced] (waits indefinitely for a future announcement): it returns an
+/// already-announced broadcast at once, otherwise falls back to a dynamic handler on the origin
+/// (if any), and fails when neither can serve the path. It does NOT wait for a later
+/// announcement.
+///
+/// `on_broadcast` is invoked with a positive broadcast handle once served, then exactly once more
+/// with a terminal code: `0` (finished, including after [moq_origin_request_close]) or a negative
+/// error. After the terminal (`<= 0`) callback, `user_data` is never touched again, so release it
+/// there. The broadcast handle is usable with [moq_consume_catalog] / [moq_consume_track] and must
+/// be freed separately with [moq_consume_close].
+///
+/// Returns a non-zero handle to the request on success, or a negative code on (immediate) failure.
+///
+/// # Safety
+/// - The caller must ensure that path is a valid pointer to path_len bytes of data.
+/// - The caller must keep `user_data` valid until the terminal (`<= 0`) `on_broadcast` callback.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_origin_request(
+	origin: u32,
+	path: *const c_char,
+	path_len: usize,
+	on_broadcast: Option<extern "C" fn(user_data: *mut c_void, broadcast: i32)>,
+	user_data: *mut c_void,
+) -> i32 {
+	ffi::enter(move || {
+		let origin = ffi::parse_id(origin)?;
+		let path = unsafe { ffi::parse_str(path, path_len)? }.to_string();
+		let on_broadcast = unsafe { ffi::OnStatus::new(user_data, on_broadcast) };
+		State::lock().origin.request(origin, path, on_broadcast)
+	})
+}
+
+/// Abort a request started by [moq_origin_request].
+///
+/// Returns immediately: zero on success, or a negative code if already closed. Does NOT free
+/// `user_data`; the [moq_origin_request] `on_broadcast` callback fires once more with a terminal
+/// code, which is where `user_data` should be released. Any broadcast handle already delivered is
+/// unaffected and must still be freed with [moq_consume_close].
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_origin_request_close(task: u32) -> i32 {
+	ffi::enter(move || {
+		let task = ffi::parse_id(task)?;
+		State::lock().origin.consume_announced_close(task)
+	})
+}
+
 /// Close an origin and clean up its resources.
 ///
 /// Returns a zero on success, or a negative code on failure.

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -177,6 +177,61 @@ impl Origin {
 		Ok(())
 	}
 
+	/// Request the broadcast at `path`, delivering its handle once it can be served.
+	///
+	/// Unlike [`Self::consume`] (announced-only, fails fast) and [`Self::consume_announced`]
+	/// (waits indefinitely for a future announcement), this resolves against what is announced
+	/// now plus any dynamic fallback handler on the origin: the callback fires the broadcast
+	/// handle (> 0) once served, then a terminal `0`; or a single terminal code (`0` on close,
+	/// negative on error) if it can't be served. Returns a task handle for cancellation.
+	pub fn request(&mut self, origin: Id, path: String, on_broadcast: OnStatus) -> Result<Id, Error> {
+		let origin = self.active.get_mut(origin).ok_or(Error::OriginNotFound)?;
+		let consumer = origin.consume();
+		let channel = oneshot::channel();
+
+		let entry = TaskEntry {
+			close: Some(channel.0),
+			callback: on_broadcast,
+		};
+		let id = self.consume_task.insert(Some(entry))?;
+
+		tokio::spawn(async move {
+			let res = Self::run_request(on_broadcast, consumer, path, channel.1).await;
+
+			// Deliver one final terminal callback (code <= 0), then drop the entry.
+			// Pull it out from under the lock so the callback never runs while held.
+			let entry = State::lock().origin.consume_task.remove(id).flatten();
+			if let Some(entry) = entry {
+				entry.callback.call(res);
+			}
+		});
+
+		Ok(id)
+	}
+
+	async fn run_request(
+		callback: OnStatus,
+		consumer: moq_net::OriginConsumer,
+		path: String,
+		mut close: oneshot::Receiver<()>,
+	) -> Result<(), Error> {
+		// Registration is synchronous; this errors immediately if the path can never be served
+		// (not announced and no dynamic handler).
+		let pending = consumer.request_broadcast(path.as_str())?;
+
+		// `biased` so a pending close always wins over a ready broadcast.
+		let broadcast = tokio::select! {
+			biased;
+			_ = &mut close => return Ok(()),
+			res = pending => res?,
+		};
+
+		// Hold the lock only to buffer the broadcast; release it before the callback.
+		let broadcast_id = State::lock().consume.start(broadcast)?;
+		callback.call(broadcast_id);
+		Ok(())
+	}
+
 	pub fn consume_announced_close(&mut self, task: Id) -> Result<(), Error> {
 		// Signal shutdown; the task delivers a final callback and removes itself.
 		self.consume_task

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -133,13 +133,6 @@ impl Origin {
 		Ok(())
 	}
 
-	pub fn consume<P: moq_net::AsPath>(&mut self, origin: Id, path: P) -> Result<moq_net::BroadcastConsumer, Error> {
-		let origin = self.active.get_mut(origin).ok_or(Error::OriginNotFound)?;
-		// Synchronous lookup races announcement gossip; consume() is a cheap handle over this
-		// origin's tree. Use `consume_announced` to wait for the announcement instead.
-		origin.consume().get_broadcast(path).ok_or(Error::BroadcastNotFound)
-	}
-
 	/// Wait until the broadcast at `path` is announced, then deliver its handle via the callback.
 	///
 	/// The callback fires the broadcast handle (> 0) once announced, then a terminal `0`. On error

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -109,6 +109,18 @@ impl Origin {
 		Ok(())
 	}
 
+	/// Free a single announcement record delivered to an `on_announce` callback.
+	///
+	/// Each announce/unannounce event allocates a record (read via [`Self::announced_info`]);
+	/// the caller releases it here once done. This is per-record, distinct from
+	/// [`Self::announced_close`], which stops the whole listener. Records are freed explicitly
+	/// rather than on unannounce: an unannounce is its own delivered record, and auto-freeing
+	/// the prior one would race a caller still reading it.
+	pub fn announced_free(&mut self, announced: Id) -> Result<(), Error> {
+		self.announced.remove(announced).ok_or(Error::AnnouncementNotFound)?;
+		Ok(())
+	}
+
 	pub fn announced_close(&mut self, announced: Id) -> Result<(), Error> {
 		// Signal shutdown; the task delivers a final callback and removes itself.
 		self.announced_task

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -411,6 +411,48 @@ fn close_invalid_or_zero_ids() {
 }
 
 #[test]
+fn announced_free_lifecycle() {
+	let origin = id(moq_origin_create());
+	let broadcast = id(moq_publish_create());
+
+	// Publish a broadcast so the announce listener has something to deliver.
+	let path = b"announced-free";
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+
+	let ann_cb = Callback::new();
+	let ann_task = id(unsafe { moq_origin_announced(origin, Some(channel_callback), ann_cb.ptr) });
+
+	// The first callback is the announcement for our broadcast.
+	let announced = id(ann_cb.recv());
+
+	// Its info reports our path, active.
+	let mut info = moq_announced {
+		path: std::ptr::null(),
+		path_len: 0,
+		active: false,
+	};
+	assert_eq!(unsafe { moq_origin_announced_info(announced, &mut info) }, 0);
+	assert!(info.active, "broadcast should be active");
+	let got = unsafe { std::slice::from_raw_parts(info.path as *const u8, info.path_len) };
+	assert_eq!(got, path, "announced path should match");
+
+	// Freeing the record succeeds once; the handle is then unknown.
+	assert_eq!(moq_origin_announced_free(announced), 0);
+	assert!(moq_origin_announced_free(announced) < 0, "double-free should fail");
+	assert!(
+		unsafe { moq_origin_announced_info(announced, &mut info) } < 0,
+		"info on a freed handle should fail"
+	);
+
+	// Stop the listener and drain its terminal callback before the Callback drops.
+	assert_eq!(moq_origin_announced_close(ann_task), 0);
+	ann_cb.recv_terminal();
+
+	assert_eq!(moq_origin_close(origin), 0);
+	assert_eq!(moq_publish_close(broadcast), 0);
+}
+
+#[test]
 fn double_close_all_resource_types() {
 	let origin = id(moq_origin_create());
 	assert_eq!(moq_origin_close(origin), 0);

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -12,6 +12,26 @@ fn id(raw: i32) -> u32 {
 	raw as u32
 }
 
+/// Request an already-announced broadcast via `moq_origin_request` and return its handle.
+///
+/// The broadcast resolves immediately (it was published locally), so this drains both the
+/// broadcast handle and the terminal callback before returning.
+fn request_broadcast(origin: u32, path: &[u8]) -> u32 {
+	let cb = Callback::new();
+	let _task = id(unsafe {
+		moq_origin_request(
+			origin,
+			path.as_ptr() as *const c_char,
+			path.len(),
+			Some(channel_callback),
+			cb.ptr,
+		)
+	});
+	let broadcast = id(cb.recv());
+	cb.recv_terminal();
+	broadcast
+}
+
 /// RAII guard that calls a closure on drop.
 struct Guard<F: FnOnce()>(Option<F>);
 impl<F: FnOnce()> Drop for Guard<F> {
@@ -242,7 +262,7 @@ fn publish_catalog_roundtrip() {
 	let path = b"catalog-producer";
 	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
-	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
+	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
 	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
 	let catalog_id = id(catalog_cb.recv());
@@ -329,7 +349,7 @@ fn raw_track_publish_consume() {
 	let path = b"raw-track";
 	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
-	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
+	let consume = request_broadcast(origin, path);
 
 	let frame_cb = Callback::new();
 	let consumer = id(unsafe {
@@ -490,7 +510,7 @@ fn double_close_all_resource_types() {
 	let path = b"double-close-test";
 	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
-	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
+	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
 	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
 
@@ -630,7 +650,7 @@ fn local_publish_consume() {
 	let path = b"live";
 	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
-	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
+	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
 	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
 
@@ -746,7 +766,7 @@ fn consume_announced_local() {
 	let consume = id(cb.recv());
 	assert_eq!(cb.recv_terminal(), 0, "wait delivers terminal 0 after the handle");
 
-	// The delivered handle behaves like one from moq_origin_consume.
+	// The delivered handle behaves like one from moq_origin_request.
 	let catalog_cb = Callback::new();
 	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
 	let catalog_id = id(catalog_cb.recv());
@@ -818,7 +838,7 @@ fn video_publish_consume() {
 	let path = b"video-test";
 	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
-	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
+	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
 	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
 
@@ -926,7 +946,7 @@ fn multiple_frames_ordering() {
 	let path = b"ordering-test";
 	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
-	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
+	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
 	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
 	let catalog_id = id(catalog_cb.recv());
@@ -992,7 +1012,7 @@ fn catalog_update_on_new_track() {
 	let path = b"catalog-update";
 	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
-	let consume = id(unsafe { moq_origin_consume(origin, path.as_ptr() as *const c_char, path.len()) });
+	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
 	let catalog_task = id(unsafe { moq_consume_catalog(consume, Some(channel_callback), catalog_cb.ptr) });
 

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -151,6 +151,18 @@ impl MoqOriginConsumer {
 			}),
 		}))
 	}
+
+	/// Request a broadcast by path, resolving as soon as it can be served.
+	///
+	/// Returns the announced broadcast immediately if one exists; otherwise falls back to a
+	/// dynamic handler on the origin (if any) and resolves once it serves the broadcast, or
+	/// errors if nothing can serve it. Unlike `announced_broadcast`, this does *not* wait
+	/// indefinitely for a future announcement: it resolves or fails based on what is
+	/// announced now plus any dynamic fallback. Drop the returned future to cancel.
+	pub async fn request_broadcast(&self, path: String) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
+		let broadcast = self.inner.request_broadcast(path.as_str())?.await?;
+		Ok(Arc::new(MoqBroadcastConsumer::new(broadcast)))
+	}
 }
 
 // ---- MoqAnnounced ----

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -154,7 +154,8 @@ impl Client {
 				)?;
 
 				// Block until the initial announce set has landed (Lite05 reports it
-				// via AnnounceOk + N), so a synchronous get_broadcast() won't race it.
+				// via AnnounceOk + N), so a `request_broadcast()` for a live path resolves
+				// immediately instead of racing announcement gossip.
 				connecting.ready().await;
 
 				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -131,11 +131,15 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let track_stats = std::sync::Arc::new(self.stats.broadcast(&absolute).publisher_track(&track_name));
 
 		// We just received a subscribe for this exact namespace, so the peer must have already
-		// seen the announcement — synchronous lookup is appropriate here.
-		let Some(broadcast) = self.origin.get_broadcast(&msg.track_namespace) else {
-			self.write_subscribe_error(&mut stream.writer, request_id, 404, "Broadcast not found")
-				.await?;
-			return Ok(());
+		// seen the announcement. `request_broadcast` resolves it immediately, or falls back to
+		// an `OriginDynamic` handler if one is registered.
+		let broadcast = match async { self.origin.request_broadcast(&msg.track_namespace)?.await }.await {
+			Ok(broadcast) => broadcast,
+			Err(_) => {
+				self.write_subscribe_error(&mut stream.writer, request_id, 404, "Broadcast not found")
+					.await?;
+				return Ok(());
+			}
 		};
 
 		let subscription = Subscription {

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -4,8 +4,8 @@ use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use web_transport_trait::Stats;
 
 use crate::{
-	AnnounceConsumer, AsPath, BroadcastConsumer, Compression, Error, Origin, OriginConsumer, OriginList,
-	StatsHandle as MoqStats, TrackSubscriber,
+	AnnounceConsumer, AsPath, Compression, Error, Origin, OriginConsumer, OriginList, StatsHandle as MoqStats,
+	TrackSubscriber,
 	coding::{Stream, Writer},
 	lite::{
 		self,
@@ -422,9 +422,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	async fn run_track_info(&self, stream: &mut Stream<S, Version>, request: &lite::Track<'_>) -> Result<(), Error> {
-		// The peer requested this exact path, so it has already seen an announcement
-		// for it; a synchronous lookup is appropriate (as in recv_subscribe).
-		let broadcast = self.origin.get_broadcast(&request.broadcast).ok_or(Error::NotFound)?;
+		// The peer requested this exact path, so it has already seen an announcement for it.
+		// `request_broadcast` resolves it immediately, or falls back to an `OriginDynamic`
+		// handler (as in recv_subscribe).
+		let broadcast = self.origin.request_broadcast(&request.broadcast)?.await?;
 		let info = broadcast.track(&request.track)?.info().await?;
 
 		// Same negotiation as a subscription, just answered once: codec only when
@@ -466,8 +467,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		tracing::info!(%id, broadcast = %absolute, %track, "subscribed started");
 
 		// We just received a subscribe for this exact path, so by definition the peer has
-		// already seen an announcement for it — synchronous lookup is appropriate here.
-		let broadcast = self.origin.get_broadcast(&subscribe.broadcast);
+		// already seen an announcement for it. `request_broadcast` resolves an announced
+		// broadcast immediately; if it isn't announced it falls back to an `OriginDynamic`
+		// handler (or fails fast when there is none). Registration is synchronous.
+		let broadcast = self.origin.request_broadcast(&subscribe.broadcast);
 
 		// Per-track subscription guard (bumps `subscriptions`). The per-(session,
 		// broadcast) `broadcasts` sentinel that counts viewers is taken inside
@@ -507,7 +510,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		session: S,
 		stream: &mut Stream<S, Version>,
 		subscribe: &lite::Subscribe<'_>,
-		consumer: Option<BroadcastConsumer>,
+		broadcast: Result<kio::Pending<crate::BroadcastRequested>, Error>,
 		priority: PriorityQueue,
 		// The track guard (bumps `subscriptions`), the per-session broadcast
 		// tracker, and the broadcast path. The `broadcasts` sentinel is taken
@@ -524,7 +527,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			group_end: subscribe.end_group,
 		};
 
-		let broadcast = consumer.ok_or(Error::NotFound)?;
+		// Awaits the dynamic fallback if the broadcast wasn't announced; resolves
+		// immediately otherwise.
+		let broadcast = broadcast?.await?;
 		let track = broadcast.track(&subscribe.track)?.subscribe(subscription)?.await?;
 
 		// Compress only when the producer marked the track worth it and the
@@ -618,9 +623,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		tracing::info!(broadcast = %absolute, %track, %group, "fetch started");
 
-		// The peer fetched this exact path, so it has already seen an announcement
-		// for it; a synchronous lookup is appropriate (as in recv_subscribe).
-		let broadcast = self.origin.get_broadcast(&fetch.broadcast);
+		// The peer fetched this exact path, so it has already seen an announcement for it.
+		// `request_broadcast` resolves it immediately, or falls back to an `OriginDynamic`
+		// handler (as in recv_subscribe).
+		let broadcast = self.origin.request_broadcast(&fetch.broadcast);
 		let track_stats = self.stats.broadcast(&absolute).publisher_track(&track);
 
 		if let Err(err) = Self::run_fetch(&mut stream, &fetch, broadcast, track_stats, self.version).await {
@@ -641,11 +647,11 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	async fn run_fetch(
 		stream: &mut Stream<S, Version>,
 		fetch: &lite::Fetch<'_>,
-		consumer: Option<BroadcastConsumer>,
+		broadcast: Result<kio::Pending<crate::BroadcastRequested>, Error>,
 		track_stats: crate::PublisherTrack,
 		version: Version,
 	) -> Result<(), Error> {
-		let broadcast = consumer.ok_or(Error::NotFound)?;
+		let broadcast = broadcast?.await?;
 		let track = broadcast.track(&fetch.track)?;
 
 		let group = track

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -10,7 +10,7 @@ use web_async::Lock;
 
 use super::BroadcastConsumer;
 use crate::{
-	AsPath, BroadcastDynamic, BroadcastInfo, BroadcastProducer, Error, Path, PathOwned, PathPrefixes,
+	AsPath, BroadcastInfo, BroadcastProducer, Error, Path, PathOwned, PathPrefixes,
 	coding::{Decode, DecodeError, Encode, EncodeError},
 };
 
@@ -983,11 +983,13 @@ impl std::ops::DerefMut for BroadcastPublish {
 /// broadcast and track models.
 #[derive(Default)]
 struct OriginDynamicState {
-	// Pending requests keyed by absolute path, waiting for a handler to accept them.
-	requests: HashMap<PathOwned, BroadcastRequest>,
+	// Result channels for queued requests, keyed by absolute path. Concurrent
+	// `request_broadcast` calls for the same path coalesce onto the same channel while
+	// it is queued. The producer is moved out (and the entry removed) when the handler
+	// picks the request up via [`OriginDynamic::requested_broadcast`].
+	requests: HashMap<PathOwned, kio::Producer<PendingBroadcast>>,
 
-	// Requested paths in FIFO order for the handler to drain. A path stays in
-	// `requests` (but not here) once handed out as a `BroadcastRequest`.
+	// Requested paths in FIFO order for the handler to drain.
 	request_order: VecDeque<PathOwned>,
 
 	// The number of live `OriginDynamic` handlers. While zero, `request_broadcast`
@@ -996,20 +998,31 @@ struct OriginDynamicState {
 }
 
 impl OriginDynamicState {
-	/// Drop every pending request, closing the pending broadcasts handed to requesters.
-	/// Called when the last handler goes away so consumers don't block forever.
+	/// Drop every queued request, closing its result channel so awaiting requesters
+	/// resolve to an error. Called when the last handler goes away.
 	fn reject_requests(&mut self) {
 		self.requests.clear();
 		self.request_order.clear();
 	}
 }
 
+/// One-shot result of a dynamic broadcast request.
+///
+/// Stays `None` until a handler [`accept`](BroadcastRequest::accept)s (yielding the served
+/// broadcast) or [`reject`](BroadcastRequest::reject)s (yielding an error). The producer is
+/// dropped right after writing, closing the channel; kio checks the value before the closed
+/// flag, so an awaiting requester still observes the final result.
+#[derive(Default)]
+struct PendingBroadcast {
+	resolved: Option<Result<BroadcastConsumer, Error>>,
+}
+
 /// Picks up [`OriginConsumer::request_broadcast`] calls for paths that are not announced.
 ///
-/// The origin-level analogue of [`BroadcastDynamic`]: where that serves tracks on demand
-/// within a broadcast, this serves whole broadcasts on demand within an origin. A relay
-/// uses it as a fallback router, fetching a broadcast from upstream only when a downstream
-/// consumer asks for an exact path that nobody announced.
+/// The origin-level analogue of [`crate::BroadcastDynamic`]: where that serves tracks on
+/// demand within a broadcast, this serves whole broadcasts on demand within an origin. A
+/// relay uses it as a fallback router, fetching a broadcast from upstream only when a
+/// downstream consumer asks for an exact path that nobody announced.
 ///
 /// Served broadcasts are deliberately *not* announced, so they never appear in
 /// [`OriginConsumer::announced`]. Drop this handle (and every clone) to reject the
@@ -1051,7 +1064,7 @@ impl OriginDynamic {
 		&self.info
 	}
 
-	// Gate readiness on a pending request; mutate through the returned `Mut`.
+	// Gate readiness on a queued request; mutate through the returned `Mut`.
 	fn poll<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, OriginDynamicState>, Error>>
 	where
 		F: FnMut(&kio::Ref<'_, OriginDynamicState>) -> Poll<()>,
@@ -1073,8 +1086,8 @@ impl OriginDynamic {
 		}))?;
 
 		let path = state.request_order.pop_front().expect("predicate guaranteed a request");
-		let request = state.requests.remove(&path).expect("request_order out of sync");
-		Poll::Ready(Ok(request))
+		let producer = state.requests.remove(&path).expect("request_order out of sync");
+		Poll::Ready(Ok(BroadcastRequest { path, producer }))
 	}
 
 	/// Block until a consumer requests an unannounced broadcast, returning a
@@ -1095,7 +1108,7 @@ impl Drop for OriginDynamic {
 			// Saturating sub so `OriginProducer::dynamic` can stay infallible.
 			state.dynamic = state.dynamic.saturating_sub(1);
 			if state.dynamic == 0 {
-				// No handlers left to fulfill pending requests; close them.
+				// No handlers left to fulfill queued requests; close them.
 				state.reject_requests();
 			}
 		}
@@ -1104,63 +1117,99 @@ impl Drop for OriginDynamic {
 
 /// A pending request for a broadcast that was not announced.
 ///
-/// Yielded by [`OriginDynamic::requested_broadcast`]. The requester already holds a
-/// [`BroadcastConsumer`] over this request; [`accept`](Self::accept) returns a
-/// [`BroadcastDynamic`] so the handler can serve its tracks on demand (e.g. by proxying
-/// upstream). Dropping the request without accepting closes the pending broadcast.
+/// Yielded by [`OriginDynamic::requested_broadcast`]. The requester is awaiting inside
+/// [`OriginConsumer::request_broadcast`]; [`accept`](Self::accept) resolves it with a live
+/// broadcast (which the handler keeps producing into) and [`reject`](Self::reject) resolves
+/// it with an error. Dropping the request without either rejects it.
 pub struct BroadcastRequest {
 	// Absolute path that was requested.
 	path: PathOwned,
 
-	// The broadcast handed to requesters. Held until accepted, then dropped: the
-	// returned `BroadcastDynamic` keeps the same channel alive.
-	producer: BroadcastProducer,
-
-	// Keeps the pending broadcast fetch-capable before `accept`, so a requester's
-	// `track()` waits to be served instead of failing `NotFound`. Transferred out on
-	// accept so there is no window where the count drops to zero.
-	dynamic: BroadcastDynamic,
+	// Result channel back to the awaiting requester(s). Writing `resolved` and dropping
+	// this wakes them with the outcome.
+	producer: kio::Producer<PendingBroadcast>,
 }
 
 impl BroadcastRequest {
-	fn new(path: PathOwned) -> Self {
-		let producer = BroadcastInfo::new().produce();
-		let dynamic = producer.dynamic();
-		Self {
-			path,
-			producer,
-			dynamic,
-		}
-	}
-
 	/// The absolute path that was requested.
 	pub fn path(&self) -> &Path<'_> {
 		&self.path
 	}
 
-	/// A consumer for the broadcast that will be served. Clones coalesce onto the same
-	/// pending broadcast, so every requester for this path observes the served tracks.
-	pub fn consume(&self) -> BroadcastConsumer {
-		self.producer.consume()
+	/// Accept the request, resolving every awaiting requester with `broadcast`.
+	///
+	/// The caller keeps producing into `broadcast` (e.g. a relay proxying tracks from
+	/// upstream); the requesters receive a consumer for it. The broadcast is *not*
+	/// announced.
+	pub fn accept(self, broadcast: impl Consume<BroadcastConsumer>) {
+		if let Ok(mut state) = self.producer.write() {
+			state.resolved = Some(Ok(broadcast.consume()));
+		}
+		// `self.producer` drops here, closing the channel; the value is still observable.
 	}
 
-	/// Accept the request, returning a [`BroadcastDynamic`] that serves tracks on demand.
-	///
-	/// This is the same handler that kept the pending broadcast alive, so a requester's
-	/// `track()` call never fails in the handoff. Run its
-	/// [`requested_track`](BroadcastDynamic::requested_track) loop to serve tracks (a
-	/// relay proxies them from upstream). The served broadcast is not announced.
-	pub fn accept(self) -> BroadcastDynamic {
-		// `self.producer` drops here, but `self.dynamic` (returned) holds a clone of the
-		// same channel, so the broadcast and its `dynamic` count stay alive.
-		self.dynamic
+	/// Reject the request, resolving every awaiting requester with `err`.
+	pub fn reject(self, err: Error) {
+		if let Ok(mut state) = self.producer.write() {
+			state.resolved = Some(Err(err));
+		}
+	}
+}
+
+/// The pollable result of [`OriginConsumer::request_broadcast`].
+///
+/// Awaited via the [`kio::Pending`] wrapper; resolves to the [`BroadcastConsumer`]
+/// immediately when the broadcast was already announced, or once an [`OriginDynamic`]
+/// handler serves the request. Resolves to an error if the request is rejected or every
+/// handler drops before serving it.
+pub struct BroadcastRequested {
+	inner: Requested,
+}
+
+enum Requested {
+	// Already announced: resolves immediately with a clone of this broadcast.
+	Ready(BroadcastConsumer),
+	// Awaiting a handler: resolves when the request's result channel is written.
+	Pending(kio::Consumer<PendingBroadcast>),
+}
+
+impl BroadcastRequested {
+	fn ready(broadcast: BroadcastConsumer) -> Self {
+		Self {
+			inner: Requested::Ready(broadcast),
+		}
 	}
 
-	/// Reject the request, closing the pending broadcast handed to requesters.
-	///
-	/// A broadcast carries no abort code (it only ends when every producer drops), so
-	/// this just drops the request. Requesters observe [`BroadcastConsumer::closed`].
-	pub fn reject(self) {}
+	fn pending(consumer: kio::Consumer<PendingBroadcast>) -> Self {
+		Self {
+			inner: Requested::Pending(consumer),
+		}
+	}
+
+	/// Poll for the requested broadcast without blocking.
+	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<BroadcastConsumer, Error>> {
+		match &self.inner {
+			Requested::Ready(broadcast) => Poll::Ready(Ok(broadcast.clone())),
+			Requested::Pending(consumer) => Poll::Ready(
+				match ready!(consumer.poll(waiter, |state| match &state.resolved {
+					Some(result) => Poll::Ready(result.clone()),
+					None => Poll::Pending,
+				})) {
+					Ok(result) => result,
+					// The handler dropped without resolving: nobody could serve it.
+					Err(_closed) => Err(Error::NotFound),
+				},
+			),
+		}
+	}
+}
+
+impl kio::Future for BroadcastRequested {
+	type Output = Result<BroadcastConsumer, Error>;
+
+	fn poll(&self, waiter: &kio::Waiter) -> Poll<Self::Output> {
+		self.poll_ok(waiter)
+	}
 }
 
 /// Cheap read handle over an origin's broadcast tree.
@@ -1351,22 +1400,24 @@ impl OriginConsumer {
 
 	/// Get a broadcast by path, falling back to a dynamic request when it is not announced.
 	///
-	/// First tries [`Self::get_broadcast`]. If that returns nothing and an
-	/// [`OriginDynamic`] handler is live (see [`OriginProducer::dynamic`]), the call
-	/// registers a fallback request and returns a pending [`BroadcastConsumer`]: its
-	/// tracks stay pending until the handler [`accept`](BroadcastRequest::accept)s the
-	/// request, and the broadcast closes if every handler is dropped first. Concurrent
-	/// requests for the same path coalesce onto one handler request.
+	/// Returns a [`kio::Pending`] future (resolved synchronously for an announced broadcast,
+	/// otherwise once a handler serves it), mirroring [`TrackConsumer::fetch_group`](crate::TrackConsumer::fetch_group).
+	/// The lookup order is: an announced broadcast ([`Self::get_broadcast`]) resolves
+	/// immediately; otherwise, if an [`OriginDynamic`] handler is live (see
+	/// [`OriginProducer::dynamic`]), a fallback request is registered and the future resolves
+	/// when the handler [`accept`](BroadcastRequest::accept)s it (or errors if it
+	/// [`reject`](BroadcastRequest::reject)s or every handler drops). Concurrent requests for
+	/// the same unannounced path coalesce onto one handler request.
 	///
-	/// Returns [`Error::NotFound`] when the path is not announced and no handler exists,
-	/// or [`Error::Dropped`] once the origin is gone. Unlike an announced broadcast, a
-	/// dynamically served one is never visible to [`Self::announced`].
-	pub fn request_broadcast(&self, path: impl AsPath) -> Result<BroadcastConsumer, Error> {
+	/// Fails synchronously with [`Error::NotFound`] when the path is not announced and no
+	/// handler exists, or [`Error::Dropped`] once the origin is gone. Unlike an announced
+	/// broadcast, a dynamically served one is never visible to [`Self::announced`].
+	pub fn request_broadcast(&self, path: impl AsPath) -> Result<kio::Pending<BroadcastRequested>, Error> {
 		let path = path.as_path();
 
 		// Prefer a live announcement when one is present; the dynamic queue is only a fallback.
 		if let Some(broadcast) = self.get_broadcast(&path) {
-			return Ok(broadcast);
+			return Ok(kio::Pending::new(BroadcastRequested::ready(broadcast)));
 		}
 
 		// Key requests by absolute path so a scoped/rooted consumer and the handler
@@ -1375,22 +1426,22 @@ impl OriginConsumer {
 
 		let mut state = self.dynamic.write().map_err(|_| Error::Dropped)?;
 
-		if let Some(pending) = state.requests.get(&absolute) {
-			// Coalesce onto an in-flight request for the same path.
-			return Ok(pending.consume());
-		}
+		// Coalesce onto a queued request for the same path; otherwise register a new one.
+		let consumer = if let Some(producer) = state.requests.get(&absolute) {
+			producer.consume()
+		} else {
+			if state.dynamic == 0 {
+				return Err(Error::NotFound);
+			}
 
-		if state.dynamic == 0 {
-			return Err(Error::NotFound);
-		}
+			let producer = kio::Producer::<PendingBroadcast>::default();
+			let consumer = producer.consume();
+			state.requests.insert(absolute.clone(), producer);
+			state.request_order.push_back(absolute);
+			consumer
+		};
 
-		let request = BroadcastRequest::new(absolute.clone());
-		let consumer = request.consume();
-
-		state.requests.insert(absolute.clone(), request);
-		state.request_order.push_back(absolute);
-
-		Ok(consumer)
+		Ok(kio::Pending::new(BroadcastRequested::pending(consumer)))
 	}
 
 	/// Returns a new OriginConsumer that automatically strips out the provided prefix.
@@ -2889,7 +2940,7 @@ mod tests {
 		assert_eq!(paths, ["test1", "test2"]);
 	}
 
-	// With no OriginDynamic handler, an unannounced path fails fast.
+	// With no OriginDynamic handler, an unannounced path fails fast (synchronously).
 	#[tokio::test]
 	async fn dynamic_request_not_found_without_handler() {
 		let origin = Origin::random().produce();
@@ -2897,7 +2948,8 @@ mod tests {
 		assert!(matches!(consumer.request_broadcast("missing"), Err(Error::NotFound)));
 	}
 
-	// A dynamically served broadcast resolves a requester's tracks but is never announced.
+	// A dynamically served broadcast resolves the requester and serves tracks, but is
+	// never announced.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_served_not_announced() {
 		let origin = Origin::random().produce();
@@ -2908,17 +2960,24 @@ mod tests {
 		let mut announced = origin.consume().announced();
 		announced.assert_next_wait();
 
-		// Request a path that nobody announced; subscribing stays pending until served.
-		let broadcast = consumer.request_broadcast("fallback").unwrap();
-		let track_fut = broadcast.track("video").unwrap().subscribe(None).unwrap();
+		// Request a path that nobody announced; the future stays pending until served.
+		// Registration is synchronous, so the handler sees the request immediately.
+		let request_fut = consumer.request_broadcast("fallback").unwrap();
 
-		// The handler picks up the request and serves the track on demand.
+		// The handler serves it with a live broadcast it keeps producing into.
+		let served = BroadcastInfo::new().produce();
+		let mut served_dynamic = served.dynamic();
+
 		let request = dynamic.requested_broadcast().await.unwrap();
 		assert_eq!(request.path(), &Path::new("fallback"));
+		request.accept(&served);
 
-		let mut served = request.accept();
-		let mut producer = served.requested_track().await.unwrap().accept(None);
+		let broadcast = request_fut.await.unwrap();
+		assert!(broadcast.is_clone(&served.consume()));
 
+		// The served broadcast is live: a track subscription resolves via its handler.
+		let track_fut = broadcast.track("video").unwrap().subscribe(None).unwrap();
+		let mut producer = served_dynamic.requested_track().await.unwrap().accept(None);
 		let mut track = track_fut.await.unwrap();
 		producer.append_group().unwrap();
 		track.assert_group();
@@ -2927,39 +2986,60 @@ mod tests {
 		announced.assert_next_wait();
 	}
 
-	// Concurrent requests for the same path coalesce onto one pending broadcast.
+	// Concurrent requests for the same queued path coalesce onto one handler request.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_coalesces() {
 		let origin = Origin::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
-		let b1 = consumer.request_broadcast("dup").unwrap();
-		let b2 = consumer.request_broadcast("dup").unwrap();
-		assert!(b1.is_clone(&b2), "same path should coalesce onto one pending broadcast");
+		// Both register synchronously before the handler drains either.
+		let f1 = consumer.request_broadcast("dup").unwrap();
+		let f2 = consumer.request_broadcast("dup").unwrap();
 
-		// Exactly one request to serve, then nothing.
+		// Exactly one request reaches the handler.
 		let request = dynamic.requested_broadcast().await.unwrap();
 		assert_eq!(request.path(), &Path::new("dup"));
 		assert!(
 			dynamic.requested_broadcast().now_or_never().is_none(),
 			"a coalesced request must not be served twice"
 		);
+
+		// Accepting resolves both awaiting requesters with the same broadcast.
+		let served = BroadcastInfo::new().produce();
+		request.accept(&served);
+		assert!(f1.await.unwrap().is_clone(&served.consume()));
+		assert!(f2.await.unwrap().is_clone(&served.consume()));
 	}
 
-	// Dropping the last handler closes pending broadcasts and reverts to NotFound.
+	// Rejecting a request resolves the requester with the error.
 	#[tokio::test(start_paused = true)]
-	async fn dynamic_request_rejected_on_drop() {
+	async fn dynamic_request_rejected() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let request_fut = consumer.request_broadcast("fallback").unwrap();
+
+		let request = dynamic.requested_broadcast().await.unwrap();
+		request.reject(Error::Cancel);
+
+		assert!(matches!(request_fut.await, Err(Error::Cancel)));
+	}
+
+	// Dropping the last handler resolves queued requests with an error and reverts to
+	// failing fast.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_handler_dropped() {
 		let origin = Origin::random().produce();
 		let dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
-		let broadcast = consumer.request_broadcast("fallback").unwrap();
-		broadcast.assert_not_closed();
-
+		let request_fut = consumer.request_broadcast("fallback").unwrap();
 		drop(dynamic);
-		broadcast.assert_closed();
+		assert!(request_fut.await.is_err());
 
+		// With no handler left, a fresh request fails fast.
 		assert!(matches!(consumer.request_broadcast("again"), Err(Error::NotFound)));
 	}
 
@@ -2973,7 +3053,7 @@ mod tests {
 		let broadcast = BroadcastInfo::new().produce();
 		let _publish = origin.publish_broadcast("live", &broadcast).unwrap();
 
-		let got = consumer.request_broadcast("live").unwrap();
+		let got = consumer.request_broadcast("live").unwrap().await.unwrap();
 		assert!(
 			got.is_clone(&broadcast.consume()),
 			"should return the announced broadcast"
@@ -2993,8 +3073,13 @@ mod tests {
 
 		drop(dynamic.clone());
 
-		// The original handle is still live, so the request registers instead of failing.
-		let broadcast = consumer.request_broadcast("fallback").unwrap();
-		broadcast.assert_not_closed();
+		// The original handle is still live, so the request registers (stays pending)
+		// instead of failing fast.
+		let request_fut = consumer.request_broadcast("fallback");
+		assert!(request_fut.is_ok(), "request should register, not fail");
+		assert!(
+			request_fut.unwrap().now_or_never().is_none(),
+			"request should stay pending until served"
+		);
 	}
 }

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1352,10 +1352,10 @@ impl OriginConsumer {
 	/// is closed before the broadcast is announced. The returned broadcast may itself be closed
 	/// later. Subscribers should watch [`BroadcastConsumer::closed`] to react to that.
 	///
-	/// Prefer this over [`Self::get_broadcast`] when you know the exact path you want but
+	/// Prefer this over [`Self::request_broadcast`] when you know the exact path you want but
 	/// cannot guarantee the announcement has already been received. With moq-lite-05 (and
 	/// the older Lite01/02) `connect()` already blocks until the initial announce set lands,
-	/// so [`Self::get_broadcast`] is race-free for broadcasts that were live at connect time;
+	/// so [`Self::request_broadcast`] is race-free for broadcasts that were live at connect time;
 	/// this method is still needed to wait for a broadcast that comes online *after* connect.
 	pub async fn announced_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();
@@ -1401,7 +1401,7 @@ impl OriginConsumer {
 	///
 	/// Returns a [`kio::Pending`] future (resolved synchronously for an announced broadcast,
 	/// otherwise once a handler serves it), mirroring [`TrackConsumer::fetch_group`](crate::TrackConsumer::fetch_group).
-	/// The lookup order is: an announced broadcast ([`Self::get_broadcast`]) resolves
+	/// The lookup order is: an already-announced broadcast resolves
 	/// immediately; otherwise, if an [`OriginDynamic`] handler is live (see
 	/// [`OriginProducer::dynamic`]), a fallback request is registered and the future resolves
 	/// when the handler [`accept`](BroadcastRequest::accept)s it (or errors if it

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -10,7 +10,7 @@ use web_async::Lock;
 
 use super::BroadcastConsumer;
 use crate::{
-	AsPath, BroadcastInfo, BroadcastProducer, Error, Path, PathOwned, PathPrefixes,
+	AsPath, BroadcastDynamic, BroadcastInfo, BroadcastProducer, Error, Path, PathOwned, PathPrefixes,
 	coding::{Decode, DecodeError, Encode, EncodeError},
 };
 
@@ -739,6 +739,11 @@ pub struct OriginProducer {
 
 	// The prefix that is automatically stripped from all paths.
 	root: PathOwned,
+
+	// Fallback request queue, shared with every derived consumer. Separate from
+	// `nodes` because dynamic broadcasts are never announced: they only resolve a
+	// consumer's `request_broadcast` when no live announcement exists.
+	dynamic: kio::Producer<OriginDynamicState>,
 }
 
 impl std::ops::Deref for OriginProducer {
@@ -757,6 +762,7 @@ impl OriginProducer {
 			info,
 			nodes: OriginNodes::default(),
 			root: PathOwned::default(),
+			dynamic: kio::Producer::default(),
 		}
 	}
 
@@ -769,6 +775,7 @@ impl OriginProducer {
 			info,
 			nodes: OriginNodes { nodes: Vec::new() },
 			root: PathOwned::default(),
+			dynamic: kio::Producer::default(),
 		}
 	}
 
@@ -843,7 +850,20 @@ impl OriginProducer {
 			info: self.info,
 			nodes: self.nodes.select(&prefixes)?,
 			root: self.root.clone(),
+			dynamic: self.dynamic.clone(),
 		})
+	}
+
+	/// Create a dynamic handler that picks up [`OriginConsumer::request_broadcast`]
+	/// calls for paths that are not announced.
+	///
+	/// This is the origin-level analogue of [`BroadcastProducer::dynamic`]: it serves
+	/// broadcasts on demand rather than tracks. Crucially the served broadcasts are
+	/// *not* announced, so [`OriginConsumer::announced`] never sees them; they exist
+	/// only as a fallback for a consumer that asks for an exact path with no live
+	/// announcement. Drop the handler (and every clone) to reject pending requests.
+	pub fn dynamic(&self) -> OriginDynamic {
+		OriginDynamic::new(self.info, self.root.clone(), self.dynamic.clone())
 	}
 
 	/// Cheap read handle over this origin's broadcast tree.
@@ -851,7 +871,7 @@ impl OriginProducer {
 	/// Use [`OriginConsumer::announced`] to register interest and start receiving
 	/// announcement events; the consumer itself does not allocate any channels.
 	pub fn consume(&self) -> OriginConsumer {
-		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone())
+		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.consume())
 	}
 
 	/// Handle to the announcement stream for this producer's subtree.
@@ -874,6 +894,7 @@ impl OriginProducer {
 			info: self.info,
 			root: self.root.join(&prefix).to_owned(),
 			nodes: self.nodes.root(&prefix)?,
+			dynamic: self.dynamic.clone(),
 		})
 	}
 
@@ -955,6 +976,193 @@ impl std::ops::DerefMut for BroadcastPublish {
 	}
 }
 
+/// Shared fallback request queue for an origin.
+///
+/// Lives off to the side of the announce tree because dynamically served broadcasts
+/// are never announced. Mirrors the `dynamic`/`requests`/`request_order` fields of the
+/// broadcast and track models.
+#[derive(Default)]
+struct OriginDynamicState {
+	// Pending requests keyed by absolute path, waiting for a handler to accept them.
+	requests: HashMap<PathOwned, BroadcastRequest>,
+
+	// Requested paths in FIFO order for the handler to drain. A path stays in
+	// `requests` (but not here) once handed out as a `BroadcastRequest`.
+	request_order: VecDeque<PathOwned>,
+
+	// The number of live `OriginDynamic` handlers. While zero, `request_broadcast`
+	// fails fast with `NotFound` rather than queueing a request nobody will serve.
+	dynamic: usize,
+}
+
+impl OriginDynamicState {
+	/// Drop every pending request, closing the pending broadcasts handed to requesters.
+	/// Called when the last handler goes away so consumers don't block forever.
+	fn reject_requests(&mut self) {
+		self.requests.clear();
+		self.request_order.clear();
+	}
+}
+
+/// Picks up [`OriginConsumer::request_broadcast`] calls for paths that are not announced.
+///
+/// The origin-level analogue of [`BroadcastDynamic`]: where that serves tracks on demand
+/// within a broadcast, this serves whole broadcasts on demand within an origin. A relay
+/// uses it as a fallback router, fetching a broadcast from upstream only when a downstream
+/// consumer asks for an exact path that nobody announced.
+///
+/// Served broadcasts are deliberately *not* announced, so they never appear in
+/// [`OriginConsumer::announced`]. Drop this handle (and every clone) to reject the
+/// requests still waiting to be served.
+pub struct OriginDynamic {
+	info: Origin,
+	root: PathOwned,
+	state: kio::Producer<OriginDynamicState>,
+}
+
+impl Clone for OriginDynamic {
+	fn clone(&self) -> Self {
+		// Mirror `new`: bump `dynamic` so each live handle is counted. Without this,
+		// dropping a clone would decrement past `new`'s increment and prematurely flip
+		// `dynamic` to zero, making future `request_broadcast` calls return `NotFound`.
+		if let Ok(mut state) = self.state.write() {
+			state.dynamic += 1;
+		}
+
+		Self {
+			info: self.info,
+			root: self.root.clone(),
+			state: self.state.clone(),
+		}
+	}
+}
+
+impl OriginDynamic {
+	fn new(info: Origin, root: PathOwned, state: kio::Producer<OriginDynamicState>) -> Self {
+		if let Ok(mut state) = state.write() {
+			state.dynamic += 1;
+		}
+
+		Self { info, root, state }
+	}
+
+	/// The origin this handler belongs to.
+	pub fn info(&self) -> &Origin {
+		&self.info
+	}
+
+	// Gate readiness on a pending request; mutate through the returned `Mut`.
+	fn poll<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, OriginDynamicState>, Error>>
+	where
+		F: FnMut(&kio::Ref<'_, OriginDynamicState>) -> Poll<()>,
+	{
+		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
+			Ok(state) => Ok(state),
+			Err(_) => Err(Error::Dropped),
+		})
+	}
+
+	/// Poll for the next requested broadcast, without blocking.
+	pub fn poll_requested_broadcast(&mut self, waiter: &kio::Waiter) -> Poll<Result<BroadcastRequest, Error>> {
+		let mut state = ready!(self.poll(waiter, |state| {
+			if state.request_order.is_empty() {
+				Poll::Pending
+			} else {
+				Poll::Ready(())
+			}
+		}))?;
+
+		let path = state.request_order.pop_front().expect("predicate guaranteed a request");
+		let request = state.requests.remove(&path).expect("request_order out of sync");
+		Poll::Ready(Ok(request))
+	}
+
+	/// Block until a consumer requests an unannounced broadcast, returning a
+	/// [`BroadcastRequest`] to serve.
+	pub async fn requested_broadcast(&mut self) -> Result<BroadcastRequest, Error> {
+		kio::wait(|waiter| self.poll_requested_broadcast(waiter)).await
+	}
+
+	/// Returns the prefix that is automatically stripped from requested paths.
+	pub fn root(&self) -> &Path<'_> {
+		&self.root
+	}
+}
+
+impl Drop for OriginDynamic {
+	fn drop(&mut self) {
+		if let Ok(mut state) = self.state.write() {
+			// Saturating sub so `OriginProducer::dynamic` can stay infallible.
+			state.dynamic = state.dynamic.saturating_sub(1);
+			if state.dynamic == 0 {
+				// No handlers left to fulfill pending requests; close them.
+				state.reject_requests();
+			}
+		}
+	}
+}
+
+/// A pending request for a broadcast that was not announced.
+///
+/// Yielded by [`OriginDynamic::requested_broadcast`]. The requester already holds a
+/// [`BroadcastConsumer`] over this request; [`accept`](Self::accept) returns a
+/// [`BroadcastDynamic`] so the handler can serve its tracks on demand (e.g. by proxying
+/// upstream). Dropping the request without accepting closes the pending broadcast.
+pub struct BroadcastRequest {
+	// Absolute path that was requested.
+	path: PathOwned,
+
+	// The broadcast handed to requesters. Held until accepted, then dropped: the
+	// returned `BroadcastDynamic` keeps the same channel alive.
+	producer: BroadcastProducer,
+
+	// Keeps the pending broadcast fetch-capable before `accept`, so a requester's
+	// `track()` waits to be served instead of failing `NotFound`. Transferred out on
+	// accept so there is no window where the count drops to zero.
+	dynamic: BroadcastDynamic,
+}
+
+impl BroadcastRequest {
+	fn new(path: PathOwned) -> Self {
+		let producer = BroadcastInfo::new().produce();
+		let dynamic = producer.dynamic();
+		Self {
+			path,
+			producer,
+			dynamic,
+		}
+	}
+
+	/// The absolute path that was requested.
+	pub fn path(&self) -> &Path<'_> {
+		&self.path
+	}
+
+	/// A consumer for the broadcast that will be served. Clones coalesce onto the same
+	/// pending broadcast, so every requester for this path observes the served tracks.
+	pub fn consume(&self) -> BroadcastConsumer {
+		self.producer.consume()
+	}
+
+	/// Accept the request, returning a [`BroadcastDynamic`] that serves tracks on demand.
+	///
+	/// This is the same handler that kept the pending broadcast alive, so a requester's
+	/// `track()` call never fails in the handoff. Run its
+	/// [`requested_track`](BroadcastDynamic::requested_track) loop to serve tracks (a
+	/// relay proxies them from upstream). The served broadcast is not announced.
+	pub fn accept(self) -> BroadcastDynamic {
+		// `self.producer` drops here, but `self.dynamic` (returned) holds a clone of the
+		// same channel, so the broadcast and its `dynamic` count stay alive.
+		self.dynamic
+	}
+
+	/// Reject the request, closing the pending broadcast handed to requesters.
+	///
+	/// A broadcast carries no abort code (it only ends when every producer drops), so
+	/// this just drops the request. Requesters observe [`BroadcastConsumer::closed`].
+	pub fn reject(self) {}
+}
+
 /// Cheap read handle over an origin's broadcast tree.
 ///
 /// Derive a read view from a handle.
@@ -978,7 +1186,7 @@ impl Consume<OriginConsumer> for OriginProducer {
 	fn consume(&self) -> OriginConsumer {
 		// Mirrors the inherent `OriginProducer::consume`; inlined to avoid the
 		// inherent-vs-trait `consume` ambiguity.
-		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone())
+		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.consume())
 	}
 }
 
@@ -1024,6 +1232,10 @@ pub struct OriginConsumer {
 
 	// A prefix that is automatically stripped from all paths.
 	root: PathOwned,
+
+	// Shared fallback request queue, fed to any `OriginDynamic` handler on the
+	// producer side. Used only by `request_broadcast`; announced lookups ignore it.
+	dynamic: kio::Consumer<OriginDynamicState>,
 }
 
 impl std::ops::Deref for OriginConsumer {
@@ -1035,8 +1247,13 @@ impl std::ops::Deref for OriginConsumer {
 }
 
 impl OriginConsumer {
-	fn new(info: Origin, root: PathOwned, nodes: OriginNodes) -> Self {
-		Self { info, nodes, root }
+	fn new(info: Origin, root: PathOwned, nodes: OriginNodes, dynamic: kio::Consumer<OriginDynamicState>) -> Self {
+		Self {
+			info,
+			nodes,
+			root,
+			dynamic,
+		}
 	}
 
 	/// A view with this consumer's identity and root but no broadcasts:
@@ -1048,6 +1265,7 @@ impl OriginConsumer {
 			info: self.info,
 			nodes: OriginNodes { nodes: Vec::new() },
 			root: self.root.clone(),
+			dynamic: self.dynamic.clone(),
 		}
 	}
 
@@ -1127,7 +1345,52 @@ impl OriginConsumer {
 			self.info,
 			self.root.clone(),
 			self.nodes.select(&prefixes)?,
+			self.dynamic.clone(),
 		))
+	}
+
+	/// Get a broadcast by path, falling back to a dynamic request when it is not announced.
+	///
+	/// First tries [`Self::get_broadcast`]. If that returns nothing and an
+	/// [`OriginDynamic`] handler is live (see [`OriginProducer::dynamic`]), the call
+	/// registers a fallback request and returns a pending [`BroadcastConsumer`]: its
+	/// tracks stay pending until the handler [`accept`](BroadcastRequest::accept)s the
+	/// request, and the broadcast closes if every handler is dropped first. Concurrent
+	/// requests for the same path coalesce onto one handler request.
+	///
+	/// Returns [`Error::NotFound`] when the path is not announced and no handler exists,
+	/// or [`Error::Dropped`] once the origin is gone. Unlike an announced broadcast, a
+	/// dynamically served one is never visible to [`Self::announced`].
+	pub fn request_broadcast(&self, path: impl AsPath) -> Result<BroadcastConsumer, Error> {
+		let path = path.as_path();
+
+		// Prefer a live announcement when one is present; the dynamic queue is only a fallback.
+		if let Some(broadcast) = self.get_broadcast(&path) {
+			return Ok(broadcast);
+		}
+
+		// Key requests by absolute path so a scoped/rooted consumer and the handler
+		// (which may have a different root) agree on the same entry.
+		let absolute = self.root.join(&path).to_owned();
+
+		let mut state = self.dynamic.write().map_err(|_| Error::Dropped)?;
+
+		if let Some(pending) = state.requests.get(&absolute) {
+			// Coalesce onto an in-flight request for the same path.
+			return Ok(pending.consume());
+		}
+
+		if state.dynamic == 0 {
+			return Err(Error::NotFound);
+		}
+
+		let request = BroadcastRequest::new(absolute.clone());
+		let consumer = request.consume();
+
+		state.requests.insert(absolute.clone(), request);
+		state.request_order.push_back(absolute);
+
+		Ok(consumer)
 	}
 
 	/// Returns a new OriginConsumer that automatically strips out the provided prefix.
@@ -1141,6 +1404,7 @@ impl OriginConsumer {
 			self.info,
 			self.root.join(&prefix).to_owned(),
 			self.nodes.root(&prefix)?,
+			self.dynamic.clone(),
 		))
 	}
 
@@ -2623,5 +2887,114 @@ mod tests {
 		let mut paths: Vec<_> = [&b1, &b2].iter().map(|(p, _)| p.to_string()).collect();
 		paths.sort();
 		assert_eq!(paths, ["test1", "test2"]);
+	}
+
+	// With no OriginDynamic handler, an unannounced path fails fast.
+	#[tokio::test]
+	async fn dynamic_request_not_found_without_handler() {
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+		assert!(matches!(consumer.request_broadcast("missing"), Err(Error::NotFound)));
+	}
+
+	// A dynamically served broadcast resolves a requester's tracks but is never announced.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_served_not_announced() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		// A separate announce cursor must never observe the dynamic broadcast.
+		let mut announced = origin.consume().announced();
+		announced.assert_next_wait();
+
+		// Request a path that nobody announced; subscribing stays pending until served.
+		let broadcast = consumer.request_broadcast("fallback").unwrap();
+		let track_fut = broadcast.track("video").unwrap().subscribe(None).unwrap();
+
+		// The handler picks up the request and serves the track on demand.
+		let request = dynamic.requested_broadcast().await.unwrap();
+		assert_eq!(request.path(), &Path::new("fallback"));
+
+		let mut served = request.accept();
+		let mut producer = served.requested_track().await.unwrap().accept(None);
+
+		let mut track = track_fut.await.unwrap();
+		producer.append_group().unwrap();
+		track.assert_group();
+
+		// Still nothing announced.
+		announced.assert_next_wait();
+	}
+
+	// Concurrent requests for the same path coalesce onto one pending broadcast.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_coalesces() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let b1 = consumer.request_broadcast("dup").unwrap();
+		let b2 = consumer.request_broadcast("dup").unwrap();
+		assert!(b1.is_clone(&b2), "same path should coalesce onto one pending broadcast");
+
+		// Exactly one request to serve, then nothing.
+		let request = dynamic.requested_broadcast().await.unwrap();
+		assert_eq!(request.path(), &Path::new("dup"));
+		assert!(
+			dynamic.requested_broadcast().now_or_never().is_none(),
+			"a coalesced request must not be served twice"
+		);
+	}
+
+	// Dropping the last handler closes pending broadcasts and reverts to NotFound.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_rejected_on_drop() {
+		let origin = Origin::random().produce();
+		let dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let broadcast = consumer.request_broadcast("fallback").unwrap();
+		broadcast.assert_not_closed();
+
+		drop(dynamic);
+		broadcast.assert_closed();
+
+		assert!(matches!(consumer.request_broadcast("again"), Err(Error::NotFound)));
+	}
+
+	// A live announcement wins over the dynamic fallback; no request is queued.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_prefers_announced() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let broadcast = BroadcastInfo::new().produce();
+		let _publish = origin.publish_broadcast("live", &broadcast).unwrap();
+
+		let got = consumer.request_broadcast("live").unwrap();
+		assert!(
+			got.is_clone(&broadcast.consume()),
+			"should return the announced broadcast"
+		);
+		assert!(
+			dynamic.requested_broadcast().now_or_never().is_none(),
+			"an announced path must not queue a fallback request"
+		);
+	}
+
+	// Cloning a handler and dropping the clone must not flip the count to zero.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_clone_keeps_alive() {
+		let origin = Origin::random().produce();
+		let dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		drop(dynamic.clone());
+
+		// The original handle is still live, so the request registers instead of failing.
+		let broadcast = consumer.request_broadcast("fallback").unwrap();
+		broadcast.assert_not_closed();
 	}
 }

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1333,14 +1333,13 @@ impl OriginConsumer {
 		self.clone()
 	}
 
-	/// Get a broadcast by path if it has *already* been announced.
+	/// Internal synchronous peek: the broadcast at `path` if it is *already* announced.
 	///
-	/// Returns `None` when the path is unknown to this consumer right now. Synchronous
-	/// lookup races announcement gossip. A freshly-connected consumer will see `None`
-	/// even when the broadcast is about to arrive. Prefer [`Self::announced_broadcast`]
-	/// (blocks until announced) unless you can guarantee the announcement has already
-	/// landed (e.g. you're responding to an `announced()` callback).
-	pub fn get_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
+	/// Races announcement gossip (a freshly-connected consumer sees `None` even when the
+	/// broadcast is about to arrive), so it is not public. [`Self::request_broadcast`] is the
+	/// public lookup: it builds on this for the announced case, then falls back to a dynamic
+	/// handler. [`Self::announced_broadcast`] waits for a future announcement.
+	fn get_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();
 		let (root, rest) = self.nodes.get(&path)?;
 		let state = root.lock();

--- a/rs/moq-rtc/bin/moq-rtc.rs
+++ b/rs/moq-rtc/bin/moq-rtc.rs
@@ -207,9 +207,9 @@ async fn run_client(
 			// Once the per-codec re-packetizer lands, this should poll
 			// `subscriber.announced()` to await the broadcast rather than
 			// erroring on first-miss.
-			let broadcast = subscriber
-				.get_broadcast(broadcast_name)
-				.ok_or_else(|| anyhow::anyhow!("broadcast {} not announced", broadcast_name))?;
+			let broadcast = async { subscriber.request_broadcast(broadcast_name)?.await }
+				.await
+				.map_err(|_| anyhow::anyhow!("broadcast {} not announced", broadcast_name))?;
 			client.publish(url, broadcast).await?;
 		}
 	}

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -44,13 +44,12 @@ async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: By
 	let sdp = std::str::from_utf8(&body).map_err(|err| Error::InvalidSdp(err.to_string()))?;
 	let offer = sdp::parse_offer(sdp)?;
 
-	// Look up the MoQ broadcast on the subscriber origin. v1 uses
-	// `get_broadcast`: if the broadcast hasn't been announced yet, the
-	// WHEP client retries (typical) or fails fast.
-	let consumer = server
-		.subscriber()
-		.get_broadcast(path)
-		.ok_or_else(|| Error::Other(anyhow::anyhow!("broadcast {path} not announced")))?;
+	// Look up the MoQ broadcast on the subscriber origin. `request_broadcast` resolves an
+	// already-announced broadcast immediately and falls back to a dynamic handler if the
+	// origin has one; with neither, it fails fast and the WHEP client retries (typical).
+	let consumer = async { server.subscriber().request_broadcast(path)?.await }
+		.await
+		.map_err(|_| Error::Other(anyhow::anyhow!("broadcast {path} not announced")))?;
 
 	let source = EgressSource::new(consumer).await?;
 	let codecs = source.catalog_codecs();

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -41,6 +41,14 @@ public final class OriginConsumer: Sendable {
     public func announcedBroadcast(path: String) throws -> AnnouncedBroadcast {
         AnnouncedBroadcast(try ffi.announcedBroadcast(path: path))
     }
+
+    /// Request a broadcast by path, resolving as soon as it can be served: the announced
+    /// broadcast if present, otherwise a dynamic fallback on the origin, or an error if
+    /// neither can serve it. Unlike `announcedBroadcast`, this does not wait for a future
+    /// announcement.
+    public func requestBroadcast(path: String) async throws -> BroadcastConsumer {
+        BroadcastConsumer(try await ffi.requestBroadcast(path: path))
+    }
 }
 
 /// A stream of broadcast announcements. Iterate directly:


### PR DESCRIPTION
## Summary

Adds `OriginDynamic`, the origin-level analogue of the existing `BroadcastDynamic`/`TrackDynamic` on-demand handlers, makes `request_broadcast` the one public broadcast-lookup, and reworks the FFI surface around it.

| Level | Container | On-demand handler |
|---|---|---|
| **Origin** | broadcasts by path | **`OriginDynamic`** (new) |
| Broadcast | tracks by name | `BroadcastDynamic` |
| Track | groups by sequence | `TrackDynamic` |

### `request_broadcast` (the unified lookup)

`OriginConsumer::request_broadcast(path) -> Result<kio::Pending<BroadcastRequested>, Error>` — a `kio::Pending` future you await (not an `async fn`), mirroring `TrackConsumer::fetch_group`. Registration is **synchronous** (a handler sees the request immediately); the future then resolves:

- **announced** → immediately with the announced broadcast;
- **not announced + live `OriginDynamic`** → once the handler `accept`s (live broadcast) or `reject`s (error), coalescing concurrent requests for the same path;
- **not announced + no handler** → fails fast, synchronously, with `NotFound` (`Dropped` once the origin is gone).

### Not announced, by design

Dynamically served broadcasts are **never announced** — `OriginConsumer::announced` never observes them. The request queue lives in a shared `OriginDynamicState` off to the side of the announce tree (ref-counted handlers, coalesced requests, reject-on-last-drop). The result rides a one-shot kio channel; kio checks the value before the closed flag, so the outcome is observed without a close race.

### Handler side

`OriginProducer::dynamic() -> OriginDynamic`; `requested_broadcast()` yields a `BroadcastRequest`. `accept(broadcast)` resolves every awaiting requester with the supplied live broadcast (the handler keeps producing into it, e.g. a relay proxying upstream); `reject(err)` resolves them with an error.

### `get_broadcast` retired from the public API

`OriginConsumer::get_broadcast` was a synchronous announced-only peek that races announcement gossip. It's now **private** — the internal helper backing `request_broadcast`'s announced case (and the tree-state test assertions). Every caller moved to `request_broadcast`:

- moq-net serve paths: lite `recv_subscribe`, `run_track_info`, `run_fetch`, ietf subscribe.
- moq-rtc: WHIP/WHEP gateways.

With no `OriginDynamic` registered this is behavior-identical (resolve-if-announced, else fail fast); a registered handler adds the fallback. `announced_broadcast` is unchanged (race-free await-for-announce).

### FFI: dynamic broadcast requesting

Neither libmoq nor moq-ffi could previously request a broadcast that hadn't been announced. Now:

- **rs/moq-ffi**: `MoqOriginConsumer::request_broadcast` (async).
- **rs/libmoq**: `moq_origin_request` + `moq_origin_request_close` (callback style). **Removes the synchronous `moq_origin_consume`** (breaking): it was a racy announced-only peek; `moq_origin_request` resolves an already-announced broadcast immediately (same common case, no race) and adds the dynamic fallback. Callers reacting to an announcement use the broadcast delivered by `moq_origin_announced`.
- **Wrappers**: py (`OriginConsumer` + `Client`), swift (`OriginConsumer`), go (`OriginConsumer` + `Client`); kt via the uniffi typealias.
- **Docs**: py README + `doc/lib/py`; libmoq README + `doc/lib/c`.

### FFI: free delivered announcements

`moq_origin_announced` handed its callback a fresh announce ID per event with no way to release one (they accumulated). Adds `moq_origin_announced_free` to drop a delivered record once read. Explicit free, not auto-on-unannounce: an unannounce is its own record, and auto-freeing the prior one would race a caller still reading its borrowed `path` pointer.

### Scope / follow-ups

- Targets `dev` (new public surface in `rs/moq-net` + `rs/moq-ffi`; `get_broadcast` privatized; `moq_origin_consume` removed).
- **Follow-up:** register an `OriginDynamic` in the relay/cluster to actually fetch from upstream on a fallback request; `js/net` mirror; carry the `BroadcastConsumer` in libmoq's announced record (+ accessor) so announce→consume is fully race-free (now unblocked by `moq_origin_announced_free`).

## Public API changes

**`rs/moq-net`:** added `OriginProducer::dynamic`, `OriginConsumer::request_broadcast`, `OriginDynamic`, `BroadcastRequest`, `BroadcastRequested`; **`OriginConsumer::get_broadcast` is now private**.
**`rs/moq-ffi`:** added `MoqOriginConsumer::request_broadcast`.
**`rs/libmoq`:** added `moq_origin_request`, `moq_origin_request_close`, `moq_origin_announced_free`; **removed `moq_origin_consume`**.

## Test plan

- [x] moq-net: 385 lib tests (7 new for OriginDynamic incl. "never announced")
- [x] request_broadcast fail-fast / served / coalesce / reject / handler-dropped / prefers-announced / clone-keeps-alive
- [x] libmoq `announced_free_lifecycle`; 7 roundtrip tests migrated onto `moq_origin_request`
- [x] `cargo test -p moq-ffi -p libmoq` (24 + 25); moq-rtc / moq-relay build
- [x] `cargo fmt --check` + `clippy --all-targets` clean for moq-net / moq-ffi / libmoq / moq-rtc (via nix)

(Written by Claude)