### PR TITLE
refactor(moq-rtc): feature-gate the binary so the gateway is embeddable

### DIFF
--- a/rs/moq-rtc/Cargo.toml
+++ b/rs/moq-rtc/Cargo.toml
@@ -19,36 +19,48 @@ doctest = false
 name = "moq-rtc"
 path = "bin/moq-rtc.rs"
 doc = false
+# The binary (TLS listener, CLI, relay client) needs the `server` feature; the
+# library can be depended on with `default-features = false` to embed the
+# WHIP/WHEP gateway (the axum routers and WHEP/WHIP client) into another process.
+required-features = ["server"]
 
 [features]
-default = ["iroh", "quinn", "websocket"]
-iroh = ["moq-native/iroh"]
-quinn = ["moq-native/quinn"]
-quiche = ["moq-native/quiche"]
-websocket = ["moq-native/websocket"]
+default = ["server", "iroh", "quinn", "websocket"]
+# Standalone binary: TLS-terminating listener, CORS, CLI parsing, and the
+# moq-native relay client. Pulls in axum-server / clap / moq-native / rustls /
+# sd-notify / tower-http.
+server = ["dep:axum-server", "dep:clap", "dep:moq-native", "dep:rustls", "dep:sd-notify", "dep:tower-http"]
+iroh = ["server", "moq-native/iroh"]
+quinn = ["server", "moq-native/quinn"]
+quiche = ["server", "moq-native/quiche"]
+websocket = ["server", "moq-native/websocket"]
 
+# The embeddable gateway library needs only anyhow/axum/bytes/hang/moq-mux/
+# moq-net/reqwest/str0m/thiserror/tokio/tracing/url/uuid. The rest
+# (axum-server/clap/moq-native/rustls/sd-notify/tower-http) are `optional` and
+# pulled in by the `server` feature for the binary.
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 axum = { version = "0.8", features = ["tokio"] }
-axum-server = { version = "0.8", features = ["tls-rustls"] }
+axum-server = { version = "0.8", features = ["tls-rustls"], optional = true }
 bytes = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive"], optional = true }
 hang = { workspace = true }
 moq-mux = { workspace = true }
-moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
+moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"], optional = true }
 moq-net = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false }
+rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false, optional = true }
 str0m = "0.19"
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors"], optional = true }
 tracing = "0.1"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
-sd-notify = "0.5"
+sd-notify = { version = "0.5", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-rtc/src/lib.rs
+++ b/rs/moq-rtc/src/lib.rs
@@ -14,6 +14,17 @@
 //! the per-direction split lives in [`session::MediaSink`] (ingest) /
 //! [`egress::EgressSource`] (egress).
 //!
+//! ## Embedding
+//!
+//! Depend on this crate with `default-features = false` to embed the gateway
+//! in another process: build a [`Server`] over your own
+//! [`OriginProducer`](moq_net::OriginProducer) /
+//! [`OriginConsumer`](moq_net::OriginConsumer) and merge
+//! [`Server::publish_router`] into your own axum app, or dial out with
+//! [`Client`]. That lean build skips the standalone binary's deps
+//! (axum-server, clap, moq-native, rustls, sd-notify, tower-http), which the
+//! `server` feature (on by default) pulls back in for the `moq-rtc` binary.
+//!
 //! ## Bitstream gotcha
 //!
 //! The WebRTC ↔ MoQ shape conversion for H.264 is handled by `moq-mux`'s


### PR DESCRIPTION
## Summary

Makes `moq-rtc` embeddable as a library, mirroring the `moq-srt` / `moq-hls` layout. The goal is to run a WebRTC (WHIP/WHEP) ingest endpoint **in-process** in production, instead of shelling out to a separate `moq-rtc` localhost binary.

Before this change every dependency in `moq-rtc` was unconditional, so depending on the crate as a library dragged in the whole HTTP-listener + CLI + relay-client stack. Now:

- The **default library** (`default-features = false`) is the embeddable WHIP/WHEP gateway: the axum routers, the WHEP/WHIP client, the session driver, and the codec bridges. It pulls only `anyhow/axum/bytes/hang/moq-mux/moq-net/reqwest/str0m/thiserror/tokio/tracing/url/uuid`.
- A new **`server` feature** (on by default) gates the standalone binary's extra deps: `axum-server`, `clap`, `moq-native`, `rustls`, `sd-notify`, `tower-http`.
- The transport features (`iroh`/`quinn`/`quiche`/`websocket`) imply `server` and forward to `moq-native`, exactly like `moq-srt`/`moq-hls`.
- `[[bin]]` gains `required-features = ["server"]`.

A consumer embeds WebRTC ingest with `moq-rtc = { workspace = true, default-features = false }`, builds a `Server` over its own `OriginProducer`/`OriginConsumer`, and merges `Server::publish_router()` into its own axum app.

### Deliberately **not** done

- **No code moved into `moq-mux`.** str0m owns all RTP de/packetization; `moq-rtc` only ever sees decoded codec frames, and the codec-shape conversions it needs (Annex-B↔AVCC, etc.) already live in `moq-mux` and are called from here. There is no generic RTP layer to extract today.
- **No code moved into `moq-cli`.** `moq-cli` is a binary, so folding the gateway there would make it un-embeddable, which is the opposite of the goal. Binary packaging (e.g. a unified `moq` CLI with feature-gated subcommands) is deferred.

## Test plan

- [x] `cargo build -p moq-rtc --no-default-features --lib` (lean embed build)
- [x] `cargo build -p moq-rtc` (default: binary + `server`)
- [x] `cargo clippy -p moq-rtc --no-default-features --lib` and `--all-targets` clean
- [x] `cargo test -p moq-rtc` (5 passed)
- [x] Verified the lean dependency tree excludes `moq-native`/`clap`/`axum-server`/`sd-notify` (`rustls`/`tower-http` remain only transitively via `reqwest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELbTGpbGPyFrvJS7CfWYmQ)_