### PR TITLE
ci: add 60m timeout to the Check job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,9 @@ jobs:
     # persistent CARGO_TARGET_DIR). Fork PRs fall back to GitHub-hosted ARM so
     # untrusted code never runs on the box.
     runs-on: ${{ github.event.pull_request.head.repo.fork && fromJSON('["ubuntu-24.04-arm"]') || fromJSON('["self-hosted", "nix"]') }}
+    # Backstop a hang (e.g. a wedged test) instead of holding the runner for the
+    # 6-hour default. Generous enough for a cold first build.
+    timeout-minutes: 60
 
     steps:
       # GitHub-hosted fallback only: the self-hosted box already has disk space,


### PR DESCRIPTION
Adds `timeout-minutes: 60` to the self-hosted `Check` job (follow-up to #1775).

Without it, a wedged step holds the runner for GitHub's 6-hour default — the earlier `vitest`/`workerd` hang stalled ~45 min before being cancelled by hand. 60 min is comfortably above a cold first build while still failing fast on a true hang.

(Written by Claude)