### PR TITLE
fix(ci): unbreak the self-hosted A1 runner (libmoq clippy + ffmpeg bindgen headers)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,10 @@
             git
             cmake
             pkg-config
+            # Sets LIBCLANG_PATH + BINDGEN_EXTRA_CLANG_ARGS so ffmpeg-sys-next's
+            # bindgen finds libc headers (<errno.h>) on hosts without system
+            # headers in /usr/include, e.g. the self-hosted runner.
+            rustPlatform.bindgenHook
             glib
             libressl
             ffmpeg
@@ -223,18 +227,6 @@
           # Nix's _FORTIFY_SOURCE hardening (requires -O).
           hardeningDisable = [ "fortify" ];
 
-          shellHook =
-            ''
-              export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
-            ''
-            # ffmpeg-sys-next runs bindgen, whose libclang doesn't inherit the
-            # nix cc wrapper's libc include paths. On a host without system
-            # headers in /usr/include (e.g. the self-hosted runner) it then
-            # can't find <errno.h>. Feed it the same libc cflags the C compiler
-            # uses. macOS finds headers via the SDK, so this is Linux-only.
-            + pkgs.lib.optionalString (!pkgs.stdenv.isDarwin) ''
-              export BINDGEN_EXTRA_CLANG_ARGS="''${BINDGEN_EXTRA_CLANG_ARGS:-} $(< ${pkgs.stdenv.cc}/nix-support/libc-cflags)"
-            '';
         };
 
         formatter = pkgs.nixfmt-tree;

--- a/flake.nix
+++ b/flake.nix
@@ -223,9 +223,18 @@
           # Nix's _FORTIFY_SOURCE hardening (requires -O).
           hardeningDisable = [ "fortify" ];
 
-          shellHook = ''
-            export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
-          '';
+          shellHook =
+            ''
+              export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
+            ''
+            # ffmpeg-sys-next runs bindgen, whose libclang doesn't inherit the
+            # nix cc wrapper's libc include paths. On a host without system
+            # headers in /usr/include (e.g. the self-hosted runner) it then
+            # can't find <errno.h>. Feed it the same libc cflags the C compiler
+            # uses. macOS finds headers via the SDK, so this is Linux-only.
+            + pkgs.lib.optionalString (!pkgs.stdenv.isDarwin) ''
+              export BINDGEN_EXTRA_CLANG_ARGS="''${BINDGEN_EXTRA_CLANG_ARGS:-} $(< ${pkgs.stdenv.cc}/nix-support/libc-cflags)"
+            '';
         };
 
         formatter = pkgs.nixfmt-tree;

--- a/rs/libmoq/src/ffi.rs
+++ b/rs/libmoq/src/ffi.rs
@@ -228,7 +228,7 @@ pub fn parse_url(url: *const c_char, url_len: usize) -> Result<Url, Error> {
 /// # Safety
 /// The caller must ensure that cstr is valid for 'a.
 pub unsafe fn parse_str<'a>(cstr: *const c_char, cstr_len: usize) -> Result<&'a str, Error> {
-	let slice = unsafe { parse_slice(cstr as *const u8, cstr_len)? };
+	let slice = unsafe { parse_slice(cstr.cast::<u8>(), cstr_len)? };
 	let string = std::str::from_utf8(slice)?;
 	Ok(string)
 }

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -264,7 +264,7 @@ fn publish_catalog_roundtrip() {
 	assert_eq!(unsafe { moq_consume_video_config(catalog_id, 0, &mut video_cfg) }, 0);
 	let codec = unsafe {
 		std::str::from_utf8(std::slice::from_raw_parts(
-			video_cfg.codec as *const u8,
+			video_cfg.codec.cast::<u8>(),
 			video_cfg.codec_len,
 		))
 	}
@@ -539,7 +539,7 @@ fn local_announce() {
 	assert!(info.active, "broadcast should be active");
 
 	let announced_path =
-		unsafe { std::str::from_utf8(std::slice::from_raw_parts(info.path as *const u8, info.path_len)).unwrap() };
+		unsafe { std::str::from_utf8(std::slice::from_raw_parts(info.path.cast::<u8>(), info.path_len)).unwrap() };
 	assert_eq!(announced_path, "test/broadcast");
 
 	assert_eq!(moq_origin_announced_close(announced_task), 0);
@@ -626,7 +626,7 @@ fn local_publish_consume() {
 
 	let codec = unsafe {
 		std::str::from_utf8(std::slice::from_raw_parts(
-			audio_cfg.codec as *const u8,
+			audio_cfg.codec.cast::<u8>(),
 			audio_cfg.codec_len,
 		))
 	}
@@ -822,7 +822,7 @@ fn video_publish_consume() {
 
 	let codec = unsafe {
 		std::str::from_utf8(std::slice::from_raw_parts(
-			video_cfg.codec as *const u8,
+			video_cfg.codec.cast::<u8>(),
 			video_cfg.codec_len,
 		))
 	}


### PR DESCRIPTION
Two independent failures break the `Check` job on the self-hosted A1 (arm64) runner introduced in #1775. Both are masked on GitHub-hosted Ubuntu and block trusted PRs (e.g. #1781).

## 1. libmoq clippy: platform-dependent cast

```
error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
   --> rs/libmoq/src/ffi.rs:231:35
```

`cstr` is `*const c_char`. `c_char` is `u8` on arm64 Linux (no-op cast → `unnecessary_cast` under `-D warnings`) but `i8` on x86/macOS (cast required, can't be removed). Fix: `cstr.cast::<u8>()` works on both and isn't flagged.

## 2. ffmpeg-sys-next bindgen can't find `<errno.h>`

```
.../ffmpeg-8.1-dev/include/libavutil/common.h:33:10: fatal error: 'errno.h' file not found
Unable to generate bindings: ClangDiagnostic(...)
```

The devshell exports `LIBCLANG_PATH` but not `BINDGEN_EXTRA_CLANG_ARGS`, so bindgen's libclang has no path to libc headers. GitHub-hosted Ubuntu has system glibc headers in `/usr/include`, which hid this; the A1 runner is headerless, so any cold-cache `ffmpeg-sys-next` build fails (a warm cache passes, which is why it looked intermittent). Fix: export `BINDGEN_EXTRA_CLANG_ARGS` from the cc wrapper's `libc-cflags` (Linux only; macOS uses the SDK).

## Test plan

- [x] `cargo clippy -p libmoq --all-targets` clean on macOS (`c_char = i8`)
- [x] `nix eval` of both devShell `shellHook`s succeeds; Linux branch emits the `BINDGEN_EXTRA_CLANG_ARGS` export, Darwin branch unchanged
- [ ] `Check` green on the A1 runner (the real verification — neither issue reproduces on macOS)

(Written by Claude)