### PR TITLE
fix(net): cap random origin id at 53 bits in JS client

### DIFF
--- a/js/net/src/lite/origin.ts
+++ b/js/net/src/lite/origin.ts
@@ -16,16 +16,22 @@ export const OriginSchema = z
 export type Origin = z.infer<typeof OriginSchema>;
 
 /**
- * Generate a fresh origin with a random non-zero 62-bit id.
+ * Generate a fresh origin with a random non-zero id.
  *
  * `crypto.getRandomValues` is overkill for best-effort loop detection, but
  * used for slightly better distribution than `Math.random` at negligible cost.
+ *
+ * TEMPORARY: the wire format allows 62 bits, but older `@moq/lite` JS clients
+ * decode `AnnounceInterest.exclude_hop` as a u53 (number) and throw on anything
+ * > 2^53-1. To keep those clients alive against fresh peers, we cap the random
+ * id at 53 bits. Restore to 62 bits once the u62 fix has propagated to deployed
+ * bundles. Mirrors `Origin::random` in rs/moq-net.
  */
 export function randomOrigin(): Origin {
 	const buf = new BigUint64Array(1);
 	crypto.getRandomValues(buf);
-	// Mask to 62 bits.
-	const raw = buf[0] & 0x3fff_ffff_ffff_ffffn;
+	// Mask to 53 bits.
+	const raw = buf[0] & 0x1f_ffff_ffff_ffffn;
 	// Guard against the (astronomically unlikely) zero draw.
 	return OriginSchema.parse(raw === 0n ? 1n : raw);
 }


### PR DESCRIPTION
## Summary

The JS client (`@moq/net`) generated a **62-bit** random origin id, while the Rust client (`rs/moq-net`) already caps its generated id at **53 bits**. This brings the two into sync.

Older `@moq/lite` JS clients decode `AnnounceInterest.exclude_hop` as a `u53` (a JS `number`) and throw on any value `> 2^53-1`. A 62-bit origin generated by a fresh peer would crash those deployed bundles. Capping the *generated* value at 53 bits keeps them alive against fresh peers.

This is the JS half of the same TEMPORARY workaround already present in `Origin::random` (rs/moq-net). The wire format and `OriginSchema` still permit the full 62 bits. Only the value we generate is capped. Both should be restored to 62 bits once the u62 fix has propagated to deployed bundles.

## Changes

- `js/net/src/lite/origin.ts`: mask `randomOrigin()` to 53 bits (`0x1f_ffff_ffff_ffffn`) instead of 62 bits, with a comment mirroring the Rust rationale.

## Test plan

- [x] `biome check` passes on the changed file
- [x] Non-zero guard and `OriginSchema` validation unchanged

(Written by Claude)