### PR TITLE
feat(relay): add --cluster-id to set a fixed origin id

### DIFF
--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -61,7 +61,7 @@ Set `cluster.id` to pin a stable id across restarts:
 id = 12345
 ```
 
-The id must be non-zero and below 2^62 (the wire varint limit); an out-of-range value is ignored and a random id is used instead. Keep it below 2^53 if older `@moq/lite` browser clients connect to the cluster, since they decode hop ids as a `u53` and reject anything larger. Give each relay a distinct id, otherwise two nodes sharing one id can break loop detection.
+The id must be non-zero and below 2^62 (the wire varint limit); an out-of-range value is an error at startup. Keep it below 2^53 if older `@moq/lite` browser clients connect to the cluster, since they decode hop ids as a `u53` and reject anything larger. Give each relay a distinct id, otherwise two nodes sharing one id can break loop detection.
 
 ## Dynamic peer lists
 

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -50,6 +50,19 @@ When two gossiping nodes discover each other, only one of them dials: the node w
 
 A relay with `node` + `mesh` and no `connect` is a passive rendezvous: it sits and waits for inbound connections, then helps everyone else find each other.
 
+## Origin id
+
+Each relay has an origin id: the value it adds to a broadcast's hop list for loop detection and shortest-path routing. By default a fresh random id is picked on every start, which is fine for loop detection but means a relay looks like a brand-new node each time it restarts.
+
+Set `cluster.id` to pin a stable id across restarts:
+
+```toml
+[cluster]
+id = 12345
+```
+
+The id must be non-zero and below 2^62 (the wire varint limit); an out-of-range value is ignored and a random id is used instead. Keep it below 2^53 if older `@moq/lite` browser clients connect to the cluster, since they decode hop ids as a `u53` and reject anything larger. Give each relay a distinct id, otherwise two nodes sharing one id can break loop detection.
+
 ## Dynamic peer lists
 
 `cluster.connect` is fixed at startup, so adding or removing a node means editing every affected config and restarting. When you'd rather keep the topology somewhere external and change it without a redeploy, point `cluster.connect_api` at an HTTP(S) endpoint or a local file:

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -242,9 +242,9 @@ pub struct ClusterConfig {
 	///
 	/// Unset (the default) picks a fresh random id on every start. Set it to give
 	/// a node a stable identity across restarts. Must be non-zero and below 2^62
-	/// (the wire varint limit); an out-of-range value is ignored in favor of a
-	/// random id. Keep it below 2^53 for compatibility with older `@moq/lite` JS
-	/// clients, which decode hop ids as a `u53` and reject anything larger.
+	/// (the wire varint limit); an out-of-range value errors at startup. Keep it
+	/// below 2^53 for compatibility with older `@moq/lite` JS clients, which
+	/// decode hop ids as a `u53` and reject anything larger.
 	#[arg(id = "cluster-id", long = "cluster-id", env = "MOQ_CLUSTER_ID")]
 	pub id: Option<u64>,
 
@@ -356,39 +356,27 @@ impl Cluster {
 	/// Use [`with_client`](Self::with_client) to enable dialing remote peers
 	/// (required when `config.connect` is non-empty), and
 	/// [`with_stats`](Self::with_stats) to enable metrics publishing.
-	pub fn new(config: ClusterConfig) -> Self {
+	///
+	/// Errors if `config.id` is set but invalid: it must be non-zero and below
+	/// 2^62 (the wire varint limit). An unset id picks a fresh random origin.
+	pub fn new(config: ClusterConfig) -> anyhow::Result<Self> {
 		let origin = match config.id {
-			Some(0) => {
-				tracing::warn!("--cluster-id 0 is reserved; using a random origin instead");
-				Origin::random()
-			}
+			Some(0) => anyhow::bail!("--cluster-id must be non-zero"),
 			Some(id) if id >= 1 << 62 => {
-				tracing::warn!(
-					id,
-					"--cluster-id must be below 2^62 (wire varint limit); using a random origin instead"
-				);
-				Origin::random()
+				anyhow::bail!("--cluster-id must be below 2^62 (wire varint limit), got {id}")
 			}
-			Some(id) => {
-				if id >= 1 << 53 {
-					tracing::warn!(
-						id,
-						"--cluster-id exceeds 2^53-1; older @moq/lite JS clients may reject it"
-					);
-				}
-				Origin::from(id)
-			}
+			Some(id) => Origin::from(id),
 			None => Origin::random(),
 		}
 		.produce();
 		tracing::info!(origin_id = %origin.id, configured = config.id.is_some(), "cluster initialized");
-		Cluster {
+		Ok(Cluster {
 			config,
 			client: None,
 			client_tls: None,
 			origin,
 			stats: Stats::default(),
-		}
+		})
 	}
 
 	/// Attach a QUIC client used to dial cluster peers.
@@ -1141,7 +1129,7 @@ mod tests {
 			root: Some("legacy-root.example.com:4443".to_string()),
 			..Default::default()
 		};
-		let err = Cluster::new(config).run().await.expect_err("should error");
+		let err = Cluster::new(config).unwrap().run().await.expect_err("should error");
 		let msg = format!("{err}");
 		assert!(msg.contains("cluster.root"), "missing cluster.root in: {msg}");
 		assert!(msg.contains("--cluster-connect"), "missing --cluster-connect in: {msg}");
@@ -1156,7 +1144,7 @@ mod tests {
 			mesh: Some("true".to_string()),
 			..Default::default()
 		};
-		let err = Cluster::new(config).run().await.expect_err("should error");
+		let err = Cluster::new(config).unwrap().run().await.expect_err("should error");
 		let msg = format!("{err}");
 		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
 		assert!(msg.contains("--cluster-mesh"), "missing --cluster-mesh in: {msg}");
@@ -1169,21 +1157,23 @@ mod tests {
 		let cluster = Cluster::new(ClusterConfig {
 			id: Some(42),
 			..Default::default()
-		});
+		})
+		.expect("valid id");
 		assert_eq!(cluster.origin.id, 42);
 	}
 
-	/// A reserved (0) or out-of-range (>= 2^62) `cluster.id` is ignored in favor
-	/// of a random origin rather than producing an unencodable hop id.
+	/// A reserved (0) or out-of-range (>= 2^62) `cluster.id` is rejected rather
+	/// than producing an unencodable hop id.
 	#[test]
-	fn cluster_id_out_of_range_falls_back_to_random() {
+	fn cluster_id_out_of_range_errors() {
 		for bad in [0, 1u64 << 62] {
-			let cluster = Cluster::new(ClusterConfig {
+			let err = Cluster::new(ClusterConfig {
 				id: Some(bad),
 				..Default::default()
-			});
-			assert_ne!(cluster.origin.id, bad);
-			assert!(cluster.origin.id > 0 && cluster.origin.id < 1 << 62);
+			})
+			.err()
+			.expect("should error");
+			assert!(format!("{err}").contains("--cluster-id"), "got: {err}");
 		}
 	}
 
@@ -1202,7 +1192,7 @@ mod tests {
 
 		let rt = tokio::runtime::Runtime::new().unwrap();
 		let err = rt
-			.block_on(Cluster::new(config.cluster).run())
+			.block_on(Cluster::new(config.cluster).unwrap().run())
 			.expect_err("should error");
 		assert!(format!("{err}").contains("cluster.root"));
 	}
@@ -1217,7 +1207,8 @@ mod tests {
 			node: Some("rendezvous.example.com:4443".to_string()),
 			mesh: Some("true".to_string()),
 			..Default::default()
-		});
+		})
+		.unwrap();
 
 		// Snapshot a consumer on the cluster origin before run() takes ownership of
 		// `cluster` so we can later check that the registration was published.
@@ -1272,7 +1263,8 @@ mod tests {
 		let cluster = Cluster::new(ClusterConfig {
 			mesh: Some("rendezvous.example.com:4443".to_string()),
 			..Default::default()
-		});
+		})
+		.unwrap();
 		let (gossip, node) = cluster.resolve_mesh().expect("legacy mesh url resolves");
 		assert!(gossip);
 		assert_eq!(node.as_deref(), Some("rendezvous.example.com:4443"));
@@ -1330,7 +1322,8 @@ mod tests {
 			mesh: Some("a.example.com:4443".to_string()),
 			node: Some("b.example.com:4443".to_string()),
 			..Default::default()
-		});
+		})
+		.unwrap();
 		let err = cluster.resolve_mesh().expect_err("conflict should error");
 		assert!(format!("{err}").contains("conflicts with"), "got: {err}");
 	}

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -237,6 +237,17 @@ impl DialMap {
 #[non_exhaustive]
 #[group(id = "cluster-config")]
 pub struct ClusterConfig {
+	/// Fixed origin (hop) id for this relay, identifying it in the hop chains
+	/// carried on each broadcast for loop detection and shortest-path routing.
+	///
+	/// Unset (the default) picks a fresh random id on every start. Set it to give
+	/// a node a stable identity across restarts. Must be non-zero and below 2^62
+	/// (the wire varint limit); an out-of-range value is ignored in favor of a
+	/// random id. Keep it below 2^53 for compatibility with older `@moq/lite` JS
+	/// clients, which decode hop ids as a `u53` and reject anything larger.
+	#[arg(id = "cluster-id", long = "cluster-id", env = "MOQ_CLUSTER_ID")]
+	pub id: Option<u64>,
+
 	/// Connect to one or more other cluster nodes. Each peer is a full URL, e.g.
 	/// `https://host/?jwt=TOKEN`; a bare host or `host:port` is deprecated but
 	/// still accepted (wrapped in `https://.../`). Accepts a comma-separated list
@@ -346,8 +357,31 @@ impl Cluster {
 	/// (required when `config.connect` is non-empty), and
 	/// [`with_stats`](Self::with_stats) to enable metrics publishing.
 	pub fn new(config: ClusterConfig) -> Self {
-		let origin = Origin::random().produce();
-		tracing::info!(origin_id = %origin.id, "cluster initialized");
+		let origin = match config.id {
+			Some(0) => {
+				tracing::warn!("--cluster-id 0 is reserved; using a random origin instead");
+				Origin::random()
+			}
+			Some(id) if id >= 1 << 62 => {
+				tracing::warn!(
+					id,
+					"--cluster-id must be below 2^62 (wire varint limit); using a random origin instead"
+				);
+				Origin::random()
+			}
+			Some(id) => {
+				if id >= 1 << 53 {
+					tracing::warn!(
+						id,
+						"--cluster-id exceeds 2^53-1; older @moq/lite JS clients may reject it"
+					);
+				}
+				Origin::from(id)
+			}
+			None => Origin::random(),
+		}
+		.produce();
+		tracing::info!(origin_id = %origin.id, configured = config.id.is_some(), "cluster initialized");
 		Cluster {
 			config,
 			client: None,
@@ -1126,6 +1160,31 @@ mod tests {
 		let msg = format!("{err}");
 		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
 		assert!(msg.contains("--cluster-mesh"), "missing --cluster-mesh in: {msg}");
+	}
+
+	/// A valid `cluster.id` is used verbatim as the relay's origin id, giving the
+	/// node a stable identity across restarts.
+	#[test]
+	fn cluster_id_sets_origin() {
+		let cluster = Cluster::new(ClusterConfig {
+			id: Some(42),
+			..Default::default()
+		});
+		assert_eq!(cluster.origin.id, 42);
+	}
+
+	/// A reserved (0) or out-of-range (>= 2^62) `cluster.id` is ignored in favor
+	/// of a random origin rather than producing an unencodable hop id.
+	#[test]
+	fn cluster_id_out_of_range_falls_back_to_random() {
+		for bad in [0, 1u64 << 62] {
+			let cluster = Cluster::new(ClusterConfig {
+				id: Some(bad),
+				..Default::default()
+			});
+			assert_ne!(cluster.origin.id, bad);
+			assert!(cluster.origin.id > 0 && cluster.origin.id < 1 << 62);
+		}
 	}
 
 	/// `cluster.root` parsed from TOML triggers the same migration error.

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -289,4 +289,59 @@ system_roots = true
 			"TOML's client.tls.system_roots must not be clobbered by the CLI re-parse"
 		);
 	}
+
+	/// Same clap+TOML clobber guard for `cluster.id`. It's typed as `Option<u64>`
+	/// so an absent `--cluster-id` CLI flag must not wipe a TOML-configured value
+	/// during the `update_from` re-parse. A bare `u64` would reset it to `0`,
+	/// which the cluster treats as reserved and silently swaps for a random id,
+	/// defeating the point of pinning a stable origin via TOML.
+	static CLUSTER_ID_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	#[test]
+	fn cli_does_not_clobber_toml_cluster_id() {
+		let _guard = CLUSTER_ID_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: CLUSTER_ID_ENV_LOCK serializes this with any sibling test
+		// touching the same env var.
+		unsafe { std::env::remove_var("MOQ_CLUSTER_ID") };
+
+		let toml = r#"
+[cluster]
+id = 12345
+"#;
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("cluster-id-toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(
+			config.cluster.id,
+			Some(12345),
+			"TOML's cluster.id must not be clobbered by the CLI re-parse"
+		);
+	}
+
+	#[test]
+	fn cli_flag_overrides_toml_cluster_id() {
+		let _guard = CLUSTER_ID_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: CLUSTER_ID_ENV_LOCK serializes this with any sibling test
+		// touching the same env var.
+		unsafe { std::env::remove_var("MOQ_CLUSTER_ID") };
+
+		let toml = "[cluster]\nid = 12345\n";
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("cluster-id-cli-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![
+			std::ffi::OsString::from("moq-relay"),
+			std::ffi::OsString::from(&path),
+			std::ffi::OsString::from("--cluster-id=67890"),
+		];
+		let config = Config::parse_and_merge(args).expect("config load");
+		assert_eq!(config.cluster.id, Some(67890));
+	}
 }

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> anyhow::Result<()> {
 		config.auth.init().await?
 	};
 
-	let cluster = Cluster::new(config.cluster)
+	let cluster = Cluster::new(config.cluster)?
 		.with_client(client)
 		.with_client_tls(config.client.tls.build()?);
 	let stats = config.stats.build(cluster.origin.clone());

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -46,7 +46,7 @@ async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
 	auth_config.public = Some(public);
 	let auth = auth_config.init().await.expect("auth init");
 
-	let cluster = Cluster::new(ClusterConfig::default());
+	let cluster = Cluster::new(ClusterConfig::default()).expect("cluster init");
 
 	// moq_native::Server is needed for `tls_info`, even though we never
 	// expose HTTPS or QUIC in this test. Binding QUIC to `[::]:0` picks an


### PR DESCRIPTION
## Summary

A relay previously always generated a **random** origin id on startup ([`Origin::random()`](rs/moq-relay/src/cluster.rs)), so it looked like a brand-new node to the cluster after every restart. There was no way for an operator to assign a stable identity.

This adds a `cluster.id` config field (`--cluster-id` / `MOQ_CLUSTER_ID`) to pin the relay's origin/hop id across restarts. The origin id is the value a relay adds to a broadcast's hop list for loop detection and shortest-path routing.

```toml
[cluster]
id = 12345
```

## Behavior

- **Unset (default):** unchanged — a fresh random id per start.
- **Set to a valid value (`1 .. 2^62`):** used verbatim as the origin id.
- **Reserved (`0`) or out of range (`>= 2^62`, the wire varint limit):** **errors at startup** (`Cluster::new` returns `Err`), rather than producing an unencodable hop id.

Keep an explicit id below 2^53 if older `@moq/lite` browser clients connect, since they decode hop ids as a `u53`; this is documented but not enforced.

Typed as `Option<u64>` per the repo's config-flag convention so an absent CLI flag doesn't clobber a TOML-configured value during the merge re-parse.

## Public API changes

- `ClusterConfig` gains a `pub id: Option<u64>` field. `ClusterConfig` is `#[non_exhaustive]` with a `Default`, so additive.
- `Cluster::new` signature changes from `-> Self` to `-> anyhow::Result<Self>` so an invalid id fails loudly. Technically breaking for the (in-repo only) callers; all call sites updated.

## Files

- `rs/moq-relay/src/cluster.rs`: new `id` field; `Cluster::new` validates it and returns `Result`.
- `rs/moq-relay/src/main.rs`: propagate the new `Result`.
- `rs/moq-relay/src/config.rs`: regression tests for the clap+TOML clobber and CLI-override paths.
- `rs/moq-relay/tests/smoke.rs`: updated for the new `Result`.
- `doc/bin/relay/cluster.md`: new "Origin id" section (Cross-Package Sync).

## Test plan

- [x] `cargo test -p moq-relay` — all pass, including new tests (`cluster_id_sets_origin`, `cluster_id_out_of_range_errors`, `cli_does_not_clobber_toml_cluster_id`, `cli_flag_overrides_toml_cluster_id`)
- [x] `cargo clippy -p moq-relay` clean (via nix)
- [x] `cargo fmt --check` clean (via nix)

## Notes

Related to (but independent of) #1785, which caps the *randomly generated* id at 53 bits for the same `@moq/lite` u53 compatibility reason. This PR lets operators set an explicit id.

(Written by Claude)