### PR TITLE
feat(moq-net): encode Hop ID as fixed-width 64-bit on lite-05

### DIFF
--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -2,7 +2,7 @@ import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
 import { type Origin, OriginSchema } from "./origin.ts";
-import { Version } from "./version.ts";
+import { hopsFixedWidth, Version } from "./version.ts";
 
 // Must match the MAX_HOPS in Rust's model/origin.rs. Broadcasts with longer
 // hop chains are rejected; this keeps loop-detection bounded and rejects
@@ -35,10 +35,15 @@ export class Announce {
 				await w.u53(this.hops.length);
 				break;
 			default:
-				// Lite04+: hop count + individual Origin varints.
+				// Lite04+: hop count + individual Hop IDs. Lite05+ carries each id
+				// fixed-width (64-bit); Lite04 used a 62-bit varint.
 				await w.u53(this.hops.length);
 				for (const origin of this.hops) {
-					await w.u62(origin);
+					if (hopsFixedWidth(version)) {
+						await w.u64(origin);
+					} else {
+						await w.u62(origin);
+					}
 				}
 				break;
 		}
@@ -63,12 +68,13 @@ export class Announce {
 				break;
 			}
 			default: {
-				// Lite04+: hop count + individual Origin varints.
+				// Lite04+: hop count + individual Hop IDs. Lite05+ carries each id
+				// fixed-width (64-bit); Lite04 used a 62-bit varint.
 				const count = await r.u53();
 				if (count > MAX_HOPS) throw new Error(`hop count ${count} exceeds maximum ${MAX_HOPS}`);
 				hops = [];
 				for (let i = 0; i < count; i++) {
-					hops.push(OriginSchema.parse(await r.u62()));
+					hops.push(OriginSchema.parse(hopsFixedWidth(version) ? await r.u64() : await r.u62()));
 				}
 				break;
 			}
@@ -92,8 +98,8 @@ export class Announce {
 
 export class AnnounceInterest {
 	prefix: Path.Valid;
-	// 62-bit Origin id of the peer asking for announces. Zero means "no exclusion".
-	// Must be a bigint: peer origins are up to 62 bits and overflow u53.
+	// Hop ID of the peer asking for announces. Zero means "no exclusion".
+	// Must be a bigint: peer origins are up to 64 bits and overflow u53.
 	excludeHop: bigint;
 
 	constructor(prefix: Path.Valid, excludeHop: bigint = 0n) {
@@ -109,8 +115,12 @@ export class AnnounceInterest {
 			case Version.DRAFT_03:
 				break;
 			default:
-				// Lite04+: exclude_hop field (u62 varint).
-				await w.u62(this.excludeHop);
+				// Lite04+: exclude_hop Hop ID. Lite05+ fixed-width (64-bit); Lite04 a 62-bit varint.
+				if (hopsFixedWidth(version)) {
+					await w.u64(this.excludeHop);
+				} else {
+					await w.u62(this.excludeHop);
+				}
 				break;
 		}
 	}
@@ -124,7 +134,7 @@ export class AnnounceInterest {
 			case Version.DRAFT_03:
 				break;
 			default:
-				excludeHop = await r.u62();
+				excludeHop = hopsFixedWidth(version) ? await r.u64() : await r.u62();
 				break;
 		}
 		return new AnnounceInterest(prefix, excludeHop);
@@ -211,12 +221,13 @@ export class AnnounceOk {
 	}
 
 	async #encode(w: Writer) {
-		await w.u62(this.origin);
+		// lite-05 carries the Hop ID fixed-width (64-bit).
+		await w.u64(this.origin);
 		await w.u53(this.active);
 	}
 
 	static async #decode(r: Reader): Promise<AnnounceOk> {
-		const raw = await r.u62();
+		const raw = await r.u64();
 		// A zero responder id is never legitimate; it would stamp a placeholder onto chains.
 		if (raw === 0n) throw new Error("announce ok origin must be non-zero");
 		const origin = OriginSchema.parse(raw);

--- a/js/net/src/lite/origin.ts
+++ b/js/net/src/lite/origin.ts
@@ -1,22 +1,28 @@
 import * as z from "zod/mini";
 
 /**
- * A relay origin id, encoded as a 62-bit varint on the wire.
+ * A relay origin id (Hop ID), randomly assigned and carried in the hop chain.
  *
- * The {@link OriginSchema} validates any incoming value and brands it so the
- * type system enforces "only validated origins flow into hop lists." Internal
- * code that synthesizes an id (e.g. {@link randomOrigin}) uses
- * `OriginSchema.parse(...)` to produce a branded value from the raw bigint.
+ * On the wire lite-05+ encodes it as a fixed-width 64-bit integer (the full
+ * 64-bit space); older versions used a 62-bit varint. The {@link OriginSchema}
+ * validates any incoming value and brands it so the type system enforces "only
+ * validated origins flow into hop lists." Internal code that synthesizes an id
+ * (e.g. {@link randomOrigin}) uses `OriginSchema.parse(...)` to produce a
+ * branded value from the raw bigint.
  */
 export const OriginSchema = z
 	.bigint()
-	.check(z.refine((value) => value >= 0n && value < 1n << 62n, "Origin must be a non-negative 62-bit integer"))
+	.check(z.refine((value) => value >= 0n && value < 1n << 64n, "Origin must be a non-negative 64-bit integer"))
 	.brand("Origin");
 
 export type Origin = z.infer<typeof OriginSchema>;
 
 /**
- * Generate a fresh origin with a random non-zero 62-bit id.
+ * Generate a fresh origin with a random non-zero id.
+ *
+ * Masked to 62 bits: the same id is encoded as our self/exclude Hop ID, which on
+ * lite-04 is still a 62-bit varint (lite-05 carries the full 64-bit space). Staying
+ * within 62 bits keeps one generated id valid across both negotiated versions.
  *
  * `crypto.getRandomValues` is overkill for best-effort loop detection, but
  * used for slightly better distribution than `Math.random` at negligible cost.

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -11,6 +11,23 @@ export const Version = {
 
 export type Version = (typeof Version)[keyof typeof Version];
 
+/// Whether Hop IDs (ANNOUNCE / ANNOUNCE_OK) and `Exclude Hop` (ANNOUNCE_INTEREST) are
+/// carried as fixed-width 64-bit integers rather than varints. Added in lite-05: Hop IDs
+/// are randomly assigned, so a varint would almost never be shorter, and the fixed width
+/// buys the full 64-bit space (a varint caps at 62 bits).
+export function hopsFixedWidth(version: Version): boolean {
+	// Explicitly list older versions so future versions default to fixed-width.
+	switch (version) {
+		case Version.DRAFT_01:
+		case Version.DRAFT_02:
+		case Version.DRAFT_03:
+		case Version.DRAFT_04:
+			return false;
+		default:
+			return true;
+	}
+}
+
 /// The WebTransport subprotocol identifier for moq-lite.
 /// Version negotiation still happens via SETUP when this is used.
 export const ALPN = "moql";

--- a/js/net/src/stream.test.ts
+++ b/js/net/src/stream.test.ts
@@ -206,6 +206,34 @@ test("Reader u62 varint decoding", async () => {
 	expect(await reader.done()).toBe(true);
 });
 
+test("Reader u64 fixed-width decoding", async () => {
+	// Fixed-width always uses 8 bytes, including the full 64-bit space a varint can't reach.
+	const testValues = [0n, 1n, 63n, 1n << 53n, (1n << 62n) - 1n, 1n << 62n, (1n << 64n) - 1n];
+
+	const { stream, written } = createTestWritableStream();
+	const testWriter = new Writer(stream);
+
+	for (const value of testValues) {
+		await testWriter.u64(value);
+	}
+
+	testWriter.close();
+	await testWriter.closed;
+
+	const data = concatChunks(written);
+	// Every value occupies exactly 8 bytes.
+	expect(data.byteLength).toBe(testValues.length * 8);
+
+	const reader = new Reader(undefined, data);
+
+	for (const expectedValue of testValues) {
+		const actualValue = await reader.u64();
+		expect(actualValue).toBe(expectedValue);
+	}
+
+	expect(await reader.done()).toBe(true);
+});
+
 test("Reader string decoding", async () => {
 	const testStrings = ["hello", "🎉", "", "world with spaces", "multi\nline\nstring"];
 

--- a/js/net/src/stream.ts
+++ b/js/net/src/stream.ts
@@ -170,6 +170,16 @@ export class Reader {
 		return result;
 	}
 
+	// Fixed-width big-endian 64-bit integer (8 bytes), as opposed to the variable-length
+	// u62 varint. Used for randomly-assigned Hop IDs on lite-05+, where a varint would
+	// almost never be shorter and the fixed width buys the full 64-bit space.
+	async u64(): Promise<bigint> {
+		await this.#fillTo(8);
+		const slice = this.#slice(8);
+		const view = new DataView(slice.buffer, slice.byteOffset, slice.byteLength);
+		return view.getBigUint64(0);
+	}
+
 	// Returns a Number using 53-bits, the max Javascript can use for integer math.
 	// Values > 2^53-1 are coerced to a Number (precision is lost) and logged. We
 	// downgrade overflow from throw to warn so a stray u64 field on the wire (e.g.
@@ -294,6 +304,11 @@ export class Writer {
 		await this.write(setUint16(this.#scratch, v));
 	}
 
+	// Fixed-width big-endian 64-bit integer (8 bytes); counterpart to {@link Reader.u64}.
+	async u64(v: bigint) {
+		await this.write(setBigUint64(this.#scratch, v));
+	}
+
 	async i32(v: number) {
 		if (Math.abs(v) > MAX_U31) {
 			throw new Error(`overflow, value larger than 32-bits: ${v.toString()}`);
@@ -370,6 +385,12 @@ function setUint16(dst: ArrayBuffer, v: number): Uint8Array {
 function setInt32(dst: ArrayBuffer, v: number): Uint8Array {
 	const view = new DataView(dst, 0, 4);
 	view.setInt32(0, v);
+	return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+}
+
+function setBigUint64(dst: ArrayBuffer, v: bigint): Uint8Array {
+	const view = new DataView(dst, 0, 8);
+	view.setBigUint64(0, BigInt.asUintN(64, v));
 	return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
 }
 

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -97,6 +97,7 @@ pub struct AnnounceInterest<'a> {
 	// Request tracks with this prefix.
 	pub prefix: Path<'a>,
 	// If non-zero, the publisher SHOULD skip announces whose hop IDs contain this value.
+	// Carried as a Hop ID (varint on Lite04, fixed-width 64-bit on Lite05+); 0 means no exclusion.
 	pub exclude_hop: u64,
 }
 
@@ -105,7 +106,8 @@ impl Message for AnnounceInterest<'_> {
 		let prefix = Path::decode(r, version)?;
 		let exclude_hop = match version {
 			Version::Lite01 | Version::Lite02 | Version::Lite03 => 0,
-			_ => u64::decode(r, version)?,
+			// Decode as a Hop ID so the fixed-width vs varint choice tracks the version.
+			_ => Origin::decode(r, version)?.id,
 		};
 		Ok(Self { prefix, exclude_hop })
 	}
@@ -115,7 +117,7 @@ impl Message for AnnounceInterest<'_> {
 		match version {
 			Version::Lite01 | Version::Lite02 | Version::Lite03 => {}
 			_ => {
-				self.exclude_hop.encode(w, version)?;
+				Origin::from(self.exclude_hop).encode(w, version)?;
 			}
 		}
 
@@ -318,6 +320,49 @@ mod tests {
 	}
 
 	#[test]
+	fn announce_ok_full_64_bit_origin() {
+		// lite-05 carries the Hop ID fixed-width, so the full 64-bit space round-trips
+		// (a value a 62-bit varint could not hold).
+		let msg = AnnounceOk {
+			origin: Origin { id: u64::MAX },
+			active: 1,
+		};
+		assert_eq!(round_trip(&msg), msg);
+	}
+
+	#[test]
+	fn announce_ok_origin_is_fixed_width() {
+		let mut buf = bytes::BytesMut::new();
+		AnnounceOk {
+			origin: Origin { id: 1 },
+			active: 0,
+		}
+		.encode(&mut buf, Version::Lite05Wip)
+		.unwrap();
+		// size(1) + origin(8 fixed) + active(1 varint) = 10 bytes; a varint origin id of 1
+		// would have been a single byte, giving 3.
+		assert_eq!(buf.len(), 10);
+	}
+
+	#[test]
+	fn announce_interest_exclude_hop_round_trip() {
+		// A value above the old 62-bit varint ceiling only survives the fixed-width lite-05 path.
+		for &exclude_hop in &[0u64, 7, 1u64 << 53, u64::MAX] {
+			let msg = AnnounceInterest {
+				prefix: Path::new("foo/bar"),
+				exclude_hop,
+			};
+			let mut buf = bytes::BytesMut::new();
+			msg.encode(&mut buf, Version::Lite05Wip).unwrap();
+			let mut slice = &buf[..];
+			let got = AnnounceInterest::decode(&mut slice, Version::Lite05Wip).unwrap();
+			assert!(slice.is_empty(), "trailing bytes after decode");
+			assert_eq!(got.exclude_hop, exclude_hop);
+			assert_eq!(got.prefix, msg.prefix);
+		}
+	}
+
+	#[test]
 	fn announce_ok_rejects_old_versions() {
 		let msg = AnnounceOk {
 			origin: Origin { id: 1 },
@@ -340,11 +385,13 @@ mod tests {
 		}
 		.encode(&mut buf, Version::Lite05Wip)
 		.unwrap();
-		// origin id 1 sits right after the size prefix; rewrite it to 0.
+		// origin sits right after the size prefix; rewrite it to 0.
 		let bytes = &buf[..];
 		let mut patched = bytes.to_vec();
-		// size(1 byte) | origin varint(1 byte = 0x01) | active varint(1 byte)
-		patched[1] = 0x00;
+		// size(1 byte) | origin fixed-width 64-bit (8 bytes) | active varint(1 byte)
+		for b in &mut patched[1..9] {
+			*b = 0x00;
+		}
 		let mut slice = &patched[..];
 		assert!(matches!(
 			AnnounceOk::decode(&mut slice, Version::Lite05Wip),

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -29,6 +29,20 @@ impl Version {
 			_ => true,
 		}
 	}
+
+	/// Whether Hop IDs (ANNOUNCE / ANNOUNCE_OK) and `Exclude Hop` (ANNOUNCE_INTEREST)
+	/// are carried as fixed-width 64-bit integers rather than varints. Added in lite-05:
+	/// Hop IDs are randomly assigned, so a varint would almost never be shorter than its
+	/// fixed-width equivalent, and the fixed width buys the full 64-bit space (a varint
+	/// caps at 62 bits).
+	#[allow(clippy::match_like_matches_macro)]
+	pub fn hops_fixed_width(self) -> bool {
+		// Match form so future versions default forward (CLAUDE.md convention).
+		match self {
+			Self::Lite01 | Self::Lite02 | Self::Lite03 | Self::Lite04 => false,
+			_ => true,
+		}
+	}
 }
 
 impl fmt::Display for Version {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -14,16 +14,17 @@ use crate::{
 	coding::{Decode, DecodeError, Encode, EncodeError},
 };
 
-/// A relay origin, identified by a 62-bit varint on the wire.
+/// A relay origin (Hop ID), a randomly-assigned identifier carried in the hop chain.
 ///
 /// `id` must be non-zero for a real origin; `id == 0` is reserved as a
 /// placeholder for Lite03-style hops where the actual value isn't carried.
-/// Encoding a value outside the 62-bit range (>= 2^62) will fail at the
-/// varint layer; [`Origin::random`] picks a valid random nonzero id.
+/// On the wire lite-05+ encodes the id as a fixed-width 64-bit integer (the full
+/// 64-bit space), while older versions used a 62-bit varint. [`Origin::random`]
+/// picks a random nonzero id.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Origin {
-	/// Non-zero 62-bit identifier. Encoded as a QUIC varint on the wire.
+	/// Non-zero identifier. Encoded as a fixed-width 64-bit integer on the wire (lite-05+).
 	pub id: u64,
 }
 
@@ -64,25 +65,37 @@ impl fmt::Display for Origin {
 	}
 }
 
-impl<V: Copy> Encode<V> for Origin
-where
-	u64: Encode<V>,
-{
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) -> Result<(), EncodeError> {
-		self.id.encode(w, version)
+impl Encode<crate::lite::Version> for Origin {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: crate::lite::Version) -> Result<(), EncodeError> {
+		if version.hops_fixed_width() {
+			// lite-05+: fixed-width 64-bit. Hop IDs are random, so a varint would almost
+			// never be shorter, and the fixed width buys the full 64-bit space.
+			if w.remaining_mut() < 8 {
+				return Err(EncodeError::Short);
+			}
+			w.put_u64(self.id);
+			Ok(())
+		} else {
+			self.id.encode(w, version)
+		}
 	}
 }
 
-impl<V: Copy> Decode<V> for Origin
-where
-	u64: Decode<V>,
-{
-	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
-		let id = u64::decode(r, version)?;
-		if id >= 1u64 << 62 {
-			return Err(DecodeError::InvalidValue);
+impl Decode<crate::lite::Version> for Origin {
+	fn decode<R: bytes::Buf>(r: &mut R, version: crate::lite::Version) -> Result<Self, DecodeError> {
+		if version.hops_fixed_width() {
+			if r.remaining() < 8 {
+				return Err(DecodeError::Short);
+			}
+			// The full 64-bit space is valid here (no 62-bit cap).
+			Ok(Self { id: r.get_u64() })
+		} else {
+			let id = u64::decode(r, version)?;
+			if id >= 1u64 << 62 {
+				return Err(DecodeError::InvalidValue);
+			}
+			Ok(Self { id })
 		}
-		Ok(Self { id })
 	}
 }
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -87,14 +87,13 @@ impl Decode<crate::lite::Version> for Origin {
 			if r.remaining() < 8 {
 				return Err(DecodeError::Short);
 			}
-			// The full 64-bit space is valid here (no 62-bit cap).
+			// Fixed-width carries the full 64-bit space.
 			Ok(Self { id: r.get_u64() })
 		} else {
-			let id = u64::decode(r, version)?;
-			if id >= 1u64 << 62 {
-				return Err(DecodeError::InvalidValue);
-			}
-			Ok(Self { id })
+			// A lite varint is QUIC-encoded, so it already caps at 62 bits.
+			Ok(Self {
+				id: u64::decode(r, version)?,
+			})
 		}
 	}
 }


### PR DESCRIPTION
Implements [moq-dev/drafts#33](https://github.com/moq-dev/drafts/pull/33) ("Encode Hop ID as fixed-width 64-bit integer") for **moq-lite-05**.

Hop IDs are randomly assigned, so a variable-length integer would almost never be shorter than its fixed-width equivalent. Switching to a fixed-width big-endian 64-bit integer also recovers the 2 bits a 62-bit varint would have cost (the value can now use the full 64-bit space).

## Summary

Applies to the three moq-lite wire fields that carry Hop ID values, gated to lite-05+ so lite-04 and earlier keep the varint:

- **ANNOUNCE_OK** `Hop ID` → `(64)`
- **ANNOUNCE** `Hop ID` list → `(64)`
- **ANNOUNCE_INTEREST** `Exclude Hop` → `(64)`

### Rust (`rs/moq-net`)
- New `Version::hops_fixed_width()` predicate. Older versions are listed explicitly so future versions default forward (per the version-matching convention).
- `Origin`'s `Encode`/`Decode` are now concrete over `lite::Version` so they can branch: the fixed-width path uses big-endian `put_u64`/`get_u64` and carries the full 64-bit space (no 62-bit cap); older versions keep the varint + cap.
- `exclude_hop` routes through `Origin` to share the same branch.

### JS mirror (`js/net`)
- Added `Reader.u64()` / `Writer.u64()` fixed-width helpers (+ `setBigUint64`).
- `hopsFixedWidth(version)` predicate mirroring Rust.
- `OriginSchema` widened 62 → 64 bits. `randomOrigin` deliberately stays masked to 62 bits, because the same id must still varint-encode if a session negotiates lite-04.

### Not included
The **moqt relay-hops** half of the draft PR (`HOP_PATH` list of 8-byte entries, `EXCLUDE_HOP` type `0x40B58` → `0x40B59` length-prefixed) targets the moq-transport KVP parameters, which are not implemented anywhere in this repo yet, so there is nothing to change.

## Branch targeting
Targets **dev** per the branch-targeting rules (wire-protocol change under `rs/moq-net`).

## Test plan
- [x] `cargo test -p moq-net` (389 pass), incl. new tests: full `u64::MAX` origin round-trip, fixed-width byte count, `exclude_hop` round-trip across `[0, 7, 1<<53, u64::MAX]`.
- [x] Full Rust workspace builds (moq-relay / moq-bench included).
- [x] `bun test` in `js/net` (180 pass), incl. new `u64` fixed-width stream test; integration test exercises the AnnounceOk + hops flow end-to-end.
- [x] clippy + `cargo fmt --check` (via nix), biome, and `tsc --noEmit` all clean.

(Written by Claude)