### PR TITLE
feat(relay): close sessions when the token/cert expires

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,6 +3948,7 @@ dependencies = [
  "web-transport-quiche",
  "web-transport-quinn",
  "web-transport-trait",
+ "x509-parser",
 ]
 
 [[package]]

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -120,6 +120,8 @@ The JWT payload contains these claims:
 | `exp` | Expiration time (Unix timestamp) |
 | `iat` | Issued-at time (Unix timestamp) |
 
+The `exp` claim is enforced for the whole session, not just at connect time. The relay closes the connection once `exp` passes, so a client must reconnect with a fresh token to continue. The same applies to mTLS: the connection is closed when the client certificate's `notAfter` is reached.
+
 ### Path Matching
 
 The `root` claim sets a base path. The `pub` and `sub` claims are suffixes:

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -17,8 +17,8 @@ doctest = false
 
 [features]
 default = ["quinn", "aws-lc-rs", "websocket"]
-quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
-noq = ["dep:web-transport-noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
+quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "dep:x509-parser", "watch"]
+noq = ["dep:web-transport-noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "dep:x509-parser", "watch"]
 quiche = ["dep:web-transport-quiche", "dep:rcgen"]
 # Filesystem watcher for hot-reloading on-disk TLS certs/keys; the QUIC backends imply it.
 watch = ["dep:notify"]
@@ -64,6 +64,7 @@ web-transport-proto = { workspace = true, optional = true }
 web-transport-quiche = { workspace = true, optional = true }
 web-transport-quinn = { workspace = true, optional = true }
 web-transport-trait = { workspace = true }
+x509-parser = { version = "0.18", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-android = { version = "0.2", optional = true }

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -17,8 +17,8 @@ doctest = false
 
 [features]
 default = ["quinn", "aws-lc-rs", "websocket"]
-quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "dep:x509-parser", "watch"]
-noq = ["dep:web-transport-noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "dep:x509-parser", "watch"]
+quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
+noq = ["dep:web-transport-noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
 quiche = ["dep:web-transport-quiche", "dep:rcgen"]
 # Filesystem watcher for hot-reloading on-disk TLS certs/keys; the QUIC backends imply it.
 watch = ["dep:notify"]
@@ -64,7 +64,7 @@ web-transport-proto = { workspace = true, optional = true }
 web-transport-quiche = { workspace = true, optional = true }
 web-transport-quinn = { workspace = true, optional = true }
 web-transport-trait = { workspace = true }
-x509-parser = { version = "0.18", optional = true }
+x509-parser = "0.18"
 
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-android = { version = "0.2", optional = true }

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -515,25 +515,14 @@ impl NoqRequest {
 		}
 	}
 
-	/// Whether the peer presented a client certificate that rustls validated
-	/// against the configured `tls.root` during the handshake.
-	pub fn has_peer_certificate(&self) -> bool {
+	/// The client certificate chain the peer presented, if any, validated by
+	/// rustls against the configured `tls.root` during the handshake.
+	pub fn peer_identity(&self) -> Option<crate::tls::PeerIdentity> {
 		let conn = match self {
 			NoqRequest::Raw { connection, .. } => connection,
 			NoqRequest::WebTransport { request, .. } => request.conn(),
 		};
-		conn.peer_identity().is_some()
-	}
-
-	/// The `notAfter` of the peer's end-entity certificate, if it presented one
-	/// that rustls validated during the handshake. Used to close the session
-	/// once the certificate expires.
-	pub fn peer_certificate_expiry(&self) -> Option<std::time::SystemTime> {
-		let conn = match self {
-			NoqRequest::Raw { connection, .. } => connection,
-			NoqRequest::WebTransport { request, .. } => request.conn(),
-		};
-		crate::tls::peer_certificate_expiry(conn.peer_identity())
+		crate::tls::PeerIdentity::from_any(conn.peer_identity())
 	}
 
 	/// Reject the session with a status code.

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -525,6 +525,17 @@ impl NoqRequest {
 		conn.peer_identity().is_some()
 	}
 
+	/// The `notAfter` of the peer's end-entity certificate, if it presented one
+	/// that rustls validated during the handshake. Used to close the session
+	/// once the certificate expires.
+	pub fn peer_certificate_expiry(&self) -> Option<std::time::SystemTime> {
+		let conn = match self {
+			NoqRequest::Raw { connection, .. } => connection,
+			NoqRequest::WebTransport { request, .. } => request.conn(),
+		};
+		crate::tls::peer_certificate_expiry(conn.peer_identity())
+	}
+
 	/// Reject the session with a status code.
 	pub async fn close(
 		self,

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -514,25 +514,14 @@ impl QuinnRequest {
 		}
 	}
 
-	/// Whether the peer presented a client certificate that rustls validated
-	/// against the configured `tls.root` during the handshake.
-	pub fn has_peer_certificate(&self) -> bool {
+	/// The client certificate chain the peer presented, if any, validated by
+	/// rustls against the configured `tls.root` during the handshake.
+	pub fn peer_identity(&self) -> Option<crate::tls::PeerIdentity> {
 		let conn = match self {
 			QuinnRequest::Raw { connection, .. } => connection,
 			QuinnRequest::WebTransport { request, .. } => request.conn(),
 		};
-		conn.peer_identity().is_some()
-	}
-
-	/// The `notAfter` of the peer's end-entity certificate, if it presented one
-	/// that rustls validated during the handshake. Used to close the session
-	/// once the certificate expires.
-	pub fn peer_certificate_expiry(&self) -> Option<std::time::SystemTime> {
-		let conn = match self {
-			QuinnRequest::Raw { connection, .. } => connection,
-			QuinnRequest::WebTransport { request, .. } => request.conn(),
-		};
-		crate::tls::peer_certificate_expiry(conn.peer_identity())
+		crate::tls::PeerIdentity::from_any(conn.peer_identity())
 	}
 
 	/// Reject the session with a status code.

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -524,6 +524,17 @@ impl QuinnRequest {
 		conn.peer_identity().is_some()
 	}
 
+	/// The `notAfter` of the peer's end-entity certificate, if it presented one
+	/// that rustls validated during the handshake. Used to close the session
+	/// once the certificate expires.
+	pub fn peer_certificate_expiry(&self) -> Option<std::time::SystemTime> {
+		let conn = match self {
+			QuinnRequest::Raw { connection, .. } => connection,
+			QuinnRequest::WebTransport { request, .. } => request.conn(),
+		};
+		crate::tls::peer_certificate_expiry(conn.peer_identity())
+	}
+
 	/// Reject the session with a status code.
 	pub async fn close(
 		self,

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -618,7 +618,6 @@ impl Request {
 	/// Only the Quinn and noq backends support mTLS; other backends always
 	/// return `None`. Use it to grant elevated access or to close the session
 	/// once the certificate expires (see [`crate::tls::PeerIdentity::expiry`]).
-	#[cfg(any(feature = "quinn", feature = "noq"))]
 	pub fn peer_identity(&self) -> Option<crate::tls::PeerIdentity> {
 		match self.kind {
 			#[cfg(feature = "quinn")]
@@ -631,6 +630,14 @@ impl Request {
 			RequestKind::Iroh(_) => None,
 			#[cfg(feature = "websocket")]
 			RequestKind::WebSocket(_) => None,
+			#[cfg(not(any(
+				feature = "noq",
+				feature = "quinn",
+				feature = "quiche",
+				feature = "iroh",
+				feature = "websocket"
+			)))]
+			_ => None,
 		}
 	}
 }

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -612,58 +612,25 @@ impl Request {
 		}
 	}
 
-	/// Whether the peer presented a client certificate during the handshake
-	/// that chained to a configured [`crate::tls::Server::root`].
-	///
-	/// Only the Quinn and noq backends support mTLS; other backends always return `false`.
-	pub fn has_peer_certificate(&self) -> bool {
-		match self.kind {
-			#[cfg(feature = "quinn")]
-			RequestKind::Quinn(ref request) => request.has_peer_certificate(),
-			#[cfg(feature = "noq")]
-			RequestKind::Noq(ref request) => request.has_peer_certificate(),
-			#[cfg(feature = "quiche")]
-			RequestKind::Quiche(_) => false,
-			#[cfg(feature = "iroh")]
-			RequestKind::Iroh(_) => false,
-			#[cfg(feature = "websocket")]
-			RequestKind::WebSocket(_) => false,
-			#[cfg(not(any(
-				feature = "noq",
-				feature = "quinn",
-				feature = "quiche",
-				feature = "iroh",
-				feature = "websocket"
-			)))]
-			_ => false,
-		}
-	}
-
-	/// The expiry (`notAfter`) of the peer's end-entity certificate, if it
-	/// presented one that chained to a configured [`crate::tls::Server::root`].
+	/// The client certificate chain the peer presented, if any, validated
+	/// against a configured [`crate::tls::Server::root`] during the handshake.
 	///
 	/// Only the Quinn and noq backends support mTLS; other backends always
-	/// return `None`. Lets the caller close the session once the cert expires.
-	pub fn peer_certificate_expiry(&self) -> Option<std::time::SystemTime> {
+	/// return `None`. Use it to grant elevated access or to close the session
+	/// once the certificate expires (see [`crate::tls::PeerIdentity::expiry`]).
+	#[cfg(any(feature = "quinn", feature = "noq"))]
+	pub fn peer_identity(&self) -> Option<crate::tls::PeerIdentity> {
 		match self.kind {
 			#[cfg(feature = "quinn")]
-			RequestKind::Quinn(ref request) => request.peer_certificate_expiry(),
+			RequestKind::Quinn(ref request) => request.peer_identity(),
 			#[cfg(feature = "noq")]
-			RequestKind::Noq(ref request) => request.peer_certificate_expiry(),
+			RequestKind::Noq(ref request) => request.peer_identity(),
 			#[cfg(feature = "quiche")]
 			RequestKind::Quiche(_) => None,
 			#[cfg(feature = "iroh")]
 			RequestKind::Iroh(_) => None,
 			#[cfg(feature = "websocket")]
 			RequestKind::WebSocket(_) => None,
-			#[cfg(not(any(
-				feature = "noq",
-				feature = "quinn",
-				feature = "quiche",
-				feature = "iroh",
-				feature = "websocket"
-			)))]
-			_ => None,
 		}
 	}
 }

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -638,6 +638,34 @@ impl Request {
 			_ => false,
 		}
 	}
+
+	/// The expiry (`notAfter`) of the peer's end-entity certificate, if it
+	/// presented one that chained to a configured [`crate::tls::Server::root`].
+	///
+	/// Only the Quinn and noq backends support mTLS; other backends always
+	/// return `None`. Lets the caller close the session once the cert expires.
+	pub fn peer_certificate_expiry(&self) -> Option<std::time::SystemTime> {
+		match self.kind {
+			#[cfg(feature = "quinn")]
+			RequestKind::Quinn(ref request) => request.peer_certificate_expiry(),
+			#[cfg(feature = "noq")]
+			RequestKind::Noq(ref request) => request.peer_certificate_expiry(),
+			#[cfg(feature = "quiche")]
+			RequestKind::Quiche(_) => None,
+			#[cfg(feature = "iroh")]
+			RequestKind::Iroh(_) => None,
+			#[cfg(feature = "websocket")]
+			RequestKind::WebSocket(_) => None,
+			#[cfg(not(any(
+				feature = "noq",
+				feature = "quinn",
+				feature = "quiche",
+				feature = "iroh",
+				feature = "websocket"
+			)))]
+			_ => None,
+		}
+	}
 }
 
 /// Server ID for QUIC-LB support.

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -365,6 +365,10 @@ impl PeerIdentity {
 	}
 
 	/// The validated certificate chain, leaf first.
+	///
+	/// Exposes [`rustls::pki_types::CertificateDer`] directly (already part of
+	/// this crate's public API via the `rustls` re-export), so a major `rustls`
+	/// bump is a breaking change for consumers of this method.
 	pub fn chain(&self) -> &[CertificateDer<'static>] {
 		&self.chain
 	}

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -344,6 +344,23 @@ impl Server {
 	}
 }
 
+/// Extract the end-entity certificate's `notAfter` from a QUIC peer identity.
+///
+/// The quinn and noq backends both return their validated client chain (leaf
+/// first) as a `Vec<CertificateDer>` from `Connection::peer_identity()`. Returns
+/// `None` if the peer presented no certificate, the chain is empty, or the leaf
+/// fails to parse. A `notAfter` before the Unix epoch is also reported as `None`.
+#[cfg(any(feature = "quinn", feature = "noq"))]
+pub(crate) fn peer_certificate_expiry(identity: Option<Box<dyn std::any::Any>>) -> Option<std::time::SystemTime> {
+	use std::time::{Duration, UNIX_EPOCH};
+
+	let chain = identity?.downcast::<Vec<CertificateDer<'static>>>().ok()?;
+	let leaf = chain.first()?;
+	let (_, cert) = x509_parser::parse_x509_certificate(leaf).ok()?;
+	let secs = u64::try_from(cert.validity().not_after.timestamp()).ok()?;
+	Some(UNIX_EPOCH + Duration::from_secs(secs))
+}
+
 /// TLS certificate information including fingerprints.
 #[derive(Debug)]
 pub struct Info {
@@ -457,6 +474,33 @@ mod tests {
 		let key = rcgen::KeyPair::generate().unwrap();
 		let params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
 		params.self_signed(&key).unwrap().into()
+	}
+
+	#[test]
+	fn peer_certificate_expiry_reads_not_after() {
+		// notAfter at a whole second so the round-trip is exact.
+		let not_after = ::time::OffsetDateTime::from_unix_timestamp(2_000_000_000).unwrap();
+
+		let key = rcgen::KeyPair::generate().unwrap();
+		let mut params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+		params.not_after = not_after;
+		let cert: CertificateDer<'static> = params.self_signed(&key).unwrap().into();
+
+		// quinn/noq hand back the chain as a boxed Vec<CertificateDer>.
+		let identity: Box<dyn std::any::Any> = Box::new(vec![cert]);
+		let expiry = peer_certificate_expiry(Some(identity)).expect("expiry parsed");
+		assert_eq!(
+			expiry.duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+			2_000_000_000
+		);
+	}
+
+	#[test]
+	fn peer_certificate_expiry_none_without_identity() {
+		assert!(peer_certificate_expiry(None).is_none());
+		// A wrong downcast type (not a cert chain) yields None rather than panicking.
+		let bogus: Box<dyn std::any::Any> = Box::new(42u32);
+		assert!(peer_certificate_expiry(Some(bogus)).is_none());
 	}
 
 	#[test]

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -311,7 +311,7 @@ pub struct Server {
 	/// PEM file(s) of root CAs for validating optional client certificates (mTLS).
 	///
 	/// When set, clients *may* present a certificate during the TLS handshake.
-	/// Valid presentations are reported via [`crate::Request::has_peer_certificate`]
+	/// Valid presentations are reported via [`crate::Request::peer_identity`]
 	/// and can be used by the application to grant elevated access. Clients that
 	/// do not present a certificate are unaffected.
 	///
@@ -344,21 +344,42 @@ impl Server {
 	}
 }
 
-/// Extract the end-entity certificate's `notAfter` from a QUIC peer identity.
+/// A peer's validated client-certificate chain from the mTLS handshake.
 ///
-/// The quinn and noq backends both return their validated client chain (leaf
-/// first) as a `Vec<CertificateDer>` from `Connection::peer_identity()`. Returns
-/// `None` if the peer presented no certificate, the chain is empty, or the leaf
-/// fails to parse. A `notAfter` before the Unix epoch is also reported as `None`.
+/// Returned by [`crate::Request::peer_identity`] when the peer presented a
+/// certificate that chained to a configured [`Server::root`]. Owns the chain
+/// (leaf first) so callers can inspect it, e.g. [`expiry`](Self::expiry),
+/// without re-parsing the type-erased QUIC identity.
 #[cfg(any(feature = "quinn", feature = "noq"))]
-pub(crate) fn peer_certificate_expiry(identity: Option<Box<dyn std::any::Any>>) -> Option<std::time::SystemTime> {
-	use std::time::{Duration, UNIX_EPOCH};
+pub struct PeerIdentity {
+	chain: Vec<CertificateDer<'static>>,
+}
 
-	let chain = identity?.downcast::<Vec<CertificateDer<'static>>>().ok()?;
-	let leaf = chain.first()?;
-	let (_, cert) = x509_parser::parse_x509_certificate(leaf).ok()?;
-	let secs = u64::try_from(cert.validity().not_after.timestamp()).ok()?;
-	Some(UNIX_EPOCH + Duration::from_secs(secs))
+#[cfg(any(feature = "quinn", feature = "noq"))]
+impl PeerIdentity {
+	/// Wrap the type-erased identity from `quinn::Connection::peer_identity`.
+	/// Returns `None` if the peer presented no certificate or the identity is
+	/// not a certificate chain.
+	pub(crate) fn from_any(identity: Option<Box<dyn std::any::Any>>) -> Option<Self> {
+		let chain = identity?.downcast::<Vec<CertificateDer<'static>>>().ok()?;
+		Some(Self { chain: *chain })
+	}
+
+	/// The validated certificate chain, leaf first.
+	pub fn chain(&self) -> &[CertificateDer<'static>] {
+		&self.chain
+	}
+
+	/// The leaf certificate's `notAfter`, if it parses. A `notAfter` before the
+	/// Unix epoch is reported as `None`.
+	pub fn expiry(&self) -> Option<std::time::SystemTime> {
+		use std::time::{Duration, UNIX_EPOCH};
+
+		let leaf = self.chain.first()?;
+		let (_, cert) = x509_parser::parse_x509_certificate(leaf).ok()?;
+		let secs = u64::try_from(cert.validity().not_after.timestamp()).ok()?;
+		Some(UNIX_EPOCH + Duration::from_secs(secs))
+	}
 }
 
 /// TLS certificate information including fingerprints.
@@ -476,8 +497,9 @@ mod tests {
 		params.self_signed(&key).unwrap().into()
 	}
 
+	#[cfg(any(feature = "quinn", feature = "noq"))]
 	#[test]
-	fn peer_certificate_expiry_reads_not_after() {
+	fn peer_identity_expiry_reads_not_after() {
 		// notAfter at a whole second so the round-trip is exact.
 		let not_after = ::time::OffsetDateTime::from_unix_timestamp(2_000_000_000).unwrap();
 
@@ -488,19 +510,21 @@ mod tests {
 
 		// quinn/noq hand back the chain as a boxed Vec<CertificateDer>.
 		let identity: Box<dyn std::any::Any> = Box::new(vec![cert]);
-		let expiry = peer_certificate_expiry(Some(identity)).expect("expiry parsed");
+		let parsed = PeerIdentity::from_any(Some(identity)).expect("chain parsed");
+		let expiry = parsed.expiry().expect("expiry parsed");
 		assert_eq!(
 			expiry.duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
 			2_000_000_000
 		);
 	}
 
+	#[cfg(any(feature = "quinn", feature = "noq"))]
 	#[test]
-	fn peer_certificate_expiry_none_without_identity() {
-		assert!(peer_certificate_expiry(None).is_none());
+	fn peer_identity_none_without_chain() {
+		assert!(PeerIdentity::from_any(None).is_none());
 		// A wrong downcast type (not a cert chain) yields None rather than panicking.
 		let bogus: Box<dyn std::any::Any> = Box::new(42u32);
-		assert!(peer_certificate_expiry(Some(bogus)).is_none());
+		assert!(PeerIdentity::from_any(Some(bogus)).is_none());
 	}
 
 	#[test]

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -350,16 +350,15 @@ impl Server {
 /// certificate that chained to a configured [`Server::root`]. Owns the chain
 /// (leaf first) so callers can inspect it, e.g. [`expiry`](Self::expiry),
 /// without re-parsing the type-erased QUIC identity.
-#[cfg(any(feature = "quinn", feature = "noq"))]
 pub struct PeerIdentity {
 	chain: Vec<CertificateDer<'static>>,
 }
 
-#[cfg(any(feature = "quinn", feature = "noq"))]
 impl PeerIdentity {
 	/// Wrap the type-erased identity from `quinn::Connection::peer_identity`.
 	/// Returns `None` if the peer presented no certificate or the identity is
 	/// not a certificate chain.
+	#[cfg(any(feature = "quinn", feature = "noq"))]
 	pub(crate) fn from_any(identity: Option<Box<dyn std::any::Any>>) -> Option<Self> {
 		let chain = identity?.downcast::<Vec<CertificateDer<'static>>>().ok()?;
 		Some(Self { chain: *chain })

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -180,7 +180,7 @@ async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend) {
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		// The peer cert must be visible before we accept the session.
-		let has_cert = request.has_peer_certificate();
+		let has_cert = request.peer_identity().is_some();
 		let session = request.with_publish(pub_origin.consume()).ok().await?;
 		let _ = session.closed().await;
 		Ok::<_, anyhow::Error>(has_cert)

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -559,6 +559,12 @@ pub struct AuthToken {
 	/// a JWT. Used to record stats on the internal tier so cluster peers can
 	/// be billed separately from end-user traffic.
 	pub internal: bool,
+	/// When the credential backing this session expires, if it has an expiry.
+	///
+	/// For JWT auth this is the token's `exp` claim; for mTLS it's the peer
+	/// certificate's `notAfter`. The relay closes the session once this passes
+	/// instead of trusting a credential that was only checked at connect time.
+	pub expires: Option<std::time::SystemTime>,
 }
 
 impl AuthToken {
@@ -579,6 +585,8 @@ impl AuthToken {
 			subscribe: PathPrefixes::from(vec![Path::new("").to_owned()]),
 			publish: PathPrefixes::from(vec![Path::new("").to_owned()]),
 			internal: true,
+			// Filled in by the caller from the peer certificate's notAfter.
+			expires: None,
 		}
 	}
 }
@@ -1031,6 +1039,7 @@ impl Auth {
 			subscribe,
 			publish,
 			internal: false,
+			expires: claims.expires,
 		})
 	}
 
@@ -1186,6 +1195,47 @@ mod tests {
 		assert_eq!(token.root, "room/123".as_path());
 		assert_eq!(token.subscribe, vec!["".as_path()]);
 		assert_eq!(token.publish, vec!["alice".as_path()]);
+
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn test_jwt_expiry_carried_through() -> anyhow::Result<()> {
+		let key = create_test_key_with_kid("test-key");
+		let dir = setup_key_dir(&[("test-key", &key)]);
+
+		let auth = Auth::new(AuthConfig {
+			key_dir: Some(dir.path().to_string_lossy().to_string()),
+			..Default::default()
+		})
+		.await?;
+
+		// JWT `exp` has second granularity, so use a whole-second expiry to avoid
+		// rounding ambiguity on the round-trip.
+		let want = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)?
+			.as_secs()
+			+ 3600;
+		let expires = std::time::UNIX_EPOCH + std::time::Duration::from_secs(want);
+		let claims = moq_token::Claims {
+			root: "room/123".to_string(),
+			subscribe: vec!["".to_string()],
+			publish: vec!["alice".into()],
+			expires: Some(expires),
+			..Default::default()
+		};
+		let token = key.encode(&claims)?;
+
+		let token = auth
+			.verify(&AuthParams {
+				path: "/room/123".into(),
+				jwt: Some(token),
+			})
+			.await?;
+
+		// The `exp` claim survives finalize() so the relay can close on expiry.
+		let got = token.expires.expect("expiry should be carried through");
+		assert_eq!(got.duration_since(std::time::UNIX_EPOCH)?.as_secs(), want);
 
 		Ok(())
 	}

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -89,7 +89,7 @@ impl Connection {
 		// NOTE: subscribe and publish seem backwards because of how relays work.
 		// We publish the tracks the client is allowed to subscribe to.
 		// We subscribe to the tracks the client is allowed to publish.
-		let session = self
+		let mut session = self
 			.request
 			.with_publish(subscribe)
 			.with_consume(publish)
@@ -99,8 +99,26 @@ impl Connection {
 
 		tracing::info!(version = %session.version(), transport, "negotiated");
 
-		// Wait until the session is closed.
-		session.closed().await?;
+		// The credential (JWT `exp` or client cert `notAfter`) is only checked at
+		// connect time, so hold the session open no longer than the credential is
+		// valid. Without an expiry, sleep forever and just wait for close.
+		let expiry = async {
+			match token.expires {
+				Some(expires) => {
+					let remaining = expires.duration_since(std::time::SystemTime::now()).unwrap_or_default();
+					tokio::time::sleep(remaining).await;
+				}
+				None => std::future::pending().await,
+			}
+		};
+
+		tokio::select! {
+			res = session.closed() => return Ok(res?),
+			_ = expiry => {}
+		}
+
+		tracing::info!("credential expired, closing session");
+		session.close(moq_net::Error::Unauthorized);
 		Ok(())
 	}
 
@@ -126,6 +144,9 @@ impl Connection {
 			let (root, internal) = self.auth.resolve_mtls(&params.path).await?;
 			let mut token = AuthToken::unrestricted(Path::new(&root).to_owned());
 			token.internal = internal;
+			// Close the session when the client certificate expires, mirroring
+			// the JWT `exp` handling. Validated once at the TLS handshake otherwise.
+			token.expires = self.request.peer_certificate_expiry();
 			return Ok(token);
 		}
 

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -101,25 +101,20 @@ impl Connection {
 
 		// The credential (JWT `exp` or client cert `notAfter`) is only checked at
 		// connect time, so hold the session open no longer than the credential is
-		// valid. Without an expiry, sleep forever and just wait for close.
-		let expiry = async {
-			match token.expires {
-				Some(expires) => {
-					let remaining = expires.duration_since(std::time::SystemTime::now()).unwrap_or_default();
-					tokio::time::sleep(remaining).await;
-				}
-				None => std::future::pending().await,
-			}
+		// valid. Without an expiry, just wait for the session to close.
+		let Some(expires) = token.expires else {
+			return Ok(session.closed().await?);
 		};
 
-		tokio::select! {
-			res = session.closed() => return Ok(res?),
-			_ = expiry => {}
+		let remaining = expires.duration_since(std::time::SystemTime::now()).unwrap_or_default();
+		match tokio::time::timeout(remaining, session.closed()).await {
+			Ok(res) => Ok(res?),
+			Err(_) => {
+				tracing::info!("credential expired, closing session");
+				session.close(moq_net::Error::Unauthorized);
+				Ok(())
+			}
 		}
-
-		tracing::info!("credential expired, closing session");
-		session.close(moq_net::Error::Unauthorized);
-		Ok(())
 	}
 
 	/// Resolve an [`AuthToken`] from the request's URL and (optional) mTLS peer
@@ -135,7 +130,7 @@ impl Connection {
 			None => AuthParams::default(),
 		};
 
-		if self.request.has_peer_certificate() {
+		if let Some(identity) = self.request.peer_identity() {
 			tracing::debug!("mTLS peer authenticated");
 			// Scope the grant to the canonical root. An mTLS publisher dialing a
 			// vanity alias lands on the same tree a JWT would; cluster peers dial
@@ -146,7 +141,7 @@ impl Connection {
 			token.internal = internal;
 			// Close the session when the client certificate expires, mirroring
 			// the JWT `exp` handling. Validated once at the TLS handshake otherwise.
-			token.expires = self.request.peer_certificate_expiry();
+			token.expires = identity.expiry();
 			return Ok(token);
 		}
 

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -284,7 +284,7 @@ async fn reload_https_config(config: RustlsConfig, cert: PathBuf, key: PathBuf, 
 
 /// Marker inserted as a request extension when rustls verified a client cert
 /// against the configured mTLS CA. We don't carry the cert bytes. "Verified
-/// by our CA" is the entire signal we need (mirrors `has_peer_certificate` on
+/// by our CA" is the entire signal we need (mirrors `peer_identity` on
 /// the QUIC side).
 #[derive(Clone, Debug)]
 pub(crate) struct MtlsPeer;


### PR DESCRIPTION
## Summary

Authentication was a one-time gate. The JWT `exp` claim was checked only in `Key::decode` at connect time, the relay's `AuthToken` then **dropped** `claims.expires`, and the session was held open indefinitely via a bare `session.closed().await?`. mTLS client certificates were validated only during the TLS handshake and never re-checked. So a credential that expired mid-session kept working until the client disconnected.

This enforces the credential's expiry for the whole session: the relay now closes the connection once the JWT `exp` (or the mTLS certificate's `notAfter`) passes, forcing the client to reconnect with a fresh credential.

## What changed

- **`rs/moq-relay/src/auth.rs`** — added `expires: Option<SystemTime>` to `AuthToken` (the struct is `#[non_exhaustive]`, so this is additive). Populated from `claims.expires` in `finalize()`, so both the JWT path and the auth-API path carry it.
- **`rs/moq-relay/src/connection.rs`** — `Connection::run` races `session.closed()` against `tokio::time::sleep` until `token.expires` (sleeps forever via `pending()` when there's no expiry), closing with `Error::Unauthorized` when the deadline passes. The mTLS branch sets `token.expires` from the peer certificate.
- **`rs/moq-native`** — new `peer_certificate_expiry()` helper that downcasts the backend's `peer_identity()` to `Vec<CertificateDer>` and parses the leaf's `notAfter` with `x509-parser` (already in the lockfile). Exposed on `QuinnRequest`, `NoqRequest`, and the `Request` wrapper; other backends return `None`.
- **`doc/bin/relay/auth.md`** — notes that `exp` (and mTLS `notAfter`) is enforced for the session lifetime, not just at connect.

## Reviewer notes

- **Public API (additive, non-breaking):** `AuthToken.expires` field (on a `#[non_exhaustive]` struct); new `pub fn peer_certificate_expiry()` on `moq_native::Request`, `QuinnRequest`, `NoqRequest`. New optional dep `x509-parser`, gated behind the `quinn`/`noq` features. Targets `main` since there are no wire or breaking changes.
- **Clock caveat:** the timer computes the delay from wall-clock `SystemTime` but `tokio::time::sleep` runs on the monotonic clock, so a large wall-clock jump after connect isn't tracked. This matches how `exp` was originally validated (`SystemTime::now()`). Exactness under clock skew would need a periodic re-check instead; happy to switch if preferred.

## Test plan

- [x] New unit tests: JWT `exp` survives `finalize`; cert `notAfter` parses correctly; `None`/wrong-type identity yields `None` without panicking.
- [x] `cargo fmt --check`, `clippy` (both crates, `noq` feature on), and all lib tests pass via nix.

(Written by Claude)