### PR TITLE
fix(moq-native): keep has_peer_certificate as deprecated, release 0.17.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "moq-native"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.17.2"
+version = "0.17.3"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -640,6 +640,12 @@ impl Request {
 			_ => None,
 		}
 	}
+
+	/// Whether the peer presented a valid client certificate during the handshake.
+	#[deprecated(note = "use `peer_identity` instead")]
+	pub fn has_peer_certificate(&self) -> bool {
+		self.peer_identity().is_some()
+	}
 }
 
 /// Server ID for QUIC-LB support.


### PR DESCRIPTION
## Summary

[#1789](https://github.com/moq-dev/moq/pull/1789) renamed `Request::has_peer_certificate` to `peer_identity` (returning `Option<PeerIdentity>` instead of `bool`). cargo-semver-checks flagged the rename as a breaking change, so release-plz proposed bumping `moq-native` to `0.18.0` in the release PR [#1774](https://github.com/moq-dev/moq/pull/1774).

That bump is heavier than it needs to be, and a plain rename is also a compatibility hazard: `moq-relay` (and other in-tree crates) depend on `moq-native` via a caret `"0.17"` range. An older `moq-relay` that still calls `has_peer_certificate` would resolve forward to a freshly published `0.17.x` and **fail to compile** if the method were gone. So restoring the method is what makes a patch release legitimate.

This PR:

- Re-adds `Request::has_peer_certificate(&self) -> bool` as a `#[deprecated(note = "use peer_identity instead")]` shim that delegates to `self.peer_identity().is_some()`, preserving the original behavior and API surface.
- Bumps `moq-native` `0.17.2 -> 0.17.3` (+ matching `Cargo.lock`).

With the method restored, cargo-semver-checks no longer sees a breaking change, so this ships as a clean `0.17.3` patch. Once merged, release-plz will regenerate [#1774](https://github.com/moq-dev/moq/pull/1774) with `0.17.3` instead of `0.18.0`.

Nothing outside the repo consumes this API (no external consumers yet), and the only in-tree caller, `moq-relay`, already migrated to `peer_identity()`, so it won't trigger the deprecation warning.

## Test plan

- [x] `cargo check -p moq-native` passes
- [x] Repo-wide grep confirms no remaining `has_peer_certificate` callers in-tree (shim is purely for external/older pins)

(Written by Claude)