### PR TITLE
fix(libmoq): declare the full Windows system-lib set for C consumers

### DIFF
--- a/rs/libmoq/CMakeLists.txt
+++ b/rs/libmoq/CMakeLists.txt
@@ -57,6 +57,17 @@ if(APPLE)
     target_link_options(moq INTERFACE "LINKER:-framework,CoreFoundation" "LINKER:-framework,Security")
 endif()
 
+# System libraries Rust std/deps pull in on Windows (from
+# `cargo rustc -- --print native-static-libs`). When the staticlib is linked
+# into a C/C++ target by an external linker, cargo can't inject these itself.
+# Keep in sync with the find_package config in cmake/moq-config.cmake.in.
+if(WIN32)
+    target_link_libraries(
+        moq
+        INTERFACE ntdll userenv ws2_32 bcrypt dbghelp advapi32 legacy_stdio_definitions
+    )
+endif()
+
 if(BUILD_RUST_LIB)
     add_dependencies(moq rust_build)
 endif()

--- a/rs/libmoq/cmake/moq-config.cmake.in
+++ b/rs/libmoq/cmake/moq-config.cmake.in
@@ -29,10 +29,13 @@ if(NOT TARGET moq::moq)
         )
     endif()
 
-    # On Windows, add required system libraries
+    # On Windows, add the system libraries Rust std/deps pull in (from
+    # `cargo rustc -- --print native-static-libs`). An external linker
+    # consuming the staticlib needs these spelled out; cargo can't inject them.
     if(WIN32)
         set_property(TARGET moq::moq APPEND PROPERTY
-            INTERFACE_LINK_LIBRARIES "ws2_32" "userenv" "bcrypt" "ntdll"
+            INTERFACE_LINK_LIBRARIES
+                "ws2_32" "userenv" "bcrypt" "ntdll" "dbghelp" "advapi32" "legacy_stdio_definitions"
         )
     endif()
 


### PR DESCRIPTION
When an external linker consumes `libmoq.a` on Windows, cargo cannot inject the system libraries Rust std/deps require, so they must be declared in the CMake config consumers link against.

The `find_package` config (`rs/libmoq/cmake/moq-config.cmake.in`) listed only `ws2_32`/`userenv`/`bcrypt`/`ntdll`; this adds `dbghelp`/`advapi32`/`legacy_stdio_definitions` to match `cargo rustc -- --print native-static-libs`. The same set is mirrored onto the `add_subdirectory` `moq` target so both consumption paths (released config + in-tree) link cleanly.

Surfaced while linking `libmoq.a` into a C++ consumer on Windows (`__imp_NtCreateNamedPipeFile` and similar unresolved externals).

(Written by Claude)