### PR TITLE
ci: move Nix workflows to the self-hosted ARM runner + warm cache for aarch64-linux

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Custom labels for the moq-dev self-hosted A1 runner, so actionlint accepts
+# `runs-on: [self-hosted, nix]`. `self-hosted` is built in; `nix` is ours.
+self-hosted-runner:
+  labels:
+    - nix

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -15,15 +15,23 @@ jobs:
   # (e.g. moq-relay) maps 1:1 to a flake attribute.
   release:
     name: Release (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        include:
+          # `os` is just the cache pin label; keep the existing values stable so
+          # old pins aren't orphaned.
+          - os: ubuntu-latest # x86_64-linux
+            runs-on: ubuntu-latest
+          - os: macos-latest # aarch64-darwin
+            runs-on: macos-latest
+          # aarch64-linux on the moq-dev self-hosted A1 (warm /nix/store). Tag
+          # pushes are trusted, so no fork concern.
+          - os: aarch64-linux
+            runs-on: [self-hosted, nix]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -45,7 +53,17 @@ jobs:
           fi
           echo "name=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
 
-      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+      # The cachix action and `nix build` below run `nix` directly, so put it on
+      # PATH. A login shell resolves it via /etc/profile.d regardless of the
+      # box's install path. Self-hosted only; the hosted runners get Nix from
+      # the installer step.
+      - name: Add Nix to PATH
+        if: runner.environment == 'self-hosted'
+        shell: bash -leo pipefail {0}
+        run: dirname "$(command -v nix)" >> "$GITHUB_PATH"
+
+      - if: runner.environment == 'github-hosted'
+        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
 
@@ -53,6 +71,11 @@ jobs:
         with:
           name: kixelated
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # The self-hosted box's runner user isn't a Nix trusted-user and the
+          # box deliberately substitutes only from its warm local store, so
+          # don't let `cachix use` rewrite nix.conf there. Push auth (above)
+          # still works; this leg only pushes.
+          skipAddingSubstituter: ${{ runner.environment == 'self-hosted' }}
 
       - name: Build and cache
         env:

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -18,7 +18,9 @@ concurrency:
 jobs:
   release:
     name: Release JS Packages
-    runs-on: ubuntu-latest
+    # Trusted push to main, so run on the moq-dev self-hosted A1 runner (warm
+    # /nix/store).
+    runs-on: [self-hosted, nix]
     if: github.repository_owner == 'moq-dev'
 
     steps:
@@ -26,17 +28,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
-        with:
-          determinate: false
-
       - name: Setup npm registry
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           registry-url: 'https://registry.npmjs.org'
 
+      # Login shell so /etc/profile.d puts Nix on PATH; Actions shells don't by
+      # default.
       - name: Install dependencies
         run: nix develop --command bun install --frozen-lockfile
+        shell: bash -leo pipefail {0}
 
       - name: Release packages
         # Web-component packages register custom elements via global type
@@ -45,3 +46,4 @@ jobs:
         env:
           JSR_ALLOW_SLOW_TYPES: "true"
         run: nix develop --command bun --filter '*' release
+        shell: bash -leo pipefail {0}

--- a/.github/workflows/release-py.yml
+++ b/.github/workflows/release-py.yml
@@ -31,7 +31,10 @@ concurrency:
 jobs:
   build:
     name: Build wheel + sdist
-    runs-on: ubuntu-latest
+    # Trusted push to main and the wrapper wheel is pure-python (arch
+    # independent), so run on the moq-dev self-hosted A1 runner (warm
+    # /nix/store).
+    runs-on: [self-hosted, nix]
     if: ${{ github.repository_owner == 'moq-dev' }}
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -56,12 +59,11 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: .github/scripts/release.sh pypi-exists moq-rs "$VERSION"
 
-      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
-        with:
-          determinate: false
-
+      # Login shell so /etc/profile.d puts Nix on PATH; Actions shells don't by
+      # default.
       - name: Build
         run: nix develop --command just py package
+        shell: bash -leo pipefail {0}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release-rs.yml
+++ b/.github/workflows/release-rs.yml
@@ -18,7 +18,9 @@ jobs:
   release:
     name: Plz
 
-    runs-on: ubuntu-latest
+    # Trusted push to main, so run on the moq-dev self-hosted A1 runner (warm
+    # /nix/store + persistent CARGO_TARGET_DIR).
+    runs-on: [self-hosted, nix]
     if: ${{ github.repository_owner == 'moq-dev' }}
 
     steps:
@@ -37,13 +39,16 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 
-      # Install Nix for system dependencies (e.g. ffmpeg)
-      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
-        with:
-          determinate: false
+      # Persist the cargo target outside the workspace (checkout clean wipes the
+      # workspace, not $HOME). Scope per runner so a second service on the box
+      # gets its own dir instead of racing on a shared one.
+      - run: echo "CARGO_TARGET_DIR=$HOME/cargo-target/moq-$RUNNER_NAME" >> "$GITHUB_ENV"
 
+      # Login shell so /etc/profile.d puts Nix on PATH; Actions shells don't by
+      # default.
       - name: Release
         run: nix develop --command just rs release
+        shell: bash -leo pipefail {0}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -12,16 +12,21 @@ on:
 jobs:
   update-flake:
     name: Update flake.lock
-    runs-on: ubuntu-latest
+    # Run on the moq-dev self-hosted A1 runner (already has Nix); fork dispatches
+    # have no such runner, so guard on the owner to avoid queueing forever.
+    runs-on: [self-hosted, nix]
+    if: ${{ github.repository_owner == 'moq-dev' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
-        with:
-          determinate: false
+      # The update-flake-lock action runs `nix` directly (not through a shell),
+      # so put Nix on GITHUB_PATH. A login shell resolves it via /etc/profile.d
+      # regardless of the box's install path.
+      - name: Add Nix to PATH
+        shell: bash -leo pipefail {0}
+        run: dirname "$(command -v nix)" >> "$GITHUB_PATH"
 
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@b83e0671a67dfd774680fb1beaa1497ef7e58bfc # main


### PR DESCRIPTION
## Summary

Moves the Nix-based, architecture-independent release workflows onto the moq-dev self-hosted A1 (aarch64) runner, following the pattern `check.yml` already established, and adds an aarch64-linux leg to the cachix binary cache so that platform is warmed too.

| Workflow | Job moved | Trigger (all trusted) |
|---|---|---|
| `release-rs.yml` | release-plz (crates.io) | push to `main` |
| `release-js.yml` | npm/JSR publish | push to `main` (js paths) |
| `release-py.yml` | build wheel/sdist | push to `main` (py paths) |
| `update-flake.yml` | flake.lock update | monthly cron + dispatch |
| `cachix.yml` | **new** aarch64-linux leg | release tags |

These all use Nix and produce arch-independent output (or, for cachix, the box natively *is* the target arch), so the aarch64 box is a valid runner. Unlike `check.yml` they trigger solely on trusted events (push/tag/schedule/dispatch), so no fork fallback is needed.

## Per-workflow notes

For the moved jobs: `runs-on` → `[self-hosted, nix]`, dropped `nix-installer-action` (the box already has Nix), and ran Nix steps in a login shell (`bash -leo pipefail {0}`) so `/etc/profile.d` puts Nix on PATH.

- **release-rs**: also reuses the persistent `CARGO_TARGET_DIR=$HOME/cargo-target/moq-$RUNNER_NAME` (same warm-cache trick as `check.yml`) since release-plz compiles.
- **release-py**: only the `build` job moved; `publish` stays on `ubuntu-latest` (no Nix, just OIDC trusted-publish to PyPI).
- **update-flake**: the `update-flake-lock` action invokes `nix` directly rather than through a shell, so a login shell wouldn't help. Added an `Add Nix to PATH` step that resolves the binary via a login shell and writes its dir to `GITHUB_PATH`. Also added an `if: repository_owner == 'moq-dev'` guard so a fork's manual dispatch doesn't queue forever on a runner that doesn't exist.
- **cachix**: matrix moved to `include` form so each leg carries its own `runs-on` (string for hosted runners, `[self-hosted, nix]` for the box) while `os` stays the cache-pin label, keeping existing pins stable. The new aarch64-linux leg gates the installer on github-hosted, adds Nix to PATH for the cachix action + `nix build`, and sets `skipAddingSubstituter` on self-hosted: the box's runner user isn't a Nix trusted-user and it substitutes only from its warm local store, so `cachix use` must not rewrite nix.conf there. Push auth is unaffected; this leg only pushes.

## Still left alone (arch-specific)

- **moq-cli / moq-relay / moq-token-cli / moq-gst, libmoq, release-py-ffi** — per-arch release binaries / native wheels.

## Caveats for the reviewer

- **No availability fallback**: like `check.yml`, the moved jobs hard-target the single self-hosted box. If it's offline, a release queues until it's back (or hits the runner timeout). Matches the existing trade-off.
- The cachix aarch64-linux leg adds load to the box on every release tag, but tags are infrequent and `fail-fast: false` keeps a failing arm build from killing the x86_64 / darwin legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)