### PR TITLE
chore: remove deprecated aliases and redundant catalog fields

### DIFF
--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -84,7 +84,7 @@ See [Authentication](/bin/relay/auth) for the full setup.
 
 ## Migration from older configs
 
-`cluster.root` was removed; setting it errors at startup with a message pointing at the replacement. `cluster.mesh` is now a boolean gossip toggle (it used to take this relay's URL); the URL moved to `cluster.node`. The old `mesh = "<url>"` form still works for backwards compatibility: it enables gossip and is treated as `cluster.node`, with a deprecation warning (or an error if it conflicts with an explicit `cluster.node`).
+`cluster.root` was removed. To dial cluster peers use `cluster.connect`; to advertise this relay's own address set `cluster.node` and enable `cluster.mesh`. `cluster.mesh` is now a boolean gossip toggle (it used to take this relay's URL); the URL moved to `cluster.node`. The old `mesh = "<url>"` form still works for backwards compatibility: it enables gossip and is treated as `cluster.node`, with a deprecation warning (or an error if it conflicts with an explicit `cluster.node`).
 
 `cluster.connect` entries are now full URLs; a bare host or `host:port` still works but logs a deprecation warning. A JWT for a static peer belongs inline as a `?jwt=` query parameter (the `cluster.token` file remains for gossip / `connect_api` peers, which can't carry an inline token).
 

--- a/js/hang/src/catalog/container.ts
+++ b/js/hang/src/catalog/container.ts
@@ -1,5 +1,4 @@
 import * as z from "zod/mini";
-import { u53Schema } from "./integers";
 
 /**
  * Container format for frame timestamp encoding and frame payload structure.
@@ -16,14 +15,9 @@ export const ContainerSchema = z._default(
 		// The default hang container
 		z.object({ kind: z.literal("legacy") }),
 		// CMAF container with base64-encoded init segment (ftyp+moov).
-		// `timescale` and `trackId` are deprecated: they duplicate info in `init`
-		// and are accepted only so catalogs from newer publishers (which still
-		// emit them for older players) round-trip cleanly.
 		z.object({
 			kind: z.literal("cmaf"),
 			init: z.base64(),
-			timescale: z.optional(u53Schema),
-			trackId: z.optional(u53Schema),
 		}),
 		// Low Overhead Container.
 		z.object({ kind: z.literal("loc") }),

--- a/js/hang/src/index.ts
+++ b/js/hang/src/index.ts
@@ -6,8 +6,6 @@
  */
 
 export * as Net from "@moq/net";
-/** @deprecated Use `Net` instead. */
-export * as Moq from "@moq/net";
 export * as Signals from "@moq/signals";
 export * as Catalog from "./catalog";
 export * as Container from "./container";

--- a/js/net/src/ietf/subscribe_namespace.ts
+++ b/js/net/src/ietf/subscribe_namespace.ts
@@ -322,9 +322,3 @@ export class PublishBlocked {
 		return new PublishBlocked({ suffix, trackName });
 	}
 }
-
-// Backward compatibility aliases
-export const SubscribeAnnounces = SubscribeNamespace;
-export const SubscribeAnnouncesOk = SubscribeNamespaceOk;
-export const SubscribeAnnouncesError = SubscribeNamespaceError;
-export const UnsubscribeAnnounces = UnsubscribeNamespace;

--- a/js/publish/src/index.ts
+++ b/js/publish/src/index.ts
@@ -1,8 +1,6 @@
 export * as Hang from "@moq/hang";
 export * as Json from "@moq/json";
 export * as Net from "@moq/net";
-/** @deprecated Use `Net` instead. */
-export * as Lite from "@moq/net";
 export * as Signals from "@moq/signals";
 export * as Audio from "./audio";
 export * from "./broadcast";

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -523,11 +523,6 @@ export class Effect {
 		this.#dispose.push(() => effect.close());
 	}
 
-	/** Alias for {@link run}, kept for backwards compatibility. */
-	effect(fn: (effect: Effect) => void) {
-		return this.run(fn);
-	}
-
 	/** Creates a derived signal scoped to this effect, closed when the effect reruns or closes. */
 	computed<T>(fn: (effect: Effect) => T): Computed<T> {
 		const computed = new Computed(fn);

--- a/js/signals/src/react.ts
+++ b/js/signals/src/react.ts
@@ -31,7 +31,3 @@ export function useSignal<T>(signal: Signal<T>): [T, (value: T | ((prev: T) => T
 	);
 	return [value, setter];
 }
-
-/** @deprecated Use `useValue` instead. */
-const react = useValue;
-export default react;

--- a/js/signals/src/solid.ts
+++ b/js/signals/src/solid.ts
@@ -39,7 +39,3 @@ export function createSetter<T>(signal: Signal<T>): SolidSetter<T> {
 export function createPair<T>(signal: Signal<T>): SolidSignal<T> {
 	return [createAccessor(signal), createSetter(signal)];
 }
-
-/** @deprecated Use `createAccessor` instead. */
-const solid = createAccessor;
-export default solid;

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -365,11 +365,6 @@ export default class MoqWatch extends HTMLElement {
 		return this.backend.output.jitter.peek();
 	}
 
-	/** @deprecated Use `latency = <number>` instead. */
-	set jitter(value: number) {
-		this.controls.latency.set(Moq.Time.Milli(value));
-	}
-
 	get catalogFormat(): CatalogFormat | undefined {
 		return this.#catalogFormat.peek();
 	}

--- a/js/watch/src/index.ts
+++ b/js/watch/src/index.ts
@@ -1,8 +1,6 @@
 export * as Hang from "@moq/hang";
 export * as Json from "@moq/json";
 export * as Net from "@moq/net";
-/** @deprecated Use `Net` instead. */
-export * as Lite from "@moq/net";
 export * as Signals from "@moq/signals";
 export * as Audio from "./audio";
 export * from "./backend";

--- a/js/watch/src/ui/components/buffer-control.ts
+++ b/js/watch/src/ui/components/buffer-control.ts
@@ -1,4 +1,4 @@
-import { Moq } from "@moq/hang";
+import * as Moq from "@moq/net";
 import type { Effect } from "@moq/signals";
 import type { BufferedRanges } from "../..";
 import type MoqWatch from "../../element";

--- a/js/watch/src/ui/components/latency.ts
+++ b/js/watch/src/ui/components/latency.ts
@@ -1,4 +1,4 @@
-import { Moq } from "@moq/hang";
+import * as Moq from "@moq/net";
 import type { Effect } from "@moq/signals";
 import * as DOM from "@moq/signals/dom";
 import type MoqWatch from "../../element";

--- a/rs/hang/src/catalog/container.rs
+++ b/rs/hang/src/catalog/container.rs
@@ -28,18 +28,6 @@ pub enum Container {
 		/// CMAF init segment (ftyp+moov). Encoded as base64 over the wire.
 		#[serde_as(as = "Base64")]
 		init: Bytes,
-
-		/// Duplicates `mdhd.timescale` from `init`. Emitted for backwards
-		/// compatibility with players that predate the `init` field.
-		#[deprecated(note = "parse from `init` instead")]
-		#[serde(default, skip_serializing_if = "Option::is_none")]
-		timescale: Option<u32>,
-
-		/// Duplicates `tkhd.track_id` from `init`. Emitted for backwards
-		/// compatibility with players that predate the `init` field.
-		#[deprecated(note = "parse from `init` instead")]
-		#[serde(default, skip_serializing_if = "Option::is_none")]
-		track_id: Option<u32>,
 	},
 	Loc,
 }

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -27,11 +27,7 @@ impl From<Container> for hang::catalog::Container {
 	fn from(container: Container) -> Self {
 		match container {
 			Container::Legacy => Self::Legacy,
-			Container::Cmaf { init } => Self::Cmaf {
-				init: init.into(),
-				timescale: None,
-				track_id: None,
-			},
+			Container::Cmaf { init } => Self::Cmaf { init: init.into() },
 			Container::Loc => Self::Loc,
 		}
 	}

--- a/rs/moq-mux/src/catalog/msf/consumer.rs
+++ b/rs/moq-mux/src/catalog/msf/consumer.rs
@@ -147,12 +147,7 @@ fn container_from_msf(track: &moq_msf::Track) -> Result<Option<Container>> {
 		moq_msf::Packaging::Loc | moq_msf::Packaging::Legacy => Ok(Some(Container::Legacy)),
 		moq_msf::Packaging::Cmaf => {
 			let init = decode_init_data(track)?.ok_or_else(|| Error::MissingCmafInit(track.name.clone()))?;
-			#[allow(deprecated)]
-			Ok(Some(Container::Cmaf {
-				init,
-				timescale: None,
-				track_id: None,
-			}))
+			Ok(Some(Container::Cmaf { init }))
 		}
 		_ => Ok(None),
 	}

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -397,8 +397,6 @@ mod test {
 				.decode("AAAYZ2Z0eXA=")
 				.unwrap()
 				.into(),
-			timescale: None,
-			track_id: None,
 		};
 
 		let mut video_renditions = BTreeMap::new();

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -244,11 +244,7 @@ impl Import {
 			ftyp.encode(&mut buf)?;
 			single_moov.encode(&mut buf)?;
 
-			Ok(Container::Cmaf {
-				init: buf.into(),
-				timescale: Some(trak.mdia.mdhd.timescale),
-				track_id: Some(trak.tkhd.track_id),
-			})
+			Ok(Container::Cmaf { init: buf.into() })
 		}
 	}
 

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -275,8 +275,6 @@ async fn export_rejects_cmaf_track() {
 	config.description = Some(Bytes::from(vec![0u8; 8]));
 	config.container = Container::Cmaf {
 		init: Bytes::from(vec![0u8; 32]),
-		timescale: None,
-		track_id: None,
 	};
 	catalog.lock().video.renditions.insert(track.name().to_string(), config);
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -302,10 +302,6 @@ pub struct ClusterConfig {
 	/// token). For static `--cluster-connect` peers, prefer an inline `?jwt=`.
 	#[arg(id = "cluster-token", long = "cluster-token", env = "MOQ_CLUSTER_TOKEN")]
 	pub token: Option<PathBuf>,
-
-	/// Removed; present only to emit a migration error. Use [`Self::connect`] instead.
-	#[arg(id = "cluster-root", long = "cluster-root", env = "MOQ_CLUSTER_ROOT", hide = true)]
-	pub root: Option<String>,
 }
 
 /// A relay cluster built around a single [`OriginProducer`].
@@ -436,20 +432,9 @@ impl Cluster {
 	/// (`connect` / `connect_api` set) dials peers and, when `mesh` gossip is on,
 	/// also advertises `node` and runs discovery.
 	///
-	/// Bails when the removed flag `cluster.root` is set, when `mesh` gossip is on
-	/// without `node`, or when peers are configured to dial but no client was
-	/// attached via [`with_client`](Self::with_client).
+	/// Bails when `mesh` gossip is on without `node`, or when peers are configured
+	/// to dial but no client was attached via [`with_client`](Self::with_client).
 	pub async fn run(self) -> anyhow::Result<()> {
-		if let Some(root) = &self.config.root {
-			anyhow::bail!(
-				"`cluster.root` / `--cluster-root` was removed (value: {root:?}). \
-				 Use `--cluster-connect <peer-url>` to dial cluster peers. To gossip \
-				 this relay's address, set `--cluster-node <self-url>` and enable \
-				 `--cluster-mesh`. \
-				 See https://doc.moq.dev/bin/relay/cluster."
-			);
-		}
-
 		let (gossip, node) = self.resolve_mesh()?;
 		anyhow::ensure!(
 			!gossip || node.is_some(),
@@ -1103,21 +1088,6 @@ mod tests {
 		assert!(!should_dial("self.example.com:4443", "self.example.com:4443"));
 	}
 
-	/// Setting `cluster.root` (the removed flag) at startup must surface a migration
-	/// message that names the replacement flags.
-	#[tokio::test]
-	async fn cluster_root_errors_with_migration_message() {
-		let config = ClusterConfig {
-			root: Some("legacy-root.example.com:4443".to_string()),
-			..Default::default()
-		};
-		let err = Cluster::new(config).run().await.expect_err("should error");
-		let msg = format!("{err}");
-		assert!(msg.contains("cluster.root"), "missing cluster.root in: {msg}");
-		assert!(msg.contains("--cluster-connect"), "missing --cluster-connect in: {msg}");
-		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
-	}
-
 	/// Enabling gossip (`--cluster-mesh`) without `--cluster-node` has no address to
 	/// advertise, so it must fail fast with a message naming the missing flag.
 	#[tokio::test]
@@ -1130,26 +1100,6 @@ mod tests {
 		let msg = format!("{err}");
 		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
 		assert!(msg.contains("--cluster-mesh"), "missing --cluster-mesh in: {msg}");
-	}
-
-	/// `cluster.root` parsed from TOML triggers the same migration error.
-	#[test]
-	fn cluster_root_toml_parses_then_errors() {
-		let toml = "[cluster]\nroot = \"legacy-root.example.com:4443\"\n";
-		let dir = std::env::temp_dir().join("moq-relay-cluster-test");
-		std::fs::create_dir_all(&dir).unwrap();
-		let path = dir.join("cluster-root-toml.toml");
-		std::fs::write(&path, toml).unwrap();
-
-		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
-		let config = Config::parse_and_merge(args).expect("config load");
-		assert_eq!(config.cluster.root.as_deref(), Some("legacy-root.example.com:4443"));
-
-		let rt = tokio::runtime::Runtime::new().unwrap();
-		let err = rt
-			.block_on(Cluster::new(config.cluster).run())
-			.expect_err("should error");
-		assert!(format!("{err}").contains("cluster.root"));
 	}
 
 	/// A relay configured with `cluster.node` + `cluster.mesh` gossip and no peers


### PR DESCRIPTION
## Summary

Clears out backwards-compat surface that the breaking-change cycle on `dev` no longer needs to carry. Per request, the `with_publish` / `with_consume` aliases are **kept**.

### JS/TS
- Drop the `solid` / `react` default-export aliases → use `createAccessor` / `useValue`.
- Drop `Effect.effect()` → use `run()`.
- Drop the `Lite` (`@moq/publish`, `@moq/watch`) and `Moq` (`@moq/hang`) namespace re-exports of `@moq/net`. The two internal `@moq/hang` `Moq` consumers (`buffer-control.ts`, `latency.ts`) now import `@moq/net` directly, matching the rest of the codebase.
- Drop the deprecated `jitter` **setter** on `<moq-watch>` → use `latency`. The non-deprecated read-only getter stays.
- Drop the `SubscribeAnnounces*` IETF backwards-compat aliases.

### Catalog format (`rs/hang` + `js/hang`, lockstep)
- Drop the deprecated `Container::Cmaf { timescale, track_id }` fields. They duplicated values already present in `init` (which every consumer parses), and nothing read them back. The single real emitter (fmp4 import) and the `None` call-sites are updated accordingly.

### Relay (`rs/moq-relay`)
- Drop the `cluster.root` / `--cluster-root` migration-error shim: the field, the startup bail block, and the two tests. The flag was already removed; this drops the tailored migration hint (an old config setting it now gets a generic unknown-field error). `doc/bin/relay/cluster.md`'s migration note is updated to point at the replacement flags (`cluster.connect` / `cluster.node` + `cluster.mesh`).

## Public API / breaking changes
All of the above are removals of `@deprecated` / `#[deprecated]` / already-removed surface, so each is technically breaking — hence targeting `dev`:
- `@moq/signals`: removed default exports of `solid.ts` / `react.ts`; removed `Effect.effect()`.
- `@moq/publish`, `@moq/watch`: removed `Lite` re-export.
- `@moq/hang`: removed `Moq` re-export.
- `@moq/watch`: removed `<moq-watch>` `jitter` setter.
- `@moq/net`: removed `SubscribeAnnounces`/`SubscribeAnnouncesOk`/`SubscribeAnnouncesError`/`UnsubscribeAnnounces` aliases.
- `rs/hang`: removed `timescale` / `track_id` fields from `catalog::Container::Cmaf`.
- `rs/moq-relay`: removed the `root` field from `ClusterConfig` (`--cluster-root` / `MOQ_CLUSTER_ROOT`).

## Held back (not in this PR)
- `PublicConfig::Simple` (`rs/moq-relay`) backs the compact TOML serialization (`public = "anon"` round-trips as a bare string/array); removing it is a serialization-preserving refactor, not a delete. Left for a follow-up.

## Test plan
- [x] `just check` passes (Rust + JS lint/typecheck/tests).
- [x] `cargo test -p moq-relay --lib` passes (118 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)