### PR TITLE
ci: crane-based Rust checks (clippy/doc/test) via nix flake check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,20 +49,39 @@ jobs:
         uses: DeterminateSystems/flake-checker-action@9ee1c5473f1abdfb299f6c4f0fab813147c97fe3 # main
 
       # GitHub-hosted fallback caches Rust via the Actions cache. The self-hosted
-      # box instead persists CARGO_TARGET_DIR outside the workspace (checkout
-      # clean + the runner's job cleanup wipe the workspace, not $HOME). Scope it
-      # per runner ($RUNNER_NAME) so a second runner service on the same box gets
-      # its own target dir instead of racing on a shared one.
+      # box runs the heavy Rust CI (clippy/doc/test) as crane derivations via
+      # `nix flake check`, so deps cache in /nix/store and there's no persistent
+      # CARGO_TARGET_DIR to manage -- the residual `cargo check`s use the
+      # workspace ./target, which the runner wipes per job.
       - name: Rust Cache
         if: runner.environment == 'github-hosted'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
-      - if: runner.environment == 'self-hosted'
-        run: echo "CARGO_TARGET_DIR=$HOME/cargo-target/moq-$RUNNER_NAME" >> "$GITHUB_ENV"
+
+      # Mark a baseline so the post-run assertion can tell whether anything wrote
+      # under the old persistent target dir (i.e. a CARGO_TARGET_DIR override
+      # leaked back in and would re-grow an unbounded tree).
+      - name: Target-dir baseline
+        if: runner.environment == 'self-hosted'
+        run: touch "$RUNNER_TEMP/target-baseline"
 
       # `just ci` calls `just changed` internally to skip unchanged scopes.
       # Login shell so /etc/profile.d puts Nix on PATH; Actions shells don't by
       # default. Harmless on the hosted fallback.
       - run: nix develop --command just ci
         shell: bash -leo pipefail {0}
+
+      # Invariant: nothing should write to the old persistent target dir anymore.
+      # Fails loudly if a CARGO_TARGET_DIR override sneaks back in.
+      - name: Assert the persistent target dir stayed unused
+        if: runner.environment == 'self-hosted'
+        run: |
+          mkdir -p "$HOME/cargo-target"
+          leaked=$(find "$HOME/cargo-target" -type f -newer "$RUNNER_TEMP/target-baseline" 2>/dev/null | head)
+          if [ -n "$leaked" ]; then
+            echo "::error::cargo wrote to the persistent target dir; a CARGO_TARGET_DIR override leaked back in"
+            echo "$leaked"
+            exit 1
+          fi
+          echo "OK: \$HOME/cargo-target untouched this run"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -73,15 +73,19 @@ jobs:
         shell: bash -leo pipefail {0}
 
       # Invariant: nothing should write to the old persistent target dir anymore.
-      # Fails loudly if a CARGO_TARGET_DIR override sneaks back in.
+      # Fails loudly if a CARGO_TARGET_DIR override sneaks back in. Scope it to
+      # *this* repo's old per-runner dir (moq-$RUNNER_NAME) -- the box's
+      # $HOME/cargo-target is shared with other repos (e.g. moq-pro) and runners,
+      # whose jobs may run concurrently and legitimately still write there.
       - name: Assert the persistent target dir stayed unused
         if: runner.environment == 'self-hosted'
         run: |
-          mkdir -p "$HOME/cargo-target"
-          leaked=$(find "$HOME/cargo-target" -type f -newer "$RUNNER_TEMP/target-baseline" 2>/dev/null | head)
+          target="$HOME/cargo-target/moq-$RUNNER_NAME"
+          mkdir -p "$target"
+          leaked=$(find "$target" -type f -newer "$RUNNER_TEMP/target-baseline" 2>/dev/null | head)
           if [ -n "$leaked" ]; then
-            echo "::error::cargo wrote to the persistent target dir; a CARGO_TARGET_DIR override leaked back in"
+            echo "::error::cargo wrote to $target; a CARGO_TARGET_DIR override leaked back in"
             echo "$leaked"
             exit 1
           fi
-          echo "OK: \$HOME/cargo-target untouched this run"
+          echo "OK: $target untouched this run"

--- a/flake.nix
+++ b/flake.nix
@@ -230,6 +230,14 @@
         };
 
         formatter = pkgs.nixfmt-tree;
+
+        # Heavy Rust CI (clippy / doc / test, all features) as crane
+        # derivations: deps compile once and cache, only first-party code
+        # recompiles per run, and there's no persistent CARGO_TARGET_DIR to
+        # bound. Run with `nix flake check` or a single one via
+        # `nix build .#checks.<system>.clippy`. The cheap, non-compiling lints
+        # (rustfmt, cargo-deny/shear/sort) stay in `just rs ci`.
+        checks = overlayPkgs.moqChecks;
       }
     );
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -272,7 +272,9 @@ let
       checkCommonArgs
       // {
         cargoArtifacts = checkDeps;
-        cargoClippyExtraArgs = "--workspace --all-targets --all-features -- -D warnings";
+        # --workspace/--all-features come from checkCommonArgs.cargoExtraArgs,
+        # which crane prepends; only add the clippy-specific flags here.
+        cargoClippyExtraArgs = "--all-targets -- -D warnings";
       }
     );
 
@@ -280,7 +282,9 @@ let
       checkCommonArgs
       // {
         cargoArtifacts = checkDeps;
-        cargoDocExtraArgs = "--workspace --no-deps --all-features";
+        # --all-targets is invalid for `cargo doc`, so it stays out of the
+        # shared cargoExtraArgs; --workspace/--all-features are inherited.
+        cargoDocExtraArgs = "--no-deps";
         RUSTDOCFLAGS = "-D warnings";
       }
     );
@@ -289,7 +293,7 @@ let
       checkCommonArgs
       // {
         cargoArtifacts = checkDeps;
-        cargoTestExtraArgs = "--workspace --all-targets --all-features";
+        cargoTestExtraArgs = "--all-targets";
       }
     );
   };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -200,8 +200,103 @@ let
       fi
     '';
   };
+
+  # --- CI checks (run via `nix flake check`) -------------------------------
+  #
+  # The heavy Rust CI (clippy / doc / test) used to run as plain `cargo` on the
+  # self-hosted runner, compiling into a persistent CARGO_TARGET_DIR that grew
+  # unbounded (every branch's artifacts, never pruned) and was unsafe to share
+  # across parallel jobs. Expressing those checks as crane derivations instead
+  # makes Nix the cache: dependencies compile exactly once (`checkDeps`), land
+  # in the binary cache, are shared across machines, and are LRU-evicted by the
+  # store's free-space GC. Only first-party code recompiles, inside Nix's
+  # sandbox (which is wiped per build), so there is no target dir to bound.
+
+  # Keep .pc.in alongside the cargo sources: libmoq's build.rs reads moq.pc.in,
+  # and the default cleanCargoSource filter would drop it (see libmoqArgs).
+  checkSrc = final.lib.cleanSourceWith {
+    src = ../.;
+    name = "source";
+    filter = path: type: (final.lib.hasSuffix ".pc.in" path) || (craneLib.filterCargoSources path type);
+  };
+
+  # Every system lib the workspace needs to compile with all features on:
+  # bindgen (clang) for ffmpeg/vaapi, GStreamer for moq-gst, ALSA for
+  # moq-audio's capture feature, libva for moq-video's vaapi feature. The
+  # Linux-only libs match the devShell's `lib.optionals (!isDarwin)` set.
+  checkCommonArgs = {
+    src = checkSrc;
+    # The workspace root Cargo.toml has no [package], so name it explicitly
+    # (otherwise crane warns and uses a placeholder).
+    pname = "moq-workspace";
+    version = "0.0.0";
+    strictDeps = true;
+    nativeBuildInputs = with final; [
+      pkg-config
+      clang
+      cmake
+      # boring-sys (quiche, under --all-features) shells out to `git` to apply
+      # its BoringSSL patches; the devShell has it on $PATH, the sandbox doesn't.
+      git
+    ];
+    buildInputs =
+      (with final; [
+        ffmpeg
+        glib
+        curl
+        gst_all_1.gstreamer
+        gst_all_1.gst-plugins-base
+      ])
+      ++ final.lib.optionals final.stdenv.isLinux (
+        with final;
+        [
+          alsa-lib
+          libva
+        ]
+      );
+    LIBCLANG_PATH = "${final.libclang.lib}/lib";
+    # jemalloc (pulled in by --all-features) builds -O0 configure tests that
+    # clash with Nix's _FORTIFY_SOURCE hardening (needs -O). Same as the
+    # package builds and the devShell.
+    hardeningDisable = [ "fortify" ];
+    # Scope the dep build to the whole workspace with every feature so a single
+    # checkDeps covers clippy/doc/test below.
+    cargoExtraArgs = "--workspace --all-features";
+  };
+
+  # Compile all third-party deps once; the checks reuse this artifact.
+  checkDeps = craneLib.buildDepsOnly (checkCommonArgs // { pname = "moq-workspace-deps"; });
+
+  moqChecks = {
+    clippy = craneLib.cargoClippy (
+      checkCommonArgs
+      // {
+        cargoArtifacts = checkDeps;
+        cargoClippyExtraArgs = "--workspace --all-targets --all-features -- -D warnings";
+      }
+    );
+
+    doc = craneLib.cargoDoc (
+      checkCommonArgs
+      // {
+        cargoArtifacts = checkDeps;
+        cargoDocExtraArgs = "--workspace --no-deps --all-features";
+        RUSTDOCFLAGS = "-D warnings";
+      }
+    );
+
+    test = craneLib.cargoTest (
+      checkCommonArgs
+      // {
+        cargoArtifacts = checkDeps;
+        cargoTestExtraArgs = "--workspace --all-targets --all-features";
+      }
+    );
+  };
 in
 {
+  inherit moqChecks;
+
   moq-relay = craneLib.buildPackage moqRelayArgs;
   moq-relay-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqRelayArgs);
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -212,12 +212,30 @@ let
   # store's free-space GC. Only first-party code recompiles, inside Nix's
   # sandbox (which is wiped per build), so there is no target dir to bound.
 
-  # Keep .pc.in alongside the cargo sources: libmoq's build.rs reads moq.pc.in,
-  # and the default cleanCargoSource filter would drop it (see libmoqArgs).
+  # crane's cleanCargoSource keeps only Rust-relevant files, but the test
+  # targets compiled under `--all-targets` `include_str!`/`include_bytes!` data
+  # fixtures (rs/moq-mux test_data/*.ts, rs/moq-json tests/vectors.json, etc.)
+  # and libmoq's build.rs reads moq.pc.in. Rather than enumerate every asset
+  # (fragile -- a new fixture would break CI), take the whole tree minus the
+  # heavy non-source dirs. Dep caching is unaffected (buildDepsOnly keys on
+  # Cargo.lock); only the first-party check rebuilds on a non-Rust change.
   checkSrc = final.lib.cleanSourceWith {
     src = ../.;
     name = "source";
-    filter = path: type: (final.lib.hasSuffix ".pc.in" path) || (craneLib.filterCargoSources path type);
+    filter =
+      path: _type:
+      let
+        # Prune a dir both as an entry ("…/target") and its contents
+        # ("…/target/…") so we don't walk node_modules etc. at all.
+        excluded = name: final.lib.hasSuffix "/${name}" path || final.lib.hasInfix "/${name}/" path;
+      in
+      !(
+        excluded "node_modules"
+        || excluded "target"
+        || excluded ".direnv"
+        || excluded ".venv"
+        || excluded ".git"
+      );
   };
 
   # Every system lib the workspace needs to compile with all features on:

--- a/rs/justfile
+++ b/rs/justfile
@@ -35,12 +35,21 @@ ci FILES="":
     	echo "rs: no Rust changes; skipping."
     	exit 0
     fi
-    just check --workspace
+    # Heavy compiles -- clippy, doc, and the --all-features test run -- are crane
+    # derivations built by `nix flake check` (see flake.nix `checks` and
+    # nix/overlay.nix): deps cache in /nix/store, only first-party code rebuilds
+    # in the sandbox, and there's no persistent cargo target dir to bound. What
+    # stays here is non-compiling hygiene, cargo-deny (hits the network, so it
+    # can't run in the Nix sandbox), and the default / no-default-feature
+    # `cargo check`s the all-features crane run doesn't cover -- those compile
+    # into the in-workspace ./target, which the runner wipes per job.
+    # (Local devs still get the full cargo loop via `just rs check`.)
+    cargo fmt --all --check
+    cargo sort --workspace --check --no-format
+    cargo shear
+    cargo check --workspace --all-targets
     cargo check --workspace --no-default-features
-    cargo check --workspace --all-features
     cargo deny check --show-stats
-    just rs test --all-features
-    just build
 
 # Auto-fix clippy/format/shear/sort.
 fix:


### PR DESCRIPTION
## Why

The self-hosted A1 runner filled its 200G boot volume and CI started failing with `No space left on device`. Root cause: the heavy Rust CI (`just rs ci` → `cargo clippy/doc/test --all-features`) compiled into a **persistent `CARGO_TARGET_DIR`** (`$HOME/cargo-target/moq-$RUNNER_NAME`) that grew unbounded (every branch's artifacts, never pruned — **161G**), was unsafe to share across parallel jobs, and lived outside the workspace so the per-job cleanup never touched it. Crane already built the release binaries, but the CI *checks* never went through it.

## What

Move the heavy checks into crane, exposed via flake `checks`, and make `nix flake check` the thing that runs them:

- `clippy` — `--all-targets --all-features -- -D warnings`
- `doc` — `--no-deps --all-features`, `RUSTDOCFLAGS=-D warnings`
- `test` — `--all-targets --all-features`

Dependencies compile once (`cargoArtifacts = buildDepsOnly`), land in the Cachix binary cache, are shared across machines, and are **LRU-evicted by the Nix store's free-space GC**. Only first-party code recompiles, inside Nix's sandbox — **no persistent target dir to bound.**

Then (stage 2 in this PR):
- `just rs ci` no longer repeats cargo clippy/doc/test (crane owns them); it keeps non-compiling hygiene (`fmt`/`shear`/`sort`), `cargo-deny` (needs network, can't run in the sandbox), and the default / no-default-feature `cargo check`s the all-features crane run doesn't cover.
- `check.yml` drops the persistent `CARGO_TARGET_DIR`; residual `cargo check`s use the in-workspace `./target`, which the runner wipes per job.
- A self-hosted CI step **asserts nothing wrote under `$HOME/cargo-target`**, so a `CARGO_TARGET_DIR` override can't silently reintroduce an unbounded target dir.

Local `just rs check` (the fast cargo inner loop) is unchanged.

## Verification

CI on the self-hosted aarch64-linux runner is authoritative (Linux-only features: alsa, libva, jemalloc). Confirmed green through iterations: the `--all-features` dep graph — including `boring-sys`/quiche — builds in the sandbox (needed `git` for BoringSSL patches), test fixtures (`include_*!` data) are kept in the check source, and the `test` suite passes inside the sandbox.

## Notes

- Companion to the runner disk fix (disk-guard timer + `CARGO_INCREMENTAL=0`, in the `oci` infra repo).
- Dropping the persistent `CARGO_TARGET_DIR` also removes the hardcoded-`./target` `wasm`-recipe footgun that bit branch `claude/merge-main-into-dev-992spq` on the self-hosted runner.
- Follow-up ideas: a single shared `cargoArtifacts` across packages+checks to cut redundant dep compiles; Nix-vendoring the other languages (Go `buildGoModule`, uv via `uv2nix`, bun via `bun2nix`) to extend the "sandbox-except-`/nix`" model beyond Rust.
