### PR TITLE
feat(moq-mux): synthesize fMP4/CMAF init for AV1 video

### DIFF
--- a/doc/lib/rs/crate/moq-mux.md
+++ b/doc/lib/rs/crate/moq-mux.md
@@ -54,6 +54,9 @@ See the [moq-cli source](https://github.com/moq-dev/moq/tree/main/rs/moq-cli) fo
 
 - H.264 (AVC) - requires `h264` feature
 - H.265 (HEVC) - requires `h265` feature
+- AV1
+- VP8
+- VP9
 
 **Audio:**
 

--- a/rs/moq-mux/src/codec/av1/mod.rs
+++ b/rs/moq-mux/src/codec/av1/mod.rs
@@ -61,6 +61,32 @@ pub(crate) fn av1_from_av1c(av1c: &mp4_atom::Av1c) -> AV1 {
 	}
 }
 
+/// Build an `mp4_atom::Av1c` (AV1CodecConfigurationRecord) from the hang
+/// catalog's AV1 codec struct, the inverse of [`av1_from_av1c`].
+///
+/// `config_obus` is left empty: moq-video publishes AV1 with the sequence
+/// header inline in the bitstream (the `.av01` in-band case, analogous to
+/// `hev1`/`avc3`), so the decoder reads it from the keyframe rather than the
+/// out-of-band config record. The catalog's color fields (color primaries,
+/// transfer characteristics, matrix coefficients, full range) have no slot in
+/// av1C; they live in the sequence header OBU instead.
+pub(crate) fn av1c_from_av1(av1: &AV1) -> mp4_atom::Av1c {
+	let (twelve_bit, high_bitdepth) = bitdepth_flags(av1.bitdepth);
+	mp4_atom::Av1c {
+		seq_profile: av1.profile,
+		seq_level_idx_0: av1.level,
+		seq_tier_0: av1.tier == 'H',
+		high_bitdepth,
+		twelve_bit,
+		monochrome: av1.mono_chrome,
+		chroma_subsampling_x: av1.chroma_subsampling_x,
+		chroma_subsampling_y: av1.chroma_subsampling_y,
+		chroma_sample_position: av1.chroma_sample_position,
+		initial_presentation_delay: None,
+		config_obus: Vec::new(),
+	}
+}
+
 /// Bit depth from the (twelve_bit, high_bitdepth) av1C flag pair
 /// (ISO/IEC 14496-15 + av1-isobmff §2.3.3).
 ///
@@ -69,9 +95,17 @@ pub(crate) fn bitdepth(twelve_bit: bool, high_bitdepth: bool) -> u8 {
 	8 + 2 * u8::from(high_bitdepth) + 2 * u8::from(twelve_bit)
 }
 
+/// The (twelve_bit, high_bitdepth) av1C flag pair for a given bit depth, the
+/// inverse of [`bitdepth`]. 8-bit -> (false, false), 10-bit -> (false, true),
+/// 12-bit -> (true, true).
+pub(crate) fn bitdepth_flags(bitdepth: u8) -> (bool, bool) {
+	(bitdepth >= 12, bitdepth >= 10)
+}
+
 #[cfg(test)]
 mod tests {
-	use super::bitdepth;
+	use super::{av1_from_av1c, av1c_from_av1, bitdepth, bitdepth_flags};
+	use hang::catalog::AV1;
 
 	#[test]
 	fn maps_bitdepth_flags() {
@@ -81,5 +115,51 @@ mod tests {
 		// twelve_bit=true with high_bitdepth=false is not a valid combination
 		// per the spec, but the additive formula still gives a defined answer.
 		assert_eq!(bitdepth(true, false), 10);
+	}
+
+	#[test]
+	fn bitdepth_flags_round_trip() {
+		for (depth, flags) in [(8, (false, false)), (10, (false, true)), (12, (true, true))] {
+			assert_eq!(bitdepth_flags(depth), flags);
+			let (twelve_bit, high_bitdepth) = flags;
+			assert_eq!(bitdepth(twelve_bit, high_bitdepth), depth);
+		}
+	}
+
+	#[test]
+	fn av1c_round_trips_catalog_fields() {
+		let av1 = AV1 {
+			profile: 0,
+			level: 8,
+			tier: 'H',
+			bitdepth: 10,
+			mono_chrome: false,
+			chroma_subsampling_x: true,
+			chroma_subsampling_y: true,
+			chroma_sample_position: 2,
+			// Color fields have no av1C slot; they live in the sequence header.
+			..Default::default()
+		};
+
+		let av1c = av1c_from_av1(&av1);
+		assert_eq!(av1c.seq_profile, 0);
+		assert_eq!(av1c.seq_level_idx_0, 8);
+		assert!(av1c.seq_tier_0);
+		assert!(av1c.high_bitdepth);
+		assert!(!av1c.twelve_bit);
+		assert!(av1c.chroma_subsampling_x);
+		assert!(av1c.chroma_subsampling_y);
+		assert_eq!(av1c.chroma_sample_position, 2);
+		assert!(av1c.config_obus.is_empty());
+
+		// The av1C-backed fields survive a round trip back to the catalog.
+		let back = av1_from_av1c(&av1c);
+		assert_eq!(back.profile, av1.profile);
+		assert_eq!(back.level, av1.level);
+		assert_eq!(back.bitdepth, av1.bitdepth);
+		assert_eq!(back.mono_chrome, av1.mono_chrome);
+		assert_eq!(back.chroma_subsampling_x, av1.chroma_subsampling_x);
+		assert_eq!(back.chroma_subsampling_y, av1.chroma_subsampling_y);
+		assert_eq!(back.chroma_sample_position, av1.chroma_sample_position);
 	}
 }

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -375,6 +375,109 @@ async fn vp9_source_to_cmaf_export_synthesizes_vp09() {
 	moov.encode(&mut buf).expect("encode synthesized moov");
 }
 
+/// AV1 source (catalog `Container::Legacy`, codec `av01`, no `description`) →
+/// fMP4 export must synthesize an `av01` sample entry whose `av1C` round-trips
+/// the catalog's AV1 parameters. AV1 publishes its sequence header in-band
+/// (like `hev1`/`avc3`), so there is no out-of-band config and `config_obus`
+/// stays empty.
+#[tokio::test(start_paused = true)]
+async fn av1_source_to_cmaf_export_synthesizes_av01() {
+	use bytes::Bytes;
+	use hang::catalog::{AV1, Container, VideoConfig};
+	use moq_net::Timestamp;
+
+	let broadcast = moq_net::BroadcastInfo::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let track = producer
+		.create_track(
+			producer.unique_name(".av01"),
+			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+		)
+		.unwrap();
+	let mut config = VideoConfig::new(AV1 {
+		profile: 0,
+		level: 8,
+		tier: 'M',
+		bitdepth: 10,
+		mono_chrome: false,
+		chroma_subsampling_x: true,
+		chroma_subsampling_y: true,
+		chroma_sample_position: 2,
+		color_primaries: 9,
+		transfer_characteristics: 16,
+		matrix_coefficients: 9,
+		full_range: false,
+	});
+	config.coded_width = Some(320);
+	config.coded_height = Some(240);
+	config.container = Container::Legacy;
+	catalog.lock().video.renditions.insert(track.name().to_string(), config);
+
+	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
+	track_producer
+		.write(crate::container::Frame {
+			timestamp: Timestamp::from_micros(0).unwrap(),
+			payload: Bytes::from_static(&[0x12, 0x00, 0x0a, 0x0b]),
+			keyframe: true,
+			duration: None,
+		})
+		.unwrap();
+	track_producer.finish().unwrap();
+
+	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
+		.await
+		.expect("catalog consumer");
+	let mut exporter = crate::container::fmp4::Export::new(consumer, catalog_stream);
+
+	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
+		.await
+		.expect("exporter timed out")
+		.expect("exporter result")
+		.expect("expected init bytes");
+
+	drop(track_producer);
+	drop(catalog);
+	drop(producer);
+
+	let mut cursor = Cursor::new(init.as_ref());
+	let mut moov: Option<mp4_atom::Moov> = None;
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).expect("decode init") {
+		if let mp4_atom::Any::Moov(m) = atom {
+			moov = Some(m);
+		}
+	}
+	let moov = moov.expect("init segment missing moov");
+	assert_eq!(moov.trak.len(), 1, "expected single track in moov");
+
+	let trak = &moov.trak[0];
+	let stsd = &trak.mdia.minf.stbl.stsd;
+	assert_eq!(stsd.codecs.len(), 1, "expected single sample entry");
+	let av01 = match &stsd.codecs[0] {
+		mp4_atom::Codec::Av01(av01) => av01,
+		other => panic!("expected Av01 sample entry, got {:?}", other),
+	};
+	assert_eq!(av01.visual.width, 320);
+	assert_eq!(av01.visual.height, 240);
+
+	let av1c = &av01.av1c;
+	assert_eq!(av1c.seq_profile, 0);
+	assert_eq!(av1c.seq_level_idx_0, 8);
+	assert!(!av1c.seq_tier_0, "Main tier");
+	assert!(av1c.high_bitdepth, "10-bit");
+	assert!(!av1c.twelve_bit);
+	assert!(av1c.chroma_subsampling_x);
+	assert!(av1c.chroma_subsampling_y);
+	assert_eq!(av1c.chroma_sample_position, 2);
+	assert!(av1c.config_obus.is_empty(), "sequence header stays in-band");
+
+	// The synthesized init (av1C included) must round-trip through encode.
+	let mut buf = Vec::new();
+	moov.encode(&mut buf).expect("encode synthesized moov");
+}
+
 /// CMAF source (catalog `Container::Cmaf`) → fMP4 export should keep using
 /// the passthrough init path: existing init bytes are merged into the moov.
 ///

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -424,6 +424,11 @@ pub(crate) fn synthesize_video_trak(
 				})
 			}
 		}
+		VideoCodec::AV1(av1) => mp4_atom::Codec::from(mp4_atom::Av01 {
+			visual,
+			av1c: crate::codec::av1::av1c_from_av1(av1),
+			..Default::default()
+		}),
 		VideoCodec::VP8 => mp4_atom::Codec::from(mp4_atom::Vp08 {
 			visual,
 			vpcc: crate::codec::vp8::vpcc(),


### PR DESCRIPTION
## Summary

`moq-mux`'s fMP4/CMAF init-segment writer could only synthesize a sample entry for H.264 and H.265; every other codec fell through to `UnsupportedSynthesis`. Remuxing an AV1 MoQ broadcast to fMP4 therefore failed:

```
moq-cli subscribe --format fmp4   # (or accept ... --format fmp4) against an AV1 broadcast
Error: cmaf: can't synthesize CMAF init for video codec AV1(AV1 { profile: 0, level: 31, ... })
```

This adds the AV1 case so `synthesize_video_trak` builds an `av01` sample entry carrying an `av1C` box.

## Changes

- **`rs/moq-mux/src/codec/av1/mod.rs`**: new `av1c_from_av1` helper, the inverse of the existing `av1_from_av1c` (import direction). Maps the catalog `AV1` config (profile, level, tier, bit depth, chroma subsampling, monochrome, chroma sample position) into an `mp4_atom::Av1c`. Adds a `bitdepth_flags` helper (inverse of `bitdepth`) for the `(twelve_bit, high_bitdepth)` flag pair.
- **`rs/moq-mux/src/container/fmp4/mod.rs`**: `synthesize_video_trak` now handles `VideoCodec::AV1`, building an `av01` sample entry + `av1C`.
- **`config_obus` is left empty.** moq-video publishes AV1 with the sequence header inline in the bitstream (the `.av01` in-band case, analogous to `hev1`/`avc3`), so the decoder reads it from the keyframe rather than the out-of-band config record. The catalog's color fields (color primaries / transfer / matrix / full range) have no slot in `av1C`; they live in the sequence header OBU.
- **`doc/lib/rs/crate/moq-mux.md`**: brought the supported-codec list up to date (it also omitted VP8/VP9, which were already supported).

## Public API

No public surface changes. `av1c_from_av1` / `bitdepth_flags` are `pub(crate)`; the new arm is inside a `pub(crate)` function. No wire or breaking change.

## Branch targeting

Targets `dev` per CLAUDE.md: this is a catalog/container-format area change in `moq-mux`.

## Test plan

- [x] `cargo test -p moq-mux` (265 passed) — new `av1_source_to_cmaf_export_synthesizes_av01` round-trips a synthesized init back to an `av01` sample entry with a well-formed `av1C` (empty `config_obus`), plus `bitdepth_flags_round_trip` and `av1c_round_trips_catalog_fields` unit tests.
- [x] `cargo clippy -p moq-mux --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-mux --no-deps`
- [ ] End-to-end `moq-cli accept ... --format fmp4` + `ffprobe`: not run locally (this Windows box lacks `pkg-config`/ffmpeg for the full-workspace build); covered by the export round-trip test.

(Written by Claude)