### PR TITLE
feat(moq-video): H.265 encode on Windows via Media Foundation

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -101,8 +101,8 @@ Linux, Media Foundation on Windows). The codec is chosen with `--codec`
 (`h264` default, or `h265`). For H.264 it picks a hardware encoder
 (VideoToolbox on macOS, NVENC on Linux NVIDIA, VAAPI on Linux Intel/AMD) when one
 is present, falling back to the built-in software encoder (openh264); force either
-with `--hardware` / `--software`. H.265 is hardware-only (VideoToolbox on macOS).
-`--camera` takes a bare integer as a device index, otherwise a
+with `--hardware` / `--software`. H.265 is hardware-only (VideoToolbox on macOS,
+Media Foundation on Windows). `--camera` takes a bare integer as a device index, otherwise a
 device path (Linux) or name (a friendly-name substring on Windows, the
 AVFoundation `uniqueID` on macOS). Audio capture uses cpal (CoreAudio / WASAPI /
 ALSA) and encodes Opus.

--- a/rs/moq-video/DESIGN-native-codecs.md
+++ b/rs/moq-video/DESIGN-native-codecs.md
@@ -464,13 +464,18 @@ afterward on top of the same `Backend` seam:
   `moq_mux::codec` importer (`.avc3` / `.hev1`). The mux + `hang` catalog already
   supported both, so only `moq-video` needed work.
 - Backends advertise the codecs they emit and `backend::open` filters by the
-  requested codec before applying `Kind`. **H.265**: VideoToolbox only (one extra
-  codec type + profile, an HVCC->Annex-B path reusing the H.264 conversion, and
-  HEVC NAL/IRAP parsing); no software encoder, so it's hardware-only.
+  requested codec before applying `Kind`. **H.265**: hardware-only (no software
+  encoder). On macOS, VideoToolbox (one extra codec type + profile, an
+  HVCC->Annex-B path reusing the H.264 conversion, and HEVC NAL/IRAP parsing). On
+  Windows, the Media Foundation MFT, which natively emits Annex-B with inline
+  VPS/SPS/PPS like its H.264 output, so it only needs the HEVC output subtype +
+  Main profile, no rewrite. The MFT is vendor-agnostic (NVIDIA/Intel/AMD).
 - Verified on macOS (`just check`): VideoToolbox HEVC emits a self-contained
   VPS+SPS+PPS+IDR Annex-B keyframe, and the full encode -> split -> import ->
   catalog round-trip registers the right rendition for each codec.
-- Follow-ups: NVENC/VAAPI HEVC, and a live camera run per codec.
+- Verified on Windows (RTX 3070 Ti, live camera): Media Foundation HEVC publishes
+  a `.hev1` rendition; the round-trip into Matroska decodes as Main-profile HEVC.
+- Follow-ups: Linux NVENC/VAAPI HEVC, and a live camera run per platform.
 
 AV1 is intentionally left out: there is no hardware AV1 encoder available to us
 (none on macOS; NVENC/VAAPI AV1 are Linux-only and not yet wired), and software

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -1,16 +1,16 @@
-//! Hardware H.264 backend via a Media Foundation encoder MFT.
+//! Hardware H.264 / H.265 backend via a Media Foundation encoder MFT.
 //!
-//! Enumerates a hardware (`MFT_ENUM_FLAG_HARDWARE`) H.264 encoder and drives it
-//! through the async-MFT event model. When capture hands us a [`Frame::Texture`]
-//! the encoder runs on that texture's Direct3D11 device (via a DXGI device
-//! manager) and consumes the surface zero-copy; a CPU [`Frame::I420`] is uploaded
-//! into a system-memory NV12 sample instead.
+//! Enumerates a hardware (`MFT_ENUM_FLAG_HARDWARE`) encoder for the requested
+//! codec and drives it through the async-MFT event model. When capture hands us
+//! a [`Frame::Texture`] the encoder runs on that texture's Direct3D11 device (via
+//! a DXGI device manager) and consumes the surface zero-copy; a CPU
+//! [`Frame::I420`] is uploaded into a system-memory NV12 sample instead.
 //!
-//! The MFT emits an Annex-B byte stream for `MFVideoFormat_H264`, with SPS/PPS
-//! inline ahead of each IDR, which is exactly what `moq_mux` avc3 mode wants, so
-//! unlike VideoToolbox there's no AVCC -> Annex-B rewrite. Used only from the one
-//! capture/encode thread, so the COM handles are wrapped in a thread-confined
-//! `Send` type.
+//! The MFT emits an Annex-B byte stream with parameter sets inline ahead of each
+//! IDR/IRAP (SPS/PPS for H.264, VPS/SPS/PPS for H.265), which is exactly what
+//! `moq_mux` avc3 / hev1 mode wants, so unlike VideoToolbox there's no
+//! AVCC/HVCC -> Annex-B rewrite. Used only from the one capture/encode thread, so
+//! the COM handles are wrapped in a thread-confined `Send` type.
 
 use std::mem::ManuallyDrop;
 use std::ptr;
@@ -29,13 +29,13 @@ use windows::Win32::Media::MediaFoundation::{
 	MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN,
 	MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM,
 	MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO,
-	MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_NV12, MFVideoInterlace_Progressive, eAVEncCommonRateControlMode_CBR,
-	eAVEncH264VProfile_High,
+	MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoInterlace_Progressive,
+	eAVEncCommonRateControlMode_CBR, eAVEncH264VProfile_High, eAVEncH265VProfile_Main_420_8,
 };
 use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_UI4};
-use windows::core::Interface;
+use windows::core::{GUID, Interface};
 
-use super::super::encoder::Config;
+use super::super::encoder::{Codec, Config};
 use super::Backend;
 use crate::Error;
 use crate::frame::{Frame, interleave_uv};
@@ -52,6 +52,7 @@ pub(crate) struct MediaFoundation {
 	transform: IMFTransform,
 	events: IMFMediaEventGenerator,
 	codec_api: ICodecAPI,
+	codec: Codec,
 	width: u32,
 	height: u32,
 	framerate: u32,
@@ -79,8 +80,9 @@ unsafe impl Send for MediaFoundation {}
 
 impl MediaFoundation {
 	pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
+		let format = OutputFormat::for_codec(config.codec);
 		let com = ComGuard::new()?;
-		let transform = enumerate_encoder()?;
+		let transform = enumerate_encoder(format.subtype)?;
 
 		// Unlock the async interface before any other use (hardware MFTs are async).
 		let attrs = unsafe { transform.GetAttributes().map_err(|e| mf_err("MFT GetAttributes", e))? };
@@ -99,14 +101,16 @@ impl MediaFoundation {
 
 		tracing::info!(
 			encoder = NAME,
+			codec = format.label,
 			width = config.width,
 			height = config.height,
-			"opened H.264 encoder"
+			"opened encoder"
 		);
 		Ok(Box::new(Self {
 			transform,
 			events,
 			codec_api,
+			codec: config.codec,
 			width: config.width,
 			height: config.height,
 			framerate: config.framerate,
@@ -190,13 +194,14 @@ impl MediaFoundation {
 	}
 
 	fn set_output_type(&self) -> Result<(), Error> {
+		let format = OutputFormat::for_codec(self.codec);
 		let media = unsafe { MFCreateMediaType().map_err(|e| mf_err("create output type", e))? };
 		unsafe {
 			media
 				.SetGUID(&MF_MT_MAJOR_TYPE, &MFMediaType_Video)
 				.map_err(|e| mf_err("output major type", e))?;
 			media
-				.SetGUID(&MF_MT_SUBTYPE, &MFVideoFormat_H264)
+				.SetGUID(&MF_MT_SUBTYPE, &format.subtype)
 				.map_err(|e| mf_err("output subtype", e))?;
 			media
 				.SetUINT32(&MF_MT_AVG_BITRATE, self.bitrate)
@@ -205,7 +210,7 @@ impl MediaFoundation {
 				.SetUINT32(&MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive.0 as u32)
 				.map_err(|e| mf_err("output interlace", e))?;
 			media
-				.SetUINT32(&MF_MT_MPEG2_PROFILE, eAVEncH264VProfile_High.0 as u32)
+				.SetUINT32(&MF_MT_MPEG2_PROFILE, format.profile)
 				.map_err(|e| mf_err("output profile", e))?;
 			media
 				.SetUINT64(&MF_MT_FRAME_SIZE, pack_2x32(self.width, self.height))
@@ -455,15 +460,15 @@ impl Backend for MediaFoundation {
 	}
 }
 
-/// Pick the first hardware H.264 encoder MFT (NV12 in, H.264 out).
-fn enumerate_encoder() -> Result<IMFTransform, Error> {
+/// Pick the first hardware encoder MFT (NV12 in, `subtype` out).
+fn enumerate_encoder(subtype: GUID) -> Result<IMFTransform, Error> {
 	let input = MFT_REGISTER_TYPE_INFO {
 		guidMajorType: MFMediaType_Video,
 		guidSubtype: MFVideoFormat_NV12,
 	};
 	let output = MFT_REGISTER_TYPE_INFO {
 		guidMajorType: MFMediaType_Video,
-		guidSubtype: MFVideoFormat_H264,
+		guidSubtype: subtype,
 	};
 
 	let mut activates: *mut Option<windows::Win32::Media::MediaFoundation::IMFActivate> = ptr::null_mut();
@@ -480,7 +485,7 @@ fn enumerate_encoder() -> Result<IMFTransform, Error> {
 		.map_err(|e| mf_err("MFTEnumEx", e))?;
 	}
 	if count == 0 {
-		return Err(Error::Codec(anyhow::anyhow!("no hardware H.264 encoder found")));
+		return Err(Error::Codec(anyhow::anyhow!("no hardware encoder found")));
 	}
 
 	let entries = unsafe { std::slice::from_raw_parts_mut(activates, count as usize) };
@@ -497,7 +502,33 @@ fn enumerate_encoder() -> Result<IMFTransform, Error> {
 		windows::Win32::System::Com::CoTaskMemFree(Some(activates as *const std::ffi::c_void));
 	}
 
-	transform.ok_or_else(|| Error::Codec(anyhow::anyhow!("failed to activate H.264 encoder MFT")))
+	transform.ok_or_else(|| Error::Codec(anyhow::anyhow!("failed to activate encoder MFT")))
+}
+
+/// The Media Foundation output type for a codec: the format subtype enumerated
+/// and set on the MFT, plus the `MF_MT_MPEG2_PROFILE` value (the attribute MF
+/// reuses to carry the H.264/H.265 profile).
+struct OutputFormat {
+	subtype: GUID,
+	profile: u32,
+	label: &'static str,
+}
+
+impl OutputFormat {
+	fn for_codec(codec: Codec) -> Self {
+		match codec {
+			Codec::H264 => Self {
+				subtype: MFVideoFormat_H264,
+				profile: eAVEncH264VProfile_High.0 as u32,
+				label: "H.264",
+			},
+			Codec::H265 => Self {
+				subtype: MFVideoFormat_HEVC,
+				profile: eAVEncH265VProfile_Main_420_8.0 as u32,
+				label: "H.265",
+			},
+		}
+	}
 }
 
 /// A DXGI device manager wrapping `device`, so the MFT shares the capture

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -64,7 +64,7 @@ const HARDWARE: &[Candidate] = &[
 	#[cfg(target_os = "windows")]
 	Candidate {
 		name: mediafoundation::NAME,
-		codecs: &[Codec::H264],
+		codecs: &[Codec::H264, Codec::H265],
 		open: mediafoundation::MediaFoundation::open,
 	},
 	#[cfg(all(target_os = "linux", feature = "nvenc"))]


### PR DESCRIPTION
## Summary

Stacked on #1802 (the H.265/AV1 encode PR). That PR added HEVC encode for **macOS only** (VideoToolbox); on Windows `--codec h265` returned `NoEncoder`. This wires HEVC into the existing Windows **Media Foundation** backend.

- The MF encoder MFT now enumerates and configures `MFVideoFormat_HEVC` with HEVC **Main** profile (`eAVEncH265VProfile_Main_420_8`), selected via a small `OutputFormat::for_codec` helper; H.264 stays `MFVideoFormat_H264` + High.
- Like its H.264 output, the MFT emits **Annex-B with inline VPS/SPS/PPS**, so unlike the macOS VideoToolbox path there is **no HVCC -> Annex-B rewrite**: the existing `moq_mux` hev1 importer consumes it directly.
- The Windows hardware candidate in `backend::open` now advertises `[H264, H265]`.
- The MFT is **vendor-agnostic** (NVIDIA / Intel QSV / AMD), so this is not NVENC-specific and covers more hardware than an NVENC backend would.

## Why Media Foundation, not NVENC

The request was "at least NVENC." Media Foundation clears that bar and exceeds it: it's already the wired-in Windows hardware backend, needs no NVENC SDK or build-system work (the `nvenc` backend is `#[cfg(target_os = "linux")]`), and drives every Windows GPU vendor's HEVC encoder, not just NVIDIA's.

## Public API changes

None. This only widens the codec set a private backend (`backend::mediafoundation`) advertises. No `pub` items added, renamed, or changed.

## Test plan

Verified on **Windows 11, NVIDIA RTX 3070 Ti, live camera** (headless local relay loop: `moq-cli accept` + `publish ... capture --codec h265`):

- [x] Backend opens: `opened encoder encoder="mediafoundation" codec="H.265"`.
- [x] Producer publishes the `.hev1` rendition; relay subscribes `track=0.hev1`.
- [x] Round-trip into Matroska decodes cleanly: `ffprobe` reports `codec_name=hevc`, `profile=Main`, `1280x720`, **181 frames decoded** (confirms the inline VPS/SPS/PPS framing).
- [x] `cargo test -p moq-video` (10 passed / 2 ignored), `cargo clippy -p moq-video`, `cargo fmt --check`: all green.
- [ ] H.264 on Windows MF unchanged in practice (same code path, profile/subtype branch only); not re-validated live this round.

## Cross-package sync

`rs/moq-video` encode change. Consumers (`moq-boy`, `moq-cli`) need no change (no signature change). Docs updated: `doc/bin/cli.md` (HEVC now lists Windows) and `rs/moq-video/DESIGN-native-codecs.md` (platform matrix + Windows verification note).

## Branch targeting

Stacked on #1802's branch for a clean diff. Both target **dev** (this builds on #1802's unmerged `Codec` enum + backend dispatch). Retarget this to `dev` once #1802 merges, or fold it in.

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)