### PR TITLE
fix(moq-native): back off when a session flaps instead of busy-looping

### DIFF
--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -37,7 +37,9 @@ pub struct Backoff {
 	pub max: Duration,
 
 	/// Maximum time to spend retrying before giving up.
-	/// Resets after each successful connection. Set to 0 for unlimited retries.
+	/// Resets after a stable connection (one that outlives the initial backoff), so a flapping
+	/// session that reconnects then immediately drops still counts toward the timeout. Set to 0 for
+	/// unlimited retries.
 	#[arg(
 		id = "backoff-timeout",
 		long,
@@ -133,28 +135,48 @@ impl Reconnect {
 			match client.connect(url.clone()).await {
 				Ok(session) => {
 					tracing::info!(%url, "connected");
-					delay = backoff.initial;
-					last_error = None;
 					if let Ok(mut state) = state.write() {
 						state.status = Some(Status::Connected);
 					}
-					let _ = session.closed().await;
-					tracing::warn!(%url, "session closed, reconnecting");
+
+					let connected = tokio::time::Instant::now();
+					let closed = session.closed().await;
 					if let Ok(mut state) = state.write() {
 						state.status = Some(Status::Disconnected);
 					}
-					retry_start = tokio::time::Instant::now();
+
+					if connected.elapsed() >= backoff.initial {
+						// Stayed up past the initial backoff: a healthy session. Reset the backoff
+						// window so a one-off drop reconnects promptly.
+						tracing::warn!(%url, "session closed, reconnecting");
+						delay = backoff.initial;
+						retry_start = tokio::time::Instant::now();
+						last_error = None;
+					} else {
+						// Connected then dropped almost immediately (e.g. the server accepts then
+						// resets). Treat it as a failed connection: keep the close reason so the
+						// give-up timeout reports a real cause, and fall through to the shared backoff
+						// sleep below so repeated flaps escalate instead of spinning the CPU.
+						if let Err(err) = closed {
+							let err = Error::from(err);
+							tracing::warn!(%url, %err, "session severed immediately, retrying");
+							last_error = Some(err);
+						} else {
+							tracing::warn!(%url, "session severed immediately, retrying");
+						}
+					}
 				}
 				Err(err) => {
 					if err.is_auth() {
 						return Err(err);
 					}
-					tracing::warn!(%url, %err, ?delay, "connection failed, retrying");
 					last_error = Some(err);
-					tokio::time::sleep(delay).await;
-					delay = std::cmp::min(delay * backoff.multiplier, backoff.max);
 				}
 			}
+
+			tracing::warn!(%url, ?delay, "reconnecting after backoff");
+			tokio::time::sleep(delay).await;
+			delay = std::cmp::min(delay * backoff.multiplier, backoff.max);
 		}
 	}
 


### PR DESCRIPTION
## Summary

A user hit a busy loop where the reconnect logs scrolled by at full CPU: the client connected (`connected version=moq-lite-05-wip`), the session dropped in the same millisecond (`session closed, reconnecting`), and it reconnected instantly, over and over.

The backoff config (`initial`/`multiplier`/`max`/`timeout`) was already wired up, but the sleep only ran on the `Err` branch when `client.connect()` itself failed. The observed failure is the opposite: connect **succeeds**, then the established session is severed immediately. That path (`Ok(session)` → `session.closed()`) had no sleep, so it spun.

A second, compounding bug: `retry_start` reset on *every* drop, so during a flap `retry_start.elapsed()` was always ~0 and the 5-minute give-up `timeout` never fired. The loop could never escape on its own.

## Changes

In `rs/moq-native/src/reconnect.rs`, restructured the loop so the backoff sleep runs at the end of **every** iteration (connect-failure and session-drop alike):

- **Stable connection** (uptime ≥ `backoff.initial`, default 1s) → reset delay to initial and reset the timeout window, then sleep the initial delay. A one-off drop after a healthy session reconnects promptly and isn't rate-escalated.
- **Immediate flap** (uptime < initial, e.g. server accepts then resets) → treated as a failed connection: the close reason from `session.closed()` (the `code=0` / `code=5 invalid value` in the logs) is captured into `last_error` instead of being discarded, logged as `session severed immediately, retrying`, and the loop falls through to the shared backoff sleep. Delay escalates 1s → 2s → … → 30s and `retry_start` keeps accumulating, so a server that perpetually accepts-then-resets eventually fails with `reconnect timed out after 300s: <close reason>` — a real cause, not a generic timeout.

Also updated the `Backoff::timeout` doc to note it resets after a *stable* connection, not after every drop.

## Notes for reviewers

- No public API or wire change; behavioral bug fix in `moq-native`, so targeting `main`.
- A healthy session now waits ~1s before reconnecting rather than reconnecting instantly, which also rate-limits a thundering-herd reconnect after a server restart.
- Reproduced on `dev`; the fix on `main` flows to `dev` on the next merge.

## Test plan

- [x] `cargo clippy -p moq-native --all-targets` (via `nix develop`) — clean
- [x] `cargo fmt -p moq-native --check` — clean
- [x] Existing `moq-native` reconnect integration test passes
- [ ] A flapping-session integration test would need a server that accepts then instantly resets (timing-flaky); not added

(Written by Claude)