### PR TITLE
moq-gst: fix plugin license + broadcast-aligned timestamps

### DIFF
--- a/rs/moq-gst/src/lib.rs
+++ b/rs/moq-gst/src/lib.rs
@@ -32,7 +32,9 @@ gst::plugin_define!(
 	env!("CARGO_PKG_DESCRIPTION"),
 	plugin_init,
 	concat!(env!("CARGO_PKG_VERSION"), "-", env!("COMMIT_ID")),
-	"Apache 2.0",
+	// GStreamer only loads plugins whose license string is in its recognised set. "Apache 2.0" is not,
+	// so the registry silently refuses the plugin. The crate is MIT OR Apache-2.0, so declare the MIT side.
+	"MIT/X11",
 	env!("CARGO_PKG_NAME"),
 	env!("CARGO_PKG_NAME"),
 	env!("CARGO_PKG_REPOSITORY"),

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -82,7 +82,8 @@ impl SessionHandle {
 
 struct PadState {
 	decoder: moq_mux::import::Framed,
-	reference_pts: Option<gst::ClockTime>,
+	// The pad's most recent TIME segment, used to map a buffer PTS to GStreamer running time.
+	segment: Option<gst::FormattedSegment<gst::ClockTime>>,
 }
 
 struct RuntimeState {
@@ -98,6 +99,10 @@ enum ControlMessage {
 	SetCaps {
 		pad_name: String,
 		caps: gst::Caps,
+	},
+	Segment {
+		pad_name: String,
+		segment: gst::Segment,
 	},
 	Buffer {
 		pad_name: String,
@@ -352,6 +357,29 @@ impl MoqSink {
 
 				gst::Pad::event_default(pad, Some(&*self.obj()), event)
 			}
+			gst::EventView::Segment(segment) => {
+				let Some(sender) = self
+					.session
+					.lock()
+					.unwrap()
+					.as_ref()
+					.map(|handle| handle.sender.clone())
+				else {
+					return false;
+				};
+
+				if sender
+					.send(ControlMessage::Segment {
+						pad_name: pad.name().to_string(),
+						segment: segment.segment().to_owned(),
+					})
+					.is_err()
+				{
+					return false;
+				}
+
+				gst::Pad::event_default(pad, Some(&*self.obj()), event)
+			}
 			gst::EventView::Eos(_) => {
 				let Some(sender) = self
 					.session
@@ -417,6 +445,11 @@ async fn run_session(
 			ControlMessage::SetCaps { pad_name, caps } => {
 				if let Err(err) = handle_caps(&mut runtime, pad_name, caps) {
 					gst::error!(CAT, "failed to configure pad: {err:#}");
+				}
+			}
+			ControlMessage::Segment { pad_name, segment } => {
+				if let Err(err) = handle_segment(&mut runtime, pad_name, segment) {
+					gst::error!(CAT, "failed to set segment: {err:#}");
 				}
 			}
 			ControlMessage::Buffer { pad_name, data, pts } => {
@@ -492,13 +525,15 @@ fn handle_caps(runtime: &mut RuntimeState, pad_name: String, caps: gst::Caps) ->
 		other => anyhow::bail!("unsupported caps: {}", other),
 	};
 
-	runtime.pads.insert(
-		pad_name,
-		PadState {
-			decoder,
-			reference_pts: None,
-		},
-	);
+	runtime.pads.insert(pad_name, PadState { decoder, segment: None });
+	Ok(())
+}
+
+fn handle_segment(runtime: &mut RuntimeState, pad_name: String, segment: gst::Segment) -> Result<()> {
+	let pad = runtime.pads.get_mut(&pad_name).context("pad not configured")?;
+	// Only TIME segments map to a media timeline; a non-TIME (e.g. BYTES) segment leaves it unset so
+	// the buffer path falls back to the raw PTS.
+	pad.segment = segment.downcast::<gst::ClockTime>().ok();
 	Ok(())
 }
 
@@ -519,10 +554,16 @@ fn handle_buffer(
 ) -> Result<()> {
 	let pad = runtime.pads.get_mut(&pad_name).context("pad not configured")?;
 
+	// Emit the GStreamer running time, which is the broadcast-aligned timeline shared by every pad in
+	// the pipeline. Rebasing each pad to its own first PTS (the previous behavior) would zero them
+	// independently and break A/V alignment. Fall back to the raw PTS only if no TIME segment is known.
 	let ts = pts.and_then(|pts| {
-		let reference = *pad.reference_pts.get_or_insert(pts);
-		let relative = pts.checked_sub(reference)?;
-		hang::container::Timestamp::from_micros(relative.nseconds() / 1000).ok()
+		let timeline = pad
+			.segment
+			.as_ref()
+			.and_then(|segment| segment.to_running_time(pts))
+			.unwrap_or(pts);
+		hang::container::Timestamp::from_micros(timeline.nseconds() / 1000).ok()
 	});
 
 	pad.decoder.decode_frame(&mut data, ts).map_err(|e| anyhow::anyhow!(e))


### PR DESCRIPTION
## Summary

Two small, independent `moqsink` fixes cherry-picked from the larger rewrite in [#1771](https://github.com/moq-dev/moq/pull/1771), without the FLUSH/seek handling or the per-pad/session generation machinery from that PR.

### 1. Plugin license so the plugin actually loads

GStreamer's registry only loads plugins whose license string is in its recognised set. The `plugin_define!` license was `"Apache 2.0"`, which is **not** in that set, so the `moq` plugin (`moqsink`/`moqsrc`) is silently refused at registry load. The crate is `MIT OR Apache-2.0`, so this declares the MIT side (`"MIT/X11"`), which is valid.

This commit is self-contained and can be cherry-picked on its own if you want it in faster.

### 2. Broadcast-aligned timestamps instead of per-pad PTS rebasing

The sink rebased each pad to its own first PTS (`reference_pts`), zeroing every pad's timeline independently. That breaks A/V alignment: audio and video both start at ~0 regardless of their real offset.

Now the sink forwards the `SEGMENT` event to the worker and maps each buffer's PTS to GStreamer **running time**, the broadcast-aligned timeline shared by every pad in the pipeline. It falls back to the raw PTS only when no TIME segment is known (e.g. a BYTES segment).

## What this deliberately leaves out (vs #1771)

- FLUSH/seek handling (per-pad watch channels, `send_or_flush`, re-anchoring). `moqsink` is a live-publish sink; the flush path adds significant concurrency surface for a case it doesn't exercise.
- Two-level pad/session generation tracking and generation-keyed failure maps.
- The module split and the bounded-channel / error-to-bus changes (separable follow-ups).

## Testing

- `cargo build -p moq-gst`, `cargo clippy -p moq-gst --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test -p moq-gst` all pass (via the nix dev shell).

(Written by Claude)