### PR TITLE
fix(moq-gst): deterministic moqsrc pad names so CMAF playback works

### DIFF
--- a/demo/sub/justfile
+++ b/demo/sub/justfile
@@ -4,6 +4,10 @@ set fallback
 gst name url='http://localhost:4443' *args:
     cargo build -p moq-gst
 
+    # moqsrc exposes one pad per rendition (video_0, audio_0, ...). Link the video pad
+    # by name so a bare `! decodebin3` can't latch onto the audio pad and leave the
+    # video sink empty; route audio to its own sink so it doesn't stall the session.
     GST_PLUGIN_PATH_1_0="${PWD}/../../target/debug${GST_PLUGIN_PATH_1_0:+:$GST_PLUGIN_PATH_1_0}" \
-    gst-launch-1.0 -v -e moqsrc url="{{ url }}" broadcast="{{ name }}" {{ args }} \
-    	! decodebin3 ! videoconvert ! autovideosink
+    gst-launch-1.0 -v -e moqsrc name=s url="{{ url }}" broadcast="{{ name }}" {{ args }} \
+    	s.video_0 ! queue ! decodebin3 ! videoconvert ! autovideosink \
+    	s.audio_0 ! queue ! decodebin3 ! audioconvert ! autoaudiosink

--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -58,11 +58,15 @@ Lists `moqsink` and `moqsrc`. As a one-liner: `nix run github:moq-dev/moq#moq-gs
 
 ```bash
 nix shell github:moq-dev/moq#moq-gst --command gst-launch-1.0 -v -e \
-  moqsrc url=https://cdn.moq.dev/demo broadcast=bbb.hang \
-  ! decodebin3 ! videoconvert ! autovideosink
+  moqsrc name=s url=https://cdn.moq.dev/demo broadcast=bbb.hang \
+  s.video_0 ! queue ! decodebin3 ! videoconvert ! autovideosink \
+  s.audio_0 ! queue ! decodebin3 ! audioconvert ! autoaudiosink
 ```
 
-Audio-only variant: swap the tail for `! decodebin3 ! audioconvert ! autoaudiosink`.
+`bbb.hang` carries both video and audio, so each is linked by pad name (`video_0` /
+`audio_0`). For video only, drop the `s.audio_0` branch; the audio pad simply stays
+unlinked. The terse `moqsrc ! decodebin3 ! ...` form links just the first pad GStreamer
+offers, which on a multi-track broadcast may be the audio one, so prefer naming the pad.
 
 ### Publish your own broadcast
 
@@ -185,6 +189,22 @@ gst-launch-1.0 -v -e \
     ! decodebin3 ! videoconvert ! autovideosink
 ```
 
+::: warning
+`moqsrc` exposes one source pad per rendition: `video_0`, `audio_0`, and so on
+(see [moqsrc pads](#moqsrc-subscribe)). The single-branch `moqsrc ! decodebin3 ...`
+above only links the *first* pad GStreamer offers, so on a broadcast with both video
+and audio it may pick up the audio pad and a video-only sink chain then renders nothing.
+Link the pad you want by name, and route the rest to a sink so they don't stall:
+
+```bash
+gst-launch-1.0 -v -e moqsrc name=s url="http://localhost:4443" broadcast="bbb" \
+  s.video_0 ! queue ! decodebin3 ! videoconvert ! autovideosink \
+  s.audio_0 ! queue ! decodebin3 ! audioconvert ! autoaudiosink
+```
+
+The first pad of each kind is always `video_0` / `audio_0` regardless of catalog order.
+:::
+
 ## Supported Codecs
 
 ### moqsink (publish)
@@ -202,6 +222,13 @@ gst-launch-1.0 -v -e \
 ### moqsrc (subscribe)
 
 Outputs the same caps based on the catalog, compatible with `decodebin3`.
+
+One source pad is created per rendition, named after its kind: `video_0`, `video_1`,
+`audio_0`, and so on. The first pad of each kind is always numbered `0`, so a
+`gst-launch` pipeline can link the stream it wants by name (`moqsrc name=s s.video_0 ! ...`)
+no matter which rendition the catalog announces first. Pads appear once their rendition
+shows up in the catalog (sometimes-pads), so an application links them from a
+`pad-added` handler.
 
 ## Debugging
 

--- a/rs/moq-gst/README.md
+++ b/rs/moq-gst/README.md
@@ -40,9 +40,13 @@ The `moq-gst` flake output bundles the plugin with wrappers around `gst-inspect-
 nix shell github:moq-dev/moq#moq-gst --command gst-inspect-1.0 moq
 
 # Subscribe to the always-on public test broadcast and render to a window.
+# moqsrc emits one pad per rendition (video_0, audio_0, ...); link the one(s) you
+# want by name. A bare `moqsrc ! decodebin3 ! ...` only links the first pad offered,
+# which on a video+audio broadcast may be the audio pad (so a video sink shows nothing).
 nix shell github:moq-dev/moq#moq-gst --command gst-launch-1.0 -v -e \
-  moqsrc url=https://cdn.moq.dev/demo broadcast=bbb.hang \
-  ! decodebin3 ! videoconvert ! autovideosink
+  moqsrc name=s url=https://cdn.moq.dev/demo broadcast=bbb.hang \
+  s.video_0 ! queue ! decodebin3 ! videoconvert ! autovideosink \
+  s.audio_0 ! queue ! decodebin3 ! audioconvert ! autoaudiosink
 
 # Publish your own broadcast on the public anon relay (then sub to it from anywhere).
 curl -fsSL https://vid.moq.dev/bbb.mp4 -o bbb.mp4

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -21,9 +21,16 @@ static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
 		.expect("spawn tokio runtime")
 });
 
-/// Process-wide pad id counter. Kept global (not per-session) so a pad created by a
-/// restarted session can't collide with one still being torn down by the previous one.
-static NEXT_PAD_ID: AtomicU64 = AtomicU64::new(0);
+/// Process-wide pad id counters, one per pad kind. Kept global (not per-session) so a pad
+/// created by a restarted session can't collide with one still being torn down by the
+/// previous one, and split per kind so the *first* video pad is reliably `video_0` and the
+/// first audio pad `audio_0`. That predictability matters because `gst-launch` links a
+/// source's sometimes-pads by name (`moqsrc name=s s.video_0 ! ...`); a single shared counter
+/// made the first pad's number depend on catalog arrival order (audio could claim `0`),
+/// silently breaking those pipelines. Counters only ever increment, so a mid-stream reshape
+/// still gets a fresh, collision-free id.
+static NEXT_VIDEO_PAD_ID: AtomicU64 = AtomicU64::new(0);
+static NEXT_AUDIO_PAD_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Default)]
 struct Settings {
@@ -411,7 +418,11 @@ fn reconcile(
 			}
 		};
 
-		let id = NEXT_PAD_ID.fetch_add(1, Ordering::Relaxed);
+		let id = match d.kind {
+			TrackKind::Video => &NEXT_VIDEO_PAD_ID,
+			TrackKind::Audio => &NEXT_AUDIO_PAD_ID,
+		}
+		.fetch_add(1, Ordering::Relaxed);
 
 		let track_consumer = broadcast.subscribe_track(&moq_net::Track::new(&name))?;
 		let track = moq_mux::container::Consumer::new(track_consumer, container).with_latency(Duration::from_secs(1));
@@ -463,9 +474,11 @@ fn plan_reconcile<S: PartialEq>(desired: &HashMap<String, S>, active: &HashMap<S
 }
 
 /// Identifies a pump's pad. Pads are named `video_<id>` / `audio_<id>` from a
-/// process-unique counter (matching the `%u` templates) rather than after the
-/// track name, so a rendition can be torn down and recreated (when its
-/// codec/resolution changes mid-stream) without two pads ever sharing a name.
+/// per-kind, process-unique counter (matching the `%u` templates) rather than after
+/// the track name, so a rendition can be torn down and recreated (when its
+/// codec/resolution changes mid-stream) without two pads ever sharing a name. The
+/// first pad of each kind is `video_0` / `audio_0`, so `gst-launch` can link them by
+/// name regardless of which rendition the catalog announces first.
 struct TrackDescriptor {
 	kind: TrackKind,
 	name: String,


### PR DESCRIPTION
## What

`moqsrc` exposes one *sometimes-pad* per rendition (`video_0`, `audio_0`, …). Pad ids were drawn from a **single process-global counter**, so the first pad's number depended on catalog arrival order — audio could claim slot `0`, making the video pad `video_1`. That:

- silently broke any pipeline linking by name (`moqsrc name=s s.video_0 ! …`), and
- left the naive `moqsrc ! decodebin3 ! sink` one-liner latched onto whichever rendition arrived first (often audio), so video never rendered.

The failure was **nondeterministic** (same command decoded video on some runs, nothing on others), which is what made CMAF/fMP4 (`.m4s`) broadcasts — what `moq-cli cmaf`, `just dev`, and `cdn.moq.dev` publish — appear unplayable through GStreamer.

## Fix

- Split the global pad counter into **per-kind counters** (`NEXT_VIDEO_PAD_ID` / `NEXT_AUDIO_PAD_ID`) so the first video pad is always `video_0` and the first audio pad always `audio_0`, regardless of catalog order. Counters still increment monotonically, so a mid-stream rendition reshape never collides (the property the global counter originally existed to guarantee).
- Update `doc/bin/gstreamer.md`, `rs/moq-gst/README.md`, and the `just sub gst` recipe (`demo/sub/justfile`) to the reliable named-pad pattern (link `s.video_0` / `s.audio_0` to their own sinks), with a note explaining the sometimes-pad model.

## Not the bug

The moq-mux CMAF container consumer is **not** at fault — driving `Consumer<HangContainer>` directly against a live CMAF broadcast yields a clean, monotonic frame stream, and `moq-cli subscribe --format fmp4` (same consumer) reconstructs playable H.264. The `remote error: code=0` / `Remote(0)` seen on the relay is just the *other* rendition's clean cancel when a pipeline consumes only one stream (it also appears in fully-working elementary-track playback).

`moqsink` intentionally publishes **elementary** tracks (`.avc3`/`.aac`); CMAF input is handled upstream via `parsebin ! moqsink`, so on-the-wire CMAF publishing would be redundant — not changed here.

## Test plan

- [x] CMAF publisher (`moq-cli … fmp4`) → `moqsrc name=s s.video_0 ! …`: **0/4 → 5/5 runs** decode video (178–202 frames/run) after the fix.
- [x] Elementary regression (`moqsink` publish → `moqsrc`): 261 frames, no regression.
- [x] `cargo test -p moq-gst` (5), `cargo test -p moq-mux --lib container::` (116), `cargo clippy -p moq-gst`, `cargo fmt --check` — all green via `nix develop`.

## Branch targeting

`main`: behavior bug fix + docs, no wire / public-API / catalog-format change (the modified statics are private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)