### PR TITLE
feat(relay): unauthenticated internal listener over qmux (tcp:// + unix://)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5464,9 +5464,9 @@ dependencies = [
 
 [[package]]
 name = "qmux"
-version = "0.0.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a761722f4499404d45c4971e332b8d0d1fe4a1882d404c2c5f96f3e49933e9"
+checksum = "f466003646aebc080ad4237b5a4c00ea435eaba1be04496ab780ced381c3395f"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ moq-native = { version = "0.17", path = "rs/moq-native", default-features = fals
 moq-net = { version = "0.1", path = "rs/moq-net" }
 moq-token = { version = "0.6", path = "rs/moq-token" }
 moq-video = { version = "0.0.4", path = "rs/moq-video" }
-qmux = { version = "0.0.8", default-features = false }
+qmux = { version = "0.2", default-features = false }
 
 serde = { version = "1", features = ["derive"] }
 tokio = "1.48"

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -244,14 +244,13 @@ stream. It performs **no token/certificate authentication**: every accepted
 connection is granted full, unrestricted publish and subscribe access on the
 internal tier, exactly like a cluster peer dialing `/`.
 
-The single `listen` value picks the transport: a `host:port` binds a plain-TCP
-listener (the `tcp://` scheme), and a filesystem path binds a Unix socket (the
-`unix://` scheme).
+A TCP and a Unix-socket listener can each be enabled independently, under
+`[internal.tcp]` and `[internal.uds]`.
 
 ### TCP
 
 ```toml
-[internal]
+[internal.tcp]
 # Plain-TCP qmux listener. No TLS, no UDP, no auth: anyone who can reach this
 # socket gets full access. Bind it only to a trusted interface.
 listen = "127.0.0.1:4444"
@@ -274,14 +273,13 @@ specific worker user rather than any local process. Requires the relay to be
 built with the `uds` feature.
 
 ```toml
-[internal]
-# A path (optionally `unix:`-prefixed) binds a Unix socket instead of TCP.
+[internal.uds]
 listen = "/run/moq/internal.sock"
 
 # Only accept connections from these credentials. Each list is matched
 # independently (AND across fields, OR within a field); an empty/omitted list
 # imposes no constraint on that field.
-[internal.allow]
+[internal.uds.allow]
 uid = [1001]   # only the worker's user
 # gid = [2000]
 # pid = [12345]

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -236,6 +236,75 @@ peers to discover and dial.
 The `quinn` and `noq` QUIC backends support mTLS; configuring `tls.root` with a
 backend that does not (e.g. `quiche`) is a startup error.
 
+## Internal Listener
+
+For trusted local workers that don't want the overhead of TLS or UDP, the relay
+can bind a second listener that speaks the qmux wire format directly over a plain
+stream. It performs **no token/certificate authentication**: every accepted
+connection is granted full, unrestricted publish and subscribe access on the
+internal tier, exactly like a cluster peer dialing `/`.
+
+The single `listen` value picks the transport: a `host:port` binds a plain-TCP
+listener (the `tcp://` scheme), and a filesystem path binds a Unix socket (the
+`unix://` scheme).
+
+### TCP
+
+```toml
+[internal]
+# Plain-TCP qmux listener. No TLS, no UDP, no auth: anyone who can reach this
+# socket gets full access. Bind it only to a trusted interface.
+listen = "127.0.0.1:4444"
+```
+
+TCP carries no peer identity, so **any local process of any user** can connect.
+Loopback is the safest bind; a private VPC interface is also valid. The relay
+logs a warning when `listen` is not a loopback address but does not refuse to
+start, so firewalling the port is your responsibility.
+
+```bash
+moq publish tcp://127.0.0.1:4444/my-broadcast < video.mp4
+```
+
+### Unix socket (with a uid/gid/pid allowlist)
+
+A Unix socket lets the relay authenticate the connecting process by its kernel
+credentials (`SO_PEERCRED` / `LOCAL_PEERCRED`), so you can restrict access to a
+specific worker user rather than any local process. Requires the relay to be
+built with the `uds` feature.
+
+```toml
+[internal]
+# A path (optionally `unix:`-prefixed) binds a Unix socket instead of TCP.
+listen = "/run/moq/internal.sock"
+
+# Only accept connections from these credentials. Each list is matched
+# independently (AND across fields, OR within a field); an empty/omitted list
+# imposes no constraint on that field.
+[internal.allow]
+uid = [1001]   # only the worker's user
+# gid = [2000]
+# pid = [12345]
+```
+
+A connection whose credentials fail the allowlist is closed immediately with no
+access granted. A `pid` requirement rejects peers whose PID the platform doesn't
+report (e.g. some macOS versions). With no `allow` list configured the socket is
+unauthenticated (the relay logs a warning), so the socket's filesystem
+permissions become the only gate.
+
+```bash
+moq publish unix:///run/moq/internal.sock --broadcast my-broadcast < video.mp4
+```
+
+### Notes
+
+Both transports are native-only: browsers can't open raw TCP or Unix sockets, so
+the JS client doesn't support them. The plain-stream path has no TLS ALPN, so the
+MoQ version is negotiated in-band via qmux (a transport parameter on the first
+frame) and the exact version is agreed up front. Neither transport reads a path
+from the URL for routing; the grant is always the empty root (everything).
+
 ## Example Configurations
 
 See the [`demo/relay/`](https://github.com/moq-dev/moq/tree/main/demo/relay) directory for complete working configuration files, including authentication setup:

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -96,6 +96,29 @@ cert = "cert.pem"
 key = "key.pem"
 ```
 
+### \[internal]
+
+Unauthenticated qmux listener (no TLS) for trusted local workers. Every
+connection is granted full, unrestricted access. The `listen` value picks the
+transport: a `host:port` binds plain TCP, a path binds a Unix socket.
+
+```toml
+[internal]
+# host:port  -> plain-TCP listener (tcp:// scheme)
+# a path     -> Unix-socket listener (unix:// scheme), requires the `uds` build feature
+# Defaults to disabled if not specified.
+listen = "127.0.0.1:4444"
+
+# Unix-socket only: restrict callers by peer credentials. Empty/omitted = no check.
+[internal.allow]
+uid = [1001]
+# gid = [2000]
+# pid = [12345]
+```
+
+A non-loopback TCP bind logs a warning but is allowed. See
+[Internal Listener](/bin/relay/auth#internal-listener) for details.
+
 ### \[auth]
 
 Authentication configuration.

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -98,19 +98,21 @@ key = "key.pem"
 
 ### \[internal]
 
-Unauthenticated qmux listener (no TLS) for trusted local workers. Every
-connection is granted full, unrestricted access. The `listen` value picks the
-transport: a `host:port` binds plain TCP, a path binds a Unix socket.
+Unauthenticated qmux listeners (no TLS) for trusted local workers. Every
+connection is granted full, unrestricted access. A TCP and a Unix-socket
+listener can each be enabled independently; both default to disabled.
 
 ```toml
-[internal]
-# host:port  -> plain-TCP listener (tcp:// scheme)
-# a path     -> Unix-socket listener (unix:// scheme), requires the `uds` build feature
-# Defaults to disabled if not specified.
+# Plain-TCP listener (tcp:// scheme).
+[internal.tcp]
 listen = "127.0.0.1:4444"
 
-# Unix-socket only: restrict callers by peer credentials. Empty/omitted = no check.
-[internal.allow]
+# Unix-socket listener (unix:// scheme), requires the `uds` build feature.
+[internal.uds]
+listen = "/run/moq/internal.sock"
+
+# Restrict the Unix-socket callers by peer credentials. Empty/omitted = no check.
+[internal.uds.allow]
 uid = [1001]
 # gid = [2000]
 # pid = [12345]

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["multimedia", "network-programming", "web-programming"]
 doctest = false
 
 [features]
-default = ["quinn", "aws-lc-rs", "websocket"]
+default = ["quinn", "aws-lc-rs", "websocket", "tcp", "uds"]
 quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
 noq = ["dep:web-transport-noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
 quiche = ["dep:web-transport-quiche", "dep:rcgen"]
@@ -26,6 +26,11 @@ aws-lc-rs = ["rustls/aws-lc-rs", "rcgen?/aws_lc_rs", "quinn?/rustls-aws-lc-rs"]
 iroh = ["dep:web-transport-iroh", "dep:web-transport-proto"]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 websocket = ["dep:qmux"]
+# Plain-TCP qmux transport (`tcp://`), no TLS. Server-side and client-side.
+tcp = ["dep:qmux"]
+# Unix-domain-socket qmux transport (`unix://`), unix-only. Adds peer-credential
+# inspection on accept. Pulls in `tcp` (shares qmux's stream transport).
+uds = ["tcp", "qmux/uds"]
 ring = ["rustls/ring", "rcgen?/ring", "quinn?/rustls-ring"]
 android-logcat = ["dep:tracing-android"]
 
@@ -39,7 +44,7 @@ humantime-serde = "1.1"
 moq-net = { workspace = true, features = ["serde"] }
 notify = { version = "8", optional = true }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
-qmux = { workspace = true, features = ["wss", "tls"], optional = true }
+qmux = { workspace = true, features = ["wss", "tls", "tcp"], optional = true }
 quinn = { version = "0.11", default-features = false, features = ["platform-verifier", "runtime-tokio", "bloom"], optional = true }
 rand = "0.10.1"
 rcgen = { version = "0.14", default-features = false, optional = true }

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -111,15 +111,27 @@ pub struct Client {
 }
 
 impl Client {
-	#[cfg(not(any(feature = "noq", feature = "quinn", feature = "quiche", feature = "websocket")))]
+	#[cfg(not(any(
+		feature = "noq",
+		feature = "quinn",
+		feature = "quiche",
+		feature = "websocket",
+		feature = "tcp"
+	)))]
 	pub fn new(_config: ClientConfig) -> crate::Result<Self> {
 		Err(Error::NoBackend(
-			"no QUIC or WebSocket backend compiled; enable noq, quinn, quiche, or websocket feature",
+			"no QUIC or WebSocket backend compiled; enable noq, quinn, quiche, websocket, or tcp feature",
 		))
 	}
 
 	/// Create a new client
-	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche", feature = "websocket"))]
+	#[cfg(any(
+		feature = "noq",
+		feature = "quinn",
+		feature = "quiche",
+		feature = "websocket",
+		feature = "tcp"
+	))]
 	pub fn new(config: ClientConfig) -> crate::Result<Self> {
 		#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 		let backend = config.backend.clone().unwrap_or({
@@ -227,11 +239,12 @@ impl Client {
 		feature = "quinn",
 		feature = "quiche",
 		feature = "iroh",
-		feature = "websocket"
+		feature = "websocket",
+		feature = "tcp"
 	)))]
 	pub async fn connect(&self, _url: Url) -> crate::Result<moq_net::Session> {
 		Err(Error::NoBackend(
-			"no backend compiled; enable noq, quinn, quiche, iroh, or websocket feature",
+			"no backend compiled; enable noq, quinn, quiche, iroh, websocket, or tcp feature",
 		))
 	}
 
@@ -240,7 +253,8 @@ impl Client {
 		feature = "quinn",
 		feature = "quiche",
 		feature = "iroh",
-		feature = "websocket"
+		feature = "websocket",
+		feature = "tcp"
 	))]
 	pub async fn connect(&self, url: Url) -> crate::Result<moq_net::Session> {
 		let session = self.connect_inner(url).await?;
@@ -253,9 +267,26 @@ impl Client {
 		feature = "quinn",
 		feature = "quiche",
 		feature = "iroh",
-		feature = "websocket"
+		feature = "websocket",
+		feature = "tcp"
 	))]
 	async fn connect_inner(&self, url: Url) -> crate::Result<moq_net::Session> {
+		// Plain TCP (qmux, no TLS). Explicit opt-in scheme; never raced against
+		// QUIC, which can't speak it. Use only on a trusted network.
+		#[cfg(feature = "tcp")]
+		if url.scheme() == "tcp" {
+			let session = crate::tcp::connect(url, &self.versions.alpns()).await?;
+			return Ok(self.moq.connect(session).await?);
+		}
+
+		// Unix domain socket (qmux, no TLS). Same-host only; the server can
+		// authenticate us by uid/gid via SO_PEERCRED.
+		#[cfg(all(feature = "uds", unix))]
+		if url.scheme() == "unix" {
+			let session = crate::unix::connect(url, &self.versions.alpns()).await?;
+			return Ok(self.moq.connect(session).await?);
+		}
+
 		#[cfg(feature = "iroh")]
 		if url.scheme() == "iroh" {
 			let endpoint = self.iroh.as_ref().ok_or(Error::IrohDisabled)?;

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -116,11 +116,12 @@ impl Client {
 		feature = "quinn",
 		feature = "quiche",
 		feature = "websocket",
-		feature = "tcp"
+		feature = "tcp",
+		feature = "uds"
 	)))]
 	pub fn new(_config: ClientConfig) -> crate::Result<Self> {
 		Err(Error::NoBackend(
-			"no QUIC or WebSocket backend compiled; enable noq, quinn, quiche, websocket, or tcp feature",
+			"no QUIC or WebSocket backend compiled; enable noq, quinn, quiche, websocket, tcp, or uds feature",
 		))
 	}
 
@@ -130,7 +131,8 @@ impl Client {
 		feature = "quinn",
 		feature = "quiche",
 		feature = "websocket",
-		feature = "tcp"
+		feature = "tcp",
+		feature = "uds"
 	))]
 	pub fn new(config: ClientConfig) -> crate::Result<Self> {
 		#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
@@ -240,11 +242,12 @@ impl Client {
 		feature = "quiche",
 		feature = "iroh",
 		feature = "websocket",
-		feature = "tcp"
+		feature = "tcp",
+		feature = "uds"
 	)))]
 	pub async fn connect(&self, _url: Url) -> crate::Result<moq_net::Session> {
 		Err(Error::NoBackend(
-			"no backend compiled; enable noq, quinn, quiche, iroh, websocket, or tcp feature",
+			"no backend compiled; enable noq, quinn, quiche, iroh, websocket, tcp, or uds feature",
 		))
 	}
 
@@ -254,7 +257,8 @@ impl Client {
 		feature = "quiche",
 		feature = "iroh",
 		feature = "websocket",
-		feature = "tcp"
+		feature = "tcp",
+		feature = "uds"
 	))]
 	pub async fn connect(&self, url: Url) -> crate::Result<moq_net::Session> {
 		let session = self.connect_inner(url).await?;
@@ -268,7 +272,8 @@ impl Client {
 		feature = "quiche",
 		feature = "iroh",
 		feature = "websocket",
-		feature = "tcp"
+		feature = "tcp",
+		feature = "uds"
 	))]
 	async fn connect_inner(&self, url: Url) -> crate::Result<moq_net::Session> {
 		// Plain TCP (qmux, no TLS). Explicit opt-in scheme; never raced against

--- a/rs/moq-native/src/error.rs
+++ b/rs/moq-native/src/error.rs
@@ -71,6 +71,14 @@ pub enum Error {
 	#[cfg(feature = "websocket")]
 	#[error(transparent)]
 	WebSocket(Arc<crate::websocket::Error>),
+
+	#[cfg(feature = "tcp")]
+	#[error(transparent)]
+	Tcp(Arc<crate::tcp::Error>),
+
+	#[cfg(all(feature = "uds", unix))]
+	#[error(transparent)]
+	Unix(Arc<crate::unix::Error>),
 }
 
 impl Error {
@@ -165,6 +173,20 @@ impl From<crate::websocket::Error> for Error {
 		}
 
 		Self::WebSocket(Arc::new(err))
+	}
+}
+
+#[cfg(feature = "tcp")]
+impl From<crate::tcp::Error> for Error {
+	fn from(err: crate::tcp::Error) -> Self {
+		Self::Tcp(Arc::new(err))
+	}
+}
+
+#[cfg(all(feature = "uds", unix))]
+impl From<crate::unix::Error> for Error {
+	fn from(err: crate::unix::Error) -> Self {
+		Self::Unix(Arc::new(err))
 	}
 }
 

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -4,6 +4,8 @@
 //! - WebTransport (HTTP/3)
 //! - Raw QUIC (with ALPN negotiation)
 //! - WebSocket (fallback via [web-transport-ws](https://crates.io/crates/web-transport-ws))
+//! - Plain TCP via the `tcp://` scheme (qmux, no TLS; requires `tcp` feature)
+//! - Unix domain socket via the `unix://` scheme (qmux, peer-credential aware; requires `uds` feature, unix-only)
 //! - Iroh P2P (requires `iroh` feature)
 //!
 //! See [`Client`] for connecting to relays and [`Server`] for accepting connections.
@@ -25,7 +27,11 @@ pub mod noq;
 pub mod quinn;
 mod reconnect;
 mod server;
+#[cfg(feature = "tcp")]
+pub mod tcp;
 pub mod tls;
+#[cfg(all(feature = "uds", unix))]
+pub mod unix;
 mod util;
 #[cfg(feature = "watch")]
 pub mod watch;

--- a/rs/moq-native/src/tcp.rs
+++ b/rs/moq-native/src/tcp.rs
@@ -1,0 +1,111 @@
+//! Plain-TCP qmux transport, reachable via the `tcp://` URL scheme.
+//!
+//! Runs the QMux wire format directly over TCP with no TLS or WebSocket
+//! framing. There is no transport encryption and no authentication, so only
+//! use this on a trusted network (loopback, a private VPC interface, etc.).
+//!
+//! TCP has no TLS handshake, so the application protocol (the moq ALPN) is
+//! negotiated in-band: pass the offered/supported protocols and the resulting
+//! [`qmux::Session::protocol`] is populated before connect/accept returns.
+
+use std::net;
+use url::Url;
+
+/// The QMux wire-format version both ends speak over a raw stream. Fixed (not
+/// negotiated) since there's no TLS ALPN to carry it.
+const WIRE_VERSION: qmux::Version = qmux::Version::QMux01;
+
+/// Errors specific to the plain-TCP qmux transport.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+	/// The TCP socket failed to bind, accept, or connect.
+	#[error(transparent)]
+	Io(#[from] std::io::Error),
+
+	/// The `tcp://` URL had no host.
+	#[error("missing hostname")]
+	MissingHostname,
+
+	/// The `tcp://` URL had no port. Unlike `https`, there is no default.
+	#[error("missing port")]
+	MissingPort,
+
+	/// The qmux handshake failed while dialing.
+	#[error("qmux connect failed")]
+	Connect(#[source] qmux::Error),
+
+	/// The qmux handshake failed while accepting.
+	#[error("qmux accept failed")]
+	Accept(#[source] qmux::Error),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Dial a `tcp://host:port` URL, advertising `protocols` for in-band ALPN
+/// negotiation. Returns a qmux session over plain TCP.
+///
+/// The port is required; there is no default for the `tcp` scheme.
+pub(crate) async fn connect(url: Url, protocols: &[&str]) -> Result<qmux::Session> {
+	let host = url.host_str().ok_or(Error::MissingHostname)?;
+	let port = url.port().ok_or(Error::MissingPort)?;
+
+	tracing::debug!(%url, "connecting via TCP");
+	qmux::tcp::Config::new(WIRE_VERSION)
+		.protocols(protocols.iter().copied())
+		.connect((host, port))
+		.await
+		.map_err(Error::Connect)
+}
+
+/// Listens for incoming plain-TCP qmux connections on a TCP port.
+pub struct Listener {
+	listener: tokio::net::TcpListener,
+	protocols: Vec<String>,
+}
+
+impl Listener {
+	/// Bind a TCP listener to the given address.
+	pub async fn bind(addr: net::SocketAddr) -> Result<Self> {
+		let listener = tokio::net::TcpListener::bind(addr).await?;
+		Ok(Self {
+			listener,
+			protocols: Vec::new(),
+		})
+	}
+
+	/// Advertise these application protocols (moq ALPNs) for in-band negotiation,
+	/// in preference order. The first server entry the client also offers wins.
+	pub fn with_protocols<I, S>(mut self, protocols: I) -> Self
+	where
+		I: IntoIterator<Item = S>,
+		S: Into<String>,
+	{
+		self.protocols = protocols.into_iter().map(Into::into).collect();
+		self
+	}
+
+	/// The local address the listener is bound to.
+	pub fn local_addr(&self) -> Result<net::SocketAddr> {
+		Ok(self.listener.local_addr()?)
+	}
+
+	/// Accept the next connection, performing the qmux handshake over plain TCP.
+	///
+	/// Returns `None` only if the listener itself is gone; a per-connection
+	/// failure is yielded as `Some(Err(..))` so the accept loop keeps running.
+	pub async fn accept(&self) -> Option<Result<qmux::Session>> {
+		match self.listener.accept().await {
+			Ok((stream, addr)) => {
+				tracing::debug!(%addr, "accepted TCP connection");
+				let session = qmux::tcp::Config::new(WIRE_VERSION)
+					.protocols(self.protocols.iter().map(String::as_str))
+					.accept(stream)
+					.await
+					.map_err(Error::Accept);
+				Some(session)
+			}
+			Err(e) => Some(Err(e.into())),
+		}
+	}
+}

--- a/rs/moq-native/src/tcp.rs
+++ b/rs/moq-native/src/tcp.rs
@@ -6,7 +6,7 @@
 //!
 //! TCP has no TLS handshake, so the application protocol (the moq ALPN) is
 //! negotiated in-band: pass the offered/supported protocols and the resulting
-//! [`qmux::Session::protocol`] is populated before connect/accept returns.
+//! `qmux::Session::protocol()` is populated before connect/accept returns.
 
 use std::net;
 use url::Url;

--- a/rs/moq-native/src/unix.rs
+++ b/rs/moq-native/src/unix.rs
@@ -1,0 +1,175 @@
+//! Unix-domain-socket qmux transport, reachable via the `unix://` URL scheme.
+//!
+//! Runs the QMux wire format over an `AF_UNIX` stream. Unlike the `tcp://`
+//! transport, the kernel reports the connecting process's credentials
+//! (`SO_PEERCRED` / `LOCAL_PEERCRED`), so a server can authenticate the peer's
+//! uid/gid/pid without a shared secret. Unix-only.
+
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+use url::Url;
+
+/// The QMux wire-format version both ends speak. Fixed (not negotiated) since a
+/// raw stream has no TLS ALPN to carry it.
+const WIRE_VERSION: qmux::Version = qmux::Version::QMux01;
+
+/// Errors specific to the Unix-domain-socket qmux transport.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+	/// The socket failed to bind, accept, connect, or chmod.
+	#[error(transparent)]
+	Io(#[from] io::Error),
+
+	/// The `unix://` URL had no socket path.
+	#[error("missing socket path in unix:// URL")]
+	MissingPath,
+
+	/// The qmux handshake failed while dialing.
+	#[error("qmux connect failed")]
+	Connect(#[source] qmux::Error),
+
+	/// The qmux handshake failed while accepting.
+	#[error("qmux accept failed")]
+	Accept(#[source] qmux::Error),
+
+	/// The bind path already exists and is not a socket, so we refuse to unlink it.
+	#[error("refusing to replace existing non-socket file at {0}")]
+	NotASocket(PathBuf),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// Credentials of a connected Unix-socket peer.
+///
+/// `pid` is `None` on platforms that don't report it (e.g. some macOS versions);
+/// `uid`/`gid` are always available.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PeerCred {
+	/// The peer process's effective user ID.
+	pub uid: u32,
+	/// The peer process's effective group ID.
+	pub gid: u32,
+	/// The peer process's PID, if the platform reports it.
+	pub pid: Option<i32>,
+}
+
+/// Dial a `unix://<path>` URL, advertising `protocols` for in-band ALPN
+/// negotiation. Returns a qmux session over the socket.
+///
+/// The path is taken from the URL path, so use a triple slash for an absolute
+/// path: `unix:///run/moq/internal.sock`.
+pub(crate) async fn connect(url: Url, protocols: &[&str]) -> Result<qmux::Session> {
+	let path = socket_path(&url).ok_or(Error::MissingPath)?;
+	tracing::debug!(%url, "connecting via Unix socket");
+	qmux::uds::Config::new(WIRE_VERSION)
+		.protocols(protocols.iter().copied())
+		.connect(path)
+		.await
+		.map_err(Error::Connect)
+}
+
+fn socket_path(url: &Url) -> Option<PathBuf> {
+	let path = url.path();
+	if path.is_empty() {
+		None
+	} else {
+		Some(PathBuf::from(path))
+	}
+}
+
+/// Listens for incoming qmux connections on a Unix domain socket.
+///
+/// Each accepted connection yields the session plus the peer's [`PeerCred`], so
+/// the caller can enforce a uid/gid/pid allowlist. The socket file is removed on
+/// drop.
+pub struct Listener {
+	listener: tokio::net::UnixListener,
+	path: PathBuf,
+	protocols: Vec<String>,
+}
+
+impl Listener {
+	/// Bind a Unix socket at `path`, replacing a stale socket file left by a
+	/// previous run.
+	///
+	/// Refuses to unlink the path if it exists and is not a socket, to avoid
+	/// clobbering an unrelated file.
+	pub async fn bind(path: impl AsRef<Path>) -> Result<Self> {
+		let path = path.as_ref().to_path_buf();
+
+		// A leftover socket from a crashed run would make bind() fail with
+		// EADDRINUSE, so unlink it first. Anything that isn't a socket we leave
+		// alone and error out.
+		match fs::symlink_metadata(&path) {
+			Ok(meta) if meta.file_type().is_socket() => fs::remove_file(&path)?,
+			Ok(_) => return Err(Error::NotASocket(path)),
+			Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+			Err(err) => return Err(err.into()),
+		}
+
+		let listener = tokio::net::UnixListener::bind(&path)?;
+		Ok(Self {
+			listener,
+			path,
+			protocols: Vec::new(),
+		})
+	}
+
+	/// Advertise these application protocols (moq ALPNs) for in-band negotiation,
+	/// in preference order. The first server entry the client also offers wins.
+	pub fn with_protocols<I, S>(mut self, protocols: I) -> Self
+	where
+		I: IntoIterator<Item = S>,
+		S: Into<String>,
+	{
+		self.protocols = protocols.into_iter().map(Into::into).collect();
+		self
+	}
+
+	/// Set the socket file's permission bits (e.g. `0o660`).
+	pub fn set_mode(&self, mode: u32) -> Result<()> {
+		fs::set_permissions(&self.path, fs::Permissions::from_mode(mode))?;
+		Ok(())
+	}
+
+	/// The bound socket path.
+	pub fn path(&self) -> &Path {
+		&self.path
+	}
+
+	/// Accept the next connection, returning the session and the peer's credentials.
+	///
+	/// Returns `None` only if the listener itself is gone; a per-connection
+	/// failure is yielded as `Some(Err(..))` so the accept loop keeps running.
+	pub async fn accept(&self) -> Option<Result<(qmux::Session, PeerCred)>> {
+		match self.listener.accept().await {
+			Ok((stream, _addr)) => {
+				let cred = match stream.peer_cred() {
+					Ok(cred) => PeerCred {
+						uid: cred.uid(),
+						gid: cred.gid(),
+						pid: cred.pid(),
+					},
+					Err(err) => return Some(Err(err.into())),
+				};
+				let session = qmux::uds::Config::new(WIRE_VERSION)
+					.protocols(self.protocols.iter().map(String::as_str))
+					.accept(stream)
+					.await
+					.map_err(Error::Accept);
+				Some(session.map(|session| (session, cred)))
+			}
+			Err(err) => Some(Err(err.into())),
+		}
+	}
+}
+
+impl Drop for Listener {
+	fn drop(&mut self) {
+		// Best-effort: don't leave a stale socket file behind.
+		let _ = fs::remove_file(&self.path);
+	}
+}

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -200,10 +200,16 @@ fn websocket_subprotocols(alpns: &[&str]) -> Vec<String> {
 	// Each moq ALPN under every QMux wire version (`qmux-01.moq-lite-04`, ...),
 	// newest first, then the bare qmux fallbacks. Mirrors qmux's own ALPN
 	// builder, which isn't public.
+	//
+	// `qmux-00.moqt-18` is excluded: moq-transport-18 requires qmux-01, so that
+	// pair is illegal (matches the relay and js/net's connect.ts).
 	let versions = [qmux::Version::QMux01, qmux::Version::QMux00];
 	let mut protocols = Vec::with_capacity(versions.len() * alpns.len() + qmux::ALPNS.len());
 	for &alpn in alpns {
 		for version in versions {
+			if version == qmux::Version::QMux00 && alpn == "moqt-18" {
+				continue;
+			}
 			protocols.push(format!("{}{alpn}", version.prefix()));
 		}
 	}

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -183,12 +183,12 @@ pub(crate) async fn connect(
 		.get(http::header::SEC_WEBSOCKET_PROTOCOL)
 		.and_then(|header| header.to_str().ok())
 		.map(str::to_owned);
-	let bare = qmux::ws::Bare::new(socket).with_keep_alive(qmux::KeepAlive::default());
-	let bare = match alpn.as_deref() {
-		Some(alpn) => bare.with_alpn(alpn),
-		None => bare,
+	let upgraded = qmux::ws::Upgraded::new(socket).with_keep_alive(qmux::KeepAlive::default());
+	let upgraded = match alpn.as_deref() {
+		Some(alpn) => upgraded.with_alpn(alpn),
+		None => upgraded,
 	};
-	let session = bare.connect();
+	let session = upgraded.connect();
 
 	tracing::warn!(%url, "using WebSocket fallback");
 	WEBSOCKET_WON.lock().unwrap().insert(key);
@@ -197,11 +197,17 @@ pub(crate) async fn connect(
 }
 
 fn websocket_subprotocols(alpns: &[&str]) -> Vec<String> {
-	let mut protocols = Vec::with_capacity(qmux::ALPNS.len() + qmux::PREFIXES.len() * alpns.len());
-	for (&bare, &prefix) in qmux::ALPNS.iter().zip(qmux::PREFIXES) {
-		protocols.push(bare.to_string());
-		protocols.extend(alpns.iter().map(|alpn| format!("{prefix}{alpn}")));
+	// Each moq ALPN under every QMux wire version (`qmux-01.moq-lite-04`, ...),
+	// newest first, then the bare qmux fallbacks. Mirrors qmux's own ALPN
+	// builder, which isn't public.
+	let versions = [qmux::Version::QMux01, qmux::Version::QMux00];
+	let mut protocols = Vec::with_capacity(versions.len() * alpns.len() + qmux::ALPNS.len());
+	for &alpn in alpns {
+		for version in versions {
+			protocols.push(format!("{}{alpn}", version.prefix()));
+		}
 	}
+	protocols.extend(qmux::ALPNS.iter().map(|s| s.to_string()));
 	protocols
 }
 
@@ -240,7 +246,9 @@ impl Listener {
 
 	pub async fn bind_with_alpns(addr: net::SocketAddr, alpns: &[&str]) -> Result<Self> {
 		let listener = tokio::net::TcpListener::bind(addr).await?;
-		let server = qmux::Server::new().with_protocols(alpns);
+		// Empty version slice = every QMux draft qmux knows about.
+		let any: &[qmux::Version] = &[];
+		let server = qmux::Server::new().with_protocols(alpns.iter().map(|&alpn| (alpn, any)));
 		Ok(Self { listener, server })
 	}
 

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -21,13 +21,16 @@ path = "src/main.rs"
 doc = false
 
 [features]
-default = ["iroh", "quinn", "websocket"]
+default = ["iroh", "quinn", "websocket", "uds"]
 iroh = ["moq-native/iroh"]
 jemalloc = ["moq-native/jemalloc"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]
 quiche = ["moq-native/quiche"]
 websocket = ["moq-native/websocket", "dep:qmux", "axum/ws"]
+# Unix-domain-socket internal listener (`unix://`), unix-only. In the default
+# set; drop via --no-default-features on platforms without Unix sockets.
+uds = ["moq-native/uds"]
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
@@ -39,7 +42,7 @@ futures = "0.3"
 http-body = "1"
 http-cache-reqwest = { version = "0.16", features = ["manager-moka"], default-features = false }
 jsonwebtoken = "10"
-moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs", "watch"] }
+moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs", "watch", "tcp"] }
 moq-net = { workspace = true, features = ["serde"] }
 moq-token = { workspace = true, features = ["tokio"] }
 qmux = { workspace = true, features = ["ws"], optional = true }
@@ -57,6 +60,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 tower-service = "0.3"
 tracing = "0.1"
 url = { version = "2", features = ["serde"] }
+web-transport-trait = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 sd-notify = "0.5"
@@ -64,5 +68,4 @@ sd-notify = "0.5"
 [dev-dependencies]
 rcgen = "0.14"
 tempfile = "3"
-web-transport-trait = { workspace = true }
 wiremock = "0.6"

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
-use crate::{AuthConfig, ClusterConfig, StatsConfig, WebConfig};
+use crate::{AuthConfig, ClusterConfig, InternalConfig, StatsConfig, WebConfig};
 
 /// Top-level relay configuration, loadable from CLI arguments, environment
 /// variables, or a TOML file.
@@ -39,6 +39,11 @@ pub struct Config {
 	#[command(flatten)]
 	#[serde(default)]
 	pub web: WebConfig,
+
+	/// Optionally run an unauthenticated plain-TCP listener for trusted clients.
+	#[command(flatten)]
+	#[serde(default)]
+	pub internal: InternalConfig,
 
 	/// Stats publishing configuration. Disabled unless `stats.enabled = true`.
 	#[command(flatten)]
@@ -320,6 +325,58 @@ id = 12345
 			config.cluster.id,
 			Some(12345),
 			"TOML's cluster.id must not be clobbered by the CLI re-parse"
+		);
+	}
+
+	/// Same clap+TOML clobber guard for `internal.listen`. It's typed as
+	/// `Option<SocketAddr>` so an absent `--internal-listen` CLI flag must not
+	/// wipe a TOML-configured value during the `update_from` re-parse. A bare
+	/// field would reset it to its default and silently disable the internal
+	/// listener for a deployment that enabled it via TOML.
+	static INTERNAL_LISTEN_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	#[test]
+	fn cli_does_not_clobber_toml_internal_listen() {
+		let _guard = INTERNAL_LISTEN_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: INTERNAL_LISTEN_ENV_LOCK serializes this with any sibling test
+		// touching the same env var.
+		unsafe { std::env::remove_var("MOQ_INTERNAL_LISTEN") };
+
+		let toml = r#"
+[internal]
+listen = "127.0.0.1:4444"
+"#;
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("internal-listen-toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(
+			config.internal.listen,
+			Some(crate::InternalListen::Tcp("127.0.0.1:4444".parse().unwrap())),
+			"TOML's internal.listen must not be clobbered by the CLI re-parse"
+		);
+	}
+
+	#[test]
+	fn internal_listen_parses_tcp_and_unix() {
+		use crate::InternalListen;
+		assert_eq!(
+			"127.0.0.1:4444".parse::<InternalListen>().unwrap(),
+			InternalListen::Tcp("127.0.0.1:4444".parse().unwrap())
+		);
+		// A bare path with no port is a Unix socket.
+		assert_eq!(
+			"/run/moq/internal.sock".parse::<InternalListen>().unwrap(),
+			InternalListen::Unix("/run/moq/internal.sock".into())
+		);
+		// The `unix:` prefix forces a path even if it would otherwise parse as an address.
+		assert_eq!(
+			"unix:127.0.0.1:4444".parse::<InternalListen>().unwrap(),
+			InternalListen::Unix("127.0.0.1:4444".into())
 		);
 	}
 

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -328,23 +328,32 @@ id = 12345
 		);
 	}
 
-	/// Same clap+TOML clobber guard for `internal.listen`. It's typed as
-	/// `Option<SocketAddr>` so an absent `--internal-listen` CLI flag must not
-	/// wipe a TOML-configured value during the `update_from` re-parse. A bare
-	/// field would reset it to its default and silently disable the internal
-	/// listener for a deployment that enabled it via TOML.
+	/// Same clap+TOML clobber guard for the internal listeners. Both
+	/// `internal.tcp.listen` (`Option<SocketAddr>`) and `internal.uds.listen`
+	/// (`Option<PathBuf>`) must survive the `update_from` re-parse when their
+	/// CLI flags are absent, or a TOML-configured listener gets silently
+	/// disabled.
 	static INTERNAL_LISTEN_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 	#[test]
 	fn cli_does_not_clobber_toml_internal_listen() {
 		let _guard = INTERNAL_LISTEN_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		// SAFETY: INTERNAL_LISTEN_ENV_LOCK serializes this with any sibling test
-		// touching the same env var.
-		unsafe { std::env::remove_var("MOQ_INTERNAL_LISTEN") };
+		// touching the same env vars.
+		unsafe {
+			std::env::remove_var("MOQ_INTERNAL_LISTEN");
+			std::env::remove_var("MOQ_INTERNAL_UDS_LISTEN");
+		}
 
 		let toml = r#"
-[internal]
+[internal.tcp]
 listen = "127.0.0.1:4444"
+
+[internal.uds]
+listen = "/run/moq/internal.sock"
+
+[internal.uds.allow]
+uid = [1001]
 "#;
 		let dir = std::env::temp_dir().join("moq-relay-config-test");
 		std::fs::create_dir_all(&dir).unwrap();
@@ -355,29 +364,16 @@ listen = "127.0.0.1:4444"
 		let config = Config::parse_and_merge(args).expect("config load");
 
 		assert_eq!(
-			config.internal.listen,
-			Some(crate::InternalListen::Tcp("127.0.0.1:4444".parse().unwrap())),
-			"TOML's internal.listen must not be clobbered by the CLI re-parse"
+			config.internal.tcp.listen,
+			Some("127.0.0.1:4444".parse().unwrap()),
+			"TOML's internal.tcp.listen must not be clobbered by the CLI re-parse"
 		);
-	}
-
-	#[test]
-	fn internal_listen_parses_tcp_and_unix() {
-		use crate::InternalListen;
 		assert_eq!(
-			"127.0.0.1:4444".parse::<InternalListen>().unwrap(),
-			InternalListen::Tcp("127.0.0.1:4444".parse().unwrap())
+			config.internal.uds.listen.as_deref(),
+			Some(std::path::Path::new("/run/moq/internal.sock")),
+			"TOML's internal.uds.listen must not be clobbered by the CLI re-parse"
 		);
-		// A bare path with no port is a Unix socket.
-		assert_eq!(
-			"/run/moq/internal.sock".parse::<InternalListen>().unwrap(),
-			InternalListen::Unix("/run/moq/internal.sock".into())
-		);
-		// The `unix:` prefix forces a path even if it would otherwise parse as an address.
-		assert_eq!(
-			"unix:127.0.0.1:4444".parse::<InternalListen>().unwrap(),
-			InternalListen::Unix("127.0.0.1:4444".into())
-		);
+		assert_eq!(config.internal.uds.allow.uid, vec![1001]);
 	}
 
 	#[test]

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -1,7 +1,5 @@
-use std::fmt;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use clap::Parser;
 use serde::{Deserialize, Serialize};
@@ -9,49 +7,59 @@ use tracing::Instrument;
 
 use crate::{AuthToken, Cluster};
 
-/// Where the internal listener binds.
+/// Configuration for the unauthenticated internal listener(s).
 ///
-/// Parsed from a single string: a `host:port` socket address binds a plain-TCP
-/// listener, anything else (or a `unix:` prefix) is treated as a Unix-socket
-/// path. So `127.0.0.1:4444` is TCP and `/run/moq/internal.sock` (or
-/// `unix:/run/moq/internal.sock`) is a Unix socket.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum InternalListen {
-	/// A plain-TCP qmux listener. No peer identity is available.
-	Tcp(SocketAddr),
-	/// A Unix-domain-socket qmux listener. Supports the [`InternalAllow`] uid/gid/pid check.
-	Unix(PathBuf),
+/// A TCP and a Unix-socket listener can each be enabled independently. Both
+/// grant every accepted connection full internal access (publish and subscribe
+/// to everything, no JWT or client certificate), so only expose them to trusted
+/// clients. This is the local-worker analogue of a cluster peer dialing `/`.
+#[derive(Parser, Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct InternalConfig {
+	/// Plain-TCP listener (`tcp://`).
+	#[command(flatten)]
+	#[serde(default)]
+	pub tcp: InternalTcp,
+
+	/// Unix-socket listener (`unix://`), with an optional peer-credential allowlist.
+	#[command(flatten)]
+	#[serde(default)]
+	pub uds: InternalUds,
 }
 
-impl FromStr for InternalListen {
-	type Err = std::convert::Infallible;
-
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		// An explicit `unix:` prefix forces a path, even one that might parse as
-		// an address. Otherwise a valid socket address is TCP and everything
-		// else is a path.
-		if let Some(rest) = s.strip_prefix("unix:") {
-			return Ok(Self::Unix(PathBuf::from(rest)));
-		}
-		Ok(match s.parse::<SocketAddr>() {
-			Ok(addr) => Self::Tcp(addr),
-			Err(_) => Self::Unix(PathBuf::from(s)),
-		})
-	}
+/// Plain-TCP internal listener.
+///
+/// TCP carries no peer identity, so it must only be reachable from trusted
+/// clients. Bind it to loopback or a private interface; a non-loopback bind
+/// logs a warning but is allowed.
+#[derive(Parser, Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct InternalTcp {
+	/// Bind an unauthenticated plain-TCP (qmux, no TLS) listener on this address.
+	#[arg(long = "internal-listen", id = "internal-listen", env = "MOQ_INTERNAL_LISTEN")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub listen: Option<SocketAddr>,
 }
 
-impl fmt::Display for InternalListen {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		match self {
-			Self::Tcp(addr) => write!(f, "{addr}"),
-			// Prefix so it round-trips back through FromStr as a path.
-			Self::Unix(path) => write!(f, "unix:{}", path.display()),
-		}
-	}
-}
+/// Unix-socket internal listener.
+///
+/// The kernel reports the connecting process's credentials, so [`allow`](Self::allow)
+/// can restrict callers to a specific worker user. Requires the `uds` build feature.
+#[derive(Parser, Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct InternalUds {
+	/// Bind an unauthenticated Unix-socket (qmux, no TLS) listener at this path.
+	#[arg(long = "internal-uds-listen", id = "internal-uds-listen", env = "MOQ_INTERNAL_UDS_LISTEN")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub listen: Option<PathBuf>,
 
-fn parse_listen(s: &str) -> Result<InternalListen, std::convert::Infallible> {
-	s.parse()
+	/// Peer-credential allowlist applied to accepted connections.
+	#[command(flatten)]
+	#[serde(default)]
+	pub allow: InternalAllow,
 }
 
 /// Peer-credential allowlist for the Unix-socket internal listener.
@@ -60,8 +68,6 @@ fn parse_listen(s: &str) -> Result<InternalListen, std::convert::Infallible> {
 /// imposes no constraint. A connection is allowed when it satisfies every
 /// populated field (AND across fields, OR within a field). All empty means no
 /// check, so the socket's filesystem permissions are the only gate.
-///
-/// Only applies to a Unix-socket [`InternalListen`]; TCP carries no peer identity.
 #[derive(Parser, Clone, Debug, Deserialize, Serialize, Default)]
 #[serde(deny_unknown_fields, default)]
 #[non_exhaustive]
@@ -85,58 +91,41 @@ pub struct InternalAllow {
 
 impl InternalAllow {
 	/// Whether this allowlist imposes any constraint.
+	#[cfg_attr(not(all(feature = "uds", unix)), allow(dead_code))]
 	fn is_empty(&self) -> bool {
 		self.uid.is_empty() && self.gid.is_empty() && self.pid.is_empty()
 	}
 }
 
-/// Configuration for the unauthenticated internal listener.
+/// Run the configured internal listener(s) until one fails; wait forever if none.
 ///
-/// When [`listen`](Self::listen) is set, the relay binds a listener (plain TCP
-/// or a Unix socket) that grants every accepted connection full internal
-/// access: publish and subscribe to everything, with no JWT or client
-/// certificate.
-///
-/// There is no transport encryption. A TCP listener has no peer identity, so it
-/// must only be reachable from trusted clients (loopback or a private
-/// interface). A Unix-socket listener can additionally restrict callers by
-/// uid/gid/pid via [`allow`](Self::allow).
-#[serde_with::serde_as]
-#[derive(Parser, Clone, Debug, Deserialize, Serialize, Default)]
-#[serde(deny_unknown_fields, default)]
-#[non_exhaustive]
-pub struct InternalConfig {
-	/// Bind the internal listener here: a `host:port` for TCP, or a path
-	/// (optionally `unix:`-prefixed) for a Unix socket.
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	#[serde_as(as = "Option<serde_with::DisplayFromStr>")]
-	#[arg(long = "internal-listen", env = "MOQ_INTERNAL_LISTEN", value_parser = parse_listen)]
-	pub listen: Option<InternalListen>,
-
-	/// Peer-credential allowlist (Unix-socket listeners only).
-	#[command(flatten)]
-	#[serde(default)]
-	pub allow: InternalAllow,
-}
-
-/// Run the internal listener if one is configured, otherwise wait forever.
-///
-/// Used directly in the relay's top-level `select!` so it composes whether or
-/// not `internal.listen` is set.
+/// Used directly in the relay's top-level `select!`. The TCP and Unix listeners
+/// run concurrently when both are configured.
 pub async fn run_internal(config: InternalConfig, cluster: Cluster) -> anyhow::Result<()> {
-	match config.listen {
-		None => std::future::pending().await,
-		Some(InternalListen::Tcp(addr)) => run_tcp(addr, config.allow, cluster).await,
-		Some(InternalListen::Unix(path)) => run_unix(path, config.allow, cluster).await,
+	let tcp = {
+		let cluster = cluster.clone();
+		async move {
+			match config.tcp.listen {
+				Some(addr) => run_tcp(addr, cluster).await,
+				None => std::future::pending().await,
+			}
+		}
+	};
+
+	let uds = async move {
+		match config.uds.listen {
+			Some(path) => run_uds(path, config.uds.allow, cluster).await,
+			None => std::future::pending().await,
+		}
+	};
+
+	tokio::select! {
+		res = tcp => res,
+		res = uds => res,
 	}
 }
 
-async fn run_tcp(addr: SocketAddr, allow: InternalAllow, cluster: Cluster) -> anyhow::Result<()> {
-	// TCP carries no peer identity, so an allowlist can't be honored here.
-	if !allow.is_empty() {
-		tracing::warn!("internal.allow is ignored for a TCP listener; it only applies to Unix sockets");
-	}
-
+async fn run_tcp(addr: SocketAddr, cluster: Cluster) -> anyhow::Result<()> {
 	// No transport security, so a non-loopback bind is worth flagging. We still
 	// allow it (private VPC interfaces are a valid use), just loudly.
 	if addr.ip().is_loopback() {
@@ -155,11 +144,11 @@ async fn run_tcp(addr: SocketAddr, allow: InternalAllow, cluster: Cluster) -> an
 		}
 	}
 
-	anyhow::bail!("internal listener stopped accepting connections")
+	anyhow::bail!("internal TCP listener stopped accepting connections")
 }
 
 #[cfg(all(feature = "uds", unix))]
-async fn run_unix(path: PathBuf, allow: InternalAllow, cluster: Cluster) -> anyhow::Result<()> {
+async fn run_uds(path: PathBuf, allow: InternalAllow, cluster: Cluster) -> anyhow::Result<()> {
 	if allow.is_empty() {
 		tracing::warn!(path = %path.display(), "internal Unix listener has no allow list; any local user able to reach the socket gets full access");
 	} else {
@@ -191,13 +180,13 @@ async fn run_unix(path: PathBuf, allow: InternalAllow, cluster: Cluster) -> anyh
 		spawn_session(session, cluster.clone());
 	}
 
-	anyhow::bail!("internal listener stopped accepting connections")
+	anyhow::bail!("internal Unix listener stopped accepting connections")
 }
 
 #[cfg(not(all(feature = "uds", unix)))]
-async fn run_unix(path: PathBuf, _allow: InternalAllow, _cluster: Cluster) -> anyhow::Result<()> {
+async fn run_uds(path: PathBuf, _allow: InternalAllow, _cluster: Cluster) -> anyhow::Result<()> {
 	anyhow::bail!(
-		"internal.listen requests a Unix socket ({}) but this relay was built without the `uds` feature",
+		"internal.uds.listen requests a Unix socket ({}) but this relay was built without the `uds` feature",
 		path.display()
 	)
 }

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -1,0 +1,248 @@
+use std::fmt;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use tracing::Instrument;
+
+use crate::{AuthToken, Cluster};
+
+/// Where the internal listener binds.
+///
+/// Parsed from a single string: a `host:port` socket address binds a plain-TCP
+/// listener, anything else (or a `unix:` prefix) is treated as a Unix-socket
+/// path. So `127.0.0.1:4444` is TCP and `/run/moq/internal.sock` (or
+/// `unix:/run/moq/internal.sock`) is a Unix socket.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InternalListen {
+	/// A plain-TCP qmux listener. No peer identity is available.
+	Tcp(SocketAddr),
+	/// A Unix-domain-socket qmux listener. Supports the [`InternalAllow`] uid/gid/pid check.
+	Unix(PathBuf),
+}
+
+impl FromStr for InternalListen {
+	type Err = std::convert::Infallible;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		// An explicit `unix:` prefix forces a path, even one that might parse as
+		// an address. Otherwise a valid socket address is TCP and everything
+		// else is a path.
+		if let Some(rest) = s.strip_prefix("unix:") {
+			return Ok(Self::Unix(PathBuf::from(rest)));
+		}
+		Ok(match s.parse::<SocketAddr>() {
+			Ok(addr) => Self::Tcp(addr),
+			Err(_) => Self::Unix(PathBuf::from(s)),
+		})
+	}
+}
+
+impl fmt::Display for InternalListen {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Tcp(addr) => write!(f, "{addr}"),
+			// Prefix so it round-trips back through FromStr as a path.
+			Self::Unix(path) => write!(f, "unix:{}", path.display()),
+		}
+	}
+}
+
+fn parse_listen(s: &str) -> Result<InternalListen, std::convert::Infallible> {
+	s.parse()
+}
+
+/// Peer-credential allowlist for the Unix-socket internal listener.
+///
+/// Each populated field constrains the corresponding credential; an empty field
+/// imposes no constraint. A connection is allowed when it satisfies every
+/// populated field (AND across fields, OR within a field). All empty means no
+/// check, so the socket's filesystem permissions are the only gate.
+///
+/// Only applies to a Unix-socket [`InternalListen`]; TCP carries no peer identity.
+#[derive(Parser, Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct InternalAllow {
+	/// Allowed peer user IDs. Empty means any uid.
+	#[arg(long = "internal-allow-uid", env = "MOQ_INTERNAL_ALLOW_UID", value_delimiter = ',')]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub uid: Vec<u32>,
+
+	/// Allowed peer group IDs. Empty means any gid.
+	#[arg(long = "internal-allow-gid", env = "MOQ_INTERNAL_ALLOW_GID", value_delimiter = ',')]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub gid: Vec<u32>,
+
+	/// Allowed peer process IDs. Empty means any pid. A populated list rejects
+	/// peers whose pid the platform doesn't report.
+	#[arg(long = "internal-allow-pid", env = "MOQ_INTERNAL_ALLOW_PID", value_delimiter = ',')]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub pid: Vec<i32>,
+}
+
+impl InternalAllow {
+	/// Whether this allowlist imposes any constraint.
+	fn is_empty(&self) -> bool {
+		self.uid.is_empty() && self.gid.is_empty() && self.pid.is_empty()
+	}
+}
+
+/// Configuration for the unauthenticated internal listener.
+///
+/// When [`listen`](Self::listen) is set, the relay binds a listener (plain TCP
+/// or a Unix socket) that grants every accepted connection full internal
+/// access: publish and subscribe to everything, with no JWT or client
+/// certificate.
+///
+/// There is no transport encryption. A TCP listener has no peer identity, so it
+/// must only be reachable from trusted clients (loopback or a private
+/// interface). A Unix-socket listener can additionally restrict callers by
+/// uid/gid/pid via [`allow`](Self::allow).
+#[serde_with::serde_as]
+#[derive(Parser, Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct InternalConfig {
+	/// Bind the internal listener here: a `host:port` for TCP, or a path
+	/// (optionally `unix:`-prefixed) for a Unix socket.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	#[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+	#[arg(long = "internal-listen", env = "MOQ_INTERNAL_LISTEN", value_parser = parse_listen)]
+	pub listen: Option<InternalListen>,
+
+	/// Peer-credential allowlist (Unix-socket listeners only).
+	#[command(flatten)]
+	#[serde(default)]
+	pub allow: InternalAllow,
+}
+
+/// Run the internal listener if one is configured, otherwise wait forever.
+///
+/// Used directly in the relay's top-level `select!` so it composes whether or
+/// not `internal.listen` is set.
+pub async fn run_internal(config: InternalConfig, cluster: Cluster) -> anyhow::Result<()> {
+	match config.listen {
+		None => std::future::pending().await,
+		Some(InternalListen::Tcp(addr)) => run_tcp(addr, config.allow, cluster).await,
+		Some(InternalListen::Unix(path)) => run_unix(path, config.allow, cluster).await,
+	}
+}
+
+async fn run_tcp(addr: SocketAddr, allow: InternalAllow, cluster: Cluster) -> anyhow::Result<()> {
+	// TCP carries no peer identity, so an allowlist can't be honored here.
+	if !allow.is_empty() {
+		tracing::warn!("internal.allow is ignored for a TCP listener; it only applies to Unix sockets");
+	}
+
+	// No transport security, so a non-loopback bind is worth flagging. We still
+	// allow it (private VPC interfaces are a valid use), just loudly.
+	if addr.ip().is_loopback() {
+		tracing::info!(%addr, "internal listener (tcp)");
+	} else {
+		tracing::warn!(%addr, "internal listener bound to a non-loopback address; it is UNAUTHENTICATED, ensure the network is trusted");
+	}
+
+	let listener = moq_native::tcp::Listener::bind(addr)
+		.await?
+		.with_protocols(moq_net::ALPNS.iter().copied());
+	while let Some(session) = listener.accept().await {
+		match session {
+			Ok(session) => spawn_session(session, cluster.clone()),
+			Err(err) => tracing::warn!(%err, "internal listener accept failed"),
+		}
+	}
+
+	anyhow::bail!("internal listener stopped accepting connections")
+}
+
+#[cfg(all(feature = "uds", unix))]
+async fn run_unix(path: PathBuf, allow: InternalAllow, cluster: Cluster) -> anyhow::Result<()> {
+	if allow.is_empty() {
+		tracing::warn!(path = %path.display(), "internal Unix listener has no allow list; any local user able to reach the socket gets full access");
+	} else {
+		tracing::info!(path = %path.display(), ?allow, "internal listener (unix)");
+	}
+
+	let listener = moq_native::unix::Listener::bind(&path)
+		.await?
+		.with_protocols(moq_net::ALPNS.iter().copied());
+	// Loose file permissions: the uid/gid/pid allow list is the real gate, and
+	// the worker typically runs as a different user than the relay.
+	listener.set_mode(0o666)?;
+
+	while let Some(accepted) = listener.accept().await {
+		let (session, cred) = match accepted {
+			Ok(accepted) => accepted,
+			Err(err) => {
+				tracing::warn!(%err, "internal listener accept failed");
+				continue;
+			}
+		};
+
+		if !cred_allowed(&allow, &cred) {
+			tracing::warn!(uid = cred.uid, gid = cred.gid, pid = ?cred.pid, "internal connection rejected by allow list");
+			drop(session);
+			continue;
+		}
+
+		spawn_session(session, cluster.clone());
+	}
+
+	anyhow::bail!("internal listener stopped accepting connections")
+}
+
+#[cfg(not(all(feature = "uds", unix)))]
+async fn run_unix(path: PathBuf, _allow: InternalAllow, _cluster: Cluster) -> anyhow::Result<()> {
+	anyhow::bail!(
+		"internal.listen requests a Unix socket ({}) but this relay was built without the `uds` feature",
+		path.display()
+	)
+}
+
+#[cfg(all(feature = "uds", unix))]
+fn cred_allowed(allow: &InternalAllow, cred: &moq_native::unix::PeerCred) -> bool {
+	let uid_ok = allow.uid.is_empty() || allow.uid.contains(&cred.uid);
+	let gid_ok = allow.gid.is_empty() || allow.gid.contains(&cred.gid);
+	// A required pid can't be satisfied if the platform doesn't report one.
+	let pid_ok = allow.pid.is_empty() || cred.pid.is_some_and(|pid| allow.pid.contains(&pid));
+	uid_ok && gid_ok && pid_ok
+}
+
+/// Spawn a task that serves one accepted session with full internal access.
+fn spawn_session<S>(session: S, cluster: Cluster)
+where
+	S: web_transport_trait::Session,
+{
+	// Full access to everything under the empty root, on the internal tier.
+	let token = AuthToken::unrestricted(moq_net::Path::new("").to_owned());
+	let publish = cluster.publisher(&token);
+	let subscribe = cluster.subscriber(&token);
+	let stats = cluster.stats.tier(moq_net::Tier::Internal);
+
+	let serve = async move {
+		// subscribe/publish look backwards on purpose: see connection.rs. We publish
+		// the tracks the client may subscribe to, and subscribe to what it may publish.
+		let session = moq_net::Server::new()
+			.with_publish(subscribe)
+			.with_consume(publish)
+			.with_stats(stats)
+			.accept(session)
+			.await?;
+
+		tracing::info!(version = %session.version(), "negotiated");
+		session.closed().await?;
+		anyhow::Ok(())
+	};
+
+	tokio::spawn(
+		async move {
+			if let Err(err) = serve.await {
+				tracing::warn!(%err, "internal connection closed");
+			}
+		}
+		.instrument(tracing::info_span!("internal")),
+	);
+}

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -52,7 +52,11 @@ pub struct InternalTcp {
 #[non_exhaustive]
 pub struct InternalUds {
 	/// Bind an unauthenticated Unix-socket (qmux, no TLS) listener at this path.
-	#[arg(long = "internal-uds-listen", id = "internal-uds-listen", env = "MOQ_INTERNAL_UDS_LISTEN")]
+	#[arg(
+		long = "internal-uds-listen",
+		id = "internal-uds-listen",
+		env = "MOQ_INTERNAL_UDS_LISTEN"
+	)]
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub listen: Option<PathBuf>,
 

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -12,6 +12,7 @@ mod cluster;
 mod config;
 mod connection;
 mod http_client;
+mod internal;
 mod stats;
 mod web;
 #[cfg(feature = "websocket")]
@@ -25,5 +26,6 @@ pub use auth::*;
 pub use cluster::*;
 pub use config::*;
 pub use connection::*;
+pub use internal::*;
 pub use stats::*;
 pub use web::*;

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -80,6 +80,7 @@ async fn main() -> anyhow::Result<()> {
 	tokio::select! {
 		Err(err) = cluster.clone().run() => return Err(err).context("cluster failed"),
 		Err(err) = web.run() => return Err(err).context("web server failed"),
+		Err(err) = run_internal(config.internal, cluster.clone()) => return Err(err).context("internal server failed"),
 		Err(err) = serve(server, cluster, auth) => return Err(err).context("server failed"),
 		Err(err) = jemalloc => return Err(err).context("jemalloc profiler failed"),
 		else => Ok(()),

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -117,19 +117,32 @@ where
 	session.closed().await.map_err(Into::into)
 }
 
+/// QMux wire-format versions that can ride under a `{prefix}{alpn}` pair.
+/// Newest first so axum's exact-string match picks the freshest one.
+const QMUX_VERSIONS: &[qmux::Version] = &[qmux::Version::QMux01, qmux::Version::QMux00];
+
+/// moq-transport-18 requires qmux-01, so we never pair it with qmux-00.
+/// Mirrors `js/net`'s `connect.ts` and moq-native's `qmux_versions_for`.
+const QMUX01_ONLY_ALPN: &str = "moqt-18";
+
 /// Subprotocols to advertise on the WebSocket upgrade.
 ///
-/// Generates the cross product of the QMux wire versions × `moq_net::ALPNS`,
-/// with the bare qmux fallbacks (`qmux-01`, `qmux-00`, `webtransport`) appended
-/// last so versioned subprotocols always win the exact-string match axum
-/// performs. Without the versioned entries, axum picks bare `webtransport`,
-/// qmux can't resolve a moq version from it, and the relay silently downgrades
-/// clients to Lite02 via SETUP-based negotiation.
+/// Generates the cross product of [`QMUX_VERSIONS`] × `moq_net::ALPNS`, with
+/// the bare qmux fallbacks (`qmux-01`, `qmux-00`, `webtransport`) appended last
+/// so versioned subprotocols always win the exact-string match axum performs.
+/// Without the versioned entries, axum picks bare `webtransport`, qmux can't
+/// resolve a moq version from it, and the relay silently downgrades clients to
+/// Lite02 via SETUP-based negotiation.
+///
+/// `qmux-00.moqt-18` is excluded: moq-transport-18 requires qmux-01, so that
+/// pair is illegal.
 fn supported_subprotocols() -> Vec<String> {
-	let versions = [qmux::Version::QMux01, qmux::Version::QMux00];
-	let mut out = Vec::with_capacity(versions.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
-	for version in versions {
+	let mut out = Vec::with_capacity(QMUX_VERSIONS.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
+	for &version in QMUX_VERSIONS {
 		for &alpn in moq_net::ALPNS {
+			if version == qmux::Version::QMux00 && alpn == QMUX01_ONLY_ALPN {
+				continue;
+			}
 			out.push(format!("{}{alpn}", version.prefix()));
 		}
 	}
@@ -206,6 +219,12 @@ mod tests {
 
 	#[test]
 	fn supported_subprotocols_lists_full_matrix() {
+		// Guard the literal: it must stay the IETF draft-18 ALPN (wire 0xff000012).
+		assert_eq!(
+			moq_net::Version::from_alpn(QMUX01_ONLY_ALPN).map(|v| v.code()),
+			Some(0xff000012)
+		);
+
 		let list = supported_subprotocols();
 
 		// Newest moq ALPN under the preferred prefix must come first so axum
@@ -213,10 +232,15 @@ mod tests {
 		let expected_first = format!("{}{}", preferred_qmux_prefix(), newest_moq_alpn());
 		assert_eq!(list.first().map(String::as_str), Some(expected_first.as_str()));
 
-		// Every moq ALPN must appear under every qmux wire version.
-		for version in [qmux::Version::QMux01, qmux::Version::QMux00] {
+		// Every moq ALPN must appear under every qmux wire version, except the
+		// illegal `qmux-00.moqt-18` pair (moq-transport-18 needs qmux-01).
+		for &version in QMUX_VERSIONS {
 			for &alpn in moq_net::ALPNS {
 				let entry = format!("{}{alpn}", version.prefix());
+				if version == qmux::Version::QMux00 && alpn == QMUX01_ONLY_ALPN {
+					assert!(!list.contains(&entry), "illegal pair {entry} must not be advertised");
+					continue;
+				}
 				assert!(list.contains(&entry), "missing {entry}");
 			}
 		}

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -102,12 +102,12 @@ where
 	// Wrap the WebSocket in a WebTransport compatibility layer. We have to
 	// forward the negotiated subprotocol explicitly; axum performed the
 	// upgrade, so qmux can't sniff it from the handshake.
-	let bare = qmux::ws::Bare::new(socket);
-	let bare = match alpn.as_deref() {
-		Some(alpn) => bare.with_alpn(alpn),
-		None => bare,
+	let upgraded = qmux::ws::Upgraded::new(socket);
+	let upgraded = match alpn.as_deref() {
+		Some(alpn) => upgraded.with_alpn(alpn),
+		None => upgraded,
 	};
-	let ws = bare.accept();
+	let ws = upgraded.accept();
 	let session = moq_net::Server::new()
 		.with_publish(subscribe)
 		.with_consume(publish)
@@ -119,17 +119,18 @@ where
 
 /// Subprotocols to advertise on the WebSocket upgrade.
 ///
-/// Generates the cross product of `qmux::PREFIXES` × `moq_net::ALPNS`, with
-/// the bare qmux fallbacks (`qmux-00`, `webtransport`) appended last so
-/// versioned subprotocols always win the exact-string match axum performs.
-/// Without the versioned entries, axum picks bare `webtransport`, qmux can't
-/// resolve a moq version from it, and the relay silently downgrades clients
-/// to Lite02 via SETUP-based negotiation.
+/// Generates the cross product of the QMux wire versions × `moq_net::ALPNS`,
+/// with the bare qmux fallbacks (`qmux-01`, `qmux-00`, `webtransport`) appended
+/// last so versioned subprotocols always win the exact-string match axum
+/// performs. Without the versioned entries, axum picks bare `webtransport`,
+/// qmux can't resolve a moq version from it, and the relay silently downgrades
+/// clients to Lite02 via SETUP-based negotiation.
 fn supported_subprotocols() -> Vec<String> {
-	let mut out = Vec::with_capacity(qmux::PREFIXES.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
-	for &prefix in qmux::PREFIXES {
+	let versions = [qmux::Version::QMux01, qmux::Version::QMux00];
+	let mut out = Vec::with_capacity(versions.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
+	for version in versions {
 		for &alpn in moq_net::ALPNS {
-			out.push(format!("{prefix}{alpn}"));
+			out.push(format!("{}{alpn}", version.prefix()));
 		}
 	}
 	for &alpn in qmux::ALPNS {
@@ -200,7 +201,7 @@ mod tests {
 	}
 
 	fn preferred_qmux_prefix() -> &'static str {
-		qmux::PREFIXES.first().copied().expect("qmux::PREFIXES is empty")
+		qmux::Version::QMux01.prefix()
 	}
 
 	#[test]
@@ -212,10 +213,10 @@ mod tests {
 		let expected_first = format!("{}{}", preferred_qmux_prefix(), newest_moq_alpn());
 		assert_eq!(list.first().map(String::as_str), Some(expected_first.as_str()));
 
-		// Every moq ALPN must appear under every qmux prefix.
-		for &prefix in qmux::PREFIXES {
+		// Every moq ALPN must appear under every qmux wire version.
+		for version in [qmux::Version::QMux01, qmux::Version::QMux00] {
 			for &alpn in moq_net::ALPNS {
-				let entry = format!("{prefix}{alpn}");
+				let entry = format!("{}{alpn}", version.prefix());
 				assert!(list.contains(&entry), "missing {entry}");
 			}
 		}
@@ -244,7 +245,7 @@ mod tests {
 	/// ALPN list to an axum router that mirrors `serve_ws`'s subprotocol
 	/// wiring. Both client and server must observe the newest moq ALPN
 	/// (`moq_net::ALPNS[0]`) on the resulting qmux session. A bug in
-	/// `supported_subprotocols` or in the `Bare::with_alpn` plumbing
+	/// `supported_subprotocols` or in the `Upgraded::with_alpn` plumbing
 	/// collapses this to `None` / bare `webtransport`, and moq-net then
 	/// downgrades to Lite02 via SETUP.
 	#[tokio::test]
@@ -265,12 +266,12 @@ mod tests {
 							.sink_map_err(|_| tungstenite::Error::ConnectionClosed)
 							.with(tungstenite_to_axum);
 
-						let bare = qmux::ws::Bare::new(socket);
-						let bare = match alpn.as_deref() {
-							Some(alpn) => bare.with_alpn(alpn),
-							None => bare,
+						let upgraded = qmux::ws::Upgraded::new(socket);
+						let upgraded = match alpn.as_deref() {
+							Some(alpn) => upgraded.with_alpn(alpn),
+							None => upgraded,
 						};
-						let session = bare.accept();
+						let session = upgraded.accept();
 						if let Some(tx) = server_alpn_tx.lock().unwrap().take() {
 							let _ = tx.send(session.protocol().map(str::to_owned));
 						}
@@ -292,8 +293,9 @@ mod tests {
 			axum::serve(listener, app).await.expect("axum serve");
 		});
 
+		let any: &[qmux::Version] = &[];
 		let session = qmux::Client::new()
-			.with_protocols(moq_net::ALPNS)
+			.with_protocols(moq_net::ALPNS.iter().map(|&alpn| (alpn, any)))
 			.connect(&format!("ws://{addr}/"))
 			.await
 			.expect("qmux client connect");
@@ -312,7 +314,7 @@ mod tests {
 		assert_eq!(
 			server_alpn.as_deref(),
 			Some(newest_moq_alpn()),
-			"server side should see the newest moq ALPN after Bare::with_alpn",
+			"server side should see the newest moq ALPN after Upgraded::with_alpn",
 		);
 
 		drop(session);

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -10,7 +10,10 @@
 use std::{net::TcpListener, sync::atomic::AtomicU64, time::Duration};
 
 use moq_native::moq_net::{self, Origin, Track};
-use moq_relay::{AuthConfig, Cluster, ClusterConfig, PublicConfig, Web, WebConfig, WebState};
+use moq_relay::{
+	AuthConfig, Cluster, ClusterConfig, InternalConfig, InternalListen, PublicConfig, Web, WebConfig, WebState,
+	run_internal,
+};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -252,6 +255,211 @@ async fn two_publish_only_clients_coexist() {
 	drop(sess_b);
 	drop(sub_session);
 	web_handle.abort();
+}
+
+/// Stand up just the unauthenticated internal listener (plain-TCP qmux, no
+/// auth stack) on a free loopback port. Returns the port and an abort handle.
+async fn spawn_internal_relay() -> (u16, tokio::task::JoinHandle<()>) {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	let cluster = Cluster::new(ClusterConfig::default()).expect("cluster init");
+
+	// Pick a free TCP port, then drop the probe so the listener can bind it.
+	let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
+	let port = probe.local_addr().expect("local addr").port();
+	drop(probe);
+
+	let mut internal = InternalConfig::default();
+	internal.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
+
+	let handle = tokio::spawn(async move {
+		// `run_internal` only returns on error; aborted at teardown.
+		let _ = run_internal(internal, cluster).await;
+	});
+
+	let deadline = std::time::Instant::now() + Duration::from_secs(5);
+	loop {
+		if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+			break;
+		}
+		if std::time::Instant::now() >= deadline {
+			panic!("internal listener never became ready on port {port}");
+		}
+		tokio::time::sleep(Duration::from_millis(25)).await;
+	}
+
+	(port, handle)
+}
+
+/// Connect a publisher and subscriber to the unauthenticated internal listener
+/// over `tcp://` (plain TCP, no TLS, no JWT) and confirm a frame round-trips.
+/// Exercises the qmux-over-TCP transport and the unrestricted internal grant.
+#[tokio::test]
+async fn internal_tcp_round_trip() {
+	let (port, handle) = spawn_internal_relay().await;
+	// The raw-TCP transport dials host:port only; any URL path is ignored.
+	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
+	let expected_version = newest_lite_version();
+
+	// ── publisher ───────────────────────────────────────────────────
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	let mut track = broadcast.create_track(Track::new("video")).expect("create track");
+	let mut group = track.append_group().expect("append group");
+	group.write_frame(b"hello".as_ref()).expect("write frame");
+	group.finish().expect("finish group");
+
+	let pub_session = tokio::time::timeout(
+		TIMEOUT,
+		client().with_publish(pub_origin.consume()).connect(url.clone()),
+	)
+	.await
+	.expect("publisher connect timeout")
+	.expect("publisher connect failed");
+	assert_eq!(
+		pub_session.version(),
+		expected_version,
+		"publisher should negotiate the newest moq-lite version in-band over TCP"
+	);
+
+	// ── subscriber ──────────────────────────────────────────────────
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume();
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consume(sub_origin).connect(url))
+		.await
+		.expect("subscriber connect timeout")
+		.expect("subscriber connect failed");
+
+	// ── data path ───────────────────────────────────────────────────
+	// The internal listener grants the empty root, so the broadcast announces
+	// at its own name with no path prefix.
+	let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+		.await
+		.expect("announcement timeout")
+		.expect("origin closed");
+	assert_eq!(path.as_str(), "test");
+	let bc = bc.expect("expected announce, got unannounce");
+
+	let mut track_sub = bc.subscribe_track(&Track::new("video")).expect("subscribe_track");
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
+		.await
+		.expect("recv_group timeout")
+		.expect("recv_group failed")
+		.expect("track closed prematurely");
+	let frame = tokio::time::timeout(TIMEOUT, group_sub.read_frame())
+		.await
+		.expect("read_frame timeout")
+		.expect("read_frame failed")
+		.expect("group closed prematurely");
+	assert_eq!(&*frame, b"hello");
+
+	drop(track);
+	drop(broadcast);
+	drop(pub_session);
+	drop(sub_session);
+	handle.abort();
+}
+
+/// Stand up the internal listener on a Unix socket and return the socket path
+/// plus an abort handle.
+#[cfg(unix)]
+async fn spawn_internal_unix_relay() -> (std::path::PathBuf, tokio::task::JoinHandle<()>) {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	let cluster = Cluster::new(ClusterConfig::default()).expect("cluster init");
+
+	// Keep the path short: macOS caps AF_UNIX paths around 104 bytes, and the
+	// system temp dir is long. /tmp is fine on macOS and Linux.
+	let path = std::path::PathBuf::from(format!("/tmp/moq-internal-{}.sock", std::process::id()));
+
+	let mut internal = InternalConfig::default();
+	internal.listen = Some(InternalListen::Unix(path.clone()));
+
+	let handle = tokio::spawn(async move {
+		let _ = run_internal(internal, cluster).await;
+	});
+
+	// Wait for the socket file to appear.
+	let deadline = std::time::Instant::now() + Duration::from_secs(5);
+	loop {
+		if tokio::net::UnixStream::connect(&path).await.is_ok() {
+			break;
+		}
+		if std::time::Instant::now() >= deadline {
+			panic!("internal Unix listener never became ready at {}", path.display());
+		}
+		tokio::time::sleep(Duration::from_millis(25)).await;
+	}
+
+	(path, handle)
+}
+
+/// Connect over `unix://` (qmux on a Unix socket) and confirm a frame
+/// round-trips. Also asserts both sides land on the newest moq-lite version,
+/// which proves the in-band ALPN negotiation populated the protocol.
+#[cfg(unix)]
+#[tokio::test]
+async fn internal_unix_round_trip() {
+	let (path, handle) = spawn_internal_unix_relay().await;
+	// `unix://` + an absolute path yields the triple-slash form the client expects.
+	let url: url::Url = format!("unix://{}", path.display()).parse().expect("parse url");
+	let expected_version = newest_lite_version();
+
+	// ── publisher ───────────────────────────────────────────────────
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	let mut track = broadcast.create_track(Track::new("video")).expect("create track");
+	let mut group = track.append_group().expect("append group");
+	group.write_frame(b"hello".as_ref()).expect("write frame");
+	group.finish().expect("finish group");
+
+	let pub_session = tokio::time::timeout(
+		TIMEOUT,
+		client().with_publish(pub_origin.consume()).connect(url.clone()),
+	)
+	.await
+	.expect("publisher connect timeout")
+	.expect("publisher connect failed");
+	assert_eq!(
+		pub_session.version(),
+		expected_version,
+		"publisher should negotiate the newest moq-lite version in-band over the Unix socket"
+	);
+
+	// ── subscriber ──────────────────────────────────────────────────
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume();
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consume(sub_origin).connect(url))
+		.await
+		.expect("subscriber connect timeout")
+		.expect("subscriber connect failed");
+
+	// ── data path ───────────────────────────────────────────────────
+	let (announced_path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+		.await
+		.expect("announcement timeout")
+		.expect("origin closed");
+	assert_eq!(announced_path.as_str(), "test");
+	let bc = bc.expect("expected announce, got unannounce");
+
+	let mut track_sub = bc.subscribe_track(&Track::new("video")).expect("subscribe_track");
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
+		.await
+		.expect("recv_group timeout")
+		.expect("recv_group failed")
+		.expect("track closed prematurely");
+	let frame = tokio::time::timeout(TIMEOUT, group_sub.read_frame())
+		.await
+		.expect("read_frame timeout")
+		.expect("read_frame failed")
+		.expect("group closed prematurely");
+	assert_eq!(&*frame, b"hello");
+
+	drop(track);
+	drop(broadcast);
+	drop(pub_session);
+	drop(sub_session);
+	handle.abort();
 }
 
 /// `/health` is a liveness probe that always returns `200 ok`.

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -11,8 +11,7 @@ use std::{net::TcpListener, sync::atomic::AtomicU64, time::Duration};
 
 use moq_native::moq_net::{self, Origin, Track};
 use moq_relay::{
-	AuthConfig, Cluster, ClusterConfig, InternalConfig, InternalListen, PublicConfig, Web, WebConfig, WebState,
-	run_internal,
+	AuthConfig, Cluster, ClusterConfig, InternalConfig, PublicConfig, Web, WebConfig, WebState, run_internal,
 };
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -270,7 +269,7 @@ async fn spawn_internal_relay() -> (u16, tokio::task::JoinHandle<()>) {
 	drop(probe);
 
 	let mut internal = InternalConfig::default();
-	internal.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
+	internal.tcp.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
 
 	let handle = tokio::spawn(async move {
 		// `run_internal` only returns on error; aborted at teardown.
@@ -373,7 +372,7 @@ async fn spawn_internal_unix_relay() -> (std::path::PathBuf, tokio::task::JoinHa
 	let path = std::path::PathBuf::from(format!("/tmp/moq-internal-{}.sock", std::process::id()));
 
 	let mut internal = InternalConfig::default();
-	internal.listen = Some(InternalListen::Unix(path.clone()));
+	internal.uds.listen = Some(path.clone());
 
 	let handle = tokio::spawn(async move {
 		let _ = run_internal(internal, cluster).await;


### PR DESCRIPTION
## Why

We want to run localhost (and trusted same-host / private-VPC) workers against the relay over qmux without paying for TLS and UDP. They should be treated as fully privileged (`internal`), with no JWT or certificate ceremony.

This adds dedicated, opt-in listeners for exactly that. They're isolated from the public QUIC/HTTPS paths, so the privilege can't leak: the only thing that grants unrestricted access is connecting to one of these sockets.

## What changed

### Relay (`rs/moq-relay`)

- New `[internal]` config with two independent, opt-in listeners:
  - `[internal.tcp] listen = "host:port"` → plain-TCP qmux (`tcp://`), flag `--internal-listen` / `MOQ_INTERNAL_LISTEN`.
  - `[internal.uds] listen = "/path"` → Unix-socket qmux (`unix://`), flag `--internal-uds-listen` / `MOQ_INTERNAL_UDS_LISTEN`.
  - Both can run at once.
- Every accepted connection gets `AuthToken::unrestricted("")` on the internal tier (full publish/subscribe under the empty root) — the local-worker analogue of an mTLS cluster peer dialing `/`.
- TCP has no peer identity, so a **non-loopback** bind logs a warning (operator firewalls it); it is not refused.
- Unix sockets support `[internal.uds.allow]` with `uid` / `gid` / `pid` lists, checked against kernel-reported peer credentials (`SO_PEERCRED` / `LOCAL_PEERCRED`) at accept. Empty = no check; AND across fields, OR within a field; a required `pid` fails closed if the platform doesn't report one. This is how you restrict access to a specific worker user rather than any local process (loopback TCP can't do that). The allowlist lives inside `[internal.uds]` because it's Unix-only.

### moq-native (`rs/moq-native`)

- New `tcp://` and `unix://` schemes (qmux directly over a raw stream — no TLS, no WebSocket framing) with client `connect` + server `Listener`s. The Unix `Listener` surfaces `PeerCred` and sets socket perms.
- Both are **always-on for native** via `default` features and drop out of `--no-default-features` (wasm) builds. `uds` is unix-only.
- The application protocol (moq ALPN) is negotiated **in-band** (qmux 0.2 transport parameter), so the exact moq version is agreed up front instead of defaulting via SETUP.

### qmux 0.0.8 → 0.2.0 (breaking dep bump)

- tcp/uds/ws builder API replaces the old free functions.
- `ws::Bare` → `ws::Upgraded`.
- `qmux::PREFIXES` was removed; the WebSocket subprotocol builders now reconstruct the `{prefix}{alpn}` cross-product from `qmux::Version::prefix()`. The existing WS negotiation regression test was updated and still passes.

### Docs

- `doc/bin/relay/auth.md` (new "Internal Listener" section) and `doc/bin/relay/config.md` (`[internal.tcp]` / `[internal.uds]`).

## Reviewer notes

- **Public API:** new additive surface — `moq_native::{tcp, unix}` modules (`Listener`, `PeerCred`, `Error`) and `moq_relay::{InternalConfig, InternalTcp, InternalUds, InternalAllow, run_internal}`. No existing public signatures changed; qmux is not re-exported, so its major bump isn't a breaking change to moq-native's surface. Hence targeting `main`.
- **Security:** the listeners are unauthenticated by design. TCP relies on the bind interface + firewall; Unix relies on filesystem perms + the `allow` peercred check. Root on the host can always bypass either (it can read the socket / ptrace the worker) — the threat model is *other non-root users on a shared host*.
- **wasm:** `tcp://`/`unix://` are native-only (browsers can't open raw TCP/Unix sockets); the JS client is unaffected.
- **Not wired:** `moq-cli` doesn't yet expose the `tcp`/`uds` features, so the `moq publish tcp://…` doc examples assume a CLI built with them. Happy to add that wiring in a follow-up if wanted.

## Test plan

- [x] `cargo check --workspace --all-targets` (qmux 0.2 bump clean across all crates)
- [x] `cargo fmt --check` + `clippy -D warnings` (moq-native, moq-relay)
- [x] moq-native + moq-relay test suites pass, including the reworked WS subprotocol regression test
- [x] Smoke tests `internal_tcp_round_trip` and `internal_unix_round_trip` round-trip a frame end-to-end and assert the newest moq-lite version is negotiated **in-band**
- [x] `moq-native --no-default-features` (wasm-style) build is clean with tcp/uds compiled out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)