### PR TITLE
docs: fix stale CLI sample commands across doc/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,8 +192,11 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 | `rs/moq-token` | `js/token` |
 | `rs/moq-relay` config/behavior | `doc/bin/relay/` |
 | `rs/moq-cli` | `doc/bin/cli.md` |
+| `rs/moq-token-cli` | `doc/bin/relay/auth.md`, `doc/lib/rs/crate/moq-token.md` |
 | `rs/moq-gst` | `doc/bin/gstreamer.md` |
 | `js/{watch,publish}` UI/API | `demo/web` if it consumes the API |
+
+**When a command-line tool's interface changes (a flag, argument, subcommand, or positional renamed/added/removed/reordered), update every doc that shows an example invocation, not just the tool's primary page.** Sample commands for `moq-cli`, `moq-relay`, and `moq-token-cli` are scattered across `doc/bin/`, `doc/lib/`, `doc/setup/`, and `doc/concept/`, plus the `justfile`s under `demo/`. Grep the whole repo for the binary name and reconcile each hit against the binary's `--help`. A stale example that no longer parses is worse than no example.
 
 ## Branch Targeting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 | `rs/moq-token` | `js/token` |
 | `rs/moq-relay` config/behavior | `doc/bin/relay/` |
 | `rs/moq-cli` | `doc/bin/cli.md` |
-| `rs/moq-token-cli` | `doc/bin/relay/auth.md`, `doc/lib/rs/crate/moq-token.md` |
+| `rs/moq-token-cli` | `doc/bin/relay/auth.md`, `doc/lib/rs/crate/moq-token.md`, `doc/lib/rs/index.md` |
 | `rs/moq-gst` | `doc/bin/gstreamer.md` |
 | `js/{watch,publish}` UI/API | `demo/web` if it consumes the API |
 

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -35,7 +35,11 @@ nix build github:moq-dev/moq#moq-cli
 
 ```bash
 docker pull moqdev/moq-cli
-docker run -v "$(pwd)/video.mp4:/app/video.mp4:ro" moqdev/moq-cli publish /app/video.mp4 https://relay.example.com/anon/stream
+
+# moq-cli reads media from stdin, so pipe an MPEG-TS stream into the container.
+# `-i` forwards stdin to the container process.
+ffmpeg -i video.mp4 -c copy -f mpegts - | \
+    docker run -i moqdev/moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub](https://hub.docker.com/r/moqdev/moq-cli).
@@ -52,10 +56,17 @@ The binary will be in `target/release/moq-cli`.
 
 ## Basic Usage
 
+`moq-cli publish` reads media from stdin and selects the input container with a
+subcommand (`ts`, `fmp4`, `flv`, `avc3`, `hls`). The destination is set with
+`--url` (the server) and `--broadcast` (the broadcast name), not a path on the URL.
+
 ### Publish a Video File
 
+Remux a file to MPEG-TS and pipe it in (`-c copy` avoids re-encoding):
+
 ```bash
-moq-cli publish video.mp4 https://relay.example.com/anon/my-stream
+ffmpeg -i video.mp4 -c copy -f mpegts - | \
+    moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 ### Publish from FFmpeg
@@ -63,7 +74,7 @@ moq-cli publish video.mp4 https://relay.example.com/anon/my-stream
 Pipe FFmpeg output directly to moq-cli:
 
 ```bash
-ffmpeg -i input.mp4 -f mpegts - | moq-cli publish - https://relay.example.com/anon/my-stream
+ffmpeg -i input.mp4 -f mpegts - | moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 ### Capture a Webcam
@@ -72,20 +83,20 @@ Pipe an external FFmpeg process as MPEG-TS:
 
 ```bash
 # macOS
-ffmpeg -f avfoundation -i "0:0" -f mpegts - | moq-cli publish - https://relay.example.com/anon/webcam
+ffmpeg -f avfoundation -i "0:0" -f mpegts - | moq-cli publish --url https://relay.example.com/anon --broadcast webcam ts
 
 # Linux
-ffmpeg -f v4l2 -i /dev/video0 -f mpegts - | moq-cli publish - https://relay.example.com/anon/webcam
+ffmpeg -f v4l2 -i /dev/video0 -f mpegts - | moq-cli publish --url https://relay.example.com/anon --broadcast webcam ts
 ```
 
 ### Publish Screen
 
 ```bash
 # macOS
-ffmpeg -f avfoundation -i "1:" -f mpegts - | moq-cli publish - https://relay.example.com/anon/screen
+ffmpeg -f avfoundation -i "1:" -f mpegts - | moq-cli publish --url https://relay.example.com/anon --broadcast screen ts
 
 # Linux (X11)
-ffmpeg -f x11grab -i :0.0 -f mpegts - | moq-cli publish - https://relay.example.com/anon/screen
+ffmpeg -f x11grab -i :0.0 -f mpegts - | moq-cli publish --url https://relay.example.com/anon --broadcast screen ts
 ```
 
 ## Encoding Options
@@ -97,7 +108,7 @@ ffmpeg -i input.mp4 \
     -c:v libx264 -preset ultrafast -tune zerolatency \
     -b:v 2500k -maxrate 2500k -bufsize 5000k \
     -c:a aac -b:a 128k \
-    -f mpegts - | moq-cli publish - https://relay.example.com/anon/stream
+    -f mpegts - | moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 ### Low Latency Settings
@@ -107,7 +118,7 @@ ffmpeg -i input.mp4 \
     -c:v libx264 -preset ultrafast -tune zerolatency \
     -g 30 -keyint_min 30 \
     -c:a aac \
-    -f mpegts - | moq-cli publish - https://relay.example.com/anon/stream
+    -f mpegts - | moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 ### H.265/HEVC
@@ -116,7 +127,7 @@ ffmpeg -i input.mp4 \
 ffmpeg -i input.mp4 \
     -c:v libx265 -preset ultrafast \
     -c:a aac \
-    -f mpegts - | moq-cli publish - https://relay.example.com/anon/stream
+    -f mpegts - | moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 ## Container Formats
@@ -185,10 +196,11 @@ are not supported.
 
 ## Authentication
 
-Pass a JWT token via the URL:
+Pass a JWT token via the URL's `?jwt=` query parameter:
 
 ```bash
-moq-cli publish video.mp4 "https://relay.example.com/room/123?jwt=<token>"
+ffmpeg -i video.mp4 -c copy -f mpegts - | \
+    moq-cli publish --url "https://relay.example.com/?jwt=<token>" --broadcast my-stream ts
 ```
 
 See [Authentication](/bin/relay/auth) for token generation.
@@ -211,10 +223,10 @@ Publish and subscribe to clock broadcasts for testing:
 
 ```bash
 # Publish a clock
-just clock publish https://relay.example.com/anon
+just pub clock publish https://relay.example.com/anon
 
 # Subscribe to a clock
-just clock subscribe https://relay.example.com/anon
+just pub clock subscribe https://relay.example.com/anon
 ```
 
 ## Debugging
@@ -222,7 +234,8 @@ just clock subscribe https://relay.example.com/anon
 ### Verbose Output
 
 ```bash
-RUST_LOG=debug moq-cli publish video.mp4 https://relay.example.com/anon/stream
+ffmpeg -i video.mp4 -c copy -f mpegts - | \
+    RUST_LOG=debug moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 ### Check Connection

--- a/doc/bin/index.md
+++ b/doc/bin/index.md
@@ -26,7 +26,7 @@ Another tool does the encoding (ex. ffmpeg), making it easy to pipe any media in
 
 ```bash
 # Publish your webcam
-ffmpeg -f avfoundation -i "0" -f mp4 - | moq-cli publish https://relay.example.com my-stream
+ffmpeg -f avfoundation -i "0" -f mpegts - | moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 ## [OBS Plugin](/bin/obs)

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -5,12 +5,10 @@ description: TOML configuration reference for moq-relay
 
 # Configuration
 
-moq-relay is configured via a TOML file. Pass the path as the only argument:
+moq-relay is configured via a TOML file. Pass the path as the only positional argument:
 
 ```bash
 moq-relay relay.toml
-# or
-moq-relay --config relay.toml
 ```
 
 ## Minimal Example

--- a/doc/bin/relay/index.md
+++ b/doc/bin/relay/index.md
@@ -57,7 +57,7 @@ nix build github:moq-dev/moq#moq-relay
 
 ```bash
 docker pull moqdev/moq-relay
-docker run -p 4443:4443/udp -v "$(pwd)/relay.toml:/app/relay.toml:ro" moqdev/moq-relay -- --config /app/relay.toml
+docker run -p 4443:4443/udp -v "$(pwd)/relay.toml:/app/relay.toml:ro" moqdev/moq-relay -- /app/relay.toml
 ```
 
 Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub](https://hub.docker.com/r/moqdev/moq-relay).
@@ -83,11 +83,7 @@ See [localhost.toml](https://github.com/moq-dev/moq/blob/main/demo/relay/localho
 
 ## Running
 
-```bash
-moq-relay --config relay.toml
-```
-
-Or with the config path as the only argument:
+Pass the config path as the only positional argument:
 
 ```bash
 moq-relay relay.toml

--- a/doc/lib/js/@moq/demo.md
+++ b/doc/lib/js/@moq/demo.md
@@ -15,7 +15,7 @@ Follow the [Quick Start](/setup/) guide to get started.
 You can target a remote relay instead of a local one with the command:
 
 ```bash
-just web https://cdn.moq.dev/anon
+just web serve https://cdn.moq.dev/anon
 ```
 
 ## Watch Demo

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -151,7 +151,7 @@ job.cancel()  // releases native resources
 To build and run the JVM tests locally:
 
 ```bash
-just check-ffi
+just kt check
 ```
 
 This builds `moq-ffi` for the host arch, regenerates the UniFFI Kotlin bindings, drops the host cdylib into the JNA resource layout, and runs `gradle :moq:jvmTest`.

--- a/doc/lib/rs/crate/hang.md
+++ b/doc/lib/rs/crate/hang.md
@@ -132,14 +132,13 @@ The `moq-cli` package provides a command-line tool (binary name: `moq-cli`):
 # Install
 cargo install moq-cli
 
-# Publish a video file
-moq-cli publish video.mp4
+# Publish a video file (remux to MPEG-TS and pipe it in)
+ffmpeg -i input.mp4 -c copy -f mpegts - | \
+    moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 
 # Publish from FFmpeg
-ffmpeg -i input.mp4 -f mpegts - | moq-cli publish -
-
-# Custom encoding settings
-moq-cli publish --codec h264 --bitrate 2000000 video.mp4
+ffmpeg -i input.mp4 -f mpegts - | \
+    moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 See `moq-cli --help` for all options, or [FFmpeg documentation](/bin/cli).

--- a/doc/lib/rs/crate/moq-mux.md
+++ b/doc/lib/rs/crate/moq-mux.md
@@ -93,11 +93,13 @@ For command-line importing, use [moq-cli](/bin/cli):
 # Install
 cargo install moq-cli
 
-# Publish a video file
-moq-cli publish video.mp4
+# Publish a video file (remux to MPEG-TS and pipe it in)
+ffmpeg -i input.mp4 -c copy -f mpegts - | \
+    moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 
 # Publish from FFmpeg
-ffmpeg -i input.mp4 -f mpegts - | moq-cli publish -
+ffmpeg -i input.mp4 -f mpegts - | \
+    moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 ## Next Steps

--- a/doc/lib/rs/crate/moq-token.md
+++ b/doc/lib/rs/crate/moq-token.md
@@ -51,7 +51,7 @@ nix build github:moq-dev/moq#moq-token-cli
 
 ```bash
 docker pull moqdev/moq-token-cli
-docker run -v "$(pwd):/app" -w /app moqdev/moq-token-cli --key root.jwk generate
+docker run -v "$(pwd):/app" -w /app moqdev/moq-token-cli generate --out root.jwk
 ```
 
 Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub](https://hub.docker.com/r/moqdev/moq-token-cli).

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -122,11 +122,13 @@ cargo install moq-cli
 **Usage:**
 
 ```bash
-# Publish a video file
-moq-cli publish video.mp4
+# Publish a video file (remux to MPEG-TS and pipe it in)
+ffmpeg -i input.mp4 -c copy -f mpegts - | \
+    moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 
 # Publish from FFmpeg
-ffmpeg -i input.mp4 -f mpegts - | moq-cli publish -
+ffmpeg -i input.mp4 -f mpegts - | \
+    moq-cli publish --url https://relay.example.com/anon --broadcast my-stream ts
 ```
 
 [Learn more](/bin/cli)
@@ -145,10 +147,10 @@ cargo install moq-token-cli
 
 ```bash
 # Generate a key
-moq-token-cli --key root.jwk generate
+moq-token-cli generate --out root.jwk
 
 # Sign a token
-moq-token-cli --key root.jwk sign \
+moq-token-cli sign --key root.jwk \
   --root "rooms/123" \
   --publish "alice" \
   --expires 1735689600

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -139,7 +139,7 @@ task.cancel()   // releases native resources
 To run the test suite, build a host-only XCFramework first:
 
 ```bash
-just check-ffi
+just swift check
 ```
 
 This runs `swift/scripts/check.sh`, which builds `moq-ffi` for the host arch, regenerates the UniFFI Swift bindings, drops a single-slice `MoqFFI.xcframework` into `swift/`, and then runs `swift test`. Requires macOS with `xcodebuild`.

--- a/doc/setup/dev.md
+++ b/doc/setup/dev.md
@@ -38,7 +38,7 @@ just fix
 just test
 
 # Publish a HLS broadcast (CMAF) over MoQ
-just pub-hls tos
+just pub hls tos
 ```
 
 Want more? See the [justfile](https://github.com/moq-dev/moq/blob/main/justfile) for all commands.
@@ -60,19 +60,19 @@ Anything you publish is public and discoverable... so be careful and don't abuse
 ```bash
 # Run the web server, pointing to the public relay
 # NOTE: The `bbb` demo on moq.dev uses a different path so it won't show up.
-just web https://cdn.moq.dev/anon
+just web serve https://cdn.moq.dev/anon
 
 # Publish Tears of Steel, watch it via https://moq.dev/watch?name=tos
 just pub tos https://cdn.moq.dev/anon
 
 # Publish a clock broadcast
-just clock publish https://cdn.moq.dev/anon
+just pub clock publish https://cdn.moq.dev/anon
 
 # Subscribe to said clock broadcast (different tab)
-just clock subscribe https://cdn.moq.dev/anon
+just pub clock subscribe https://cdn.moq.dev/anon
 
 # Publish an authentication broadcast
-just pub av1 https://cdn.moq.dev/?jwt=not_a_real_token_ask_for_one
+just pub bbb https://cdn.moq.dev/?jwt=not_a_real_token_ask_for_one
 ```
 
 ## Debugging


### PR DESCRIPTION
## Summary

A sweep through `doc/` revealed that many sample commands no longer matched the actual binaries/recipes. Each command was verified by building the binaries and checking it against `--help` (or `just` recipe resolution); the ones that no longer parse are corrected here. Docs-only, no code or wire changes, so this targets `main`.

### moq-cli
The real interface is `publish --url <URL> --broadcast <NAME> <fmp4|ts|flv|avc3|hls>` reading media from **stdin** (the broadcast name is a flag, not part of the URL path). Docs used an old positional `publish <file> <url>` form (confirmed `error: unrecognized subcommand 'video.mp4'`) and nonexistent `--codec`/`--bitrate` flags.
- `doc/bin/cli.md` (rewrote the quick-start / webcam / screen / encoding / docker / auth / RUST_LOG examples to match the file's own correct "Container Formats" section)
- `doc/bin/index.md`, `doc/lib/rs/index.md`, `doc/lib/rs/crate/hang.md`, `doc/lib/rs/crate/moq-mux.md`

### moq-relay
No `--config` flag exists; the config path is a positional `[FILE]` (`moq-relay relay.toml`).
- `doc/bin/relay/config.md`, `doc/bin/relay/index.md` (incl. the docker example)

### moq-token-cli
No global `--key`; it is per-subcommand (`sign --key`, `verify --key`) and `generate` uses `--out`.
- `doc/lib/rs/index.md`, `doc/lib/rs/crate/moq-token.md` (docker example)

### just recipes
Names that didn't resolve:
- `just clock ...` → `just pub clock ...`
- `just pub-hls tos` → `just pub hls tos`
- `just web <url>` → `just web serve <url>`
- `just check-ffi` → `just kt check` / `just swift check`
- `just pub av1 ...` → `just pub bbb ...` (no `av1` recipe exists)

### CLAUDE.md
Added a Cross-Package Sync note: when a CLI tool's interface changes, update **every** doc with an example invocation (they're scattered across `doc/bin`, `doc/lib`, `doc/setup`, `doc/concept`, and the `demo/` justfiles), grepping the binary name repo-wide and reconciling against `--help`. Also added the missing `rs/moq-token-cli` row to the sync table.

## Test plan
- [x] Re-grep for the broken patterns — zero residual hits
- [x] All corrected `just` recipes resolve (`just --show`)
- [x] `moq-token-cli generate/sign/verify` run end-to-end; `moq-cli publish` parses cleanly
- [x] `bun remark doc/ --quiet --frail` passes

(Written by Claude)