### PR TITLE
fix(moq-mux): carry all distinct SPS/PPS/VPS through transmux, not just the last seen

### DIFF
--- a/rs/moq-mux/src/codec/annexb.rs
+++ b/rs/moq-mux/src/codec/annexb.rs
@@ -17,17 +17,25 @@ pub(crate) fn push_distinct(set: &mut Vec<Bytes>, nal: &Bytes) -> bool {
 	true
 }
 
-/// Append each `cached` parameter-set NAL not yet in `seen` to `chunks` as
-/// Annex-B, marking it seen. Called before a keyframe slice so every parameter
-/// set the GOP references is carried for mid-stream tune-in, not just the latest.
-pub(crate) fn reinject_params(chunks: &mut BytesMut, cached: &[Bytes], seen: &mut Vec<Bytes>) {
-	for nal in cached {
-		if seen.iter().any(|s| s == nal) {
-			continue;
+/// Reconcile the retained parameter sets with what a keyframe access unit carried
+/// inline, called when the keyframe slice is reached:
+///
+/// - If the AU presented its own set (`seen` non-empty), adopt it as the retained
+///   set, dropping any the new GOP no longer uses (a mid-stream reinit).
+/// - If the AU carried none, re-inject the retained set into `chunks` as Annex-B
+///   so a receiver tuning in at this keyframe still gets them.
+///
+/// `seen` is this AU's inline NALs (already appended to `chunks`); `retained` is
+/// the cross-GOP set re-injected on bare keyframes.
+pub(crate) fn reconcile_keyframe_params(chunks: &mut BytesMut, retained: &mut Vec<Bytes>, seen: &mut Vec<Bytes>) {
+	if seen.is_empty() {
+		for nal in retained.iter() {
+			chunks.extend_from_slice(&START_CODE);
+			chunks.extend_from_slice(nal);
 		}
-		chunks.extend_from_slice(&START_CODE);
-		chunks.extend_from_slice(nal);
-		seen.push(nal.clone());
+		seen.clone_from(retained);
+	} else if seen != retained {
+		retained.clone_from(seen);
 	}
 }
 

--- a/rs/moq-mux/src/codec/annexb.rs
+++ b/rs/moq-mux/src/codec/annexb.rs
@@ -1,7 +1,35 @@
 use anyhow::{self};
-use bytes::{Buf, Bytes};
+use bytes::{Buf, Bytes, BytesMut};
 
 pub const START_CODE: Bytes = Bytes::from_static(&[0, 0, 0, 1]);
+
+/// Append `nal` to `set` unless a byte-identical entry is already present,
+/// preserving insertion order. Returns true if it was added.
+///
+/// Used to accumulate the distinct parameter-set NALs (SPS/PPS, plus VPS for
+/// H.265) a stream carries: avcC/hvcC hold an ordered list, and a source may
+/// define several (e.g. two PPS) that slices reference by id.
+pub(crate) fn push_distinct(set: &mut Vec<Bytes>, nal: &Bytes) -> bool {
+	if set.iter().any(|existing| existing == nal) {
+		return false;
+	}
+	set.push(nal.clone());
+	true
+}
+
+/// Append each `cached` parameter-set NAL not yet in `seen` to `chunks` as
+/// Annex-B, marking it seen. Called before a keyframe slice so every parameter
+/// set the GOP references is carried for mid-stream tune-in, not just the latest.
+pub(crate) fn reinject_params(chunks: &mut BytesMut, cached: &[Bytes], seen: &mut Vec<Bytes>) {
+	for nal in cached {
+		if seen.iter().any(|s| s == nal) {
+			continue;
+		}
+		chunks.extend_from_slice(&START_CODE);
+		chunks.extend_from_slice(nal);
+		seen.push(nal.clone());
+	}
+}
 
 pub struct NalIterator<'a, T: Buf + AsRef<[u8]> + 'a> {
 	buf: &'a mut T,

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -48,10 +48,12 @@ enum State {
 	/// avc3 wire shape: Annex-B NALU, inline SPS/PPS.
 	Avc3 {
 		current: Avc3Frame,
-		/// Distinct SPS NALs seen so far, re-injected on keyframes that lack them.
+		/// Retained SPS NALs from the latest keyframe that carried them, re-injected
+		/// on bare keyframes. Replaced (not accumulated) when a keyframe presents a
+		/// different set, so a mid-stream reinit drops the superseded ones.
 		sps: Vec<Bytes>,
-		/// Distinct PPS NALs seen so far. A stream may define several (slices
-		/// reference them by id), so all are kept and re-injected, not just the last.
+		/// Retained PPS NALs. A keyframe may carry several (slices reference them by
+		/// id); all are kept and re-injected, but a new GOP's set supersedes them.
 		pps: Vec<Bytes>,
 	},
 }
@@ -317,31 +319,31 @@ impl<E: CatalogExt> Import<E> {
 			Some(Avc3NalType::Sps) => {
 				self.maybe_start_frame(pts)?;
 				let parsed = Sps::parse(&nal)?;
-				// A changed config (resolution/profile) means the old parameter sets
-				// no longer apply; reconfigured tells us to drop them.
+				// A changed config (resolution/profile) means the retained parameter
+				// sets no longer apply; reconfigured tells us to drop them.
 				let reconfigured = self.init_from_sps(&parsed)?;
 				let State::Avc3 { current, sps, pps } = &mut self.state else {
 					unreachable!("decode_nal is avc3 only")
 				};
 				if reconfigured {
-					// The cached SPS/PPS are tied to the old config and may already
+					// The retained SPS/PPS are tied to the old config and may already
 					// have been appended to current.chunks earlier in this AU; reset
-					// the caches and AU so only the new parameter sets emit.
+					// the sets and AU so only the new parameter sets emit.
 					sps.clear();
 					pps.clear();
 					current.chunks.clear();
 					current.sps_seen.clear();
 					current.pps_seen.clear();
 				}
-				crate::codec::annexb::push_distinct(sps, &nal);
+				// Track only what this AU carries; the retained set is reconciled at
+				// the keyframe so a new GOP's set replaces (not accumulates onto) it.
 				crate::codec::annexb::push_distinct(&mut current.sps_seen, &nal);
 			}
 			Some(Avc3NalType::Pps) => {
 				self.maybe_start_frame(pts)?;
-				let State::Avc3 { current, pps, .. } = &mut self.state else {
+				let State::Avc3 { current, .. } = &mut self.state else {
 					unreachable!()
 				};
-				crate::codec::annexb::push_distinct(pps, &nal);
 				crate::codec::annexb::push_distinct(&mut current.pps_seen, &nal);
 			}
 			Some(Avc3NalType::Aud) | Some(Avc3NalType::Sei) => {
@@ -351,11 +353,10 @@ impl<E: CatalogExt> Import<E> {
 				let State::Avc3 { current, sps, pps } = &mut self.state else {
 					unreachable!()
 				};
-				// Re-inject every cached parameter set not already inline in this AU,
-				// so a receiver tuning in at this keyframe has each SPS/PPS its slices
-				// may reference (not just the most recent one).
-				crate::codec::annexb::reinject_params(&mut current.chunks, sps, &mut current.sps_seen);
-				crate::codec::annexb::reinject_params(&mut current.chunks, pps, &mut current.pps_seen);
+				// Adopt this keyframe's inline set (dropping any the new GOP no longer
+				// uses), or re-inject the retained set if the keyframe carried none.
+				crate::codec::annexb::reconcile_keyframe_params(&mut current.chunks, sps, &mut current.sps_seen);
+				crate::codec::annexb::reconcile_keyframe_params(&mut current.chunks, pps, &mut current.pps_seen);
 				current.contains_idr = true;
 				current.contains_slice = true;
 			}
@@ -692,6 +693,64 @@ mod tests {
 		assert_eq!(frames.len(), 2, "expected two keyframes");
 		// The bare IDR keyframe must carry SPS + both PPS, re-injected in order.
 		assert_eq!(frames[1].payload.as_ref(), annexb(&[sps, pps0, pps1, idr]).as_ref());
+	}
+
+	/// A keyframe that presents a smaller parameter set than a prior one reinits
+	/// the retained set: the dropped PPS must not be re-injected on later bare
+	/// keyframes.
+	#[tokio::test(start_paused = true)]
+	async fn avc3_reinit_drops_superseded_pps_on_keyframe() {
+		const SC: &[u8] = &[0, 0, 0, 1];
+		let sps: &[u8] = &[
+			0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xe9, 0xb8, 0x08, 0x08, 0x0a, 0x00, 0x00, 0x07, 0xd0, 0x00,
+			0x01, 0xd4, 0xc0, 0x80,
+		];
+		let pps0: &[u8] = &[0x68, 0xce, 0x3c, 0x80];
+		let pps1: &[u8] = &[0x68, 0xce, 0x3c, 0x81];
+		let idr: &[u8] = &[0x65, 0x88, 0x84, 0x21];
+
+		let annexb = |nals: &[&[u8]]| {
+			let mut buf = bytes::BytesMut::new();
+			for nal in nals {
+				buf.extend_from_slice(SC);
+				buf.extend_from_slice(nal);
+			}
+			buf
+		};
+
+		let mut producer = moq_net::Broadcast::new().produce();
+		let consumer = producer.consume();
+		let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+		let mut importer = Import::new(producer, catalog.clone())
+			.with_mode(Mode::Avc3)
+			.expect("avc3 mode");
+		let name = importer.track().unwrap().name.clone();
+
+		// GOP 1 defines both PPS; GOP 2 redefines the set with only PPS 0; GOP 3 is
+		// a bare IDR that must re-inject the reduced set, not the dropped PPS 1.
+		let times = [0u64, 40, 80];
+		let gops: [&[&[u8]]; 3] = [&[sps, pps0, pps1, idr], &[sps, pps0, idr], &[idr]];
+		for (gop, t) in gops.iter().zip(times) {
+			importer
+				.decode_frame(
+					&mut annexb(gop),
+					Some(crate::container::Timestamp::from_millis(t).unwrap()),
+				)
+				.unwrap();
+		}
+		importer.finish().unwrap();
+
+		let track = consumer.subscribe_track(&moq_net::Track::new(name)).unwrap();
+		let mut reader = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy);
+		let mut frames = Vec::new();
+		while let Ok(Ok(Some(frame))) = tokio::time::timeout(std::time::Duration::from_millis(50), reader.read()).await
+		{
+			frames.push(frame);
+		}
+
+		assert_eq!(frames.len(), 3, "expected three keyframes");
+		// The bare third keyframe re-injects only the surviving SPS + PPS 0.
+		assert_eq!(frames[2].payload.as_ref(), annexb(&[sps, pps0, idr]).as_ref());
 	}
 }
 

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -48,8 +48,11 @@ enum State {
 	/// avc3 wire shape: Annex-B NALU, inline SPS/PPS.
 	Avc3 {
 		current: Avc3Frame,
-		sps: Option<Bytes>,
-		pps: Option<Bytes>,
+		/// Distinct SPS NALs seen so far, re-injected on keyframes that lack them.
+		sps: Vec<Bytes>,
+		/// Distinct PPS NALs seen so far. A stream may define several (slices
+		/// reference them by id), so all are kept and re-injected, not just the last.
+		pps: Vec<Bytes>,
 	},
 }
 
@@ -58,8 +61,10 @@ struct Avc3Frame {
 	chunks: BytesMut,
 	contains_idr: bool,
 	contains_slice: bool,
-	contains_sps: bool,
-	contains_pps: bool,
+	/// SPS NALs already inline in this access unit, so re-injection skips them.
+	sps_seen: Vec<Bytes>,
+	/// PPS NALs already inline in this access unit.
+	pps_seen: Vec<Bytes>,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -108,8 +113,8 @@ impl<E: CatalogExt> Import<E> {
 				);
 				self.state = State::Avc3 {
 					current: Avc3Frame::default(),
-					sps: None,
-					pps: None,
+					sps: Vec::new(),
+					pps: Vec::new(),
 				};
 			}
 		}
@@ -179,8 +184,8 @@ impl<E: CatalogExt> Import<E> {
 		if !matches!(self.state, State::Avc3 { .. }) {
 			self.state = State::Avc3 {
 				current: Avc3Frame::default(),
-				sps: None,
-				pps: None,
+				sps: Vec::new(),
+				pps: Vec::new(),
 			};
 			if self.track.is_none() {
 				self.tracks.set_suffix(".avc3");
@@ -311,31 +316,33 @@ impl<E: CatalogExt> Import<E> {
 		match nal_type {
 			Some(Avc3NalType::Sps) => {
 				self.maybe_start_frame(pts)?;
-				let sps = Sps::parse(&nal)?;
-				self.init_from_sps(&sps)?;
+				let parsed = Sps::parse(&nal)?;
+				// A changed config (resolution/profile) means the old parameter sets
+				// no longer apply; reconfigured tells us to drop them.
+				let reconfigured = self.init_from_sps(&parsed)?;
 				let State::Avc3 { current, sps, pps } = &mut self.state else {
 					unreachable!("decode_nal is avc3 only")
 				};
-				if sps.as_ref().is_some_and(|cached| cached != &nal) {
-					// SPS changed mid-AU. The cached PPS is tied to the old SPS
-					// and may already have been appended to current.chunks
-					// earlier in this AU; reset the AU so the new SPS+PPS pair
-					// is the only parameter set we emit.
-					*pps = None;
+				if reconfigured {
+					// The cached SPS/PPS are tied to the old config and may already
+					// have been appended to current.chunks earlier in this AU; reset
+					// the caches and AU so only the new parameter sets emit.
+					sps.clear();
+					pps.clear();
 					current.chunks.clear();
-					current.contains_pps = false;
-					current.contains_sps = false;
+					current.sps_seen.clear();
+					current.pps_seen.clear();
 				}
-				*sps = Some(nal.clone());
-				current.contains_sps = true;
+				crate::codec::annexb::push_distinct(sps, &nal);
+				crate::codec::annexb::push_distinct(&mut current.sps_seen, &nal);
 			}
 			Some(Avc3NalType::Pps) => {
 				self.maybe_start_frame(pts)?;
 				let State::Avc3 { current, pps, .. } = &mut self.state else {
 					unreachable!()
 				};
-				*pps = Some(nal.clone());
-				current.contains_pps = true;
+				crate::codec::annexb::push_distinct(pps, &nal);
+				crate::codec::annexb::push_distinct(&mut current.pps_seen, &nal);
 			}
 			Some(Avc3NalType::Aud) | Some(Avc3NalType::Sei) => {
 				self.maybe_start_frame(pts)?;
@@ -344,20 +351,11 @@ impl<E: CatalogExt> Import<E> {
 				let State::Avc3 { current, sps, pps } = &mut self.state else {
 					unreachable!()
 				};
-				if !current.contains_sps
-					&& let Some(sps) = sps.as_ref()
-				{
-					current.chunks.extend_from_slice(&START_CODE);
-					current.chunks.extend_from_slice(sps);
-					current.contains_sps = true;
-				}
-				if !current.contains_pps
-					&& let Some(pps) = pps.as_ref()
-				{
-					current.chunks.extend_from_slice(&START_CODE);
-					current.chunks.extend_from_slice(pps);
-					current.contains_pps = true;
-				}
+				// Re-inject every cached parameter set not already inline in this AU,
+				// so a receiver tuning in at this keyframe has each SPS/PPS its slices
+				// may reference (not just the most recent one).
+				crate::codec::annexb::reinject_params(&mut current.chunks, sps, &mut current.sps_seen);
+				crate::codec::annexb::reinject_params(&mut current.chunks, pps, &mut current.pps_seen);
 				current.contains_idr = true;
 				current.contains_slice = true;
 			}
@@ -386,7 +384,11 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	fn init_from_sps(&mut self, sps: &Sps) -> anyhow::Result<()> {
+	/// Publish (or republish) the catalog rendition for this SPS. Returns true if
+	/// the config changed an existing one (a reconfiguration), so the caller can
+	/// drop parameter sets tied to the old config. The first SPS is not a
+	/// reconfiguration.
+	fn init_from_sps(&mut self, sps: &Sps) -> anyhow::Result<bool> {
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::H264 {
 			profile: sps.profile,
 			constraints: sps.constraints,
@@ -397,19 +399,18 @@ impl<E: CatalogExt> Import<E> {
 		config.coded_height = Some(sps.coded_height);
 		config.container = hang::catalog::Container::Legacy;
 
-		if let Some(old) = &self.config
-			&& old == &config
-		{
-			return Ok(());
+		match &self.config {
+			Some(old) if old == &config => Ok(false),
+			old => {
+				let reconfigured = old.is_some();
+				// The avc3 track was created eagerly in initialize_avc3; just publish
+				// (or republish) the catalog rendition with the latest config.
+				let track_name = self.track.as_ref().context("avc3 track not created")?.name.clone();
+				self.catalog.lock().video.renditions.insert(track_name, config.clone());
+				self.config = Some(config);
+				Ok(reconfigured)
+			}
 		}
-
-		// The avc3 track was created eagerly in initialize_avc3; just publish
-		// (or republish) the catalog rendition with the latest config.
-		let track_name = self.track.as_ref().context("avc3 track not created")?.name.clone();
-		let mut catalog = self.catalog.lock();
-		catalog.video.renditions.insert(track_name, config.clone());
-		self.config = Some(config);
-		Ok(())
 	}
 
 	fn maybe_start_frame(&mut self, pts: Option<crate::container::Timestamp>) -> anyhow::Result<()> {
@@ -424,8 +425,8 @@ impl<E: CatalogExt> Import<E> {
 		let keyframe = current.contains_idr;
 		current.contains_idr = false;
 		current.contains_slice = false;
-		current.contains_sps = false;
-		current.contains_pps = false;
+		current.sps_seen.clear();
+		current.pps_seen.clear();
 
 		let track = self.track.as_mut().context("avc3 track not created")?;
 		track.write(crate::container::Frame {
@@ -631,6 +632,66 @@ mod tests {
 		assert!(cfg.description.is_none(), "avc3 has no out-of-band description");
 		assert_eq!(h264.profile, sps[1]);
 		assert_eq!(h264.level, sps[3]);
+	}
+
+	/// A source that defines two PPS once, then sends a bare IDR (no inline
+	/// parameter sets): the importer must re-inject BOTH cached PPS on the
+	/// keyframe, not just the last one. Regression for the multi-PPS collapse.
+	#[tokio::test(start_paused = true)]
+	async fn avc3_reinjects_all_cached_pps_on_keyframe() {
+		const SC: &[u8] = &[0, 0, 0, 1];
+		// A real, parseable SPS so init_from_sps can read the resolution.
+		let sps: &[u8] = &[
+			0x67, 0x42, 0xc0, 0x1f, 0xda, 0x01, 0x40, 0x16, 0xe9, 0xb8, 0x08, 0x08, 0x0a, 0x00, 0x00, 0x07, 0xd0, 0x00,
+			0x01, 0xd4, 0xc0, 0x80,
+		];
+		let pps0: &[u8] = &[0x68, 0xce, 0x3c, 0x80];
+		let pps1: &[u8] = &[0x68, 0xce, 0x3c, 0x81];
+		let idr: &[u8] = &[0x65, 0x88, 0x84, 0x21];
+
+		let annexb = |nals: &[&[u8]]| {
+			let mut buf = bytes::BytesMut::new();
+			for nal in nals {
+				buf.extend_from_slice(SC);
+				buf.extend_from_slice(nal);
+			}
+			buf
+		};
+
+		let mut producer = moq_net::Broadcast::new().produce();
+		let consumer = producer.consume();
+		let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+		let mut importer = Import::new(producer, catalog.clone())
+			.with_mode(Mode::Avc3)
+			.expect("avc3 mode");
+		let name = importer.track().unwrap().name.clone();
+
+		// First AU defines both PPS inline; the second is a bare IDR.
+		importer
+			.decode_frame(
+				&mut annexb(&[sps, pps0, pps1, idr]),
+				Some(crate::container::Timestamp::from_millis(0).unwrap()),
+			)
+			.unwrap();
+		importer
+			.decode_frame(
+				&mut annexb(&[idr]),
+				Some(crate::container::Timestamp::from_millis(40).unwrap()),
+			)
+			.unwrap();
+		importer.finish().unwrap();
+
+		let track = consumer.subscribe_track(&moq_net::Track::new(name)).unwrap();
+		let mut reader = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy);
+		let mut frames = Vec::new();
+		while let Ok(Ok(Some(frame))) = tokio::time::timeout(std::time::Duration::from_millis(50), reader.read()).await
+		{
+			frames.push(frame);
+		}
+
+		assert_eq!(frames.len(), 2, "expected two keyframes");
+		// The bare IDR keyframe must carry SPS + both PPS, re-injected in order.
+		assert_eq!(frames[1].payload.as_ref(), annexb(&[sps, pps0, pps1, idr]).as_ref());
 	}
 }
 

--- a/rs/moq-mux/src/codec/h264/mod.rs
+++ b/rs/moq-mux/src/codec/h264/mod.rs
@@ -201,16 +201,19 @@ fn read_param_set_array(buf: &[u8], mut pos: usize, count: usize, params: &mut V
 /// Transform H.264 frames from Annex-B (inline SPS/PPS, "avc3") to
 /// length-prefixed NALU (out-of-band AVCDecoderConfigurationRecord, "avc1").
 ///
-/// The avcC is synthesized from cached SPS+PPS the first time both are
-/// observed and is exposed via [`Self::avcc`]. Once [`Self::avcc`] returns
-/// `Some`, all subsequent calls to [`Self::transform`] return length-prefixed
-/// sample data suitable for an avc1 container (e.g. MKV `V_MPEG4/ISO/AVC` with
-/// the avcC in CodecPrivate).
+/// The avcC is synthesized from the active SPS+PPS and exposed via
+/// [`Self::avcc`]. Once it returns `Some`, all subsequent calls to
+/// [`Self::transform`] return length-prefixed sample data suitable for an avc1
+/// container (e.g. MKV `V_MPEG4/ISO/AVC` with the avcC in CodecPrivate).
+///
+/// The active set is scoped to the latest keyframe: a frame that carries
+/// parameter sets redefines them, so a mid-stream reconfiguration drops the
+/// superseded SPS/PPS instead of accumulating them forever.
 pub struct Avc1 {
 	avcc: Option<Bytes>,
-	/// Distinct SPS NALs observed, in arrival order.
+	/// The active SPS NALs (from the most recent keyframe that carried them).
 	sps: Vec<Bytes>,
-	/// Distinct PPS NALs observed, in arrival order.
+	/// The active PPS NALs.
 	pps: Vec<Bytes>,
 }
 
@@ -243,14 +246,15 @@ impl Avc1 {
 	///   transform is still waiting for slice NALs (avcC may have been built
 	///   as a side effect).
 	pub fn transform(&mut self, payload: Bytes) -> anyhow::Result<Option<Bytes>> {
-		// Parse Annex-B NALs, strip SPS/PPS into the cache, length-prefix
-		// the rest. NalIterator advances the Bytes cursor; the trailing NAL
-		// has to be pulled separately via flush().
+		// Parse Annex-B NALs, collect this frame's SPS/PPS, length-prefix the
+		// rest. NalIterator advances the Bytes cursor; the trailing NAL has to be
+		// pulled separately via flush().
 		let mut buf = payload.clone();
 		let mut nal_iter = crate::codec::annexb::NalIterator::new(&mut buf);
 
 		let mut out = BytesMut::with_capacity(payload.remaining());
-		let mut sps_pps_changed = false;
+		let mut frame_sps: Vec<Bytes> = Vec::new();
+		let mut frame_pps: Vec<Bytes> = Vec::new();
 		let mut emitted_any_slice = false;
 
 		loop {
@@ -259,19 +263,31 @@ impl Avc1 {
 				Some(Err(e)) => return Err(e),
 				None => break,
 			};
-			if self.process_nal(&nal, &mut out, &mut sps_pps_changed)? {
+			if process_nal(&nal, &mut out, &mut frame_sps, &mut frame_pps)? {
 				emitted_any_slice = true;
 			}
 		}
 
 		if let Some(nal) = nal_iter.flush()? {
-			let was_slice = self.process_nal(&nal, &mut out, &mut sps_pps_changed)?;
-			if was_slice {
+			if process_nal(&nal, &mut out, &mut frame_sps, &mut frame_pps)? {
 				emitted_any_slice = true;
 			}
 		}
 
-		if sps_pps_changed {
+		// A frame that carries parameter sets (a keyframe) redefines the active
+		// set; adopt it so SPS/PPS from a superseded configuration are dropped
+		// rather than lingering in the avcC. Per type, so a frame that updates only
+		// one of SPS/PPS keeps the other.
+		let mut changed = false;
+		if !frame_sps.is_empty() && frame_sps != self.sps {
+			self.sps = frame_sps;
+			changed = true;
+		}
+		if !frame_pps.is_empty() && frame_pps != self.pps {
+			self.pps = frame_pps;
+			changed = true;
+		}
+		if changed {
 			self.rebuild_avcc()?;
 		}
 
@@ -282,42 +298,42 @@ impl Avc1 {
 		Ok(Some(out.freeze()))
 	}
 
-	/// Process one NAL: SPS/PPS go into the cache, everything else gets
-	/// length-prefixed and appended to `out`. Returns true if the NAL was a
-	/// slice (i.e. produced sample bytes).
-	fn process_nal(&mut self, nal: &Bytes, out: &mut BytesMut, sps_pps_changed: &mut bool) -> anyhow::Result<bool> {
-		if nal.is_empty() {
-			return Ok(false);
-		}
-		let nal_type = nal[0] & 0x1f;
-		match nal_type {
-			NAL_TYPE_SPS => {
-				if crate::codec::annexb::push_distinct(&mut self.sps, nal) {
-					*sps_pps_changed = true;
-				}
-				Ok(false)
-			}
-			NAL_TYPE_PPS => {
-				if crate::codec::annexb::push_distinct(&mut self.pps, nal) {
-					*sps_pps_changed = true;
-				}
-				Ok(false)
-			}
-			_ => {
-				let len = u32::try_from(nal.len()).context("NAL too large for 4-byte length prefix")?;
-				out.extend_from_slice(&len.to_be_bytes());
-				out.extend_from_slice(nal);
-				Ok(true)
-			}
-		}
-	}
-
 	fn rebuild_avcc(&mut self) -> anyhow::Result<()> {
 		if self.sps.is_empty() || self.pps.is_empty() {
 			return Ok(());
 		}
 		self.avcc = Some(build_avcc(&self.sps, &self.pps)?);
 		Ok(())
+	}
+}
+
+/// Process one NAL: SPS/PPS are collected (distinctly) into this frame's sets,
+/// everything else is length-prefixed and appended to `out`. Returns true if the
+/// NAL was a slice (i.e. produced sample bytes).
+fn process_nal(
+	nal: &Bytes,
+	out: &mut BytesMut,
+	frame_sps: &mut Vec<Bytes>,
+	frame_pps: &mut Vec<Bytes>,
+) -> anyhow::Result<bool> {
+	if nal.is_empty() {
+		return Ok(false);
+	}
+	match nal[0] & 0x1f {
+		NAL_TYPE_SPS => {
+			crate::codec::annexb::push_distinct(frame_sps, nal);
+			Ok(false)
+		}
+		NAL_TYPE_PPS => {
+			crate::codec::annexb::push_distinct(frame_pps, nal);
+			Ok(false)
+		}
+		_ => {
+			let len = u32::try_from(nal.len()).context("NAL too large for 4-byte length prefix")?;
+			out.extend_from_slice(&len.to_be_bytes());
+			out.extend_from_slice(nal);
+			Ok(true)
+		}
 	}
 }
 
@@ -390,8 +406,28 @@ mod tests {
 	}
 
 	#[test]
-	fn avc3_accumulates_distinct_pps() {
-		// Two distinct PPS arrive across keyframes; the synthesized avcC carries both.
+	fn avc3_keyframe_with_two_pps_keeps_both() {
+		// One keyframe carrying both PPS: the synthesized avcC keeps both, in order.
+		let sps = &[0x67, 0x42, 0xc0, 0x1f, 0xde][..];
+		let pps0 = &[0x68, 0xce, 0x3c, 0x80][..];
+		let pps1 = &[0x68, 0xce, 0x3c, 0x81][..];
+		let idr = &[0x65, 0x88][..];
+
+		let mut tx = Avc1::new();
+		tx.transform(annexb_frame(&[sps, pps0, pps1, idr])).unwrap();
+
+		let avcc = tx.avcc().expect("avcC available");
+		let (_, params) = avcc_params(avcc).unwrap();
+		assert_eq!(
+			params.iter().map(|p| p.as_ref()).collect::<Vec<_>>(),
+			vec![sps, pps0, pps1]
+		);
+	}
+
+	#[test]
+	fn avc3_reinit_drops_superseded_pps() {
+		// A later keyframe presents a different PPS set: the avcC adopts the new set
+		// and drops the old one rather than accumulating both forever.
 		let sps = &[0x67, 0x42, 0xc0, 0x1f, 0xde][..];
 		let pps0 = &[0x68, 0xce, 0x3c, 0x80][..];
 		let pps1 = &[0x68, 0xce, 0x3c, 0x81][..];
@@ -403,10 +439,11 @@ mod tests {
 
 		let avcc = tx.avcc().expect("avcC available");
 		let (_, params) = avcc_params(avcc).unwrap();
-		assert_eq!(params.len(), 3, "expected 1 SPS + 2 PPS, got {params:?}");
-		assert_eq!(params[0].as_ref(), sps);
-		assert_eq!(params[1].as_ref(), pps0);
-		assert_eq!(params[2].as_ref(), pps1);
+		assert_eq!(
+			params.iter().map(|p| p.as_ref()).collect::<Vec<_>>(),
+			vec![sps, pps1],
+			"reinit must drop the superseded PPS"
+		);
 	}
 
 	#[test]

--- a/rs/moq-mux/src/codec/h264/mod.rs
+++ b/rs/moq-mux/src/codec/h264/mod.rs
@@ -109,39 +109,59 @@ fn pack_constraint_flags(sps: &h264_parser::Sps) -> u8 {
 		| ((sps.constraint_set5_flag as u8) << 2)
 }
 
-/// Build an AVCDecoderConfigurationRecord (ISO/IEC 14496-15 §5.3.3.1.2) from a
-/// single SPS and PPS NAL.
-pub(crate) fn build_avcc(sps_nal: &[u8], pps_nal: &[u8]) -> anyhow::Result<Bytes> {
+/// Build an AVCDecoderConfigurationRecord (ISO/IEC 14496-15 §5.3.3.1.2) from the
+/// given SPS and PPS NALs. At least one SPS is required; the profile/level fields
+/// are read from the first SPS. A stream may legitimately carry several distinct
+/// SPS/PPS (slices reference them by id), so the record holds an ordered list of
+/// each rather than a single one.
+pub(crate) fn build_avcc(sps_nals: &[Bytes], pps_nals: &[Bytes]) -> anyhow::Result<Bytes> {
+	let first_sps = sps_nals.first().context("avcC requires at least one SPS")?;
+	anyhow::ensure!(first_sps.len() >= 4, "SPS NAL too short");
+	// numOfSequenceParameterSets is a 5-bit field, numOfPictureParameterSets a byte.
 	anyhow::ensure!(
-		sps_nal.len() <= u16::MAX as usize,
-		"SPS too large for avcC length field ({} > {})",
-		sps_nal.len(),
-		u16::MAX
+		sps_nals.len() <= 0x1f,
+		"too many SPS for avcC ({} > 31)",
+		sps_nals.len()
 	);
 	anyhow::ensure!(
-		pps_nal.len() <= u16::MAX as usize,
-		"PPS too large for avcC length field ({} > {})",
-		pps_nal.len(),
-		u16::MAX
+		pps_nals.len() <= u8::MAX as usize,
+		"too many PPS for avcC ({} > 255)",
+		pps_nals.len()
 	);
-	anyhow::ensure!(sps_nal.len() >= 4, "SPS NAL too short");
+	for (label, nal) in sps_nals
+		.iter()
+		.map(|n| ("SPS", n))
+		.chain(pps_nals.iter().map(|n| ("PPS", n)))
+	{
+		anyhow::ensure!(
+			nal.len() <= u16::MAX as usize,
+			"{label} too large for avcC length field ({} > {})",
+			nal.len(),
+			u16::MAX
+		);
+	}
 
-	let profile_idc = sps_nal[1];
-	let constraints = sps_nal[2];
-	let level_idc = sps_nal[3];
+	let profile_idc = first_sps[1];
+	let constraints = first_sps[2];
+	let level_idc = first_sps[3];
 
-	let mut out = BytesMut::with_capacity(11 + sps_nal.len() + pps_nal.len());
+	let payload: usize = sps_nals.iter().chain(pps_nals).map(|n| 2 + n.len()).sum();
+	let mut out = BytesMut::with_capacity(7 + payload);
 	out.put_u8(1); // configurationVersion
 	out.put_u8(profile_idc);
 	out.put_u8(constraints);
 	out.put_u8(level_idc);
 	out.put_u8(0xff); // reserved (6 bits) | lengthSizeMinusOne (2 bits = 3)
-	out.put_u8(0xe1); // reserved (3 bits) | numOfSequenceParameterSets (5 bits = 1)
-	out.put_u16(sps_nal.len() as u16);
-	out.put_slice(sps_nal);
-	out.put_u8(1); // numOfPictureParameterSets
-	out.put_u16(pps_nal.len() as u16);
-	out.put_slice(pps_nal);
+	out.put_u8(0xe0 | sps_nals.len() as u8); // reserved (3 bits) | numOfSequenceParameterSets
+	for sps in sps_nals {
+		out.put_u16(sps.len() as u16);
+		out.put_slice(sps);
+	}
+	out.put_u8(pps_nals.len() as u8); // numOfPictureParameterSets
+	for pps in pps_nals {
+		out.put_u16(pps.len() as u16);
+		out.put_slice(pps);
+	}
 	Ok(out.freeze())
 }
 
@@ -188,8 +208,10 @@ fn read_param_set_array(buf: &[u8], mut pos: usize, count: usize, params: &mut V
 /// the avcC in CodecPrivate).
 pub struct Avc1 {
 	avcc: Option<Bytes>,
-	sps: Option<Bytes>,
-	pps: Option<Bytes>,
+	/// Distinct SPS NALs observed, in arrival order.
+	sps: Vec<Bytes>,
+	/// Distinct PPS NALs observed, in arrival order.
+	pps: Vec<Bytes>,
 }
 
 impl Default for Avc1 {
@@ -203,8 +225,8 @@ impl Avc1 {
 	pub fn new() -> Self {
 		Self {
 			avcc: None,
-			sps: None,
-			pps: None,
+			sps: Vec::new(),
+			pps: Vec::new(),
 		}
 	}
 
@@ -270,15 +292,13 @@ impl Avc1 {
 		let nal_type = nal[0] & 0x1f;
 		match nal_type {
 			NAL_TYPE_SPS => {
-				if self.sps.as_deref() != Some(nal.as_ref()) {
-					self.sps = Some(nal.clone());
+				if crate::codec::annexb::push_distinct(&mut self.sps, nal) {
 					*sps_pps_changed = true;
 				}
 				Ok(false)
 			}
 			NAL_TYPE_PPS => {
-				if self.pps.as_deref() != Some(nal.as_ref()) {
-					self.pps = Some(nal.clone());
+				if crate::codec::annexb::push_distinct(&mut self.pps, nal) {
 					*sps_pps_changed = true;
 				}
 				Ok(false)
@@ -293,10 +313,10 @@ impl Avc1 {
 	}
 
 	fn rebuild_avcc(&mut self) -> anyhow::Result<()> {
-		let (Some(sps), Some(pps)) = (&self.sps, &self.pps) else {
+		if self.sps.is_empty() || self.pps.is_empty() {
 			return Ok(());
-		};
-		self.avcc = Some(build_avcc(sps, pps)?);
+		}
+		self.avcc = Some(build_avcc(&self.sps, &self.pps)?);
 		Ok(())
 	}
 }
@@ -341,16 +361,52 @@ mod tests {
 
 	#[test]
 	fn avcc_params_roundtrips_build_avcc() {
-		let sps = &[0x67, 0x42, 0xc0, 0x1f, 0xde][..];
-		let pps = &[0x68, 0xce, 0x3c, 0x80][..];
+		let sps = Bytes::from_static(&[0x67, 0x42, 0xc0, 0x1f, 0xde]);
+		let pps = Bytes::from_static(&[0x68, 0xce, 0x3c, 0x80]);
 
-		let avcc = build_avcc(sps, pps).unwrap();
+		let avcc = build_avcc(std::slice::from_ref(&sps), std::slice::from_ref(&pps)).unwrap();
 		let (length_size, params) = avcc_params(&avcc).unwrap();
 
 		assert_eq!(length_size, 4);
 		assert_eq!(params.len(), 2);
+		assert_eq!(params[0], sps);
+		assert_eq!(params[1], pps);
+	}
+
+	#[test]
+	fn build_avcc_carries_multiple_pps() {
+		// A source with one SPS and two PPS (ids 0 and 1): the avcC must keep both,
+		// in order, so slices referencing either id stay decodable.
+		let sps = Bytes::from_static(&[0x67, 0x42, 0xc0, 0x1f, 0xde]);
+		let pps0 = Bytes::from_static(&[0x68, 0xce, 0x3c, 0x80]);
+		let pps1 = Bytes::from_static(&[0x68, 0xce, 0x3c, 0x81]);
+
+		let avcc = build_avcc(std::slice::from_ref(&sps), &[pps0.clone(), pps1.clone()]).unwrap();
+		// numOfSequenceParameterSets is the low 5 bits of byte 5.
+		assert_eq!(avcc[5] & 0x1f, 1);
+
+		let (_, params) = avcc_params(&avcc).unwrap();
+		assert_eq!(params, vec![sps, pps0, pps1]);
+	}
+
+	#[test]
+	fn avc3_accumulates_distinct_pps() {
+		// Two distinct PPS arrive across keyframes; the synthesized avcC carries both.
+		let sps = &[0x67, 0x42, 0xc0, 0x1f, 0xde][..];
+		let pps0 = &[0x68, 0xce, 0x3c, 0x80][..];
+		let pps1 = &[0x68, 0xce, 0x3c, 0x81][..];
+		let idr = &[0x65, 0x88][..];
+
+		let mut tx = Avc1::new();
+		tx.transform(annexb_frame(&[sps, pps0, idr])).unwrap();
+		tx.transform(annexb_frame(&[sps, pps1, idr])).unwrap();
+
+		let avcc = tx.avcc().expect("avcC available");
+		let (_, params) = avcc_params(avcc).unwrap();
+		assert_eq!(params.len(), 3, "expected 1 SPS + 2 PPS, got {params:?}");
 		assert_eq!(params[0].as_ref(), sps);
-		assert_eq!(params[1].as_ref(), pps);
+		assert_eq!(params[1].as_ref(), pps0);
+		assert_eq!(params[2].as_ref(), pps1);
 	}
 
 	#[test]

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -28,9 +28,10 @@ pub struct Import<E: CatalogExt = ()> {
 	// Used to compute wall clock timestamps if needed.
 	zero: Option<tokio::time::Instant>,
 
-	// Distinct cached parameter set NALs for re-insertion before keyframes. A
-	// stream may define several of each (slices reference them by id), so all are
-	// kept and re-injected, not just the last seen.
+	// Retained parameter set NALs from the latest keyframe that carried them,
+	// re-injected before bare keyframes. A keyframe may define several of each
+	// (slices reference them by id); all are kept, but a new GOP's set supersedes
+	// them (replace, not accumulate) so a mid-stream reinit drops stale entries.
 	vps: Vec<Bytes>,
 	sps: Vec<Bytes>,
 	pps: Vec<Bytes>,
@@ -215,7 +216,8 @@ impl<E: CatalogExt> Import<E> {
 			NALUnitType::VpsNut => {
 				self.maybe_start_frame(pts)?;
 
-				crate::codec::annexb::push_distinct(&mut self.vps, &nal);
+				// Track only what this AU carries; the retained set is reconciled at
+				// the keyframe so a new GOP's set replaces (not accumulates onto) it.
 				crate::codec::annexb::push_distinct(&mut self.current.vps_seen, &nal);
 			}
 			NALUnitType::SpsNut => {
@@ -225,9 +227,9 @@ impl<E: CatalogExt> Import<E> {
 				let sps = SpsNALUnit::parse(&mut &nal[..]).context("failed to parse SPS NAL unit")?;
 				let reconfigured = self.init(&sps)?;
 
-				// A changed config means the cached VPS/SPS/PPS no longer apply; they
+				// A changed config means the retained VPS/SPS/PPS no longer apply; they
 				// may already have been appended to current.chunks earlier in this AU,
-				// so reset the caches and AU so only the new parameter sets emit.
+				// so reset the sets and AU so only the new parameter sets emit.
 				if reconfigured {
 					self.vps.clear();
 					self.sps.clear();
@@ -238,13 +240,11 @@ impl<E: CatalogExt> Import<E> {
 					self.current.pps_seen.clear();
 				}
 
-				crate::codec::annexb::push_distinct(&mut self.sps, &nal);
 				crate::codec::annexb::push_distinct(&mut self.current.sps_seen, &nal);
 			}
 			NALUnitType::PpsNut => {
 				self.maybe_start_frame(pts)?;
 
-				crate::codec::annexb::push_distinct(&mut self.pps, &nal);
 				crate::codec::annexb::push_distinct(&mut self.current.pps_seen, &nal);
 			}
 			NALUnitType::AudNut | NALUnitType::PrefixSeiNut | NALUnitType::SuffixSeiNut => {
@@ -257,12 +257,23 @@ impl<E: CatalogExt> Import<E> {
 			| NALUnitType::BlaWRadl
 			| NALUnitType::BlaWLp
 			| NALUnitType::CraNut => {
-				// Re-inject every cached parameter set not already inline in this AU,
-				// so a receiver tuning in at this keyframe has each VPS/SPS/PPS its
-				// slices may reference (not just the most recent one).
-				crate::codec::annexb::reinject_params(&mut self.current.chunks, &self.vps, &mut self.current.vps_seen);
-				crate::codec::annexb::reinject_params(&mut self.current.chunks, &self.sps, &mut self.current.sps_seen);
-				crate::codec::annexb::reinject_params(&mut self.current.chunks, &self.pps, &mut self.current.pps_seen);
+				// Adopt this keyframe's inline set (dropping any the new GOP no longer
+				// uses), or re-inject the retained set if the keyframe carried none.
+				crate::codec::annexb::reconcile_keyframe_params(
+					&mut self.current.chunks,
+					&mut self.vps,
+					&mut self.current.vps_seen,
+				);
+				crate::codec::annexb::reconcile_keyframe_params(
+					&mut self.current.chunks,
+					&mut self.sps,
+					&mut self.current.sps_seen,
+				);
+				crate::codec::annexb::reconcile_keyframe_params(
+					&mut self.current.chunks,
+					&mut self.pps,
+					&mut self.current.pps_seen,
+				);
 
 				self.current.contains_idr = true;
 				self.current.contains_slice = true;

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -235,7 +235,13 @@ impl<E: CatalogExt> Import<E> {
 					self.sps.clear();
 					self.pps.clear();
 					self.current.chunks.clear();
-					self.current.vps_seen.clear();
+					// Keep vps_seen: in H.265 the VPS precedes the reconfiguring SPS, so
+					// any VPS already seen this AU belongs to the new config. Re-append
+					// it to the cleared chunks so the keyframe still carries it.
+					for nal in &self.current.vps_seen {
+						self.current.chunks.extend_from_slice(&START_CODE);
+						self.current.chunks.extend_from_slice(nal);
+					}
 					self.current.sps_seen.clear();
 					self.current.pps_seen.clear();
 				}

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -28,10 +28,12 @@ pub struct Import<E: CatalogExt = ()> {
 	// Used to compute wall clock timestamps if needed.
 	zero: Option<tokio::time::Instant>,
 
-	// Cached parameter set NALs for re-insertion before keyframes.
-	vps: Option<Bytes>,
-	sps: Option<Bytes>,
-	pps: Option<Bytes>,
+	// Distinct cached parameter set NALs for re-insertion before keyframes. A
+	// stream may define several of each (slices reference them by id), so all are
+	// kept and re-injected, not just the last seen.
+	vps: Vec<Bytes>,
+	sps: Vec<Bytes>,
+	pps: Vec<Bytes>,
 
 	// Tracks the minimum frame duration and updates the catalog `jitter` field.
 	jitter: MinFrameDuration,
@@ -46,9 +48,9 @@ impl<E: CatalogExt> Import<E> {
 			config: None,
 			current: Default::default(),
 			zero: None,
-			vps: None,
-			sps: None,
-			pps: None,
+			vps: Vec::new(),
+			sps: Vec::new(),
+			pps: Vec::new(),
 			jitter: MinFrameDuration::new(),
 		}
 	}
@@ -61,14 +63,17 @@ impl<E: CatalogExt> Import<E> {
 			config: None,
 			current: Default::default(),
 			zero: None,
-			vps: None,
-			sps: None,
-			pps: None,
+			vps: Vec::new(),
+			sps: Vec::new(),
+			pps: Vec::new(),
 			jitter: MinFrameDuration::new(),
 		}
 	}
 
-	fn init(&mut self, sps: &SpsNALUnit) -> anyhow::Result<()> {
+	/// Publish (or republish) the catalog rendition for this SPS. Returns true if
+	/// it changed an existing config (a reconfiguration), so the caller drops the
+	/// parameter sets tied to the old config. The first SPS is not a reconfiguration.
+	fn init(&mut self, sps: &SpsNALUnit) -> anyhow::Result<bool> {
 		let profile = &sps.rbsp.profile_tier_level.general_profile;
 		let vui_data = sps.rbsp.vui_parameters.as_ref().map(VuiData::new).unwrap_or_default();
 
@@ -91,9 +96,10 @@ impl<E: CatalogExt> Import<E> {
 		if let Some(old) = &self.config
 			&& old == &config
 		{
-			return Ok(());
+			return Ok(false);
 		}
 
+		let reconfigured = self.config.is_some();
 		let mut catalog = self.catalog.lock();
 
 		if self.track.is_some() && self.tracks.is_fixed() {
@@ -113,7 +119,7 @@ impl<E: CatalogExt> Import<E> {
 		self.track =
 			Some(crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy).with_lenient_start());
 
-		Ok(())
+		Ok(reconfigured)
 	}
 
 	/// Initialize the decoder with SPS/PPS and other non-slice NALs.
@@ -209,36 +215,37 @@ impl<E: CatalogExt> Import<E> {
 			NALUnitType::VpsNut => {
 				self.maybe_start_frame(pts)?;
 
-				self.vps = Some(nal.clone());
-				self.current.contains_vps = true;
+				crate::codec::annexb::push_distinct(&mut self.vps, &nal);
+				crate::codec::annexb::push_distinct(&mut self.current.vps_seen, &nal);
 			}
 			NALUnitType::SpsNut => {
 				self.maybe_start_frame(pts)?;
 
 				// Try to reinitialize the track if the SPS has changed.
 				let sps = SpsNALUnit::parse(&mut &nal[..]).context("failed to parse SPS NAL unit")?;
-				self.init(&sps)?;
+				let reconfigured = self.init(&sps)?;
 
-				// SPS changed mid-AU. Cached VPS/PPS are tied to the old SPS
-				// and may already have been appended to current.chunks earlier
-				// in this AU; reset the AU so the new VPS+SPS+PPS triple is
-				// the only parameter set we emit.
-				if self.sps.as_ref().is_some_and(|cached| cached != &nal) {
-					self.pps = None;
+				// A changed config means the cached VPS/SPS/PPS no longer apply; they
+				// may already have been appended to current.chunks earlier in this AU,
+				// so reset the caches and AU so only the new parameter sets emit.
+				if reconfigured {
+					self.vps.clear();
+					self.sps.clear();
+					self.pps.clear();
 					self.current.chunks.clear();
-					self.current.contains_vps = false;
-					self.current.contains_sps = false;
-					self.current.contains_pps = false;
+					self.current.vps_seen.clear();
+					self.current.sps_seen.clear();
+					self.current.pps_seen.clear();
 				}
 
-				self.sps = Some(nal.clone());
-				self.current.contains_sps = true;
+				crate::codec::annexb::push_distinct(&mut self.sps, &nal);
+				crate::codec::annexb::push_distinct(&mut self.current.sps_seen, &nal);
 			}
 			NALUnitType::PpsNut => {
 				self.maybe_start_frame(pts)?;
 
-				self.pps = Some(nal.clone());
-				self.current.contains_pps = true;
+				crate::codec::annexb::push_distinct(&mut self.pps, &nal);
+				crate::codec::annexb::push_distinct(&mut self.current.pps_seen, &nal);
 			}
 			NALUnitType::AudNut | NALUnitType::PrefixSeiNut | NALUnitType::SuffixSeiNut => {
 				self.maybe_start_frame(pts)?;
@@ -250,28 +257,12 @@ impl<E: CatalogExt> Import<E> {
 			| NALUnitType::BlaWRadl
 			| NALUnitType::BlaWLp
 			| NALUnitType::CraNut => {
-				// Insert cached VPS/SPS/PPS before keyframes if not already present in this frame.
-				if !self.current.contains_vps
-					&& let Some(vps) = &self.vps
-				{
-					self.current.chunks.extend_from_slice(&START_CODE);
-					self.current.chunks.extend_from_slice(vps);
-					self.current.contains_vps = true;
-				}
-				if !self.current.contains_sps
-					&& let Some(sps) = &self.sps
-				{
-					self.current.chunks.extend_from_slice(&START_CODE);
-					self.current.chunks.extend_from_slice(sps);
-					self.current.contains_sps = true;
-				}
-				if !self.current.contains_pps
-					&& let Some(pps) = &self.pps
-				{
-					self.current.chunks.extend_from_slice(&START_CODE);
-					self.current.chunks.extend_from_slice(pps);
-					self.current.contains_pps = true;
-				}
+				// Re-inject every cached parameter set not already inline in this AU,
+				// so a receiver tuning in at this keyframe has each VPS/SPS/PPS its
+				// slices may reference (not just the most recent one).
+				crate::codec::annexb::reinject_params(&mut self.current.chunks, &self.vps, &mut self.current.vps_seen);
+				crate::codec::annexb::reinject_params(&mut self.current.chunks, &self.sps, &mut self.current.sps_seen);
+				crate::codec::annexb::reinject_params(&mut self.current.chunks, &self.pps, &mut self.current.pps_seen);
 
 				self.current.contains_idr = true;
 				self.current.contains_slice = true;
@@ -331,9 +322,9 @@ impl<E: CatalogExt> Import<E> {
 
 		self.current.contains_idr = false;
 		self.current.contains_slice = false;
-		self.current.contains_vps = false;
-		self.current.contains_sps = false;
-		self.current.contains_pps = false;
+		self.current.vps_seen.clear();
+		self.current.sps_seen.clear();
+		self.current.pps_seen.clear();
 
 		Ok(())
 	}
@@ -382,9 +373,10 @@ struct Frame {
 	chunks: BytesMut,
 	contains_idr: bool,
 	contains_slice: bool,
-	contains_vps: bool,
-	contains_sps: bool,
-	contains_pps: bool,
+	/// VPS/SPS/PPS NALs already inline in this access unit, so re-injection skips them.
+	vps_seen: Vec<Bytes>,
+	sps_seen: Vec<Bytes>,
+	pps_seen: Vec<Bytes>,
 }
 
 #[derive(Default)]

--- a/rs/moq-mux/src/codec/h265/mod.rs
+++ b/rs/moq-mux/src/codec/h265/mod.rs
@@ -15,13 +15,17 @@ use scuffle_h265::{NALUnitType, SpsNALUnit};
 
 /// Annex-B → length-prefixed transmuxer; the H.265 analogue of
 /// [`crate::codec::h264::Avc1`].
+///
+/// The active VPS/SPS/PPS set is scoped to the latest keyframe: a frame that
+/// carries parameter sets redefines them, so a mid-stream reconfiguration drops
+/// the superseded ones instead of accumulating them forever.
 pub struct Hvc1 {
 	hvcc: Option<Bytes>,
-	/// Distinct VPS NALs observed, in arrival order.
+	/// The active VPS NALs (from the most recent keyframe that carried them).
 	vps: Vec<Bytes>,
-	/// Distinct SPS NALs observed, in arrival order.
+	/// The active SPS NALs.
 	sps: Vec<Bytes>,
-	/// Distinct PPS NALs observed, in arrival order.
+	/// The active PPS NALs.
 	pps: Vec<Bytes>,
 }
 
@@ -59,7 +63,9 @@ impl Hvc1 {
 		let mut nal_iter = crate::codec::annexb::NalIterator::new(&mut buf);
 
 		let mut out = BytesMut::with_capacity(payload.remaining());
-		let mut params_changed = false;
+		let mut frame_vps: Vec<Bytes> = Vec::new();
+		let mut frame_sps: Vec<Bytes> = Vec::new();
+		let mut frame_pps: Vec<Bytes> = Vec::new();
 		let mut emitted_any_slice = false;
 
 		loop {
@@ -68,19 +74,35 @@ impl Hvc1 {
 				Some(Err(e)) => return Err(e),
 				None => break,
 			};
-			if self.process_nal(&nal, &mut out, &mut params_changed)? {
+			if process_nal(&nal, &mut out, &mut frame_vps, &mut frame_sps, &mut frame_pps)? {
 				emitted_any_slice = true;
 			}
 		}
 
 		if let Some(nal) = nal_iter.flush()? {
-			let was_slice = self.process_nal(&nal, &mut out, &mut params_changed)?;
-			if was_slice {
+			if process_nal(&nal, &mut out, &mut frame_vps, &mut frame_sps, &mut frame_pps)? {
 				emitted_any_slice = true;
 			}
 		}
 
-		if params_changed {
+		// A frame that carries parameter sets (a keyframe) redefines the active
+		// set; adopt it so a superseded configuration's VPS/SPS/PPS are dropped
+		// rather than lingering in the hvcC. Per type, so a frame that updates only
+		// one kind keeps the others.
+		let mut changed = false;
+		if !frame_vps.is_empty() && frame_vps != self.vps {
+			self.vps = frame_vps;
+			changed = true;
+		}
+		if !frame_sps.is_empty() && frame_sps != self.sps {
+			self.sps = frame_sps;
+			changed = true;
+		}
+		if !frame_pps.is_empty() && frame_pps != self.pps {
+			self.pps = frame_pps;
+			changed = true;
+		}
+		if changed {
 			self.rebuild_hvcc()?;
 		}
 
@@ -91,48 +113,48 @@ impl Hvc1 {
 		Ok(Some(out.freeze()))
 	}
 
-	fn process_nal(&mut self, nal: &Bytes, out: &mut BytesMut, params_changed: &mut bool) -> anyhow::Result<bool> {
-		if nal.is_empty() {
-			return Ok(false);
-		}
-		// HEVC NAL header is 2 bytes; type is bits 1..=6 of byte 0.
-		let nal_unit_type = (nal[0] >> 1) & 0x3f;
-		let nal_type = NALUnitType::from(nal_unit_type);
-
-		match nal_type {
-			NALUnitType::VpsNut => {
-				if crate::codec::annexb::push_distinct(&mut self.vps, nal) {
-					*params_changed = true;
-				}
-				Ok(false)
-			}
-			NALUnitType::SpsNut => {
-				if crate::codec::annexb::push_distinct(&mut self.sps, nal) {
-					*params_changed = true;
-				}
-				Ok(false)
-			}
-			NALUnitType::PpsNut => {
-				if crate::codec::annexb::push_distinct(&mut self.pps, nal) {
-					*params_changed = true;
-				}
-				Ok(false)
-			}
-			_ => {
-				let len = u32::try_from(nal.len()).context("NAL too large for 4-byte length prefix")?;
-				out.extend_from_slice(&len.to_be_bytes());
-				out.extend_from_slice(nal);
-				Ok(true)
-			}
-		}
-	}
-
 	fn rebuild_hvcc(&mut self) -> anyhow::Result<()> {
 		if self.vps.is_empty() || self.sps.is_empty() || self.pps.is_empty() {
 			return Ok(());
 		}
 		self.hvcc = Some(build_hvcc(&self.vps, &self.sps, &self.pps)?);
 		Ok(())
+	}
+}
+
+/// Process one NAL: VPS/SPS/PPS are collected (distinctly) into this frame's
+/// sets, everything else is length-prefixed and appended to `out`. Returns true
+/// if the NAL was a slice (i.e. produced sample bytes).
+fn process_nal(
+	nal: &Bytes,
+	out: &mut BytesMut,
+	frame_vps: &mut Vec<Bytes>,
+	frame_sps: &mut Vec<Bytes>,
+	frame_pps: &mut Vec<Bytes>,
+) -> anyhow::Result<bool> {
+	if nal.is_empty() {
+		return Ok(false);
+	}
+	// HEVC NAL header is 2 bytes; type is bits 1..=6 of byte 0.
+	match NALUnitType::from((nal[0] >> 1) & 0x3f) {
+		NALUnitType::VpsNut => {
+			crate::codec::annexb::push_distinct(frame_vps, nal);
+			Ok(false)
+		}
+		NALUnitType::SpsNut => {
+			crate::codec::annexb::push_distinct(frame_sps, nal);
+			Ok(false)
+		}
+		NALUnitType::PpsNut => {
+			crate::codec::annexb::push_distinct(frame_pps, nal);
+			Ok(false)
+		}
+		_ => {
+			let len = u32::try_from(nal.len()).context("NAL too large for 4-byte length prefix")?;
+			out.extend_from_slice(&len.to_be_bytes());
+			out.extend_from_slice(nal);
+			Ok(true)
+		}
 	}
 }
 

--- a/rs/moq-mux/src/codec/h265/mod.rs
+++ b/rs/moq-mux/src/codec/h265/mod.rs
@@ -17,9 +17,12 @@ use scuffle_h265::{NALUnitType, SpsNALUnit};
 /// [`crate::codec::h264::Avc1`].
 pub struct Hvc1 {
 	hvcc: Option<Bytes>,
-	vps: Option<Bytes>,
-	sps: Option<Bytes>,
-	pps: Option<Bytes>,
+	/// Distinct VPS NALs observed, in arrival order.
+	vps: Vec<Bytes>,
+	/// Distinct SPS NALs observed, in arrival order.
+	sps: Vec<Bytes>,
+	/// Distinct PPS NALs observed, in arrival order.
+	pps: Vec<Bytes>,
 }
 
 impl Default for Hvc1 {
@@ -33,9 +36,9 @@ impl Hvc1 {
 	pub fn new() -> Self {
 		Self {
 			hvcc: None,
-			vps: None,
-			sps: None,
-			pps: None,
+			vps: Vec::new(),
+			sps: Vec::new(),
+			pps: Vec::new(),
 		}
 	}
 
@@ -98,22 +101,19 @@ impl Hvc1 {
 
 		match nal_type {
 			NALUnitType::VpsNut => {
-				if self.vps.as_deref() != Some(nal.as_ref()) {
-					self.vps = Some(nal.clone());
+				if crate::codec::annexb::push_distinct(&mut self.vps, nal) {
 					*params_changed = true;
 				}
 				Ok(false)
 			}
 			NALUnitType::SpsNut => {
-				if self.sps.as_deref() != Some(nal.as_ref()) {
-					self.sps = Some(nal.clone());
+				if crate::codec::annexb::push_distinct(&mut self.sps, nal) {
 					*params_changed = true;
 				}
 				Ok(false)
 			}
 			NALUnitType::PpsNut => {
-				if self.pps.as_deref() != Some(nal.as_ref()) {
-					self.pps = Some(nal.clone());
+				if crate::codec::annexb::push_distinct(&mut self.pps, nal) {
 					*params_changed = true;
 				}
 				Ok(false)
@@ -128,35 +128,52 @@ impl Hvc1 {
 	}
 
 	fn rebuild_hvcc(&mut self) -> anyhow::Result<()> {
-		let (Some(vps), Some(sps), Some(pps)) = (&self.vps, &self.sps, &self.pps) else {
+		if self.vps.is_empty() || self.sps.is_empty() || self.pps.is_empty() {
 			return Ok(());
-		};
-		self.hvcc = Some(build_hvcc(vps, sps, pps)?);
+		}
+		self.hvcc = Some(build_hvcc(&self.vps, &self.sps, &self.pps)?);
 		Ok(())
 	}
 }
 
 /// Build an HEVCDecoderConfigurationRecord (ISO/IEC 14496-15 §8.3.3).
-/// Single-layer streams only.
-pub(crate) fn build_hvcc(vps_nal: &[u8], sps_nal: &[u8], pps_nal: &[u8]) -> anyhow::Result<Bytes> {
-	for (label, nal) in [("VPS", vps_nal), ("SPS", sps_nal), ("PPS", pps_nal)] {
+/// Single-layer streams only. Each NAL array (VPS, SPS, PPS) carries every
+/// distinct parameter set the stream defined, in arrival order; the profile/tier
+/// fields are read from the first SPS.
+pub(crate) fn build_hvcc(vps_nals: &[Bytes], sps_nals: &[Bytes], pps_nals: &[Bytes]) -> anyhow::Result<Bytes> {
+	let first_sps = sps_nals.first().context("hvcC requires at least one SPS")?;
+	for (label, nals) in [("VPS", vps_nals), ("SPS", sps_nals), ("PPS", pps_nals)] {
 		anyhow::ensure!(
-			nal.len() <= u16::MAX as usize,
-			"{} too large for hvcC length field ({} > {})",
+			nals.len() <= u16::MAX as usize,
+			"too many {} for hvcC ({} > 65535)",
 			label,
-			nal.len(),
-			u16::MAX
+			nals.len()
 		);
+		for nal in nals {
+			anyhow::ensure!(
+				nal.len() <= u16::MAX as usize,
+				"{} too large for hvcC length field ({} > {})",
+				label,
+				nal.len(),
+				u16::MAX
+			);
+		}
 	}
 
-	let sps = SpsNALUnit::parse(&mut &sps_nal[..]).context("failed to parse SPS NAL unit for hvcC")?;
+	let sps = SpsNALUnit::parse(&mut &first_sps[..]).context("failed to parse SPS NAL unit for hvcC")?;
 	let profile = &sps.rbsp.profile_tier_level.general_profile;
 	let level_idc = profile.level_idc.context("missing level_idc in SPS")?;
 	let constraint_flags = pack_constraint_flags(profile);
 	let compat = profile.profile_compatibility_flag.bits().to_be_bytes();
 	let num_temporal_layers = sps.rbsp.sps_max_sub_layers_minus1 + 1;
 
-	let mut out = BytesMut::with_capacity(23 + vps_nal.len() + sps_nal.len() + pps_nal.len() + 9 * 3);
+	let params_len: usize = vps_nals
+		.iter()
+		.chain(sps_nals)
+		.chain(pps_nals)
+		.map(|n| 2 + n.len())
+		.sum();
+	let mut out = BytesMut::with_capacity(23 + 3 * 3 + params_len);
 	out.put_u8(1); // configurationVersion
 	out.put_u8(((profile.profile_space & 0x3) << 6) | ((profile.tier_flag as u8) << 5) | (profile.profile_idc & 0x1f));
 	out.put_slice(&compat);
@@ -169,17 +186,19 @@ pub(crate) fn build_hvcc(vps_nal: &[u8], sps_nal: &[u8], pps_nal: &[u8]) -> anyh
 	out.put_u8(0xf8 | (sps.rbsp.bit_depth_chroma_minus8 & 0x7));
 	out.put_u16(0); // avgFrameRate unspecified
 	out.put_u8(((num_temporal_layers & 0x7) << 3) | ((sps.rbsp.sps_temporal_id_nesting_flag as u8) << 2) | 0x3);
-	out.put_u8(3); // numOfArrays
+	out.put_u8(3); // numOfArrays (VPS, SPS, PPS)
 
-	for (nal_type, nal) in [
-		(u8::from(NALUnitType::VpsNut), vps_nal),
-		(u8::from(NALUnitType::SpsNut), sps_nal),
-		(u8::from(NALUnitType::PpsNut), pps_nal),
+	for (nal_type, nals) in [
+		(u8::from(NALUnitType::VpsNut), vps_nals),
+		(u8::from(NALUnitType::SpsNut), sps_nals),
+		(u8::from(NALUnitType::PpsNut), pps_nals),
 	] {
 		out.put_u8(0x80 | (nal_type & 0x3f)); // array_completeness = 1
-		out.put_u16(1); // numNalus
-		out.put_u16(nal.len() as u16);
-		out.put_slice(nal);
+		out.put_u16(nals.len() as u16); // numNalus
+		for nal in nals {
+			out.put_u16(nal.len() as u16);
+			out.put_slice(nal);
+		}
 	}
 
 	Ok(out.freeze())

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -212,11 +212,13 @@ impl ExportSource {
 	}
 
 	fn refresh_description(&mut self) {
-		if self.description.is_some() {
-			return;
-		}
+		// Track the transform's record even after it is first set: a mid-stream
+		// reconfiguration rebuilds the avcC/hvcC with a new parameter set, and the
+		// muxer re-injects from this on every keyframe, so a stale record would
+		// carry superseded SPS/PPS.
 		if let Some(transform) = self.transform.as_ref()
 			&& let Some(d) = transform.codec_private()
+			&& self.description.as_ref() != Some(d)
 		{
 			self.description = Some(d.clone());
 		}

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -22,6 +22,8 @@ const SC: &[u8] = &[0, 0, 0, 1];
 // Reusable H.264 parameter-set and slice NALs (NAL type = first byte & 0x1f).
 const SPS: &[u8] = &[0x67, 0x42, 0xc0, 0x1f, 0xde];
 const PPS: &[u8] = &[0x68, 0xce, 0x3c, 0x80];
+// A second, distinct PPS (id 1): broadcast feeds often define more than one.
+const PPS1: &[u8] = &[0x68, 0xce, 0x3c, 0x81];
 
 // libklvanc public-sample SCTE-35 cue: splice_info_section, table_id 0xFC, 30 bytes.
 const CUE: &[u8] = &[
@@ -239,6 +241,50 @@ async fn export_avc3_in_band_reassembles() {
 	assert_eq!(reassembled.as_slice(), annexb(&[SPS, PPS, &idr]).as_ref());
 }
 
+/// In-band avc3 carrying two distinct PPS (a real broadcast trait): both must
+/// survive the round-trip, or slices referencing the dropped one stop decoding
+/// (regression for non-existing PPS 0 referenced).
+#[tokio::test(start_paused = true)]
+async fn export_avc3_preserves_multiple_pps() {
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	let track = broadcast.unique_track(".avc3").unwrap();
+	let name = track.name.clone();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0,
+			level: 0x1f,
+			inline: true,
+		});
+		cfg.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(name.clone(), cfg);
+	}
+	let mut producer = Producer::new(track, HangContainer::Legacy);
+
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xAB, 300));
+	// Annex-B keyframe: inline SPS + both PPS + IDR.
+	producer
+		.write(Frame {
+			timestamp: Timestamp::from_millis(0).unwrap(),
+			payload: annexb(&[SPS, PPS, PPS1, &idr]),
+			keyframe: true,
+		})
+		.unwrap();
+	producer.finish().unwrap();
+
+	// Keep the producers alive (see `export_aac_roundtrip`).
+	let ts = drain(consumer).await;
+	assert_packet_aligned(&ts);
+
+	let reassembled = reassemble_video(&ts, StreamType::H264);
+	// Both PPS must be re-injected on the keyframe, in order, ahead of the slice.
+	assert_eq!(reassembled.as_slice(), annexb(&[SPS, PPS, PPS1, &idr]).as_ref());
+}
+
 /// Out-of-band avc1 (e.g. from fmp4 import): length-prefixed NALs with the
 /// SPS/PPS only in the catalog `description` (avcC). The muxer must parse the
 /// avcC, prepend the parameter sets as Annex-B on the keyframe, and rewrite the
@@ -249,7 +295,7 @@ async fn export_avc1_out_of_band_reassembles() {
 	let consumer = broadcast.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
-	let avcc = crate::codec::h264::build_avcc(SPS, PPS).unwrap();
+	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 
 	let track = broadcast.unique_track(".avc1").unwrap();
 	let name = track.name.clone();


### PR DESCRIPTION
## Summary

Fixes [moq-dev/moq#1798](https://github.com/moq-dev/moq/issues/1798) (work item 1).

Publishing a real broadcast MPEG-TS feed and subscribing back with `--format ts` produced undecodable H.264: ffplay/ffprobe reported `non-existing PPS 0 referenced` / `no frame!` continuously. The source defines **two** PPS (ids 0 and 1) and ~97% of slices reference PPS 0, but the H.264/H.265 transmux held a single parameter set each, so only the last-seen PPS (id 1) survived the round-trip.

`avcC`/`hvcC` store SPS/PPS (and VPS for HEVC) as **count-prefixed arrays**, and slices reference them by id, so a single-slot cache is wrong by construction. This keeps an ordered set of parameter-set NALs and emits/re-injects all of them.

## What changed

- **`Avc1` / `Hvc1` transforms** (`h264/mod.rs`, `h265/mod.rs`): keep the parameter sets carried by a keyframe and emit them all. `build_avcc` / `build_hvcc` now emit `numOf{Sequence,Picture}ParameterSets > 1` (and multi-NAL hvcC arrays). The egress `avcc_params` / `hvcc_params` already loop over the counts, so TS re-injection needed no further change.
- **avc3 / hev1 importers** (`h264/import.rs`, `h265/import.rs`): re-inject every parameter set the keyframe references for mid-stream tune-in, with per-AU "seen" tracking.
- Shared `push_distinct` / `reconcile_keyframe_params` helpers added to `annexb.rs`.

### Reinit: dropping superseded parameter sets

The active parameter set is **scoped to the latest keyframe** rather than accumulated for the life of the stream:

- In the transforms, a frame that carries parameter sets (a keyframe) redefines the active set per type (replace, not accumulate); the avcC/hvcC is rebuilt only when the set actually changes.
- In the importers, each keyframe reconciles: if it presents its own set, that set is adopted (dropping any the new GOP no longer uses); if it carries none, the retained set is re-injected for tune-in.
- `ExportSource::refresh_description` now tracks the transform's record after it is first set, so a reinit's new avcC/hvcC reaches the muxer's per-keyframe re-injection instead of a stale one.

So a mid-stream reconfiguration (resolution change, a PPS dropped from the rotation) drops the superseded entries instead of letting them linger. A single keyframe carrying multiple PPS (the original #1798 case) still keeps all of them.

## Why `main`

This changes inline keyframe bytes and the synthesized `avcC`/`hvcC` only, not the wire or catalog format (`avcC`/`hvcC` carrying multiples is standard), so it is additive and non-breaking.

## Out of scope

Issue items 2 (proper DTS / B-frame timing) and 3 (opaque MPEG-TS carriage) are larger, `dev`-targeted (wire / `Frame` / catalog changes), and independent of this blocker. Left for separate PRs as the issue recommends.

## Test plan

- [x] `cargo test -p moq-mux` (240 passing) including:
  - `build_avcc_carries_multiple_pps`
  - `avc3_keyframe_with_two_pps_keeps_both`
  - `avc3_reinit_drops_superseded_pps` (transform drops on reinit)
  - `avc3_reinjects_all_cached_pps_on_keyframe` (importer re-injection)
  - `avc3_reinit_drops_superseded_pps_on_keyframe` (importer drops on reinit)
  - `export_avc3_preserves_multiple_pps` (end-to-end TS export round-trip)
- [x] `cargo clippy -p moq-mux --all-targets` clean
- [x] `cargo fmt`
- [x] `moq-cli` and `hang` build against the change

## Cross-package sync

No `js/net` or `js/hang` mirror needed: this is internal moq-mux transmux, not a `moq-net` wire change or a `hang` catalog/container format change.

(Written by Claude)