### PR TITLE
feat(moq-net): raise max frame size to 32 MiB to match the group cache cap

### DIFF
--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -13,10 +13,14 @@ use crate::{Error, Result};
 /// untrusted peer could otherwise request a multi-gigabyte allocation with a
 /// single varint. Subscribers reject frames whose declared size exceeds this.
 ///
+/// Matches the per-group cache cap (`MAX_GROUP_CACHE`), so a single frame may fill
+/// a group. 16 MiB was too tight for a high-bitrate CMAF fragment carried as one
+/// frame; 32 MiB covers that while keeping the per-frame preallocation bounded.
+///
 // TODO enforce this in [Frame::produce] / [FrameProducer::new] so the limit is
 // guaranteed for every caller, not just the wire decode paths. Blocked on
 // making the constructor fallible (returning [Result]), which is an API break.
-pub(crate) const MAX_FRAME_SIZE: u64 = 16 * 1024 * 1024;
+pub(crate) const MAX_FRAME_SIZE: u64 = 32 * 1024 * 1024;
 
 /// A chunk of data with an upfront size.
 ///

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -17,6 +17,8 @@ use crate::{Error, Result};
 use super::{Frame, FrameConsumer, FrameProducer};
 
 /// Maximum total size of frames cached in a group before old frames are evicted.
+///
+/// Kept equal to `MAX_FRAME_SIZE` so a single maximum-size frame can fill a group's cache.
 const MAX_GROUP_CACHE: u64 = 32 * 1024 * 1024; // 32 MB
 
 /// Maximum number of frames cached in a group before old frames are evicted.


### PR DESCRIPTION
## Summary

Raises the per-frame wire cap `MAX_FRAME_SIZE` from 16 MiB to 32 MiB so it matches the existing per-group cache cap (`MAX_GROUP_CACHE`, already 32 MiB). 16 MiB was too tight for a high-bitrate CMAF/fMP4 fragment carried as a single frame (e.g. 30 Mbps × 6 s ≈ 22 MB), which the receiver would reject. 32 MiB covers that while keeping the per-frame preallocation bounded, and lets one maximum-size frame fill a group's cache.

## What changed

- `model/frame.rs`: `MAX_FRAME_SIZE` 16 MiB → 32 MiB, with a note that it tracks the group cache cap.
- `model/group.rs`: doc note that `MAX_GROUP_CACHE` is kept equal to `MAX_FRAME_SIZE`.

No wire-format or API change: this only widens an inbound validation threshold.

## Context / follow-up

`MAX_FRAME_SIZE` is a DoS preallocation guard enforced only on the wire-decode paths (the producer constructor is unchecked — see the existing TODO in `frame.rs`). The cleaner long-term fix is to decouple the anti-DoS preallocation cap from the legitimate frame size: preallocate `min(declared, CAP)` and grow as bytes arrive, so a bogus huge declaration stays bounded while genuinely large frames stream in. This PR is the minimal bump; that refactor is left for later.

## Test plan

- [x] `cargo test -p moq-net` (model frame/group tests pass)
- [x] `cargo clippy -p moq-net --lib` clean; `cargo fmt --check` clean

(Written by Claude)
