### PR TITLE
feat(moq-relay): add a `Relay` embed entry point + flatten-friendly config loader

### DIFF
--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
@@ -87,14 +88,63 @@ impl Config {
 		I: IntoIterator<Item = T>,
 		T: Into<std::ffi::OsString> + Clone,
 	{
-		let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
-		let mut config = Config::parse_from(&args);
-		if let Some(file) = config.file.clone() {
-			config = toml::from_str(&std::fs::read_to_string(file)?)?;
-			config.update_from(&args);
-		}
-		Ok(config)
+		merge_from_args(args, |config: &Config| config.file.clone())
 	}
+}
+
+/// Parse a clap config from CLI args, merging a TOML file if one is named.
+///
+/// This is the generic core of [`Config::load`], exposed so embedders that
+/// **flatten** [`Config`] into their own clap parser (to add extra flags
+/// alongside every relay flag) can reuse the exact same merge semantics:
+///
+/// ```no_run
+/// #[derive(clap::Parser, serde::Deserialize)]
+/// struct MyConfig {
+///     #[command(flatten)]
+///     #[serde(flatten)]
+///     relay: moq_relay::Config,
+///     #[arg(long)]
+///     my_flag: bool,
+/// }
+///
+/// let config: MyConfig = moq_relay::load_config(|c| c.relay.file.clone())?;
+/// config.relay.log.init()?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+///
+/// `file` extracts the optional TOML path from the parsed value (e.g.
+/// `|c| c.relay.file.clone()`). Unlike [`Config::load`] this does NOT initialize
+/// the logger; call `config.relay.log.init()` yourself once you have the value.
+///
+/// The clap+TOML clobber pitfall documented on [`Config::load`] applies to the
+/// flattening config too: type any extra TOML-overridable flag as `Option<T>`.
+pub fn load_config<T, F>(file: F) -> anyhow::Result<T>
+where
+	T: Parser + serde::de::DeserializeOwned,
+	F: FnOnce(&T) -> Option<String>,
+{
+	merge_from_args(std::env::args_os(), file)
+}
+
+/// Shared implementation behind [`Config::parse_and_merge`] and [`load_config`].
+/// Merge order: CLI args -> TOML file (if named) -> CLI args re-applied so
+/// explicit flags / env vars win over the file.
+fn merge_from_args<I, A, T, F>(args: I, file: F) -> anyhow::Result<T>
+where
+	I: IntoIterator<Item = A>,
+	A: Into<std::ffi::OsString> + Clone,
+	T: Parser + serde::de::DeserializeOwned,
+	F: FnOnce(&T) -> Option<String>,
+{
+	let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
+	let mut config = T::parse_from(&args);
+	if let Some(path) = file(&config) {
+		let text = std::fs::read_to_string(&path).with_context(|| format!("reading config file {path}"))?;
+		config = toml::from_str(&text).with_context(|| format!("parsing config file {path}"))?;
+		config.update_from(&args);
+	}
+	Ok(config)
 }
 
 #[cfg(test)]
@@ -343,5 +393,46 @@ id = 12345
 		];
 		let config = Config::parse_and_merge(args).expect("config load");
 		assert_eq!(config.cluster.id, Some(67890));
+	}
+
+	/// The embed contract: a downstream binary can flatten [`Config`] into its
+	/// own clap parser (adding extra flags alongside every relay flag) and reuse
+	/// the relay's CLI -> TOML -> CLI merge via the generic [`merge_from_args`]
+	/// (the core of the public [`load_config`]). Exercises all four corners at
+	/// once: clap flatten + the positional `file`, serde flatten of `Config`
+	/// (whose `deny_unknown_fields` must not break embedding), and the CLI
+	/// re-apply landing the extra flag.
+	#[test]
+	fn embedder_can_flatten_config() {
+		#[derive(clap::Parser, serde::Deserialize, Debug)]
+		struct Embed {
+			#[command(flatten)]
+			#[serde(flatten)]
+			relay: Config,
+
+			/// An embedder-specific flag the relay knows nothing about.
+			#[arg(long = "worker-enabled")]
+			#[serde(skip)]
+			worker_enabled: bool,
+		}
+
+		let toml = "[stats]\nenabled = true\nnode = \"embed\"\n";
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("embed-flatten.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![
+			std::ffi::OsString::from("my-edge"),
+			std::ffi::OsString::from(&path),
+			std::ffi::OsString::from("--worker-enabled"),
+		];
+		let config: Embed = merge_from_args(args, |c: &Embed| c.relay.file.clone()).expect("embed config load");
+
+		// The relay's TOML section was applied through the flattened field...
+		assert_eq!(config.relay.stats.enabled, Some(true));
+		assert_eq!(config.relay.stats.node.as_deref(), Some("embed"));
+		// ...and the embedder's own flag came through the CLI re-apply.
+		assert!(config.worker_enabled);
 	}
 }

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -104,7 +104,12 @@ impl Config {
 ///     #[command(flatten)]
 ///     #[serde(flatten)]
 ///     relay: moq_relay::Config,
+///     // CLI/env only: `#[serde(skip)]` keeps this out of the TOML so the
+///     // clobber pitfall below can't apply to it (an absent flag overwriting a
+///     // TOML value on the re-parse). Drop the skip + use `Option<T>` if you
+///     // want it TOML-settable.
 ///     #[arg(long)]
+///     #[serde(skip)]
 ///     my_flag: bool,
 /// }
 ///
@@ -400,8 +405,9 @@ id = 12345
 	/// the relay's CLI -> TOML -> CLI merge via the generic [`merge_from_args`]
 	/// (the core of the public [`load_config`]). Exercises all four corners at
 	/// once: clap flatten + the positional `file`, serde flatten of `Config`
-	/// (whose `deny_unknown_fields` must not break embedding), and the CLI
-	/// re-apply landing the extra flag.
+	/// (its `deny_unknown_fields` must not be enforced *through* the flatten, or
+	/// an embedder's own top-level TOML key would be rejected), and the CLI
+	/// re-apply landing the embedder's extra flag.
 	#[test]
 	fn embedder_can_flatten_config() {
 		#[derive(clap::Parser, serde::Deserialize, Debug)]
@@ -416,7 +422,11 @@ id = 12345
 			worker_enabled: bool,
 		}
 
-		let toml = "[stats]\nenabled = true\nnode = \"embed\"\n";
+		// `embedder_only` is a top-level key the relay's `Config` has no field
+		// for. It must NOT trip `Config`'s `deny_unknown_fields` (serde can't
+		// enforce that through a flatten), or embedders couldn't carry their own
+		// TOML config alongside the relay's.
+		let toml = "embedder_only = \"ignored\"\n\n[stats]\nenabled = true\nnode = \"embed\"\n";
 		let dir = std::env::temp_dir().join("moq-relay-config-test");
 		std::fs::create_dir_all(&dir).unwrap();
 		let path = dir.join("embed-flatten.toml");

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -12,6 +12,7 @@ mod cluster;
 mod config;
 mod connection;
 mod http_client;
+mod relay;
 mod stats;
 mod web;
 #[cfg(feature = "websocket")]
@@ -25,5 +26,6 @@ pub use auth::*;
 pub use cluster::*;
 pub use config::*;
 pub use connection::*;
+pub use relay::*;
 pub use stats::*;
 pub use web::*;

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -1,6 +1,4 @@
-use moq_relay::*;
-
-use anyhow::Context;
+use moq_relay::{Config, Relay};
 
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
@@ -14,96 +12,9 @@ async fn main() -> anyhow::Result<()> {
 		.install_default()
 		.expect("failed to install default crypto provider");
 
-	let mut config = Config::load()?;
-
-	config.client.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
-	config.server.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
-
-	let mtls_enabled = !config.server.tls.root.is_empty();
-
-	#[allow(unused_mut)]
-	let mut server = config.server.init()?;
-	let client = config.client.clone().init()?;
-
-	let addr = server.local_addr()?;
-
-	#[cfg(feature = "iroh")]
-	let (server, client) = {
-		let iroh = config.iroh.bind().await?;
-		(server.with_iroh(iroh.clone()), client.with_iroh(iroh))
-	};
-
-	// Reject configs where neither JWT nor mTLS can authenticate anyone.
-	if config.auth.is_empty() {
-		anyhow::ensure!(
-			mtls_enabled,
-			"no auth-key, auth-key-dir, public path, or server tls.root configured; \
-			 nobody can authenticate"
-		);
-		tracing::warn!("no JWT/public auth configured; only mTLS peers will be accepted");
-	}
-
-	let auth = if config.auth.is_empty() {
-		Auth::default()
-	} else {
-		config.auth.init().await?
-	};
-
-	let cluster = Cluster::new(config.cluster)?
-		.with_client(client)
-		.with_client_tls(config.client.tls.build()?);
-	let stats = config.stats.build(cluster.origin.clone());
-	let cluster = cluster.with_stats(stats);
-
-	// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
-	let web = Web::new(
-		WebState {
-			auth: auth.clone(),
-			cluster: cluster.clone(),
-			tls_info: server.tls_info(),
-			conn_id: Default::default(),
-		},
-		config.web,
-	);
-
-	tracing::info!(%addr, "listening");
-
-	#[cfg(unix)]
-	// Notify systemd that we're ready after all initialization is complete
-	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
-
-	#[cfg(feature = "jemalloc")]
-	let jemalloc = moq_native::jemalloc::run();
-	#[cfg(not(feature = "jemalloc"))]
-	let jemalloc = std::future::pending::<anyhow::Result<()>>();
-
-	tokio::select! {
-		Err(err) = cluster.clone().run() => return Err(err).context("cluster failed"),
-		Err(err) = web.run() => return Err(err).context("web server failed"),
-		Err(err) = serve(server, cluster, auth) => return Err(err).context("server failed"),
-		Err(err) = jemalloc => return Err(err).context("jemalloc profiler failed"),
-		else => Ok(()),
-	}
-}
-
-async fn serve(mut server: moq_native::Server, cluster: Cluster, auth: Auth) -> anyhow::Result<()> {
-	let mut conn_id = 0;
-
-	while let Some(request) = server.accept().await {
-		let conn = Connection {
-			id: conn_id,
-			request,
-			cluster: cluster.clone(),
-			auth: auth.clone(),
-		};
-
-		conn_id += 1;
-		tokio::spawn(async move {
-			if let Err(err) = conn.run().await {
-				tracing::warn!(%err, "connection closed");
-			}
-		});
-	}
-
-	anyhow::bail!("stopped accepting connections")
+	// Build the relay stack from CLI/env/TOML config and run it. Embedders that
+	// want in-process workers build a `Relay` the same way, spawn tasks against
+	// `relay.origin()`, then call `relay.run()` (see `Relay` docs).
+	let config = Config::load()?;
+	Relay::new(config).await?.run().await
 }

--- a/rs/moq-relay/src/relay.rs
+++ b/rs/moq-relay/src/relay.rs
@@ -1,0 +1,179 @@
+//! High-level [`Relay`]: wires the building blocks ([`Cluster`], [`Web`],
+//! [`Auth`], the QUIC server) into a runnable server.
+//!
+//! This is the recommended entry point both for the standalone binary (see
+//! `main.rs`) and for embedding the relay in a larger process. Embedders build a
+//! [`Relay`], spawn their own tasks against [`Relay::origin`] (the one
+//! [`OriginProducer`] every session and cluster peer publishes into), and then
+//! call [`Relay::run`]:
+//!
+//! ```no_run
+//! # async fn example(config: moq_relay::Config) -> anyhow::Result<()> {
+//! let relay = moq_relay::Relay::new(config).await?;
+//! let origin = relay.origin().clone();
+//! tokio::spawn(async move {
+//!     // a worker consuming the shared origin in-process
+//!     let _ = origin;
+//! });
+//! relay.run().await
+//! # }
+//! ```
+
+use anyhow::Context;
+use moq_net::OriginProducer;
+
+use crate::{Auth, Cluster, Config, Connection, DEFAULT_MAX_STREAMS, Web, WebState};
+
+/// A fully wired relay, ready to [`run`](Self::run).
+///
+/// Construct with [`Relay::new`]. Between construction and [`run`](Self::run),
+/// [`origin`](Self::origin) exposes the shared [`OriginProducer`] so embedders
+/// can attach in-process producers/consumers (workers) to the same broadcast
+/// set the relay serves.
+pub struct Relay {
+	server: moq_native::Server,
+	cluster: Cluster,
+	auth: Auth,
+	web: Web,
+}
+
+impl Relay {
+	/// Build the relay stack from [`Config`]: the QUIC server + cluster client,
+	/// authentication, the [`Cluster`] (and its origin + stats), and the web
+	/// server. This is the wiring the binary previously inlined in `main`.
+	///
+	/// Async because binding the optional iroh endpoint is async.
+	///
+	/// Errors if no authentication is configured at all (neither JWT/public nor
+	/// mTLS could authenticate anyone), or if any sub-config fails to initialize.
+	pub async fn new(mut config: Config) -> anyhow::Result<Self> {
+		config.client.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
+		config.server.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
+
+		let mtls_enabled = !config.server.tls.root.is_empty();
+
+		#[allow(unused_mut)]
+		let mut server = config.server.init()?;
+		let client = config.client.clone().init()?;
+
+		#[cfg(feature = "iroh")]
+		let (server, client) = {
+			let iroh = config.iroh.bind().await?;
+			(server.with_iroh(iroh.clone()), client.with_iroh(iroh))
+		};
+
+		// Reject configs where neither JWT nor mTLS can authenticate anyone.
+		if config.auth.is_empty() {
+			anyhow::ensure!(
+				mtls_enabled,
+				"no auth-key, auth-key-dir, public path, or server tls.root configured; \
+				 nobody can authenticate"
+			);
+			tracing::warn!("no JWT/public auth configured; only mTLS peers will be accepted");
+		}
+
+		let auth = if config.auth.is_empty() {
+			Auth::default()
+		} else {
+			config.auth.init().await?
+		};
+
+		let cluster = Cluster::new(config.cluster)?
+			.with_client(client)
+			.with_client_tls(config.client.tls.build()?);
+		let stats = config.stats.build(cluster.origin.clone());
+		let cluster = cluster.with_stats(stats);
+
+		// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
+		let web = Web::new(
+			WebState {
+				auth: auth.clone(),
+				cluster: cluster.clone(),
+				tls_info: server.tls_info(),
+				conn_id: Default::default(),
+			},
+			config.web,
+		);
+
+		Ok(Self {
+			server,
+			cluster,
+			auth,
+			web,
+		})
+	}
+
+	/// The shared [`OriginProducer`] every local session and cluster peer
+	/// publishes into. Embedders clone this to attach in-process workers, scoped
+	/// via [`OriginProducer::scope`] / [`OriginProducer::consume`].
+	pub fn origin(&self) -> &OriginProducer {
+		&self.cluster.origin
+	}
+
+	/// The relay's [`Cluster`], for embedders that need the full handle (e.g.
+	/// to derive auth-scoped publishers/subscribers).
+	pub fn cluster(&self) -> &Cluster {
+		&self.cluster
+	}
+
+	/// Run the relay until a fatal error. Drives the cluster mesh, the web
+	/// server, the QUIC accept loop, and (when the `jemalloc` feature is on) the
+	/// heap profiler, returning the first error any of them produces.
+	///
+	/// Notifies systemd readiness (a no-op when not run under systemd) once the
+	/// server is listening, so embedders inherit the `Type=notify` contract for
+	/// free.
+	pub async fn run(self) -> anyhow::Result<()> {
+		let Relay {
+			server,
+			cluster,
+			auth,
+			web,
+		} = self;
+
+		let addr = server.local_addr()?;
+		tracing::info!(%addr, "listening");
+
+		#[cfg(unix)]
+		// Notify systemd that we're ready after all initialization is complete.
+		let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
+
+		#[cfg(feature = "jemalloc")]
+		let jemalloc = moq_native::jemalloc::run();
+		#[cfg(not(feature = "jemalloc"))]
+		let jemalloc = std::future::pending::<anyhow::Result<()>>();
+
+		tokio::select! {
+			Err(err) = cluster.clone().run() => Err(err).context("cluster failed"),
+			Err(err) = web.run() => Err(err).context("web server failed"),
+			Err(err) = serve(server, cluster, auth) => Err(err).context("server failed"),
+			Err(err) = jemalloc => Err(err).context("jemalloc profiler failed"),
+			else => Ok(()),
+		}
+	}
+}
+
+/// Accept incoming sessions and spawn a [`Connection`] task for each. Every
+/// connection shares the one `cluster` (and thus its origin), so a publisher on
+/// one session is immediately visible to subscribers (and embedder workers).
+async fn serve(mut server: moq_native::Server, cluster: Cluster, auth: Auth) -> anyhow::Result<()> {
+	let mut conn_id = 0;
+
+	while let Some(request) = server.accept().await {
+		let conn = Connection {
+			id: conn_id,
+			request,
+			cluster: cluster.clone(),
+			auth: auth.clone(),
+		};
+
+		conn_id += 1;
+		tokio::spawn(async move {
+			if let Err(err) = conn.run().await {
+				tracing::warn!(%err, "connection closed");
+			}
+		});
+	}
+
+	anyhow::bail!("stopped accepting connections")
+}


### PR DESCRIPTION
## What

Extracts the wiring that `main.rs` inlined into a reusable **`Relay`** type and a generic **config loader**, so the relay can be embedded in a larger binary with almost no boilerplate — e.g. a node that runs the relay *plus* in-process workers against its shared origin.

`main.rs` itself is rewritten to use the new API (~80 lines → ~6), dogfooding it with no behavior change.

## Why

The relay is already a library, but embedding it meant copy-pasting ~80 lines of `main.rs` (build server/client/auth/cluster/web, the `serve` accept loop, the `tokio::select!`) plus re-listing every sub-config to add one flag. A downstream binary ([moq-pro's `moq-edge`](https://github.com/moq-dev/moq-pro)) wants exactly this: run the relay and host in-process workers (a VOD recorder) that consume `cluster.origin` directly, with no localhost QUIC hop. This gives it a clean seam instead of a fork of `main`.

## API

```rust
let relay = moq_relay::Relay::new(config).await?;   // build the stack
let origin = relay.origin().clone();                // the one OriginProducer
tokio::spawn(my_worker(origin));                    // attach in-process work
relay.run().await                                   // cluster + web + accept loop + jemalloc
```

- **`Relay::new(config).await?`** builds the full stack (QUIC server, cluster + origin + stats, auth, web).
- **`Relay::origin()`** exposes the `OriginProducer` every session and cluster peer publishes into, so embedders can attach producers/consumers before running. `Relay::cluster()` gives the full handle.
- **`Relay::run().await`** drives the cluster mesh, web server, QUIC accept loop, and (under `jemalloc`) the heap profiler, returning the first error. It logs `listening` and notifies **systemd readiness**, so embedders inherit the `Type=notify` contract for free. The private `serve` loop moved into the new `relay` module.
- **`load_config::<T>(|c| c.relay.file.clone())`** lets a downstream binary **flatten** `Config` into its own clap parser (adding flags alongside every relay flag) and reuse the exact `CLI → TOML → CLI` merge. `Config::parse_and_merge` now delegates to the same generic `merge_from_args`, so there's a single merge implementation.

## Tests

- New `embedder_can_flatten_config` exercises all four corners of the embed contract at once: clap `flatten` + the positional `file`, **serde `flatten` of `Config`** (its `deny_unknown_fields` must not break embedding — confirmed it doesn't), and the CLI re-apply landing an embedder-specific flag.
- Doc-tests on `Relay` and `load_config` show the intended usage and are compiled/run.
- All **125 lib tests + 3 doc-tests pass**, `clippy` clean, `cargo fmt` clean (default and `jemalloc` features build).

## Notes

- No behavior change to the standalone binary: `Relay::run` reproduces `main`'s exact `select!` arms, ordering, "listening" log, and systemd notify.
- `Relay::new` is `async` only because binding the optional iroh endpoint is async.

🤖 Generated with [Claude Code](https://claude.com/claude-code)