### PR TITLE
prototype: Rust CI checks via cargo (sccache) instead of crane

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -231,13 +231,18 @@
 
         formatter = pkgs.nixfmt-tree;
 
-        # Heavy Rust CI (clippy / doc / test, all features) as crane
-        # derivations: deps compile once and cache, only first-party code
-        # recompiles per run, and there's no persistent CARGO_TARGET_DIR to
-        # bound. Run with `nix flake check` or a single one via
-        # `nix build .#checks.<system>.clippy`. The cheap, non-compiling lints
-        # (rustfmt, cargo-deny/shear/sort) stay in `just rs ci`.
-        checks = overlayPkgs.moqChecks;
+        # Heavy Rust CI (clippy / doc / test) runs as plain cargo via `just rs
+        # ci` (see rs/justfile), no longer through crane. `nix flake check` is
+        # kept -- it still validates flake eval + builds the dev shell -- but no
+        # longer compiles the workspace, so it's cheap. Release artifacts still
+        # build via crane `buildPackage` (see `packages` above / release-*.yml).
+        #
+        # On the self-hosted runner those cargo checks transparently reuse a
+        # per-crate compiler cache (rustc is wrapped by sccache via the runner
+        # environment), so a Cargo.lock change recompiles only the changed crate
+        # + its reverse-deps. That's a runner-side concern -- nothing here or in
+        # the workflows configures it.
+        checks = { };
       }
     );
 }

--- a/justfile
+++ b/justfile
@@ -90,10 +90,20 @@ ci BASE="":
     	just go    ci "$files"
     fi
 
+    # Validate the flake (eval + dev shell build) via `nix flake check`. This no
+    # longer compiles the workspace -- the heavy Rust CI (clippy/doc/test) moved
+    # to `just rs ci` (plain cargo) and `checks` is unwired (see flake.nix) -- so
+    # it's cheap. Gate it to Nix/Rust input changes anyway: a pure doc/JS PR
+    # can't affect flake eval. Empty $files is a force-run, so run then.
+    if [[ -z "$files" ]] || echo "$files" | grep -qE '(^rs/|^Cargo\.(toml|lock)$|^flake\.lock$|\.nix$)'; then
+    	nix flake check
+    else
+    	echo "ci: no Nix/Rust inputs changed; skipping nix flake check."
+    fi
+
     # Cheap; always run. `bun install` is needed for remark-cli, since
     # `just js ci` (where bun deps would otherwise install) is skipped
     # when the diff has no JS-scoped files.
-    nix flake check
     bun install --frozen-lockfile
     bun remark . --quiet --frail
     shfmt --diff $(shfmt -f .)

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -201,124 +201,15 @@ let
     '';
   };
 
-  # --- CI checks (run via `nix flake check`) -------------------------------
-  #
-  # The heavy Rust CI (clippy / doc / test) used to run as plain `cargo` on the
-  # self-hosted runner, compiling into a persistent CARGO_TARGET_DIR that grew
-  # unbounded (every branch's artifacts, never pruned) and was unsafe to share
-  # across parallel jobs. Expressing those checks as crane derivations instead
-  # makes Nix the cache: dependencies compile exactly once (`checkDeps`), land
-  # in the binary cache, are shared across machines, and are LRU-evicted by the
-  # store's free-space GC. Only first-party code recompiles, inside Nix's
-  # sandbox (which is wiped per build), so there is no target dir to bound.
-
-  # crane's cleanCargoSource keeps only Rust-relevant files, but the test
-  # targets compiled under `--all-targets` `include_str!`/`include_bytes!` data
-  # fixtures (rs/moq-mux test_data/*.ts, rs/moq-json tests/vectors.json, etc.)
-  # and libmoq's build.rs reads moq.pc.in. Rather than enumerate every asset
-  # (fragile -- a new fixture would break CI), take the whole tree minus the
-  # heavy non-source dirs. Dep caching is unaffected (buildDepsOnly keys on
-  # Cargo.lock); only the first-party check rebuilds on a non-Rust change.
-  checkSrc = final.lib.cleanSourceWith {
-    src = ../.;
-    name = "source";
-    filter =
-      path: _type:
-      let
-        # Prune a dir both as an entry ("…/target") and its contents
-        # ("…/target/…") so we don't walk node_modules etc. at all.
-        excluded = name: final.lib.hasSuffix "/${name}" path || final.lib.hasInfix "/${name}/" path;
-      in
-      !(
-        excluded "node_modules"
-        || excluded "target"
-        || excluded ".direnv"
-        || excluded ".venv"
-        || excluded ".git"
-      );
-  };
-
-  # Every system lib the workspace needs to compile with all features on:
-  # bindgen (clang) for ffmpeg/vaapi, GStreamer for moq-gst, ALSA for
-  # moq-audio's capture feature, libva for moq-video's vaapi feature. The
-  # Linux-only libs match the devShell's `lib.optionals (!isDarwin)` set.
-  checkCommonArgs = {
-    src = checkSrc;
-    # The workspace root Cargo.toml has no [package], so name it explicitly
-    # (otherwise crane warns and uses a placeholder).
-    pname = "moq-workspace";
-    version = "0.0.0";
-    strictDeps = true;
-    nativeBuildInputs = with final; [
-      pkg-config
-      clang
-      cmake
-      # boring-sys (quiche, under --all-features) shells out to `git` to apply
-      # its BoringSSL patches; the devShell has it on $PATH, the sandbox doesn't.
-      git
-    ];
-    buildInputs =
-      (with final; [
-        ffmpeg
-        glib
-        curl
-        gst_all_1.gstreamer
-        gst_all_1.gst-plugins-base
-      ])
-      ++ final.lib.optionals final.stdenv.isLinux (
-        with final;
-        [
-          alsa-lib
-          libva
-        ]
-      );
-    LIBCLANG_PATH = "${final.libclang.lib}/lib";
-    # jemalloc (pulled in by --all-features) builds -O0 configure tests that
-    # clash with Nix's _FORTIFY_SOURCE hardening (needs -O). Same as the
-    # package builds and the devShell.
-    hardeningDisable = [ "fortify" ];
-    # Scope the dep build to the whole workspace with every feature so a single
-    # checkDeps covers clippy/doc/test below.
-    cargoExtraArgs = "--workspace --all-features";
-  };
-
-  # Compile all third-party deps once; the checks reuse this artifact.
-  checkDeps = craneLib.buildDepsOnly (checkCommonArgs // { pname = "moq-workspace-deps"; });
-
-  moqChecks = {
-    clippy = craneLib.cargoClippy (
-      checkCommonArgs
-      // {
-        cargoArtifacts = checkDeps;
-        # --workspace/--all-features come from checkCommonArgs.cargoExtraArgs,
-        # which crane prepends; only add the clippy-specific flags here.
-        cargoClippyExtraArgs = "--all-targets -- -D warnings";
-      }
-    );
-
-    doc = craneLib.cargoDoc (
-      checkCommonArgs
-      // {
-        cargoArtifacts = checkDeps;
-        # --all-targets is invalid for `cargo doc`, so it stays out of the
-        # shared cargoExtraArgs; --workspace/--all-features are inherited.
-        cargoDocExtraArgs = "--no-deps";
-        RUSTDOCFLAGS = "-D warnings";
-      }
-    );
-
-    test = craneLib.cargoTest (
-      checkCommonArgs
-      // {
-        cargoArtifacts = checkDeps;
-        cargoTestExtraArgs = "--all-targets";
-      }
-    );
-  };
+  # CI checks (clippy / doc / test) run as plain cargo via `just rs ci`, not
+  # through crane/`nix flake check`. The self-hosted runner caches compilation
+  # per-crate with sccache (wired into the runner environment, not here), so a
+  # Cargo.lock change recompiles only the changed crate + its reverse-deps.
+  # ./target stays ephemeral (wiped per job) -- the persistent CARGO_TARGET_DIR
+  # growth that the old crane checks were introduced to fix doesn't recur.
+  # Release artifacts still build via crane `buildPackage` below.
 in
 {
-  inherit moqChecks;
-
   moq-relay = craneLib.buildPackage moqRelayArgs;
   moq-relay-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqRelayArgs);
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -35,21 +35,26 @@ ci FILES="":
     	echo "rs: no Rust changes; skipping."
     	exit 0
     fi
-    # Heavy compiles -- clippy, doc, and the --all-features test run -- are crane
-    # derivations built by `nix flake check` (see flake.nix `checks` and
-    # nix/overlay.nix): deps cache in /nix/store, only first-party code rebuilds
-    # in the sandbox, and there's no persistent cargo target dir to bound. What
-    # stays here is non-compiling hygiene, cargo-deny (hits the network, so it
-    # can't run in the Nix sandbox), and the default / no-default-feature
-    # `cargo check`s the all-features crane run doesn't cover -- those compile
-    # into the in-workspace ./target, which the runner wipes per job.
-    # (Local devs still get the full cargo loop via `just rs check`.)
+    # Hygiene (non-compiling) + cargo-deny (hits the network, so it couldn't run
+    # in the old Nix sandbox; runs fine here).
     cargo fmt --all --check
     cargo sort --workspace --check --no-format
     cargo shear
+    cargo deny check --show-stats
+
+    # Compiles. The all-features clippy / doc / test were crane derivations built
+    # by `nix flake check`; they now run here as plain cargo (flake.nix `checks`
+    # is unwired). The default / no-default-feature `cargo check`s cover feature
+    # edges the all-features run doesn't. Everything builds into the in-workspace
+    # ./target, which the runner wipes per job; on the self-hosted runner the
+    # heavy compilation is transparently cached per-crate by sccache (wired into
+    # the runner environment, not here), so there's no persistent target dir to
+    # bound. (Local devs still get the full cargo loop via `just rs check`.)
     cargo check --workspace --all-targets
     cargo check --workspace --no-default-features
-    cargo deny check --show-stats
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+    cargo test --workspace --all-targets --all-features
 
 # Auto-fix clippy/format/shear/sort.
 fix:


### PR DESCRIPTION
**Prototype — not for merge as-is.** A/B test for replacing the crane `nix flake check` Rust CI with plain `cargo`, accelerated transparently by sccache on the self-hosted runner.

## Why
The crane checks build one `buildDepsOnly` blob keyed on `Cargo.lock`. Any dependency add/bump (e.g. adding `serde_with`) re-hashes that derivation and **recompiles the entire third-party graph** before clippy/doc/test can start — ~tens of minutes when the box is busy.

## What this does
- `flake.nix`: unwire `checks` (`{ }`). `nix flake check` still validates flake eval + dev shell, but no longer compiles the workspace.
- `rs/justfile`: run the all-features clippy/doc/test + feature-edge `cargo check`s here as plain cargo. `./target` stays ephemeral (wiped per job).
- `justfile`: also gates `nix flake check` to Nix/Rust diffs, and (separately) cancels in-flight runs on PR close.

## Where sccache lives
**Not in this repo.** rustc is wrapped by sccache via the runner environment (see the `oci` infra repo): `RUSTC_WRAPPER` + `SCCACHE_DIR` in the runner `.env`. The repo just runs `cargo`; a `Cargo.lock` change then recompiles only the changed crate + its reverse-deps. Builds inside a `nix flake check` sandbox are unaffected, so **release artifacts still build hermetically via crane `buildPackage`**.

## A/B to watch
1. This run = cold cache → full cargo compile (baseline).
2. A follow-up commit that bumps `Cargo.lock` → should recompile only the delta, vs. the ~9 min full crane deps rebuild we measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)