### PR TITLE
feat(moq-rtmp): RTMP / enhanced-RTMP ingest gateway + E-RTMP codecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,6 +4316,7 @@ dependencies = [
  "sd-notify",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tower-http",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,15 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1351,6 +1360,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1707,15 @@ name = "diatomic-waker"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "digest"
@@ -2784,7 +2812,17 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -4258,6 +4296,29 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "moq-rtmp"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "axum",
+ "axum-server",
+ "bytes",
+ "clap",
+ "futures",
+ "moq-mux",
+ "moq-native",
+ "moq-net",
+ "rml_rtmp",
+ "rustls",
+ "sd-notify",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6349,7 +6410,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -6365,6 +6426,31 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rml_amf0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63551cfcd4d1f42733c190e4b58dd268b1eacb73410d9afbf62784aa12cac240"
+dependencies = [
+ "byteorder",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rml_rtmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a354e80eb7aa2a6fed09b3bd25c19bcfd32cf51f81f1219f4ec04f34519989da"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "hmac 0.10.1",
+ "rand 0.8.6",
+ "rml_amf0",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6988,6 +7074,19 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
@@ -7290,7 +7389,7 @@ dependencies = [
  "ctr",
  "derive_more 0.99.20",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "keyed_priority_queue",
  "log",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "rs/moq-net",
     "rs/moq-relay",
     "rs/moq-rtc",
+    "rs/moq-rtmp",
     "rs/moq-srt",
     "rs/moq-token",
     "rs/moq-token-cli",
@@ -43,6 +44,7 @@ default-members = [
     "rs/moq-native",
     "rs/moq-relay",
     "rs/moq-rtc",
+    "rs/moq-rtmp",
     "rs/moq-srt",
     "rs/moq-token",
     "rs/moq-token-cli",
@@ -66,6 +68,7 @@ moq-msf = { version = "0.2", path = "rs/moq-msf" }
 moq-mux = { version = "0.5", path = "rs/moq-mux" }
 moq-native = { version = "0.17", path = "rs/moq-native", default-features = false }
 moq-net = { version = "0.1", path = "rs/moq-net" }
+moq-rtmp = { version = "0.0.1", path = "rs/moq-rtmp", default-features = false }
 moq-token = { version = "0.6", path = "rs/moq-token" }
 # Standalone crate (moq-dev/vaapi); vendored from cros-libva + cros-codecs.
 moq-vaapi = "0.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ moq-msf = { version = "0.2", path = "rs/moq-msf" }
 moq-mux = { version = "0.5", path = "rs/moq-mux" }
 moq-native = { version = "0.17", path = "rs/moq-native", default-features = false }
 moq-net = { version = "0.1", path = "rs/moq-net" }
-moq-rtmp = { version = "0.0.1", path = "rs/moq-rtmp", default-features = false }
 moq-token = { version = "0.6", path = "rs/moq-token" }
 # Standalone crate (moq-dev/vaapi); vendored from cros-libva + cros-codecs.
 moq-vaapi = "0.0.2"

--- a/doc/bin/index.md
+++ b/doc/bin/index.md
@@ -40,6 +40,12 @@ WHEP egress is in progress.
 An HLS / LL-HLS <-> MoQ gateway. Serves a MoQ broadcast as HLS and
 Low-Latency HLS over HTTP, or imports a remote HLS playlist into MoQ.
 
+## [moq-rtmp](/bin/rtmp)
+
+An RTMP / enhanced-RTMP -> MoQ ingest gateway. Accepts RTMP from any encoder
+(OBS, ffmpeg) and publishes it into MoQ, supporting H.264/HEVC/AV1/VP9 and
+AAC/Opus/AC-3.
+
 ## [OBS Plugin](/bin/obs)
 
 Real-time latency with the familiar OBS interface.

--- a/doc/bin/rtmp.md
+++ b/doc/bin/rtmp.md
@@ -59,6 +59,24 @@ ffmpeg -re -i input.mp4 -c copy -f flv rtmp://127.0.0.1:1935/live/cam0
 - `--rtmp-prefix`: prepended to every broadcast path, to namespace a listener's
   streams (e.g. `live/`).
 
+### RTMPS flags
+
+RTMPS (RTMP over TLS, `rtmps://`) is served on a second listener alongside
+plaintext RTMP, sharing the same `--rtmp-prefix`:
+
+- `--rtmps-listen`: TCP bind address for the RTMPS server (off unless set). RTMPS
+  has no well-known port; 443 or a custom one are common.
+- `--rtmps-tls-cert` / `--rtmps-tls-key`: PEM certificate chain and key.
+- `--rtmps-tls-generate <hostname>`: or generate a throwaway self-signed cert
+  (testing only; clients must disable verification).
+
+```bash
+moq-rtmp serve --server-bind [::]:443 --tls-generate localhost \
+  --rtmp-listen 0.0.0.0:1935 \
+  --rtmps-listen 0.0.0.0:1936 --rtmps-tls-cert cert.pem --rtmps-tls-key key.pem \
+  --rtmp-prefix live/
+```
+
 ## Routing
 
 Each connection's broadcast path is `<app>/<key>` from the RTMP app and stream
@@ -80,6 +98,10 @@ connection to the same path is rejected.
   origin for the unauthenticated case, or use `Server` / `Request` to plug in the
   relay's existing JWT/path auth and scope the origin per token. Either way the
   media is published locally with no extra hop.
+- **RTMPS.** Embedders can terminate TLS themselves: set `Config::tls` (or
+  `Server::with_tls`) with a `rustls::ServerConfig`, or accept the connection and
+  finish the TLS handshake by hand and hand the stream to `moq_rtmp::accept_stream`
+  (which works over any `AsyncRead + AsyncWrite` transport).
 - **Codecs.** FLAC and MP3 enhanced-audio payloads are dropped (no MoQ catalog
   codec); everything else (H.264/HEVC/AV1/VP9 video, AAC/Opus/AC-3/E-AC-3 audio)
   is supported.

--- a/doc/bin/rtmp.md
+++ b/doc/bin/rtmp.md
@@ -1,0 +1,87 @@
+---
+title: moq-rtmp
+description: RTMP / enhanced-RTMP -> MoQ contribution ingest gateway
+---
+
+# moq-rtmp
+
+`moq-rtmp` ingests [RTMP](https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol)
+(the protocol OBS, ffmpeg, and most hardware encoders speak) and publishes each
+stream into Media over QUIC as an ordinary broadcast.
+
+RTMP carries media as FLV-format audio/video messages. `moq-rtmp` runs the RTMP
+handshake and chunk/AMF session (via the pure-Rust
+[`rml_rtmp`](https://crates.io/crates/rml_rtmp), no librtmp), re-wraps each
+message as an FLV tag, and feeds it to `moq-mux`'s FLV demuxer, which routes the
+media onto MoQ tracks. It's the contribution-ingest sibling of `moq-srt`
+(SRT/MPEG-TS) and `moq-rtc` (WHIP).
+
+Both **legacy RTMP** (H.264 + AAC) and **enhanced RTMP** (E-RTMP: the HEVC, AV1,
+VP9, Opus, and AC-3 FourCC payloads) are supported, because all codec handling
+lives in the `moq-mux` FLV demuxer.
+
+## CLI shape
+
+The binary has two modes, mirroring `moq-srt`:
+
+```bash
+# serve: ingest RTMP and serve it directly as a local relay
+moq-rtmp serve --server-bind [::]:443 --tls-generate localhost \
+  --rtmp-listen 0.0.0.0:1935 --rtmp-prefix live/
+
+# publish: ingest RTMP and forward broadcasts to a remote relay
+moq-rtmp publish --relay https://relay.example.com \
+  --rtmp-listen 0.0.0.0:1935 --rtmp-prefix live/
+```
+
+Point any encoder at it. In OBS, set the server to `rtmp://127.0.0.1:1935/live`
+and the stream key to `cam0`; with ffmpeg:
+
+```bash
+# Lands at broadcast `live/cam0`.
+ffmpeg -re -i input.mp4 -c copy -f flv rtmp://127.0.0.1:1935/live/cam0
+```
+
+### `serve` flags
+
+- `--server-bind`: QUIC/WebTransport bind address (default `[::]:443`). Also
+  serves the `/certificate.sha256` endpoint browsers need for self-signed
+  `http://` origins, and a static player directory with `--dir`.
+- `--tls-generate <hostname>` / `--tls-cert` / `--tls-key`: server TLS.
+
+### `publish` flags
+
+- `--relay`: upstream MoQ relay to publish every ingested broadcast into.
+
+### RTMP flags
+
+- `--rtmp-listen`: TCP bind address for the RTMP server (default `[::]:1935`).
+- `--rtmp-prefix`: prepended to every broadcast path, to namespace a listener's
+  streams (e.g. `live/`).
+
+## Routing
+
+Each connection's broadcast path is `<app>/<key>` from the RTMP app and stream
+key (`rtmp://host/<app>/<key>`), falling back to just the app when the key is
+empty, with `--rtmp-prefix` prepended. First publisher on a path wins; a second
+connection to the same path is rejected.
+
+## Notes and limitations
+
+- **Auth.** The binary (and the `moq_rtmp::run` convenience) is unauthenticated:
+  anyone who can reach the TCP port can publish. Gate it with a host firewall or
+  a private network. To authenticate, embed the library and drive its
+  `Server` / `Request` API: `Server::accept` yields a pending publish, and you
+  verify the app / stream key (e.g. the stream key as a moq-token JWT) before
+  calling `request.accept(origin, path)` or `request.reject(reason)` -- no
+  callback, the policy lives in your loop.
+- **Embedding.** A relay can run ingest in-process by depending on the `moq-rtmp`
+  library (`default-features = false`). Call `moq_rtmp::run` against its own
+  origin for the unauthenticated case, or use `Server` / `Request` to plug in the
+  relay's existing JWT/path auth and scope the origin per token. Either way the
+  media is published locally with no extra hop.
+- **Codecs.** FLAC and MP3 enhanced-audio payloads are dropped (no MoQ catalog
+  codec); everything else (H.264/HEVC/AV1/VP9 video, AAC/Opus/AC-3/E-AC-3 audio)
+  is supported.
+
+(Written by Claude)

--- a/rs/moq-mux/src/codec/av1/mod.rs
+++ b/rs/moq-mux/src/codec/av1/mod.rs
@@ -43,6 +43,39 @@ impl From<std::io::Error> for Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Build a catalog [`VideoConfig`](hang::catalog::VideoConfig) for the `av01`
+/// shape from an AV1CodecConfigurationRecord (av1C).
+///
+/// Used by the enhanced-RTMP / FLV importer, where the av1C arrives out of band
+/// in the sequence-header tag (leading `0x81` marker) and the coded samples are
+/// raw OBU temporal units, so the record passes straight through as the catalog
+/// `description`. Resolution and color live in the inline sequence header, not
+/// the av1C, so `coded_width`/`coded_height` are left unset here.
+pub(crate) fn config_from_av1c(av1c: &[u8]) -> Result<hang::catalog::VideoConfig> {
+	// av1C: byte 0 = marker(1)|version(7) = 0x81, byte 1 = seq_profile(3)|seq_level_idx_0(5),
+	// byte 2 = seq_tier_0|high_bitdepth|twelve_bit|monochrome|subsampling_x|subsampling_y|sample_position(2).
+	if av1c.len() < 4 || av1c[0] != 0x81 {
+		return Err(Error::ObuTooShort);
+	}
+	let high_bitdepth = ((av1c[2] >> 6) & 0x01) == 1;
+	let twelve_bit = ((av1c[2] >> 5) & 0x01) == 1;
+
+	let mut config = hang::catalog::VideoConfig::new(AV1 {
+		profile: (av1c[1] >> 5) & 0x07,
+		level: av1c[1] & 0x1f,
+		tier: if ((av1c[2] >> 7) & 0x01) == 1 { 'H' } else { 'M' },
+		bitdepth: bitdepth(twelve_bit, high_bitdepth),
+		mono_chrome: ((av1c[2] >> 4) & 0x01) == 1,
+		chroma_subsampling_x: ((av1c[2] >> 3) & 0x01) == 1,
+		chroma_subsampling_y: ((av1c[2] >> 2) & 0x01) == 1,
+		chroma_sample_position: av1c[2] & 0x03,
+		..Default::default()
+	});
+	config.description = Some(bytes::Bytes::copy_from_slice(av1c));
+	config.container = hang::catalog::Container::Legacy;
+	Ok(config)
+}
+
 /// Map a parsed `mp4_atom::Av1c` (AV1CodecConfigurationRecord) to the
 /// hang catalog's AV1 codec struct.
 ///

--- a/rs/moq-mux/src/codec/h265/mod.rs
+++ b/rs/moq-mux/src/codec/h265/mod.rs
@@ -130,6 +130,36 @@ pub fn parse_hvcc_param_sets(hvcc: &[u8]) -> Result<HvccParamSets> {
 	})
 }
 
+/// Build a catalog [`VideoConfig`](hang::catalog::VideoConfig) for the `hvc1`
+/// shape from an HEVCDecoderConfigurationRecord (hvcC).
+///
+/// The H.265 analogue of [`crate::codec::h264::Avcc::parse`] feeding a
+/// `VideoConfig`. Used by the enhanced-RTMP / FLV importer, where the hvcC
+/// arrives out of band in the sequence-header tag and the coded samples are
+/// already length-prefixed NALU, so the record passes straight through as the
+/// catalog `description` (`in_band: false`).
+pub(crate) fn config_from_hvcc(hvcc: &[u8]) -> Result<hang::catalog::VideoConfig> {
+	let params = parse_hvcc_param_sets(hvcc)?;
+	let sps_nal = params.sps.first().ok_or(Error::MissingSps)?;
+	let sps = SpsNALUnit::parse(&mut &sps_nal[..]).map_err(|_| Error::SpsParse)?;
+	let profile = &sps.rbsp.profile_tier_level.general_profile;
+
+	let mut config = hang::catalog::VideoConfig::new(hang::catalog::H265 {
+		in_band: false,
+		profile_space: profile.profile_space,
+		profile_idc: profile.profile_idc,
+		profile_compatibility_flags: profile.profile_compatibility_flag.bits().to_be_bytes(),
+		tier_flag: profile.tier_flag,
+		level_idc: profile.level_idc.ok_or(Error::MissingLevelIdc)?,
+		constraint_flags: pack_constraint_flags(profile),
+	});
+	config.coded_width = Some(sps.rbsp.cropped_width() as u32);
+	config.coded_height = Some(sps.rbsp.cropped_height() as u32);
+	config.description = Some(Bytes::copy_from_slice(hvcc));
+	config.container = hang::catalog::Container::Legacy;
+	Ok(config)
+}
+
 /// Annex-B → length-prefixed transmuxer; the H.265 analogue of
 /// [`crate::codec::h264::Avc1`].
 pub struct Hvc1 {

--- a/rs/moq-mux/src/codec/vp9/mod.rs
+++ b/rs/moq-mux/src/codec/vp9/mod.rs
@@ -172,6 +172,25 @@ impl KeyFrame {
 	}
 }
 
+/// Build a catalog [`VideoConfig`](hang::catalog::VideoConfig) from a VP9 frame,
+/// or `None` if the frame is not a key frame.
+///
+/// Used by the enhanced-RTMP / FLV importer. VP9 carries its config in band (the
+/// uncompressed key-frame header), so unlike H.264/H.265/AV1 there is no
+/// out-of-band record to pass through as `description`; the config is read from
+/// the key frame itself.
+pub(crate) fn config_from_keyframe(data: &[u8]) -> Result<Option<hang::catalog::VideoConfig>> {
+	let Some(key) = FrameHeader::parse(data)?.key else {
+		return Ok(None);
+	};
+	let (width, height) = (key.width, key.height);
+	let mut config = hang::catalog::VideoConfig::new(key.to_catalog());
+	config.coded_width = Some(width as u32);
+	config.coded_height = Some(height as u32);
+	config.container = hang::catalog::Container::Legacy;
+	Ok(Some(config))
+}
+
 /// `vpcC` chroma subsampling enum from the VP9 `subsampling_x`/`subsampling_y`
 /// flags. VP9 doesn't signal chroma siting, so 4:2:0 maps to "colocated" (1),
 /// the value encoders conventionally write.

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -1,27 +1,61 @@
 //! FLV muxer.
 //!
 //! [`Export`] subscribes to a MoQ broadcast and produces a single FLV byte
-//! stream: the file header, an AVC and/or AAC sequence header, then one tag per
-//! media frame interleaved by timestamp. Frames flow through [`ExportSource`],
-//! which normalizes H.264 to length-prefixed NALU plus a resolved avcC (parsing
-//! inline avc3 parameter sets when needed) and hands audio through with its
-//! `AudioSpecificConfig`. FLV carries a single video and a single audio stream,
-//! so only the first rendition of each kind is muxed; extra renditions and any
-//! non-AVC/AAC codec are rejected.
+//! stream: the file header, the video/audio sequence headers, then one tag per
+//! media frame interleaved by timestamp. Legacy H.264 + AAC are muxed as the
+//! classic CodecID tags; HEVC, AV1, VP9, Opus, AC-3, and E-AC-3 are muxed as the
+//! enhanced-RTMP (E-RTMP) FourCC payloads. Frames flow through [`ExportSource`],
+//! which normalizes H.264/H.265 to length-prefixed NALU plus a resolved
+//! avcC/hvcC (parsing inline avc3/hev1 parameter sets when needed) and hands the
+//! other codecs through unchanged. FLV carries a single video and a single audio
+//! stream, so only the first rendition of each kind is muxed; extra renditions
+//! and any unsupported codec are rejected.
 
 use std::task::Poll;
 use std::time::Duration;
 
 use anyhow::Context;
 use bytes::{BufMut, Bytes, BytesMut};
-use hang::catalog::{AudioCodec, Catalog, Container, VideoCodec};
+use hang::catalog::{AV1, AudioCodec, Catalog, Container, VideoCodec};
 
 use super::{
-	AAC_AUDIO_TAG_HEADER, AAC_RAW, AAC_SEQUENCE_HEADER, AVC_NALU, AVC_SEQUENCE_HEADER, FRAME_TYPE_INTER,
-	FRAME_TYPE_KEY, TAG_AUDIO, TAG_HEADER_LEN, TAG_VIDEO, VIDEO_CODEC_AVC,
+	AAC_AUDIO_TAG_HEADER, AAC_RAW, AAC_SEQUENCE_HEADER, AUDIO_FORMAT_EX, AUDIO_PACKET_CODED_FRAMES,
+	AUDIO_PACKET_SEQUENCE_START, AVC_NALU, AVC_SEQUENCE_HEADER, FRAME_TYPE_INTER, FRAME_TYPE_KEY, TAG_AUDIO,
+	TAG_HEADER_LEN, TAG_VIDEO, VIDEO_CODEC_AVC, VIDEO_EX_HEADER, VIDEO_PACKET_CODED_FRAMES,
+	VIDEO_PACKET_SEQUENCE_START,
 };
 use crate::catalog::{CatalogFormat, Stream};
 use crate::container::{ExportSource, Frame};
+
+/// Which FLV payload shape a bound track is muxed as: a legacy CodecID
+/// (`Avc`/`Aac`) or an enhanced-RTMP FourCC codec.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Flavor {
+	Avc,
+	Hevc,
+	Av1,
+	Vp9,
+	Aac,
+	Opus,
+	Ac3,
+	Eac3,
+}
+
+impl Flavor {
+	/// The enhanced-RTMP FourCC for this codec, or `None` for the legacy
+	/// (CodecID-signaled) AVC and AAC shapes.
+	fn fourcc(self) -> Option<[u8; 4]> {
+		match self {
+			Flavor::Hevc => Some(*b"hvc1"),
+			Flavor::Av1 => Some(*b"av01"),
+			Flavor::Vp9 => Some(*b"vp09"),
+			Flavor::Opus => Some(*b"Opus"),
+			Flavor::Ac3 => Some(*b"ac-3"),
+			Flavor::Eac3 => Some(*b"ec-3"),
+			Flavor::Avc | Flavor::Aac => None,
+		}
+	}
+}
 
 /// Subscribe to a broadcast and produce an FLV byte stream.
 ///
@@ -55,6 +89,13 @@ struct FlvTrack {
 	source: ExportSource,
 	pending: Option<Frame>,
 	finished: bool,
+	/// The FLV payload shape (legacy CodecID vs enhanced FourCC) to mux this
+	/// track as, fixed from its catalog codec when it's bound.
+	flavor: Flavor,
+	/// A codec config record synthesized at bind time for the sequence-header
+	/// tag, used when the catalog (and thus [`ExportSource::description`]) carries
+	/// none. Only AV1 needs this today (its av1C is optional in the catalog).
+	fallback_description: Option<Bytes>,
 }
 
 impl Export {
@@ -188,14 +229,22 @@ impl Export {
 		if self.video.is_none()
 			&& let Some((name, config)) = catalog.video.renditions.iter().next()
 		{
-			ensure_supported_video(config)?;
+			let flavor = video_flavor(config)?;
 			ensure_legacy(&config.container, "video", name)?;
+			// AV1's av1C is optional in the catalog; synthesize one from the codec
+			// struct so the enhanced SequenceStart tag always has a config record.
+			let fallback_description = match (&config.codec, config.description.as_ref()) {
+				(VideoCodec::AV1(av1), None) => Some(Bytes::copy_from_slice(&av1c_bytes(av1))),
+				_ => None,
+			};
 			let source = ExportSource::for_video(&self.broadcast, name, config, self.latency)?;
 			self.video = Some(FlvTrack {
 				name: name.clone(),
 				source,
 				pending: None,
 				finished: false,
+				flavor,
+				fallback_description,
 			});
 		}
 		if catalog.video.renditions.len() > 1 {
@@ -205,7 +254,7 @@ impl Export {
 		if self.audio.is_none()
 			&& let Some((name, config)) = catalog.audio.renditions.iter().next()
 		{
-			ensure_supported_audio(config)?;
+			let flavor = audio_flavor(config)?;
 			ensure_legacy(&config.container, "audio", name)?;
 			let source = ExportSource::for_audio(&self.broadcast, name, config, self.latency)?;
 			self.audio = Some(FlvTrack {
@@ -213,6 +262,8 @@ impl Export {
 				source,
 				pending: None,
 				finished: false,
+				flavor,
+				fallback_description: None,
 			});
 		}
 		if catalog.audio.renditions.len() > 1 {
@@ -264,24 +315,14 @@ impl Export {
 		// PreviousTagSize0 is always zero.
 		out.put_u32(0);
 
-		if let Some(track) = &self.video {
-			let avcc = track.source.description().context("H.264 track missing avcC")?;
-			let mut body = BytesMut::with_capacity(5 + avcc.len());
-			body.put_u8((FRAME_TYPE_KEY << 4) | VIDEO_CODEC_AVC);
-			body.put_u8(AVC_SEQUENCE_HEADER);
-			body.put_slice(&[0, 0, 0]); // composition time
-			body.put_slice(avcc);
+		if let Some(track) = &self.video
+			&& let Some(body) = video_sequence_header(track)?
+		{
 			write_tag(&mut out, TAG_VIDEO, 0, &body)?;
 		}
-		if let Some(track) = &self.audio {
-			let asc = track
-				.source
-				.description()
-				.context("AAC track missing AudioSpecificConfig")?;
-			let mut body = BytesMut::with_capacity(2 + asc.len());
-			body.put_u8(AAC_AUDIO_TAG_HEADER);
-			body.put_u8(AAC_SEQUENCE_HEADER);
-			body.put_slice(asc);
+		if let Some(track) = &self.audio
+			&& let Some(body) = audio_sequence_header(track)?
+		{
 			write_tag(&mut out, TAG_AUDIO, 0, &body)?;
 		}
 
@@ -317,22 +358,45 @@ impl Export {
 
 		let mut out = BytesMut::with_capacity(TAG_HEADER_LEN + frame.payload.len() + 8);
 		if is_video {
-			let mut body = BytesMut::with_capacity(5 + frame.payload.len());
+			let flavor = self.video.as_ref().expect("video frame without a video track").flavor;
 			let frame_type = if frame.keyframe {
 				FRAME_TYPE_KEY
 			} else {
 				FRAME_TYPE_INTER
 			};
-			body.put_u8((frame_type << 4) | VIDEO_CODEC_AVC);
-			body.put_u8(AVC_NALU);
-			// We carry PTS in the tag timestamp, so the composition offset is zero.
-			body.put_slice(&[0, 0, 0]);
+			let mut body = BytesMut::with_capacity(8 + frame.payload.len());
+			match flavor.fourcc() {
+				// Legacy AVC: CodecID + AVCPacketType + composition time (PTS in the tag).
+				None => {
+					body.put_u8((frame_type << 4) | VIDEO_CODEC_AVC);
+					body.put_u8(AVC_NALU);
+					body.put_slice(&[0, 0, 0]);
+				}
+				// Enhanced FourCC CodedFrames. hvc1 keeps the 3-byte composition
+				// time (zero, since we carry PTS in the tag); av01/vp09 omit it.
+				Some(fourcc) => {
+					body.put_u8(VIDEO_EX_HEADER | (frame_type << 4) | VIDEO_PACKET_CODED_FRAMES);
+					body.put_slice(&fourcc);
+					if flavor == Flavor::Hevc {
+						body.put_slice(&[0, 0, 0]);
+					}
+				}
+			}
 			body.put_slice(&frame.payload);
 			write_tag(&mut out, TAG_VIDEO, timestamp_ms, &body)?;
 		} else {
-			let mut body = BytesMut::with_capacity(2 + frame.payload.len());
-			body.put_u8(AAC_AUDIO_TAG_HEADER);
-			body.put_u8(AAC_RAW);
+			let flavor = self.audio.as_ref().expect("audio frame without an audio track").flavor;
+			let mut body = BytesMut::with_capacity(5 + frame.payload.len());
+			match flavor.fourcc() {
+				None => {
+					body.put_u8(AAC_AUDIO_TAG_HEADER);
+					body.put_u8(AAC_RAW);
+				}
+				Some(fourcc) => {
+					body.put_u8((AUDIO_FORMAT_EX << 4) | AUDIO_PACKET_CODED_FRAMES);
+					body.put_slice(&fourcc);
+				}
+			}
 			body.put_slice(&frame.payload);
 			write_tag(&mut out, TAG_AUDIO, timestamp_ms, &body)?;
 		}
@@ -368,16 +432,110 @@ fn ensure_legacy(container: &Container, kind: &str, name: &str) -> anyhow::Resul
 	}
 }
 
-fn ensure_supported_video(config: &hang::catalog::VideoConfig) -> anyhow::Result<()> {
+fn video_flavor(config: &hang::catalog::VideoConfig) -> anyhow::Result<Flavor> {
 	match &config.codec {
-		VideoCodec::H264(_) => Ok(()),
-		other => anyhow::bail!("FLV export only supports H.264 video, got {other:?}"),
+		VideoCodec::H264(_) => Ok(Flavor::Avc),
+		VideoCodec::H265(_) => Ok(Flavor::Hevc),
+		VideoCodec::AV1(_) => Ok(Flavor::Av1),
+		VideoCodec::VP9(_) => Ok(Flavor::Vp9),
+		other => anyhow::bail!("FLV export does not support video codec {other:?}"),
 	}
 }
 
-fn ensure_supported_audio(config: &hang::catalog::AudioConfig) -> anyhow::Result<()> {
+fn audio_flavor(config: &hang::catalog::AudioConfig) -> anyhow::Result<Flavor> {
 	match &config.codec {
-		AudioCodec::AAC(_) => Ok(()),
-		other => anyhow::bail!("FLV export only supports AAC audio, got {other:?}"),
+		AudioCodec::AAC(_) => Ok(Flavor::Aac),
+		AudioCodec::Opus => Ok(Flavor::Opus),
+		AudioCodec::Ac3 => Ok(Flavor::Ac3),
+		AudioCodec::Ec3 => Ok(Flavor::Eac3),
+		other => anyhow::bail!("FLV export does not support audio codec {other:?}"),
 	}
+}
+
+/// Build the FLV video sequence-header tag body, or `None` for codecs that carry
+/// their config in band (VP9), so no out-of-band record is emitted.
+fn video_sequence_header(track: &FlvTrack) -> anyhow::Result<Option<BytesMut>> {
+	let mut body = BytesMut::new();
+	match track.flavor {
+		Flavor::Avc => {
+			let avcc = track.source.description().context("H.264 track missing avcC")?;
+			body.put_u8((FRAME_TYPE_KEY << 4) | VIDEO_CODEC_AVC);
+			body.put_u8(AVC_SEQUENCE_HEADER);
+			body.put_slice(&[0, 0, 0]); // composition time
+			body.put_slice(avcc);
+		}
+		Flavor::Hevc => {
+			let hvcc = track.source.description().context("H.265 track missing hvcC")?;
+			ex_video_sequence_start(&mut body, b"hvc1", hvcc);
+		}
+		Flavor::Av1 => {
+			// av1C from the catalog `description`, or the record synthesized at bind
+			// time (the sequence header is carried in band, so an empty configOBUs
+			// record is enough for the decoder).
+			let av1c = track
+				.source
+				.description()
+				.or(track.fallback_description.as_ref())
+				.context("AV1 track missing av1C")?;
+			ex_video_sequence_start(&mut body, b"av01", av1c);
+		}
+		// VP9 configures the decoder from the key frame; no sequence header tag.
+		Flavor::Vp9 => return Ok(None),
+		Flavor::Aac | Flavor::Opus | Flavor::Ac3 | Flavor::Eac3 => unreachable!("audio flavor on a video track"),
+	}
+	Ok(Some(body))
+}
+
+/// Build the FLV audio sequence-header tag body, or `None` for codecs that carry
+/// their config in band (AC-3 / E-AC-3).
+fn audio_sequence_header(track: &FlvTrack) -> anyhow::Result<Option<BytesMut>> {
+	let mut body = BytesMut::new();
+	match track.flavor {
+		Flavor::Aac => {
+			let asc = track
+				.source
+				.description()
+				.context("AAC track missing AudioSpecificConfig")?;
+			body.put_u8(AAC_AUDIO_TAG_HEADER);
+			body.put_u8(AAC_SEQUENCE_HEADER);
+			body.put_slice(asc);
+		}
+		Flavor::Opus => {
+			let head = track.source.description().context("Opus track missing OpusHead")?;
+			body.put_u8((AUDIO_FORMAT_EX << 4) | AUDIO_PACKET_SEQUENCE_START);
+			body.put_slice(b"Opus");
+			body.put_slice(head);
+		}
+		// AC-3 / E-AC-3 carry their config in each sync frame; no sequence header tag.
+		Flavor::Ac3 | Flavor::Eac3 => return Ok(None),
+		Flavor::Avc | Flavor::Hevc | Flavor::Av1 | Flavor::Vp9 => unreachable!("video flavor on an audio track"),
+	}
+	Ok(Some(body))
+}
+
+/// Append an enhanced-RTMP video `SequenceStart` tag body: ex-header + FourCC +
+/// the codec config record.
+fn ex_video_sequence_start(body: &mut BytesMut, fourcc: &[u8; 4], config: &[u8]) {
+	body.put_u8(VIDEO_EX_HEADER | (FRAME_TYPE_KEY << 4) | VIDEO_PACKET_SEQUENCE_START);
+	body.put_slice(fourcc);
+	body.put_slice(config);
+}
+
+/// Build a minimal `AV1CodecConfigurationRecord` (av1C) from the catalog AV1
+/// struct, with an empty `configOBUs` (the sequence header is carried in band).
+fn av1c_bytes(av1: &AV1) -> [u8; 4] {
+	let high_bitdepth = av1.bitdepth >= 10;
+	let twelve_bit = av1.bitdepth >= 12;
+	[
+		0x81, // marker (1) + version (1)
+		((av1.profile & 0x07) << 5) | (av1.level & 0x1f),
+		((av1.tier == 'H') as u8) << 7
+			| (high_bitdepth as u8) << 6
+			| (twelve_bit as u8) << 5
+			| (av1.mono_chrome as u8) << 4
+			| (av1.chroma_subsampling_x as u8) << 3
+			| (av1.chroma_subsampling_y as u8) << 2
+			| (av1.chroma_sample_position & 0x03),
+		0x00, // no initial presentation delay
+	]
 }

--- a/rs/moq-mux/src/container/flv/export_test.rs
+++ b/rs/moq-mux/src/container/flv/export_test.rs
@@ -185,6 +185,96 @@ async fn export_emits_sequence_headers_and_frames() {
 	assert_eq!(audio_frames, 2, "expected two audio frames");
 }
 
+/// A real VP9 key frame (profile 0, 320x240) from the VP9 parser's test vector.
+const VP9_KEYFRAME: &[u8] = &[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00];
+
+/// Build an enhanced-RTMP FLV: VP9 video + Opus audio via the FourCC payloads.
+fn synth_enhanced_flv() -> Vec<u8> {
+	let head = crate::codec::opus::Config {
+		sample_rate: 48000,
+		channel_count: 2,
+	}
+	.encode();
+
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1);
+	out.push(0x05);
+	out.extend_from_slice(&9u32.to_be_bytes());
+	out.extend_from_slice(&0u32.to_be_bytes());
+
+	// Opus sequence start.
+	let mut aseq = vec![(super::AUDIO_FORMAT_EX << 4) | super::AUDIO_PACKET_SEQUENCE_START];
+	aseq.extend_from_slice(b"Opus");
+	aseq.extend_from_slice(&head);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &aseq);
+
+	// VP9 key frame (enhanced CodedFrames, no composition time).
+	let mut vkey = vec![super::VIDEO_EX_HEADER | (super::FRAME_TYPE_KEY << 4) | super::VIDEO_PACKET_CODED_FRAMES];
+	vkey.extend_from_slice(b"vp09");
+	vkey.extend_from_slice(VP9_KEYFRAME);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &vkey);
+
+	// One Opus frame.
+	let mut a0 = vec![(super::AUDIO_FORMAT_EX << 4) | super::AUDIO_PACKET_CODED_FRAMES];
+	a0.extend_from_slice(b"Opus");
+	a0.extend_from_slice(&[0xfc, 0xff, 0xfe]);
+	write_tag(&mut out, super::TAG_AUDIO, 20, &a0);
+
+	out
+}
+
+/// Enhanced codecs (VP9 video, Opus audio) survive an import -> export -> import
+/// round trip as enhanced-RTMP FourCC payloads.
+#[tokio::test(start_paused = true)]
+async fn export_roundtrips_enhanced() {
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let consumer = producer.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	importer
+		.decode(&bytes::BytesMut::from(synth_enhanced_flv().as_slice()))
+		.unwrap();
+	catalog.finish().unwrap();
+
+	let exporter = Export::new(consumer).await.unwrap();
+	let exported = drain_export(exporter, importer).await;
+
+	let tags = parse_tags(&exported);
+	// The video frame is an enhanced (FourCC) vp09 tag.
+	assert!(
+		tags.iter().any(|t| t.tag_type == super::TAG_VIDEO
+			&& t.body[0] & super::VIDEO_EX_HEADER != 0
+			&& &t.body[1..5] == b"vp09"),
+		"expected an enhanced vp09 video tag"
+	);
+	// The audio carries an enhanced Opus sequence header.
+	assert!(
+		tags.iter().any(|t| t.tag_type == super::TAG_AUDIO
+			&& (t.body[0] >> 4) == super::AUDIO_FORMAT_EX
+			&& &t.body[1..5] == b"Opus"),
+		"expected an enhanced Opus audio tag"
+	);
+
+	// Re-import the exported bytes and confirm the codecs rebuild.
+	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
+	let mut imp2 = Import::new(bcast2, cat2.clone());
+	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
+	imp2.finish().unwrap();
+
+	let snap = cat2.snapshot();
+	assert!(matches!(
+		snap.video.renditions.values().next().unwrap().codec,
+		VideoCodec::VP9(_)
+	));
+	assert!(matches!(
+		snap.audio.renditions.values().next().unwrap().codec,
+		AudioCodec::Opus
+	));
+}
+
 struct ParsedTag {
 	tag_type: u8,
 	timestamp: u32,

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -1,20 +1,32 @@
 //! FLV demuxer.
 //!
 //! [`Import`] reads an FLV byte stream, splits it into tags, and routes the
-//! H.264 (AVC) video and AAC audio onto MoQ tracks. FLV carries codec config
-//! out of band: the AVC sequence header is an `AVCDecoderConfigurationRecord`
-//! (avcC) and the AAC sequence header is an `AudioSpecificConfig`, both reused
-//! verbatim as the catalog `description`. Video access units are already
-//! length-prefixed NALU (the avc1 shape) and audio frames are raw AAC, so the
-//! sample bytes pass through to the [`Legacy`](crate::catalog::hang::Container)
-//! container unchanged.
+//! video and audio onto MoQ tracks. Two payload generations are handled:
+//!
+//! - **Legacy FLV/RTMP**: H.264 (AVC) video carried as length-prefixed NALU with
+//!   an out-of-band `AVCDecoderConfigurationRecord` (avcC), and AAC audio with an
+//!   out-of-band `AudioSpecificConfig`.
+//! - **Enhanced RTMP (E-RTMP)**: the FourCC-signaled payloads OBS and ffmpeg emit
+//!   for HEVC (`hvc1`), AV1 (`av01`), VP9 (`vp09`), and the legacy AVC FourCC
+//!   (`avc1`); plus enhanced audio for Opus (`Opus`), AC-3 (`ac-3`), E-AC-3
+//!   (`ec-3`), and AAC (`mp4a`).
+//!
+//! Each codec's out-of-band config record (avcC / hvcC / av1C / `AudioSpecificConfig`
+//! / `OpusHead`) becomes the catalog `description`; VP9 and the verbatim audio
+//! codecs (AC-3 / E-AC-3) carry their config in band, so they configure from the
+//! first frame instead. Sample bytes already match the [`Legacy`](crate::catalog::hang::Container)
+//! container, so no codec transform is needed. FLAC (`fLaC`) and MP3 (`.mp3`)
+//! enhanced audio, and any other codec, are logged and dropped.
 
 use bytes::{Buf, Bytes, BytesMut};
-use hang::catalog::{AAC, AudioConfig, Container, H264, VideoConfig};
+use hang::catalog::{AAC, AudioCodec, AudioConfig, Container, H264, VideoConfig};
 
 use super::{
-	AAC_RAW, AAC_SEQUENCE_HEADER, AUDIO_FORMAT_AAC, AVC_NALU, AVC_SEQUENCE_HEADER, FILE_HEADER_LEN, FRAME_TYPE_KEY,
-	PREV_TAG_SIZE_LEN, TAG_AUDIO, TAG_HEADER_LEN, TAG_SCRIPT, TAG_VIDEO, VIDEO_CODEC_AVC, read_i24, read_u24,
+	AAC_RAW, AAC_SEQUENCE_HEADER, AUDIO_FORMAT_AAC, AUDIO_FORMAT_EX, AUDIO_PACKET_CODED_FRAMES,
+	AUDIO_PACKET_MULTICHANNEL_CONFIG, AUDIO_PACKET_SEQUENCE_END, AUDIO_PACKET_SEQUENCE_START, AVC_NALU,
+	AVC_SEQUENCE_HEADER, FILE_HEADER_LEN, FRAME_TYPE_KEY, PREV_TAG_SIZE_LEN, TAG_AUDIO, TAG_HEADER_LEN, TAG_SCRIPT,
+	TAG_VIDEO, VIDEO_CODEC_AVC, VIDEO_EX_HEADER, VIDEO_PACKET_CODED_FRAMES, VIDEO_PACKET_CODED_FRAMES_X,
+	VIDEO_PACKET_METADATA, VIDEO_PACKET_SEQUENCE_END, VIDEO_PACKET_SEQUENCE_START, read_i24, read_u24,
 };
 use moq_net::Timestamp;
 
@@ -26,9 +38,9 @@ const MAX_DATA_OFFSET: usize = 64 * 1024;
 
 /// Demuxes an FLV byte stream into a MoQ broadcast.
 ///
-/// Supports H.264 (CodecID 7) video and AAC (SoundFormat 10) audio, the modern
-/// FLV payload produced by RTMP encoders and `ffmpeg -f flv`. Every other codec,
-/// plus the enhanced E-RTMP FourCC tags and `onMetaData` script tags, is logged
+/// Supports legacy H.264 + AAC and the enhanced-RTMP FourCC codecs (HEVC, AV1,
+/// VP9, Opus, AC-3, E-AC-3), the payloads produced by RTMP encoders and
+/// `ffmpeg -f flv`. Unsupported codecs, plus `onMetaData` script tags, are logged
 /// and dropped. A single FLV stream carries at most one video and one audio
 /// track; a new sequence header replaces the previous configuration.
 pub struct Import {
@@ -41,15 +53,21 @@ pub struct Import {
 	/// True once the 9-byte FLV file header and its `PreviousTagSize0` have been consumed.
 	header_seen: bool,
 
-	video: Option<Stream>,
-	audio: Option<Stream>,
+	video: Option<VideoStream>,
+	audio: Option<AudioStream>,
 }
 
-/// One demuxed track: its producer plus the sequence-header bytes last seen, so a
-/// repeated (identical) sequence header is a no-op rather than a track rebuild.
-struct Stream {
+/// The demuxed video track plus its current catalog config, so a repeated
+/// (identical) sequence header is a no-op rather than a track rebuild.
+struct VideoStream {
 	track: crate::container::Producer<crate::catalog::hang::Container>,
-	description: Bytes,
+	config: VideoConfig,
+}
+
+/// The demuxed audio track plus its current catalog config.
+struct AudioStream {
+	track: crate::container::Producer<crate::catalog::hang::Container>,
+	config: AudioConfig,
 }
 
 impl Import {
@@ -126,11 +144,11 @@ impl Import {
 			return Ok(());
 		};
 		// The enhanced E-RTMP signaling sets the high bit and switches to FourCC
-		// codec identification; we only speak classic AVC.
-		if first & 0x80 != 0 {
-			tracing::warn!("enhanced FLV (FourCC) video not supported, dropping");
-			return Ok(());
+		// codec identification.
+		if first & VIDEO_EX_HEADER != 0 {
+			return self.handle_video_enhanced(first, body, timestamp);
 		}
+
 		let frame_type = first >> 4;
 		let codec_id = first & 0x0f;
 		if codec_id != VIDEO_CODEC_AVC {
@@ -144,30 +162,64 @@ impl Import {
 		let data = &body[5..];
 
 		match avc_packet_type {
-			AVC_SEQUENCE_HEADER => self.init_video(data),
-			AVC_NALU => {
-				let Some(stream) = self.video.as_mut() else {
-					tracing::debug!("AVC NALU before sequence header, dropping");
-					return Ok(());
-				};
-				// FLV stores DTS in the tag; PTS is DTS plus the composition offset.
-				let pts_ms = (timestamp as i64) + (composition_time as i64);
-				anyhow::ensure!(pts_ms >= 0, "negative AVC presentation timestamp");
-				// Live FLV can join mid-GOP: a leading delta before the first
-				// keyframe has no group to anchor, so the producer reports
-				// MissingKeyframe and we drop it rather than abort.
-				match stream.track.write(Frame {
-					timestamp: Timestamp::from_millis(pts_ms as u64)?,
-					duration: None,
-					payload: Bytes::copy_from_slice(data),
-					keyframe: frame_type == FRAME_TYPE_KEY,
-				}) {
-					Ok(()) | Err(crate::Error::MissingKeyframe(_)) => Ok(()),
-					Err(e) => Err(e.into()),
-				}
-			}
+			AVC_SEQUENCE_HEADER => self.init_video(config_from_avcc(data)?),
+			AVC_NALU => self.write_video(data, timestamp, composition_time, frame_type == FRAME_TYPE_KEY),
 			// AVCPacketType 2 is "end of sequence"; nothing to emit.
 			_ => Ok(()),
+		}
+	}
+
+	/// Handle an enhanced-RTMP (FourCC) video tag.
+	fn handle_video_enhanced(&mut self, first: u8, body: &[u8], timestamp: u64) -> anyhow::Result<()> {
+		let frame_type = (first >> 4) & 0x07;
+		let packet_type = first & 0x0f;
+		anyhow::ensure!(body.len() >= 5, "enhanced video tag too short for FourCC");
+		let fourcc: [u8; 4] = body[1..5].try_into().expect("slice is 4 bytes");
+		let payload = &body[5..];
+		let keyframe = frame_type == FRAME_TYPE_KEY;
+
+		match packet_type {
+			VIDEO_PACKET_SEQUENCE_START => {
+				let config = match &fourcc {
+					b"avc1" => config_from_avcc(payload)?,
+					b"hvc1" => crate::codec::h265::config_from_hvcc(payload)?,
+					b"av01" => crate::codec::av1::config_from_av1c(payload)?,
+					// VP9 carries its config in band; the SequenceStart vpcC is
+					// redundant with the key-frame header we configure from.
+					b"vp09" => return Ok(()),
+					other => {
+						tracing::warn!(fourcc = ?other, "unsupported enhanced FLV video codec, dropping");
+						return Ok(());
+					}
+				};
+				self.init_video(config)
+			}
+			VIDEO_PACKET_CODED_FRAMES | VIDEO_PACKET_CODED_FRAMES_X => {
+				// hvc1/avc1 CodedFrames prefix a 3-byte composition time; CodedFramesX
+				// and the always-zero-offset av01/vp09 do not.
+				let has_cts = packet_type == VIDEO_PACKET_CODED_FRAMES && matches!(&fourcc, b"hvc1" | b"avc1");
+				let (data, cts) = if has_cts {
+					anyhow::ensure!(payload.len() >= 3, "enhanced CodedFrames missing composition time");
+					(&payload[3..], read_i24(&payload[0..3]))
+				} else {
+					(payload, 0)
+				};
+
+				// VP9 has no out-of-band config record, so configure from the first
+				// key frame's uncompressed header.
+				if &fourcc == b"vp09" && self.video.is_none() && keyframe {
+					if let Some(config) = crate::codec::vp9::config_from_keyframe(data)? {
+						self.init_video(config)?;
+					}
+				}
+
+				self.write_video(data, timestamp, cts, keyframe)
+			}
+			VIDEO_PACKET_SEQUENCE_END | VIDEO_PACKET_METADATA => Ok(()),
+			other => {
+				tracing::debug!(packet_type = other, "ignoring enhanced FLV video packet type");
+				Ok(())
+			}
 		}
 	}
 
@@ -176,6 +228,9 @@ impl Import {
 			return Ok(());
 		};
 		let sound_format = first >> 4;
+		if sound_format == AUDIO_FORMAT_EX {
+			return self.handle_audio_enhanced(first, body, timestamp);
+		}
 		if sound_format != AUDIO_FORMAT_AAC {
 			tracing::warn!(sound_format, "unsupported FLV audio format, dropping");
 			return Ok(());
@@ -186,81 +241,129 @@ impl Import {
 		let data = &body[2..];
 
 		match aac_packet_type {
-			AAC_SEQUENCE_HEADER => self.init_audio(data),
-			AAC_RAW => {
-				let Some(stream) = self.audio.as_mut() else {
-					tracing::debug!("AAC frame before sequence header, dropping");
-					return Ok(());
-				};
-				// Each frame is its own group so the relay can forward it immediately.
-				stream.track.write(Frame {
-					timestamp: Timestamp::from_millis(timestamp)?,
-					duration: None,
-					payload: Bytes::copy_from_slice(data),
-					keyframe: true,
-				})?;
-				stream.track.finish_group()?;
-				Ok(())
-			}
+			AAC_SEQUENCE_HEADER => self.init_audio(config_from_asc(data)?),
+			AAC_RAW => self.write_audio(data, timestamp),
 			_ => Ok(()),
 		}
 	}
 
-	/// Handle an AVC sequence header (an `AVCDecoderConfigurationRecord`). On the
-	/// first one, or whenever the bytes change, (re)build the video track.
-	fn init_video(&mut self, avcc_bytes: &[u8]) -> anyhow::Result<()> {
-		if self.video.as_ref().is_some_and(|s| s.description == avcc_bytes) {
+	/// Handle an enhanced-RTMP (FourCC) audio tag.
+	fn handle_audio_enhanced(&mut self, first: u8, body: &[u8], timestamp: u64) -> anyhow::Result<()> {
+		let packet_type = first & 0x0f;
+		anyhow::ensure!(body.len() >= 5, "enhanced audio tag too short for FourCC");
+		let fourcc: [u8; 4] = body[1..5].try_into().expect("slice is 4 bytes");
+		let payload = &body[5..];
+
+		match packet_type {
+			AUDIO_PACKET_SEQUENCE_START => {
+				let config = match &fourcc {
+					b"Opus" => config_from_opus_head(payload)?,
+					b"mp4a" => config_from_asc(payload)?,
+					// AC-3 / E-AC-3 are verbatim with no sequence header; they
+					// configure from the first frame. Anything else is unsupported.
+					other => {
+						tracing::warn!(fourcc = ?other, "unsupported enhanced FLV audio codec, dropping");
+						return Ok(());
+					}
+				};
+				self.init_audio(config)
+			}
+			AUDIO_PACKET_CODED_FRAMES => {
+				// AC-3 / E-AC-3 carry their config in the frame header, so configure
+				// from the first frame when no sequence header preceded it.
+				if self.audio.is_none() {
+					let config = match &fourcc {
+						b"ac-3" => Some(config_from_ac3(payload)?),
+						b"ec-3" => Some(config_from_eac3(payload)?),
+						_ => None,
+					};
+					if let Some(config) = config {
+						self.init_audio(config)?;
+					}
+				}
+				self.write_audio(payload, timestamp)
+			}
+			AUDIO_PACKET_SEQUENCE_END | AUDIO_PACKET_MULTICHANNEL_CONFIG => Ok(()),
+			other => {
+				tracing::debug!(packet_type = other, "ignoring enhanced FLV audio packet type");
+				Ok(())
+			}
+		}
+	}
+
+	/// Write one decoded video sample, dropping a leading delta before the first
+	/// keyframe (a mid-GOP join) rather than aborting.
+	fn write_video(&mut self, data: &[u8], dts: u64, composition_time: i32, keyframe: bool) -> anyhow::Result<()> {
+		let Some(stream) = self.video.as_mut() else {
+			tracing::debug!("video frame before sequence header, dropping");
+			return Ok(());
+		};
+		// FLV stores DTS in the tag; PTS is DTS plus the composition offset.
+		let pts_ms = (dts as i64) + (composition_time as i64);
+		anyhow::ensure!(pts_ms >= 0, "negative video presentation timestamp");
+		match stream.track.write(Frame {
+			timestamp: Timestamp::from_millis(pts_ms as u64)?,
+			duration: None,
+			payload: Bytes::copy_from_slice(data),
+			keyframe,
+		}) {
+			Ok(()) | Err(crate::Error::MissingKeyframe(_)) => Ok(()),
+			Err(e) => Err(e.into()),
+		}
+	}
+
+	/// Write one audio frame as its own group, so the relay can forward it immediately.
+	fn write_audio(&mut self, data: &[u8], timestamp: u64) -> anyhow::Result<()> {
+		let Some(stream) = self.audio.as_mut() else {
+			tracing::debug!("audio frame before config, dropping");
+			return Ok(());
+		};
+		stream.track.write(Frame {
+			timestamp: Timestamp::from_millis(timestamp)?,
+			duration: None,
+			payload: Bytes::copy_from_slice(data),
+			keyframe: true,
+		})?;
+		stream.track.finish_group()?;
+		Ok(())
+	}
+
+	/// (Re)build the video track for `config`, unless it matches the current one.
+	fn init_video(&mut self, config: VideoConfig) -> anyhow::Result<()> {
+		if self.video.as_ref().is_some_and(|s| s.config == config) {
 			return Ok(());
 		}
-
-		let avcc = crate::codec::h264::Avcc::parse(avcc_bytes)?;
-		let mut config = VideoConfig::new(H264 {
-			profile: avcc.profile,
-			constraints: avcc.constraints,
-			level: avcc.level,
-			inline: false,
-		});
-		config.description = Some(Bytes::copy_from_slice(avcc_bytes));
-		config.coded_width = avcc.coded_width;
-		config.coded_height = avcc.coded_height;
-		config.container = Container::Legacy;
 
 		let net_track = self.replace_video()?;
 		self.catalog
 			.lock()
 			.video
 			.renditions
-			.insert(net_track.name().to_string(), config);
-		self.video = Some(Stream {
+			.insert(net_track.name().to_string(), config.clone());
+		self.video = Some(VideoStream {
 			// Leading deltas before the first keyframe are skipped at the write
 			// site (the producer reports MissingKeyframe), so a mid-GOP join works.
 			track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy),
-			description: Bytes::copy_from_slice(avcc_bytes),
+			config,
 		});
 		Ok(())
 	}
 
-	/// Handle an AAC sequence header (an `AudioSpecificConfig`).
-	fn init_audio(&mut self, asc_bytes: &[u8]) -> anyhow::Result<()> {
-		if self.audio.as_ref().is_some_and(|s| s.description == asc_bytes) {
+	/// (Re)build the audio track for `config`, unless it matches the current one.
+	fn init_audio(&mut self, config: AudioConfig) -> anyhow::Result<()> {
+		if self.audio.as_ref().is_some_and(|s| s.config == config) {
 			return Ok(());
 		}
-
-		let mut cursor = asc_bytes;
-		let cfg = crate::codec::aac::Config::parse(&mut cursor)?;
-		let mut config = AudioConfig::new(AAC { profile: cfg.profile }, cfg.sample_rate, cfg.channel_count);
-		config.description = Some(Bytes::copy_from_slice(asc_bytes));
-		config.container = Container::Legacy;
 
 		let net_track = self.replace_audio()?;
 		self.catalog
 			.lock()
 			.audio
 			.renditions
-			.insert(net_track.name().to_string(), config);
-		self.audio = Some(Stream {
+			.insert(net_track.name().to_string(), config.clone());
+		self.audio = Some(AudioStream {
 			track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy),
-			description: Bytes::copy_from_slice(asc_bytes),
+			config,
 		});
 		Ok(())
 	}
@@ -324,4 +427,56 @@ impl Drop for Import {
 			catalog.audio.renditions.remove(stream.track.name());
 		}
 	}
+}
+
+/// Build a video config for the `avc1` shape from an `AVCDecoderConfigurationRecord`.
+fn config_from_avcc(avcc_bytes: &[u8]) -> anyhow::Result<VideoConfig> {
+	let avcc = crate::codec::h264::Avcc::parse(avcc_bytes)?;
+	let mut config = VideoConfig::new(H264 {
+		profile: avcc.profile,
+		constraints: avcc.constraints,
+		level: avcc.level,
+		inline: false,
+	});
+	config.description = Some(Bytes::copy_from_slice(avcc_bytes));
+	config.coded_width = avcc.coded_width;
+	config.coded_height = avcc.coded_height;
+	config.container = Container::Legacy;
+	Ok(config)
+}
+
+/// Build an audio config for AAC from an `AudioSpecificConfig`.
+fn config_from_asc(asc_bytes: &[u8]) -> anyhow::Result<AudioConfig> {
+	let mut cursor = asc_bytes;
+	let cfg = crate::codec::aac::Config::parse(&mut cursor)?;
+	let mut config = AudioConfig::new(AAC { profile: cfg.profile }, cfg.sample_rate, cfg.channel_count);
+	config.description = Some(Bytes::copy_from_slice(asc_bytes));
+	config.container = Container::Legacy;
+	Ok(config)
+}
+
+/// Build an audio config for Opus from an `OpusHead` (RFC 7845) record.
+fn config_from_opus_head(head: &[u8]) -> anyhow::Result<AudioConfig> {
+	let mut cursor = head;
+	let cfg = crate::codec::opus::Config::parse(&mut cursor)?;
+	let mut config = AudioConfig::new(AudioCodec::Opus, cfg.sample_rate, cfg.channel_count);
+	config.description = Some(Bytes::copy_from_slice(head));
+	config.container = Container::Legacy;
+	Ok(config)
+}
+
+/// Build an audio config for AC-3 from a sync frame header.
+fn config_from_ac3(frame: &[u8]) -> anyhow::Result<AudioConfig> {
+	let header = crate::codec::ac3::parse_header(frame)?;
+	let mut config = AudioConfig::new(AudioCodec::Ac3, header.sample_rate, header.channel_count);
+	config.container = Container::Legacy;
+	Ok(config)
+}
+
+/// Build an audio config for E-AC-3 from a sync frame header.
+fn config_from_eac3(frame: &[u8]) -> anyhow::Result<AudioConfig> {
+	let header = crate::codec::eac3::parse_header(frame)?;
+	let mut config = AudioConfig::new(AudioCodec::Ec3, header.sample_rate, header.channel_count);
+	config.container = Container::Legacy;
+	Ok(config)
 }

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -205,11 +205,15 @@ impl Import {
 					(payload, 0)
 				};
 
-				// VP9 has no out-of-band config record, so configure from the first
-				// key frame's uncompressed header.
-				if &fourcc == b"vp09" && self.video.is_none() && keyframe {
-					if let Some(config) = crate::codec::vp9::config_from_keyframe(data)? {
-						self.init_video(config)?;
+				// VP9 has no out-of-band config record, so (re)configure from each key
+				// frame's uncompressed header. `init_video` dedups when unchanged, so
+				// this is a no-op except on the first key frame or a resolution change.
+				// A malformed header drops just this frame rather than aborting the stream.
+				if &fourcc == b"vp09" && keyframe {
+					match crate::codec::vp9::config_from_keyframe(data) {
+						Ok(Some(config)) => self.init_video(config)?,
+						Ok(None) => {}
+						Err(err) => tracing::warn!(%err, "dropping malformed VP9 key frame"),
 					}
 				}
 

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -149,6 +149,85 @@ async fn import_handles_split_input() {
 	assert_eq!(snap.audio.renditions.len(), 1);
 }
 
+/// A real VP9 key frame (profile 0, 320x240), borrowed from the VP9 parser's
+/// own test vector. Bytes after the frame size are irrelevant to the header.
+const VP9_KEYFRAME_320X240: &[u8] = &[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00];
+
+/// Enhanced-RTMP (FourCC) VP9 video configures from the key frame and emits it.
+#[tokio::test(start_paused = true)]
+async fn import_enhanced_vp9() {
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1);
+	out.push(0x01); // video only
+	out.extend_from_slice(&9u32.to_be_bytes());
+	out.extend_from_slice(&0u32.to_be_bytes());
+
+	// Ex-video CodedFrames keyframe: high bit set, frame type 1, packet type 1.
+	let first = super::VIDEO_EX_HEADER | (super::FRAME_TYPE_KEY << 4) | super::VIDEO_PACKET_CODED_FRAMES;
+	let mut body = vec![first];
+	body.extend_from_slice(b"vp09");
+	body.extend_from_slice(VP9_KEYFRAME_320X240);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &body);
+
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	assert_eq!(snap.video.renditions.len(), 1);
+	let v = snap.video.renditions.values().next().unwrap();
+	assert!(matches!(v.codec, VideoCodec::VP9(_)));
+	assert_eq!(v.coded_width, Some(320));
+	assert_eq!(v.coded_height, Some(240));
+}
+
+/// Enhanced-RTMP (FourCC) Opus audio configures from the `OpusHead` sequence
+/// header and carries the frames through.
+#[tokio::test(start_paused = true)]
+async fn import_enhanced_opus() {
+	let head = crate::codec::opus::Config {
+		sample_rate: 48000,
+		channel_count: 2,
+	}
+	.encode();
+
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1);
+	out.push(0x04); // audio only
+	out.extend_from_slice(&9u32.to_be_bytes());
+	out.extend_from_slice(&0u32.to_be_bytes());
+
+	// Ex-audio SequenceStart: SoundFormat 9, packet type 0.
+	let mut seq = vec![(super::AUDIO_FORMAT_EX << 4) | super::AUDIO_PACKET_SEQUENCE_START];
+	seq.extend_from_slice(b"Opus");
+	seq.extend_from_slice(&head);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &seq);
+
+	// Ex-audio CodedFrames: SoundFormat 9, packet type 1.
+	let mut frame = vec![(super::AUDIO_FORMAT_EX << 4) | super::AUDIO_PACKET_CODED_FRAMES];
+	frame.extend_from_slice(b"Opus");
+	frame.extend_from_slice(&[0xfc, 0xff, 0xfe]);
+	write_tag(&mut out, super::TAG_AUDIO, 20, &frame);
+
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	assert_eq!(snap.audio.renditions.len(), 1);
+	let a = snap.audio.renditions.values().next().unwrap();
+	assert!(matches!(a.codec, AudioCodec::Opus));
+	assert_eq!(a.sample_rate, 48000);
+	assert_eq!(a.channel_count, 2);
+	assert_eq!(a.description.as_ref().map(|b| b.as_ref()), Some(head.as_ref()));
+}
+
 #[tokio::test(start_paused = true)]
 async fn import_rejects_non_flv() {
 	let mut producer = moq_net::BroadcastInfo::new().produce();

--- a/rs/moq-mux/src/container/flv/mod.rs
+++ b/rs/moq-mux/src/container/flv/mod.rs
@@ -1,15 +1,21 @@
 //! FLV (Flash Video / RTMP container).
 //!
 //! An interchange format only, not a wire format: [`Import`] demuxes an FLV byte
-//! stream into a broadcast and [`Export`] muxes a broadcast back into FLV. Only
-//! the modern FLV payload is handled: H.264 (AVC) video carried as
-//! length-prefixed NALU with an out-of-band `AVCDecoderConfigurationRecord`
-//! (avcC), and AAC audio carried raw with an out-of-band `AudioSpecificConfig`.
-//! Both records pass straight through as the catalog `description`, and the
-//! sample bytes already match the [`Legacy`](crate::catalog::hang::Container)
-//! container, so no codec transform is needed. Other legacy codecs (VP6, MP3,
-//! Speex, …) and the enhanced E-RTMP FourCC payloads are logged and dropped on
-//! import, and rejected on export.
+//! stream into a broadcast and [`Export`] muxes a broadcast back into FLV. Two
+//! payload generations are handled:
+//!
+//! - **Legacy FLV/RTMP**: H.264 (AVC) video as length-prefixed NALU with an
+//!   out-of-band `AVCDecoderConfigurationRecord` (avcC), and AAC audio with an
+//!   out-of-band `AudioSpecificConfig`.
+//! - **Enhanced RTMP (E-RTMP)**: the FourCC payloads for HEVC (`hvc1`), AV1
+//!   (`av01`), VP9 (`vp09`), Opus (`Opus`), AC-3 (`ac-3`), and E-AC-3 (`ec-3`).
+//!
+//! Each codec's config record passes straight through as the catalog
+//! `description` (or, for the in-band codecs VP9 / AC-3 / E-AC-3, is read from the
+//! frame), and the sample bytes already match the
+//! [`Legacy`](crate::catalog::hang::Container) container, so no codec transform is
+//! needed. Other legacy codecs (VP6, MP3, Speex, …) and the E-RTMP FLAC / MP3
+//! audio are logged and dropped on import, and rejected on export.
 
 mod export;
 mod import;
@@ -60,6 +66,28 @@ const AAC_RAW: u8 = 1;
 /// (44 kHz flag), SoundSize 1 (16-bit), SoundType 1 (stereo). The real rate and
 /// channel layout live in the `AudioSpecificConfig`, so these bits are nominal.
 const AAC_AUDIO_TAG_HEADER: u8 = (AUDIO_FORMAT_AAC << 4) | (3 << 2) | (1 << 1) | 1;
+
+/// Enhanced-RTMP (E-RTMP) video signaling: a set high bit on a video tag's
+/// first byte switches from a legacy CodecID to a FourCC codec + packet type.
+const VIDEO_EX_HEADER: u8 = 0x80;
+
+/// Enhanced video `VideoPacketType` (low nibble of an ex-video tag's first byte).
+const VIDEO_PACKET_SEQUENCE_START: u8 = 0;
+const VIDEO_PACKET_CODED_FRAMES: u8 = 1;
+const VIDEO_PACKET_SEQUENCE_END: u8 = 2;
+/// Coded frames with the composition-time offset omitted (always zero).
+const VIDEO_PACKET_CODED_FRAMES_X: u8 = 3;
+const VIDEO_PACKET_METADATA: u8 = 4;
+
+/// Enhanced-RTMP audio signaling: SoundFormat 9 in the high nibble of an audio
+/// tag's first byte switches to a FourCC codec + packet type.
+const AUDIO_FORMAT_EX: u8 = 9;
+
+/// Enhanced audio `AudioPacketType` (low nibble of an ex-audio tag's first byte).
+const AUDIO_PACKET_SEQUENCE_START: u8 = 0;
+const AUDIO_PACKET_CODED_FRAMES: u8 = 1;
+const AUDIO_PACKET_SEQUENCE_END: u8 = 2;
+const AUDIO_PACKET_MULTICHANNEL_CONFIG: u8 = 3;
 
 /// Read a 24-bit big-endian unsigned integer.
 fn read_u24(b: &[u8]) -> u32 {

--- a/rs/moq-mux/src/container/flv/mod.rs
+++ b/rs/moq-mux/src/container/flv/mod.rs
@@ -87,7 +87,7 @@ const AUDIO_FORMAT_EX: u8 = 9;
 const AUDIO_PACKET_SEQUENCE_START: u8 = 0;
 const AUDIO_PACKET_CODED_FRAMES: u8 = 1;
 const AUDIO_PACKET_SEQUENCE_END: u8 = 2;
-const AUDIO_PACKET_MULTICHANNEL_CONFIG: u8 = 3;
+const AUDIO_PACKET_MULTICHANNEL_CONFIG: u8 = 4;
 
 /// Read a 24-bit big-endian unsigned integer.
 fn read_u24(b: &[u8]) -> u32 {

--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name = "moq-rtmp"
+description = "RTMP / enhanced-RTMP contribution ingest gateway for Media over QUIC"
+authors = ["Luke Curley <kixelated@gmail.com>"]
+repository = "https://github.com/moq-dev/moq"
+license = "MIT OR Apache-2.0"
+
+version = "0.0.1"
+edition = "2024"
+rust-version.workspace = true
+
+keywords = ["rtmp", "moq", "media", "live", "flv"]
+categories = ["multimedia", "network-programming", "web-programming"]
+
+[lib]
+doctest = false
+
+[[bin]]
+name = "moq-rtmp"
+path = "bin/moq-rtmp.rs"
+doc = false
+# The binary (relay client/server, CLI) needs the `server` feature; the library
+# can be depended on with `default-features = false` for ingest only (e.g. a
+# relay that embeds the RTMP listener and publishes into its own origin).
+required-features = ["server"]
+
+[features]
+default = ["server", "quinn", "websocket"]
+# Relay client/server transports + the moq-rtmp binary. Pulls in moq-native /
+# axum / clap / rustls.
+server = ["dep:axum", "dep:axum-server", "dep:clap", "dep:moq-native", "dep:rustls", "dep:sd-notify", "dep:tower-http", "dep:url"]
+quinn = ["server", "moq-native/quinn"]
+quiche = ["server", "moq-native/quiche"]
+websocket = ["server", "moq-native/websocket"]
+iroh = ["server", "moq-native/iroh"]
+
+# The ingest library needs only anyhow/bytes/moq-mux/moq-net/rml_rtmp/thiserror/
+# tokio/tracing; the rest (axum/clap/moq-native/rustls/tower-http/url/sd-notify)
+# are `optional` and pulled in by the `server` feature for the binary.
+[dependencies]
+anyhow = { version = "1", features = ["backtrace"] }
+axum = { version = "0.8", features = ["tokio"], optional = true }
+axum-server = { version = "0.8", features = ["tls-rustls"], optional = true }
+bytes = "1"
+clap = { version = "4", features = ["derive"], optional = true }
+futures = "0.3"
+moq-mux = { workspace = true }
+moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"], optional = true }
+moq-net = { workspace = true }
+# Pure-Rust RTMP (no librtmp / ffmpeg): handshake + chunk codec + the
+# server-session state machine. RTMP carries FLV, demuxed by moq-mux.
+rml_rtmp = "0.8"
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"], optional = true }
+thiserror = "2"
+tokio = { workspace = true, features = ["full"] }
+tower-http = { version = "0.6", features = ["cors", "fs"], optional = true }
+tracing = "0.1"
+url = { version = "2", optional = true }
+
+[target.'cfg(unix)'.dependencies]
+sd-notify = { version = "0.5", optional = true }

--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -28,15 +28,17 @@ required-features = ["server"]
 default = ["server", "quinn", "websocket"]
 # Relay client/server transports + the moq-rtmp binary. Pulls in moq-native /
 # axum / clap / rustls.
-server = ["dep:axum", "dep:axum-server", "dep:clap", "dep:moq-native", "dep:rustls", "dep:sd-notify", "dep:tower-http", "dep:url"]
+server = ["dep:axum", "dep:axum-server", "dep:clap", "dep:moq-native", "dep:rustls", "dep:sd-notify", "dep:tokio-rustls", "dep:tower-http", "dep:url"]
 quinn = ["server", "moq-native/quinn"]
 quiche = ["server", "moq-native/quiche"]
 websocket = ["server", "moq-native/websocket"]
 iroh = ["server", "moq-native/iroh"]
 
 # The ingest library needs only anyhow/bytes/moq-mux/moq-net/rml_rtmp/thiserror/
-# tokio/tracing; the rest (axum/clap/moq-native/rustls/tower-http/url/sd-notify)
-# are `optional` and pulled in by the `server` feature for the binary.
+# tokio/tracing; the rest (axum/clap/moq-native/rustls/tokio-rustls/tower-http/
+# url/sd-notify) are `optional` and pulled in by the `server` feature. RTMPS
+# (Config::tls / Server::with_tls) needs rustls + tokio-rustls, so it's
+# server-gated too.
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 axum = { version = "0.8", features = ["tokio"], optional = true }
@@ -53,6 +55,10 @@ rml_rtmp = "0.8"
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"], optional = true }
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }
+# RTMPS: TLS-terminate accepted connections. Mirrors moq-relay's pinning so the
+# workspace shares one tokio-rustls; the crypto provider comes from the supplied
+# `rustls::ServerConfig`, so no default crypto feature is needed here.
+tokio-rustls = { version = "0.26", default-features = false, optional = true }
 tower-http = { version = "0.6", features = ["cors", "fs"], optional = true }
 tracing = "0.1"
 url = { version = "2", optional = true }

--- a/rs/moq-rtmp/README.md
+++ b/rs/moq-rtmp/README.md
@@ -66,6 +66,35 @@ while let Some(request) = server.accept().await {
 }
 ```
 
+### RTMPS (RTMP over TLS)
+
+Two ways to serve `rtmps://`:
+
+- **Let the gateway terminate TLS.** Set `Config::tls` (or call
+  `Server::with_tls`) with a `rustls::ServerConfig`, and the listener speaks
+  RTMPS with no other change. Build the config from a cert/key with
+  `moq_native::tls::Server::server_config(vec![])` (RTMPS has no ALPN), or any
+  `rustls::ServerConfig`. To serve both RTMP and RTMPS, run two listeners
+  (`run` once per config) against a cloned origin.
+
+  ```rust
+  let mut rtmps = moq_rtmp::Config::default();
+  rtmps.listen = Some("0.0.0.0:443".parse()?);
+  rtmps.tls = Some(server_config); // Arc<rustls::ServerConfig>
+  ```
+
+- **Bring your own transport.** Accept the connection and complete the TLS
+  handshake yourself (or use any other `AsyncRead + AsyncWrite` stream: a proxy
+  socket, a test pipe), then hand the established stream to `accept_stream`,
+  which runs the RTMP handshake and yields the same `Request`:
+
+  ```rust
+  let tls = acceptor.accept(tcp).await?; // your tokio_rustls TlsAcceptor
+  if let Some(request) = moq_rtmp::accept_stream(tls, peer).await? {
+      // authorize, then request.accept(&origin, &path).await?
+  }
+  ```
+
 ## Binary
 
 The `moq-rtmp` binary (needs the default `server` feature) has two modes.
@@ -86,6 +115,17 @@ WebTransport (like `moq-srt publish` / `moq-hls import`):
 ```bash
 moq-rtmp publish --relay https://relay.example.com \
   --rtmp-listen 0.0.0.0:1935 --rtmp-prefix live/
+```
+
+Either mode also accepts RTMPS alongside plaintext RTMP. Add `--rtmps-listen`
+with a cert (`--rtmps-tls-cert` / `--rtmps-tls-key`, or `--rtmps-tls-generate`
+for a throwaway self-signed cert), and OBS/ffmpeg can publish to `rtmps://`:
+
+```bash
+moq-rtmp serve --server-bind [::]:443 --tls-generate localhost \
+  --rtmp-listen 0.0.0.0:1935 \
+  --rtmps-listen 0.0.0.0:1936 --rtmps-tls-cert cert.pem --rtmps-tls-key key.pem \
+  --rtmp-prefix live/
 ```
 
 Feed either mode with any RTMP source. OBS: set the server to

--- a/rs/moq-rtmp/README.md
+++ b/rs/moq-rtmp/README.md
@@ -1,0 +1,116 @@
+# moq-rtmp
+
+RTMP / enhanced-RTMP contribution ingest gateway for Media over QUIC.
+
+RTMP carries FLV-format audio/video. This crate runs an RTMP server, re-wraps
+each connection's messages as FLV tags, demuxes them with
+[`moq-mux`](../moq-mux), and publishes the result into a MoQ origin as ordinary
+broadcasts. It's the contribution-ingest analogue of `moq-srt`, `moq-hls`'s
+import, and `moq-rtc`'s WHIP. Both legacy RTMP (H.264 + AAC) and enhanced RTMP
+(E-RTMP: HEVC, AV1, VP9, Opus, AC-3) work, since the codec handling lives in the
+`moq-mux` FLV demuxer. Pure Rust: the protocol is provided by `rml_rtmp`, with no
+librtmp or ffmpeg dependency.
+
+## Library
+
+Depend on it with `default-features = false` to skip the binary's relay
+client/server and CLI dependencies:
+
+```toml
+moq-rtmp = { version = "0.0.1", default-features = false }
+```
+
+There are two entry points.
+
+### `run` (unauthenticated)
+
+`Config` + `run` accepts every publisher and routes by prefix + app/key. A relay
+embeds ingest by calling `run` against its own origin, so the ingested media is
+published locally with no extra hop:
+
+```rust
+let mut rtmp = moq_rtmp::Config::default();
+rtmp.listen = Some("0.0.0.0:1935".parse()?);
+rtmp.prefix = "live/".to_string();
+
+// `origin` is your relay's local origin (e.g. `cluster.origin.clone()`).
+tokio::select! {
+    res = moq_rtmp::run(origin, rtmp) => res?,
+    // ... your relay's accept loop, web server, etc.
+}
+```
+
+### `Server` / `Request` (bring your own auth)
+
+To gate ingest, drive the `Server` directly. `accept` runs the handshake and the
+connect/publish exchange, then yields a `Request` once the client wants to
+publish. You inspect the app and stream key, make a decision, and `accept` or
+`reject` it. This mirrors `moq-native`'s `Server` / `Request`, so there's no
+callback: the auth policy lives in your loop.
+
+```rust
+let mut server = moq_rtmp::Server::bind("0.0.0.0:1935".parse()?).await?;
+while let Some(request) = server.accept().await {
+    let origin = origin.clone();
+    // Spawn per connection: `accept` pumps media for the whole connection, so
+    // handling it inline would serialize publishers.
+    tokio::spawn(async move {
+        // Treat the stream key as a token (e.g. a moq-token JWT) and the app as
+        // the broadcast path. Verify however you like; on success choose where to
+        // publish (`origin` can be scoped per token with `with_root` / `scope`).
+        match authorize(request.app(), request.stream_key()).await {
+            Ok(path) => { let _ = request.accept(&origin, &path).await; }
+            Err(err) => { let _ = request.reject(&err.to_string()).await; }
+        }
+    });
+}
+```
+
+## Binary
+
+The `moq-rtmp` binary (needs the default `server` feature) has two modes.
+
+`serve` ingests RTMP and serves it directly as a local relay, so MoQ subscribers
+(native or browser) connect straight to this binary. It also exposes the
+`/certificate.sha256` endpoint browsers need for self-signed `http://` origins,
+and can serve a static player directory with `--dir`:
+
+```bash
+moq-rtmp serve --server-bind [::]:443 --tls-generate localhost \
+  --rtmp-listen 0.0.0.0:1935 --rtmp-prefix live/
+```
+
+`publish` instead forwards every ingested broadcast out to a remote relay over
+WebTransport (like `moq-srt publish` / `moq-hls import`):
+
+```bash
+moq-rtmp publish --relay https://relay.example.com \
+  --rtmp-listen 0.0.0.0:1935 --rtmp-prefix live/
+```
+
+Feed either mode with any RTMP source. OBS: set the server to
+`rtmp://127.0.0.1:1935/live` and the stream key to `cam0`. ffmpeg:
+
+```bash
+# Lands at broadcast `live/cam0`.
+ffmpeg -re -i input.mp4 -c copy -f flv rtmp://127.0.0.1:1935/live/cam0
+
+# Enhanced RTMP (HEVC) lands the same way.
+ffmpeg -re -i input.mp4 -c:v hevc -c:a aac -f flv rtmp://127.0.0.1:1935/live/cam0
+```
+
+## Routing
+
+Each connection's broadcast path is `<app>/<key>`, from the RTMP app and stream
+key (`rtmp://host/<app>/<key>`), falling back to just the app when the key is
+empty. `--rtmp-prefix` is prepended to namespace a listener's streams. First
+publisher on a path wins; a second connection to the same path is rejected.
+
+## Auth
+
+The `run` entry point and the `moq-rtmp` binary are unauthenticated: anyone who
+can reach the TCP port can publish, so gate them with a host firewall or a
+private network. To authenticate, use the `Server` / `Request` API above and
+verify each publish in your accept loop (e.g. the stream key as a moq-token JWT,
+the app as the broadcast path) before calling `request.accept`. That is the
+intended integration point for a relay that already has JWT/path auth.

--- a/rs/moq-rtmp/bin/moq-rtmp.rs
+++ b/rs/moq-rtmp/bin/moq-rtmp.rs
@@ -1,0 +1,152 @@
+//! `moq-rtmp` binary.
+//!
+//! Ingests RTMP / enhanced-RTMP (OBS, ffmpeg, hardware encoders) and exposes it
+//! over MoQ two ways:
+//!
+//! - `serve` runs a local QUIC/WebTransport server so subscribers connect
+//!   straight to this binary (no separate relay needed).
+//! - `publish` forwards every ingested broadcast out to a remote relay over
+//!   WebTransport, like `moq-srt publish` / `moq-hls import` / `moq-rtc` WHIP.
+//!
+//! A relay that wants in-process ingest should instead depend on the `moq-rtmp`
+//! library and call `moq_rtmp::run` against its own origin.
+
+mod serve;
+mod web;
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::{Args, Parser, Subcommand};
+use url::Url;
+
+#[derive(Parser, Clone)]
+#[command(name = "moq-rtmp", version)]
+struct Cli {
+	#[command(flatten)]
+	log: moq_native::Log,
+
+	#[command(subcommand)]
+	command: Command,
+}
+
+#[derive(Subcommand, Clone)]
+enum Command {
+	/// Ingest RTMP and serve it directly as a local relay.
+	Serve {
+		/// The QUIC/WebTransport server configuration.
+		#[command(flatten)]
+		config: moq_native::ServerConfig,
+
+		/// Optionally serve static files (e.g. a web player) from this directory.
+		#[arg(long)]
+		dir: Option<PathBuf>,
+
+		#[command(flatten)]
+		rtmp: RtmpArgs,
+	},
+	/// Ingest RTMP and publish the broadcasts to a remote MoQ relay.
+	Publish {
+		/// The MoQ client configuration.
+		#[command(flatten)]
+		config: moq_native::ClientConfig,
+
+		/// URL of the MoQ relay to publish into (e.g. `https://relay.example.com`).
+		///
+		/// `https://` makes a WebTransport connection over QUIC. `http://` first
+		/// fetches `/certificate.sha256` for the TLS fingerprint (insecure). The
+		/// `?jwt=` query parameter supplies a moq-token-cli JWT; otherwise the
+		/// public path (if any) is used.
+		#[arg(long, env = "MOQ_RTMP_RELAY")]
+		relay: Url,
+
+		#[command(flatten)]
+		rtmp: RtmpArgs,
+	},
+}
+
+/// CLI flags for the RTMP listener, converted into a [`moq_rtmp::Config`].
+#[derive(Args, Clone)]
+struct RtmpArgs {
+	/// Address to listen on for RTMP ingest. RTMP's well-known port is 1935.
+	#[arg(long = "rtmp-listen", env = "MOQ_RTMP_LISTEN", default_value = "[::]:1935")]
+	listen: SocketAddr,
+
+	/// Prefix prepended to every ingested broadcast path (e.g. `live/`).
+	#[arg(long = "rtmp-prefix", env = "MOQ_RTMP_PREFIX", default_value = "")]
+	prefix: String,
+}
+
+impl From<RtmpArgs> for moq_rtmp::Config {
+	fn from(args: RtmpArgs) -> Self {
+		let mut config = moq_rtmp::Config::default();
+		config.listen = Some(args.listen);
+		config.prefix = args.prefix;
+		config
+	}
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+	// moq-native pulls in `ring` somewhere transitively, so install the
+	// aws-lc-rs provider explicitly (mirrors moq-cli's main).
+	rustls::crypto::aws_lc_rs::default_provider()
+		.install_default()
+		.expect("failed to install default crypto provider");
+
+	let cli = Cli::parse();
+	cli.log.init()?;
+
+	match cli.command {
+		Command::Serve { config, dir, rtmp } => run_serve(config, dir, rtmp.into()).await,
+		Command::Publish { config, relay, rtmp } => run_publish(config, relay, rtmp.into()).await,
+	}
+}
+
+/// Run a local QUIC/WebTransport server and ingest RTMP directly into it.
+async fn run_serve(
+	config: moq_native::ServerConfig,
+	dir: Option<PathBuf>,
+	rtmp: moq_rtmp::Config,
+) -> anyhow::Result<()> {
+	let web_bind = config.bind.clone().unwrap_or_else(|| "[::]:443".to_string());
+
+	let server = config.init().context("init moq server")?;
+	let web_tls = server.tls_info();
+
+	// RTMP publishes broadcasts into this origin; the server serves them out.
+	let origin = moq_net::Origin::random().produce();
+
+	tracing::info!(%web_bind, "moq-rtmp serving");
+
+	#[cfg(unix)]
+	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
+
+	tokio::select! {
+		res = serve::run(server, origin.clone()) => res.context("moq server failed"),
+		res = web::run(&web_bind, web_tls, dir) => res.context("web server failed"),
+		res = moq_rtmp::run(origin, rtmp) => res.context("rtmp ingest failed"),
+		_ = tokio::signal::ctrl_c() => Ok(()),
+	}
+}
+
+/// Ingest RTMP and forward every broadcast to a remote relay at `relay`.
+async fn run_publish(config: moq_native::ClientConfig, relay: Url, rtmp: moq_rtmp::Config) -> anyhow::Result<()> {
+	let client = config.init().context("init moq client")?;
+
+	// RTMP publishes broadcasts into this origin; the client forwards them on.
+	let origin = moq_net::Origin::random().produce();
+	let reconnect = client.with_publisher(&origin).reconnect(relay.clone());
+
+	tracing::info!(%relay, "moq-rtmp publishing");
+
+	#[cfg(unix)]
+	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
+
+	tokio::select! {
+		res = moq_rtmp::run(origin, rtmp) => res.context("rtmp ingest failed"),
+		res = reconnect.closed() => res.context("relay connection failed"),
+		_ = tokio::signal::ctrl_c() => Ok(()),
+	}
+}

--- a/rs/moq-rtmp/bin/moq-rtmp.rs
+++ b/rs/moq-rtmp/bin/moq-rtmp.rs
@@ -66,24 +66,65 @@ enum Command {
 	},
 }
 
-/// CLI flags for the RTMP listener, converted into a [`moq_rtmp::Config`].
+/// CLI flags for the RTMP listener(s), converted into [`moq_rtmp::Config`]s.
 #[derive(Args, Clone)]
 struct RtmpArgs {
-	/// Address to listen on for RTMP ingest. RTMP's well-known port is 1935.
+	/// Address to listen on for plaintext RTMP ingest (`rtmp://`). RTMP's
+	/// well-known port is 1935.
 	#[arg(long = "rtmp-listen", env = "MOQ_RTMP_LISTEN", default_value = "[::]:1935")]
 	listen: SocketAddr,
 
 	/// Prefix prepended to every ingested broadcast path (e.g. `live/`).
 	#[arg(long = "rtmp-prefix", env = "MOQ_RTMP_PREFIX", default_value = "")]
 	prefix: String,
+
+	/// Also listen for RTMPS (RTMP over TLS, `rtmps://`) on this address, in
+	/// addition to plaintext RTMP. Requires a certificate via `--rtmps-tls-cert`
+	/// /`--rtmps-tls-key` or a self-signed `--rtmps-tls-generate`. RTMPS has no
+	/// well-known port; common choices are 443 or a custom one.
+	#[arg(long = "rtmps-listen", env = "MOQ_RTMPS_LISTEN")]
+	rtmps_listen: Option<SocketAddr>,
+
+	/// PEM certificate chain for RTMPS.
+	#[arg(long = "rtmps-tls-cert", env = "MOQ_RTMPS_TLS_CERT")]
+	rtmps_cert: Option<PathBuf>,
+
+	/// PEM private key for RTMPS.
+	#[arg(long = "rtmps-tls-key", env = "MOQ_RTMPS_TLS_KEY")]
+	rtmps_key: Option<PathBuf>,
+
+	/// Or generate a self-signed RTMPS certificate for these hostnames (testing
+	/// only; clients must disable verification or pin the fingerprint).
+	#[arg(long = "rtmps-tls-generate", env = "MOQ_RTMPS_TLS_GENERATE", value_delimiter = ',')]
+	rtmps_generate: Vec<String>,
 }
 
-impl From<RtmpArgs> for moq_rtmp::Config {
-	fn from(args: RtmpArgs) -> Self {
-		let mut config = moq_rtmp::Config::default();
-		config.listen = Some(args.listen);
-		config.prefix = args.prefix;
-		config
+impl RtmpArgs {
+	/// Build the listener configs: always plaintext RTMP, plus RTMPS when
+	/// `--rtmps-listen` is set. Both share the `--rtmp-prefix`.
+	fn configs(&self) -> anyhow::Result<Vec<moq_rtmp::Config>> {
+		let mut plain = moq_rtmp::Config::default();
+		plain.listen = Some(self.listen);
+		plain.prefix = self.prefix.clone();
+		let mut configs = vec![plain];
+
+		if let Some(addr) = self.rtmps_listen {
+			// Reuse moq-native's cert loader (on-disk pair or self-signed). RTMPS
+			// has no ALPN convention, so advertise none.
+			let mut tls = moq_native::tls::Server::default();
+			tls.cert = self.rtmps_cert.clone().into_iter().collect();
+			tls.key = self.rtmps_key.clone().into_iter().collect();
+			tls.generate = self.rtmps_generate.clone();
+			let server_config = tls.server_config(vec![]).context("build RTMPS TLS config")?;
+
+			let mut rtmps = moq_rtmp::Config::default();
+			rtmps.listen = Some(addr);
+			rtmps.prefix = self.prefix.clone();
+			rtmps.tls = Some(server_config);
+			configs.push(rtmps);
+		}
+
+		Ok(configs)
 	}
 }
 
@@ -99,16 +140,33 @@ async fn main() -> anyhow::Result<()> {
 	cli.log.init()?;
 
 	match cli.command {
-		Command::Serve { config, dir, rtmp } => run_serve(config, dir, rtmp.into()).await,
-		Command::Publish { config, relay, rtmp } => run_publish(config, relay, rtmp.into()).await,
+		Command::Serve { config, dir, rtmp } => run_serve(config, dir, rtmp.configs()?).await,
+		Command::Publish { config, relay, rtmp } => run_publish(config, relay, rtmp.configs()?).await,
 	}
+}
+
+/// Run every configured RTMP/RTMPS listener against `origin`, failing if any of
+/// them does. Stays pending while at least one listener is alive.
+async fn run_ingest(origin: moq_net::OriginProducer, configs: Vec<moq_rtmp::Config>) -> anyhow::Result<()> {
+	use futures::StreamExt;
+
+	let mut listeners: futures::stream::FuturesUnordered<_> = configs
+		.into_iter()
+		.map(|config| moq_rtmp::run(origin.clone(), config))
+		.collect();
+
+	while let Some(res) = listeners.next().await {
+		res.context("rtmp ingest failed")?;
+	}
+
+	Ok(())
 }
 
 /// Run a local QUIC/WebTransport server and ingest RTMP directly into it.
 async fn run_serve(
 	config: moq_native::ServerConfig,
 	dir: Option<PathBuf>,
-	rtmp: moq_rtmp::Config,
+	rtmp: Vec<moq_rtmp::Config>,
 ) -> anyhow::Result<()> {
 	let web_bind = config.bind.clone().unwrap_or_else(|| "[::]:443".to_string());
 
@@ -126,13 +184,13 @@ async fn run_serve(
 	tokio::select! {
 		res = serve::run(server, origin.clone()) => res.context("moq server failed"),
 		res = web::run(&web_bind, web_tls, dir) => res.context("web server failed"),
-		res = moq_rtmp::run(origin, rtmp) => res.context("rtmp ingest failed"),
+		res = run_ingest(origin, rtmp) => res,
 		_ = tokio::signal::ctrl_c() => Ok(()),
 	}
 }
 
 /// Ingest RTMP and forward every broadcast to a remote relay at `relay`.
-async fn run_publish(config: moq_native::ClientConfig, relay: Url, rtmp: moq_rtmp::Config) -> anyhow::Result<()> {
+async fn run_publish(config: moq_native::ClientConfig, relay: Url, rtmp: Vec<moq_rtmp::Config>) -> anyhow::Result<()> {
 	let client = config.init().context("init moq client")?;
 
 	// RTMP publishes broadcasts into this origin; the client forwards them on.
@@ -145,7 +203,7 @@ async fn run_publish(config: moq_native::ClientConfig, relay: Url, rtmp: moq_rtm
 	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
 
 	tokio::select! {
-		res = moq_rtmp::run(origin, rtmp) => res.context("rtmp ingest failed"),
+		res = run_ingest(origin, rtmp) => res,
 		res = reconnect.closed() => res.context("relay connection failed"),
 		_ = tokio::signal::ctrl_c() => Ok(()),
 	}

--- a/rs/moq-rtmp/bin/serve.rs
+++ b/rs/moq-rtmp/bin/serve.rs
@@ -1,0 +1,38 @@
+//! Local QUIC/WebTransport server for `serve` mode.
+//!
+//! Accepts MoQ sessions and serves every broadcast the RTMP listener has
+//! published into `origin`, so subscribers connect straight to this binary
+//! instead of a separate relay.
+
+use moq_net::{OriginConsumer, OriginProducer};
+
+/// Accept sessions and publish `origin`'s broadcasts to each subscriber.
+pub async fn run(mut server: moq_native::Server, origin: OriginProducer) -> anyhow::Result<()> {
+	tracing::info!(addr = ?server.local_addr(), "listening");
+
+	let mut conn_id = 0;
+	while let Some(request) = server.accept().await {
+		let id = conn_id;
+		conn_id += 1;
+
+		let consumer = origin.consume();
+		tokio::spawn(async move {
+			if let Err(err) = serve_session(id, request, consumer).await {
+				tracing::warn!(%err, "session ended");
+			}
+		});
+	}
+
+	anyhow::bail!("server stopped accepting connections")
+}
+
+#[tracing::instrument("session", skip_all, fields(id))]
+async fn serve_session(id: u64, request: moq_native::Request, consumer: OriginConsumer) -> anyhow::Result<()> {
+	// Blindly accept the session (WebTransport or QUIC), serving every ingested
+	// broadcast to the subscriber.
+	let session = request.with_publisher(consumer).ok().await?;
+
+	tracing::info!(id, "accepted session");
+
+	session.closed().await.map_err(Into::into)
+}

--- a/rs/moq-rtmp/bin/web.rs
+++ b/rs/moq-rtmp/bin/web.rs
@@ -1,0 +1,64 @@
+//! HTTP sidecar for `serve` mode.
+//!
+//! Serves `/certificate.sha256` (the TLS fingerprint browsers fetch when
+//! connecting to a self-signed `http://` origin) and, optionally, a static
+//! directory for local development. Mirrors `moq-cli`'s web server.
+
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+use anyhow::Context;
+use axum::handler::HandlerWithoutStateExt;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::{Router, http::Method, routing::get};
+use tower_http::cors::{Any, CorsLayer};
+use tower_http::services::ServeDir;
+
+/// Serve the cert-fingerprint endpoint (and optional static `public` dir) on `bind`.
+pub async fn run(
+	bind: &str,
+	tls_info: Arc<RwLock<moq_native::tls::Info>>,
+	public: Option<PathBuf>,
+) -> anyhow::Result<()> {
+	let listen = tokio::net::lookup_host(bind)
+		.await
+		.context("invalid listen address")?
+		.next()
+		.context("invalid listen address")?;
+
+	async fn handle_404() -> impl IntoResponse {
+		(StatusCode::NOT_FOUND, "Not found")
+	}
+
+	let fingerprint_handler = move || async move {
+		tls_info
+			.read()
+			.expect("tls_info read lock poisoned")
+			.fingerprints
+			.first()
+			.expect("missing certificate")
+			.clone()
+	};
+
+	let mut app = Router::new()
+		.route("/certificate.sha256", get(fingerprint_handler))
+		.layer(CorsLayer::new().allow_origin(Any).allow_methods([Method::GET]));
+
+	if let Some(public) = public.as_ref() {
+		tracing::info!(public = %public.display(), "serving directory");
+
+		let public = ServeDir::new(public).not_found_service(handle_404.into_service());
+		app = app.fallback_service(public);
+	} else {
+		app = app.fallback_service(handle_404.into_service());
+	}
+
+	// Dual-stack so the cert endpoint answers over IPv4 too, even on Windows
+	// where `[::]` is IPv6-only by default.
+	let listener = moq_native::bind::tcp(listen).context("failed to bind web listener")?;
+	let server = axum_server::from_tcp(listener)?;
+	server.serve(app.into_make_service()).await?;
+
+	Ok(())
+}

--- a/rs/moq-rtmp/src/error.rs
+++ b/rs/moq-rtmp/src/error.rs
@@ -1,0 +1,36 @@
+//! Errors for the RTMP ingest gateway.
+
+use std::sync::Arc;
+
+/// Errors produced while ingesting RTMP into MoQ.
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+	/// Error from the underlying moq-net transport (e.g. publishing into the origin).
+	#[error("moq: {0}")]
+	Moq(#[from] moq_net::Error),
+
+	/// I/O error from the RTMP listener or a connection.
+	#[error("io: {0}")]
+	Io(Arc<std::io::Error>),
+
+	/// Catch-all for ingest logic that reports via `anyhow` (the RTMP session and
+	/// the moq-mux demuxer surface their errors this way).
+	#[error("{0}")]
+	Other(Arc<anyhow::Error>),
+}
+
+impl From<std::io::Error> for Error {
+	fn from(err: std::io::Error) -> Self {
+		Error::Io(Arc::new(err))
+	}
+}
+
+impl From<anyhow::Error> for Error {
+	fn from(err: anyhow::Error) -> Self {
+		Error::Other(Arc::new(err))
+	}
+}
+
+/// Result alias for the RTMP ingest gateway.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/rs/moq-rtmp/src/flv.rs
+++ b/rs/moq-rtmp/src/flv.rs
@@ -1,0 +1,104 @@
+//! Synthesize an FLV byte stream from RTMP audio/video messages.
+//!
+//! RTMP carries media as messages whose payloads are exactly FLV tag *bodies*:
+//! an audio message (type 8) is an FLV AUDIODATA body, a video message (type 9)
+//! is an FLV VIDEODATA body. moq-mux's [`flv::Import`](moq_mux::container::flv)
+//! consumes a whole FLV byte stream (file header + framed tags), so to reuse it
+//! we re-wrap each RTMP message in the FLV file/tag framing it expects rather
+//! than demuxing RTMP ourselves. That demuxer handles both legacy (H.264 / AAC)
+//! and enhanced-RTMP (HEVC / AV1 / VP9 / Opus / AC-3) payloads, so this framing
+//! is codec-agnostic.
+//!
+//! See `moq-mux/src/container/flv` for the matching reader; the field layout
+//! here mirrors what it parses (11-byte tag header, 24-bit + 8-bit extended
+//! millisecond timestamp, trailing `PreviousTagSize`).
+
+use bytes::{BufMut, Bytes, BytesMut};
+
+/// FLV tag type for audio data (matches moq-mux's `TAG_AUDIO`).
+pub const TAG_AUDIO: u8 = 8;
+/// FLV tag type for video data (matches moq-mux's `TAG_VIDEO`).
+pub const TAG_VIDEO: u8 = 9;
+
+/// The 9-byte FLV file header plus its 4-byte `PreviousTagSize0`, emitted once
+/// at the start of the synthesized stream before any tag.
+///
+/// `46 4C 56` = "FLV", version 1, flags `0x05` (audio + video present),
+/// data offset 9, then a zero `PreviousTagSize0`. moq-mux only checks the
+/// "FLV" magic and the data offset, but we emit a spec-correct header anyway.
+pub fn file_header() -> Bytes {
+	Bytes::from_static(&[
+		b'F', b'L', b'V', // signature
+		0x01, // version
+		0x05, // flags: audio (bit 2) + video (bit 0)
+		0x00, 0x00, 0x00, 0x09, // data offset (header length)
+		0x00, 0x00, 0x00, 0x00, // PreviousTagSize0
+	])
+}
+
+/// Frame one RTMP message body as an FLV tag: the 11-byte tag header (type,
+/// 24-bit data size, 24-bit + 8-bit extended timestamp, 24-bit stream id = 0),
+/// the body, then the 4-byte `PreviousTagSize` trailer (header + body length).
+///
+/// `timestamp` is the RTMP message timestamp in milliseconds; FLV splits it into
+/// a low 24 bits and a high "extended" byte, exactly how moq-mux reassembles it.
+pub fn tag(tag_type: u8, timestamp: u32, body: &[u8]) -> Bytes {
+	let data_size = body.len();
+	let mut buf = BytesMut::with_capacity(11 + data_size + 4);
+
+	buf.put_u8(tag_type);
+	// 24-bit data size, big-endian.
+	buf.put_u8((data_size >> 16) as u8);
+	buf.put_u8((data_size >> 8) as u8);
+	buf.put_u8(data_size as u8);
+	// Timestamp: low 24 bits big-endian, then the extended (most significant) byte.
+	buf.put_u8((timestamp >> 16) as u8);
+	buf.put_u8((timestamp >> 8) as u8);
+	buf.put_u8(timestamp as u8);
+	buf.put_u8((timestamp >> 24) as u8);
+	// Stream id is always 0.
+	buf.put_u8(0);
+	buf.put_u8(0);
+	buf.put_u8(0);
+
+	buf.put_slice(body);
+
+	// PreviousTagSize: the size of the tag header + body that precedes it.
+	buf.put_u32(11 + data_size as u32);
+
+	buf.freeze()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn tag_layout_roundtrips_timestamp_and_size() {
+		let body = [0x17, 0x00, 0x00, 0x00, 0x00, 0xde, 0xad];
+		let ts = 0x01_02_03_04; // exercises the extended byte
+		let t = tag(TAG_VIDEO, ts, &body);
+
+		assert_eq!(t[0], TAG_VIDEO);
+		// 24-bit data size.
+		let size = ((t[1] as usize) << 16) | ((t[2] as usize) << 8) | (t[3] as usize);
+		assert_eq!(size, body.len());
+		// Timestamp = low 24 bits | extended byte << 24, matching the moq-mux reader.
+		let read = ((t[4] as u32) << 16) | ((t[5] as u32) << 8) | (t[6] as u32) | ((t[7] as u32) << 24);
+		assert_eq!(read, ts);
+		// Stream id is zero.
+		assert_eq!(&t[8..11], &[0, 0, 0]);
+		// Body follows the 11-byte header.
+		assert_eq!(&t[11..11 + body.len()], &body);
+		// Trailing PreviousTagSize = header + body.
+		let prev = u32::from_be_bytes([t[t.len() - 4], t[t.len() - 3], t[t.len() - 2], t[t.len() - 1]]);
+		assert_eq!(prev, 11 + body.len() as u32);
+	}
+
+	#[test]
+	fn file_header_has_flv_magic() {
+		let h = file_header();
+		assert_eq!(&h[0..3], b"FLV");
+		assert_eq!(h.len(), 13);
+	}
+}

--- a/rs/moq-rtmp/src/lib.rs
+++ b/rs/moq-rtmp/src/lib.rs
@@ -1,0 +1,43 @@
+//! RTMP / enhanced-RTMP contribution ingest gateway for MoQ.
+//!
+//! Runs an [RTMP](https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol)
+//! server (the protocol OBS, ffmpeg, and most hardware encoders speak), re-wraps
+//! each connection's audio/video messages as FLV tags, demuxes them with
+//! [`moq_mux`], and publishes the result into a [`moq_net::OriginProducer`] as
+//! ordinary MoQ broadcasts. Whatever serves that origin (a relay, the bundled
+//! binary's serve mode) then exposes the ingested stream like any other
+//! broadcast. This is the contribution-ingest analogue of `moq-srt`, `moq-hls`'s
+//! import, and `moq-rtc`'s WHIP.
+//!
+//! Both legacy RTMP (H.264 + AAC) and enhanced RTMP (E-RTMP: the HEVC, AV1, VP9,
+//! Opus, and AC-3 FourCC payloads) are supported, because the codec handling
+//! lives entirely in the [`moq_mux`] FLV demuxer; this crate only translates the
+//! RTMP transport.
+//!
+//! Two entry points, depending on how much control you need over each publish:
+//!
+//! - **[`run`]**: the unauthenticated convenience. Build a [`Config`] and hand it
+//!   plus an origin to [`run`]; it accepts every publisher and routes by prefix +
+//!   app/key. A relay embeds this with `run(cluster.origin.clone(), config)`.
+//! - **[`Server`] / [`Request`]**: bring your own auth. Loop on
+//!   [`Server::accept`], inspect [`Request::app`] / [`Request::stream_key`] (treat
+//!   the stream key as a token if you like), then [`Request::accept`] the publish
+//!   into an origin at a path of your choosing, or [`Request::reject`] it. This is
+//!   how an embedder (e.g. a relay verifying a JWT and scoping the origin per
+//!   token) plugs its policy in, with no callback. It mirrors `moq-native`'s
+//!   `Server` / `Request`.
+//!
+//! The bundled `moq-rtmp` binary serves the origin locally or forwards it to a
+//! remote relay (those paths need the `server` feature).
+//!
+//! Pure Rust: the RTMP handshake, chunk codec, and session state machine come
+//! from [`rml_rtmp`], with no librtmp or ffmpeg dependency.
+
+mod error;
+mod flv;
+mod listen;
+mod server;
+
+pub use error::{Error, Result};
+pub use listen::{Config, run};
+pub use server::{Request, Server};

--- a/rs/moq-rtmp/src/lib.rs
+++ b/rs/moq-rtmp/src/lib.rs
@@ -30,6 +30,17 @@
 //! The bundled `moq-rtmp` binary serves the origin locally or forwards it to a
 //! remote relay (those paths need the `server` feature).
 //!
+//! RTMPS (RTMP over TLS) is supported two ways:
+//!
+//! - **Let the gateway terminate TLS**: set [`Config::tls`] (or call
+//!   [`Server::with_tls`]) with a [`rustls::ServerConfig`], and the listener
+//!   speaks `rtmps://` with no other change.
+//! - **Bring your own transport**: accept the connection and complete the TLS
+//!   handshake yourself (any [`Stream`]: a `tokio_rustls` stream, a custom
+//!   socket, a test pipe), then hand the established stream to [`accept_stream`].
+//!   Useful when an existing TLS terminator, proxy, or non-TCP transport already
+//!   owns the socket.
+//!
 //! Pure Rust: the RTMP handshake, chunk codec, and session state machine come
 //! from [`rml_rtmp`], with no librtmp or ffmpeg dependency.
 
@@ -40,4 +51,10 @@ mod server;
 
 pub use error::{Error, Result};
 pub use listen::{Config, run};
-pub use server::{Request, Server};
+pub use server::{Conn, Request, Server, Stream, accept_stream};
+
+/// Re-export of the `rustls` version this crate builds [`Config::tls`] against,
+/// so consumers construct a matching [`rustls::ServerConfig`] (a major `rustls`
+/// bump is a breaking change). Only available with the `server` feature.
+#[cfg(feature = "server")]
+pub use rustls;

--- a/rs/moq-rtmp/src/listen.rs
+++ b/rs/moq-rtmp/src/listen.rs
@@ -1,0 +1,194 @@
+//! RTMP listener, configuration, and stream-key routing.
+//!
+//! We run a TCP listener on RTMP's port, hand each connection to
+//! [`crate::server`] for the handshake + session handling, and route each
+//! publish to a broadcast path derived from its RTMP app and stream key.
+//!
+//! Routing: the usual OBS/ffmpeg URL is `rtmp://host[:1935]/<app>/<key>`, which
+//! arrives as app `<app>` and stream key `<key>`. The path is `<app>/<key>`
+//! (just `<app>` when the key is empty). The optional [`prefix`](Config::prefix)
+//! is prepended so a single listener can namespace all of its ingests (e.g.
+//! prefix `live/` + app `cam0` -> broadcast `live/cam0`).
+//!
+//! Auth: this listener is currently unauthenticated. Anyone who can reach the
+//! TCP port can publish, so gate it with the host firewall / a private network.
+//! Treating the stream key as a token (a moq-token JWT, as moq-edge does) is the
+//! obvious next step.
+
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use moq_net::OriginProducer;
+
+use crate::Result;
+use crate::server::Server;
+
+/// RTMP ingest configuration.
+///
+/// Construct via [`Config::default`] and set the fields you need, so new
+/// options stay additive. Ingest is disabled (and [`run`] stays pending) unless
+/// [`listen`](Config::listen) is set, letting an embedding relay run without
+/// RTMP until it's configured.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct Config {
+	/// Address to listen on for RTMP ingest (e.g. `0.0.0.0:1935`). When `None`,
+	/// RTMP ingest is disabled.
+	pub listen: Option<SocketAddr>,
+
+	/// Prefix prepended to every ingested broadcast path. Lets one listener
+	/// namespace all of its streams (e.g. `live/`).
+	pub prefix: String,
+}
+
+/// Run the RTMP ingest listener until it fails, publishing each connection into
+/// `origin` as a broadcast.
+///
+/// This is the unauthenticated convenience entry point: it accepts every
+/// publisher and routes by [`prefix`](Config::prefix) + app/key. To gate ingest
+/// (e.g. verify the stream key as a JWT) or to scope the origin per publisher,
+/// drive [`Server`] directly: loop on [`Server::accept`] and call
+/// [`Request::accept`](crate::Request::accept) / [`Request::reject`](crate::Request::reject)
+/// after making your own decision.
+///
+/// Stays pending forever (rather than resolving) when RTMP is disabled, so it
+/// composes cleanly inside a `tokio::select!` alongside a relay's other
+/// long-running tasks.
+pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
+	let Some(listen) = config.listen else {
+		tracing::info!("RTMP ingest disabled (no listen address)");
+		std::future::pending::<()>().await;
+		unreachable!("pending future never resolves");
+	};
+
+	let mut server = Server::bind(listen).await?;
+	tracing::info!(%listen, prefix = %config.prefix, "RTMP ingest listening");
+
+	// Tracks which broadcast paths are currently being ingested so a second
+	// publisher on the same stream key is rejected (first-publisher-wins) instead
+	// of clobbering the live one.
+	let active = ActivePaths::default();
+	let prefix = Arc::new(config.prefix);
+
+	while let Some(request) = server.accept().await {
+		let origin = origin.clone();
+		let active = active.clone();
+		let prefix = prefix.clone();
+		// Each connection runs on its own task: `accept` pumps media for the whole
+		// connection lifetime, so handling it inline would serialize publishers.
+		tokio::spawn(async move {
+			let peer = request.peer();
+			let Some(path) = resolve_path(&prefix, request.app(), request.stream_key()) else {
+				tracing::warn!(%peer, "rejecting RTMP: no usable broadcast path");
+				let _ = request.reject("missing broadcast path (RTMP app/key)").await;
+				return;
+			};
+			// Claim the path before accepting; the guard releases it when the
+			// connection task ends (success, error, or panic).
+			let Some(_guard) = active.claim(&path) else {
+				tracing::warn!(%peer, %path, "rejecting RTMP: path already being published");
+				let _ = request.reject("path already being published").await;
+				return;
+			};
+			if let Err(err) = request.accept(&origin, &path).await {
+				tracing::warn!(%peer, %path, %err, "RTMP ingest ended with error");
+			}
+		});
+	}
+
+	Err(anyhow::anyhow!("RTMP listener stopped accepting connections").into())
+}
+
+/// Derive a broadcast path from an RTMP app and stream key, applying `prefix`.
+///
+/// `rtmp://host/<app>/<key>` maps to `<prefix><app>/<key>`, falling back to just
+/// the app (or just the key) when the other half is empty. Returns `None` when
+/// there's nothing usable to route on.
+pub(crate) fn resolve_path(prefix: &str, app: &str, key: &str) -> Option<String> {
+	let app = app.trim_matches('/').trim();
+	let key = key.trim_matches('/').trim();
+	let name = match (app.is_empty(), key.is_empty()) {
+		(true, true) => return None,
+		(false, true) => app.to_string(),
+		(true, false) => key.to_string(),
+		(false, false) => format!("{app}/{key}"),
+	};
+	Some(format!("{prefix}{name}"))
+}
+
+/// The set of broadcast paths with a live ingest, used to reject duplicate
+/// stream keys. Cheap to clone (shared `Arc`).
+#[derive(Clone, Default)]
+pub(crate) struct ActivePaths(Arc<Mutex<HashSet<String>>>);
+
+impl ActivePaths {
+	/// Claim `path`, returning a guard that releases it on drop, or `None` if it
+	/// is already claimed.
+	pub(crate) fn claim(&self, path: &str) -> Option<PathGuard> {
+		let mut set = self.0.lock().expect("active paths mutex poisoned");
+		set.insert(path.to_string()).then(|| PathGuard {
+			paths: self.0.clone(),
+			path: path.to_string(),
+		})
+	}
+}
+
+/// Releases a claimed [`ActivePaths`] entry when dropped.
+pub(crate) struct PathGuard {
+	paths: Arc<Mutex<HashSet<String>>>,
+	path: String,
+}
+
+impl Drop for PathGuard {
+	fn drop(&mut self) {
+		self.paths
+			.lock()
+			.expect("active paths mutex poisoned")
+			.remove(&self.path);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn app_and_key() {
+		assert_eq!(resolve_path("", "live", "cam0").as_deref(), Some("live/cam0"));
+	}
+
+	#[test]
+	fn app_only() {
+		assert_eq!(resolve_path("", "cam0", "").as_deref(), Some("cam0"));
+	}
+
+	#[test]
+	fn prefix_is_prepended() {
+		assert_eq!(resolve_path("live/", "cam0", "").as_deref(), Some("live/cam0"));
+	}
+
+	#[test]
+	fn slashes_are_trimmed() {
+		assert_eq!(resolve_path("", "/live/", "/cam0/").as_deref(), Some("live/cam0"));
+	}
+
+	#[test]
+	fn empty_is_rejected() {
+		assert_eq!(resolve_path("", "", ""), None);
+	}
+
+	#[test]
+	fn active_paths_rejects_duplicates_and_releases_on_drop() {
+		let active = ActivePaths::default();
+
+		let guard = active.claim("live/cam0").expect("first claim succeeds");
+		assert!(active.claim("live/cam0").is_none());
+		let other = active.claim("live/cam1").expect("distinct path claims");
+
+		drop(guard);
+		assert!(active.claim("live/cam0").is_some());
+
+		drop(other);
+	}
+}

--- a/rs/moq-rtmp/src/listen.rs
+++ b/rs/moq-rtmp/src/listen.rs
@@ -40,6 +40,17 @@ pub struct Config {
 	/// Prefix prepended to every ingested broadcast path. Lets one listener
 	/// namespace all of its streams (e.g. `live/`).
 	pub prefix: String,
+
+	/// TLS configuration for RTMPS (RTMP over TLS). When set, the
+	/// [`listen`](Self::listen) address speaks RTMPS instead of plaintext RTMP,
+	/// so clients connect with `rtmps://`. Build it with
+	/// [`moq_native::tls::Server::server_config`] (pass an empty ALPN list) or
+	/// any [`rustls::ServerConfig`]. Leave `None` for plaintext.
+	///
+	/// To serve both RTMP and RTMPS, run two listeners: call [`run`] once per
+	/// config (one with `tls`, one without) against a cloned origin.
+	#[cfg(feature = "server")]
+	pub tls: Option<std::sync::Arc<rustls::ServerConfig>>,
 }
 
 /// Run the RTMP ingest listener until it fails, publishing each connection into
@@ -62,8 +73,20 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 		unreachable!("pending future never resolves");
 	};
 
+	#[cfg_attr(not(feature = "server"), allow(unused_mut))]
 	let mut server = Server::bind(listen).await?;
-	tracing::info!(%listen, prefix = %config.prefix, "RTMP ingest listening");
+
+	#[cfg(feature = "server")]
+	let tls = config.tls.is_some();
+	#[cfg(not(feature = "server"))]
+	let tls = false;
+
+	#[cfg(feature = "server")]
+	if let Some(tls) = config.tls.clone() {
+		server = server.with_tls(tls);
+	}
+
+	tracing::info!(%listen, prefix = %config.prefix, tls, "RTMP ingest listening");
 
 	// Tracks which broadcast paths are currently being ingested so a second
 	// publisher on the same stream key is rejected (first-publisher-wins) instead

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -9,9 +9,19 @@
 //! [`Request::reject`]. This mirrors `moq-native`'s `Server` / `Request`, so the
 //! gateway stays unopinionated about auth: the embedder (e.g. a relay verifying
 //! the stream key as a JWT) owns that policy.
+//!
+//! RTMPS (RTMP over TLS): [`Server::with_tls`] makes the listener terminate TLS
+//! before the RTMP handshake, so `rtmps://` clients work with no other change.
+//! If you'd rather own the transport (custom TLS, a non-TCP socket, a test
+//! pipe), accept the connection and complete any handshake yourself, then hand
+//! the established stream to [`accept_stream`]; everything here is generic over
+//! the [`Stream`] trait.
 
 use std::collections::VecDeque;
+use std::io;
 use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::StreamExt;
@@ -21,7 +31,7 @@ use moq_mux::container::flv::Import as FlvImport;
 use moq_net::{BroadcastInfo, OriginProducer, OriginPublish};
 use rml_rtmp::handshake::{Handshake, HandshakeProcessResult, PeerType};
 use rml_rtmp::sessions::{ServerSession, ServerSessionConfig, ServerSessionEvent, ServerSessionResult};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::Result;
@@ -33,19 +43,86 @@ const READ_BUFFER: usize = 16 * 1024;
 /// How long a connection has to finish the handshake and issue its `publish`
 /// before it is dropped. Bounds the lifetime (and socket / `pending` slot) of a
 /// client that connects but never publishes, so idle or half-open connections
-/// can't accumulate without limit.
+/// can't accumulate without limit. With TLS this also covers the TLS handshake.
 const PUBLISH_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// A bidirectional byte stream carrying an RTMP session.
+///
+/// A plaintext [`tokio::net::TcpStream`] for `rtmp://`, or a TLS stream you've
+/// accepted for `rtmps://`. Implemented for every
+/// `AsyncRead + AsyncWrite + Unpin + Send`, so [`accept_stream`] and
+/// [`Request`] work over whatever transport you bring.
+pub trait Stream: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> Stream for T {}
+
+/// A connection accepted by [`Server`]: plaintext RTMP, or RTMPS over TLS.
+///
+/// This is the stream type behind a [`Server`]-produced [`Request`] (hence
+/// `Request<Conn>`). Bring-your-own-transport callers using [`accept_stream`]
+/// keep their own stream type instead.
+pub enum Conn {
+	/// A plaintext TCP connection (`rtmp://`).
+	Plain(TcpStream),
+
+	/// A TLS connection (`rtmps://`), established by [`Server::with_tls`]. Boxed
+	/// because a `TlsStream` is large relative to a bare `TcpStream`.
+	#[cfg(feature = "server")]
+	Tls(Box<tokio_rustls::server::TlsStream<TcpStream>>),
+}
+
+impl AsyncRead for Conn {
+	fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+		match self.get_mut() {
+			Conn::Plain(s) => Pin::new(s).poll_read(cx, buf),
+			#[cfg(feature = "server")]
+			Conn::Tls(s) => Pin::new(s).poll_read(cx, buf),
+		}
+	}
+}
+
+impl AsyncWrite for Conn {
+	fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+		match self.get_mut() {
+			Conn::Plain(s) => Pin::new(s).poll_write(cx, buf),
+			#[cfg(feature = "server")]
+			Conn::Tls(s) => Pin::new(s).poll_write(cx, buf),
+		}
+	}
+
+	fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		match self.get_mut() {
+			Conn::Plain(s) => Pin::new(s).poll_flush(cx),
+			#[cfg(feature = "server")]
+			Conn::Tls(s) => Pin::new(s).poll_flush(cx),
+		}
+	}
+
+	fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		match self.get_mut() {
+			Conn::Plain(s) => Pin::new(s).poll_shutdown(cx),
+			#[cfg(feature = "server")]
+			Conn::Tls(s) => Pin::new(s).poll_shutdown(cx),
+		}
+	}
+}
 
 /// An RTMP server that yields each connection's pending publish as a [`Request`].
 ///
-/// Build it with [`bind`](Self::bind), then loop on [`accept`](Self::accept).
-/// The handshake and the connect/publish exchange happen inside `accept`, so a
+/// Build it with [`bind`](Self::bind), optionally enable RTMPS with
+/// [`with_tls`](Self::with_tls), then loop on [`accept`](Self::accept). The
+/// handshake and the connect/publish exchange happen inside `accept`, so a
 /// [`Request`] is only produced once a client actually wants to publish.
 pub struct Server {
 	listener: TcpListener,
+
+	/// When set, each accepted connection is TLS-terminated (RTMPS) before the
+	/// RTMP handshake.
+	#[cfg(feature = "server")]
+	tls: Option<tokio_rustls::TlsAcceptor>,
+
 	/// In-flight handshakes; each resolves to a ready [`Request`], or `None` if
 	/// the connection closed or errored before issuing a publish.
-	pending: FuturesUnordered<BoxFuture<'static, Option<Request>>>,
+	pending: FuturesUnordered<BoxFuture<'static, Option<Request<Conn>>>>,
 }
 
 impl Server {
@@ -54,8 +131,20 @@ impl Server {
 		let listener = TcpListener::bind(addr).await?;
 		Ok(Self {
 			listener,
+			#[cfg(feature = "server")]
+			tls: None,
 			pending: FuturesUnordered::new(),
 		})
+	}
+
+	/// Terminate TLS on every accepted connection, turning this into an RTMPS
+	/// listener (`rtmps://`). Pass a `rustls::ServerConfig` (e.g. from
+	/// [`moq_native::tls::Server::server_config`] with an empty ALPN list), or
+	/// `None` to leave it plaintext.
+	#[cfg(feature = "server")]
+	pub fn with_tls(mut self, tls: impl Into<Option<std::sync::Arc<rustls::ServerConfig>>>) -> Self {
+		self.tls = tls.into().map(tokio_rustls::TlsAcceptor::from);
+		self
 	}
 
 	/// The local address the listener is bound to.
@@ -69,7 +158,7 @@ impl Server {
 	/// next one to reach its `publish` command. Connections that close or error
 	/// before publishing are dropped without surfacing here. Returns `None` only
 	/// if the listener itself stops (it currently never does).
-	pub async fn accept(&mut self) -> Option<Request> {
+	pub async fn accept(&mut self) -> Option<Request<Conn>> {
 		loop {
 			tokio::select! {
 				// A handshake finished: yield its request, or skip a dead connection.
@@ -78,15 +167,35 @@ impl Server {
 						return Some(request);
 					}
 				}
-				// A new TCP connection: start its handshake concurrently.
+				// A new TCP connection: start its (TLS +) handshake concurrently.
 				res = self.listener.accept() => match res {
 					Ok((stream, peer)) => {
 						// Nagle off: RTMP is latency-sensitive and we write whole packets.
 						if let Err(err) = stream.set_nodelay(true) {
 							tracing::debug!(%peer, %err, "failed to set TCP_NODELAY");
 						}
+						#[cfg(feature = "server")]
+						let tls = self.tls.clone();
 						self.pending.push(Box::pin(async move {
-							match tokio::time::timeout(PUBLISH_TIMEOUT, accept_until_publish(stream, peer)).await {
+							// The TLS handshake (if any) and the RTMP handshake share one
+							// budget, so a client that stalls either is dropped.
+							let outcome = tokio::time::timeout(PUBLISH_TIMEOUT, async move {
+								#[cfg(feature = "server")]
+								let conn = match tls {
+									Some(acceptor) => Conn::Tls(Box::new(
+										acceptor
+											.accept(stream)
+											.await
+											.map_err(|e| anyhow::anyhow!("rtmps tls handshake: {e}"))?,
+									)),
+									None => Conn::Plain(stream),
+								};
+								#[cfg(not(feature = "server"))]
+								let conn = Conn::Plain(stream);
+								accept_until_publish(conn, peer).await
+							})
+							.await;
+							match outcome {
 								Ok(Ok(request)) => request,
 								Ok(Err(err)) => {
 									tracing::warn!(%peer, %err, "RTMP connection closed before publish");
@@ -111,6 +220,21 @@ impl Server {
 	}
 }
 
+/// Run the RTMP handshake and connect/publish exchange on an already-established
+/// byte stream, yielding the pending publish as a [`Request`].
+///
+/// The bring-your-own-transport entry point: accept the connection (and, for
+/// `rtmps://`, complete the TLS handshake) yourself, then hand the stream here.
+/// `peer` is the remote address, used for logging and [`Request::peer`].
+///
+/// Returns `Ok(None)` if the client disconnects before issuing `publish`. Unlike
+/// [`Server`], this applies no publish timeout: wrap the call in
+/// [`tokio::time::timeout`] to bound how long a connected-but-idle client can
+/// hold the task.
+pub async fn accept_stream<S: Stream>(stream: S, peer: SocketAddr) -> Result<Option<Request<S>>> {
+	Ok(accept_until_publish(stream, peer).await?)
+}
+
 /// A pending RTMP publish, waiting on the caller to authorize it.
 ///
 /// Inspect [`app`](Self::app) and [`stream_key`](Self::stream_key) (an
@@ -118,8 +242,11 @@ impl Server {
 /// [`accept`](Self::accept) the publish into an origin at a chosen broadcast
 /// path or [`reject`](Self::reject) it. Dropping a `Request` without either
 /// closes the connection.
-pub struct Request {
-	stream: TcpStream,
+///
+/// `S` is the underlying stream: [`Conn`] for a [`Server`]-produced request, or
+/// your own transport when built via [`accept_stream`].
+pub struct Request<S = Conn> {
+	stream: S,
 	session: ServerSession,
 	/// The `rml_rtmp` request id for the pending publish, replied to on accept/reject.
 	request_id: u32,
@@ -131,7 +258,7 @@ pub struct Request {
 	peer: SocketAddr,
 }
 
-impl Request {
+impl<S: Stream> Request<S> {
 	/// The RTMP app name (the path component of `rtmp://host/<app>/<key>`).
 	pub fn app(&self) -> &str {
 		&self.app
@@ -205,7 +332,7 @@ impl Request {
 
 /// Run one connection's handshake and connect/publish exchange, returning a
 /// [`Request`] once the client issues `publish` (or `None` if it disconnects first).
-async fn accept_until_publish(mut stream: TcpStream, peer: SocketAddr) -> anyhow::Result<Option<Request>> {
+async fn accept_until_publish<S: Stream>(mut stream: S, peer: SocketAddr) -> anyhow::Result<Option<Request<S>>> {
 	let remaining = run_handshake(&mut stream, peer).await?;
 
 	let (mut session, initial) =
@@ -273,8 +400,8 @@ async fn accept_until_publish(mut stream: TcpStream, peer: SocketAddr) -> anyhow
 }
 
 /// Pump RTMP media into the publisher until the client disconnects or finishes.
-async fn pump(
-	stream: &mut TcpStream,
+async fn pump<S: Stream>(
+	stream: &mut S,
 	session: &mut ServerSession,
 	work: &mut VecDeque<ServerSessionResult>,
 	publisher: &mut Publisher,
@@ -333,7 +460,7 @@ async fn pump(
 
 /// Perform the RTMP server handshake, returning any leftover bytes that followed
 /// the client's final handshake packet (the start of the chunk stream).
-async fn run_handshake(stream: &mut TcpStream, peer: SocketAddr) -> anyhow::Result<Vec<u8>> {
+async fn run_handshake<S: Stream>(stream: &mut S, peer: SocketAddr) -> anyhow::Result<Vec<u8>> {
 	let mut handshake = Handshake::new(PeerType::Server);
 	let p0_p1 = handshake
 		.generate_outbound_p0_and_p1()
@@ -423,11 +550,11 @@ mod tests {
 		ClientSession, ClientSessionConfig, ClientSessionEvent, ClientSessionResult, PublishRequestType,
 	};
 
-	/// Drive a real RTMP client through handshake -> connect(`live`) ->
-	/// publish(`cam0`), pumping until aborted by the test.
-	async fn run_client(addr: SocketAddr) {
-		let mut stream = TcpStream::connect(addr).await.unwrap();
-
+	/// Drive a real RTMP client over an already-connected `stream` through
+	/// handshake -> connect(`live`) -> publish(`cam0`), pumping until aborted by
+	/// the test. Generic over the transport so the same client exercises both
+	/// plaintext RTMP and RTMPS.
+	async fn run_client<S: Stream>(mut stream: S) {
 		// Handshake.
 		let mut handshake = Handshake::new(PeerType::Client);
 		stream
@@ -498,7 +625,102 @@ mod tests {
 		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
 		let addr = server.local_addr().unwrap();
 
-		let client = tokio::spawn(run_client(addr));
+		let client = tokio::spawn(async move {
+			let stream = TcpStream::connect(addr).await.unwrap();
+			run_client(stream).await;
+		});
+
+		let request = tokio::time::timeout(Duration::from_secs(5), server.accept())
+			.await
+			.expect("server.accept timed out")
+			.expect("server yielded a request");
+
+		assert_eq!(request.app(), "live");
+		assert_eq!(request.stream_key(), "cam0");
+
+		request.reject("test rejection").await.unwrap();
+		client.abort();
+	}
+
+	/// The same publish flow, but over TLS: prove [`Server::with_tls`] terminates
+	/// RTMPS and yields an identical [`Request`]. Gated on `quinn` because it
+	/// borrows moq-native's cert generation (`server_config`), which needs a
+	/// moq-native backend feature.
+	#[cfg(feature = "quinn")]
+	#[tokio::test]
+	async fn rtmps_accept_yields_publish_request() {
+		use std::sync::Arc;
+
+		use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+		use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+		use rustls::{DigitallySignedStruct, SignatureScheme};
+
+		// Accept any server cert: the test uses a throwaway self-signed cert.
+		#[derive(Debug)]
+		struct NoVerify(Arc<rustls::crypto::CryptoProvider>);
+
+		impl ServerCertVerifier for NoVerify {
+			fn verify_server_cert(
+				&self,
+				_end_entity: &CertificateDer<'_>,
+				_intermediates: &[CertificateDer<'_>],
+				_server_name: &ServerName<'_>,
+				_ocsp: &[u8],
+				_now: UnixTime,
+			) -> std::result::Result<ServerCertVerified, rustls::Error> {
+				Ok(ServerCertVerified::assertion())
+			}
+
+			fn verify_tls12_signature(
+				&self,
+				message: &[u8],
+				cert: &CertificateDer<'_>,
+				dss: &DigitallySignedStruct,
+			) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+				rustls::crypto::verify_tls12_signature(message, cert, dss, &self.0.signature_verification_algorithms)
+			}
+
+			fn verify_tls13_signature(
+				&self,
+				message: &[u8],
+				cert: &CertificateDer<'_>,
+				dss: &DigitallySignedStruct,
+			) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+				rustls::crypto::verify_tls13_signature(message, cert, dss, &self.0.signature_verification_algorithms)
+			}
+
+			fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+				self.0.signature_verification_algorithms.supported_schemes()
+			}
+		}
+
+		let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+
+		// Server: a self-signed cert for `localhost`, fronting the RTMP listener.
+		let mut tls = moq_native::tls::Server::default();
+		tls.generate = vec!["localhost".to_string()];
+		let server_config = tls.server_config(vec![]).expect("build RTMPS server config");
+
+		let mut server = Server::bind("127.0.0.1:0".parse().unwrap())
+			.await
+			.unwrap()
+			.with_tls(server_config);
+		let addr = server.local_addr().unwrap();
+
+		// Client: TLS-connect (no verify), then run the ordinary RTMP client.
+		let client = tokio::spawn(async move {
+			let client_config = rustls::ClientConfig::builder_with_provider(provider.clone())
+				.with_safe_default_protocol_versions()
+				.unwrap()
+				.dangerous()
+				.with_custom_certificate_verifier(Arc::new(NoVerify(provider)))
+				.with_no_client_auth();
+			let connector = tokio_rustls::TlsConnector::from(Arc::new(client_config));
+			let tcp = TcpStream::connect(addr).await.unwrap();
+			let server_name = ServerName::try_from("localhost").unwrap();
+			let stream = connector.connect(server_name, tcp).await.unwrap();
+			run_client(stream).await;
+		});
 
 		let request = tokio::time::timeout(Duration::from_secs(5), server.accept())
 			.await

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -30,6 +30,12 @@ use crate::flv;
 /// Read buffer size for pulling RTMP chunk-stream bytes off the socket.
 const READ_BUFFER: usize = 16 * 1024;
 
+/// How long a connection has to finish the handshake and issue its `publish`
+/// before it is dropped. Bounds the lifetime (and socket / `pending` slot) of a
+/// client that connects but never publishes, so idle or half-open connections
+/// can't accumulate without limit.
+const PUBLISH_TIMEOUT: Duration = Duration::from_secs(15);
+
 /// An RTMP server that yields each connection's pending publish as a [`Request`].
 ///
 /// Build it with [`bind`](Self::bind), then loop on [`accept`](Self::accept).
@@ -80,10 +86,14 @@ impl Server {
 							tracing::debug!(%peer, %err, "failed to set TCP_NODELAY");
 						}
 						self.pending.push(Box::pin(async move {
-							match accept_until_publish(stream, peer).await {
-								Ok(request) => request,
-								Err(err) => {
+							match tokio::time::timeout(PUBLISH_TIMEOUT, accept_until_publish(stream, peer)).await {
+								Ok(Ok(request)) => request,
+								Ok(Err(err)) => {
 									tracing::warn!(%peer, %err, "RTMP connection closed before publish");
+									None
+								}
+								Err(_) => {
+									tracing::warn!(%peer, "RTMP connection did not publish before timeout");
 									None
 								}
 							}
@@ -390,6 +400,13 @@ impl Publisher {
 
 	/// Re-wrap one RTMP audio/video message body as an FLV tag and demux it.
 	fn push(&mut self, tag_type: u8, timestamp: u32, body: &[u8]) -> anyhow::Result<()> {
+		// FLV's tag DataSize is 24-bit. A larger body would truncate, declaring a
+		// wrong size that desyncs the demuxer on the next tag. Drop it instead.
+		anyhow::ensure!(
+			body.len() <= 0xFF_FFFF,
+			"RTMP message body {} exceeds FLV's 24-bit tag size limit",
+			body.len()
+		);
 		self.importer.decode(&flv::tag(tag_type, timestamp, body))
 	}
 

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -1,0 +1,497 @@
+//! RTMP server: accept connections, and hand each pending publish to the caller
+//! as a [`Request`] to authorize.
+//!
+//! [`Server::accept`] runs the RTMP handshake and the connect/publish command
+//! exchange for each TCP connection (many concurrently, so a slow client doesn't
+//! block others), then yields a [`Request`] once the client issues its `publish`
+//! command. The caller inspects the app and stream key, makes an authorization
+//! decision, and calls [`Request::accept`] (publish into an origin at a path) or
+//! [`Request::reject`]. This mirrors `moq-native`'s `Server` / `Request`, so the
+//! gateway stays unopinionated about auth: the embedder (e.g. a relay verifying
+//! the stream key as a JWT) owns that policy.
+
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use futures::StreamExt;
+use futures::future::BoxFuture;
+use futures::stream::FuturesUnordered;
+use moq_mux::container::flv::Import as FlvImport;
+use moq_net::{BroadcastInfo, OriginProducer, OriginPublish};
+use rml_rtmp::handshake::{Handshake, HandshakeProcessResult, PeerType};
+use rml_rtmp::sessions::{ServerSession, ServerSessionConfig, ServerSessionEvent, ServerSessionResult};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::Result;
+use crate::flv;
+
+/// Read buffer size for pulling RTMP chunk-stream bytes off the socket.
+const READ_BUFFER: usize = 16 * 1024;
+
+/// An RTMP server that yields each connection's pending publish as a [`Request`].
+///
+/// Build it with [`bind`](Self::bind), then loop on [`accept`](Self::accept).
+/// The handshake and the connect/publish exchange happen inside `accept`, so a
+/// [`Request`] is only produced once a client actually wants to publish.
+pub struct Server {
+	listener: TcpListener,
+	/// In-flight handshakes; each resolves to a ready [`Request`], or `None` if
+	/// the connection closed or errored before issuing a publish.
+	pending: FuturesUnordered<BoxFuture<'static, Option<Request>>>,
+}
+
+impl Server {
+	/// Bind an RTMP listener on `addr` (RTMP's well-known port is 1935).
+	pub async fn bind(addr: SocketAddr) -> Result<Self> {
+		let listener = TcpListener::bind(addr).await?;
+		Ok(Self {
+			listener,
+			pending: FuturesUnordered::new(),
+		})
+	}
+
+	/// The local address the listener is bound to.
+	pub fn local_addr(&self) -> Result<SocketAddr> {
+		Ok(self.listener.local_addr()?)
+	}
+
+	/// Wait for the next connection that wants to publish.
+	///
+	/// New connections are accepted and handshaked concurrently; this returns the
+	/// next one to reach its `publish` command. Connections that close or error
+	/// before publishing are dropped without surfacing here. Returns `None` only
+	/// if the listener itself stops (it currently never does).
+	pub async fn accept(&mut self) -> Option<Request> {
+		loop {
+			tokio::select! {
+				// A handshake finished: yield its request, or skip a dead connection.
+				Some(maybe) = self.pending.next(), if !self.pending.is_empty() => {
+					if let Some(request) = maybe {
+						return Some(request);
+					}
+				}
+				// A new TCP connection: start its handshake concurrently.
+				res = self.listener.accept() => match res {
+					Ok((stream, peer)) => {
+						// Nagle off: RTMP is latency-sensitive and we write whole packets.
+						if let Err(err) = stream.set_nodelay(true) {
+							tracing::debug!(%peer, %err, "failed to set TCP_NODELAY");
+						}
+						self.pending.push(Box::pin(async move {
+							match accept_until_publish(stream, peer).await {
+								Ok(request) => request,
+								Err(err) => {
+									tracing::warn!(%peer, %err, "RTMP connection closed before publish");
+									None
+								}
+							}
+						}));
+					}
+					Err(err) => {
+						// A failed accept must not take the listener down; back off so a
+						// persistent error doesn't busy-spin.
+						tracing::warn!(%err, "failed to accept RTMP connection; continuing");
+						tokio::time::sleep(Duration::from_millis(100)).await;
+					}
+				},
+			}
+		}
+	}
+}
+
+/// A pending RTMP publish, waiting on the caller to authorize it.
+///
+/// Inspect [`app`](Self::app) and [`stream_key`](Self::stream_key) (an
+/// `rtmp://host/<app>/<key>` URL splits into these), then either
+/// [`accept`](Self::accept) the publish into an origin at a chosen broadcast
+/// path or [`reject`](Self::reject) it. Dropping a `Request` without either
+/// closes the connection.
+pub struct Request {
+	stream: TcpStream,
+	session: ServerSession,
+	/// The `rml_rtmp` request id for the pending publish, replied to on accept/reject.
+	request_id: u32,
+	/// Session results produced alongside the publish command, processed once the
+	/// publish is accepted.
+	work: VecDeque<ServerSessionResult>,
+	app: String,
+	stream_key: String,
+	peer: SocketAddr,
+}
+
+impl Request {
+	/// The RTMP app name (the path component of `rtmp://host/<app>/<key>`).
+	pub fn app(&self) -> &str {
+		&self.app
+	}
+
+	/// The RTMP stream key (the final component of `rtmp://host/<app>/<key>`).
+	///
+	/// Conventionally a publish secret; an embedder can treat it as a token (e.g.
+	/// a moq-token JWT) to authenticate the publish.
+	pub fn stream_key(&self) -> &str {
+		&self.stream_key
+	}
+
+	/// The remote peer address.
+	pub fn peer(&self) -> SocketAddr {
+		self.peer
+	}
+
+	/// Accept the publish: announce a broadcast at `path` in `origin` and pump the
+	/// RTMP media into it until the client disconnects.
+	///
+	/// `origin` is whatever the caller wants the media published into (e.g. a
+	/// relay's shared origin, optionally re-rooted/scoped per the authenticated
+	/// token). This future resolves when the connection ends, so callers usually
+	/// run it on its own task.
+	pub async fn accept(mut self, origin: &OriginProducer, path: &str) -> Result<()> {
+		let results = self
+			.session
+			.accept_request(self.request_id)
+			.map_err(|e| anyhow::anyhow!("rtmp accept publish: {e:?}"))?;
+		self.work.extend(results);
+
+		let mut publisher = Publisher::new(origin, path)?;
+		tracing::info!(peer = %self.peer, %path, "rtmp publish accepted");
+
+		let result = pump(
+			&mut self.stream,
+			&mut self.session,
+			&mut self.work,
+			&mut publisher,
+			self.peer,
+		)
+		.await;
+
+		// Flush the importer so the final groups close cleanly before unannouncing.
+		if let Err(err) = publisher.finish() {
+			tracing::debug!(peer = %self.peer, %err, "error finishing RTMP publish");
+		}
+
+		Ok(result?)
+	}
+
+	/// Reject the publish, sending `reason` back to the client as the
+	/// `NetStream.Publish.Denied` description, then close the connection.
+	pub async fn reject(mut self, reason: &str) -> Result<()> {
+		let results = self
+			.session
+			.reject_request(self.request_id, "NetStream.Publish.Denied", reason)
+			.map_err(|e| anyhow::anyhow!("rtmp reject publish: {e:?}"))?;
+
+		// Flush any pending writes plus the rejection so it reaches the client.
+		for result in self.work.drain(..).chain(results) {
+			if let ServerSessionResult::OutboundResponse(packet) = result {
+				self.stream.write_all(&packet.bytes).await?;
+			}
+		}
+		tracing::debug!(peer = %self.peer, %reason, "rtmp publish rejected");
+		Ok(())
+	}
+}
+
+/// Run one connection's handshake and connect/publish exchange, returning a
+/// [`Request`] once the client issues `publish` (or `None` if it disconnects first).
+async fn accept_until_publish(mut stream: TcpStream, peer: SocketAddr) -> anyhow::Result<Option<Request>> {
+	let remaining = run_handshake(&mut stream, peer).await?;
+
+	let (mut session, initial) =
+		ServerSession::new(ServerSessionConfig::new()).map_err(|e| anyhow::anyhow!("rtmp session init: {e:?}"))?;
+	let mut work: VecDeque<ServerSessionResult> = VecDeque::from(initial);
+
+	// Any RTMP bytes bundled with the final handshake packet.
+	if !remaining.is_empty() {
+		let results = session
+			.handle_input(&remaining)
+			.map_err(|e| anyhow::anyhow!("rtmp handle_input: {e:?}"))?;
+		work.extend(results);
+	}
+
+	let mut buffer = [0u8; READ_BUFFER];
+	loop {
+		while let Some(result) = work.pop_front() {
+			match result {
+				ServerSessionResult::OutboundResponse(packet) => {
+					stream.write_all(&packet.bytes).await?;
+				}
+				ServerSessionResult::RaisedEvent(event) => match event {
+					// Accept every connect; authorization happens at publish time.
+					ServerSessionEvent::ConnectionRequested { request_id, app_name } => {
+						tracing::debug!(%peer, %app_name, "rtmp connect");
+						let results = session
+							.accept_request(request_id)
+							.map_err(|e| anyhow::anyhow!("rtmp accept connect: {e:?}"))?;
+						work.extend(results);
+					}
+					// The client wants to publish: hand control back to the caller.
+					ServerSessionEvent::PublishStreamRequested {
+						request_id,
+						app_name,
+						stream_key,
+						..
+					} => {
+						return Ok(Some(Request {
+							stream,
+							session,
+							request_id,
+							work,
+							app: app_name,
+							stream_key,
+							peer,
+						}));
+					}
+					other => tracing::trace!(%peer, ?other, "ignoring RTMP event before publish"),
+				},
+				ServerSessionResult::UnhandleableMessageReceived(_) => {
+					tracing::trace!(%peer, "ignoring unhandleable RTMP message");
+				}
+			}
+		}
+
+		let n = stream.read(&mut buffer).await?;
+		if n == 0 {
+			return Ok(None);
+		}
+		let results = session
+			.handle_input(&buffer[..n])
+			.map_err(|e| anyhow::anyhow!("rtmp handle_input: {e:?}"))?;
+		work.extend(results);
+	}
+}
+
+/// Pump RTMP media into the publisher until the client disconnects or finishes.
+async fn pump(
+	stream: &mut TcpStream,
+	session: &mut ServerSession,
+	work: &mut VecDeque<ServerSessionResult>,
+	publisher: &mut Publisher,
+	peer: SocketAddr,
+) -> anyhow::Result<()> {
+	let mut buffer = [0u8; READ_BUFFER];
+	loop {
+		let mut finished = false;
+		while let Some(result) = work.pop_front() {
+			match result {
+				ServerSessionResult::OutboundResponse(packet) => {
+					stream.write_all(&packet.bytes).await?;
+				}
+				ServerSessionResult::RaisedEvent(event) => match event {
+					// A frame that fails to demux is dropped, not fatal: the importer
+					// consumes whole tags atomically, so one bad frame doesn't desync
+					// the stream, and tearing down a live publish over it would be worse.
+					ServerSessionEvent::AudioDataReceived { data, timestamp, .. } => {
+						if let Err(err) = publisher.push(flv::TAG_AUDIO, timestamp.value, &data) {
+							tracing::warn!(%peer, %err, "dropping RTMP audio frame that failed to demux");
+						}
+					}
+					ServerSessionEvent::VideoDataReceived { data, timestamp, .. } => {
+						if let Err(err) = publisher.push(flv::TAG_VIDEO, timestamp.value, &data) {
+							tracing::warn!(%peer, %err, "dropping RTMP video frame that failed to demux");
+						}
+					}
+					ServerSessionEvent::PublishStreamFinished { .. } => finished = true,
+					// onMetaData and other script data: the FLV importer reads codec
+					// config from the sequence headers, so metadata isn't forwarded.
+					ServerSessionEvent::StreamMetadataChanged { .. } => {}
+					other => tracing::trace!(%peer, ?other, "ignoring RTMP event"),
+				},
+				ServerSessionResult::UnhandleableMessageReceived(_) => {
+					tracing::trace!(%peer, "ignoring unhandleable RTMP message");
+				}
+			}
+		}
+		if finished {
+			break;
+		}
+
+		let n = stream.read(&mut buffer).await?;
+		if n == 0 {
+			break;
+		}
+		let results = session
+			.handle_input(&buffer[..n])
+			.map_err(|e| anyhow::anyhow!("rtmp handle_input: {e:?}"))?;
+		work.extend(results);
+	}
+
+	tracing::debug!(%peer, "rtmp connection closed");
+	Ok(())
+}
+
+/// Perform the RTMP server handshake, returning any leftover bytes that followed
+/// the client's final handshake packet (the start of the chunk stream).
+async fn run_handshake(stream: &mut TcpStream, peer: SocketAddr) -> anyhow::Result<Vec<u8>> {
+	let mut handshake = Handshake::new(PeerType::Server);
+	let p0_p1 = handshake
+		.generate_outbound_p0_and_p1()
+		.map_err(|e| anyhow::anyhow!("rtmp handshake p0/p1: {e:?}"))?;
+	stream.write_all(&p0_p1).await?;
+
+	let mut buffer = [0u8; 4096];
+	loop {
+		let n = stream.read(&mut buffer).await?;
+		if n == 0 {
+			anyhow::bail!("peer {peer} closed during handshake");
+		}
+
+		match handshake
+			.process_bytes(&buffer[..n])
+			.map_err(|e| anyhow::anyhow!("rtmp handshake: {e:?}"))?
+		{
+			HandshakeProcessResult::InProgress { response_bytes } => {
+				if !response_bytes.is_empty() {
+					stream.write_all(&response_bytes).await?;
+				}
+			}
+			HandshakeProcessResult::Completed {
+				response_bytes,
+				remaining_bytes,
+			} => {
+				if !response_bytes.is_empty() {
+					stream.write_all(&response_bytes).await?;
+				}
+				tracing::debug!(%peer, "rtmp handshake complete");
+				return Ok(remaining_bytes);
+			}
+		}
+	}
+}
+
+/// An active publish: the moq-mux FLV importer (which owns the
+/// [`BroadcastProducer`](moq_net::BroadcastProducer) it publishes into) plus the
+/// origin announcement. Dropping it closes and unannounces the broadcast.
+struct Publisher {
+	/// Held to keep the broadcast announced for the publisher's lifetime.
+	_publish: OriginPublish,
+	importer: FlvImport,
+}
+
+impl Publisher {
+	/// Open a broadcast at `path` and prime the importer with the FLV file
+	/// header, so subsequent tags decode against an initialized demuxer.
+	fn new(origin: &OriginProducer, path: &str) -> anyhow::Result<Self> {
+		let mut broadcast = BroadcastInfo::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+		let mut importer = FlvImport::new(broadcast.clone(), catalog);
+
+		let publish = origin.publish_broadcast(path, broadcast.consume())?;
+
+		// Feed the FLV file header once up front; media tags follow per message.
+		importer.decode(&flv::file_header())?;
+
+		Ok(Self {
+			_publish: publish,
+			importer,
+		})
+	}
+
+	/// Re-wrap one RTMP audio/video message body as an FLV tag and demux it.
+	fn push(&mut self, tag_type: u8, timestamp: u32, body: &[u8]) -> anyhow::Result<()> {
+		self.importer.decode(&flv::tag(tag_type, timestamp, body))
+	}
+
+	/// Flush any buffered media and close out the broadcast's open groups.
+	fn finish(&mut self) -> anyhow::Result<()> {
+		self.importer.finish()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use rml_rtmp::sessions::{
+		ClientSession, ClientSessionConfig, ClientSessionEvent, ClientSessionResult, PublishRequestType,
+	};
+
+	/// Drive a real RTMP client through handshake -> connect(`live`) ->
+	/// publish(`cam0`), pumping until aborted by the test.
+	async fn run_client(addr: SocketAddr) {
+		let mut stream = TcpStream::connect(addr).await.unwrap();
+
+		// Handshake.
+		let mut handshake = Handshake::new(PeerType::Client);
+		stream
+			.write_all(&handshake.generate_outbound_p0_and_p1().unwrap())
+			.await
+			.unwrap();
+		let mut buffer = [0u8; 4096];
+		let remaining = loop {
+			let n = stream.read(&mut buffer).await.unwrap();
+			match handshake.process_bytes(&buffer[..n]).unwrap() {
+				HandshakeProcessResult::InProgress { response_bytes } => {
+					if !response_bytes.is_empty() {
+						stream.write_all(&response_bytes).await.unwrap();
+					}
+				}
+				HandshakeProcessResult::Completed {
+					response_bytes,
+					remaining_bytes,
+				} => {
+					if !response_bytes.is_empty() {
+						stream.write_all(&response_bytes).await.unwrap();
+					}
+					break remaining_bytes;
+				}
+			}
+		};
+
+		let (mut session, initial) = ClientSession::new(ClientSessionConfig::new()).unwrap();
+		let mut work: VecDeque<ClientSessionResult> = VecDeque::from(initial);
+		if !remaining.is_empty() {
+			work.extend(session.handle_input(&remaining).unwrap());
+		}
+		work.push_back(session.request_connection("live".to_string()).unwrap());
+
+		loop {
+			while let Some(result) = work.pop_front() {
+				match result {
+					ClientSessionResult::OutboundResponse(packet) => {
+						stream.write_all(&packet.bytes).await.unwrap();
+					}
+					// Once connected, ask to publish; the publish command is sent
+					// automatically as the createStream round trip completes.
+					ClientSessionResult::RaisedEvent(ClientSessionEvent::ConnectionRequestAccepted) => {
+						let result = session
+							.request_publishing("cam0".to_string(), PublishRequestType::Live)
+							.unwrap();
+						work.push_back(result);
+					}
+					_ => {}
+				}
+			}
+			let n = match stream.read(&mut buffer).await {
+				Ok(n) => n,
+				Err(_) => return,
+			};
+			if n == 0 {
+				return;
+			}
+			match session.handle_input(&buffer[..n]) {
+				Ok(results) => work.extend(results),
+				Err(_) => return,
+			}
+		}
+	}
+
+	#[tokio::test]
+	async fn accept_yields_publish_request() {
+		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+		let addr = server.local_addr().unwrap();
+
+		let client = tokio::spawn(run_client(addr));
+
+		let request = tokio::time::timeout(Duration::from_secs(5), server.accept())
+			.await
+			.expect("server.accept timed out")
+			.expect("server yielded a request");
+
+		assert_eq!(request.app(), "live");
+		assert_eq!(request.stream_key(), "cam0");
+
+		request.reject("test rejection").await.unwrap();
+		client.abort();
+	}
+}


### PR DESCRIPTION
Adds **`moq-rtmp`**, an RTMP contribution-ingest gateway (sibling of `moq-srt`), plus the **enhanced-RTMP codec support** in the `moq-mux` FLV demuxer it builds on.

## moq-mux FLV (import + export)

The FLV demuxer previously handled only legacy H.264 + AAC and dropped/rejected the enhanced-RTMP (E-RTMP) FourCC payloads. Both directions now handle:

- **Video**: HEVC (`hvc1`), AV1 (`av01`), VP9 (`vp09`), and the AVC FourCC (`avc1`)
- **Audio**: Opus (`Opus`), AC-3 (`ac-3`), E-AC-3 (`ec-3`), and AAC (`mp4a`)

FLAC/MP3 enhanced audio are dropped (no MoQ catalog codec). Each codec reuses the existing config parsers via new `pub(crate)` helpers (`h265::config_from_hvcc`, `av1::config_from_av1c`, `vp9::config_from_keyframe`); VP9 / AC-3 / E-AC-3 configure in band from the first frame. **No public API change** — purely additive behavior.

## moq-rtmp (new crate)

Runs an RTMP server (OBS, ffmpeg, hardware encoders) and publishes each stream into a MoQ origin. Pure Rust via `rml_rtmp` (handshake / chunk / AMF, no librtmp); RTMP audio/video messages are re-wrapped as FLV tags and fed to `moq_mux::container::flv::Import`, so both legacy and enhanced codecs flow through.

**Auth is a `moq-native`-style `Server` / `Request`** (no callback): `Server::accept()` yields a pending publish; the caller inspects `app()` / `stream_key()`, then calls `request.accept(origin, path)` or `request.reject(reason)`. An embedder (e.g. a relay verifying the stream key as a JWT and scoping the origin per token) owns the policy. The unauthenticated `run(origin, Config)` convenience powers the binary's `serve` / `publish` modes and spawns one task per connection.

Docs: `doc/bin/rtmp.md` + index entry.

## Test plan

- [x] `cargo test -p moq-mux` (268 pass) — incl. new enhanced VP9/Opus import + VP9/Opus export round-trip tests
- [x] `cargo test -p moq-rtmp` (9 pass) — incl. an **end-to-end test** driving a real `rml_rtmp` *client* through handshake → connect → publish against `Server::accept`
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --all --check` clean
- [ ] Not yet exercised against a real encoder (OBS / ffmpeg)
- [ ] `taplo` not run locally (nix devshell unavailable in this environment); TOML mirrors the taplo-clean `moq-srt`

Targets `dev` per the branch-targeting rules (new gateway crate + container-format work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)