### PR TITLE
fix(moq-video): NVENC falls back instead of aborting when no NVIDIA driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4337,6 +4337,7 @@ dependencies = [
  "bytes",
  "cudarc",
  "dispatch2",
+ "libloading 0.8.9",
  "moq-mux",
  "moq-net",
  "moq-vaapi",

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -26,7 +26,7 @@ doctest = false
 # links on a GPU-less builder and still starts on machines without the NVIDIA
 # driver, falling back to software (see backend::open). `cuda-12020` pins the CUDA
 # API version so the build needs no CUDA toolkit.
-nvenc = ["dep:nvidia-video-codec-sdk", "nvidia-video-codec-sdk/dynamic-loading", "cudarc/fallback-dynamic-loading", "cudarc/cuda-12020"]
+nvenc = ["dep:nvidia-video-codec-sdk", "nvidia-video-codec-sdk/dynamic-loading", "cudarc/fallback-dynamic-loading", "cudarc/cuda-12020", "dep:libloading"]
 # Intel/AMD VAAPI hardware encoder (Linux). Off by default; enable for a build
 # that should use VAAPI where present. The `moq-vaapi` crate (moq-dev/vaapi) builds
 # against its own vendored libva headers and dlopen's libva at runtime, so a
@@ -39,6 +39,9 @@ vaapi = ["dep:moq-vaapi"]
 anyhow = "1"
 bytes = "1"
 cudarc = { version = "0.19", optional = true, default-features = false, features = ["driver"] }
+# Probe for the NVIDIA driver libraries before calling cudarc / the NVENC SDK,
+# which panic if their library is absent. Gated behind the `nvenc` feature.
+libloading = { version = "0.8", optional = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
 # VAAPI H.264 encoder, gated behind the `vaapi` feature + a linux cfg. Listed here

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -53,6 +53,17 @@ impl Nvenc {
 			)));
 		}
 
+		// cudarc and the NVENC SDK dlopen their driver libraries lazily and
+		// *panic* (which aborts the process, since release builds set
+		// `panic = "abort"`) when a library is missing, e.g. on a host with no
+		// NVIDIA driver. Probe the libraries up front so an absent driver is a
+		// graceful error and `Kind::Auto` falls back to the next backend.
+		if !driver_libs_present() {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"NVIDIA driver libraries not found (libcuda / libnvidia-encode); NVENC unavailable"
+			)));
+		}
+
 		// cudarc 0.19's DriverError is Debug-only (no Display), so format with `{e:?}`.
 		let cuda = CudaContext::new(0).map_err(|e| Error::Codec(anyhow::anyhow!("CUDA init: {e:?}")))?;
 		let encoder = Encoder::initialize_with_cuda(cuda.clone())
@@ -156,5 +167,45 @@ impl Backend for Nvenc {
 
 	fn name(&self) -> &str {
 		NAME
+	}
+}
+
+/// Whether both NVIDIA driver libraries NVENC needs can be dlopen'd: libcuda
+/// (used by cudarc) and libnvidia-encode (the NVENC API). Each crate loads its
+/// library lazily and panics if it's absent, so we probe the same names here
+/// first and turn a missing driver into a recoverable `Err`.
+fn driver_libs_present() -> bool {
+	// libcuda is the CUDA driver API; matches cudarc's "cuda" search.
+	const CUDA: &[&str] = &["libcuda.so.1", "libcuda.so"];
+	// Matches the NVENC SDK's own dynamic-loading candidate list.
+	const NVENC: &[&str] = &["libnvidia-encode.so.1", "libnvidia-encode.so"];
+
+	// SAFETY: we only open the library to test presence and immediately drop the
+	// handle; we never call into it. Loading runs the library's initializers,
+	// which is sound for these driver libs.
+	let loadable = |names: &[&str]| {
+		names
+			.iter()
+			.any(|name| unsafe { libloading::Library::new(*name) }.is_ok())
+	};
+	loadable(CUDA) && loadable(NVENC)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::encode::Config;
+
+	/// On a host without the NVIDIA driver, opening NVENC must return an `Err`
+	/// (so `Kind::Auto` falls back) rather than panicking in cudarc / the NVENC
+	/// SDK loader. On a box that does have the driver this is a no-op.
+	#[test]
+	fn missing_driver_errors_instead_of_panicking() {
+		if driver_libs_present() {
+			return; // real driver present: open() would legitimately try to run
+		}
+		// width % 64 == 0 so we get past the pitch guard to the driver probe.
+		let config = Config::new(1920, 1080, 30);
+		assert!(Nvenc::open(&config).is_err());
 	}
 }


### PR DESCRIPTION
## Summary

On a Linux host with no NVIDIA driver, `moq-video`'s NVENC backend **aborts the process** instead of falling back to software. cudarc (`CudaContext::new`) and the NVENC SDK both dlopen their driver libraries lazily and **`panic!`** when the library is missing (`cudarc`'s `panic_no_lib_found`, the SDK's "failed to dlopen the NVIDIA encode library"). Under release's `panic = "abort"` that panic aborts; in tests (Cargo forces unwind) it shows up as a hard test failure.

So `Kind::Auto` / `Kind::Hardware` — the default for `moq-cli capture` — crashes on any GPU-less Linux box, contrary to the documented "falls back to software (see backend::open)" behavior.

This was surfaced by a `Kind::Auto` round-trip test in #1802 panicking on the GPU-less CI runner.

## Fix

Probe the driver libraries with `libloading` *before* calling into cudarc / the SDK, and return `Error::Codec` if either is absent so `backend::open` moves on to the next candidate (openh264):

- `libcuda.so.1` / `libcuda.so` (cudarc's CUDA driver), and
- `libnvidia-encode.so.1` / `libnvidia-encode.so` (matches the SDK's own candidate list).

A pre-check (not `catch_unwind`) is required because release builds use `panic = "abort"`, where `catch_unwind` can't help. `libloading` is added as an `nvenc`-feature-gated optional dep, mirroring the existing `cudarc` / `nvidia-video-codec-sdk` gating.

## Test plan

- [x] `cargo fmt --check` clean; non-NVENC `cargo build -p moq-video` unaffected (macOS).
- [x] New `#[cfg(all(target_os = "linux", feature = "nvenc"))]` test `missing_driver_errors_instead_of_panicking`: on a host without the driver, `Nvenc::open` returns `Err` rather than panicking. This runs on the GPU-less Linux CI runner (`cargo test -p moq-video --all-features`), which is exactly where the abort happened before.
- [ ] Could not compile-check the `cfg(linux)` path locally (macOS box; nix/rustup cross-toolchain split blocked a zigbuild). Relying on the Linux CI runner to compile + run the new test.

## Note

VAAPI (`moq-vaapi`, dlopen'd libva) may have the same panic-on-missing-library shape; if so, `Kind::Auto` would still abort at the VAAPI candidate after NVENC falls back. Worth a follow-up check, but out of scope here.

(Written by Claude)