### PR TITLE
feat(moq-rtmp): RTMPS support via generic stream + TLS helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,6 +4316,7 @@ dependencies = [
  "sd-notify",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tower-http",
  "tracing",
  "url",

--- a/doc/bin/rtmp.md
+++ b/doc/bin/rtmp.md
@@ -59,6 +59,24 @@ ffmpeg -re -i input.mp4 -c copy -f flv rtmp://127.0.0.1:1935/live/cam0
 - `--rtmp-prefix`: prepended to every broadcast path, to namespace a listener's
   streams (e.g. `live/`).
 
+### RTMPS flags
+
+RTMPS (RTMP over TLS, `rtmps://`) is served on a second listener alongside
+plaintext RTMP, sharing the same `--rtmp-prefix`:
+
+- `--rtmps-listen`: TCP bind address for the RTMPS server (off unless set). RTMPS
+  has no well-known port; 443 or a custom one are common.
+- `--rtmps-tls-cert` / `--rtmps-tls-key`: PEM certificate chain and key.
+- `--rtmps-tls-generate <hostname>`: or generate a throwaway self-signed cert
+  (testing only; clients must disable verification).
+
+```bash
+moq-rtmp serve --server-bind [::]:443 --tls-generate localhost \
+  --rtmp-listen 0.0.0.0:1935 \
+  --rtmps-listen 0.0.0.0:1936 --rtmps-tls-cert cert.pem --rtmps-tls-key key.pem \
+  --rtmp-prefix live/
+```
+
 ## Routing
 
 Each connection's broadcast path is `<app>/<key>` from the RTMP app and stream
@@ -80,6 +98,10 @@ connection to the same path is rejected.
   origin for the unauthenticated case, or use `Server` / `Request` to plug in the
   relay's existing JWT/path auth and scope the origin per token. Either way the
   media is published locally with no extra hop.
+- **RTMPS.** Embedders can terminate TLS themselves: set `Config::tls` (or
+  `Server::with_tls`) with a `rustls::ServerConfig`, or accept the connection and
+  finish the TLS handshake by hand and hand the stream to `moq_rtmp::accept_stream`
+  (which works over any `AsyncRead + AsyncWrite` transport).
 - **Codecs.** FLAC and MP3 enhanced-audio payloads are dropped (no MoQ catalog
   codec); everything else (H.264/HEVC/AV1/VP9 video, AAC/Opus/AC-3/E-AC-3 audio)
   is supported.

--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -28,15 +28,17 @@ required-features = ["server"]
 default = ["server", "quinn", "websocket"]
 # Relay client/server transports + the moq-rtmp binary. Pulls in moq-native /
 # axum / clap / rustls.
-server = ["dep:axum", "dep:axum-server", "dep:clap", "dep:moq-native", "dep:rustls", "dep:sd-notify", "dep:tower-http", "dep:url"]
+server = ["dep:axum", "dep:axum-server", "dep:clap", "dep:moq-native", "dep:rustls", "dep:sd-notify", "dep:tokio-rustls", "dep:tower-http", "dep:url"]
 quinn = ["server", "moq-native/quinn"]
 quiche = ["server", "moq-native/quiche"]
 websocket = ["server", "moq-native/websocket"]
 iroh = ["server", "moq-native/iroh"]
 
 # The ingest library needs only anyhow/bytes/moq-mux/moq-net/rml_rtmp/thiserror/
-# tokio/tracing; the rest (axum/clap/moq-native/rustls/tower-http/url/sd-notify)
-# are `optional` and pulled in by the `server` feature for the binary.
+# tokio/tracing; the rest (axum/clap/moq-native/rustls/tokio-rustls/tower-http/
+# url/sd-notify) are `optional` and pulled in by the `server` feature. RTMPS
+# (Config::tls / Server::with_tls) needs rustls + tokio-rustls, so it's
+# server-gated too.
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 axum = { version = "0.8", features = ["tokio"], optional = true }
@@ -53,6 +55,10 @@ rml_rtmp = "0.8"
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"], optional = true }
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }
+# RTMPS: TLS-terminate accepted connections. Mirrors moq-relay's pinning so the
+# workspace shares one tokio-rustls; the crypto provider comes from the supplied
+# `rustls::ServerConfig`, so no default crypto feature is needed here.
+tokio-rustls = { version = "0.26", default-features = false, optional = true }
 tower-http = { version = "0.6", features = ["cors", "fs"], optional = true }
 tracing = "0.1"
 url = { version = "2", optional = true }

--- a/rs/moq-rtmp/README.md
+++ b/rs/moq-rtmp/README.md
@@ -66,6 +66,35 @@ while let Some(request) = server.accept().await {
 }
 ```
 
+### RTMPS (RTMP over TLS)
+
+Two ways to serve `rtmps://`:
+
+- **Let the gateway terminate TLS.** Set `Config::tls` (or call
+  `Server::with_tls`) with a `rustls::ServerConfig`, and the listener speaks
+  RTMPS with no other change. Build the config from a cert/key with
+  `moq_native::tls::Server::server_config(vec![])` (RTMPS has no ALPN), or any
+  `rustls::ServerConfig`. To serve both RTMP and RTMPS, run two listeners
+  (`run` once per config) against a cloned origin.
+
+  ```rust
+  let mut rtmps = moq_rtmp::Config::default();
+  rtmps.listen = Some("0.0.0.0:443".parse()?);
+  rtmps.tls = Some(server_config); // Arc<rustls::ServerConfig>
+  ```
+
+- **Bring your own transport.** Accept the connection and complete the TLS
+  handshake yourself (or use any other `AsyncRead + AsyncWrite` stream: a proxy
+  socket, a test pipe), then hand the established stream to `accept_stream`,
+  which runs the RTMP handshake and yields the same `Request`:
+
+  ```rust
+  let tls = acceptor.accept(tcp).await?; // your tokio_rustls TlsAcceptor
+  if let Some(request) = moq_rtmp::accept_stream(tls, peer).await? {
+      // authorize, then request.accept(&origin, &path).await?
+  }
+  ```
+
 ## Binary
 
 The `moq-rtmp` binary (needs the default `server` feature) has two modes.
@@ -86,6 +115,17 @@ WebTransport (like `moq-srt publish` / `moq-hls import`):
 ```bash
 moq-rtmp publish --relay https://relay.example.com \
   --rtmp-listen 0.0.0.0:1935 --rtmp-prefix live/
+```
+
+Either mode also accepts RTMPS alongside plaintext RTMP. Add `--rtmps-listen`
+with a cert (`--rtmps-tls-cert` / `--rtmps-tls-key`, or `--rtmps-tls-generate`
+for a throwaway self-signed cert), and OBS/ffmpeg can publish to `rtmps://`:
+
+```bash
+moq-rtmp serve --server-bind [::]:443 --tls-generate localhost \
+  --rtmp-listen 0.0.0.0:1935 \
+  --rtmps-listen 0.0.0.0:1936 --rtmps-tls-cert cert.pem --rtmps-tls-key key.pem \
+  --rtmp-prefix live/
 ```
 
 Feed either mode with any RTMP source. OBS: set the server to

--- a/rs/moq-rtmp/bin/moq-rtmp.rs
+++ b/rs/moq-rtmp/bin/moq-rtmp.rs
@@ -66,24 +66,65 @@ enum Command {
 	},
 }
 
-/// CLI flags for the RTMP listener, converted into a [`moq_rtmp::Config`].
+/// CLI flags for the RTMP listener(s), converted into [`moq_rtmp::Config`]s.
 #[derive(Args, Clone)]
 struct RtmpArgs {
-	/// Address to listen on for RTMP ingest. RTMP's well-known port is 1935.
+	/// Address to listen on for plaintext RTMP ingest (`rtmp://`). RTMP's
+	/// well-known port is 1935.
 	#[arg(long = "rtmp-listen", env = "MOQ_RTMP_LISTEN", default_value = "[::]:1935")]
 	listen: SocketAddr,
 
 	/// Prefix prepended to every ingested broadcast path (e.g. `live/`).
 	#[arg(long = "rtmp-prefix", env = "MOQ_RTMP_PREFIX", default_value = "")]
 	prefix: String,
+
+	/// Also listen for RTMPS (RTMP over TLS, `rtmps://`) on this address, in
+	/// addition to plaintext RTMP. Requires a certificate via `--rtmps-tls-cert`
+	/// /`--rtmps-tls-key` or a self-signed `--rtmps-tls-generate`. RTMPS has no
+	/// well-known port; common choices are 443 or a custom one.
+	#[arg(long = "rtmps-listen", env = "MOQ_RTMPS_LISTEN")]
+	rtmps_listen: Option<SocketAddr>,
+
+	/// PEM certificate chain for RTMPS.
+	#[arg(long = "rtmps-tls-cert", env = "MOQ_RTMPS_TLS_CERT")]
+	rtmps_cert: Option<PathBuf>,
+
+	/// PEM private key for RTMPS.
+	#[arg(long = "rtmps-tls-key", env = "MOQ_RTMPS_TLS_KEY")]
+	rtmps_key: Option<PathBuf>,
+
+	/// Or generate a self-signed RTMPS certificate for these hostnames (testing
+	/// only; clients must disable verification or pin the fingerprint).
+	#[arg(long = "rtmps-tls-generate", env = "MOQ_RTMPS_TLS_GENERATE", value_delimiter = ',')]
+	rtmps_generate: Vec<String>,
 }
 
-impl From<RtmpArgs> for moq_rtmp::Config {
-	fn from(args: RtmpArgs) -> Self {
-		let mut config = moq_rtmp::Config::default();
-		config.listen = Some(args.listen);
-		config.prefix = args.prefix;
-		config
+impl RtmpArgs {
+	/// Build the listener configs: always plaintext RTMP, plus RTMPS when
+	/// `--rtmps-listen` is set. Both share the `--rtmp-prefix`.
+	fn configs(&self) -> anyhow::Result<Vec<moq_rtmp::Config>> {
+		let mut plain = moq_rtmp::Config::default();
+		plain.listen = Some(self.listen);
+		plain.prefix = self.prefix.clone();
+		let mut configs = vec![plain];
+
+		if let Some(addr) = self.rtmps_listen {
+			// Reuse moq-native's cert loader (on-disk pair or self-signed). RTMPS
+			// has no ALPN convention, so advertise none.
+			let mut tls = moq_native::tls::Server::default();
+			tls.cert = self.rtmps_cert.clone().into_iter().collect();
+			tls.key = self.rtmps_key.clone().into_iter().collect();
+			tls.generate = self.rtmps_generate.clone();
+			let server_config = tls.server_config(vec![]).context("build RTMPS TLS config")?;
+
+			let mut rtmps = moq_rtmp::Config::default();
+			rtmps.listen = Some(addr);
+			rtmps.prefix = self.prefix.clone();
+			rtmps.tls = Some(server_config);
+			configs.push(rtmps);
+		}
+
+		Ok(configs)
 	}
 }
 
@@ -99,16 +140,33 @@ async fn main() -> anyhow::Result<()> {
 	cli.log.init()?;
 
 	match cli.command {
-		Command::Serve { config, dir, rtmp } => run_serve(config, dir, rtmp.into()).await,
-		Command::Publish { config, relay, rtmp } => run_publish(config, relay, rtmp.into()).await,
+		Command::Serve { config, dir, rtmp } => run_serve(config, dir, rtmp.configs()?).await,
+		Command::Publish { config, relay, rtmp } => run_publish(config, relay, rtmp.configs()?).await,
 	}
+}
+
+/// Run every configured RTMP/RTMPS listener against `origin`, failing if any of
+/// them does. Stays pending while at least one listener is alive.
+async fn run_ingest(origin: moq_net::OriginProducer, configs: Vec<moq_rtmp::Config>) -> anyhow::Result<()> {
+	use futures::StreamExt;
+
+	let mut listeners: futures::stream::FuturesUnordered<_> = configs
+		.into_iter()
+		.map(|config| moq_rtmp::run(origin.clone(), config))
+		.collect();
+
+	while let Some(res) = listeners.next().await {
+		res.context("rtmp ingest failed")?;
+	}
+
+	Ok(())
 }
 
 /// Run a local QUIC/WebTransport server and ingest RTMP directly into it.
 async fn run_serve(
 	config: moq_native::ServerConfig,
 	dir: Option<PathBuf>,
-	rtmp: moq_rtmp::Config,
+	rtmp: Vec<moq_rtmp::Config>,
 ) -> anyhow::Result<()> {
 	let web_bind = config.bind.clone().unwrap_or_else(|| "[::]:443".to_string());
 
@@ -126,13 +184,13 @@ async fn run_serve(
 	tokio::select! {
 		res = serve::run(server, origin.clone()) => res.context("moq server failed"),
 		res = web::run(&web_bind, web_tls, dir) => res.context("web server failed"),
-		res = moq_rtmp::run(origin, rtmp) => res.context("rtmp ingest failed"),
+		res = run_ingest(origin, rtmp) => res,
 		_ = tokio::signal::ctrl_c() => Ok(()),
 	}
 }
 
 /// Ingest RTMP and forward every broadcast to a remote relay at `relay`.
-async fn run_publish(config: moq_native::ClientConfig, relay: Url, rtmp: moq_rtmp::Config) -> anyhow::Result<()> {
+async fn run_publish(config: moq_native::ClientConfig, relay: Url, rtmp: Vec<moq_rtmp::Config>) -> anyhow::Result<()> {
 	let client = config.init().context("init moq client")?;
 
 	// RTMP publishes broadcasts into this origin; the client forwards them on.
@@ -145,7 +203,7 @@ async fn run_publish(config: moq_native::ClientConfig, relay: Url, rtmp: moq_rtm
 	let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
 
 	tokio::select! {
-		res = moq_rtmp::run(origin, rtmp) => res.context("rtmp ingest failed"),
+		res = run_ingest(origin, rtmp) => res,
 		res = reconnect.closed() => res.context("relay connection failed"),
 		_ = tokio::signal::ctrl_c() => Ok(()),
 	}

--- a/rs/moq-rtmp/src/lib.rs
+++ b/rs/moq-rtmp/src/lib.rs
@@ -30,6 +30,17 @@
 //! The bundled `moq-rtmp` binary serves the origin locally or forwards it to a
 //! remote relay (those paths need the `server` feature).
 //!
+//! RTMPS (RTMP over TLS) is supported two ways:
+//!
+//! - **Let the gateway terminate TLS**: set [`Config::tls`] (or call
+//!   [`Server::with_tls`]) with a [`rustls::ServerConfig`], and the listener
+//!   speaks `rtmps://` with no other change.
+//! - **Bring your own transport**: accept the connection and complete the TLS
+//!   handshake yourself (any [`Stream`]: a `tokio_rustls` stream, a custom
+//!   socket, a test pipe), then hand the established stream to [`accept_stream`].
+//!   Useful when an existing TLS terminator, proxy, or non-TCP transport already
+//!   owns the socket.
+//!
 //! Pure Rust: the RTMP handshake, chunk codec, and session state machine come
 //! from [`rml_rtmp`], with no librtmp or ffmpeg dependency.
 
@@ -40,4 +51,10 @@ mod server;
 
 pub use error::{Error, Result};
 pub use listen::{Config, run};
-pub use server::{Request, Server};
+pub use server::{Conn, Request, Server, Stream, accept_stream};
+
+/// Re-export of the `rustls` version this crate builds [`Config::tls`] against,
+/// so consumers construct a matching [`rustls::ServerConfig`] (a major `rustls`
+/// bump is a breaking change). Only available with the `server` feature.
+#[cfg(feature = "server")]
+pub use rustls;

--- a/rs/moq-rtmp/src/listen.rs
+++ b/rs/moq-rtmp/src/listen.rs
@@ -40,6 +40,17 @@ pub struct Config {
 	/// Prefix prepended to every ingested broadcast path. Lets one listener
 	/// namespace all of its streams (e.g. `live/`).
 	pub prefix: String,
+
+	/// TLS configuration for RTMPS (RTMP over TLS). When set, the
+	/// [`listen`](Self::listen) address speaks RTMPS instead of plaintext RTMP,
+	/// so clients connect with `rtmps://`. Build it with
+	/// [`moq_native::tls::Server::server_config`] (pass an empty ALPN list) or
+	/// any [`rustls::ServerConfig`]. Leave `None` for plaintext.
+	///
+	/// To serve both RTMP and RTMPS, run two listeners: call [`run`] once per
+	/// config (one with `tls`, one without) against a cloned origin.
+	#[cfg(feature = "server")]
+	pub tls: Option<std::sync::Arc<rustls::ServerConfig>>,
 }
 
 /// Run the RTMP ingest listener until it fails, publishing each connection into
@@ -62,8 +73,20 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 		unreachable!("pending future never resolves");
 	};
 
+	#[cfg_attr(not(feature = "server"), allow(unused_mut))]
 	let mut server = Server::bind(listen).await?;
-	tracing::info!(%listen, prefix = %config.prefix, "RTMP ingest listening");
+
+	#[cfg(feature = "server")]
+	let tls = config.tls.is_some();
+	#[cfg(not(feature = "server"))]
+	let tls = false;
+
+	#[cfg(feature = "server")]
+	if let Some(tls) = config.tls.clone() {
+		server = server.with_tls(tls);
+	}
+
+	tracing::info!(%listen, prefix = %config.prefix, tls, "RTMP ingest listening");
 
 	// Tracks which broadcast paths are currently being ingested so a second
 	// publisher on the same stream key is rejected (first-publisher-wins) instead

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -9,9 +9,19 @@
 //! [`Request::reject`]. This mirrors `moq-native`'s `Server` / `Request`, so the
 //! gateway stays unopinionated about auth: the embedder (e.g. a relay verifying
 //! the stream key as a JWT) owns that policy.
+//!
+//! RTMPS (RTMP over TLS): [`Server::with_tls`] makes the listener terminate TLS
+//! before the RTMP handshake, so `rtmps://` clients work with no other change.
+//! If you'd rather own the transport (custom TLS, a non-TCP socket, a test
+//! pipe), accept the connection and complete any handshake yourself, then hand
+//! the established stream to [`accept_stream`]; everything here is generic over
+//! the [`Stream`] trait.
 
 use std::collections::VecDeque;
+use std::io;
 use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::StreamExt;
@@ -21,7 +31,7 @@ use moq_mux::container::flv::Import as FlvImport;
 use moq_net::{BroadcastInfo, OriginProducer, OriginPublish};
 use rml_rtmp::handshake::{Handshake, HandshakeProcessResult, PeerType};
 use rml_rtmp::sessions::{ServerSession, ServerSessionConfig, ServerSessionEvent, ServerSessionResult};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::Result;
@@ -33,19 +43,86 @@ const READ_BUFFER: usize = 16 * 1024;
 /// How long a connection has to finish the handshake and issue its `publish`
 /// before it is dropped. Bounds the lifetime (and socket / `pending` slot) of a
 /// client that connects but never publishes, so idle or half-open connections
-/// can't accumulate without limit.
+/// can't accumulate without limit. With TLS this also covers the TLS handshake.
 const PUBLISH_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// A bidirectional byte stream carrying an RTMP session.
+///
+/// A plaintext [`tokio::net::TcpStream`] for `rtmp://`, or a TLS stream you've
+/// accepted for `rtmps://`. Implemented for every
+/// `AsyncRead + AsyncWrite + Unpin + Send`, so [`accept_stream`] and
+/// [`Request`] work over whatever transport you bring.
+pub trait Stream: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> Stream for T {}
+
+/// A connection accepted by [`Server`]: plaintext RTMP, or RTMPS over TLS.
+///
+/// This is the stream type behind a [`Server`]-produced [`Request`] (hence
+/// `Request<Conn>`). Bring-your-own-transport callers using [`accept_stream`]
+/// keep their own stream type instead.
+pub enum Conn {
+	/// A plaintext TCP connection (`rtmp://`).
+	Plain(TcpStream),
+
+	/// A TLS connection (`rtmps://`), established by [`Server::with_tls`]. Boxed
+	/// because a `TlsStream` is large relative to a bare `TcpStream`.
+	#[cfg(feature = "server")]
+	Tls(Box<tokio_rustls::server::TlsStream<TcpStream>>),
+}
+
+impl AsyncRead for Conn {
+	fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+		match self.get_mut() {
+			Conn::Plain(s) => Pin::new(s).poll_read(cx, buf),
+			#[cfg(feature = "server")]
+			Conn::Tls(s) => Pin::new(s).poll_read(cx, buf),
+		}
+	}
+}
+
+impl AsyncWrite for Conn {
+	fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+		match self.get_mut() {
+			Conn::Plain(s) => Pin::new(s).poll_write(cx, buf),
+			#[cfg(feature = "server")]
+			Conn::Tls(s) => Pin::new(s).poll_write(cx, buf),
+		}
+	}
+
+	fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		match self.get_mut() {
+			Conn::Plain(s) => Pin::new(s).poll_flush(cx),
+			#[cfg(feature = "server")]
+			Conn::Tls(s) => Pin::new(s).poll_flush(cx),
+		}
+	}
+
+	fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+		match self.get_mut() {
+			Conn::Plain(s) => Pin::new(s).poll_shutdown(cx),
+			#[cfg(feature = "server")]
+			Conn::Tls(s) => Pin::new(s).poll_shutdown(cx),
+		}
+	}
+}
 
 /// An RTMP server that yields each connection's pending publish as a [`Request`].
 ///
-/// Build it with [`bind`](Self::bind), then loop on [`accept`](Self::accept).
-/// The handshake and the connect/publish exchange happen inside `accept`, so a
+/// Build it with [`bind`](Self::bind), optionally enable RTMPS with
+/// [`with_tls`](Self::with_tls), then loop on [`accept`](Self::accept). The
+/// handshake and the connect/publish exchange happen inside `accept`, so a
 /// [`Request`] is only produced once a client actually wants to publish.
 pub struct Server {
 	listener: TcpListener,
+
+	/// When set, each accepted connection is TLS-terminated (RTMPS) before the
+	/// RTMP handshake.
+	#[cfg(feature = "server")]
+	tls: Option<tokio_rustls::TlsAcceptor>,
+
 	/// In-flight handshakes; each resolves to a ready [`Request`], or `None` if
 	/// the connection closed or errored before issuing a publish.
-	pending: FuturesUnordered<BoxFuture<'static, Option<Request>>>,
+	pending: FuturesUnordered<BoxFuture<'static, Option<Request<Conn>>>>,
 }
 
 impl Server {
@@ -54,8 +131,20 @@ impl Server {
 		let listener = TcpListener::bind(addr).await?;
 		Ok(Self {
 			listener,
+			#[cfg(feature = "server")]
+			tls: None,
 			pending: FuturesUnordered::new(),
 		})
+	}
+
+	/// Terminate TLS on every accepted connection, turning this into an RTMPS
+	/// listener (`rtmps://`). Pass a `rustls::ServerConfig` (e.g. from
+	/// [`moq_native::tls::Server::server_config`] with an empty ALPN list), or
+	/// `None` to leave it plaintext.
+	#[cfg(feature = "server")]
+	pub fn with_tls(mut self, tls: impl Into<Option<std::sync::Arc<rustls::ServerConfig>>>) -> Self {
+		self.tls = tls.into().map(tokio_rustls::TlsAcceptor::from);
+		self
 	}
 
 	/// The local address the listener is bound to.
@@ -69,7 +158,7 @@ impl Server {
 	/// next one to reach its `publish` command. Connections that close or error
 	/// before publishing are dropped without surfacing here. Returns `None` only
 	/// if the listener itself stops (it currently never does).
-	pub async fn accept(&mut self) -> Option<Request> {
+	pub async fn accept(&mut self) -> Option<Request<Conn>> {
 		loop {
 			tokio::select! {
 				// A handshake finished: yield its request, or skip a dead connection.
@@ -78,15 +167,35 @@ impl Server {
 						return Some(request);
 					}
 				}
-				// A new TCP connection: start its handshake concurrently.
+				// A new TCP connection: start its (TLS +) handshake concurrently.
 				res = self.listener.accept() => match res {
 					Ok((stream, peer)) => {
 						// Nagle off: RTMP is latency-sensitive and we write whole packets.
 						if let Err(err) = stream.set_nodelay(true) {
 							tracing::debug!(%peer, %err, "failed to set TCP_NODELAY");
 						}
+						#[cfg(feature = "server")]
+						let tls = self.tls.clone();
 						self.pending.push(Box::pin(async move {
-							match tokio::time::timeout(PUBLISH_TIMEOUT, accept_until_publish(stream, peer)).await {
+							// The TLS handshake (if any) and the RTMP handshake share one
+							// budget, so a client that stalls either is dropped.
+							let outcome = tokio::time::timeout(PUBLISH_TIMEOUT, async move {
+								#[cfg(feature = "server")]
+								let conn = match tls {
+									Some(acceptor) => Conn::Tls(Box::new(
+										acceptor
+											.accept(stream)
+											.await
+											.map_err(|e| anyhow::anyhow!("rtmps tls handshake: {e}"))?,
+									)),
+									None => Conn::Plain(stream),
+								};
+								#[cfg(not(feature = "server"))]
+								let conn = Conn::Plain(stream);
+								accept_until_publish(conn, peer).await
+							})
+							.await;
+							match outcome {
 								Ok(Ok(request)) => request,
 								Ok(Err(err)) => {
 									tracing::warn!(%peer, %err, "RTMP connection closed before publish");
@@ -111,6 +220,21 @@ impl Server {
 	}
 }
 
+/// Run the RTMP handshake and connect/publish exchange on an already-established
+/// byte stream, yielding the pending publish as a [`Request`].
+///
+/// The bring-your-own-transport entry point: accept the connection (and, for
+/// `rtmps://`, complete the TLS handshake) yourself, then hand the stream here.
+/// `peer` is the remote address, used for logging and [`Request::peer`].
+///
+/// Returns `Ok(None)` if the client disconnects before issuing `publish`. Unlike
+/// [`Server`], this applies no publish timeout: wrap the call in
+/// [`tokio::time::timeout`] to bound how long a connected-but-idle client can
+/// hold the task.
+pub async fn accept_stream<S: Stream>(stream: S, peer: SocketAddr) -> Result<Option<Request<S>>> {
+	Ok(accept_until_publish(stream, peer).await?)
+}
+
 /// A pending RTMP publish, waiting on the caller to authorize it.
 ///
 /// Inspect [`app`](Self::app) and [`stream_key`](Self::stream_key) (an
@@ -118,8 +242,11 @@ impl Server {
 /// [`accept`](Self::accept) the publish into an origin at a chosen broadcast
 /// path or [`reject`](Self::reject) it. Dropping a `Request` without either
 /// closes the connection.
-pub struct Request {
-	stream: TcpStream,
+///
+/// `S` is the underlying stream: [`Conn`] for a [`Server`]-produced request, or
+/// your own transport when built via [`accept_stream`].
+pub struct Request<S = Conn> {
+	stream: S,
 	session: ServerSession,
 	/// The `rml_rtmp` request id for the pending publish, replied to on accept/reject.
 	request_id: u32,
@@ -131,7 +258,7 @@ pub struct Request {
 	peer: SocketAddr,
 }
 
-impl Request {
+impl<S: Stream> Request<S> {
 	/// The RTMP app name (the path component of `rtmp://host/<app>/<key>`).
 	pub fn app(&self) -> &str {
 		&self.app
@@ -205,7 +332,7 @@ impl Request {
 
 /// Run one connection's handshake and connect/publish exchange, returning a
 /// [`Request`] once the client issues `publish` (or `None` if it disconnects first).
-async fn accept_until_publish(mut stream: TcpStream, peer: SocketAddr) -> anyhow::Result<Option<Request>> {
+async fn accept_until_publish<S: Stream>(mut stream: S, peer: SocketAddr) -> anyhow::Result<Option<Request<S>>> {
 	let remaining = run_handshake(&mut stream, peer).await?;
 
 	let (mut session, initial) =
@@ -273,8 +400,8 @@ async fn accept_until_publish(mut stream: TcpStream, peer: SocketAddr) -> anyhow
 }
 
 /// Pump RTMP media into the publisher until the client disconnects or finishes.
-async fn pump(
-	stream: &mut TcpStream,
+async fn pump<S: Stream>(
+	stream: &mut S,
 	session: &mut ServerSession,
 	work: &mut VecDeque<ServerSessionResult>,
 	publisher: &mut Publisher,
@@ -333,7 +460,7 @@ async fn pump(
 
 /// Perform the RTMP server handshake, returning any leftover bytes that followed
 /// the client's final handshake packet (the start of the chunk stream).
-async fn run_handshake(stream: &mut TcpStream, peer: SocketAddr) -> anyhow::Result<Vec<u8>> {
+async fn run_handshake<S: Stream>(stream: &mut S, peer: SocketAddr) -> anyhow::Result<Vec<u8>> {
 	let mut handshake = Handshake::new(PeerType::Server);
 	let p0_p1 = handshake
 		.generate_outbound_p0_and_p1()
@@ -423,11 +550,11 @@ mod tests {
 		ClientSession, ClientSessionConfig, ClientSessionEvent, ClientSessionResult, PublishRequestType,
 	};
 
-	/// Drive a real RTMP client through handshake -> connect(`live`) ->
-	/// publish(`cam0`), pumping until aborted by the test.
-	async fn run_client(addr: SocketAddr) {
-		let mut stream = TcpStream::connect(addr).await.unwrap();
-
+	/// Drive a real RTMP client over an already-connected `stream` through
+	/// handshake -> connect(`live`) -> publish(`cam0`), pumping until aborted by
+	/// the test. Generic over the transport so the same client exercises both
+	/// plaintext RTMP and RTMPS.
+	async fn run_client<S: Stream>(mut stream: S) {
 		// Handshake.
 		let mut handshake = Handshake::new(PeerType::Client);
 		stream
@@ -498,7 +625,102 @@ mod tests {
 		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
 		let addr = server.local_addr().unwrap();
 
-		let client = tokio::spawn(run_client(addr));
+		let client = tokio::spawn(async move {
+			let stream = TcpStream::connect(addr).await.unwrap();
+			run_client(stream).await;
+		});
+
+		let request = tokio::time::timeout(Duration::from_secs(5), server.accept())
+			.await
+			.expect("server.accept timed out")
+			.expect("server yielded a request");
+
+		assert_eq!(request.app(), "live");
+		assert_eq!(request.stream_key(), "cam0");
+
+		request.reject("test rejection").await.unwrap();
+		client.abort();
+	}
+
+	/// The same publish flow, but over TLS: prove [`Server::with_tls`] terminates
+	/// RTMPS and yields an identical [`Request`]. Gated on `quinn` because it
+	/// borrows moq-native's cert generation (`server_config`), which needs a
+	/// moq-native backend feature.
+	#[cfg(feature = "quinn")]
+	#[tokio::test]
+	async fn rtmps_accept_yields_publish_request() {
+		use std::sync::Arc;
+
+		use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+		use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+		use rustls::{DigitallySignedStruct, SignatureScheme};
+
+		// Accept any server cert: the test uses a throwaway self-signed cert.
+		#[derive(Debug)]
+		struct NoVerify(Arc<rustls::crypto::CryptoProvider>);
+
+		impl ServerCertVerifier for NoVerify {
+			fn verify_server_cert(
+				&self,
+				_end_entity: &CertificateDer<'_>,
+				_intermediates: &[CertificateDer<'_>],
+				_server_name: &ServerName<'_>,
+				_ocsp: &[u8],
+				_now: UnixTime,
+			) -> std::result::Result<ServerCertVerified, rustls::Error> {
+				Ok(ServerCertVerified::assertion())
+			}
+
+			fn verify_tls12_signature(
+				&self,
+				message: &[u8],
+				cert: &CertificateDer<'_>,
+				dss: &DigitallySignedStruct,
+			) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+				rustls::crypto::verify_tls12_signature(message, cert, dss, &self.0.signature_verification_algorithms)
+			}
+
+			fn verify_tls13_signature(
+				&self,
+				message: &[u8],
+				cert: &CertificateDer<'_>,
+				dss: &DigitallySignedStruct,
+			) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+				rustls::crypto::verify_tls13_signature(message, cert, dss, &self.0.signature_verification_algorithms)
+			}
+
+			fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+				self.0.signature_verification_algorithms.supported_schemes()
+			}
+		}
+
+		let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+
+		// Server: a self-signed cert for `localhost`, fronting the RTMP listener.
+		let mut tls = moq_native::tls::Server::default();
+		tls.generate = vec!["localhost".to_string()];
+		let server_config = tls.server_config(vec![]).expect("build RTMPS server config");
+
+		let mut server = Server::bind("127.0.0.1:0".parse().unwrap())
+			.await
+			.unwrap()
+			.with_tls(server_config);
+		let addr = server.local_addr().unwrap();
+
+		// Client: TLS-connect (no verify), then run the ordinary RTMP client.
+		let client = tokio::spawn(async move {
+			let client_config = rustls::ClientConfig::builder_with_provider(provider.clone())
+				.with_safe_default_protocol_versions()
+				.unwrap()
+				.dangerous()
+				.with_custom_certificate_verifier(Arc::new(NoVerify(provider)))
+				.with_no_client_auth();
+			let connector = tokio_rustls::TlsConnector::from(Arc::new(client_config));
+			let tcp = TcpStream::connect(addr).await.unwrap();
+			let server_name = ServerName::try_from("localhost").unwrap();
+			let stream = connector.connect(server_name, tcp).await.unwrap();
+			run_client(stream).await;
+		});
 
 		let request = tokio::time::timeout(Duration::from_secs(5), server.accept())
 			.await


### PR DESCRIPTION
Adds RTMP-over-TLS (RTMPS) to `moq-rtmp`, both as a generic stream abstraction (bring-your-own-transport) and as built-in TLS helpers.

> [!NOTE]
> Stacked on top of #1824 (the `moq-rtmp` crate), so this PR is based on `claude/xenodochial-yonath-125237`, not `dev`. The diff will shrink to just the RTMPS changes once #1824 merges and this is retargeted to `dev`.

## Summary

Two ways to serve `rtmps://`:

- **Bring your own transport.** A new `Stream` trait (blanket impl over `AsyncRead + AsyncWrite + Unpin + Send`) makes the RTMP state machine (`Request<S>`, handshake, pump) generic. New `accept_stream(stream, peer)` runs the RTMP handshake on any already-established stream (a `tokio_rustls` TLS stream, a proxy socket, a test pipe) and yields the same `Request`. The caller owns the TLS handshake; no publish timeout is imposed.
- **Let the gateway terminate TLS.** `Server::with_tls(rustls::ServerConfig)` TLS-terminates each connection before the RTMP handshake. A new `Conn` enum (`Plain`/`Tls`) keeps `Server::accept()` returning a uniform `Request<Conn>` via enum dispatch (no `dyn`). `Config::tls` lets the `run` convenience serve RTMPS; run two listeners against a cloned origin to serve both protocols.

**Binary:** adds `--rtmps-listen` plus `--rtmps-tls-cert` / `--rtmps-tls-key` / `--rtmps-tls-generate`, reusing `moq_native::tls::Server::server_config` for cert loading. RTMPS is served alongside plaintext RTMP.

**Feature gating:** the TLS plumbing is behind the existing `server` feature (rustls + new `tokio-rustls 0.26`, matching `moq-relay`). The lib-only build (`--no-default-features`) keeps `Stream` / `accept_stream` / `Server` / `Request` with zero TLS dependencies.

## Public API changes (moq-rtmp)

All additive; the one behavioral change is internal to the unreleased crate:

- **New:** `Stream` trait, `Conn` enum, `accept_stream()`, `Server::with_tls()`, `Config::tls` field (server-gated), `pub use rustls` re-export (server-gated).
- **Changed:** `Request` is now `Request<S = Conn>` (defaults to `Conn`, so existing mentions stay short); `Server::accept` returns `Request<Conn>` instead of a `TcpStream`-bound `Request`. `moq-rtmp` is `0.0.1` and unreleased, so this is not a breaking change for any consumer.

## Test plan

- [x] `cargo check` (default + `--no-default-features --lib`)
- [x] `cargo test -p moq-rtmp` — 10/10, including a new end-to-end `rtmps_accept_yields_publish_request` (self-signed cert, real TLS client, full publish flow)
- [x] clippy (default + no-default-features), `cargo fmt --check`, `taplo --check`, `cargo doc -D warnings` all clean
- [ ] Not yet exercised against a real encoder over `rtmps://` (OBS/ffmpeg)

Docs updated: `README.md`, `doc/bin/rtmp.md`, and module/item docs.

(Written by Claude)