### PR TITLE
feat(moq-rtc): H.265 + AV1 egress, unify NALU reshaping via moq-mux

### DIFF
--- a/doc/bin/rtc.md
+++ b/doc/bin/rtc.md
@@ -31,8 +31,9 @@ peers see a black screen until the next natural keyframe arrives.
 `KeyframeRequest` events from the peer are logged but not propagated
 upstream; PLI-to-MoQ back-pressure is a future enhancement.
 
-AV1 / H.265 aren't in str0m 0.19's codec enum, so they're not negotiated;
-this is tracked as a follow-up. Use H.264 or VP9 for now.
+The egress paths (WHEP server, WHIP client) negotiate H.264, H.265, VP8,
+VP9, AV1, and Opus. The ingest paths (WHIP server, WHEP client) currently
+accept H.264, VP8, VP9, and Opus; H.265 / AV1 ingest is a follow-up.
 
 ## CLI shape
 
@@ -78,16 +79,26 @@ moq-rtc --relay https://relay.example.com --broadcast my-stream \
 
 ## Codec mapping
 
-| WebRTC codec | MoQ catalog |
-|--------------|-------------|
-| Opus         | `AudioCodec::Opus`, 48 kHz / stereo |
-| H.264        | `H264 { inline: true }` (Annex-B in catalog, no `avcC`) |
-| VP8          | `VideoCodec::VP8` |
-| VP9          | `VideoCodec::VP9` |
+| WebRTC codec | MoQ catalog | Egress | Ingest |
+|--------------|-------------|--------|--------|
+| Opus         | `AudioCodec::Opus`, 48 kHz / stereo | yes | yes |
+| H.264        | `VideoCodec::H264` (avc3 inline or avc1 + `avcC`) | yes | yes (avc3) |
+| H.265        | `VideoCodec::H265` (hev1 inline or hvc1 + `hvcC`) | yes | no |
+| VP8          | `VideoCodec::VP8` | yes | yes |
+| VP9          | `VideoCodec::VP9` | yes | yes |
+| AV1          | `VideoCodec::AV1` | yes | no |
 
-H.264 input is reassembled by str0m as Annex-B; `moq-mux`'s H.264 importer
-in `Avc3` mode publishes the inline-parameter shape directly, which lines
-up with what the WebCodecs decoder in `@moq/watch` already expects. No
+On egress, `codec::Track` reshapes each rendition into what str0m's Frame
+API expects. Opus / VP8 / VP9 / AV1 and inline-parameter H.264 (avc3) /
+H.265 (hev1) pass through untouched. Out-of-band-parameter H.264 (avc1) and
+H.265 (hvc1) are rewritten from length-prefixed NALU to Annex-B with the
+parameter sets (SPS/PPS, plus VPS for H.265) prepended to each keyframe.
+This reuses `moq-mux`'s `parse_avcc_param_sets` / `parse_hvcc_param_sets`
+and `annexb` helpers, the same logic as its `h264::Export` / `h265::Export`.
+
+On ingest, H.264 is reassembled by str0m as Annex-B; `moq-mux`'s H.264
+importer in `Avc3` mode publishes the inline-parameter shape directly, which
+lines up with what the WebCodecs decoder in `@moq/watch` already expects. No
 extra conversion needed in the gateway.
 
 (Written by Claude)

--- a/rs/moq-rtc/bin/moq-rtc.rs
+++ b/rs/moq-rtc/bin/moq-rtc.rs
@@ -5,9 +5,9 @@
 //! direction (`publish` / `subscribe`). The 2x2 is:
 //!
 //! - `server publish` -- WHIP server, ingest from a remote publisher into MoQ.
-//! - `server subscribe` -- WHEP server, egress a MoQ broadcast to remote subscribers (501).
+//! - `server subscribe` -- WHEP server, egress a MoQ broadcast to remote subscribers.
 //! - `client subscribe` -- WHEP client, pull a remote WHEP feed into MoQ.
-//! - `client publish` -- WHIP client, push a MoQ broadcast to a remote WHIP endpoint (501).
+//! - `client publish` -- WHIP client, push a MoQ broadcast to a remote WHIP endpoint.
 
 use std::net::SocketAddr;
 use std::path::PathBuf;

--- a/rs/moq-rtc/src/client/whip.rs
+++ b/rs/moq-rtc/src/client/whip.rs
@@ -21,7 +21,7 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::Broadcas
 	let codecs = source.catalog_codecs();
 	if codecs.is_empty() {
 		return Err(Error::Other(anyhow::anyhow!(
-			"catalog has no codecs we can egress (Opus / H.264 / VP8 / VP9)"
+			"catalog has no codecs we can egress (Opus / H.264 / H.265 / VP8 / VP9 / AV1)"
 		)));
 	}
 

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -66,13 +66,16 @@ pub struct Track {
 
 /// Codec-specific per-frame transform.
 enum TrackConvert {
-	/// Opus / VP8 / VP9 / avc3-stored H.264: bitstream passes through.
+	/// Opus / VP8 / VP9 / AV1, plus inline-parameter H.264 (avc3) and H.265
+	/// (hev1): the stored bitstream is already in the shape str0m's
+	/// packetizer wants, so it passes through untouched.
 	Passthrough,
-	/// avc1-stored H.264: length-prefixed NALU -> Annex-B, with cached
-	/// SPS+PPS prefixed onto every keyframe (see
-	/// [`moq_mux::codec::h264::Export`] for the equivalent stand-alone
-	/// exporter — same logic).
-	H264Avc1 { length_size: usize, keyframe_prefix: Bytes },
+	/// Out-of-band-parameter H.264 (avc1) and H.265 (hvc1): length-prefixed
+	/// NALU rewritten to Annex-B, with the cached parameter sets (SPS+PPS,
+	/// plus VPS for H.265) prepended to every keyframe. Both codecs share this
+	/// path; only the config record parsed to build it differs (avcC vs hvcC).
+	/// Mirrors moq-mux's `h264::Export` / `h265::Export`.
+	LengthPrefixed { length_size: usize, keyframe_prefix: Bytes },
 }
 
 impl Track {
@@ -88,8 +91,9 @@ impl Track {
 		})
 	}
 
-	/// Video track. Codec inferred from `config.codec`; bitstream shape
-	/// inferred from `config.description` (avc1 vs avc3).
+	/// Video track. Codec inferred from `config.codec`; for H.264 / H.265 the
+	/// bitstream shape (inline vs out-of-band parameter sets) is inferred from
+	/// `config.description` (avc1/hvc1 vs avc3/hev1).
 	pub async fn video(broadcast: &moq_net::BroadcastConsumer, name: &str, config: &VideoConfig) -> Result<Self> {
 		let container: moq_mux::catalog::hang::Container = (&config.container).try_into()?;
 		let track = broadcast.track(name)?.subscribe(None)?.await?;
@@ -98,24 +102,9 @@ impl Track {
 		let (codec, convert) = match &config.codec {
 			hang::catalog::VideoCodec::VP8 => (Codec::Vp8, TrackConvert::Passthrough),
 			hang::catalog::VideoCodec::VP9(_) => (Codec::Vp9, TrackConvert::Passthrough),
-			hang::catalog::VideoCodec::H264(_) => match config.description.as_ref().filter(|d| !d.is_empty()) {
-				None => (Codec::H264, TrackConvert::Passthrough),
-				Some(avcc) => {
-					let parsed = moq_mux::codec::h264::Avcc::parse(avcc)
-						.map_err(|err| crate::Error::Other(anyhow::anyhow!("avcc parse: {err}")))?;
-					// Pull SPS+PPS from the avcC and prebuild the Annex-B prefix
-					// to prepend ahead of every keyframe.
-					let (sps, pps) = avcc_param_sets(avcc)?;
-					let prefix = moq_mux::codec::annexb::build_prefix(sps.iter().chain(pps.iter()));
-					(
-						Codec::H264,
-						TrackConvert::H264Avc1 {
-							length_size: parsed.length_size,
-							keyframe_prefix: prefix,
-						},
-					)
-				}
-			},
+			hang::catalog::VideoCodec::AV1(_) => (Codec::Av1, TrackConvert::Passthrough),
+			hang::catalog::VideoCodec::H264(_) => (Codec::H264, h264_convert(config)?),
+			hang::catalog::VideoCodec::H265(_) => (Codec::H265, h265_convert(config)?),
 			other => return Err(crate::Error::UnsupportedCodec(format!("{other:?}"))),
 		};
 
@@ -138,7 +127,7 @@ impl Track {
 			};
 			let payload = match &self.convert {
 				TrackConvert::Passthrough => frame.payload,
-				TrackConvert::H264Avc1 {
+				TrackConvert::LengthPrefixed {
 					length_size,
 					keyframe_prefix,
 				} => {
@@ -158,57 +147,182 @@ impl Track {
 	}
 }
 
-/// Parse SPS+PPS NAL units out of an `AVCDecoderConfigurationRecord`.
+/// Build the per-frame transform for an H.264 rendition.
 ///
-/// Mirrors `moq_mux::codec::h264::parse_avcc_param_sets` which is `pub(crate)`
-/// over there. Kept tiny on purpose; the catalog avcC is always small.
-fn avcc_param_sets(avcc: &[u8]) -> Result<(Vec<Bytes>, Vec<Bytes>)> {
-	if avcc.len() < 6 {
-		return Err(crate::Error::Other(anyhow::anyhow!("avcC too short")));
-	}
-	let length_size_minus_one = avcc[4] & 0x03;
-	if length_size_minus_one != 3 {
-		// Other length sizes are technically legal, but real-world catalogs use 4.
+/// avc3 (inline SPS/PPS, empty `description`) passes through. avc1 (out-of-band
+/// avcC in `description`) parses the avcC and prebuilds the Annex-B SPS+PPS
+/// prefix to prepend ahead of every keyframe.
+fn h264_convert(config: &VideoConfig) -> Result<TrackConvert> {
+	let Some(avcc) = config.description.as_ref().filter(|d| !d.is_empty()) else {
+		return Ok(TrackConvert::Passthrough);
+	};
+	let params = moq_mux::codec::h264::parse_avcc_param_sets(avcc)
+		.map_err(|err| crate::Error::Other(anyhow::anyhow!("avcc parse: {err}")))?;
+	// Without SPS+PPS the keyframe prefix would be empty and every keyframe
+	// would reach the peer without inline parameter sets, i.e. undecodable.
+	// Fail loudly instead, matching moq-mux's `h264::Export`.
+	if params.sps.is_empty() || params.pps.is_empty() {
 		return Err(crate::Error::Other(anyhow::anyhow!(
-			"unsupported avcC lengthSizeMinusOne = {length_size_minus_one}"
+			"avc1 avcC is missing parameter sets (sps={}, pps={})",
+			params.sps.len(),
+			params.pps.len()
 		)));
 	}
-	let mut sps = Vec::new();
-	let mut pps = Vec::new();
+	let keyframe_prefix = moq_mux::codec::annexb::build_prefix(params.sps.iter().chain(params.pps.iter()));
+	Ok(TrackConvert::LengthPrefixed {
+		length_size: params.length_size,
+		keyframe_prefix,
+	})
+}
 
-	let mut pos = 5;
-	let num_sps = (avcc[pos] & 0x1f) as usize;
-	pos += 1;
-	for _ in 0..num_sps {
-		if pos + 2 > avcc.len() {
-			return Err(crate::Error::Other(anyhow::anyhow!("avcC truncated in SPS table")));
-		}
-		let len = u16::from_be_bytes([avcc[pos], avcc[pos + 1]]) as usize;
-		pos += 2;
-		if pos + len > avcc.len() {
-			return Err(crate::Error::Other(anyhow::anyhow!("avcC truncated in SPS NAL")));
-		}
-		sps.push(Bytes::copy_from_slice(&avcc[pos..pos + len]));
-		pos += len;
+/// Build the per-frame transform for an H.265 rendition.
+///
+/// The H.265 analogue of [`h264_convert`]: hev1 (inline VPS/SPS/PPS) passes
+/// through; hvc1 (out-of-band hvcC) parses the hvcC and prebuilds the Annex-B
+/// VPS+SPS+PPS prefix to prepend ahead of every keyframe.
+fn h265_convert(config: &VideoConfig) -> Result<TrackConvert> {
+	let Some(hvcc) = config.description.as_ref().filter(|d| !d.is_empty()) else {
+		return Ok(TrackConvert::Passthrough);
+	};
+	let params = moq_mux::codec::h265::parse_hvcc_param_sets(hvcc)
+		.map_err(|err| crate::Error::Other(anyhow::anyhow!("hvcc parse: {err}")))?;
+	// Same reasoning as `h264_convert`: a keyframe with no inline VPS/SPS/PPS
+	// is undecodable, so reject an hvcC that omits any of them.
+	if params.vps.is_empty() || params.sps.is_empty() || params.pps.is_empty() {
+		return Err(crate::Error::Other(anyhow::anyhow!(
+			"hvc1 hvcC is missing parameter sets (vps={}, sps={}, pps={})",
+			params.vps.len(),
+			params.sps.len(),
+			params.pps.len()
+		)));
+	}
+	let keyframe_prefix =
+		moq_mux::codec::annexb::build_prefix(params.vps.iter().chain(params.sps.iter()).chain(params.pps.iter()));
+	Ok(TrackConvert::LengthPrefixed {
+		length_size: params.length_size,
+		keyframe_prefix,
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use hang::catalog::{H264, H265, VideoConfig};
+
+	use super::*;
+
+	fn config(codec: impl Into<hang::catalog::VideoCodec>, description: Option<Bytes>) -> VideoConfig {
+		let mut config = VideoConfig::new(codec);
+		config.description = description;
+		config
 	}
 
-	if pos >= avcc.len() {
-		return Ok((sps, pps));
-	}
-	let num_pps = avcc[pos] as usize;
-	pos += 1;
-	for _ in 0..num_pps {
-		if pos + 2 > avcc.len() {
-			return Err(crate::Error::Other(anyhow::anyhow!("avcC truncated in PPS table")));
+	fn h264(inline: bool) -> H264 {
+		H264 {
+			inline,
+			profile: 0x42,
+			constraints: 0,
+			level: 0x1f,
 		}
-		let len = u16::from_be_bytes([avcc[pos], avcc[pos + 1]]) as usize;
-		pos += 2;
-		if pos + len > avcc.len() {
-			return Err(crate::Error::Other(anyhow::anyhow!("avcC truncated in PPS NAL")));
-		}
-		pps.push(Bytes::copy_from_slice(&avcc[pos..pos + len]));
-		pos += len;
 	}
 
-	Ok((sps, pps))
+	fn h265(in_band: bool) -> H265 {
+		H265 {
+			in_band,
+			profile_space: 0,
+			profile_idc: 1,
+			profile_compatibility_flags: [0; 4],
+			tier_flag: false,
+			level_idc: 0x5d,
+			constraint_flags: [0; 6],
+		}
+	}
+
+	/// Minimal avcC carrying one SPS + one PPS (lengthSizeMinusOne = 3).
+	fn build_avcc(sps: &[u8], pps: &[u8]) -> Bytes {
+		let mut v = vec![1, sps[1], sps[2], sps[3], 0xff, 0xe1];
+		v.extend_from_slice(&(sps.len() as u16).to_be_bytes());
+		v.extend_from_slice(sps);
+		v.push(1);
+		v.extend_from_slice(&(pps.len() as u16).to_be_bytes());
+		v.extend_from_slice(pps);
+		Bytes::from(v)
+	}
+
+	/// Minimal hvcC carrying one VPS + SPS + PPS array (lengthSizeMinusOne = 3).
+	/// VPS/SPS/PPS NAL unit types are 32/33/34.
+	fn build_hvcc(vps: &[u8], sps: &[u8], pps: &[u8]) -> Bytes {
+		let mut v = vec![0u8; 21];
+		v.push(0xff); // [21] lengthSizeMinusOne = 3 in the low 2 bits
+		v.push(3); // [22] numOfArrays
+		for (nal_type, nal) in [(32u8, vps), (33, sps), (34, pps)] {
+			v.push(nal_type); // array header: low 6 bits = NAL unit type
+			v.extend_from_slice(&1u16.to_be_bytes()); // numNalus
+			v.extend_from_slice(&(nal.len() as u16).to_be_bytes());
+			v.extend_from_slice(nal);
+		}
+		Bytes::from(v)
+	}
+
+	#[test]
+	fn h264_avc3_passthrough() {
+		let cfg = config(h264(true), None);
+		assert!(matches!(h264_convert(&cfg).unwrap(), TrackConvert::Passthrough));
+	}
+
+	#[test]
+	fn h264_avc1_length_prefixed() {
+		let sps: &[u8] = &[0x67, 0x42, 0xc0, 0x1f, 0xde];
+		let pps: &[u8] = &[0x68, 0xce, 0x3c, 0x80];
+		let cfg = config(h264(false), Some(build_avcc(sps, pps)));
+
+		let TrackConvert::LengthPrefixed {
+			length_size,
+			keyframe_prefix,
+		} = h264_convert(&cfg).unwrap()
+		else {
+			panic!("expected LengthPrefixed");
+		};
+		assert_eq!(length_size, 4);
+		assert!(keyframe_prefix.starts_with(&[0, 0, 0, 1]), "Annex-B start code");
+		assert!(keyframe_prefix.windows(sps.len()).any(|w| w == sps), "SPS in prefix");
+		assert!(keyframe_prefix.windows(pps.len()).any(|w| w == pps), "PPS in prefix");
+	}
+
+	#[test]
+	fn h265_hev1_passthrough() {
+		let cfg = config(h265(true), None);
+		assert!(matches!(h265_convert(&cfg).unwrap(), TrackConvert::Passthrough));
+	}
+
+	#[test]
+	fn h265_hvc1_length_prefixed() {
+		let vps: &[u8] = &[0x40, 0x01, 0x0c, 0x01];
+		let sps: &[u8] = &[0x42, 0x01, 0x01, 0x01];
+		let pps: &[u8] = &[0x44, 0x01, 0xc0, 0xf7];
+		let cfg = config(h265(false), Some(build_hvcc(vps, sps, pps)));
+
+		let TrackConvert::LengthPrefixed {
+			length_size,
+			keyframe_prefix,
+		} = h265_convert(&cfg).unwrap()
+		else {
+			panic!("expected LengthPrefixed");
+		};
+		assert_eq!(length_size, 4);
+		// Parameter sets are prefixed in VPS, SPS, PPS order.
+		let v = keyframe_prefix.windows(vps.len()).position(|w| w == vps).expect("VPS");
+		let s = keyframe_prefix.windows(sps.len()).position(|w| w == sps).expect("SPS");
+		let p = keyframe_prefix.windows(pps.len()).position(|w| w == pps).expect("PPS");
+		assert!(v < s && s < p, "VPS < SPS < PPS order in prefix");
+	}
+
+	/// An avc1 avcC that parses but carries no SPS/PPS must be rejected rather
+	/// than silently producing keyframes without inline parameter sets.
+	#[test]
+	fn h264_avc1_missing_param_sets_errors() {
+		// 6-byte header (numSPS = 0 in the low 5 bits of byte 5) + a zero PPS count.
+		let avcc = Bytes::from(vec![1, 0x42, 0, 0x1f, 0xff, 0xe0, 0x00]);
+		let cfg = config(h264(false), Some(avcc));
+		assert!(h264_convert(&cfg).is_err(), "missing SPS/PPS must error");
+	}
 }

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -122,8 +122,10 @@ impl EgressSource {
 		for rendition in self.catalog.video.renditions.values() {
 			let codec = match rendition.codec.kind() {
 				VideoCodecKind::H264 => Some(Codec::H264),
+				VideoCodecKind::H265 => Some(Codec::H265),
 				VideoCodecKind::VP8 => Some(Codec::Vp8),
 				VideoCodecKind::VP9 => Some(Codec::Vp9),
+				VideoCodecKind::AV1 => Some(Codec::Av1),
 				_ => None,
 			};
 			if let Some(c) = codec
@@ -155,11 +157,13 @@ async fn pick_track(
 			};
 			Ok(Some(codec::Track::opus(broadcast, name).await?))
 		}
-		Codec::H264 | Codec::Vp8 | Codec::Vp9 => {
+		Codec::H264 | Codec::H265 | Codec::Vp8 | Codec::Vp9 | Codec::Av1 => {
 			let target = match codec {
 				Codec::H264 => VideoCodecKind::H264,
+				Codec::H265 => VideoCodecKind::H265,
 				Codec::Vp8 => VideoCodecKind::VP8,
 				Codec::Vp9 => VideoCodecKind::VP9,
+				Codec::Av1 => VideoCodecKind::AV1,
 				_ => unreachable!(),
 			};
 			let Some((name, config)) = catalog.video.renditions.iter().find(|(_, c)| c.codec.kind() == target) else {

--- a/rs/moq-rtc/src/lib.rs
+++ b/rs/moq-rtc/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! | | RTP-in (ingest into MoQ) | RTP-out (egress from MoQ) |
 //! |---|---|---|
-//! | HTTP server | [`Server::publish_router`] (WHIP server) | [`Server::subscribe_router`] (WHEP server, 501) |
-//! | HTTP client | [`Client::subscribe`] (WHEP client) | [`Client::publish`] (WHIP client, 501) |
+//! | HTTP server | [`Server::publish_router`] (WHIP server) | [`Server::subscribe_router`] (WHEP server) |
+//! | HTTP client | [`Client::subscribe`] (WHEP client) | [`Client::publish`] (WHIP client) |
 //!
 //! The two HTTP-client paths and the two HTTP-server paths share a single
 //! [`session::Session`] driver and the same per-codec adapters in [`codec`];

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -70,8 +70,8 @@ impl Server {
 		whip::router(self.clone())
 	}
 
-	/// Router for `server subscribe` (WHEP). Currently returns 501 until
-	/// the egress re-packetizer lands.
+	/// Router for `server subscribe` (WHEP). Mount under whichever HTTP path
+	/// the deployment prefers (`/whep`, `/`, ...).
 	pub fn subscribe_router(&self) -> Router {
 		whep::router(self.clone())
 	}

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -55,7 +55,7 @@ async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: By
 	let codecs = source.catalog_codecs();
 	if codecs.is_empty() {
 		return Err(Error::Other(anyhow::anyhow!(
-			"catalog has no codecs we can egress (Opus / H.264 / VP8 / VP9)"
+			"catalog has no codecs we can egress (Opus / H.264 / H.265 / VP8 / VP9 / AV1)"
 		)));
 	}
 

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -262,11 +262,11 @@ pub fn rtc_with_codecs(codecs: &[str0m::format::Codec]) -> Rtc {
 		config = match c {
 			Codec::Opus => config.enable_opus(true),
 			Codec::H264 => config.enable_h264(true),
+			Codec::H265 => config.enable_h265(true),
 			Codec::Vp8 => config.enable_vp8(true),
 			Codec::Vp9 => config.enable_vp9(true),
-			// AV1 / H.265 are in str0m's enum but we don't yet support them
-			// on the egress side. Skip rather than enable a codec we can't
-			// pump frames for.
+			Codec::Av1 => config.enable_av1(true),
+			// Any other codec str0m grows is one we have no egress source for.
 			_ => config,
 		};
 	}


### PR DESCRIPTION
## Summary

Adds **H.265 and AV1** to the WebRTC egress paths (WHEP server, WHIP client) and routes H.264's bitstream reshaping through `moq-mux`'s codec helpers instead of a hand-rolled reimplementation in `moq-rtc`.

A browser can now `POST /<broadcast>` an SDP offer and get sub-second WebRTC playback in **Opus / H.264 / H.265 / VP8 / VP9 / AV1**.

### Changes

- **Reuse moq-mux helpers for H.264.** The local `avcc_param_sets` parser is gone (it also had a latent bug: it rejected any NALU length size other than 4). H.264 and H.265 now go through `moq_mux::codec::h264::parse_avcc_param_sets` / `h265::parse_hvcc_param_sets` plus the shared `annexb` helpers — the same path as moq-mux's `h264::Export` / `h265::Export`.
- **Unify the per-frame transform.** `TrackConvert::H264Avc1` → codec-agnostic `TrackConvert::LengthPrefixed`. avc1 and hvc1 share the identical length-prefixed→Annex-B rewrite; only the config record parsed to build the keyframe prefix differs (avcC: SPS+PPS / hvcC: VPS+SPS+PPS).
- **Reject parameter-set-less avc1/hvc1.** `h264_convert` / `h265_convert` now error if the parsed avcC/hvcC carries no SPS/PPS (or VPS), matching moq-mux's `MissingParamSets` guard, instead of silently emitting keyframes with no inline parameter sets.
- **Wire H.265 + AV1** through `rtc_with_codecs` (`enable_h265` / `enable_av1`), `catalog_codecs`, `pick_track`, and `Track::video`. AV1 is passthrough: moq-mux stores OBU temporal units with size fields and the temporal delimiter intact, and str0m's `parse_obus` reads the size fields and drops the TD itself.
- **Remove stale `501` markers** in `lib.rs`, `server/mod.rs`, and `bin/moq-rtc.rs` — all four WHIP/WHEP quadrants are implemented.
- **Docs:** update `doc/bin/rtc.md` codec table (adds H.265/AV1, egress vs ingest columns) and drop the stale "AV1 / H.265 aren't in str0m's enum" note.

### Scope

Egress only (playback). H.265 / AV1 **ingest** (a browser publishing into MoQ via the WHIP server) still lacks codec bridges and is documented as a follow-up.

## Test plan

- [x] `cargo fmt -p moq-rtc --check` clean
- [x] `cargo clippy -p moq-rtc --all-targets -- -D warnings` clean
- [x] `cargo test -p moq-rtc` — 10 pass (5 convert-helper unit tests: avc3/hev1 passthrough, avc1/hvc1 length-prefixed incl. VPS+SPS+PPS ordering, and missing-param-sets rejection; + 5 existing egress tests)
- [ ] **Not yet verified:** live browser playback. H.265 over WebRTC is Safari-only; AV1 needs a Chrome with AV1 enabled. The codec-shaping is unit-tested, but a real H.265/AV1 broadcast hasn't been driven through a live WHEP browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)