### PR TITLE
feat(moq-srt): serve broadcasts back out over SRT (m=request egress)

### DIFF
--- a/rs/moq-srt/README.md
+++ b/rs/moq-srt/README.md
@@ -1,12 +1,19 @@
 # moq-srt
 
-SRT contribution ingest gateway for Media over QUIC.
+SRT gateway for Media over QUIC, both directions.
 
-SRT carries MPEG-TS. This crate runs an SRT listener, demuxes each connection's
-transport stream with [`moq-mux`](../moq-mux), and publishes the result into a
-MoQ origin as ordinary broadcasts. It's the contribution-ingest analogue of
-`moq-hls`'s import and `moq-rtc`'s WHIP. Pure Rust: SRT is provided by
-`srt-tokio`, with no libsrt or ffmpeg dependency.
+SRT carries MPEG-TS. This crate runs an SRT listener and routes each connection
+by its stream id `m=` mode:
+
+- `m=publish` (the default): ingest. Demux the connection's transport stream
+  with [`moq-mux`](../moq-mux) and publish it into a MoQ origin as an ordinary
+  broadcast. The contribution-ingest analogue of `moq-hls`'s import and
+  `moq-rtc`'s WHIP.
+- `m=request`: egress. Re-mux a broadcast from the origin back to MPEG-TS and
+  stream it to the caller, so `vlc srt://...` and `ffmpeg -i srt://...` can play
+  any broadcast the origin carries (H.264/H.265 video, AAC/AC-3/MP2 audio).
+
+Pure Rust: SRT is provided by `srt-tokio`, with no libsrt or ffmpeg dependency.
 
 ## Library
 
@@ -56,23 +63,32 @@ moq-srt publish --relay https://relay.example.com \
 Feed either mode with any SRT source:
 
 ```bash
-# Lands at broadcast `live/cam0`.
+# Publish: lands at broadcast `live/cam0`.
 ffmpeg -re -i input.mp4 -c copy -f mpegts \
   'srt://127.0.0.1:9000?streamid=#!::r=cam0,m=publish'
+
+# Request: play `live/cam0` back out as MPEG-TS.
+ffplay 'srt://127.0.0.1:9000?streamid=#!::r=cam0,m=request'
+vlc    'srt://127.0.0.1:9000?streamid=#!::r=cam0,m=request'
 ```
+
+A request waits for the broadcast to be announced, so a player may connect before
+the publisher does.
 
 ## Routing
 
-Each connection's broadcast path comes from its SRT stream id:
+Each connection's broadcast path and direction come from its SRT stream id:
 
-- Standard form `#!::r=<resource>,m=publish` -> `<resource>`.
-- Otherwise the raw stream id (e.g. OBS-style `app/key`).
+- Standard form `#!::r=<resource>,m=<mode>` -> `<resource>`, with `m=request`
+  selecting egress and anything else (including absent) selecting ingest.
+- Otherwise the raw stream id (e.g. OBS-style `app/key`), always ingest.
 
 `--srt-prefix` is prepended to namespace a listener's streams. First publisher on
-a path wins; a second connection to the same path is rejected.
+a path wins; a second publish of the same path is rejected. Requests don't claim
+a path, so any number of players can pull the same broadcast.
 
 ## Auth
 
 The listener is currently unauthenticated: anyone who can reach the UDP port can
-publish. Gate it with a host firewall or a private network. SRT passphrase
-encryption and token checks are the planned next step.
+publish or request any broadcast. Gate it with a host firewall or a private
+network. SRT passphrase encryption and token checks are the planned next step.

--- a/rs/moq-srt/bin/moq-srt.rs
+++ b/rs/moq-srt/bin/moq-srt.rs
@@ -1,14 +1,17 @@
 //! `moq-srt` binary.
 //!
-//! Ingests SRT (MPEG-TS) and exposes it over MoQ two ways:
+//! Runs an SRT gateway (MPEG-TS in via `m=publish`, out via `m=request`) and
+//! connects it to MoQ two ways:
 //!
 //! - `serve` runs a local QUIC/WebTransport server so subscribers connect
-//!   straight to this binary (no separate relay needed).
+//!   straight to this binary (no separate relay needed). Ingested broadcasts are
+//!   also requestable back out over SRT.
 //! - `publish` forwards every ingested broadcast out to a remote relay over
-//!   WebTransport, like `moq-hls import` / `moq-rtc` WHIP.
+//!   WebTransport, like `moq-hls import` / `moq-rtc` WHIP. SRT requests are
+//!   served from the local origin (broadcasts ingested by this same process).
 //!
-//! A relay that wants in-process ingest should instead depend on the `moq-srt`
-//! library and call `moq_srt::run` against its own origin.
+//! A relay that wants an in-process gateway should instead depend on the
+//! `moq-srt` library and call `moq_srt::run` against its own origin.
 
 mod serve;
 mod web;

--- a/rs/moq-srt/src/error.rs
+++ b/rs/moq-srt/src/error.rs
@@ -10,6 +10,10 @@ pub enum Error {
 	#[error("moq: {0}")]
 	Moq(#[from] moq_net::Error),
 
+	/// Error from the moq-mux muxer/demuxer (TS demux on ingest, TS mux on egress).
+	#[error("mux: {0}")]
+	Mux(#[from] moq_mux::Error),
+
 	/// I/O error from the SRT listener or socket.
 	#[error("io: {0}")]
 	Io(Arc<std::io::Error>),

--- a/rs/moq-srt/src/lib.rs
+++ b/rs/moq-srt/src/lib.rs
@@ -1,14 +1,17 @@
-//! SRT contribution ingest gateway for MoQ.
+//! SRT gateway for MoQ, both directions.
 //!
 //! Runs an [SRT](https://www.haivision.com/products/srt-secure-reliable-transport/)
-//! listener, demuxes the MPEG-TS each connection carries with [`moq_mux`], and
-//! publishes the result into a [`moq_net::OriginProducer`] as ordinary MoQ
-//! broadcasts. Whatever serves that origin (a relay, the bundled binary's serve
-//! mode) then exposes the ingested stream like any other broadcast. This is the
-//! contribution-ingest analogue of `moq-hls`'s import and `moq-rtc`'s WHIP.
+//! listener and routes each connection by its stream-id `m=` mode against a
+//! [`moq_net::OriginProducer`]:
+//!
+//! - `m=publish` (the default): demux the MPEG-TS the connection carries with
+//!   [`moq_mux`] and publish it into the origin as an ordinary broadcast. The
+//!   contribution-ingest analogue of `moq-hls`'s import and `moq-rtc`'s WHIP.
+//! - `m=request`: re-mux a broadcast from the origin back to MPEG-TS and stream
+//!   it to the caller, so a plain SRT player (VLC, ffmpeg) can watch it.
 //!
 //! The library is one high-level entry point: build a [`Config`] and hand it
-//! plus an origin to [`run`]. A relay embeds ingest by calling
+//! plus an origin to [`run`]. A relay embeds the gateway by calling
 //! `run(cluster.origin.clone(), config)` alongside its own accept loop; the
 //! bundled `moq-srt` binary instead serves the origin locally or forwards it to
 //! a remote relay (those paths need the `server` feature).

--- a/rs/moq-srt/src/listen.rs
+++ b/rs/moq-srt/src/listen.rs
@@ -1,49 +1,61 @@
 //! SRT listener and stream-id routing.
 //!
 //! SRT is a thin reliability/encryption layer over a UDP datagram stream whose
-//! payload, by overwhelming convention, is MPEG-TS. We run an SRT listener,
-//! route each incoming connection to a broadcast path derived from its stream
-//! id, and pump the TS payload through [`crate::ts::Publisher`] into the origin.
+//! payload, by overwhelming convention, is MPEG-TS. We run an SRT listener and
+//! route each incoming connection by its stream id, in one of two directions:
 //!
-//! Routing: SRT's recommended stream-id form is `#!::r=<resource>,m=publish`.
-//! We extract the `r=` resource when present and otherwise fall back to the raw
-//! stream-id string. The optional [`prefix`](Config::prefix) is prepended so a
-//! single listener can namespace all of its ingests (e.g. prefix `live/` +
+//! - `m=publish` (the default): ingest. Pump the caller's TS payload through
+//!   [`crate::ts::Publisher`] into the origin as a broadcast.
+//! - `m=request`: egress. Re-mux the requested broadcast back to MPEG-TS with
+//!   [`crate::ts::Subscriber`] and stream it to the caller, so VLC / ffmpeg can
+//!   play `srt://host:port?streamid=#!::r=<broadcast>,m=request`.
+//!
+//! Routing: SRT's recommended stream-id form is `#!::r=<resource>,m=<mode>`. We
+//! extract the `r=` resource when present and otherwise fall back to the raw
+//! stream-id string; the `m=` mode picks the direction (absent / non-`request`
+//! means ingest). The optional [`prefix`](Config::prefix) is prepended so a
+//! single listener can namespace all of its streams (e.g. prefix `live/` +
 //! stream id `cam0` -> broadcast `live/cam0`).
 //!
 //! Auth: this listener is currently unauthenticated. Anyone who can reach the
-//! UDP port can publish, so gate it with the host firewall / a private network.
-//! SRT passphrase encryption and token checks are the obvious next step (see
-//! `request.accept(Some(KeySettings))`).
+//! UDP port can publish or request any broadcast, so gate it with the host
+//! firewall / a private network. SRT passphrase encryption and token checks are
+//! the obvious next step (see `request.accept(Some(KeySettings))`).
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use futures::StreamExt;
-use moq_net::OriginProducer;
+use futures::{SinkExt, StreamExt};
+use moq_net::{OriginConsumer, OriginProducer};
 use srt_tokio::SrtListener;
-use srt_tokio::access::{AccessControlList, RejectReason, ServerRejectReason, StandardAccessControlEntry};
+use srt_tokio::access::{
+	AccessControlList, ConnectionMode, RejectReason, ServerRejectReason, StandardAccessControlEntry,
+};
 use srt_tokio::options::StreamId;
 
 use crate::{Error, Result};
 
-/// SRT ingest configuration.
+/// SRT payload size for egress: 7 MPEG-TS packets (7 x 188), the de-facto
+/// standard for TS-over-SRT and a clean fit under the typical SRT MTU.
+const SRT_PAYLOAD: usize = 7 * 188;
+
+/// SRT gateway configuration.
 ///
 /// Construct via [`Config::default`] and set the fields you need, so new
-/// options stay additive. Ingest is disabled (and [`run`] stays pending) unless
-/// [`listen`](Config::listen) is set, letting an embedding relay run without SRT
-/// until it's configured.
+/// options stay additive. The listener is disabled (and [`run`] stays pending)
+/// unless [`listen`](Config::listen) is set, letting an embedding relay run
+/// without SRT until it's configured.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Config {
-	/// Address to listen on for SRT ingest (e.g. `0.0.0.0:9000`). When `None`,
-	/// SRT ingest is disabled.
+	/// Address to listen on for SRT (e.g. `0.0.0.0:9000`). When `None`, the SRT
+	/// gateway is disabled.
 	pub listen: Option<SocketAddr>,
 
-	/// Prefix prepended to every ingested broadcast path. Lets one listener
-	/// namespace all of its streams (e.g. `live/`).
+	/// Prefix prepended to every broadcast path, for both publish and request.
+	/// Lets one listener namespace all of its streams (e.g. `live/`).
 	pub prefix: String,
 
 	/// SRT receive latency: the negotiated buffer that trades delay for loss
@@ -61,21 +73,24 @@ impl Default for Config {
 	}
 }
 
-/// Run the SRT ingest listener until it fails, publishing each connection into
-/// `origin` as a broadcast.
+/// Run the SRT gateway until it fails, publishing `m=publish` connections into
+/// `origin` and serving `m=request` connections out of it.
 ///
 /// Stays pending forever (rather than resolving) when SRT is disabled, so it
 /// composes cleanly inside a `tokio::select!` alongside a relay's other
 /// long-running tasks.
 pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 	let Some(listen) = config.listen else {
-		tracing::info!("SRT ingest disabled (no listen address)");
+		tracing::info!("SRT gateway disabled (no listen address)");
 		std::future::pending::<()>().await;
 		unreachable!("pending future never resolves");
 	};
 
 	let (_listener, mut incoming) = SrtListener::builder().latency(config.latency).bind(listen).await?;
-	tracing::info!(%listen, prefix = %config.prefix, "SRT ingest listening");
+	tracing::info!(%listen, prefix = %config.prefix, "SRT listening");
+
+	// Read side of the origin, used to serve `m=request` callers their broadcast.
+	let consumer = origin.consume();
 
 	// Tracks which broadcast paths are currently being ingested so a second
 	// publisher on the same stream id is rejected (first-publisher-wins, like an
@@ -85,20 +100,43 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 
 	while let Some(request) = incoming.incoming().next().await {
 		let remote = request.remote();
-		let Some(path) = resolve_path(&config.prefix, request.stream_id()) else {
+		let Some(route) = resolve_route(&config.prefix, request.stream_id()) else {
 			tracing::warn!(%remote, stream_id = ?request.stream_id(), "rejecting SRT: no usable stream id");
 			reject(request, ServerRejectReason::BadRequest, remote).await;
 			continue;
 		};
 
+		// `m=request` reads a broadcast out; everything else publishes one in.
+		if route.mode == ConnectionMode::Request {
+			let path = route.path;
+			let consumer = consumer.clone();
+			tokio::spawn(async move {
+				let socket = match request.accept(None).await {
+					Ok(socket) => socket,
+					Err(err) => {
+						tracing::warn!(%remote, %err, "SRT accept failed");
+						return;
+					}
+				};
+				tracing::info!(%remote, %path, "SRT request accepted");
+				if let Err(err) = serve_request(consumer, &path, socket).await {
+					tracing::warn!(%remote, %path, %err, "SRT request ended with error");
+				} else {
+					tracing::info!(%remote, %path, "SRT request ended");
+				}
+			});
+			continue;
+		}
+
 		// Claim the path before accepting; the guard releases it when the
 		// connection task ends (success, error, or panic).
-		let Some(guard) = active.claim(&path) else {
-			tracing::warn!(%remote, %path, "rejecting SRT: path already being ingested");
+		let Some(guard) = active.claim(&route.path) else {
+			tracing::warn!(%remote, path = %route.path, "rejecting SRT: path already being ingested");
 			reject(request, ServerRejectReason::Forbidden, remote).await;
 			continue;
 		};
 
+		let path = route.path;
 		let origin = origin.clone();
 		tokio::spawn(async move {
 			let _guard = guard;
@@ -110,7 +148,7 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 				}
 			};
 			tracing::info!(%remote, %path, "SRT connection accepted");
-			if let Err(err) = serve(origin, &path, socket).await {
+			if let Err(err) = serve_publish(origin, &path, socket).await {
 				tracing::warn!(%remote, %path, %err, "SRT ingest ended with error");
 			} else {
 				tracing::info!(%remote, %path, "SRT ingest ended");
@@ -162,8 +200,8 @@ impl Drop for PathGuard {
 	}
 }
 
-/// Pump one accepted SRT socket's MPEG-TS payload into the origin.
-async fn serve(origin: OriginProducer, path: &str, mut socket: srt_tokio::SrtSocket) -> Result<()> {
+/// Pump one accepted SRT socket's MPEG-TS payload into the origin (`m=publish`).
+async fn serve_publish(origin: OriginProducer, path: &str, mut socket: srt_tokio::SrtSocket) -> Result<()> {
 	use futures::TryStreamExt;
 
 	let mut publisher = crate::ts::Publisher::new(&origin, path)?;
@@ -174,22 +212,66 @@ async fn serve(origin: OriginProducer, path: &str, mut socket: srt_tokio::SrtSoc
 	Ok(())
 }
 
-/// Derive a broadcast path from an SRT stream id, applying `prefix`.
+/// Mux the requested broadcast back to MPEG-TS and stream it to the SRT caller
+/// (`m=request`).
 ///
-/// Prefers the standard `#!::r=<resource>` form, then falls back to the raw
-/// stream-id string. Returns `None` when there's nothing usable to route on.
-fn resolve_path(prefix: &str, stream_id: Option<&StreamId>) -> Option<String> {
+/// Waits for the broadcast to be announced (so a caller may connect before the
+/// publisher), then packs the muxer's output into [`SRT_PAYLOAD`]-sized SRT
+/// messages. Returns once the broadcast ends or the caller disconnects.
+async fn serve_request(origin: OriginConsumer, path: &str, mut socket: srt_tokio::SrtSocket) -> Result<()> {
+	let Some(mut subscriber) = crate::ts::Subscriber::new(&origin, path).await? else {
+		tracing::warn!(%path, "SRT request for an unroutable broadcast");
+		return Ok(());
+	};
+
+	// MPEG-TS is a continuous byte stream, so we coalesce the muxer's per-frame
+	// chunks and slice them on a fixed boundary rather than preserving them.
+	let mut buffer = bytes::BytesMut::new();
+	while let Some(chunk) = subscriber.next().await? {
+		buffer.extend_from_slice(&chunk);
+		while buffer.len() >= SRT_PAYLOAD {
+			let payload = buffer.split_to(SRT_PAYLOAD).freeze();
+			socket.send((Instant::now(), payload)).await?;
+		}
+	}
+
+	if !buffer.is_empty() {
+		socket.send((Instant::now(), buffer.freeze())).await?;
+	}
+	socket.close().await?;
+
+	Ok(())
+}
+
+/// A routing decision derived from an SRT connection's stream id.
+struct Route {
+	/// Broadcast path (with [`Config::prefix`] applied) to publish into or read from.
+	path: String,
+	/// Direction: `Request` serves a broadcast out, anything else ingests one in.
+	mode: ConnectionMode,
+}
+
+/// Derive a [`Route`] from an SRT stream id, applying `prefix`.
+///
+/// Prefers the standard `#!::r=<resource>,m=<mode>` form, then falls back to the
+/// raw stream-id string (always treated as ingest). Returns `None` when there's
+/// nothing usable to route on.
+fn resolve_route(prefix: &str, stream_id: Option<&StreamId>) -> Option<Route> {
 	let raw = stream_id?.as_str().trim();
 
-	// Standard SRT access-control form: `#!::r=<resource>,m=publish,...`.
-	let resource = raw.parse::<AccessControlList>().ok().and_then(|acl| {
-		acl.0
-			.into_iter()
-			.find_map(|entry| match StandardAccessControlEntry::try_from(entry) {
-				Ok(StandardAccessControlEntry::ResourceName(name)) if !name.is_empty() => Some(name),
-				_ => None,
-			})
-	});
+	// Standard SRT access-control form: `#!::r=<resource>,m=<mode>,...`. Absent
+	// `m=` defaults to publish, matching a bare stream id and OBS-style ingest.
+	let mut resource = None;
+	let mut mode = ConnectionMode::Publish;
+	if let Ok(acl) = raw.parse::<AccessControlList>() {
+		for entry in acl.0 {
+			match StandardAccessControlEntry::try_from(entry) {
+				Ok(StandardAccessControlEntry::ResourceName(name)) if !name.is_empty() => resource = Some(name),
+				Ok(StandardAccessControlEntry::Mode(m)) => mode = m,
+				_ => {}
+			}
+		}
+	}
 
 	// Fall back to the raw stream id (e.g. OBS-style `app/key`), but never to an
 	// unparsed `#!::` control string.
@@ -199,7 +281,10 @@ fn resolve_path(prefix: &str, stream_id: Option<&StreamId>) -> Option<String> {
 		None => raw.to_string(),
 	};
 
-	Some(format!("{prefix}{name}"))
+	Some(Route {
+		path: format!("{prefix}{name}"),
+		mode,
+	})
 }
 
 #[cfg(test)]
@@ -210,29 +295,50 @@ mod tests {
 		StreamId::try_from(s.as_bytes().to_vec()).unwrap()
 	}
 
+	fn route(prefix: &str, s: &str) -> Option<Route> {
+		resolve_route(prefix, Some(&sid(s)))
+	}
+
 	#[test]
 	fn standard_resource_form() {
-		assert_eq!(
-			resolve_path("", Some(&sid("#!::r=live/cam0,m=publish"))).as_deref(),
-			Some("live/cam0")
-		);
+		let r = route("", "#!::r=live/cam0,m=publish").unwrap();
+		assert_eq!(r.path, "live/cam0");
+		assert_eq!(r.mode, ConnectionMode::Publish);
+	}
+
+	#[test]
+	fn request_mode_is_egress() {
+		let r = route("", "#!::r=live/cam0,m=request").unwrap();
+		assert_eq!(r.path, "live/cam0");
+		assert_eq!(r.mode, ConnectionMode::Request);
+	}
+
+	#[test]
+	fn absent_mode_defaults_to_publish() {
+		// Both a bare stream id and an `r=`-only ACL ingest by default.
+		assert_eq!(route("", "app/key").unwrap().mode, ConnectionMode::Publish);
+		assert_eq!(route("", "#!::r=cam0").unwrap().mode, ConnectionMode::Publish);
 	}
 
 	#[test]
 	fn raw_stream_id() {
-		assert_eq!(resolve_path("", Some(&sid("app/key"))).as_deref(), Some("app/key"));
+		let r = route("", "app/key").unwrap();
+		assert_eq!(r.path, "app/key");
+		assert_eq!(r.mode, ConnectionMode::Publish);
 	}
 
 	#[test]
 	fn prefix_is_prepended() {
-		assert_eq!(resolve_path("live/", Some(&sid("cam0"))).as_deref(), Some("live/cam0"));
+		assert_eq!(route("live/", "cam0").unwrap().path, "live/cam0");
+		// Prefix applies to egress requests too.
+		assert_eq!(route("live/", "#!::r=cam0,m=request").unwrap().path, "live/cam0");
 	}
 
 	#[test]
 	fn missing_or_empty_is_rejected() {
-		assert_eq!(resolve_path("", None), None);
-		assert_eq!(resolve_path("", Some(&sid(""))), None);
-		assert_eq!(resolve_path("", Some(&sid("#!::"))), None);
+		assert!(resolve_route("", None).is_none());
+		assert!(route("", "").is_none());
+		assert!(route("", "#!::").is_none());
 	}
 
 	#[test]

--- a/rs/moq-srt/src/listen.rs
+++ b/rs/moq-srt/src/listen.rs
@@ -219,7 +219,20 @@ async fn serve_publish(origin: OriginProducer, path: &str, mut socket: srt_tokio
 /// publisher), then packs the muxer's output into [`SRT_PAYLOAD`]-sized SRT
 /// messages. Returns once the broadcast ends or the caller disconnects.
 async fn serve_request(origin: OriginConsumer, path: &str, mut socket: srt_tokio::SrtSocket) -> Result<()> {
-	let Some(mut subscriber) = crate::ts::Subscriber::new(&origin, path).await? else {
+	// Resolve the broadcast, but watch the socket while we wait: `announced_broadcast`
+	// parks forever for a stream that is never published, and nothing else polls the
+	// socket during that wait, so without this a caller who requests a non-existent
+	// stream (or hangs up before it starts) would leak this task and its socket.
+	let subscriber = tokio::select! {
+		biased;
+		_ = wait_closed(&mut socket) => {
+			tracing::debug!(%path, "SRT request closed before its broadcast was available");
+			return Ok(());
+		}
+		subscriber = crate::ts::Subscriber::new(&origin, path) => subscriber?,
+	};
+
+	let Some(mut subscriber) = subscriber else {
 		tracing::warn!(%path, "SRT request for an unroutable broadcast");
 		return Ok(());
 	};
@@ -241,6 +254,14 @@ async fn serve_request(origin: OriginConsumer, path: &str, mut socket: srt_tokio
 	socket.close().await?;
 
 	Ok(())
+}
+
+/// Resolve once the SRT caller hangs up (a clean close or an error), draining and
+/// ignoring any unexpected inbound packets. A request caller normally sends
+/// nothing, so this is purely a disconnect signal to race against the announce wait.
+async fn wait_closed(socket: &mut srt_tokio::SrtSocket) {
+	use futures::TryStreamExt;
+	while let Ok(Some(_)) = socket.try_next().await {}
 }
 
 /// A routing decision derived from an SRT connection's stream id.

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -3,11 +3,13 @@
 //! SRT carries MPEG-TS, so ingest is the same three steps every time: create a
 //! broadcast, publish it into the origin so downstream subscribers can find it,
 //! and feed the incoming bytes through a [`moq_mux`] TS importer that demuxes
-//! them into MoQ tracks. [`Publisher`] packages that up.
+//! them into MoQ tracks. [`Publisher`] packages that up. [`Subscriber`] is the
+//! mirror image for egress: it consumes a broadcast from the origin and re-muxes
+//! it back to MPEG-TS for an SRT caller (VLC, ffmpeg) to play.
 
 use bytes::Bytes;
 use moq_mux::container::ts;
-use moq_net::{BroadcastInfo, OriginProducer, OriginPublish};
+use moq_net::{BroadcastInfo, OriginConsumer, OriginProducer, OriginPublish};
 
 use crate::Result;
 
@@ -53,5 +55,35 @@ impl Publisher {
 	/// Flush any buffered media and close out the broadcast's open groups.
 	pub fn finish(&mut self) -> Result<()> {
 		Ok(self.importer.finish()?)
+	}
+}
+
+/// Muxes a single MoQ broadcast back into an MPEG-TS byte stream for egress.
+///
+/// The mirror of [`Publisher`]: where that demuxes SRT-carried TS into the
+/// origin, this consumes a broadcast from the origin and re-muxes it to TS so an
+/// SRT caller can play it. Pull byte chunks with [`next`](Self::next).
+pub struct Subscriber {
+	export: ts::Export,
+}
+
+impl Subscriber {
+	/// Resolve the broadcast at `path` in the origin and prepare to mux it to TS.
+	///
+	/// Returns `Ok(None)` if the broadcast can never be served (path outside the
+	/// consumer's scope, or the origin closed). Otherwise waits for the broadcast
+	/// to be announced, so a caller may connect before the publisher does.
+	pub async fn new(origin: &OriginConsumer, path: &str) -> Result<Option<Self>> {
+		let Some(broadcast) = origin.announced_broadcast(path).await else {
+			return Ok(None);
+		};
+
+		let export = ts::Export::new(broadcast).await?;
+		Ok(Some(Self { export }))
+	}
+
+	/// Pull the next MPEG-TS byte chunk, or `None` once the broadcast ends.
+	pub async fn next(&mut self) -> Result<Option<Bytes>> {
+		Ok(self.export.next().await?)
 	}
 }


### PR DESCRIPTION
## Summary

`moq-srt` was ingest-only. This adds the reverse direction, turning it into a bidirectional SRT gateway.

A caller dialing the SRT listener with `streamid=#!::r=<broadcast>,m=request` now gets the broadcast re-muxed from the origin back to MPEG-TS and streamed to it, so a plain SRT player can watch any broadcast the origin carries:

```bash
ffplay 'srt://host:9000?streamid=#!::r=cam0,m=request'
vlc    'srt://host:9000?streamid=#!::r=cam0,m=request'
```

Routing now parses the SRT stream-id `m=` mode: `m=request` is egress, everything else (including absent / raw OBS-style ids) stays ingest, so existing publish behavior is unchanged. Requests don't claim the `ActivePaths` guard, so any number of players can pull one broadcast, and they wait for the broadcast to be announced (a player may connect before the publisher does).

The TS muxer (`moq_mux::container::ts::Export`) already existed and re-injects SPS/PPS/VPS on keyframes; this PR is just the SRT-side wiring plus its mirror of the existing ingest `Publisher`.

## Changes

- `src/listen.rs`: `resolve_path` → `resolve_route` (returns broadcast path + `ConnectionMode`); `serve` → `serve_publish`; new `serve_request` packs the muxer output into 1316-byte (7×188) SRT messages.
- `src/ts.rs`: new `Subscriber`, the egress mirror of `Publisher`, wrapping `Export`.
- `src/error.rs`: new `Mux(#[from] moq_mux::Error)` variant.
- README / module docs updated for both directions.

## Public API

New `pub` surface on `moq-srt` (already a `dev`-targeted crate): `ts::Subscriber` is `pub` within the crate but `ts` is a private module, so the only externally visible change is the new `Error::Mux` variant (additive; enum is `#[non_exhaustive]`). New behavior, no breaking changes. Targets **dev** per branch rules.

## On SRT latency

The default 200 ms SRT receive latency can drop the front-loaded keyframe burst on a low-latency link when a player tunes in (ffmpeg logs `non-existing PPS 0` until the next keyframe). This is standard SRT live behavior, not a mux issue, and it is already tunable: SRT negotiates the effective latency as `max(caller, listener)`, and for egress the caller is the receiver, so a player can raise its own buffer with `?latency=N` in the URL (e.g. `?latency=2000`). The gateway-side floor remains `--srt-latency` / `Config::latency`.

## Test plan

- [x] `cargo build/test/clippy/fmt -p moq-srt` (via nix) green; 7 unit tests incl. new mode-parsing cases.
- [x] E2E loopback with ffmpeg: published H.264+AAC TS via `m=publish`, pulled it back via `m=request`. ffprobe identified `h264 320x240 + aac 48kHz`; a capture decoded 119 video + 242 audio frames.
- [ ] Tested against VLC / a hardware SRT decoder (only ffmpeg/ffprobe exercised so far).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)