### PR TITLE
feat(moq-rtmp): RTMP play mode (egress)

### DIFF
--- a/doc/bin/rtmp.md
+++ b/doc/bin/rtmp.md
@@ -1,24 +1,31 @@
 ---
 title: moq-rtmp
-description: RTMP / enhanced-RTMP -> MoQ contribution ingest gateway
+description: RTMP / enhanced-RTMP <-> MoQ gateway (ingest and egress)
 ---
 
 # moq-rtmp
 
-`moq-rtmp` ingests [RTMP](https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol)
-(the protocol OBS, ffmpeg, and most hardware encoders speak) and publishes each
-stream into Media over QUIC as an ordinary broadcast.
+`moq-rtmp` bridges [RTMP](https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol)
+(the protocol OBS, ffmpeg, and most hardware encoders and players speak) and
+Media over QUIC, in **both directions**:
+
+- **Publish (ingest):** an encoder pushes a stream in, and `moq-rtmp` publishes it
+  into MoQ as an ordinary broadcast.
+- **Play (egress):** a player pulls `rtmp://host/<app>/<key>`, and `moq-rtmp`
+  subscribes to that broadcast from MoQ and streams it back down. VLC, ffplay, and
+  mpv can play it (browsers can't -- Flash is dead).
 
 RTMP carries media as FLV-format audio/video messages. `moq-rtmp` runs the RTMP
 handshake and chunk/AMF session (via the pure-Rust
-[`rml_rtmp`](https://crates.io/crates/rml_rtmp), no librtmp), re-wraps each
-message as an FLV tag, and feeds it to `moq-mux`'s FLV demuxer, which routes the
-media onto MoQ tracks. It's the contribution-ingest sibling of `moq-srt`
-(SRT/MPEG-TS) and `moq-rtc` (WHIP).
+[`rml_rtmp`](https://crates.io/crates/rml_rtmp), no librtmp). On ingest it re-wraps
+each message as an FLV tag and feeds it to `moq-mux`'s FLV demuxer; on egress it
+muxes the broadcast back to FLV with `moq-mux` and sends the tags out as RTMP
+messages. It's the sibling of `moq-srt` (SRT/MPEG-TS) and `moq-rtc` (WHIP/WHEP).
 
 Both **legacy RTMP** (H.264 + AAC) and **enhanced RTMP** (E-RTMP: the HEVC, AV1,
-VP9, Opus, and AC-3 FourCC payloads) are supported, because all codec handling
-lives in the `moq-mux` FLV demuxer.
+VP9, Opus, and AC-3 FourCC payloads) are supported in each direction, because all
+codec handling lives in the `moq-mux` FLV demuxer/muxer. Legacy players that speak
+only H.264 + AAC will reject the E-RTMP codecs on the play path.
 
 ## CLI shape
 
@@ -40,6 +47,15 @@ and the stream key to `cam0`; with ffmpeg:
 ```bash
 # Lands at broadcast `live/cam0`.
 ffmpeg -re -i input.mp4 -c copy -f flv rtmp://127.0.0.1:1935/live/cam0
+```
+
+Then play the same broadcast back out over RTMP from any player:
+
+```bash
+# Pulls broadcast `live/cam0` (the same URL it was pushed to).
+ffplay rtmp://127.0.0.1:1935/live/cam0
+mpv rtmp://127.0.0.1:1935/live/cam0
+vlc rtmp://127.0.0.1:1935/live/cam0
 ```
 
 ### `serve` flags
@@ -81,23 +97,32 @@ moq-rtmp serve --server-bind [::]:443 --tls-generate localhost \
 
 Each connection's broadcast path is `<app>/<key>` from the RTMP app and stream
 key (`rtmp://host/<app>/<key>`), falling back to just the app when the key is
-empty, with `--rtmp-prefix` prepended. First publisher on a path wins; a second
-connection to the same path is rejected.
+empty, with `--rtmp-prefix` prepended. The same routing applies to both
+directions, so the URL round-trips: push to `rtmp://host/live/cam0`, then pull it
+back from `rtmp://host/live/cam0`.
+
+A play waits for the broadcast to be announced, so a player can connect slightly
+before the publisher. First **publisher** on a path wins (a second publish to a
+live path is rejected); **plays** don't claim a path, so any number of players can
+pull the same broadcast at once. In `serve` mode plays are served from the same
+origin the server exposes, so anything in it -- RTMP ingests and otherwise -- can
+be pulled back out over RTMP.
 
 ## Notes and limitations
 
 - **Auth.** The binary (and the `moq_rtmp::run` convenience) is unauthenticated:
-  anyone who can reach the TCP port can publish. Gate it with a host firewall or
-  a private network. To authenticate, embed the library and drive its
-  `Server` / `Request` API: `Server::accept` yields a pending publish, and you
-  verify the app / stream key (e.g. the stream key as a moq-token JWT) before
-  calling `request.accept(origin, path)` or `request.reject(reason)` -- no
-  callback, the policy lives in your loop.
-- **Embedding.** A relay can run ingest in-process by depending on the `moq-rtmp`
-  library (`default-features = false`). Call `moq_rtmp::run` against its own
-  origin for the unauthenticated case, or use `Server` / `Request` to plug in the
-  relay's existing JWT/path auth and scope the origin per token. Either way the
-  media is published locally with no extra hop.
+  anyone who can reach the TCP port can publish or play. Gate it with a host
+  firewall or a private network. To authenticate, embed the library and drive its
+  `Server` / `Request` API: `Server::accept` yields a `Request` that is either a
+  `Publish` or a `Play`, and you verify the app / stream key (e.g. the stream key
+  as a moq-token JWT) before accepting it into / out of an origin at a path of your
+  choosing, or rejecting it -- no callback, the policy lives in your loop.
+- **Embedding.** A relay can run the gateway in-process by depending on the
+  `moq-rtmp` library (`default-features = false`). Call `moq_rtmp::run` against its
+  own origin for the unauthenticated case (publishers ingest into it, players are
+  served out of it), or use `Server` / `Request` to plug in the relay's existing
+  JWT/path auth and scope the origin per token. Either way the media stays local
+  with no extra hop.
 - **RTMPS.** Embedders can terminate TLS themselves: set `Config::tls` (or
   `Server::with_tls`) with a `rustls::ServerConfig`, or accept the connection and
   finish the TLS handshake by hand and hand the stream to `moq_rtmp::accept_stream`

--- a/rs/moq-rtmp/README.md
+++ b/rs/moq-rtmp/README.md
@@ -1,15 +1,17 @@
 # moq-rtmp
 
-RTMP / enhanced-RTMP contribution ingest gateway for Media over QUIC.
+RTMP / enhanced-RTMP gateway for Media over QUIC: contribution ingest and egress.
 
-RTMP carries FLV-format audio/video. This crate runs an RTMP server, re-wraps
-each connection's messages as FLV tags, demuxes them with
-[`moq-mux`](../moq-mux), and publishes the result into a MoQ origin as ordinary
-broadcasts. It's the contribution-ingest analogue of `moq-srt`, `moq-hls`'s
-import, and `moq-rtc`'s WHIP. Both legacy RTMP (H.264 + AAC) and enhanced RTMP
-(E-RTMP: HEVC, AV1, VP9, Opus, AC-3) work, since the codec handling lives in the
-`moq-mux` FLV demuxer. Pure Rust: the protocol is provided by `rml_rtmp`, with no
-librtmp or ffmpeg dependency.
+RTMP carries FLV-format audio/video. This crate runs an RTMP server that bridges
+both directions with [`moq-mux`](../moq-mux): on **publish** it re-wraps a
+client's messages as FLV tags, demuxes them, and publishes the result into a MoQ
+origin as ordinary broadcasts; on **play** it subscribes to a broadcast from the
+origin, muxes it back to FLV, and streams the tags down to the player. It's the
+sibling of `moq-srt`, `moq-hls`'s import/export, and `moq-rtc`'s WHIP/WHEP. Both
+legacy RTMP (H.264 + AAC) and enhanced RTMP (E-RTMP: HEVC, AV1, VP9, Opus, AC-3)
+work in each direction, since the codec handling lives in the `moq-mux` FLV
+demuxer/muxer. Pure Rust: the protocol is provided by `rml_rtmp`, with no librtmp
+or ffmpeg dependency.
 
 ## Library
 
@@ -24,9 +26,10 @@ There are two entry points.
 
 ### `run` (unauthenticated)
 
-`Config` + `run` accepts every publisher and routes by prefix + app/key. A relay
-embeds ingest by calling `run` against its own origin, so the ingested media is
-published locally with no extra hop:
+`Config` + `run` accepts every publisher and player and routes by prefix +
+app/key (publishers ingest into the origin, players are served out of it). A relay
+embeds the gateway by calling `run` against its own origin, so the media stays
+local with no extra hop:
 
 ```rust
 let mut rtmp = moq_rtmp::Config::default();
@@ -42,25 +45,34 @@ tokio::select! {
 
 ### `Server` / `Request` (bring your own auth)
 
-To gate ingest, drive the `Server` directly. `accept` runs the handshake and the
-connect/publish exchange, then yields a `Request` once the client wants to
-publish. You inspect the app and stream key, make a decision, and `accept` or
-`reject` it. This mirrors `moq-native`'s `Server` / `Request`, so there's no
-callback: the auth policy lives in your loop.
+To gate access, drive the `Server` directly. `accept` runs the handshake and the
+connect exchange, then yields a `Request` once the client wants to publish or
+play. The `Request` is either a `Publish` or a `Play`; you inspect the app and
+stream key, make a decision, and `accept` or `reject` it. This mirrors
+`moq-native`'s `Server` / `Request`, so there's no callback: the auth policy lives
+in your loop.
 
 ```rust
 let mut server = moq_rtmp::Server::bind("0.0.0.0:1935".parse()?).await?;
+let consumer = origin.consume(); // players are served out of this
 while let Some(request) = server.accept().await {
     let origin = origin.clone();
+    let consumer = consumer.clone();
     // Spawn per connection: `accept` pumps media for the whole connection, so
-    // handling it inline would serialize publishers.
+    // handling it inline would serialize clients.
     tokio::spawn(async move {
         // Treat the stream key as a token (e.g. a moq-token JWT) and the app as
-        // the broadcast path. Verify however you like; on success choose where to
-        // publish (`origin` can be scoped per token with `with_root` / `scope`).
-        match authorize(request.app(), request.stream_key()).await {
-            Ok(path) => { let _ = request.accept(&origin, &path).await; }
-            Err(err) => { let _ = request.reject(&err.to_string()).await; }
+        // the broadcast path. Verify however you like; the origin can be scoped
+        // per token with `with_root` / `scope`.
+        match request {
+            moq_rtmp::Request::Publish(publish) => match authorize(publish.app(), publish.stream_key()).await {
+                Ok(path) => { let _ = publish.accept(&origin, &path).await; }
+                Err(err) => { let _ = publish.reject(&err.to_string()).await; }
+            },
+            moq_rtmp::Request::Play(play) => match authorize(play.app(), play.stream_key()).await {
+                Ok(path) => { let _ = play.accept(&consumer, &path).await; }
+                Err(err) => { let _ = play.reject(&err.to_string()).await; }
+            },
         }
     });
 }
@@ -91,7 +103,7 @@ Two ways to serve `rtmps://`:
   ```rust
   let tls = acceptor.accept(tcp).await?; // your tokio_rustls TlsAcceptor
   if let Some(request) = moq_rtmp::accept_stream(tls, peer).await? {
-      // authorize, then request.accept(&origin, &path).await?
+      // authorize, then match on Request::Publish / Request::Play and accept it
   }
   ```
 
@@ -99,10 +111,11 @@ Two ways to serve `rtmps://`:
 
 The `moq-rtmp` binary (needs the default `server` feature) has two modes.
 
-`serve` ingests RTMP and serves it directly as a local relay, so MoQ subscribers
-(native or browser) connect straight to this binary. It also exposes the
-`/certificate.sha256` endpoint browsers need for self-signed `http://` origins,
-and can serve a static player directory with `--dir`:
+`serve` runs RTMP directly as a local relay, so MoQ subscribers (native or
+browser) connect straight to this binary; RTMP players can also pull the same
+broadcasts back out. It also exposes the `/certificate.sha256` endpoint browsers
+need for self-signed `http://` origins, and can serve a static player directory
+with `--dir`:
 
 ```bash
 moq-rtmp serve --server-bind [::]:443 --tls-generate localhost \
@@ -139,18 +152,28 @@ ffmpeg -re -i input.mp4 -c copy -f flv rtmp://127.0.0.1:1935/live/cam0
 ffmpeg -re -i input.mp4 -c:v hevc -c:a aac -f flv rtmp://127.0.0.1:1935/live/cam0
 ```
 
+Play any broadcast back out over RTMP from a player (VLC, ffplay, mpv):
+
+```bash
+# Pulls broadcast `live/cam0` (the same URL it was pushed to).
+ffplay rtmp://127.0.0.1:1935/live/cam0
+```
+
 ## Routing
 
 Each connection's broadcast path is `<app>/<key>`, from the RTMP app and stream
 key (`rtmp://host/<app>/<key>`), falling back to just the app when the key is
-empty. `--rtmp-prefix` is prepended to namespace a listener's streams. First
-publisher on a path wins; a second connection to the same path is rejected.
+empty. `--rtmp-prefix` is prepended to namespace a listener's streams. The same
+routing applies to both directions, so the URL round-trips. First publisher on a
+path wins (a second publish to a live path is rejected); plays don't claim a path,
+so any number of players can pull the same broadcast at once, and a play waits for
+the broadcast to be announced.
 
 ## Auth
 
 The `run` entry point and the `moq-rtmp` binary are unauthenticated: anyone who
-can reach the TCP port can publish, so gate them with a host firewall or a
+can reach the TCP port can publish or play, so gate them with a host firewall or a
 private network. To authenticate, use the `Server` / `Request` API above and
-verify each publish in your accept loop (e.g. the stream key as a moq-token JWT,
-the app as the broadcast path) before calling `request.accept`. That is the
-intended integration point for a relay that already has JWT/path auth.
+verify each request in your accept loop (e.g. the stream key as a moq-token JWT,
+the app as the broadcast path) before accepting it. That is the intended
+integration point for a relay that already has JWT/path auth.

--- a/rs/moq-rtmp/bin/moq-rtmp.rs
+++ b/rs/moq-rtmp/bin/moq-rtmp.rs
@@ -1,15 +1,18 @@
 //! `moq-rtmp` binary.
 //!
-//! Ingests RTMP / enhanced-RTMP (OBS, ffmpeg, hardware encoders) and exposes it
-//! over MoQ two ways:
+//! Bridges RTMP / enhanced-RTMP (OBS, ffmpeg, hardware encoders, and players like
+//! VLC / ffplay / mpv) to MoQ. Each listener does both directions: a `publish`
+//! ingests a stream in, a `play` pulls one back out (`rtmp://host/<app>/<key>`
+//! round-trips to the same path). Two binary modes wire up the MoQ side:
 //!
-//! - `serve` runs a local QUIC/WebTransport server so subscribers connect
-//!   straight to this binary (no separate relay needed).
+//! - `serve` runs a local QUIC/WebTransport server so MoQ subscribers connect
+//!   straight to this binary (no separate relay needed). RTMP players can also
+//!   pull the same broadcasts back out.
 //! - `publish` forwards every ingested broadcast out to a remote relay over
 //!   WebTransport, like `moq-srt publish` / `moq-hls import` / `moq-rtc` WHIP.
 //!
-//! A relay that wants in-process ingest should instead depend on the `moq-rtmp`
-//! library and call `moq_rtmp::run` against its own origin.
+//! A relay that wants in-process ingest/egress should instead depend on the
+//! `moq-rtmp` library and call `moq_rtmp::run` against its own origin.
 
 mod serve;
 mod web;

--- a/rs/moq-rtmp/src/flv.rs
+++ b/rs/moq-rtmp/src/flv.rs
@@ -12,8 +12,13 @@
 //! See `moq-mux/src/container/flv` for the matching reader; the field layout
 //! here mirrors what it parses (11-byte tag header, 24-bit + 8-bit extended
 //! millisecond timestamp, trailing `PreviousTagSize`).
+//!
+//! The reverse direction (play / egress) uses [`TagReader`]: it splits the FLV
+//! byte stream that [`moq_mux::container::flv::Export`] produces back into
+//! individual tags, so each tag body can be sent to a player as an RTMP
+//! audio/video message.
 
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 /// FLV tag type for audio data (matches moq-mux's `TAG_AUDIO`).
 pub const TAG_AUDIO: u8 = 8;
@@ -69,9 +74,149 @@ pub fn tag(tag_type: u8, timestamp: u32, body: &[u8]) -> Bytes {
 	buf.freeze()
 }
 
+/// One FLV media tag pulled out of an [`Export`](moq_mux::container::flv::Export)
+/// byte stream by [`TagReader`], ready to send as an RTMP message body.
+pub struct Tag {
+	/// FLV tag type: [`TAG_AUDIO`] or [`TAG_VIDEO`].
+	pub tag_type: u8,
+	/// Tag timestamp in milliseconds (the reassembled 24-bit + extended byte).
+	pub timestamp: u32,
+	/// The tag body, i.e. the bytes of the RTMP audio/video message to send.
+	pub body: Bytes,
+}
+
+/// Splits an FLV byte stream back into its individual tags.
+///
+/// The inverse of [`file_header`] + [`tag`]: feed the chunks
+/// [`Export`](moq_mux::container::flv::Export) yields via [`push`](Self::push),
+/// then drain whole tags with [`next`](Self::next). The leading FLV file header
+/// is consumed and discarded; only the audio/video tags surface, each carrying
+/// the body to forward as an RTMP message.
+#[derive(Default)]
+pub struct TagReader {
+	/// Bytes received but not yet parsed into a complete tag.
+	buf: BytesMut,
+	/// Set once the FLV file header has been consumed.
+	header_done: bool,
+}
+
+impl TagReader {
+	/// Create an empty reader.
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	/// Append a chunk of the FLV byte stream.
+	pub fn push(&mut self, bytes: &[u8]) {
+		self.buf.extend_from_slice(bytes);
+	}
+
+	/// Pop the next complete tag, or `None` if more bytes are needed first.
+	///
+	/// Errors only if the stream doesn't start with the FLV signature.
+	pub fn next(&mut self) -> anyhow::Result<Option<Tag>> {
+		if !self.header_done {
+			// File header: a 9-byte header whose last 4 bytes are the DataOffset,
+			// followed by the 4-byte PreviousTagSize0.
+			if self.buf.len() < FILE_HEADER_LEN {
+				return Ok(None);
+			}
+			anyhow::ensure!(&self.buf[0..3] == b"FLV", "not an FLV stream");
+			let data_offset = u32::from_be_bytes([self.buf[5], self.buf[6], self.buf[7], self.buf[8]]) as usize;
+			let skip = data_offset + 4;
+			if self.buf.len() < skip {
+				return Ok(None);
+			}
+			self.buf.advance(skip);
+			self.header_done = true;
+		}
+
+		// Tag header (11 bytes), body (DataSize bytes), then the 4-byte PreviousTagSize.
+		if self.buf.len() < TAG_HEADER_LEN {
+			return Ok(None);
+		}
+		let tag_type = self.buf[0];
+		let data_size = ((self.buf[1] as usize) << 16) | ((self.buf[2] as usize) << 8) | (self.buf[3] as usize);
+		let timestamp = ((self.buf[4] as u32) << 16)
+			| ((self.buf[5] as u32) << 8)
+			| (self.buf[6] as u32)
+			| ((self.buf[7] as u32) << 24);
+
+		if self.buf.len() < TAG_HEADER_LEN + data_size + 4 {
+			return Ok(None);
+		}
+
+		self.buf.advance(TAG_HEADER_LEN);
+		let body = self.buf.split_to(data_size).freeze();
+		self.buf.advance(4); // PreviousTagSize
+
+		Ok(Some(Tag {
+			tag_type,
+			timestamp,
+			body,
+		}))
+	}
+}
+
+/// Bytes in the FLV file header (signature, version, flags, DataOffset).
+const FILE_HEADER_LEN: usize = 9;
+/// Bytes in an FLV tag header (type, 24-bit size, timestamp, stream id).
+const TAG_HEADER_LEN: usize = 11;
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn tag_reader_splits_header_and_tags() {
+		let mut reader = TagReader::new();
+		reader.push(&file_header());
+		// A header chunk often carries the sequence-header tag(s) too; feed two tags.
+		reader.push(&tag(TAG_VIDEO, 0, &[0x17, 0x00]));
+		reader.push(&tag(TAG_AUDIO, 0x01_02_03_04, &[0xaf, 0x00, 0x12]));
+
+		let v = reader.next().unwrap().expect("video tag");
+		assert_eq!(v.tag_type, TAG_VIDEO);
+		assert_eq!(v.timestamp, 0);
+		assert_eq!(&v.body[..], &[0x17, 0x00]);
+
+		let a = reader.next().unwrap().expect("audio tag");
+		assert_eq!(a.tag_type, TAG_AUDIO);
+		assert_eq!(a.timestamp, 0x01_02_03_04);
+		assert_eq!(&a.body[..], &[0xaf, 0x00, 0x12]);
+
+		assert!(reader.next().unwrap().is_none());
+	}
+
+	#[test]
+	fn tag_reader_waits_for_a_whole_tag() {
+		let mut reader = TagReader::new();
+		reader.push(&file_header());
+		let full = tag(TAG_VIDEO, 7, &[1, 2, 3, 4, 5]);
+		// Feed everything but the last byte: no complete tag yet.
+		reader.push(&full[..full.len() - 1]);
+		assert!(reader.next().unwrap().is_none());
+		// The final byte completes it.
+		reader.push(&full[full.len() - 1..]);
+		let t = reader.next().unwrap().expect("tag once complete");
+		assert_eq!(t.timestamp, 7);
+		assert_eq!(&t.body[..], &[1, 2, 3, 4, 5]);
+	}
+
+	#[test]
+	fn tag_reader_round_trips_export_style_framing() {
+		// Mirrors how Export emits: header chunk, then one tag per chunk.
+		let mut reader = TagReader::new();
+		let mut header = BytesMut::new();
+		header.extend_from_slice(&file_header());
+		header.extend_from_slice(&tag(TAG_VIDEO, 0, b"seqhdr"));
+		reader.push(&header);
+		reader.push(&tag(TAG_VIDEO, 33, b"frame"));
+
+		assert_eq!(&reader.next().unwrap().unwrap().body[..], b"seqhdr");
+		assert_eq!(&reader.next().unwrap().unwrap().body[..], b"frame");
+		assert!(reader.next().unwrap().is_none());
+	}
 
 	#[test]
 	fn tag_layout_roundtrips_timestamp_and_size() {

--- a/rs/moq-rtmp/src/lib.rs
+++ b/rs/moq-rtmp/src/lib.rs
@@ -1,31 +1,38 @@
-//! RTMP / enhanced-RTMP contribution ingest gateway for MoQ.
+//! RTMP / enhanced-RTMP gateway for MoQ: contribution ingest *and* egress.
 //!
 //! Runs an [RTMP](https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol)
-//! server (the protocol OBS, ffmpeg, and most hardware encoders speak), re-wraps
-//! each connection's audio/video messages as FLV tags, demuxes them with
-//! [`moq_mux`], and publishes the result into a [`moq_net::OriginProducer`] as
-//! ordinary MoQ broadcasts. Whatever serves that origin (a relay, the bundled
-//! binary's serve mode) then exposes the ingested stream like any other
-//! broadcast. This is the contribution-ingest analogue of `moq-srt`, `moq-hls`'s
-//! import, and `moq-rtc`'s WHIP.
+//! server (the protocol OBS, ffmpeg, and most hardware encoders speak) and
+//! bridges it to MoQ in both directions:
+//!
+//! - **Publish (ingest)**: a client (OBS, ffmpeg) pushes a stream in; we re-wrap
+//!   its audio/video messages as FLV tags, demux them with [`moq_mux`], and
+//!   publish the result into a [`moq_net::OriginProducer`] as ordinary MoQ
+//!   broadcasts. This is the contribution-ingest analogue of `moq-srt`,
+//!   `moq-hls`'s import, and `moq-rtc`'s WHIP.
+//! - **Play (egress)**: a client (VLC, ffplay, mpv) pulls
+//!   `rtmp://host/<app>/<key>`; we subscribe to that broadcast from a
+//!   [`moq_net::OriginConsumer`], mux it back to FLV with [`moq_mux`], and stream
+//!   the tags down as RTMP. The counterpart to `moq-hls`'s export.
 //!
 //! Both legacy RTMP (H.264 + AAC) and enhanced RTMP (E-RTMP: the HEVC, AV1, VP9,
-//! Opus, and AC-3 FourCC payloads) are supported, because the codec handling
-//! lives entirely in the [`moq_mux`] FLV demuxer; this crate only translates the
-//! RTMP transport.
+//! Opus, and AC-3 FourCC payloads) are supported in each direction, because the
+//! codec handling lives entirely in the [`moq_mux`] FLV demuxer/muxer; this crate
+//! only translates the RTMP transport. Legacy players that speak only H.264 + AAC
+//! will of course reject the E-RTMP codecs on the play path.
 //!
-//! Two entry points, depending on how much control you need over each publish:
+//! Two entry points, depending on how much control you need over each request:
 //!
 //! - **[`run`]**: the unauthenticated convenience. Build a [`Config`] and hand it
-//!   plus an origin to [`run`]; it accepts every publisher and routes by prefix +
-//!   app/key. A relay embeds this with `run(cluster.origin.clone(), config)`.
+//!   plus an origin to [`run`]; it accepts every publisher and player and routes
+//!   by prefix + app/key (publishes into the origin, plays out of it). A relay
+//!   embeds this with `run(cluster.origin.clone(), config)`.
 //! - **[`Server`] / [`Request`]**: bring your own auth. Loop on
 //!   [`Server::accept`], inspect [`Request::app`] / [`Request::stream_key`] (treat
-//!   the stream key as a token if you like), then [`Request::accept`] the publish
-//!   into an origin at a path of your choosing, or [`Request::reject`] it. This is
-//!   how an embedder (e.g. a relay verifying a JWT and scoping the origin per
-//!   token) plugs its policy in, with no callback. It mirrors `moq-native`'s
-//!   `Server` / `Request`.
+//!   the stream key as a token if you like), then match on the [`Request`]: accept
+//!   a [`Publish`] into an origin, or accept a [`Play`] out of one, at a path of
+//!   your choosing (or reject it). This is how an embedder (e.g. a relay verifying
+//!   a JWT and scoping the origin per token) plugs its policy in, with no
+//!   callback. It mirrors `moq-native`'s `Server` / `Request`.
 //!
 //! The bundled `moq-rtmp` binary serves the origin locally or forwards it to a
 //! remote relay (those paths need the `server` feature).
@@ -51,7 +58,7 @@ mod server;
 
 pub use error::{Error, Result};
 pub use listen::{Config, run};
-pub use server::{Conn, Request, Server, Stream, accept_stream};
+pub use server::{Conn, Play, Publish, Request, Server, Stream, accept_stream};
 
 /// Re-export of the `rustls` version this crate builds [`Config::tls`] against,
 /// so consumers construct a matching [`rustls::ServerConfig`] (a major `rustls`

--- a/rs/moq-rtmp/src/listen.rs
+++ b/rs/moq-rtmp/src/listen.rs
@@ -1,19 +1,22 @@
 //! RTMP listener, configuration, and stream-key routing.
 //!
 //! We run a TCP listener on RTMP's port, hand each connection to
-//! [`crate::server`] for the handshake + session handling, and route each
-//! publish to a broadcast path derived from its RTMP app and stream key.
+//! [`crate::server`] for the handshake + session handling, and route each publish
+//! or play to a broadcast path derived from its RTMP app and stream key.
 //!
-//! Routing: the usual OBS/ffmpeg URL is `rtmp://host[:1935]/<app>/<key>`, which
-//! arrives as app `<app>` and stream key `<key>`. The path is `<app>/<key>`
+//! Routing: the usual OBS/ffmpeg/player URL is `rtmp://host[:1935]/<app>/<key>`,
+//! which arrives as app `<app>` and stream key `<key>`. The path is `<app>/<key>`
 //! (just `<app>` when the key is empty). The optional [`prefix`](Config::prefix)
-//! is prepended so a single listener can namespace all of its ingests (e.g.
-//! prefix `live/` + app `cam0` -> broadcast `live/cam0`).
+//! is prepended so a single listener can namespace everything (e.g. prefix
+//! `live/` + app `cam0` -> broadcast `live/cam0`). The same routing applies to
+//! both directions: a publish ingests *into* that path, a play serves *from* it,
+//! so the same URL round-trips (push to `rtmp://host/live/cam0`, pull it back from
+//! the same URL).
 //!
 //! Auth: this listener is currently unauthenticated. Anyone who can reach the
-//! TCP port can publish, so gate it with the host firewall / a private network.
-//! Treating the stream key as a token (a moq-token JWT, as moq-edge does) is the
-//! obvious next step.
+//! TCP port can publish or play, so gate it with the host firewall / a private
+//! network. Treating the stream key as a token (a moq-token JWT, as moq-edge
+//! does) is the obvious next step.
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -22,7 +25,7 @@ use std::sync::{Arc, Mutex};
 use moq_net::OriginProducer;
 
 use crate::Result;
-use crate::server::Server;
+use crate::server::{Request, Server};
 
 /// RTMP ingest configuration.
 ///
@@ -53,15 +56,16 @@ pub struct Config {
 	pub tls: Option<std::sync::Arc<rustls::ServerConfig>>,
 }
 
-/// Run the RTMP ingest listener until it fails, publishing each connection into
-/// `origin` as a broadcast.
+/// Run the RTMP listener until it fails, bridging each connection to `origin`:
+/// publishers ingest into it as broadcasts, players are served broadcasts from it.
 ///
 /// This is the unauthenticated convenience entry point: it accepts every
-/// publisher and routes by [`prefix`](Config::prefix) + app/key. To gate ingest
-/// (e.g. verify the stream key as a JWT) or to scope the origin per publisher,
-/// drive [`Server`] directly: loop on [`Server::accept`] and call
-/// [`Request::accept`](crate::Request::accept) / [`Request::reject`](crate::Request::reject)
-/// after making your own decision.
+/// publisher and player and routes by [`prefix`](Config::prefix) + app/key. Play
+/// requests are served from `origin.consume()`, so anything in the origin (RTMP
+/// ingests and otherwise) can be pulled back out over RTMP. To gate access (e.g.
+/// verify the stream key as a JWT) or to scope the origin per client, drive
+/// [`Server`] directly: loop on [`Server::accept`], match the [`Request`], and
+/// call accept/reject after making your own decision.
 ///
 /// Stays pending forever (rather than resolving) when RTMP is disabled, so it
 /// composes cleanly inside a `tokio::select!` alongside a relay's other
@@ -93,31 +97,54 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 	// of clobbering the live one.
 	let active = ActivePaths::default();
 	let prefix = Arc::new(config.prefix);
+	// Players are served out of the same origin the publishers write into.
+	let consumer = origin.consume();
 
 	while let Some(request) = server.accept().await {
-		let origin = origin.clone();
-		let active = active.clone();
 		let prefix = prefix.clone();
-		// Each connection runs on its own task: `accept` pumps media for the whole
-		// connection lifetime, so handling it inline would serialize publishers.
-		tokio::spawn(async move {
-			let peer = request.peer();
-			let Some(path) = resolve_path(&prefix, request.app(), request.stream_key()) else {
-				tracing::warn!(%peer, "rejecting RTMP: no usable broadcast path");
-				let _ = request.reject("missing broadcast path (RTMP app/key)").await;
-				return;
-			};
-			// Claim the path before accepting; the guard releases it when the
-			// connection task ends (success, error, or panic).
-			let Some(_guard) = active.claim(&path) else {
-				tracing::warn!(%peer, %path, "rejecting RTMP: path already being published");
-				let _ = request.reject("path already being published").await;
-				return;
-			};
-			if let Err(err) = request.accept(&origin, &path).await {
-				tracing::warn!(%peer, %path, %err, "RTMP ingest ended with error");
+		match request {
+			Request::Publish(publish) => {
+				let origin = origin.clone();
+				let active = active.clone();
+				// Each connection runs on its own task: `accept` pumps media for the
+				// whole connection lifetime, so handling it inline would serialize
+				// publishers.
+				tokio::spawn(async move {
+					let peer = publish.peer();
+					let Some(path) = resolve_path(&prefix, publish.app(), publish.stream_key()) else {
+						tracing::warn!(%peer, "rejecting RTMP publish: no usable broadcast path");
+						let _ = publish.reject("missing broadcast path (RTMP app/key)").await;
+						return;
+					};
+					// Claim the path before accepting; the guard releases it when the
+					// connection task ends (success, error, or panic).
+					let Some(_guard) = active.claim(&path) else {
+						tracing::warn!(%peer, %path, "rejecting RTMP publish: path already being published");
+						let _ = publish.reject("path already being published").await;
+						return;
+					};
+					if let Err(err) = publish.accept(&origin, &path).await {
+						tracing::warn!(%peer, %path, %err, "RTMP ingest ended with error");
+					}
+				});
 			}
-		});
+			Request::Play(play) => {
+				let consumer = consumer.clone();
+				// Many viewers can play the same path concurrently, so plays don't
+				// claim an `ActivePaths` slot.
+				tokio::spawn(async move {
+					let peer = play.peer();
+					let Some(path) = resolve_path(&prefix, play.app(), play.stream_key()) else {
+						tracing::warn!(%peer, "rejecting RTMP play: no usable broadcast path");
+						let _ = play.reject("missing broadcast path (RTMP app/key)").await;
+						return;
+					};
+					if let Err(err) = play.accept(&consumer, &path).await {
+						tracing::warn!(%peer, %path, %err, "RTMP play ended with error");
+					}
+				});
+			}
+		}
 	}
 
 	Err(anyhow::anyhow!("RTMP listener stopped accepting connections").into())

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -1,14 +1,21 @@
-//! RTMP server: accept connections, and hand each pending publish to the caller
+//! RTMP server: accept connections, and hand each pending request to the caller
 //! as a [`Request`] to authorize.
 //!
-//! [`Server::accept`] runs the RTMP handshake and the connect/publish command
-//! exchange for each TCP connection (many concurrently, so a slow client doesn't
-//! block others), then yields a [`Request`] once the client issues its `publish`
-//! command. The caller inspects the app and stream key, makes an authorization
-//! decision, and calls [`Request::accept`] (publish into an origin at a path) or
-//! [`Request::reject`]. This mirrors `moq-native`'s `Server` / `Request`, so the
-//! gateway stays unopinionated about auth: the embedder (e.g. a relay verifying
-//! the stream key as a JWT) owns that policy.
+//! [`Server::accept`] runs the RTMP handshake and the connect command exchange
+//! for each TCP connection (many concurrently, so a slow client doesn't block
+//! others), then yields a [`Request`] once the client issues its `publish` or
+//! `play` command. The caller inspects the app and stream key, makes an
+//! authorization decision, and either:
+//!
+//! - **[`Request::Publish`]**: [`Publish::accept`] (ingest into an origin at a
+//!   path) or [`Publish::reject`]. This is the contribution path (OBS, ffmpeg).
+//! - **[`Request::Play`]**: [`Play::accept`] (serve a broadcast from an origin
+//!   down to the player) or [`Play::reject`]. This is the egress path: a player
+//!   (VLC, ffplay, mpv) pulls `rtmp://host/<app>/<key>` and we stream it back.
+//!
+//! This mirrors `moq-native`'s `Server` / `Request`, so the gateway stays
+//! unopinionated about auth: the embedder (e.g. a relay verifying the stream key
+//! as a JWT) owns that policy.
 //!
 //! RTMPS (RTMP over TLS): [`Server::with_tls`] makes the listener terminate TLS
 //! before the RTMP handshake, so `rtmps://` clients work with no other change.
@@ -27,10 +34,11 @@ use std::time::Duration;
 use futures::StreamExt;
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
-use moq_mux::container::flv::Import as FlvImport;
-use moq_net::{BroadcastInfo, OriginProducer, OriginPublish};
+use moq_mux::container::flv::{Export as FlvExport, Import as FlvImport};
+use moq_net::{BroadcastInfo, OriginConsumer, OriginProducer, OriginPublish};
 use rml_rtmp::handshake::{Handshake, HandshakeProcessResult, PeerType};
 use rml_rtmp::sessions::{ServerSession, ServerSessionConfig, ServerSessionEvent, ServerSessionResult};
+use rml_rtmp::time::RtmpTimestamp;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
 
@@ -40,11 +48,12 @@ use crate::flv;
 /// Read buffer size for pulling RTMP chunk-stream bytes off the socket.
 const READ_BUFFER: usize = 16 * 1024;
 
-/// How long a connection has to finish the handshake and issue its `publish`
-/// before it is dropped. Bounds the lifetime (and socket / `pending` slot) of a
-/// client that connects but never publishes, so idle or half-open connections
-/// can't accumulate without limit. With TLS this also covers the TLS handshake.
-const PUBLISH_TIMEOUT: Duration = Duration::from_secs(15);
+/// How long a connection has to finish the handshake and issue its `publish` or
+/// `play` before it is dropped. Bounds the lifetime (and socket / `pending` slot)
+/// of a client that connects but never does either, so idle or half-open
+/// connections can't accumulate without limit. With TLS this also covers the TLS
+/// handshake.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// A bidirectional byte stream carrying an RTMP session.
 ///
@@ -106,12 +115,12 @@ impl AsyncWrite for Conn {
 	}
 }
 
-/// An RTMP server that yields each connection's pending publish as a [`Request`].
+/// An RTMP server that yields each connection's pending request as a [`Request`].
 ///
 /// Build it with [`bind`](Self::bind), optionally enable RTMPS with
 /// [`with_tls`](Self::with_tls), then loop on [`accept`](Self::accept). The
-/// handshake and the connect/publish exchange happen inside `accept`, so a
-/// [`Request`] is only produced once a client actually wants to publish.
+/// handshake and the connect exchange happen inside `accept`, so a [`Request`] is
+/// only produced once a client actually wants to publish or play.
 pub struct Server {
 	listener: TcpListener,
 
@@ -121,7 +130,7 @@ pub struct Server {
 	tls: Option<tokio_rustls::TlsAcceptor>,
 
 	/// In-flight handshakes; each resolves to a ready [`Request`], or `None` if
-	/// the connection closed or errored before issuing a publish.
+	/// the connection closed or errored before issuing a publish or play.
 	pending: FuturesUnordered<BoxFuture<'static, Option<Request<Conn>>>>,
 }
 
@@ -152,11 +161,11 @@ impl Server {
 		Ok(self.listener.local_addr()?)
 	}
 
-	/// Wait for the next connection that wants to publish.
+	/// Wait for the next connection that wants to publish or play.
 	///
 	/// New connections are accepted and handshaked concurrently; this returns the
-	/// next one to reach its `publish` command. Connections that close or error
-	/// before publishing are dropped without surfacing here. Returns `None` only
+	/// next one to reach its `publish` or `play` command. Connections that close or
+	/// error before either are dropped without surfacing here. Returns `None` only
 	/// if the listener itself stops (it currently never does).
 	pub async fn accept(&mut self) -> Option<Request<Conn>> {
 		loop {
@@ -179,7 +188,7 @@ impl Server {
 						self.pending.push(Box::pin(async move {
 							// The TLS handshake (if any) and the RTMP handshake share one
 							// budget, so a client that stalls either is dropped.
-							let outcome = tokio::time::timeout(PUBLISH_TIMEOUT, async move {
+							let outcome = tokio::time::timeout(REQUEST_TIMEOUT, async move {
 								#[cfg(feature = "server")]
 								let conn = match tls {
 									Some(acceptor) => Conn::Tls(Box::new(
@@ -192,17 +201,17 @@ impl Server {
 								};
 								#[cfg(not(feature = "server"))]
 								let conn = Conn::Plain(stream);
-								accept_until_publish(conn, peer).await
+								accept_until_request(conn, peer).await
 							})
 							.await;
 							match outcome {
 								Ok(Ok(request)) => request,
 								Ok(Err(err)) => {
-									tracing::warn!(%peer, %err, "RTMP connection closed before publish");
+									tracing::warn!(%peer, %err, "RTMP connection closed before publish/play");
 									None
 								}
 								Err(_) => {
-									tracing::warn!(%peer, "RTMP connection did not publish before timeout");
+									tracing::warn!(%peer, "RTMP connection did not publish or play before timeout");
 									None
 								}
 							}
@@ -220,32 +229,76 @@ impl Server {
 	}
 }
 
-/// Run the RTMP handshake and connect/publish exchange on an already-established
-/// byte stream, yielding the pending publish as a [`Request`].
+/// Run the RTMP handshake and connect exchange on an already-established byte
+/// stream, yielding the pending publish or play as a [`Request`].
 ///
 /// The bring-your-own-transport entry point: accept the connection (and, for
 /// `rtmps://`, complete the TLS handshake) yourself, then hand the stream here.
 /// `peer` is the remote address, used for logging and [`Request::peer`].
 ///
-/// Returns `Ok(None)` if the client disconnects before issuing `publish`. Unlike
-/// [`Server`], this applies no publish timeout: wrap the call in
+/// Returns `Ok(None)` if the client disconnects before issuing `publish` or
+/// `play`. Unlike [`Server`], this applies no timeout: wrap the call in
 /// [`tokio::time::timeout`] to bound how long a connected-but-idle client can
 /// hold the task.
 pub async fn accept_stream<S: Stream>(stream: S, peer: SocketAddr) -> Result<Option<Request<S>>> {
-	Ok(accept_until_publish(stream, peer).await?)
+	Ok(accept_until_request(stream, peer).await?)
 }
 
-/// A pending RTMP publish, waiting on the caller to authorize it.
+/// What an accepted RTMP connection wants: to contribute media ([`Publish`]) or
+/// to view it ([`Play`]).
+///
+/// Yielded by [`Server::accept`] / [`accept_stream`] once the client issues its
+/// `publish` or `play` command. Inspect [`app`](Self::app) /
+/// [`stream_key`](Self::stream_key), then match to authorize the right
+/// direction. Dropping it without accepting or rejecting closes the connection.
+///
+/// `S` is the underlying stream: [`Conn`] for a [`Server`]-produced request, or
+/// your own transport when built via [`accept_stream`].
+#[non_exhaustive]
+pub enum Request<S = Conn> {
+	/// A client pushing media in (OBS, ffmpeg). Ingest it with [`Publish::accept`].
+	Publish(Publish<S>),
+	/// A client pulling media out (VLC, ffplay, mpv). Serve it with [`Play::accept`].
+	Play(Play<S>),
+}
+
+impl<S: Stream> Request<S> {
+	/// The RTMP app name (the path component of `rtmp://host/<app>/<key>`).
+	pub fn app(&self) -> &str {
+		match self {
+			Request::Publish(r) => r.app(),
+			Request::Play(r) => r.app(),
+		}
+	}
+
+	/// The RTMP stream key (the final component of `rtmp://host/<app>/<key>`).
+	pub fn stream_key(&self) -> &str {
+		match self {
+			Request::Publish(r) => r.stream_key(),
+			Request::Play(r) => r.stream_key(),
+		}
+	}
+
+	/// The remote peer address.
+	pub fn peer(&self) -> SocketAddr {
+		match self {
+			Request::Publish(r) => r.peer(),
+			Request::Play(r) => r.peer(),
+		}
+	}
+}
+
+/// A pending RTMP publish (contribution), waiting on the caller to authorize it.
 ///
 /// Inspect [`app`](Self::app) and [`stream_key`](Self::stream_key) (an
 /// `rtmp://host/<app>/<key>` URL splits into these), then either
 /// [`accept`](Self::accept) the publish into an origin at a chosen broadcast
-/// path or [`reject`](Self::reject) it. Dropping a `Request` without either
-/// closes the connection.
+/// path or [`reject`](Self::reject) it. Dropping it without either closes the
+/// connection.
 ///
 /// `S` is the underlying stream: [`Conn`] for a [`Server`]-produced request, or
 /// your own transport when built via [`accept_stream`].
-pub struct Request<S = Conn> {
+pub struct Publish<S = Conn> {
 	stream: S,
 	session: ServerSession,
 	/// The `rml_rtmp` request id for the pending publish, replied to on accept/reject.
@@ -258,7 +311,7 @@ pub struct Request<S = Conn> {
 	peer: SocketAddr,
 }
 
-impl<S: Stream> Request<S> {
+impl<S: Stream> Publish<S> {
 	/// The RTMP app name (the path component of `rtmp://host/<app>/<key>`).
 	pub fn app(&self) -> &str {
 		&self.app
@@ -330,9 +383,119 @@ impl<S: Stream> Request<S> {
 	}
 }
 
-/// Run one connection's handshake and connect/publish exchange, returning a
-/// [`Request`] once the client issues `publish` (or `None` if it disconnects first).
-async fn accept_until_publish<S: Stream>(mut stream: S, peer: SocketAddr) -> anyhow::Result<Option<Request<S>>> {
+/// A pending RTMP play (egress), waiting on the caller to authorize it.
+///
+/// The viewing counterpart of [`Publish`]: inspect [`app`](Self::app) /
+/// [`stream_key`](Self::stream_key), then [`accept`](Self::accept) to serve a
+/// broadcast from an origin down to the player, or [`reject`](Self::reject) it.
+/// Dropping it without either closes the connection.
+///
+/// `S` is the underlying stream: [`Conn`] for a [`Server`]-produced request, or
+/// your own transport when built via [`accept_stream`].
+pub struct Play<S = Conn> {
+	stream: S,
+	session: ServerSession,
+	/// The `rml_rtmp` request id for the pending play, replied to on accept/reject.
+	request_id: u32,
+	/// The RTMP message stream id to address outbound media at (from the `play`).
+	stream_id: u32,
+	/// Session results produced alongside the play command, processed on accept.
+	work: VecDeque<ServerSessionResult>,
+	app: String,
+	stream_key: String,
+	peer: SocketAddr,
+}
+
+impl<S: Stream> Play<S> {
+	/// The RTMP app name (the path component of `rtmp://host/<app>/<key>`).
+	pub fn app(&self) -> &str {
+		&self.app
+	}
+
+	/// The RTMP stream key (the final component of `rtmp://host/<app>/<key>`).
+	///
+	/// As with a publish, an embedder can treat this as a token to authorize the
+	/// viewer.
+	pub fn stream_key(&self) -> &str {
+		&self.stream_key
+	}
+
+	/// The remote peer address.
+	pub fn peer(&self) -> SocketAddr {
+		self.peer
+	}
+
+	/// Accept the play: subscribe to the broadcast at `path` in `origin`, mux it
+	/// to FLV, and stream the tags down to the player until either side ends.
+	///
+	/// Waits for the broadcast to be announced (so a player can connect slightly
+	/// before the publisher), cancelling cleanly if the viewer disconnects first.
+	/// This future resolves when playback ends, so callers usually run it on its
+	/// own task.
+	pub async fn accept(mut self, origin: &OriginConsumer, path: &str) -> Result<()> {
+		// Tell the client playback is starting (Play.Reset / Play.Start + StreamBegin).
+		let results = self
+			.session
+			.accept_request(self.request_id)
+			.map_err(|e| anyhow::anyhow!("rtmp accept play: {e:?}"))?;
+		self.work.extend(results);
+		flush_outbound(&mut self.stream, &mut self.work).await?;
+
+		tracing::info!(peer = %self.peer, %path, "rtmp play accepted");
+
+		// Wait for the broadcast, but abandon the wait if the viewer hangs up.
+		let broadcast = tokio::select! {
+			biased;
+			res = drain_input(&mut self.stream) => {
+				res?;
+				tracing::debug!(peer = %self.peer, %path, "viewer disconnected before play started");
+				return Ok(());
+			}
+			broadcast = origin.announced_broadcast(path) => broadcast,
+		};
+		let Some(broadcast) = broadcast else {
+			tracing::debug!(peer = %self.peer, %path, "play broadcast unavailable");
+			return Ok(());
+		};
+
+		let mut export = FlvExport::new(broadcast)
+			.await
+			.map_err(|e| anyhow::anyhow!("init FLV export: {e}"))?;
+		let result = play_pump(
+			&mut self.stream,
+			&mut self.session,
+			&mut self.work,
+			&mut export,
+			self.stream_id,
+			self.peer,
+		)
+		.await;
+
+		tracing::debug!(peer = %self.peer, %path, "rtmp play ended");
+		result
+	}
+
+	/// Reject the play, sending `reason` back to the client as the
+	/// `NetStream.Play.Failed` description, then close the connection.
+	pub async fn reject(mut self, reason: &str) -> Result<()> {
+		let results = self
+			.session
+			.reject_request(self.request_id, "NetStream.Play.Failed", reason)
+			.map_err(|e| anyhow::anyhow!("rtmp reject play: {e:?}"))?;
+
+		for result in self.work.drain(..).chain(results) {
+			if let ServerSessionResult::OutboundResponse(packet) = result {
+				self.stream.write_all(&packet.bytes).await?;
+			}
+		}
+		tracing::debug!(peer = %self.peer, %reason, "rtmp play rejected");
+		Ok(())
+	}
+}
+
+/// Run one connection's handshake and connect exchange, returning a [`Request`]
+/// once the client issues `publish` or `play` (or `None` if it disconnects first).
+async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> anyhow::Result<Option<Request<S>>> {
 	let remaining = run_handshake(&mut stream, peer).await?;
 
 	let (mut session, initial) =
@@ -355,7 +518,7 @@ async fn accept_until_publish<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 					stream.write_all(&packet.bytes).await?;
 				}
 				ServerSessionResult::RaisedEvent(event) => match event {
-					// Accept every connect; authorization happens at publish time.
+					// Accept every connect; authorization happens at publish/play time.
 					ServerSessionEvent::ConnectionRequested { request_id, app_name } => {
 						tracing::debug!(%peer, %app_name, "rtmp connect");
 						let results = session
@@ -370,7 +533,7 @@ async fn accept_until_publish<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 						stream_key,
 						..
 					} => {
-						return Ok(Some(Request {
+						return Ok(Some(Request::Publish(Publish {
 							stream,
 							session,
 							request_id,
@@ -378,9 +541,28 @@ async fn accept_until_publish<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 							app: app_name,
 							stream_key,
 							peer,
-						}));
+						})));
 					}
-					other => tracing::trace!(%peer, ?other, "ignoring RTMP event before publish"),
+					// The client wants to play: hand control back to the caller.
+					ServerSessionEvent::PlayStreamRequested {
+						request_id,
+						app_name,
+						stream_key,
+						stream_id,
+						..
+					} => {
+						return Ok(Some(Request::Play(Play {
+							stream,
+							session,
+							request_id,
+							stream_id,
+							work,
+							app: app_name,
+							stream_key,
+							peer,
+						})));
+					}
+					other => tracing::trace!(%peer, ?other, "ignoring RTMP event before publish/play"),
 				},
 				ServerSessionResult::UnhandleableMessageReceived(_) => {
 					tracing::trace!(%peer, "ignoring unhandleable RTMP message");
@@ -456,6 +638,108 @@ async fn pump<S: Stream>(
 
 	tracing::debug!(%peer, "rtmp connection closed");
 	Ok(())
+}
+
+/// Stream a broadcast to an RTMP player until the broadcast ends or the viewer
+/// stops.
+///
+/// Pulls FLV from `export`, splits it back into tags, and sends each as an RTMP
+/// audio/video message; concurrently it services client input (acknowledgements,
+/// pings, `deleteStream`) so a long playback stays healthy. The read and write
+/// halves run independently, so media keeps flowing regardless of when the viewer
+/// next sends anything.
+async fn play_pump<S: Stream>(
+	stream: &mut S,
+	session: &mut ServerSession,
+	work: &mut VecDeque<ServerSessionResult>,
+	export: &mut FlvExport,
+	stream_id: u32,
+	peer: SocketAddr,
+) -> Result<()> {
+	let (mut reader, mut writer) = tokio::io::split(stream);
+	let mut tags = flv::TagReader::new();
+	let mut buffer = [0u8; READ_BUFFER];
+
+	loop {
+		// Flush responses queued by the last batch of client input.
+		while let Some(result) = work.pop_front() {
+			match result {
+				ServerSessionResult::OutboundResponse(packet) => writer.write_all(&packet.bytes).await?,
+				ServerSessionResult::RaisedEvent(ServerSessionEvent::PlayStreamFinished { .. }) => {
+					tracing::debug!(%peer, "viewer stopped playback");
+					return Ok(());
+				}
+				ServerSessionResult::RaisedEvent(other) => {
+					tracing::trace!(%peer, ?other, "ignoring RTMP event during play")
+				}
+				ServerSessionResult::UnhandleableMessageReceived(_) => {}
+			}
+		}
+
+		tokio::select! {
+			// Media from the broadcast: split into tags and send each one down.
+			chunk = export.next() => match chunk? {
+				Some(bytes) => {
+					tags.push(&bytes);
+					while let Some(tag) = tags.next()? {
+						let ts = RtmpTimestamp::new(tag.timestamp);
+						let packet = match tag.tag_type {
+							flv::TAG_VIDEO => session.send_video_data(stream_id, tag.body, ts, false),
+							flv::TAG_AUDIO => session.send_audio_data(stream_id, tag.body, ts, false),
+							_ => continue,
+						}
+						.map_err(|e| anyhow::anyhow!("rtmp send media: {e:?}"))?;
+						writer.write_all(&packet.bytes).await?;
+					}
+				}
+				// Broadcast ended: tell the player and finish.
+				None => {
+					let packet = session
+						.finish_playing(stream_id)
+						.map_err(|e| anyhow::anyhow!("rtmp finish play: {e:?}"))?;
+					writer.write_all(&packet.bytes).await?;
+					return Ok(());
+				}
+			},
+			// Client input: feed the session so it can ack / tear down.
+			res = reader.read(&mut buffer) => {
+				let n = res?;
+				if n == 0 {
+					return Ok(());
+				}
+				let results = session
+					.handle_input(&buffer[..n])
+					.map_err(|e| anyhow::anyhow!("rtmp handle_input: {e:?}"))?;
+				work.extend(results);
+			}
+		}
+	}
+}
+
+/// Write every queued [`OutboundResponse`](ServerSessionResult::OutboundResponse)
+/// to the client, dropping the other result kinds.
+async fn flush_outbound<S: Stream>(stream: &mut S, work: &mut VecDeque<ServerSessionResult>) -> anyhow::Result<()> {
+	for result in work.drain(..) {
+		if let ServerSessionResult::OutboundResponse(packet) = result {
+			stream.write_all(&packet.bytes).await?;
+		}
+	}
+	Ok(())
+}
+
+/// Read and discard client bytes until the connection closes.
+///
+/// Used to detect a viewer hanging up while we wait for their broadcast to come
+/// online. Pre-playback the client only sends control messages (window ack,
+/// buffer length) that need no response, so discarding them is safe. Returns
+/// `Ok(())` on a clean close (EOF), or an error on an I/O failure.
+async fn drain_input<S: Stream>(stream: &mut S) -> anyhow::Result<()> {
+	let mut buffer = [0u8; READ_BUFFER];
+	loop {
+		if stream.read(&mut buffer).await? == 0 {
+			return Ok(());
+		}
+	}
 }
 
 /// Perform the RTMP server handshake, returning any leftover bytes that followed
@@ -550,11 +834,18 @@ mod tests {
 		ClientSession, ClientSessionConfig, ClientSessionEvent, ClientSessionResult, PublishRequestType,
 	};
 
+	/// What the test client asks for once connected.
+	#[derive(Clone, Copy)]
+	enum ClientMode {
+		Publish,
+		Play,
+	}
+
 	/// Drive a real RTMP client over an already-connected `stream` through
-	/// handshake -> connect(`live`) -> publish(`cam0`), pumping until aborted by
-	/// the test. Generic over the transport so the same client exercises both
+	/// handshake -> connect(`live`) -> publish/play(`cam0`), pumping until aborted
+	/// by the test. Generic over the transport so the same client exercises both
 	/// plaintext RTMP and RTMPS.
-	async fn run_client<S: Stream>(mut stream: S) {
+	async fn run_client<S: Stream>(mut stream: S, mode: ClientMode) {
 		// Handshake.
 		let mut handshake = Handshake::new(PeerType::Client);
 		stream
@@ -595,12 +886,15 @@ mod tests {
 					ClientSessionResult::OutboundResponse(packet) => {
 						stream.write_all(&packet.bytes).await.unwrap();
 					}
-					// Once connected, ask to publish; the publish command is sent
+					// Once connected, ask to publish or play; the command is sent
 					// automatically as the createStream round trip completes.
 					ClientSessionResult::RaisedEvent(ClientSessionEvent::ConnectionRequestAccepted) => {
-						let result = session
-							.request_publishing("cam0".to_string(), PublishRequestType::Live)
-							.unwrap();
+						let result = match mode {
+							ClientMode::Publish => session
+								.request_publishing("cam0".to_string(), PublishRequestType::Live)
+								.unwrap(),
+							ClientMode::Play => session.request_playback("cam0".to_string()).unwrap(),
+						};
 						work.push_back(result);
 					}
 					_ => {}
@@ -620,6 +914,141 @@ mod tests {
 		}
 	}
 
+	/// A received RTMP media message: `is_video` and the message body.
+	type Media = (bool, bytes::Bytes);
+
+	/// Drive an RTMP play client over `stream` through handshake -> connect(`live`)
+	/// -> play(`cam0`), collecting media messages until `want` have arrived.
+	async fn play_client_collect<S: Stream>(mut stream: S, want: usize) -> Vec<Media> {
+		// Handshake.
+		let mut handshake = Handshake::new(PeerType::Client);
+		stream
+			.write_all(&handshake.generate_outbound_p0_and_p1().unwrap())
+			.await
+			.unwrap();
+		let mut buffer = [0u8; 4096];
+		let remaining = loop {
+			let n = stream.read(&mut buffer).await.unwrap();
+			match handshake.process_bytes(&buffer[..n]).unwrap() {
+				HandshakeProcessResult::InProgress { response_bytes } => {
+					if !response_bytes.is_empty() {
+						stream.write_all(&response_bytes).await.unwrap();
+					}
+				}
+				HandshakeProcessResult::Completed {
+					response_bytes,
+					remaining_bytes,
+				} => {
+					if !response_bytes.is_empty() {
+						stream.write_all(&response_bytes).await.unwrap();
+					}
+					break remaining_bytes;
+				}
+			}
+		};
+
+		let (mut session, initial) = ClientSession::new(ClientSessionConfig::new()).unwrap();
+		let mut work: VecDeque<ClientSessionResult> = VecDeque::from(initial);
+		if !remaining.is_empty() {
+			work.extend(session.handle_input(&remaining).unwrap());
+		}
+		work.push_back(session.request_connection("live".to_string()).unwrap());
+
+		let mut media = Vec::new();
+		loop {
+			while let Some(result) = work.pop_front() {
+				match result {
+					ClientSessionResult::OutboundResponse(packet) => {
+						stream.write_all(&packet.bytes).await.unwrap();
+					}
+					ClientSessionResult::RaisedEvent(ClientSessionEvent::ConnectionRequestAccepted) => {
+						work.push_back(session.request_playback("cam0".to_string()).unwrap());
+					}
+					ClientSessionResult::RaisedEvent(ClientSessionEvent::VideoDataReceived { data, .. }) => {
+						media.push((true, data));
+					}
+					ClientSessionResult::RaisedEvent(ClientSessionEvent::AudioDataReceived { data, .. }) => {
+						media.push((false, data));
+					}
+					_ => {}
+				}
+			}
+			if media.len() >= want {
+				return media;
+			}
+			let n = stream.read(&mut buffer).await.unwrap();
+			if n == 0 {
+				return media;
+			}
+			work.extend(session.handle_input(&buffer[..n]).unwrap());
+		}
+	}
+
+	/// End-to-end play: publish a real broadcast into an origin (via the FLV
+	/// importer, so it carries a catalog + frames), then drive an RTMP play client
+	/// and assert it receives the muxed AVC sequence header and keyframe back.
+	#[tokio::test]
+	async fn play_streams_broadcast_to_client() {
+		// An AVC sequence-header tag body: keyframe + AVC CodecID, AVCPacketType 0,
+		// composition time 0, then a minimal avcC (one SPS, one PPS).
+		let avcc = {
+			let sps = [0x67u8, 0x42, 0xc0, 0x1f];
+			let mut out = vec![0x01, 0x42, 0xc0, 0x1f, 0xff, 0xe1, 0x00, sps.len() as u8];
+			out.extend_from_slice(&sps);
+			out.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]);
+			out
+		};
+		let mut vseq = vec![0x17, 0x00, 0x00, 0x00, 0x00];
+		vseq.extend_from_slice(&avcc);
+		// A keyframe NALU tag body: AVCPacketType 1, then a length-prefixed IDR.
+		let mut vframe = vec![0x17, 0x01, 0x00, 0x00, 0x00];
+		vframe.extend_from_slice(&[0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00]);
+
+		// Publish the broadcast at `live/cam0` by feeding synthetic FLV to the importer.
+		let origin = moq_net::Origin::random().produce();
+		let mut broadcast = BroadcastInfo::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut importer = FlvImport::new(broadcast.clone(), catalog);
+		let _publish = origin.publish_broadcast("live/cam0", broadcast.consume()).unwrap();
+		importer.decode(&flv::file_header()).unwrap();
+		importer.decode(&flv::tag(flv::TAG_VIDEO, 0, &vseq)).unwrap();
+		importer.decode(&flv::tag(flv::TAG_VIDEO, 0, &vframe)).unwrap();
+		importer.finish().unwrap();
+
+		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+		let addr = server.local_addr().unwrap();
+		let consumer = origin.consume();
+
+		// Serve the first (play) request against the populated origin.
+		let server_task = tokio::spawn(async move {
+			let request = server.accept().await.expect("a request");
+			let Request::Play(play) = request else {
+				panic!("expected a play request");
+			};
+			play.accept(&consumer, "live/cam0").await.unwrap();
+		});
+
+		let stream = TcpStream::connect(addr).await.unwrap();
+		let media = tokio::time::timeout(Duration::from_secs(5), play_client_collect(stream, 2))
+			.await
+			.expect("play client timed out");
+
+		assert!(
+			media.len() >= 2,
+			"expected the seq header and a keyframe, got {}",
+			media.len()
+		);
+		// First video message is the AVC sequence header (AVCPacketType 0).
+		assert!(media[0].0, "first message should be video");
+		assert_eq!(media[0].1[0], 0x17);
+		assert_eq!(media[0].1[1], 0x00);
+		// Second is the keyframe NALU (AVCPacketType 1).
+		assert!(media[1].0, "second message should be video");
+		assert_eq!(media[1].1[1], 0x01);
+
+		server_task.abort();
+	}
+
 	#[tokio::test]
 	async fn accept_yields_publish_request() {
 		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
@@ -627,7 +1056,7 @@ mod tests {
 
 		let client = tokio::spawn(async move {
 			let stream = TcpStream::connect(addr).await.unwrap();
-			run_client(stream).await;
+			run_client(stream, ClientMode::Publish).await;
 		});
 
 		let request = tokio::time::timeout(Duration::from_secs(5), server.accept())
@@ -638,7 +1067,35 @@ mod tests {
 		assert_eq!(request.app(), "live");
 		assert_eq!(request.stream_key(), "cam0");
 
-		request.reject("test rejection").await.unwrap();
+		let Request::Publish(publish) = request else {
+			panic!("expected a publish request");
+		};
+		publish.reject("test rejection").await.unwrap();
+		client.abort();
+	}
+
+	#[tokio::test]
+	async fn accept_yields_play_request() {
+		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+		let addr = server.local_addr().unwrap();
+
+		let client = tokio::spawn(async move {
+			let stream = TcpStream::connect(addr).await.unwrap();
+			run_client(stream, ClientMode::Play).await;
+		});
+
+		let request = tokio::time::timeout(Duration::from_secs(5), server.accept())
+			.await
+			.expect("server.accept timed out")
+			.expect("server yielded a request");
+
+		assert_eq!(request.app(), "live");
+		assert_eq!(request.stream_key(), "cam0");
+
+		let Request::Play(play) = request else {
+			panic!("expected a play request");
+		};
+		play.reject("test rejection").await.unwrap();
 		client.abort();
 	}
 
@@ -719,7 +1176,7 @@ mod tests {
 			let tcp = TcpStream::connect(addr).await.unwrap();
 			let server_name = ServerName::try_from("localhost").unwrap();
 			let stream = connector.connect(server_name, tcp).await.unwrap();
-			run_client(stream).await;
+			run_client(stream, ClientMode::Publish).await;
 		});
 
 		let request = tokio::time::timeout(Duration::from_secs(5), server.accept())
@@ -730,7 +1187,10 @@ mod tests {
 		assert_eq!(request.app(), "live");
 		assert_eq!(request.stream_key(), "cam0");
 
-		request.reject("test rejection").await.unwrap();
+		let Request::Publish(publish) = request else {
+			panic!("expected a publish request");
+		};
+		publish.reject("test rejection").await.unwrap();
 		client.abort();
 	}
 }

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -443,10 +443,12 @@ impl<S: Stream> Play<S> {
 
 		tracing::info!(peer = %self.peer, %path, "rtmp play accepted");
 
-		// Wait for the broadcast, but abandon the wait if the viewer hangs up.
+		// Wait for the broadcast, but abandon the wait if the viewer hangs up. Feed
+		// the client's bytes through the session (not discard them) so its
+		// deserializer stays in sync for everything `play_pump` parses next.
 		let broadcast = tokio::select! {
 			biased;
-			res = drain_input(&mut self.stream) => {
+			res = feed_input(&mut self.stream, &mut self.session, &mut self.work) => {
 				res?;
 				tracing::debug!(peer = %self.peer, %path, "viewer disconnected before play started");
 				return Ok(());
@@ -727,16 +729,41 @@ async fn flush_outbound<S: Stream>(stream: &mut S, work: &mut VecDeque<ServerSes
 	Ok(())
 }
 
-/// Read and discard client bytes until the connection closes.
+/// Feed client bytes through the session while we wait for the broadcast, until
+/// the viewer hangs up or stops.
 ///
-/// Used to detect a viewer hanging up while we wait for their broadcast to come
-/// online. Pre-playback the client only sends control messages (window ack,
-/// buffer length) that need no response, so discarding them is safe. Returns
-/// `Ok(())` on a clean close (EOF), or an error on an I/O failure.
-async fn drain_input<S: Stream>(stream: &mut S) -> anyhow::Result<()> {
+/// Returns `Ok(())` when the client closes the connection (EOF) or issues a
+/// `play` teardown, so the caller can abandon the play. Crucially it does *not*
+/// discard the bytes: RTMP is a single continuous chunk stream, so skipping any
+/// bytes would desynchronize the session's deserializer for everything
+/// [`play_pump`] parses afterwards. Pre-playback the client's control messages
+/// (window ack, set buffer length) need no reply, so any responses are left
+/// queued in `work` for `play_pump` to flush rather than written here. The only
+/// await is the read, so dropping this future when the broadcast arrives is
+/// cancellation-safe (no half-consumed read).
+async fn feed_input<S: Stream>(
+	stream: &mut S,
+	session: &mut ServerSession,
+	work: &mut VecDeque<ServerSessionResult>,
+) -> anyhow::Result<()> {
 	let mut buffer = [0u8; READ_BUFFER];
 	loop {
-		if stream.read(&mut buffer).await? == 0 {
+		let n = stream.read(&mut buffer).await?;
+		if n == 0 {
+			return Ok(());
+		}
+		let results = session
+			.handle_input(&buffer[..n])
+			.map_err(|e| anyhow::anyhow!("rtmp handle_input: {e:?}"))?;
+		// The viewer tore down the play before media started: stop waiting.
+		let stopped = results.iter().any(|r| {
+			matches!(
+				r,
+				ServerSessionResult::RaisedEvent(ServerSessionEvent::PlayStreamFinished { .. })
+			)
+		});
+		work.extend(results);
+		if stopped {
 			return Ok(());
 		}
 	}


### PR DESCRIPTION
Builds on #1824 (RTMP ingest) to make `moq-rtmp` **bidirectional**. A player now connects to `rtmp://host/<app>/<key>` and the gateway streams the broadcast back down. VLC, ffplay, and mpv can play it (browsers can't, Flash is dead). The same URL round-trips: push to `rtmp://h/live/cam0`, pull it back from `rtmp://h/live/cam0`.

It's the egress counterpart to the publish path, and the sibling of `moq-hls`'s export.

## What changed

**Public API (`moq-rtmp`, breaking, hence `dev`):**

- `Server::accept()` / `accept_stream()` now return an enum `Request::{ Publish(Publish<S>), Play(Play<S>) }` (`#[non_exhaustive]`). The old `Request` struct is renamed `Publish`; `Play` is new. Match on it, inspect `app()` / `stream_key()`, then `accept`/`reject` the right direction. The crate is v0.0.1 with no external consumers, so impact is nil.

**Egress plumbing:**

- `flv::TagReader` — the inverse of the existing `flv::tag()` / `file_header()`. Splits the FLV byte stream `moq-mux`'s `Export` produces back into individual tags, so each body goes out as an RTMP audio/video message.
- `Play::accept` subscribes to the broadcast from an `OriginConsumer`, builds a `moq_mux::container::flv::Export`, and pumps. It waits for the broadcast to be announced (so a player can connect just before the publisher), cancelling cleanly if the viewer disconnects first.
- `play_pump` uses `tokio::io::split` to send media and service client input (acks/pings/teardown) concurrently in one `select!`; broadcast EOF → `finish_playing`.
- `listen::run` serves plays from `origin.consume()` — publishers ingest into the origin, players are served out of it. Plays don't claim an `ActivePaths` slot, so any number of viewers can pull the same broadcast at once.

All codecs flow both ways (legacy H.264/AAC + E-RTMP HEVC/AV1/VP9/Opus/AC-3), since muxing lives in `moq-mux`. Legacy-only players reject the E-RTMP codecs.

## Cross-package sync

- `doc/bin/rtmp.md` and `rs/moq-rtmp/README.md` updated for the egress direction (play examples, routing round-trip, auth/embedding notes). No other rows in the sync table apply (no wire/catalog/FFI changes).

## Test plan

- [x] `cargo test -p moq-rtmp --all-features` (15 pass), including a new **end-to-end play test**: publish a real broadcast via the FLV importer → `Server` play → a real `rml_rtmp` *client* receives the muxed avcC sequence header + keyframe back. Plus 3 `TagReader` unit tests.
- [x] `cargo check -p moq-rtmp --no-default-features` (the library-embedding path)
- [x] `cargo clippy -p moq-rtmp --all-features --all-targets` clean
- [x] `cargo fmt` (via nix devshell)
- [ ] Not yet exercised against a real player (ffplay / VLC / mpv); the e2e test drives a real RTMP client, but a live player round-trip would be the final confidence check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)