### PR TITLE
feat(mux,hls): segment-target export mode (one moof per HLS segment)

### DIFF
--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -35,6 +35,14 @@ pub struct Config {
 	pub latency: Duration,
 	/// Target segment duration for audio renditions (video rolls on GOPs).
 	pub audio_segment_target: Duration,
+	/// VOD segment mode. When set, each rendition emits exactly ONE moof+mdat per
+	/// segment, rolled on a keyframe once the segment reaches this duration (audio:
+	/// purely on duration). Combines GOPs / sub-GOP input fragments into one fragment
+	/// per segment -- the right shape for recording (no LL-HLS parts), and robust to
+	/// publishers that over-fragment (e.g. ffmpeg `frag_every_frame`, whose per-frame
+	/// moofs otherwise explode into per-frame segments). `None` (default) keeps the
+	/// per-GOP + LL-HLS-part behavior used by the live gateway.
+	pub segment_target: Option<Duration>,
 }
 
 impl Default for Config {
@@ -44,6 +52,7 @@ impl Default for Config {
 			window: Duration::from_secs(16),
 			latency: Duration::from_secs(10),
 			audio_segment_target: Duration::from_secs(2),
+			segment_target: None,
 		}
 	}
 }

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -40,6 +40,7 @@ impl Rendition {
 			cfg.part_target.as_secs_f64(),
 			cfg.audio_segment_target.as_secs_f64(),
 			cfg.window.as_secs_f64(),
+			cfg.segment_target.is_some(),
 		));
 		spawn_pump(broadcast, name.clone(), Kind::Video, store.clone(), cfg.clone());
 		Self {
@@ -59,6 +60,7 @@ impl Rendition {
 			cfg.part_target.as_secs_f64(),
 			cfg.audio_segment_target.as_secs_f64(),
 			cfg.window.as_secs_f64(),
+			cfg.segment_target.is_some(),
 		));
 		spawn_pump(broadcast, name.clone(), Kind::Audio, store.clone(), cfg.clone());
 		Self {
@@ -105,8 +107,11 @@ async fn run_pump(
 	});
 	let _ = kind; // kind only drives the store policy; the exporter is codec-agnostic.
 
+	// In VOD mode (segment_target set) the exporter emits one moof per segment and
+	// the part cap is ignored; the live gateway leaves it None for LL-HLS parts.
 	let mut export = Export::new(broadcast, filter)
 		.with_fragment_duration(cfg.part_target)
+		.with_segment_target(cfg.segment_target)
 		.with_latency(cfg.latency);
 
 	while let Some(fragment) = export.next_fragment().await? {

--- a/rs/moq-hls/src/export/store.rs
+++ b/rs/moq-hls/src/export/store.rs
@@ -86,10 +86,21 @@ pub struct SegmentStore {
 	/// Minimum duration (seconds) of media kept in the sliding window. The oldest
 	/// segment is evicted only while the remaining ones still cover this span.
 	window: f64,
+	/// VOD mode: the exporter already emits exactly one moof+mdat per segment (via
+	/// `Export::with_segment_target`), so every media fragment maps to its own
+	/// segment (one moof per segment, no LL-HLS parts). Bypasses the GOP/duration
+	/// segment-rolling policy in `push`.
+	fragment_per_segment: bool,
 }
 
 impl SegmentStore {
-	pub fn new(is_video: bool, part_target: f64, audio_segment_target: f64, window: f64) -> Self {
+	pub fn new(
+		is_video: bool,
+		part_target: f64,
+		audio_segment_target: f64,
+		window: f64,
+		fragment_per_segment: bool,
+	) -> Self {
 		let (notify, _) = watch::channel(Version::default());
 		Self {
 			inner: Mutex::new(Inner {
@@ -103,6 +114,7 @@ impl SegmentStore {
 			part_target,
 			audio_segment_target,
 			window,
+			fragment_per_segment,
 		}
 	}
 
@@ -121,7 +133,11 @@ impl SegmentStore {
 			let need_new = match inner.segments.back() {
 				None => true,
 				Some(cur) => {
-					if self.is_video {
+					if self.fragment_per_segment {
+						// VOD: the exporter already sized each fragment to a segment,
+						// so every fragment becomes its own segment (one moof each).
+						true
+					} else if self.is_video {
 						// A new GOP (independent fragment) starts a new segment.
 						fragment.independent
 					} else {

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -38,6 +38,7 @@ pub struct Export<S: Stream> {
 	catalog: Option<S>,
 	latency: Duration,
 	fragment_duration: Option<Duration>,
+	segment_target: Option<Duration>,
 
 	tracks: HashMap<String, Fmp4Track>,
 
@@ -112,6 +113,7 @@ impl<S: Stream> Export<S> {
 			catalog: Some(catalog),
 			latency: Duration::ZERO,
 			fragment_duration: None,
+			segment_target: None,
 			tracks: HashMap::new(),
 			catalog_snapshot: None,
 			init_emitted: false,
@@ -140,6 +142,22 @@ impl<S: Stream> Export<S> {
 	/// the per-GOP default).
 	pub fn with_fragment_duration(mut self, duration: impl Into<Option<Duration>>) -> Self {
 		self.fragment_duration = duration.into();
+		self
+	}
+
+	/// Emit exactly ONE fragment (one moof+mdat) per segment, rolled on a keyframe
+	/// once the segment reaches `target`, instead of the default one-fragment-per-GOP
+	/// (plus optional `fragment_duration` parts). This COMBINES GOPs and any sub-GOP
+	/// input fragmentation into a single moof per segment -- what a VOD packager wants
+	/// (no LL-HLS parts) and the robust answer to publishers that over-fragment (e.g.
+	/// ffmpeg `frag_every_frame`, which emits a moof per frame). Keyframe-aligned:
+	/// segments always start on a sync sample and run >= `target` to the next keyframe.
+	/// When set, the `fragment_duration` part cap is ignored. `None` (default) keeps
+	/// the per-GOP / LL-HLS behavior. Audio (no keyframes) rolls purely on `target`.
+	///
+	/// Accepts either `Duration` or `Option<Duration>`.
+	pub fn with_segment_target(mut self, target: impl Into<Option<Duration>>) -> Self {
+		self.segment_target = target.into();
 		self
 	}
 
@@ -243,10 +261,11 @@ impl<S: Stream> Export<S> {
 
 		if let Some(name) = chosen {
 			let frag = self.fragment_duration;
+			let segment_target = self.segment_target;
 			let has_video_track = self.tracks.values().any(|t| t.is_video);
 			let track = self.tracks.get_mut(&name).unwrap();
 			let frame = track.pending.take().unwrap();
-			let flush_before = should_flush(track, &frame, frag, has_video_track);
+			let flush_before = should_flush(track, &frame, frag, segment_target, has_video_track);
 			if flush_before {
 				let frames = std::mem::take(&mut track.buffer);
 				let fragment = emit_fragment(track, frames)?;
@@ -493,40 +512,65 @@ fn extract_init(
 	Ok(())
 }
 
+/// Presentation span of `buffer` including the incoming `frame`, in seconds.
+///
+/// Frames within a track are in *decode* order; B-frames have non-monotonic PTS,
+/// so the span is max-min of all PTS, not just first..incoming.
+fn buffer_span(buffer: &[Frame], incoming: &Frame) -> Duration {
+	let mut min = Duration::from(incoming.timestamp);
+	let mut max = min;
+	for f in buffer {
+		let pts = Duration::from(f.timestamp);
+		if pts < min {
+			min = pts;
+		}
+		if pts > max {
+			max = pts;
+		}
+	}
+	max.saturating_sub(min)
+}
+
 /// Should we flush `track.buffer` *before* appending the incoming `frame`?
 ///
-/// Triggers:
+/// In `segment_target` mode (a VOD packager wanting one moof per segment) we
+/// COMBINE frames into a single fragment per segment, rolling on a keyframe once
+/// the segment reaches the target -- ignoring the per-GOP and `fragment_duration`
+/// part triggers so over-fragmented input (e.g. ffmpeg `frag_every_frame`) doesn't
+/// explode into per-frame segments.
+///
+/// Default (`segment_target == None`) triggers:
 /// - Video keyframe and buffer non-empty (one fragment per GOP)
 /// - Optional duration cap exceeded
 /// - Per-frame mode (`Some(ZERO)`)
 /// - Audio in an audio-only broadcast under default `None` mode (otherwise
 ///   the buffer would never flush — no keyframe boundary and no time cap)
-fn should_flush(track: &Fmp4Track, frame: &Frame, fragment_duration: Option<Duration>, has_video_track: bool) -> bool {
+fn should_flush(
+	track: &Fmp4Track,
+	frame: &Frame,
+	fragment_duration: Option<Duration>,
+	segment_target: Option<Duration>,
+	has_video_track: bool,
+) -> bool {
 	if track.buffer.is_empty() {
 		return false;
+	}
+	// VOD: one fragment per segment. Video rolls on a keyframe at/after the target
+	// (combining whole GOPs); audio has no keyframes so it rolls purely on the target.
+	if let Some(target) = segment_target {
+		let span = buffer_span(&track.buffer, frame);
+		return if track.is_video {
+			frame.keyframe && span >= target
+		} else {
+			span >= target
+		};
 	}
 	if track.is_video && frame.keyframe {
 		return true;
 	}
 	match fragment_duration {
 		Some(d) if d.is_zero() => true,
-		Some(d) => {
-			// Frames within a track are in *decode* order; B-frames have
-			// non-monotonic PTS, so the span of the buffer is min..max of all
-			// PTS, not just first..incoming.
-			let mut min = Duration::from(frame.timestamp);
-			let mut max = min;
-			for f in &track.buffer {
-				let pts = Duration::from(f.timestamp);
-				if pts < min {
-					min = pts;
-				}
-				if pts > max {
-					max = pts;
-				}
-			}
-			max.saturating_sub(min) >= d
-		}
+		Some(d) => buffer_span(&track.buffer, frame) >= d,
 		// No video keyframe will ever arrive to roll the fragment, so for
 		// audio-only broadcasts in `None` mode we fall back to per-frame
 		// fragments (matches the pre-batching default).

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -637,3 +637,123 @@ async fn next_fragment_reports_segment_metadata() {
 	drop(catalog);
 	drop(producer);
 }
+
+/// `with_segment_target` COMBINES whole GOPs into one moof+mdat per segment, rolled
+/// on a keyframe once the segment reaches the target -- instead of one fragment per
+/// GOP. This is the VOD shape (one moof per segment) and the fix for publishers that
+/// over-fragment (e.g. ffmpeg `frag_every_frame`): the per-keyframe / part triggers
+/// are bypassed, so a noisy keyframe-per-frame stream still yields target-sized
+/// segments rather than per-frame ones.
+#[tokio::test(start_paused = true)]
+async fn segment_target_combines_gops_into_one_fragment() {
+	use std::time::Duration;
+
+	use bytes::BytesMut;
+	use hang::catalog::{Container, H264, VideoConfig};
+	use moq_net::Timestamp;
+
+	let broadcast = moq_net::BroadcastInfo::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let track = producer
+		.create_track(
+			producer.unique_name(".avc3"),
+			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+		)
+		.unwrap();
+	let mut config = VideoConfig::new(H264 {
+		profile: 0x42,
+		constraints: 0xc0,
+		level: 0x1f,
+		inline: true,
+	});
+	config.coded_width = Some(320);
+	config.coded_height = Some(240);
+	config.framerate = Some(30.0);
+	config.container = Container::Legacy;
+	catalog.lock().video.renditions.insert(track.name().to_string(), config);
+
+	const SC: &[u8] = &[0, 0, 0, 1];
+	let sps = &[0x67u8, 0x42, 0xc0, 0x1f, 0xde, 0xad, 0xbe, 0xef][..];
+	let pps = &[0x68u8, 0xce, 0x3c, 0x80][..];
+	let idr = &[0x65u8, 0x88, 0x84, 0x21, 0x00, 0x11, 0x22, 0x33][..];
+	let slice = &[0x41u8, 0x9a, 0x00, 0x01][..];
+
+	let annexb = |nals: &[&[u8]]| {
+		let mut buf = BytesMut::new();
+		for nal in nals {
+			buf.extend_from_slice(SC);
+			buf.extend_from_slice(nal);
+		}
+		buf.freeze()
+	};
+	let frame = |timestamp_us: u64, payload, keyframe| crate::container::Frame {
+		timestamp: Timestamp::from_micros(timestamp_us).unwrap(),
+		payload,
+		keyframe,
+		duration: None,
+	};
+
+	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
+	// Three short GOPs (keyframe every ~66ms). With a 100ms segment target the first
+	// segment must span TWO GOPs (it can't roll on the 66ms keyframe — under target),
+	// rolling only on the keyframe at 200ms; the tail (200ms, 233ms) is the second.
+	track_producer.write(frame(0, annexb(&[sps, pps, idr]), true)).unwrap();
+	track_producer.write(frame(33_000, annexb(&[slice]), false)).unwrap();
+	track_producer
+		.write(frame(66_000, annexb(&[sps, pps, idr]), true))
+		.unwrap();
+	track_producer.write(frame(100_000, annexb(&[slice]), false)).unwrap();
+	track_producer
+		.write(frame(200_000, annexb(&[sps, pps, idr]), true))
+		.unwrap();
+	track_producer.write(frame(233_000, annexb(&[slice]), false)).unwrap();
+	track_producer.finish().unwrap();
+
+	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
+		.await
+		.expect("catalog consumer");
+	let mut exporter = crate::container::fmp4::Export::new(consumer, catalog_stream)
+		.with_fragment_duration(Duration::from_millis(20)) // ignored in segment mode
+		.with_segment_target(Duration::from_millis(100));
+
+	let init = tokio::time::timeout(Duration::from_secs(1), exporter.next_fragment())
+		.await
+		.expect("exporter timed out")
+		.expect("exporter result")
+		.expect("expected init fragment");
+	assert!(init.init);
+
+	// Read all media fragments (the track finished, so they're all available).
+	let mut frags = Vec::new();
+	for _ in 0..2 {
+		let frag = tokio::time::timeout(Duration::from_secs(1), exporter.next_fragment())
+			.await
+			.expect("exporter timed out")
+			.expect("exporter result")
+			.expect("expected a media fragment");
+		assert!(!frag.init);
+		frags.push(frag);
+	}
+
+	// Exactly TWO segments despite THREE GOPs / six frames: the part cap and the
+	// per-keyframe rollover are bypassed, GOPs combine up to the target.
+	assert_eq!(frags.len(), 2, "GOPs should combine into target-sized segments");
+	// Every segment starts on a keyframe (one moof per segment, seekable).
+	assert!(
+		frags.iter().all(|f| f.independent),
+		"each segment must start on a keyframe"
+	);
+	// The first segment spans two GOPs (>= the 100ms target), proving the combine.
+	assert!(
+		frags[0].duration >= 0.1,
+		"first segment should span >= the target, got {}",
+		frags[0].duration
+	);
+
+	drop(track_producer);
+	drop(catalog);
+	drop(producer);
+}


### PR DESCRIPTION
## Problem

The HLS exporter rolls a video segment on every "independent" fragment (once per GOP), and the moq-mux importer derives a fragment's keyframe flag from the container sample flags. A publisher that over-fragments — notably ffmpeg `-movflags …+frag_every_frame` (what the demo `pub` uses) — writes **one moof per frame** with per-fragment sample flags that mark ~every frame as a sync sample. So the exporter emitted a fragment per frame and the packager rolled a **segment per frame** → zero-duration (`#EXTINF:0.00000`), unplayable HLS.

Concretely, ffmpeg writes for the P-frame fragments `tfhd.default_sample_flags = 0x02000000` (sync) with no per-sample/first-sample override, so the importer faithfully reads every P-frame as a keyframe. (ffprobe still shows correct I/P because it parses the slice headers, not the container flags.)

## Fix

Add an opt-in **segment-target** mode that combines whole GOPs (and any sub-GOP input fragmentation) into exactly **one `moof`+`mdat` per segment**, rolled on a keyframe once the segment reaches the target duration (audio, having no keyframes, rolls purely on the target). This is the shape a VOD packager wants (no LL-HLS parts) and is robust to noisy per-fragment keyframe flags: the per-keyframe and `fragment_duration` part triggers are bypassed, so segments are target-sized rather than per-frame.

- **moq-mux**: `Export::with_segment_target(Option<Duration>)`; `should_flush` gains a segment-target branch + a shared `buffer_span` helper. Default `None` keeps the existing per-GOP / LL-HLS-part behavior — **live/RTMP unaffected**.
- **moq-hls**: `export::Config::segment_target` plumbed to the exporter and to a `fragment_per_segment` mode on `SegmentStore` (each fragment becomes its own segment). Default `None` preserves the live gateway's behavior.
- **test**: `segment_target_combines_gops_into_one_fragment` — three GOPs → two target-sized, keyframe-aligned, single-moof segments.

## Validation

`cargo test -p moq-mux fmp4` → 17 pass (16 existing + new). `cargo clippy -p moq-mux -p moq-hls` clean. Built against the dev rev moq-pro currently pins (`5f047b3d`). The consumer side (moq-pro's VOD recorder) sets `segment_target: Some(~2s)` to opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)