### PR TITLE
feat(moq-video): NVENC H.265 encode + refresh README

### DIFF
--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `decode::Consumer` (the counterpart to `moq-audio`'s `AudioConsumer`) that
   subscribes to an H.264 track and returns raw I420 frames. Backends are
   VideoToolbox (macOS) and openh264 (portable software fallback); no ffmpeg.
+- H.265 encode via the NVENC backend (Linux, `nvenc` feature). The codec is
+  selected by `encode::Codec`; the NVENC HEVC path shares the H.264 preset / GOP
+  / rate-control setup and emits Annex-B with inline VPS/SPS/PPS. Not yet
+  validated on hardware.
 
 ## [0.0.4](https://github.com/moq-dev/moq/compare/moq-video-v0.0.3...moq-video-v0.0.4) - 2026-06-16
 

--- a/rs/moq-video/DESIGN-native-codecs.md
+++ b/rs/moq-video/DESIGN-native-codecs.md
@@ -475,7 +475,10 @@ afterward on top of the same `Backend` seam:
   catalog round-trip registers the right rendition for each codec.
 - Verified on Windows (RTX 3070 Ti, live camera): Media Foundation HEVC publishes
   a `.hev1` rendition; the round-trip into Matroska decodes as Main-profile HEVC.
-- Follow-ups: Linux NVENC/VAAPI HEVC, and a live camera run per platform.
+- Linux NVENC HEVC followed: the NVENC backend selects its codec GUID from
+  `Codec`, so H.265 reuses the H.264 preset / GOP / rate-control path and emits
+  Annex-B with inline VPS/SPS/PPS. Unvalidated on hardware like NVENC H.264.
+- Follow-ups: Linux VAAPI HEVC, and a live camera run per platform.
 
 AV1 is intentionally left out: there is no hardware AV1 encoder available to us
 (none on macOS; NVENC/VAAPI AV1 are Linux-only and not yet wired), and software

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -1,23 +1,55 @@
 # moq-video
 
-Native video capture, encoding, and publishing for [Media over QUIC](https://github.com/moq-dev/moq).
+Native video capture, encoding, decoding, and publishing for
+[Media over QUIC](https://github.com/moq-dev/moq).
 
-Counterpart to [`moq-audio`](https://crates.io/crates/moq-audio). Built on
-[`ffmpeg-next`](https://crates.io/crates/ffmpeg-next), but the public API is
-ffmpeg-free at the signature level (capture/encode internals that traffic in
-ffmpeg frames are private), so an `ffmpeg-next` bump isn't a breaking change.
+The video counterpart to [`moq-audio`](https://crates.io/crates/moq-audio).
+Everything is native per-platform code with no ffmpeg dependency: capture, color
+conversion, and the codec backends are all in-tree or thin wrappers over system
+frameworks / vendored static libs. The public API is codec-agnostic, so no
+signature, type, or error variant names a backend or a capture implementation;
+swapping or bumping a backend crate is not a breaking change.
+
+## Capture
+
+Per-platform, picked at compile time:
+
+- **macOS**: AVFoundation (camera) and ScreenCaptureKit (display), yielding
+  zero-copy `CVPixelBuffer` surfaces straight to VideoToolbox.
+- **Linux**: native V4L2 (camera; YUYV resampled, MJPEG via `zune-jpeg`).
+- **Windows**: native Media Foundation (`IMFSourceReader` -> CPU I420).
+
+## Encode
+
+The codec is chosen via `encode::Codec`. Backends are tried in order (hardware
+first, then software) and the first that opens wins; `encode::Kind` narrows the
+choice (`Auto` / `Hardware` / `Software` / a named backend).
+
+| Codec | Software | macOS | Windows | Linux |
+|---|---|---|---|---|
+| H.264 | openh264 (vendored, static) | VideoToolbox | Media Foundation | NVENC (`nvenc`), VAAPI (`vaapi`) |
+| H.265 | none | VideoToolbox | Media Foundation | NVENC (`nvenc`) |
+
+Every backend emits Annex-B with in-band parameter sets (SPS/PPS, plus VPS for
+H.265), so the matching `moq_mux::codec` importer handles framing and catalog
+registration directly. There is no software H.265 encoder (it's hardware-only).
 
 Two public entry points:
 
-- `encode::publish_capture(broadcast, catalog, capture::Config, encode::Options)`
-  captures a webcam (libavdevice: avfoundation / v4l2 / dshow), H.264-encodes it
-  (preferring a hardware encoder, falling back to `libx264`), and publishes on
-  demand: the camera opens only while a subscriber is watching. Screen capture
-  would slot into the same `capture` module.
-- `encode::Producer` publishes H.264 you encoded yourself, handling the catalog
-  and framing via `moq_mux::codec::h264::Import`.
+- `encode::publish_capture(...)` captures a webcam, encodes it, and publishes on
+  demand: the track and catalog are advertised up front, but the camera opens
+  only while a subscriber is watching and is released when the last one leaves.
+- `encode::Producer` publishes packets you encoded yourself, handling the catalog
+  and framing.
 
-Requires a system FFmpeg (libav\*).
+The NVENC and VAAPI backends are Linux-only and gated behind their respective
+features. Both `dlopen` the vendor driver at runtime (and fall back to software
+where the driver is absent), so a feature-enabled binary still links on a
+GPU-less builder and still starts on a GPU-less machine.
 
-The `decode` (consume) side, mirror of `moq-audio`'s `AudioConsumer`, is not
-implemented yet.
+## Decode
+
+`decode::Consumer` (the mirror of `moq-audio`'s `AudioConsumer`) subscribes to an
+H.264 track and returns raw I420 frames. Backends are VideoToolbox (macOS) and
+openh264 (portable software fallback). H.264 only for now; a non-H.264 rendition
+yields `Error::UnsupportedCodec`.

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -70,7 +70,7 @@ const HARDWARE: &[Candidate] = &[
 	#[cfg(all(target_os = "linux", feature = "nvenc"))]
 	Candidate {
 		name: nvenc::NAME,
-		codecs: &[Codec::H264],
+		codecs: &[Codec::H264, Codec::H265],
 		open: nvenc::Nvenc::open,
 	},
 	#[cfg(all(target_os = "linux", feature = "vaapi"))]

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -1,9 +1,12 @@
-//! Hardware H.264 backend via NVIDIA NVENC (`nvidia-video-codec-sdk` + cudarc).
+//! Hardware H.264 / H.265 backend via NVIDIA NVENC (`nvidia-video-codec-sdk` +
+//! cudarc).
 //!
 //! Linux only, behind the `nvenc` feature. The NVENC API lives in the driver
 //! (`libnvidia-encode.so`) and cudarc loads CUDA dynamically, so this is not a
 //! build-time dependency on the CUDA toolkit. NVENC emits Annex-B with in-band
-//! SPS/PPS, matching avc3 mode directly.
+//! parameter sets (SPS/PPS for H.264, VPS/SPS/PPS for H.265), matching the
+//! inline avc3 / hev1 mode directly. The codec is chosen by [`Config::codec`];
+//! only the codec GUID differs, the preset / GOP / rate-control setup is shared.
 //!
 //! NOT YET VALIDATED ON HARDWARE. Two things need checking on a real Linux+GPU
 //! box before this ships in releases:
@@ -12,23 +15,35 @@
 //!      are safe). Non-aligned widths would need pitched writes via the `sys`
 //!      lock API. We warn at open if the width looks risky.
 //!   2. The exact `NV_ENC_CONFIG` field set for rate control / GOP.
+//!   3. H.265: that the HEVC GUID path emits Annex-B with VPS/SPS/PPS inline
+//!      ahead of each IDR (the hev1 importer relies on it, as it does for the
+//!      VideoToolbox H.265 backend).
 
 use std::sync::Arc;
 
 use bytes::Bytes;
 use cudarc::driver::CudaContext;
 use nvidia_video_codec_sdk::sys::nvEncodeAPI::{
-	NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_PARAMS_RC_MODE, NV_ENC_PIC_TYPE, NV_ENC_PRESET_P4_GUID,
-	NV_ENC_TUNING_INFO,
+	GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID, NV_ENC_PARAMS_RC_MODE, NV_ENC_PIC_TYPE,
+	NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO,
 };
 use nvidia_video_codec_sdk::{Encoder, EncoderInitParams, Session};
 
-use super::super::encoder::Config;
+use super::super::encoder::{Codec, Config};
 use super::Backend;
 use crate::Error;
 use crate::frame::Frame;
 
 pub(crate) const NAME: &str = "nvenc";
+
+/// The NVENC codec GUID for a requested [`Codec`]. The presets, GOP, and rate
+/// control are codec-agnostic, so this is the only codec-dependent input.
+fn codec_guid(codec: Codec) -> GUID {
+	match codec {
+		Codec::H264 => NV_ENC_CODEC_H264_GUID,
+		Codec::H265 => NV_ENC_CODEC_HEVC_GUID,
+	}
+}
 
 pub(crate) struct Nvenc {
 	session: Session,
@@ -54,6 +69,8 @@ impl Nvenc {
 		}
 
 		// cudarc 0.19's DriverError is Debug-only (no Display), so format with `{e:?}`.
+		let codec_guid = codec_guid(config.codec);
+
 		let cuda = CudaContext::new(0).map_err(|e| Error::Codec(anyhow::anyhow!("CUDA init: {e:?}")))?;
 		let encoder = Encoder::initialize_with_cuda(cuda.clone())
 			.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC init: {e}")))?;
@@ -61,7 +78,7 @@ impl Nvenc {
 		// Start from the low-latency P4 preset, then set bitrate and GOP.
 		let mut preset = encoder
 			.get_preset_config(
-				NV_ENC_CODEC_H264_GUID,
+				codec_guid,
 				NV_ENC_PRESET_P4_GUID,
 				NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_LOW_LATENCY,
 			)
@@ -73,7 +90,7 @@ impl Nvenc {
 		cfg.rcParams.rateControlMode = NV_ENC_PARAMS_RC_MODE::NV_ENC_PARAMS_RC_CBR;
 		cfg.rcParams.averageBitRate = config.resolved_bitrate().min(u32::MAX as u64) as u32;
 
-		let mut init = EncoderInitParams::new(NV_ENC_CODEC_H264_GUID, config.width, config.height);
+		let mut init = EncoderInitParams::new(codec_guid, config.width, config.height);
 		init.preset_guid(NV_ENC_PRESET_P4_GUID)
 			.tuning_info(NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_LOW_LATENCY)
 			.framerate(config.framerate, 1)
@@ -86,9 +103,10 @@ impl Nvenc {
 
 		tracing::info!(
 			encoder = NAME,
+			codec = ?config.codec,
 			width = config.width,
 			height = config.height,
-			"opened H.264 encoder"
+			"opened encoder"
 		);
 		Ok(Box::new(Self {
 			session,

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -11,7 +11,8 @@
 //! - [`encode`] encodes frames with a native backend and publishes them through
 //!   the matching `moq_mux::codec` importer, which handles catalog registration
 //!   and framing. The codec is chosen via [`encode::Codec`]: H.264 (openh264 /
-//!   VideoToolbox / NVENC / VAAPI) or H.265 (VideoToolbox). Two entry points:
+//!   VideoToolbox / Media Foundation / NVENC / VAAPI) or H.265 (VideoToolbox /
+//!   Media Foundation / NVENC). Two entry points:
 //!   - [`encode::publish_capture`] captures a webcam and publishes it (turnkey).
 //!     It encodes strictly on demand: the track and catalog are advertised up
 //!     front, but the camera opens only while a subscriber is watching and is


### PR DESCRIPTION
First slice of the `moq-video` remaining-work tracking issue (#1837).

## NVENC H.265 encode (Linux)

The Linux NVENC encoder gained H.265. The backend now selects its codec GUID from `encode::Codec` (`codec_guid`), so the HEVC path reuses the existing H.264 preset / GOP / rate-control setup and emits Annex-B with inline VPS/SPS/PPS, the framing the `hev1` importer already consumes (exactly as the VideoToolbox H.265 backend does). The NVENC candidate now advertises `[H264, H265]`.

This closes the gap where **Linux could not produce HEVC at all** (it was hardware-only and previously wired only on macOS VideoToolbox and Windows Media Foundation).

### Public API
No breaking change. `encode::Codec::H265` already existed; this only makes NVENC eligible for it. No new/renamed/removed `pub` items.

## README + docs refresh

The README was badly stale: it still called the crate ffmpeg-based, said "Requires a system FFmpeg", and claimed the decode side was "not implemented yet". All three are false on `dev` (the crate is native per-platform with no ffmpeg, and `decode::Consumer` exists). Rewrote it with an accurate capture/encode/decode capability matrix. Also updated the crate-level doc in `lib.rs`, the CHANGELOG, and the DESIGN follow-up note.

## Validation
- `cargo check`/`clippy`/`test -p moq-video --features nvenc`: green (13 tests pass).
- The HEVC path itself **cannot be exercised here** (no GPU, and there is no software HEVC fallback), so it ships HW-unverified like the existing NVENC H.264 path. Validation on a Linux + NVIDIA box that VPS/SPS/PPS land inline ahead of each IDR remains a follow-up, tracked in #1837.

## Out of scope / deliberately skipped
Per the request: no software H.265/AV1 encode (HEVC stays hardware-only), and no software H.265/AV1 decode unless a backend with acceptable real-time performance and clean licensing turns up. VAAPI H.265 is left for a follow-up (need to confirm discord/cros-codecs exposes an HEVC encoder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVFm4YtH5u71sZzW6uaZC5)_