### PR TITLE
feat(moq-cli): wire verbatim MPEG-TS carriage through publish/subscribe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "moq-cli"
-version = "0.7.33"
+version = "0.7.34"
 dependencies = [
  "anyhow",
  "axum",

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -175,6 +175,13 @@ rather than mis-described. The catalog describes the codec honestly so a
 subscriber that can decode it (typically TS gear) picks it up; browsers cannot
 play these codecs and should skip the rendition.
 
+Elementary streams the CLI does not decode (SCTE-35 cues, teletext, DVB
+subtitles, private data, ...) are carried verbatim too, one MoQ track per PID,
+described in the catalog `mpegts` section. They survive `publish ts | relay |
+subscribe --format ts` end-to-end with their original PIDs, PMT descriptors, and
+PES stream_ids, so a contribution feed keeps its ancillary streams. The relay
+forwards them transparently and never parses the payload.
+
 ### FLV
 
 Ingest an FLV stream from FFmpeg and play one back out:

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.7.33"
+version = "0.7.34"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -37,3 +37,8 @@ url = "2"
 
 [target.'cfg(unix)'.dependencies]
 sd-notify = "0.5"
+
+[dev-dependencies]
+# `test-util` enables `tokio::time::pause` so the TS round-trip test simulates the
+# exporter drain timeouts instantly instead of waiting on the wall clock.
+tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -226,8 +226,10 @@ mod tests {
 	/// (which selects the `mpegts` catalog) and the subscribe-side `Export::with_ts`,
 	/// and the SCTE-35 section and the verbatim PES survive with their PIDs, framing,
 	/// PES stream_id, and byte-exact payloads.
-	#[tokio::test]
+	#[tokio::test(start_paused = true)]
 	async fn ts_verbatim_streams_round_trip_through_cli() {
+		// Paused time auto-advances when the exporter parks, so the `drain` timeouts
+		// fire instantly instead of waiting on the wall clock.
 		let input = manufacture_input().await;
 
 		// Publish side: `Publish::new(Ts)` builds a `ts::Import<Ext>`, so the verbatim

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -21,7 +21,9 @@ pub enum PublishFormat {
 enum PublishDecoder {
 	Avc3(Box<moq_mux::codec::h264::Import>),
 	Fmp4(Box<fmp4::Import>),
-	Ts(Box<ts::Import>),
+	// TS carries undecoded elementary streams (SCTE-35, teletext, DVB AC-3, ...)
+	// verbatim, so it uses the `mpegts` catalog extension rather than the media-only `()`.
+	Ts(Box<ts::Import<ts::catalog::Ext>>),
 	Flv(Box<flv::Import>),
 	Hls(Box<hls::Import>),
 }
@@ -47,8 +49,24 @@ pub struct Publish {
 impl Publish {
 	pub fn new(format: &PublishFormat) -> anyhow::Result<Self> {
 		let mut broadcast = moq_net::Broadcast::new().produce();
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 
+		// TS carries undecoded elementary streams (SCTE-35, teletext, DVB AC-3, ...)
+		// verbatim, so it uses the `mpegts` catalog extension rather than the media-only
+		// `()`. The catalog producer owns the broadcast's catalog tracks, so each broadcast
+		// gets exactly one; TS builds its `Ext` catalog here instead of the shared `()` below.
+		if let PublishFormat::Ts = format {
+			let catalog = moq_mux::catalog::Producer::with_catalog(
+				&mut broadcast,
+				moq_mux::catalog::hang::Catalog::<ts::catalog::Ext>::default(),
+			)?;
+			let ts = ts::Import::new(broadcast.clone(), catalog);
+			return Ok(Self {
+				source: PublishDecoder::Ts(Box::new(ts)),
+				broadcast,
+			});
+		}
+
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 		let source = match format {
 			PublishFormat::Avc3 => {
 				let avc3 = moq_mux::codec::h264::Import::new(broadcast.clone(), catalog.clone())
@@ -59,10 +77,7 @@ impl Publish {
 				let fmp4 = fmp4::Import::new(broadcast.clone(), catalog.clone());
 				PublishDecoder::Fmp4(Box::new(fmp4))
 			}
-			PublishFormat::Ts => {
-				let ts = ts::Import::new(broadcast.clone(), catalog.clone());
-				PublishDecoder::Ts(Box::new(ts))
-			}
+			PublishFormat::Ts => unreachable!("TS is handled above with the mpegts catalog extension"),
 			PublishFormat::Flv => {
 				let flv = flv::Import::new(broadcast.clone(), catalog.clone());
 				PublishDecoder::Flv(Box::new(flv))
@@ -99,5 +114,205 @@ impl Publish {
 				}
 			}
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::Duration;
+
+	use bytes::BytesMut;
+	use moq_mux::catalog::CatalogFormat;
+	use moq_mux::catalog::hang::{Catalog, Container};
+	use moq_mux::container::ts::{Export, Import, catalog as tscat};
+	use moq_mux::container::{Consumer, Frame, Producer, Timestamp};
+
+	use super::*;
+
+	/// Real H.264 + AAC TS, reused to give the manufactured input a video clock
+	/// (section-framed verbatim export requires one) and decodable media tracks.
+	const BBB: &[u8] = include_bytes!("../../moq-mux/src/container/ts/test_data/bbb.ts");
+
+	/// A libklvanc public-sample SCTE-35 splice_info_section (table_id 0xFC), carried
+	/// on a section-framed PID. Same bytes the moq-mux export round-trip test uses.
+	const CUE: &[u8] = &[
+		0xfc, 0x30, 0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xf0, 0x0a, 0x05, 0x00, 0x00, 0x2b, 0xb4,
+		0x7f, 0xdf, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0xad, 0x25, 0xe8, 0x39,
+	];
+
+	/// Payload of an undecoded PES-framed stream (e.g. teletext/DVB AC-3 private data),
+	/// carried verbatim on its own PID with the original PES stream_id.
+	const PES_PAYLOAD: &[u8] = &[0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02];
+
+	const SECTION_PID: u16 = 0x102;
+	const VERBATIM_PES_PID: u16 = 0x104;
+	const VERBATIM_PES_STREAM_ID: u8 = 0xC0;
+
+	/// Drain an exporter, concatenating every chunk until output stops. The producers
+	/// stay alive (retained tracks), so the stream never hard-ends; pull until a
+	/// `next()` blocks, surfaced here as a timeout once the buffered frames are gone.
+	async fn drain(mut exporter: Export<tscat::Ext>) -> Vec<u8> {
+		let mut out = Vec::new();
+		while let Ok(res) = tokio::time::timeout(Duration::from_millis(500), exporter.next()).await {
+			match res.expect("exporter error") {
+				Some(chunk) => out.extend_from_slice(&chunk),
+				None => break,
+			}
+		}
+		out
+	}
+
+	/// Manufacture a TS feed carrying real video/audio plus one section-framed
+	/// verbatim stream (SCTE-35) and one PES-framed verbatim stream, by importing
+	/// `bbb.ts` into a broadcast that also holds the two ancillary tracks and
+	/// re-exporting with the `mpegts` catalog extension.
+	async fn manufacture_input() -> Vec<u8> {
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let consumer = broadcast.consume();
+		let mut catalog =
+			moq_mux::catalog::Producer::with_catalog(&mut broadcast, Catalog::<tscat::Ext>::default()).unwrap();
+
+		// Section-framed verbatim stream (SCTE-35, stream_type 0x86).
+		let section = broadcast.unique_track(".scte35").unwrap();
+		let mut section_track = tscat::Track::new(SECTION_PID);
+		section_track.verbatim = Some(tscat::Verbatim::new(0x86, tscat::Framing::Section));
+		catalog.lock().mpegts.tracks.insert(section.name.clone(), section_track);
+		let mut section_producer = Producer::new(section, Container::Legacy);
+		section_producer
+			.write(Frame {
+				timestamp: Timestamp::from_millis(40).unwrap(),
+				payload: bytes::Bytes::from_static(CUE),
+				keyframe: true,
+			})
+			.unwrap();
+		section_producer.finish_group().unwrap();
+		section_producer.finish().unwrap();
+
+		// PES-framed verbatim stream (undecoded private data, stream_type 0x06), with
+		// an explicit PES stream_id to round-trip.
+		let pes = broadcast.unique_track(".data").unwrap();
+		let mut verbatim = tscat::Verbatim::new(0x06, tscat::Framing::Pes);
+		verbatim.stream_id = Some(VERBATIM_PES_STREAM_ID);
+		let mut pes_track = tscat::Track::new(VERBATIM_PES_PID);
+		pes_track.verbatim = Some(verbatim);
+		catalog.lock().mpegts.tracks.insert(pes.name.clone(), pes_track);
+		let mut pes_producer = Producer::new(pes, Container::Legacy);
+		pes_producer
+			.write(Frame {
+				timestamp: Timestamp::from_millis(40).unwrap(),
+				payload: bytes::Bytes::from_static(PES_PAYLOAD),
+				keyframe: true,
+			})
+			.unwrap();
+		pes_producer.finish_group().unwrap();
+		pes_producer.finish().unwrap();
+
+		// Add the real video/audio (moves `broadcast` into the importer).
+		let mut import = Import::new(broadcast, catalog.clone());
+		import.decode(&mut BytesMut::from(BBB)).unwrap();
+		import.finish().unwrap();
+
+		// `catalog`, the producers, and `import` stay alive: the exporter subscribes to
+		// the retained tracks.
+		drain(
+			Export::with_ts(consumer, CatalogFormat::Hang)
+				.unwrap()
+				.with_latency(Duration::ZERO),
+		)
+		.await
+	}
+
+	/// Full CLI round-trip: a TS feed with undecoded streams goes through `Publish`
+	/// (which selects the `mpegts` catalog) and the subscribe-side `Export::with_ts`,
+	/// and the SCTE-35 section and the verbatim PES survive with their PIDs, framing,
+	/// PES stream_id, and byte-exact payloads.
+	#[tokio::test]
+	async fn ts_verbatim_streams_round_trip_through_cli() {
+		let input = manufacture_input().await;
+
+		// Publish side: `Publish::new(Ts)` builds a `ts::Import<Ext>`, so the verbatim
+		// streams land in the broadcast instead of being dropped by the media-only path.
+		let mut publish = Publish::new(&PublishFormat::Ts).unwrap();
+		let consumer = publish.consume();
+		let mut buffer = BytesMut::from(&input[..]);
+		publish.source.decode_buf(&mut buffer).unwrap();
+		let PublishDecoder::Ts(import) = &mut publish.source else {
+			panic!("expected a TS decoder");
+		};
+		import.finish().unwrap();
+
+		// Subscribe side: the same `with_ts` call `run_ts` makes, re-emitting the
+		// ancillary streams verbatim.
+		let output = drain(
+			Export::with_ts(consumer, CatalogFormat::Hang)
+				.unwrap()
+				.with_latency(Duration::ZERO),
+		)
+		.await;
+
+		// Re-import the round-tripped TS and inspect the recovered `mpegts` section.
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let consumer = broadcast.consume();
+		let catalog =
+			moq_mux::catalog::Producer::with_catalog(&mut broadcast, Catalog::<tscat::Ext>::default()).unwrap();
+		let mut import = Import::new(broadcast, catalog.clone());
+		import.decode(&mut BytesMut::from(&output[..])).unwrap();
+		import.finish().unwrap();
+		let snapshot = catalog.snapshot();
+
+		let (section_name, section) = snapshot
+			.mpegts
+			.tracks
+			.iter()
+			.find(|(_, t)| t.verbatim.as_ref().is_some_and(|v| v.stream_type == 0x86))
+			.expect("SCTE-35 section survived the round-trip");
+		assert_eq!(section.pid, SECTION_PID, "section PID preserved");
+		assert_eq!(
+			section.verbatim.as_ref().unwrap().framing,
+			tscat::Framing::Section,
+			"section framing preserved"
+		);
+		let section_name = section_name.clone();
+
+		let (pes_name, pes) = snapshot
+			.mpegts
+			.tracks
+			.iter()
+			.find(|(_, t)| t.verbatim.as_ref().is_some_and(|v| v.stream_type == 0x06))
+			.expect("verbatim PES survived the round-trip");
+		assert_eq!(pes.pid, VERBATIM_PES_PID, "verbatim PES PID preserved");
+		let pes_verbatim = pes.verbatim.as_ref().unwrap();
+		assert_eq!(pes_verbatim.framing, tscat::Framing::Pes, "PES framing preserved");
+		assert_eq!(
+			pes_verbatim.stream_id,
+			Some(VERBATIM_PES_STREAM_ID),
+			"PES stream_id preserved"
+		);
+		let pes_name = pes_name.clone();
+
+		assert_eq!(
+			read_frame(&consumer, &section_name).await,
+			CUE,
+			"SCTE-35 section round-trips byte-for-byte"
+		);
+		assert_eq!(
+			read_frame(&consumer, &pes_name).await,
+			PES_PAYLOAD,
+			"verbatim PES payload round-trips byte-for-byte"
+		);
+	}
+
+	/// Read the first frame of a verbatim track back as raw bytes.
+	async fn read_frame(consumer: &moq_net::BroadcastConsumer, name: &str) -> Vec<u8> {
+		let track = consumer
+			.subscribe_track(&moq_net::Track::new(name.to_string()))
+			.unwrap();
+		let mut reader = Consumer::new(track, Container::Legacy).with_latency(Duration::ZERO);
+		let frame = tokio::time::timeout(Duration::from_secs(1), reader.read())
+			.await
+			.expect("verbatim read timed out")
+			.unwrap()
+			.expect("a published verbatim frame");
+		frame.payload.to_vec()
 	}
 }

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -132,9 +132,11 @@ impl Subscribe {
 
 		// TS emits PAT/PMT then a continuous PES stream (re-emitting PAT/PMT at
 		// keyframes for tune-in). Avc3/Hev1 sources pass through as Annex-B; AAC
-		// is re-framed as ADTS. `fragment_duration` does not apply to TS.
-		let mut ts = moq_mux::container::ts::Export::with_catalog_format(self.broadcast, self.catalog)?
-			.with_latency(self.args.max_latency);
+		// is re-framed as ADTS. `fragment_duration` does not apply to TS. `with_ts`
+		// selects the `mpegts` catalog extension so undecoded elementary streams
+		// (SCTE-35, teletext, DVB AC-3, ...) are re-emitted verbatim on their PIDs.
+		let mut ts =
+			moq_mux::container::ts::Export::with_ts(self.broadcast, self.catalog)?.with_latency(self.args.max_latency);
 
 		while let Some(chunk) = ts.next().await? {
 			stdout.write_all(&chunk).await?;


### PR DESCRIPTION
## Summary

[#1815](https://github.com/moq-dev/moq/pull/1815) landed generic verbatim MPEG-TS carriage in the `moq-mux` library (the `mpegts` catalog section + per-PID verbatim tracks) but left CLI wiring out of scope. Until now `moq-cli` still used the media-only `Catalog<()>` path, so SCTE-35 / teletext / DVB AC-3 / private streams were dropped when going through `moq pub | relay | moq sub`. This wires the `Ext` (mpegts) catalog through the CLI so a contribution TS feed keeps its ancillary streams end-to-end. Part of [#1799](https://github.com/moq-dev/moq/issues/1799); closes [#1835](https://github.com/moq-dev/moq/issues/1835).

The library was already generic over the catalog extension; this just selects `Ext`.

## Changes

- **`rs/moq-cli/src/publish.rs`**: `PublishDecoder::Ts` now holds `ts::Import<ts::catalog::Ext>`. The `Ts` format builds its own `Producer<Ext>` via `with_catalog`. TS is handled as an early branch in `Publish::new` rather than sharing the media-only `()` catalog created for the other formats, since a broadcast owns exactly one catalog producer (a second one would collide on the catalog tracks).
- **`rs/moq-cli/src/subscribe.rs`**: `run_ts` now calls `Export::with_ts(...)` instead of `Export::with_catalog_format(...)`, selecting the `mpegts` extension so undecoded streams are re-emitted on their original PIDs.
- **Integration test** (`ts_verbatim_streams_round_trip_through_cli`): manufactures a TS feed with real H.264/AAC plus one section-framed verbatim stream (SCTE-35) and one PES-framed verbatim stream, runs it through the real `Publish` type and the subscribe-side `Export::with_ts`, re-imports, and asserts both survive with original PIDs, framing, PES `stream_id`, and byte-exact payloads.
- **`doc/bin/cli.md`**: documents verbatim ancillary-stream preservation (per the Cross-Package Sync table).
- **Version bump** to `0.7.34` (manual, per the moq-cli semver policy: release-plz can't see binary CLI changes).

The relay needs no change: it forwards the extra tracks and the `mpegts` section transparently and never parses the payload.

## Acceptance criteria

- [x] `publish ts | relay | subscribe --format ts` preserves the undecoded streams (SCTE-35 section PIDs, PES) with original PIDs and PES stream_ids, matching the [#1815](https://github.com/moq-dev/moq/pull/1815) library round-trip.
- [x] Round-trip integration test over a fixture with at least one verbatim PES and one section PID.

## Test plan

- [x] `cargo test -p moq-cli` (new round-trip test passes)
- [x] `cargo build -p moq-cli`
- [x] `cargo fmt` + `cargo clippy -p moq-cli --all-targets` via nix (clean)

## Out of scope (per [#1815](https://github.com/moq-dev/moq/pull/1815) / [#1799](https://github.com/moq-dev/moq/issues/1799))

- DTS / B-frame timestamps, PCR-PID preservation, MPTS, and byte-for-byte whole-mux fidelity.

## Public API changes

- `rs/moq-cli` is a binary crate; no library `pub` surface changed. The visible change is behavioral (TS now carries the `mpegts` catalog extension). No breaking changes; targets `main` per the issue.

(Written by Claude)