### PR TITLE
fix(moq-video): probe NVIDIA driver libs before NVENC init (avoid abort on GPU-less box)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,6 +4401,7 @@ dependencies = [
  "cudarc",
  "dispatch2",
  "hang",
+ "libloading 0.9.0",
  "moq-mux",
  "moq-net",
  "moq-vaapi",

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -26,7 +26,7 @@ doctest = false
 # links on a GPU-less builder and still starts on machines without the NVIDIA
 # driver, falling back to software (see backend::open). `cuda-12020` pins the CUDA
 # API version so the build needs no CUDA toolkit.
-nvenc = ["dep:nvidia-video-codec-sdk", "nvidia-video-codec-sdk/dynamic-loading", "cudarc/fallback-dynamic-loading", "cudarc/cuda-12020"]
+nvenc = ["dep:nvidia-video-codec-sdk", "nvidia-video-codec-sdk/dynamic-loading", "cudarc/fallback-dynamic-loading", "cudarc/cuda-12020", "dep:libloading"]
 # Intel/AMD VAAPI hardware encoder (Linux). Off by default; enable for a build
 # that should use VAAPI where present. The `moq-vaapi` crate (moq-dev/vaapi) builds
 # against its own vendored libva headers and dlopen's libva at runtime, so a
@@ -41,6 +41,11 @@ bytes = "1"
 cudarc = { version = "0.19", optional = true, default-features = false, features = ["driver"] }
 # Catalog types (VideoConfig / VideoCodec) the decode consumer reads.
 hang = { workspace = true }
+# Probe for libcuda / libnvidia-encode before NVENC init (nvenc feature). cudarc
+# and the SDK `panic!` when their dlopen target is missing, and the workspace
+# builds with `panic = "abort"`, so a driverless box must be detected up front
+# (clean Err -> software fallback) instead of aborting the process.
+libloading = { version = "0.9", optional = true }
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
 # VAAPI H.264 encoder, gated behind the `vaapi` feature + a linux cfg. Listed here

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -120,3 +120,22 @@ pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
 
 	Err(Error::NoEncoder(tried.join(", ")))
 }
+
+#[cfg(all(test, target_os = "linux", feature = "nvenc"))]
+mod tests {
+	use super::super::encoder::{Codec, Config, Kind};
+
+	/// `Kind::Auto` (the default for `publish_capture`) must fall back to software
+	/// on a box without the NVIDIA driver, not abort. cudarc panics on a missing
+	/// libcuda and the workspace builds `panic = "abort"`, so before the driver
+	/// probe in `nvenc::open` this aborted the process; `open` should return the
+	/// openh264 backend instead. (On a real GPU box NVENC opens and this is still
+	/// Ok, so the assertion holds either way; it guards the panic regression.)
+	#[test]
+	fn auto_h264_falls_back_without_driver() {
+		let mut config = Config::new(320, 240, 30);
+		config.codec = Codec::H264;
+		config.kind = Kind::Auto;
+		assert!(super::open(&config).is_ok());
+	}
+}

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -8,6 +8,12 @@
 //! inline avc3 / hev1 mode directly. The codec is chosen by [`Config::codec`];
 //! only the codec GUID differs, the preset / GOP / rate-control setup is shared.
 //!
+//! A driverless box never reaches NVENC: [`open`](Self::open) first
+//! `dlopen`-probes libcuda / libnvidia-encode and returns an error if they're
+//! absent, so [`backend::open`](super::open) falls back to software instead of
+//! aborting (cudarc / the SDK `panic!` on a missing dlopen target, and the
+//! workspace builds `panic = "abort"`).
+//!
 //! NOT YET VALIDATED ON HARDWARE. Two things need checking on a real Linux+GPU
 //! box before this ships in releases:
 //!   1. The safe wrapper's input buffer does a flat `write`, which only matches
@@ -45,6 +51,38 @@ fn codec_guid(codec: Codec) -> GUID {
 	}
 }
 
+/// Fail (cleanly) if the NVIDIA driver libraries NVENC needs aren't present.
+///
+/// cudarc and the SDK both resolve their entry points via `dlopen` and `panic!`
+/// when the library is missing, rather than returning an error. The workspace
+/// builds with `panic = "abort"`, so reaching that panic would abort the whole
+/// process instead of letting [`open`](super::open) fall back to software. We
+/// `dlopen` the libraries here first: if they load we let cudarc proceed (a
+/// driver-present-but-GPU-absent box then fails with a normal `CUresult` error,
+/// which is handled); if they don't, we return an `Err` so the fallback chain
+/// moves on to openh264.
+fn driver_available() -> Result<(), Error> {
+	// One probe per library; cudarc searches `cuda`/`nvcuda`, the SDK loads
+	// `libnvidia-encode`. Try the versioned soname (what's installed at runtime)
+	// and the bare name (dev symlink).
+	fn any(names: &[&str]) -> bool {
+		// SAFETY: loading a shared library runs its initializers; these are the
+		// NVIDIA driver libs, which are safe to load. We drop the handle right
+		// away (this is a presence probe), reloaded for real by cudarc/the SDK.
+		names.iter().any(|n| unsafe { libloading::Library::new(*n).is_ok() })
+	}
+
+	if !any(&["libcuda.so.1", "libcuda.so"]) {
+		return Err(Error::Codec(anyhow::anyhow!("nvenc unavailable: libcuda not found")));
+	}
+	if !any(&["libnvidia-encode.so.1", "libnvidia-encode.so"]) {
+		return Err(Error::Codec(anyhow::anyhow!(
+			"nvenc unavailable: libnvidia-encode not found"
+		)));
+	}
+	Ok(())
+}
+
 pub(crate) struct Nvenc {
 	session: Session,
 	// Keep the CUDA context alive for as long as the session uses it.
@@ -57,6 +95,11 @@ unsafe impl Send for Nvenc {}
 
 impl Nvenc {
 	pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
+		// Bail before touching cudarc if the driver libs are absent: their dlopen
+		// shims panic on a miss, and `panic = "abort"` would take the process down
+		// instead of falling back to software.
+		driver_available()?;
+
 		if config.width % 64 != 0 {
 			// Flat writes assume pitch == width; NVENC aligns pitch, so a
 			// non-64-aligned width risks corrupting the encoded chroma. Fail so


### PR DESCRIPTION
## What

Reviewing the just-merged #1840 surfaced a pre-existing robustness bug that my NVENC H.265 change widened: **`Kind::Auto` aborts the process on a box without the NVIDIA driver instead of falling back to software.**

### Root cause (verified empirically on a GPU-less Linux box)
- cudarc (`fallback-dynamic-loading`) and `nvidia-video-codec-sdk` (`dynamic-loading`) resolve their entry points via `dlopen` and **`panic!` when the library is missing**, rather than returning an error. cudarc's `culib()` calls `panic_no_lib_found(...)`.
- The workspace builds with **`panic = "abort"`** (both `[profile.dev]` and `[profile.release]`).
- So `Nvenc::open` → `CudaContext::new(0)` panics → **process aborts**, before `backend::open` can fall through to openh264. The `.map_err(...)?` never runs.

This defeats the crate's central packaging goal ("one portable binary reaches the GPU at runtime, falls back to software where the driver is absent"). It's reachable via the default `publish_capture` path (`Options::kind` defaults to `Auto`). #1840 made it newly reachable for H.265, since NVENC now advertises that codec.

Proof: a temporary `Auto`+H264 test aborted with a cudarc panic backtrace at `CudaContext::new`; this box has no `libcuda` in `ldconfig`.

### Fix
`Nvenc::open` now `dlopen`-probes `libcuda` / `libnvidia-encode` up front (via `libloading`, already in the tree through cudarc) and returns a clean `Err` if either is absent, so the fallback chain proceeds to openh264. A driver-present-but-GPU-absent box still fails through the normal `CUresult` path, which was already handled.

Probing presence (not `catch_unwind`) is the right tool here precisely because `panic = "abort"` makes unwinding-based recovery impossible.

### Test
`auto_h264_falls_back_without_driver` (Linux + `nvenc` feature) asserts `backend::open` with `Auto` returns a backend rather than aborting. It holds on a GPU box (NVENC opens) and a driverless box (openh264 fallback) alike, guarding the panic regression. Full `cargo test -p moq-video --features nvenc`: 14 pass.

## Related (not fixed here)
The **VAAPI** backend almost certainly has the identical latent bug: cros-libva `dlopen`s `libva` and likely panics on a miss, so `Auto`+`--features vaapi` on a libva-less box would also abort. I couldn't build/verify it in this environment (no libva headers for cros-libva's bindgen), so I left it out rather than fix blind. Tracked as a follow-up in #1837. (Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVFm4YtH5u71sZzW6uaZC5)_