### PR TITLE
feat(demo/web): redesign relay stats page with live charts

### DIFF
--- a/demo/web/src/stats.html
+++ b/demo/web/src/stats.html
@@ -10,82 +10,123 @@
 	<link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 
-<body class="p-4 max-w-6xl mx-auto">
-	<h1 class="text-2xl font-bold mb-1">MoQ Relay Stats</h1>
-	<p class="text-neutral-400 text-sm mb-4 max-w-3xl">
-		Live view of every relay publishing a <code>.stats</code> broadcast: the whole cluster at once, not
-		just the relay you're connected to. Enable it with <code>[stats] enabled = true</code> in the relay
-		config.
-	</p>
+<body class="p-4 sm:p-6 max-w-6xl mx-auto">
+	<header class="flex flex-wrap items-center justify-between gap-3 mb-6">
+		<div>
+			<h1 class="text-2xl font-bold leading-tight">MoQ Relay Stats</h1>
+			<p class="text-neutral-500 text-xs">Live cluster activity, auto-discovered under <code>.stats/node</code>.</p>
+		</div>
+		<div class="flex items-center gap-2">
+			<input id="relay-url" type="text" spellcheck="false" placeholder="https://relay…"
+				class="w-64 max-w-full bg-neutral-900 border border-neutral-700 rounded-md px-3 py-1.5 text-white text-sm font-mono focus:outline-none focus:border-emerald-600">
+			<span id="status"
+				class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium bg-neutral-900 border border-neutral-700">connecting…</span>
+		</div>
+	</header>
 
-	<div class="flex flex-wrap items-end gap-3 mb-6">
-		<label class="text-xs text-neutral-400">
-			Relay URL
-			<input id="relay-url" type="text"
-				class="mt-1 block w-96 max-w-full bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-white text-sm font-mono">
-		</label>
-		<span id="status"
-			class="inline-flex items-center px-2 py-1 rounded text-xs bg-neutral-900 border border-neutral-700">connecting…</span>
-	</div>
-
-	<section class="mb-8">
-		<h2 class="text-lg font-semibold mb-1">Nodes</h2>
-		<p class="text-neutral-500 text-xs mb-3 max-w-3xl">
-			Every relay node publishing <code>.stats</code>, auto-discovered under <code>.stats/node</code>
-			(so this covers a whole cluster, not just one relay).
-			<b class="text-neutral-300">broadcasters</b>/<b class="text-neutral-300">viewers</b>/<b
-				class="text-neutral-300">ingress</b>/<b class="text-neutral-300">egress</b> are external clients;
-			<b class="text-neutral-300">cluster in</b>/<b class="text-neutral-300">cluster out</b> are internal
-			mTLS peer traffic (the relaying between nodes that's otherwise invisible). Click a node to drill in.
-		</p>
-		<div id="nodes" class="overflow-x-auto text-neutral-500 text-sm">searching for nodes…</div>
+	<!-- Cluster summary: six headline numbers, no prose. -->
+	<section id="overview" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Nodes</div>
+			<div id="kpi-nodes" class="text-2xl font-semibold tabular-nums mt-0.5">0</div>
+		</div>
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Broadcasters</div>
+			<div id="kpi-broadcasters" class="text-2xl font-semibold tabular-nums mt-0.5 text-sky-300">0</div>
+		</div>
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Viewers</div>
+			<div id="kpi-viewers" class="text-2xl font-semibold tabular-nums mt-0.5 text-emerald-300">0</div>
+		</div>
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Egress</div>
+			<div id="kpi-egress" class="text-2xl font-semibold tabular-nums mt-0.5 text-emerald-400">0</div>
+		</div>
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Ingress</div>
+			<div id="kpi-ingress" class="text-2xl font-semibold tabular-nums mt-0.5 text-sky-400">0</div>
+		</div>
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Sessions</div>
+			<div id="kpi-sessions" class="text-2xl font-semibold tabular-nums mt-0.5">0</div>
+		</div>
 	</section>
 
-	<section id="node-detail" hidden>
-		<h2 class="text-lg font-semibold mb-1">Node <span id="node-title" class="font-mono text-emerald-400"></span></h2>
-		<p class="text-neutral-500 text-xs mb-4 max-w-3xl">
-			Activity on this node, split by tier and direction. The relay reports external clients (JWT/public)
-			and internal cluster peers (mTLS) separately. The <code>.stats</code> feed itself is excluded
-			throughout. <span id="node-sessions" class="text-neutral-300"></span> · <span id="node-internal-sessions"
-				class="text-neutral-300"></span>
-		</p>
+	<!-- Cluster throughput over time. -->
+	<section class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-4 mb-6">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-sm font-semibold text-neutral-300">Cluster throughput</h2>
+			<div class="flex items-center gap-4 text-xs">
+				<span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm bg-emerald-400"></span>egress <span id="legend-egress" class="font-mono text-neutral-400 tabular-nums">–</span></span>
+				<span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm bg-sky-400"></span>ingress <span id="legend-ingress" class="font-mono text-neutral-400 tabular-nums">–</span></span>
+				<span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm bg-violet-400"></span>cluster <span id="legend-cluster" class="font-mono text-neutral-400 tabular-nums">–</span></span>
+			</div>
+		</div>
+		<div id="chart-throughput" class="h-44"></div>
+	</section>
 
-		<h3 class="text-sm font-semibold text-neutral-300 mt-4 mb-1">Broadcasters (external ingress)</h3>
-		<p class="text-neutral-500 text-xs mb-2 max-w-3xl">
-			Broadcasts this node ingests from upstream publishers. <b class="text-neutral-300">ingress</b> is
-			capped at one subscription per track, so it's bytes pulled once, not per-viewer.
-		</p>
-		<div id="node-publishers" class="overflow-x-auto text-neutral-500 text-sm">no broadcasters</div>
+	<!-- One card per node; click to drill in. -->
+	<section class="mb-6">
+		<h2 class="text-sm font-semibold text-neutral-300 mb-2">Nodes</h2>
+		<div id="nodes" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 text-neutral-500 text-sm">searching for nodes…</div>
+	</section>
 
-		<h3 class="text-sm font-semibold text-neutral-300 mt-4 mb-1">Viewers (external egress)</h3>
-		<p class="text-neutral-500 text-xs mb-2 max-w-3xl">
-			Broadcasts this node serves to downstream subscribers. <b class="text-neutral-300">egress</b> is
-			bytes served to viewers; the useful throughput number.
-		</p>
-		<div id="node-subscribers" class="overflow-x-auto text-neutral-500 text-sm">no viewers</div>
+	<section id="node-detail" hidden class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-4 mb-6">
+		<div class="flex flex-wrap items-baseline justify-between gap-2 mb-4">
+			<h2 class="text-base font-semibold">Node <span id="node-title" class="font-mono text-emerald-400"></span></h2>
+			<div class="text-xs text-neutral-400 font-mono"><span id="node-sessions"></span> · <span id="node-internal-sessions"></span></div>
+		</div>
 
-		<h3 class="text-sm font-semibold text-neutral-300 mt-4 mb-1">Cluster ingress (internal / mTLS)</h3>
-		<p class="text-neutral-500 text-xs mb-2 max-w-3xl">
-			Broadcasts this node pulls from upstream <em>cluster peers</em> (other relays / the CDN) rather than
-			from real publishers.
-		</p>
-		<div id="node-internal-publishers" class="overflow-x-auto text-neutral-500 text-sm">no cluster ingress</div>
+		<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+			<div>
+				<div class="flex items-center justify-between mb-1">
+					<h3 class="text-xs font-semibold text-neutral-400">External throughput</h3>
+					<div class="flex items-center gap-3 text-[11px]">
+						<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-emerald-400"></span>egress</span>
+						<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-sky-400"></span>ingress</span>
+					</div>
+				</div>
+				<div id="chart-node-external" class="h-32"></div>
+			</div>
+			<div>
+				<div class="flex items-center justify-between mb-1">
+					<h3 class="text-xs font-semibold text-neutral-400">Cluster throughput (mTLS peers)</h3>
+					<div class="flex items-center gap-3 text-[11px]">
+						<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-violet-400"></span>out</span>
+						<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-fuchsia-400"></span>in</span>
+					</div>
+				</div>
+				<div id="chart-node-cluster" class="h-32"></div>
+			</div>
+		</div>
 
-		<h3 class="text-sm font-semibold text-neutral-300 mt-4 mb-1">Cluster egress (internal / mTLS)</h3>
-		<p class="text-neutral-500 text-xs mb-2 max-w-3xl">
-			Broadcasts this node fans out to downstream <em>cluster peers</em>. This is the relaying traffic
-			that never shows up in the external numbers, e.g. a hub bridging nodes.
-		</p>
-		<div id="node-internal-subscribers" class="overflow-x-auto text-neutral-500 text-sm">no cluster egress</div>
+		<div class="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-4">
+			<div>
+				<h3 class="text-xs font-semibold text-sky-300 mb-1">Broadcasters <span class="text-neutral-500 font-normal">· ingested from upstream</span></h3>
+				<div id="node-publishers" class="overflow-x-auto text-neutral-500 text-sm">no broadcasters</div>
+			</div>
+			<div>
+				<h3 class="text-xs font-semibold text-emerald-300 mb-1">Viewers <span class="text-neutral-500 font-normal">· served downstream</span></h3>
+				<div id="node-subscribers" class="overflow-x-auto text-neutral-500 text-sm">no viewers</div>
+			</div>
+			<div>
+				<h3 class="text-xs font-semibold text-fuchsia-300 mb-1">Cluster ingress <span class="text-neutral-500 font-normal">· from peer relays</span></h3>
+				<div id="node-internal-publishers" class="overflow-x-auto text-neutral-500 text-sm">none</div>
+			</div>
+			<div>
+				<h3 class="text-xs font-semibold text-violet-300 mb-1">Cluster egress <span class="text-neutral-500 font-normal">· to peer relays</span></h3>
+				<div id="node-internal-subscribers" class="overflow-x-auto text-neutral-500 text-sm">none</div>
+			</div>
+		</div>
 	</section>
 
 	<!-- Dev-only: renders console output inline here. Defined by the
 	     console-overlay Vite plugin; absent from production builds. -->
 	<moq-console class="block mt-8"></moq-console>
 
-	<details class="mt-8">
-		<summary class="text-sm text-neutral-400 cursor-pointer">Raw frames</summary>
-		<pre id="raw" class="text-xs font-mono text-neutral-300 overflow-x-auto mt-2"></pre>
+	<details class="mt-6">
+		<summary class="text-xs text-neutral-500 cursor-pointer hover:text-neutral-300">Raw frames</summary>
+		<pre id="raw" class="text-xs font-mono text-neutral-400 overflow-x-auto mt-2"></pre>
 	</details>
 
 	<div class="prose-doc mt-8">

--- a/demo/web/src/stats.html
+++ b/demo/web/src/stats.html
@@ -17,7 +17,7 @@
 			<p class="text-neutral-500 text-xs">Live cluster activity, auto-discovered under <code>.stats/node</code>.</p>
 		</div>
 		<div class="flex items-center gap-2">
-			<input id="relay-url" type="text" spellcheck="false" placeholder="https://relay…"
+			<input id="relay-url" type="text" spellcheck="false" placeholder="https://relay…" aria-label="Relay URL"
 				class="w-64 max-w-full bg-neutral-900 border border-neutral-700 rounded-md px-3 py-1.5 text-white text-sm font-mono focus:outline-none focus:border-emerald-600">
 			<span id="status"
 				class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium bg-neutral-900 border border-neutral-700">connecting…</span>

--- a/demo/web/src/stats.ts
+++ b/demo/web/src/stats.ts
@@ -248,8 +248,14 @@ function pushSample(key: string, s: Sample) {
 
 const sampler = new Signals.Effect();
 sampler.run((effect) => {
-	// Only sample while connected; the interval restarts on reconnect.
-	if (!effect.get(connection.established)) return;
+	// Only sample while connected; the interval restarts on reconnect. Drop the
+	// rolling history when disconnected so a reconnect doesn't splice new
+	// samples onto stale ones across the downtime gap.
+	if (!effect.get(connection.established)) {
+		history.clear();
+		clock.update((n) => n + 1);
+		return;
+	}
 	effect.interval(() => {
 		const all = nodeStats.peek();
 		const nodes = Object.keys(all);
@@ -580,6 +586,12 @@ function renderTable(container: HTMLElement, headers: string[], rows: Row[]) {
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
+// Monotonic counter for gradient element ids. SVG ids are document-global and
+// every chart re-renders into the same page, so the id must be unique per
+// gradient instance, not derived from the series (which collides across charts
+// and would make `url(#id)` resolve to the wrong gradient).
+let gradSeq = 0;
+
 interface Series {
 	values: number[];
 	color: string;
@@ -588,7 +600,8 @@ interface Series {
 // Render a multi-series area/line chart into a host element, filling its width.
 function renderChart(host: HTMLElement, series: Series[]) {
 	const rect = host.getBoundingClientRect();
-	const h = Math.max(1, Math.round(rect.height)) || 120;
+	// Fall back to a sane height if the host hasn't been laid out yet (0px).
+	const h = Math.round(rect.height) || 120;
 	const svg = makeChart(series, 600, h);
 	svg.classList.add("w-full", "h-full");
 	host.replaceChildren(svg);
@@ -623,11 +636,11 @@ function makeChart(series: Series[], vw: number, vh: number): SVGSVGElement {
 	const x = (i: number) => (i / (maxLen - 1)) * vw;
 	const y = (v: number) => vh - pad - (v / maxVal) * (vh - 2 * pad);
 
-	series.forEach((s, idx) => {
-		if (s.values.length < 2) return;
+	for (const s of series) {
+		if (s.values.length < 2) continue;
 		const pts = s.values.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`);
 
-		const gradId = `g${idx}-${Math.round(maxVal)}`;
+		const gradId = `moq-grad-${gradSeq++}`;
 		const grad = document.createElementNS(SVG_NS, "linearGradient");
 		grad.setAttribute("id", gradId);
 		grad.setAttribute("x1", "0");
@@ -659,7 +672,7 @@ function makeChart(series: Series[], vw: number, vh: number): SVGSVGElement {
 		line.setAttribute("vector-effect", "non-scaling-stroke");
 		line.setAttribute("stroke-linejoin", "round");
 		svg.appendChild(line);
-	});
+	}
 
 	return svg;
 }

--- a/demo/web/src/stats.ts
+++ b/demo/web/src/stats.ts
@@ -22,7 +22,8 @@
  *
  * Each frame is `{ "<broadcast path>": Snapshot }`. Counters are cumulative;
  * "active" = open - closed. The relay only includes currently-live entries, so
- * the latest frame is a snapshot of now.
+ * the latest frame is a snapshot of now. We sample the aggregate on an interval
+ * to derive per-second throughput rates for the charts.
  */
 
 import "./highlight";
@@ -32,6 +33,10 @@ const RELAY_URL = import.meta.env.VITE_RELAY_URL ?? "http://localhost:4443";
 
 // Broadcasts under this prefix are per-node stats broadcasts.
 const STATS_PREFIX = ".stats/node";
+
+// Rolling history window for the charts.
+const SAMPLE_MS = 1000;
+const MAX_SAMPLES = 90;
 
 const $ = <T extends HTMLElement>(id: string): T => {
 	const el = document.getElementById(id);
@@ -196,6 +201,108 @@ function aggregate(stats: NodeStats) {
 	};
 }
 
+const countSessions = (f: SessionFrame) =>
+	Object.values(f).reduce((n, s) => n + active(s.sessions, s.sessions_closed), 0);
+
+// ---- Time-series history ---------------------------------------------------
+
+// One sample captures cumulative byte counters (for rate charts) plus the
+// instantaneous gauges. Keyed by node name, with "" reserved for the
+// cluster-wide aggregate.
+interface Sample {
+	t: number;
+	egress: number; // cumulative external egress bytes
+	ingress: number; // cumulative external ingress bytes
+	clusterOut: number; // cumulative internal egress bytes
+	clusterIn: number; // cumulative internal ingress bytes
+	broadcasters: number;
+	viewers: number;
+	sessions: number;
+}
+
+const history = new Map<string, Sample[]>();
+// Bumped every sample so the chart effects re-render without making the whole
+// history map reactive.
+const clock = new Signals.Signal(0);
+
+function sampleNode(t: number, stats: NodeStats): Sample {
+	const a = aggregate(stats);
+	return {
+		t,
+		egress: a.external.egressBytes,
+		ingress: a.external.ingressBytes,
+		clusterOut: a.internal.egressBytes,
+		clusterIn: a.internal.ingressBytes,
+		broadcasters: a.external.broadcasters,
+		viewers: a.external.viewers,
+		sessions: countSessions(stats.sessions),
+	};
+}
+
+function pushSample(key: string, s: Sample) {
+	const arr = history.get(key) ?? [];
+	arr.push(s);
+	if (arr.length > MAX_SAMPLES) arr.shift();
+	history.set(key, arr);
+}
+
+const sampler = new Signals.Effect();
+sampler.run((effect) => {
+	// Only sample while connected; the interval restarts on reconnect.
+	if (!effect.get(connection.established)) return;
+	effect.interval(() => {
+		const all = nodeStats.peek();
+		const nodes = Object.keys(all);
+		const t = Date.now();
+
+		const agg: Sample = {
+			t,
+			egress: 0,
+			ingress: 0,
+			clusterOut: 0,
+			clusterIn: 0,
+			broadcasters: 0,
+			viewers: 0,
+			sessions: 0,
+		};
+		for (const node of nodes) {
+			const s = sampleNode(t, all[node] as NodeStats);
+			pushSample(node, s);
+			agg.egress += s.egress;
+			agg.ingress += s.ingress;
+			agg.clusterOut += s.clusterOut;
+			agg.clusterIn += s.clusterIn;
+			agg.broadcasters += s.broadcasters;
+			agg.viewers += s.viewers;
+			agg.sessions += s.sessions;
+		}
+		pushSample("", agg);
+
+		// Drop history for nodes that have gone away.
+		for (const key of history.keys()) {
+			if (key !== "" && !nodes.includes(key)) history.delete(key);
+		}
+
+		clock.update((n) => n + 1);
+	}, SAMPLE_MS);
+});
+
+// Convert a cumulative-counter series into a per-second rate series.
+function rateSeries(samples: Sample[], field: keyof Sample): number[] {
+	const out: number[] = [];
+	for (let i = 1; i < samples.length; i++) {
+		const dt = (samples[i].t - samples[i - 1].t) / 1000;
+		const delta = (samples[i][field] as number) - (samples[i - 1][field] as number);
+		out.push(dt > 0 ? Math.max(0, delta / dt) : 0);
+	}
+	return out;
+}
+
+const lastRate = (samples: Sample[], field: keyof Sample): number => {
+	const r = rateSeries(samples, field);
+	return r.length ? (r[r.length - 1] as number) : 0;
+};
+
 // ---- Render ---------------------------------------------------------------
 
 const ui = new Signals.Effect();
@@ -217,14 +324,15 @@ ui.run((effect) => {
 ui.run((effect) => {
 	const status = effect.get(connection.status);
 	const el = $("status");
-	el.textContent = status;
-	const color =
+	const dot = status === "connected" ? "bg-emerald-400" : status === "connecting" ? "bg-amber-400" : "bg-red-400";
+	const tone =
 		status === "connected"
-			? "text-emerald-400 border-emerald-700"
+			? "text-emerald-300 border-emerald-800"
 			: status === "connecting"
-				? "text-amber-400 border-amber-700"
-				: "text-red-400 border-red-700";
-	el.className = `inline-flex items-center px-2 py-1 rounded text-xs bg-neutral-900 border ${color}`;
+				? "text-amber-300 border-amber-800"
+				: "text-red-300 border-red-800";
+	el.className = `inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium bg-neutral-900 border ${tone}`;
+	el.replaceChildren(spanDot(dot), document.createTextNode(status));
 });
 
 // Keep a valid selection: default to the first node, switch away from one that
@@ -236,8 +344,43 @@ ui.run((effect) => {
 	selectedNode.set(nodes[0]);
 });
 
-// Aggregate table: one row per node, click to drill in.
+// Cluster summary cards.
 ui.run((effect) => {
+	effect.get(clock);
+	const all = nodeStats.peek();
+	const nodes = Object.keys(all);
+	const cluster = history.get("") ?? [];
+	const latest = cluster[cluster.length - 1];
+
+	$("kpi-nodes").textContent = String(nodes.length);
+	$("kpi-broadcasters").textContent = String(latest?.broadcasters ?? 0);
+	$("kpi-viewers").textContent = String(latest?.viewers ?? 0);
+	$("kpi-sessions").textContent = String(latest?.sessions ?? 0);
+	$("kpi-egress").textContent = formatRate(lastRate(cluster, "egress"));
+	$("kpi-ingress").textContent = formatRate(lastRate(cluster, "ingress"));
+});
+
+// Cluster throughput chart.
+ui.run((effect) => {
+	effect.get(clock);
+	const cluster = history.get("") ?? [];
+	const egress = rateSeries(cluster, "egress");
+	const ingress = rateSeries(cluster, "ingress");
+	const peer = rateSeries(cluster, "clusterOut");
+
+	renderChart($("chart-throughput"), [
+		{ values: egress, color: "#34d399" }, // emerald-400
+		{ values: ingress, color: "#38bdf8" }, // sky-400
+		{ values: peer, color: "#a78bfa" }, // violet-400
+	]);
+	$("legend-egress").textContent = formatRate(egress[egress.length - 1] ?? 0);
+	$("legend-ingress").textContent = formatRate(ingress[ingress.length - 1] ?? 0);
+	$("legend-cluster").textContent = formatRate(peer[peer.length - 1] ?? 0);
+});
+
+// Node cards: one per node with a live egress sparkline. Click to drill in.
+ui.run((effect) => {
+	effect.get(clock);
 	const all = effect.get(nodeStats);
 	const sel = effect.get(selectedNode);
 	const nodes = Object.keys(all).sort();
@@ -245,30 +388,16 @@ ui.run((effect) => {
 
 	if (nodes.length === 0) {
 		el.textContent = "searching for nodes…";
+		el.className = "text-neutral-500 text-sm";
 		return;
 	}
-
-	const headers = ["node", "broadcasters", "viewers", "ingress", "egress", "cluster in", "cluster out"];
-	const rows = nodes.map((node) => {
-		const a = aggregate(all[node] as NodeStats);
-		return {
-			key: node,
-			cells: [
-				node,
-				String(a.external.broadcasters),
-				String(a.external.viewers),
-				formatBytes(a.external.ingressBytes),
-				formatBytes(a.external.egressBytes),
-				formatBytes(a.internal.ingressBytes),
-				formatBytes(a.internal.egressBytes),
-			],
-		};
-	});
-	renderTable(effect, el, headers, rows, { selected: sel, onClick: (k) => selectedNode.set(k) });
+	el.className = "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3";
+	el.replaceChildren(...nodes.map((node) => nodeCard(effect, node, history.get(node) ?? [], node === sel)));
 });
 
-// Drill-down: the selected node's broadcasts (egress-focused) + sessions.
+// Drill-down for the selected node.
 ui.run((effect) => {
+	effect.get(clock);
 	const all = effect.get(nodeStats);
 	const node = effect.get(selectedNode);
 	const detail = $("node-detail");
@@ -281,6 +410,16 @@ ui.run((effect) => {
 	detail.hidden = false;
 	$("node-title").textContent = node;
 
+	const samples = history.get(node) ?? [];
+	renderChart($("chart-node-external"), [
+		{ values: rateSeries(samples, "egress"), color: "#34d399" },
+		{ values: rateSeries(samples, "ingress"), color: "#38bdf8" },
+	]);
+	renderChart($("chart-node-cluster"), [
+		{ values: rateSeries(samples, "clusterOut"), color: "#a78bfa" },
+		{ values: rateSeries(samples, "clusterIn"), color: "#e879f9" }, // fuchsia-400
+	]);
+
 	// Broadcasters: what this node ingests (from upstream publishers / cluster peers).
 	const ingressRows = (frame: BroadcastFrame) =>
 		Object.keys(frame)
@@ -288,10 +427,7 @@ ui.run((effect) => {
 			.sort()
 			.map((path) => {
 				const i = frame[path] ?? {};
-				return {
-					key: path,
-					cells: [path, formatBytes(i.bytes ?? 0), String(i.frames ?? 0), String(i.groups ?? 0)],
-				};
+				return { key: path, cells: [path, formatBytes(i.bytes ?? 0), String(i.frames ?? 0)] };
 			});
 
 	// Viewers: what this node serves downstream (to subscribers / cluster peers).
@@ -306,71 +442,118 @@ ui.run((effect) => {
 					cells: [
 						path,
 						String(active(e.broadcasts, e.broadcasts_closed)), // viewers / peers
-						String(active(e.subscriptions, e.subscriptions_closed)), // track subs
 						formatBytes(e.bytes ?? 0), // egress
 						String(e.frames ?? 0),
-						String(e.groups ?? 0),
 					],
 				};
 			});
 
-	const inHeaders = ["broadcast", "ingress", "frames", "groups"];
-	const outHeaders = ["broadcast", "viewers", "track subs", "egress", "frames", "groups"];
-
-	renderTable(effect, $("node-publishers"), inHeaders, ingressRows(stats.ingress));
-	renderTable(effect, $("node-subscribers"), outHeaders, egressRows(stats.egress));
+	renderTable($("node-publishers"), ["broadcast", "ingress", "frames"], ingressRows(stats.ingress));
+	renderTable($("node-subscribers"), ["broadcast", "viewers", "egress", "frames"], egressRows(stats.egress));
+	renderTable($("node-internal-publishers"), ["broadcast", "ingress", "frames"], ingressRows(stats.internalIngress));
 	renderTable(
-		effect,
-		$("node-internal-publishers"),
-		["broadcast", "ingress", "frames", "groups"],
-		ingressRows(stats.internalIngress),
-	);
-	renderTable(
-		effect,
 		$("node-internal-subscribers"),
-		["broadcast", "peers", "track subs", "egress", "frames", "groups"],
+		["broadcast", "peers", "egress", "frames"],
 		egressRows(stats.internalEgress),
 	);
 
-	const countSessions = (f: SessionFrame) =>
-		Object.values(f).reduce((n, s) => n + active(s.sessions, s.sessions_closed), 0);
 	const sessions = countSessions(stats.sessions);
 	const internalSessions = countSessions(stats.internalSessions);
-	$("node-sessions").textContent = `${sessions} external session${sessions === 1 ? "" : "s"}`;
-	$("node-internal-sessions").textContent = `${internalSessions} cluster session${internalSessions === 1 ? "" : "s"}`;
+	$("node-sessions").textContent = `${sessions} session${sessions === 1 ? "" : "s"}`;
+	$("node-internal-sessions").textContent = `${internalSessions} cluster`;
 });
 
-// Raw frames for everyone who wants the numbers behind the tables.
+// Raw frames for everyone who wants the numbers behind the charts.
 ui.run((effect) => {
 	$("raw").textContent = JSON.stringify(effect.get(nodeStats), null, 2);
 });
 
-// ---- Helpers --------------------------------------------------------------
+// ---- DOM helpers -----------------------------------------------------------
+
+function spanDot(colorClass: string): HTMLSpanElement {
+	const s = document.createElement("span");
+	s.className = `inline-block w-2 h-2 rounded-full ${colorClass}`;
+	return s;
+}
+
+// A clickable card summarizing one node, with a live egress sparkline.
+function nodeCard(effect: Signals.Effect, node: string, samples: Sample[], selected: boolean): HTMLElement {
+	const latest = samples[samples.length - 1];
+	const card = document.createElement("div");
+	card.className = [
+		"rounded-lg border bg-neutral-900/50 p-3 cursor-pointer transition-colors",
+		selected ? "border-emerald-600 ring-1 ring-emerald-600/40" : "border-neutral-800 hover:border-neutral-600",
+	].join(" ");
+	card.tabIndex = 0;
+	card.setAttribute("role", "button");
+
+	const head = document.createElement("div");
+	head.className = "flex items-center justify-between gap-2 mb-2";
+	const name = document.createElement("span");
+	name.className = "font-mono text-sm text-neutral-200 truncate";
+	name.textContent = node;
+	const rate = document.createElement("span");
+	rate.className = "text-sm font-semibold tabular-nums text-emerald-400 whitespace-nowrap";
+	rate.textContent = formatRate(lastRate(samples, "egress"));
+	head.append(name, rate);
+
+	const spark = makeChart([{ values: rateSeries(samples, "egress"), color: "#34d399" }], 200, 36);
+	spark.classList.add("w-full", "h-9", "mb-2");
+
+	const stats = document.createElement("div");
+	stats.className = "flex items-center gap-4 text-xs text-neutral-400";
+	stats.append(
+		stat("broadcasters", latest?.broadcasters ?? 0, "text-sky-300"),
+		stat("viewers", latest?.viewers ?? 0, "text-emerald-300"),
+		stat("sessions", latest?.sessions ?? 0, "text-neutral-200"),
+	);
+
+	card.append(head, spark, stats);
+
+	const activate = () => selectedNode.set(node);
+	effect.event(card, "click", activate);
+	effect.event(card, "keydown", (e) => {
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault();
+			activate();
+		}
+	});
+	return card;
+}
+
+function stat(label: string, value: number, valueClass: string): HTMLElement {
+	const wrap = document.createElement("span");
+	wrap.className = "flex items-center gap-1";
+	const v = document.createElement("span");
+	v.className = `font-semibold tabular-nums ${valueClass}`;
+	v.textContent = String(value);
+	const l = document.createElement("span");
+	l.className = "text-neutral-500";
+	l.textContent = label;
+	wrap.append(v, l);
+	return wrap;
+}
 
 interface Row {
 	key: string;
 	cells: string[];
 }
 
-function renderTable(
-	effect: Signals.Effect,
-	container: HTMLElement,
-	headers: string[],
-	rows: Row[],
-	opts?: { selected?: string; onClick?: (key: string) => void },
-) {
+function renderTable(container: HTMLElement, headers: string[], rows: Row[]) {
 	if (rows.length === 0) {
-		container.textContent = "no active entries";
+		container.textContent = "none";
+		container.className = "text-neutral-600 text-xs italic";
 		return;
 	}
+	container.className = "overflow-x-auto";
 	const table = document.createElement("table");
-	table.className = "w-full text-sm border-collapse";
+	table.className = "w-full text-xs border-collapse";
 
 	const thead = document.createElement("thead");
 	const htr = document.createElement("tr");
 	for (const h of headers) {
 		const th = document.createElement("th");
-		th.className = "text-left font-medium text-neutral-400 px-2 py-1 border-b border-neutral-700";
+		th.className = "text-left font-medium text-neutral-500 px-2 py-1 border-b border-neutral-800";
 		th.textContent = h;
 		htr.appendChild(th);
 	}
@@ -380,24 +563,10 @@ function renderTable(
 	const tbody = document.createElement("tbody");
 	for (const row of rows) {
 		const tr = document.createElement("tr");
-		tr.className = "border-b border-neutral-800";
-		if (opts?.onClick) {
-			tr.classList.add("cursor-pointer", "hover:bg-neutral-800");
-			tr.tabIndex = 0;
-			tr.setAttribute("role", "button");
-			if (row.key === opts.selected) tr.classList.add("bg-neutral-800", "text-emerald-300");
-			const activate = () => opts.onClick?.(row.key);
-			effect.event(tr, "click", activate);
-			effect.event(tr, "keydown", (e) => {
-				if (e.key === "Enter" || e.key === " ") {
-					e.preventDefault();
-					activate();
-				}
-			});
-		}
+		tr.className = "border-b border-neutral-900";
 		for (const cell of row.cells) {
 			const td = document.createElement("td");
-			td.className = "px-2 py-1 font-mono text-neutral-200 whitespace-nowrap";
+			td.className = "px-2 py-1 font-mono text-neutral-300 whitespace-nowrap";
 			td.textContent = cell;
 			tr.appendChild(td);
 		}
@@ -407,9 +576,108 @@ function renderTable(
 	container.replaceChildren(table);
 }
 
+// ---- SVG charts ------------------------------------------------------------
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+interface Series {
+	values: number[];
+	color: string;
+}
+
+// Render a multi-series area/line chart into a host element, filling its width.
+function renderChart(host: HTMLElement, series: Series[]) {
+	const rect = host.getBoundingClientRect();
+	const h = Math.max(1, Math.round(rect.height)) || 120;
+	const svg = makeChart(series, 600, h);
+	svg.classList.add("w-full", "h-full");
+	host.replaceChildren(svg);
+}
+
+// Build an SVG chart in a `vw`×`vh` viewBox. All series share one vertical
+// scale so they're directly comparable. `preserveAspectRatio="none"` lets it
+// stretch to any container width; only straight lines are drawn so the
+// non-uniform scaling stays invisible.
+function makeChart(series: Series[], vw: number, vh: number): SVGSVGElement {
+	const svg = document.createElementNS(SVG_NS, "svg");
+	svg.setAttribute("viewBox", `0 0 ${vw} ${vh}`);
+	svg.setAttribute("preserveAspectRatio", "none");
+
+	const lens = series.map((s) => s.values.length);
+	const maxLen = Math.max(0, ...lens);
+	const maxVal = Math.max(1, ...series.flatMap((s) => s.values));
+
+	// Baseline along the bottom even before data arrives.
+	const baseline = document.createElementNS(SVG_NS, "line");
+	baseline.setAttribute("x1", "0");
+	baseline.setAttribute("y1", String(vh - 1));
+	baseline.setAttribute("x2", String(vw));
+	baseline.setAttribute("y2", String(vh - 1));
+	baseline.setAttribute("stroke", "#404040"); // neutral-700
+	baseline.setAttribute("stroke-width", "1");
+	svg.appendChild(baseline);
+
+	if (maxLen < 2) return svg;
+
+	const pad = 2;
+	const x = (i: number) => (i / (maxLen - 1)) * vw;
+	const y = (v: number) => vh - pad - (v / maxVal) * (vh - 2 * pad);
+
+	series.forEach((s, idx) => {
+		if (s.values.length < 2) return;
+		const pts = s.values.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`);
+
+		const gradId = `g${idx}-${Math.round(maxVal)}`;
+		const grad = document.createElementNS(SVG_NS, "linearGradient");
+		grad.setAttribute("id", gradId);
+		grad.setAttribute("x1", "0");
+		grad.setAttribute("y1", "0");
+		grad.setAttribute("x2", "0");
+		grad.setAttribute("y2", "1");
+		for (const [offset, opacity] of [
+			["0%", "0.35"],
+			["100%", "0"],
+		]) {
+			const stop = document.createElementNS(SVG_NS, "stop");
+			stop.setAttribute("offset", offset);
+			stop.setAttribute("stop-color", s.color);
+			stop.setAttribute("stop-opacity", opacity);
+			grad.appendChild(stop);
+		}
+		svg.appendChild(grad);
+
+		const area = document.createElementNS(SVG_NS, "path");
+		area.setAttribute("d", `M0,${vh} L${pts.join(" L")} L${vw},${vh} Z`);
+		area.setAttribute("fill", `url(#${gradId})`);
+		svg.appendChild(area);
+
+		const line = document.createElementNS(SVG_NS, "polyline");
+		line.setAttribute("points", pts.join(" "));
+		line.setAttribute("fill", "none");
+		line.setAttribute("stroke", s.color);
+		line.setAttribute("stroke-width", "1.5");
+		line.setAttribute("vector-effect", "non-scaling-stroke");
+		line.setAttribute("stroke-linejoin", "round");
+		svg.appendChild(line);
+	});
+
+	return svg;
+}
+
+// ---- Formatting ------------------------------------------------------------
+
 function formatBytes(n: number): string {
 	if (n < 1024) return `${n} B`;
 	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
 	if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 	return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+// Throughput as bits/second (Mbps is how operators think about a relay).
+function formatRate(bytesPerSec: number): string {
+	const bits = bytesPerSec * 8;
+	if (bits < 1000) return `${Math.round(bits)} bps`;
+	if (bits < 1_000_000) return `${(bits / 1000).toFixed(0)} kbps`;
+	if (bits < 1_000_000_000) return `${(bits / 1_000_000).toFixed(1)} Mbps`;
+	return `${(bits / 1_000_000_000).toFixed(2)} Gbps`;
 }

--- a/demo/web/src/stats.ts
+++ b/demo/web/src/stats.ts
@@ -246,6 +246,11 @@ function pushSample(key: string, s: Sample) {
 	history.set(key, arr);
 }
 
+// The set of nodes in the most recent cluster-aggregate sample. The aggregate
+// sums cumulative per-node counters, so when membership changes the summed
+// baseline jumps; we reset the aggregate series rather than splice the jump in.
+let clusterMembership = "";
+
 const sampler = new Signals.Effect();
 sampler.run((effect) => {
 	// Only sample while connected; the interval restarts on reconnect. Drop the
@@ -253,12 +258,13 @@ sampler.run((effect) => {
 	// samples onto stale ones across the downtime gap.
 	if (!effect.get(connection.established)) {
 		history.clear();
+		clusterMembership = "";
 		clock.update((n) => n + 1);
 		return;
 	}
 	effect.interval(() => {
 		const all = nodeStats.peek();
-		const nodes = Object.keys(all);
+		const nodes = Object.keys(all).sort();
 		const t = Date.now();
 
 		const agg: Sample = {
@@ -281,6 +287,13 @@ sampler.run((effect) => {
 			agg.broadcasters += s.broadcasters;
 			agg.viewers += s.viewers;
 			agg.sessions += s.sessions;
+		}
+		// A changed node set makes this aggregate's baseline incompatible with the
+		// previous one, so start the cluster series fresh instead of splicing.
+		const membership = nodes.join("\0");
+		if (membership !== clusterMembership) {
+			history.delete("");
+			clusterMembership = membership;
 		}
 		pushSample("", agg);
 
@@ -385,9 +398,11 @@ ui.run((effect) => {
 });
 
 // Node cards: one per node with a live egress sparkline. Click to drill in.
+// Driven by `clock` (sampled cadence), not raw `nodeStats` frames, so cards
+// don't rebuild (and drop focus) on every incoming frame.
 ui.run((effect) => {
 	effect.get(clock);
-	const all = effect.get(nodeStats);
+	const all = nodeStats.peek();
 	const sel = effect.get(selectedNode);
 	const nodes = Object.keys(all).sort();
 	const el = $("nodes");

--- a/demo/web/vite.config.ts
+++ b/demo/web/vite.config.ts
@@ -14,8 +14,8 @@ export default defineConfig({
 		solidPlugin(),
 		workletInline(),
 		consoleOverlay(),
-		// Open the watch and publish demos each in their own tab.
-		openTabs(["index.html", "publish.html"]),
+		// Open the watch, publish, and stats demos each in their own tab.
+		openTabs(["index.html", "publish.html", "stats.html"]),
 	],
 	build: {
 		target: "esnext",


### PR DESCRIPTION
## Summary

The relay stats dashboard (`demo/web/stats.html`) was a wall of explanatory paragraphs and dense tables. This redesigns it into a visual dashboard that surfaces the headline numbers at a glance and graphs throughput over time, with far less prose.

- **KPI cards** across the top: nodes, broadcasters, viewers, egress, ingress, sessions, color-coded.
- **Time-series history**: a sampler effect keeps a 90-sample rolling window (1s interval) and derives per-second rates from the cumulative byte counters.
- **Hand-rolled SVG area charts** (no new dependency, fitting for a demo):
  - a cluster-wide throughput chart with egress / ingress / cluster-peer lines and a live legend,
  - a live egress sparkline on each per-node card,
  - external + cluster-peer throughput charts in the node drill-down.
- **Nodes are clickable cards** with a sparkline instead of a table row. Drill-down tables trimmed (dropped the `groups` column and the long per-section copy).
- Throughput rendered in bits/s (kbps/Mbps/Gbps, how operators think about a relay). Status pill gained a colored dot. Sampling pauses while disconnected.
- **`just dev` now opens the stats tab automatically** alongside watch and publish (the open-tabs plugin doc already promised this; stats.html was just missing from the list).

All subscription/aggregation logic (node discovery, the external/internal tier split, `.`-prefixed system-broadcast exclusion) is unchanged; only the rendering layer was rewritten and a sampling layer added.

## Why

The old page buried the few numbers that matter under multiple paragraphs of explanation and six wide tables. The request was simply to make it look a lot better with graphs and less text.

## Testing

- `tsc --noEmit` and Biome clean.
- Ran the full `just dev` stack (relay with `[stats]` enabled + looping BBB broadcast + a watch tab) and confirmed against **live traffic**: KPI cards, the cluster throughput chart, and the per-node sparkline card all populate; the drill-down shows external throughput, broadcaster/viewer tables (ingress/egress/frames), and a clean `none` empty-state for the cluster-peer sections on a single node. No console errors.

## Reviewer notes

- **No public API or wire changes** — this is demo-only, hence targeting `main`.
- The dev-only `moq-console` overlay still logs benign "garbage collected / did not subscribe" warnings; these come from the relay-URL input's event-only effect (same pattern as the original code) plus HMR source-map line drift. That overlay is injected by a Vite dev plugin and stripped from production builds, so it is pre-existing dev noise, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)