### PR TITLE
fix(demo/web): close demo effects on HMR; rename index.html to watch.html

### DIFF
--- a/demo/web/README.md
+++ b/demo/web/README.md
@@ -17,7 +17,7 @@ We're using Vite but other bundlers should work too.
 
 Run `just web` (or `bun --bun vite` from this directory) and open the pages:
 
-- `index.html` - Watch inspector: one tile per live broadcast discovered under a prefix, click to make a tile active (audio + a live stats panel for video/audio/network and a custom `meta.json` metadata track).
+- `watch.html` - Watch inspector: one tile per live broadcast discovered under a prefix, click to make a tile active (audio + a live stats panel for video/audio/network and a custom `meta.json` metadata track).
 - `publish.html` - Publish from a camera/screen/file, plus an editor for the custom `meta.json` metadata track.
 - `stats.html` - Relay stats dashboard: auto-discovers every node publishing `.stats` and aggregates external vs. cluster traffic. Needs `[stats] enabled = true` on the relay (the demo configs already set it).
 

--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -347,20 +347,12 @@ ui.run((effect) => {
 });
 
 // Network section: only shown while connected to the relay with an active tile.
+// The throughput (video + audio bitrate) lives in the graph below, so there are
+// no static rows here.
 ui.run((effect) => {
 	const connected = effect.get(connection.status) === "connected";
 	const watch = effect.get(activeWatch);
-	const section = $("network-section");
-	if (!connected || !watch) {
-		section.hidden = true;
-		return;
-	}
-	section.hidden = false;
-
-	const video = effect.get(watch.backend.video.stats);
-	const audio = effect.get(watch.backend.audio.stats);
-	const bytes = (video?.bytesReceived ?? 0) + (audio?.bytesReceived ?? 0);
-	renderRows($("network-info"), [["bytes received", bytes > 0 ? formatBytes(bytes) : undefined]]);
+	$("network-section").hidden = !connected || !watch;
 });
 
 // Raw catalog (collapsible) - only rendered once the active catalog arrives.
@@ -445,12 +437,12 @@ ui.run((effect) => {
 
 const viz = new Signals.Effect();
 
-// Video bitrate is video-only; the Network "Throughput" graph is video + audio.
+// This video bitrate is video-only; the Network section's "Bitrate" graph is video + audio.
 const bitrateGraph = graph(viz, "Bitrate", { color: "#a855f7", format: formatBitrate });
 const fpsGraph = graph(viz, "Frame rate", { color: "#facc15", format: formatFps });
 $("video-graphs").append(bitrateGraph.el, fpsGraph.el);
 
-const throughputGraph = graph(viz, "Throughput", { color: "#34d399", format: formatBitrate });
+const throughputGraph = graph(viz, "Bitrate", { color: "#34d399", format: formatBitrate });
 const rttGraph = graph(viz, "Round trip", { color: "#38bdf8", format: (v) => `${Math.round(v)} ms` });
 $("network-graphs").append(throughputGraph.el, rttGraph.el);
 
@@ -528,8 +520,14 @@ function setPill(statusId: string, textId: string, label: string, state: "ok" | 
 	dot.className = `dot w-2 h-2 rounded-full ${color}`;
 }
 
-function formatBytes(n: number): string {
-	if (n < 1024) return `${n} B`;
-	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-	return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+// Vite re-evaluates this module on hot reload, dropping the references to the
+// module-scoped effects/connection above. Close them on dispose so they don't
+// get garbage collected unclosed (which the signals library warns about).
+if (import.meta.hot) {
+	import.meta.hot.dispose(() => {
+		for (const effect of [discovery, tilesEffect, ui, viz, metaEffect]) effect.close();
+		for (const tile of tiles.values()) tile.close();
+		tiles.clear();
+		connection.close();
+	});
 }

--- a/demo/web/src/publish.html
+++ b/demo/web/src/publish.html
@@ -241,7 +241,7 @@ publish.broadcast.audio.codec.set({ mime: "opus", bitrate: 64_000 });</code></pr
 			appears to the right once you go live. Codec support is probed with
 			<code class="language-typescript">VideoEncoder.isConfigSupported</code>; unsupported options are
 			disabled. The <code>simulcast</code> attribute also publishes a smaller <code>video/sd</code>
-			rendition (the panel tunes <code>video/hd</code>); the <a href="index.html">watch inspector</a>
+			rendition (the panel tunes <code>video/hd</code>); the <a href="watch.html">watch inspector</a>
 			picks whichever fits the player size.
 		</p>
 		<p>
@@ -262,7 +262,7 @@ publish.broadcast.audio.codec.set({ mime: "opus", bitrate: 64_000 });</code></pr
 
 		<h3>Other demos:</h3>
 		<ul>
-			<li><a href="index.html" target="_blank" rel="noreferrer">Watch broadcasts.</a></li>
+			<li><a href="watch.html" target="_blank" rel="noreferrer">Watch broadcasts.</a></li>
 			<li><a href="stats.html">Relay stats dashboard.</a></li>
 		</ul>
 	</footer>

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -372,3 +372,12 @@ viz.interval(() => {
 	const rtt = conn?.rtt?.peek() as unknown as number | undefined;
 	rttGraph.push(rtt && rtt > 0 ? rtt : undefined);
 }, 250);
+
+// Vite re-evaluates this module on hot reload, dropping the references to the
+// module-scoped effects above. Close them on dispose so they don't get garbage
+// collected unclosed (which the signals library warns about).
+if (import.meta.hot) {
+	import.meta.hot.dispose(() => {
+		for (const effect of [ui, viz]) effect.close();
+	});
+}

--- a/demo/web/src/stats.html
+++ b/demo/web/src/stats.html
@@ -91,7 +91,7 @@
 	<div class="prose-doc mt-8">
 		<h3>Other demos:</h3>
 		<ul>
-			<li><a href="index.html">Watch broadcasts.</a></li>
+			<li><a href="watch.html">Watch broadcasts.</a></li>
 			<li><a href="publish.html">Publish a broadcast.</a></li>
 		</ul>
 	</div>

--- a/demo/web/src/stats.ts
+++ b/demo/web/src/stats.ts
@@ -413,3 +413,13 @@ function formatBytes(n: number): string {
 	if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 	return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
+
+// Vite re-evaluates this module on hot reload, dropping the references to the
+// module-scoped effects/connection above. Close them on dispose so they don't
+// get garbage collected unclosed (which the signals library warns about).
+if (import.meta.hot) {
+	import.meta.hot.dispose(() => {
+		for (const effect of [discovery, ui]) effect.close();
+		connection.close();
+	});
+}

--- a/demo/web/src/watch.html
+++ b/demo/web/src/watch.html
@@ -77,8 +77,7 @@
 				<h3 class="text-sm font-semibold text-neutral-300 mb-2 flex items-center gap-2">
 					Network <span class="text-[10px] px-1.5 py-0.5 rounded bg-emerald-900 text-emerald-200 font-medium">WebTransport</span>
 				</h3>
-				<div id="network-info" class="space-y-0.5"></div>
-				<div id="network-graphs" class="mt-3 space-y-2"></div>
+				<div id="network-graphs" class="space-y-2"></div>
 			</section>
 
 			<section id="buffer-section" class="rounded-lg border border-neutral-700 bg-neutral-900 p-3 mb-3" hidden>

--- a/demo/web/vite.config.ts
+++ b/demo/web/vite.config.ts
@@ -15,14 +15,14 @@ export default defineConfig({
 		workletInline(),
 		consoleOverlay(),
 		// Open the watch and publish demos each in their own tab.
-		openTabs(["index.html", "publish.html"]),
+		openTabs(["watch.html", "publish.html"]),
 	],
 	build: {
 		target: "esnext",
 		sourcemap: process.env.NODE_ENV === "production" ? false : "inline",
 		rollupOptions: {
 			input: {
-				watch: resolve(__dirname, "src/index.html"),
+				watch: resolve(__dirname, "src/watch.html"),
 				publish: resolve(__dirname, "src/publish.html"),
 				stats: resolve(__dirname, "src/stats.html"),
 			},


### PR DESCRIPTION
## Summary

Fixes the `Signals was garbage collected without being closed` warnings on the demo pages, plus two small cleanups to the watch inspector.

- **HMR leak fix.** The watch/publish/stats entrypoints create module-scoped `Signals.Effect`s that live for the page lifetime and are never closed. Under Vite HMR, a hot reload re-evaluates the module and drops the references, so the old effects get garbage-collected unclosed and trip the signals leak detector. Each entrypoint now registers an `import.meta.hot.dispose` handler that closes its module-scoped effects (plus the open tiles and discovery connection in `index.ts`). It stays dormant while `server.hmr` is `false` (the current config), and activates automatically once HMR is enabled (the `// TODO: properly support HMR` in `vite.config.ts`).
- **Rename `index.html` → `watch.html`.** The dev server opens pages explicitly via `openTabs`, so there's no need for an implicit `index`. Updated the vite `rollupOptions` input and `openTabs` list, plus the cross-demo links in `publish.html`, `stats.html`, and the README. Done via `git mv` so history is preserved.
- **De-duplicate the Network section.** The watch inspector's Network panel showed both a static `bytes received` row and a throughput graph (the same information). Dropped the row, renamed the graph `Throughput` → `Bitrate` (it's a bits/sec rate), and removed the now-unused `formatBytes` helper and empty `network-info` element.

## Notes for reviewers

- Demo-only changes; no public API, wire, or catalog/container changes, so this targets `main`.
- After the rename there is no page served at `/` (the demos are opened by path), which matches how `openTabs` already works.
- The Video section keeps its own purple `Bitrate` graph (video-only); the Network section's renamed graph is the video+audio total. They're disambiguated by section. Happy to rename the network one to `Bytes received` instead if you'd prefer them visually distinct.

## Test plan

- [ ] `bun --bun vite` (via `just web`) opens `watch.html`, `publish.html`, `stats.html`; the cross-demo links navigate correctly.
- [ ] Watch inspector Network section shows only the Bitrate + Round trip graphs (no `bytes received` row).
- [ ] With `server.hmr` flipped to `true`, editing a demo `.ts` no longer logs `Signals was garbage collected without being closed`.

(Written by Claude)