### PR TITLE
feat(moq-srt,moq-rtc): bring-your-own-auth Server/Request + whep::accept

### DIFF
--- a/rs/moq-rtc/src/lib.rs
+++ b/rs/moq-rtc/src/lib.rs
@@ -20,10 +20,17 @@
 //! in another process: build a [`Server`] over your own
 //! [`OriginProducer`](moq_net::OriginProducer) /
 //! [`OriginConsumer`](moq_net::OriginConsumer) and merge
-//! [`Server::publish_router`] into your own axum app, or dial out with
-//! [`Client`]. That lean build skips the standalone binary's deps
-//! (axum-server, clap, moq-native, rustls, sd-notify, tower-http), which the
-//! `server` feature (on by default) pulls back in for the `moq-rtc` binary.
+//! [`Server::publish_router`] / [`Server::subscribe_router`] into your own axum
+//! app, or dial out with [`Client`]. That lean build skips the standalone
+//! binary's deps (axum-server, clap, moq-native, rustls, sd-notify, tower-http),
+//! which the `server` feature (on by default) pulls back in for the `moq-rtc`
+//! binary.
+//!
+//! The bundled routers are unauthenticated: they derive the broadcast name from
+//! the request path. To own the HTTP route and authorize requests yourself
+//! (resolving the broadcast name from a verified token), skip the routers and
+//! call [`whip::accept`] (ingest) / [`whep::accept`] (egress) from your own
+//! handler.
 //!
 //! ## Bitstream gotcha
 //!
@@ -43,4 +50,4 @@ pub mod session;
 
 pub use client::Client;
 pub use error::*;
-pub use server::{Server, whip};
+pub use server::{Response, Server, whep, whip};

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -14,6 +14,17 @@ use std::sync::Arc;
 
 use axum::Router;
 
+/// The result of a WHIP/WHEP [`whip::accept`] / [`whep::accept`]: the SDP answer
+/// to return to the client, plus an opaque resource id for the `Location` header
+/// (the RFC 9725 session resource URL).
+#[derive(Clone, Debug)]
+pub struct Response {
+	/// Opaque id identifying the negotiated session, for the `Location` header.
+	pub resource_id: String,
+	/// The SDP answer body (`Content-Type: application/sdp`).
+	pub answer: String,
+}
+
 /// Configuration shared by both `server publish` and `server subscribe`.
 #[derive(Clone, Debug, Default)]
 pub struct Config {
@@ -40,9 +51,7 @@ pub struct Server {
 struct Inner {
 	config: Config,
 	publisher: moq_net::OriginProducer,
-	// Held for `server subscribe`, which is gated until the per-codec
-	// re-packetizers land.
-	#[allow(dead_code)]
+	/// Source for `server subscribe` (WHEP) egress.
 	subscriber: moq_net::OriginConsumer,
 }
 
@@ -72,6 +81,11 @@ impl Server {
 
 	/// Router for `server subscribe` (WHEP). Mount under whichever HTTP path
 	/// the deployment prefers (`/whep`, `/`, ...).
+	///
+	/// The router derives the broadcast name from the request path and performs
+	/// no authentication. To own the route and authorize requests yourself
+	/// (resolving the broadcast name from a verified token), skip the router and
+	/// call [`whep::accept`] directly from your own handler.
 	pub fn subscribe_router(&self) -> Router {
 		whep::router(self.clone())
 	}
@@ -84,7 +98,6 @@ impl Server {
 		&self.inner.publisher
 	}
 
-	#[allow(dead_code)]
 	pub(crate) fn subscriber(&self) -> &moq_net::OriginConsumer {
 		&self.inner.subscriber
 	}

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -8,21 +8,24 @@ use axum::{
 	body::Bytes,
 	extract::{Path, State},
 	http::{HeaderMap, HeaderValue, StatusCode, header},
-	response::{IntoResponse, Response},
+	response::{IntoResponse, Response as HttpResponse},
 	routing::post,
 };
 use str0m::Candidate;
 
 use crate::{Error, Result, egress::EgressSource, sdp, server::Server, session};
 
+pub use crate::server::Response;
+
+/// Build the WHEP axum router.
 pub fn router(server: Server) -> Router {
 	Router::new().route("/{*path}", post(handle)).with_state(server)
 }
 
-async fn handle(server: State<Server>, path: Path<String>, headers: HeaderMap, body: Bytes) -> Response {
+async fn handle(server: State<Server>, path: Path<String>, headers: HeaderMap, body: Bytes) -> HttpResponse {
 	let (server, path) = (server.0, path.0);
 	match accept_offer(&server, &path, &headers, body).await {
-		Ok((resource_id, answer)) => {
+		Ok(Response { resource_id, answer }) => {
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
 			if let Ok(loc) = HeaderValue::from_str(&format!("/{path}/{resource_id}")) {
@@ -37,19 +40,41 @@ async fn handle(server: State<Server>, path: Path<String>, headers: HeaderMap, b
 	}
 }
 
-async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: Bytes) -> Result<(String, String)> {
+/// Router glue: enforce the WHEP `Content-Type` then hand the raw offer to
+/// [`accept`], using the request path as the (unauthenticated) broadcast name.
+async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: Bytes) -> Result<Response> {
 	if !is_sdp(headers) {
 		return Err(Error::InvalidSdp("expected Content-Type: application/sdp".into()));
 	}
-	let sdp = std::str::from_utf8(&body).map_err(|err| Error::InvalidSdp(err.to_string()))?;
-	let offer = sdp::parse_offer(sdp)?;
+	let offer = std::str::from_utf8(&body).map_err(|err| Error::InvalidSdp(err.to_string()))?;
+	accept(server, path, offer).await
+}
+
+/// Accept a WHEP SDP offer and egress the MoQ broadcast `broadcast` (a path
+/// relative to the subscribe origin's root) to the negotiated WebRTC peer.
+///
+/// This is the negotiation core behind [`router`], exposed so an embedder can own
+/// the HTTP route and authentication: verify the request, resolve the authorized
+/// broadcast name, then hand the raw SDP offer here. It parses the offer, resolves
+/// the broadcast on the subscribe origin, restricts the answer to the codecs the
+/// catalog actually has, binds the ICE socket, spawns the MoQ->RTP session, and
+/// returns the SDP answer plus an opaque `resource_id` for the WHEP `Location`
+/// header. Mirrors [`whip::accept`](super::whip::accept).
+///
+/// `offer` is the raw SDP body; the caller is responsible for checking the
+/// `Content-Type: application/sdp` request header. Fails with [`Error::InvalidSdp`]
+/// on a malformed offer, and surfaces a not-announced broadcast (or one outside
+/// the subscribe origin's scope) as [`Error::Other`].
+pub async fn accept(server: &Server, broadcast: impl moq_net::AsPath, offer: &str) -> Result<Response> {
+	let offer = sdp::parse_offer(offer)?;
 
 	// Look up the MoQ broadcast on the subscriber origin. `request_broadcast` resolves an
 	// already-announced broadcast immediately and falls back to a dynamic handler if the
 	// origin has one; with neither, it fails fast and the WHEP client retries (typical).
-	let consumer = async { server.subscriber().request_broadcast(path)?.await }
+	let broadcast = broadcast.as_path().to_string();
+	let consumer = async { server.subscriber().request_broadcast(&broadcast)?.await }
 		.await
-		.map_err(|_| Error::Other(anyhow::anyhow!("broadcast {path} not announced")))?;
+		.map_err(|_| Error::Other(anyhow::anyhow!("broadcast {broadcast} not announced")))?;
 
 	let source = EgressSource::new(consumer).await?;
 	let codecs = source.catalog_codecs();
@@ -79,7 +104,10 @@ async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: By
 		}
 	});
 
-	Ok((resource_id, sdp::render_answer(&answer)))
+	Ok(Response {
+		resource_id,
+		answer: sdp::render_answer(&answer),
+	})
 }
 
 fn is_sdp(headers: &HeaderMap) -> bool {

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -16,16 +16,7 @@ use str0m::{Candidate, Rtc};
 
 use crate::{Error, Result, ingest::IngestSink, sdp, server::Server, session};
 
-/// The result of [`accept`]: the SDP answer to return to the client, plus an
-/// opaque resource id for the WHIP `Location` header (the RFC 9725 session
-/// resource URL).
-#[derive(Clone, Debug)]
-pub struct Response {
-	/// Opaque id identifying the negotiated session, for the `Location` header.
-	pub resource_id: String,
-	/// The SDP answer body (`Content-Type: application/sdp`).
-	pub answer: String,
-}
+pub use crate::server::Response;
 
 /// Build the WHIP axum router.
 pub fn router(server: Server) -> Router {

--- a/rs/moq-srt/README.md
+++ b/rs/moq-srt/README.md
@@ -17,10 +17,11 @@ Pure Rust: SRT is provided by `srt-tokio`, with no libsrt or ffmpeg dependency.
 
 ## Library
 
-The whole surface is `Config` + `run`. A relay embeds ingest by calling `run`
-against its own origin, so the ingested media is published locally with no extra
-hop. Depend on it with `default-features = false` to skip the binary's relay
-client/server and CLI dependencies:
+Two entry points. `Config` + `run` is the unauthenticated convenience: a relay
+embeds ingest by calling `run` against its own origin, so the ingested media is
+published locally with no extra hop. For auth, drive `Server` / `Request`
+directly (see [Auth](#auth) below). Depend on it with `default-features = false`
+to skip the binary's relay client/server and CLI dependencies:
 
 ```toml
 moq-srt = { version = "0.0.1", default-features = false }
@@ -89,6 +90,26 @@ a path, so any number of players can pull the same broadcast.
 
 ## Auth
 
-The listener is currently unauthenticated: anyone who can reach the UDP port can
-publish or request any broadcast. Gate it with a host firewall or a private
-network. SRT passphrase encryption and token checks are the planned next step.
+`run` is unauthenticated: anyone who can reach the UDP port can publish or
+request any broadcast. Gate it with a host firewall or a private network, or
+bring your own auth by driving `Server` / `Request` directly, mirroring
+`moq-native`'s `Server` / `Request`:
+
+```rust
+let mut server = moq_srt::Server::bind("0.0.0.0:9000".parse()?, None).await?;
+while let Some(request) = server.accept().await {
+    // Inspect `request.resource()` / `request.stream_id()` (treat the stream id
+    // as a token if you like), verify it, and pick the broadcast path.
+    match request {
+        moq_srt::Request::Publish(publish) => {
+            tokio::spawn(publish.accept(&origin, "live/cam0"));
+        }
+        moq_srt::Request::Subscribe(subscribe) => {
+            tokio::spawn(subscribe.accept(&consumer, "live/cam0"));
+        }
+    }
+    // ...or `request`'s `reject()` to deny it.
+}
+```
+
+SRT passphrase encryption is a separate, planned next step.

--- a/rs/moq-srt/src/lib.rs
+++ b/rs/moq-srt/src/lib.rs
@@ -10,18 +10,31 @@
 //! - `m=request`: re-mux a broadcast from the origin back to MPEG-TS and stream
 //!   it to the caller, so a plain SRT player (VLC, ffmpeg) can watch it.
 //!
-//! The library is one high-level entry point: build a [`Config`] and hand it
-//! plus an origin to [`run`]. A relay embeds the gateway by calling
-//! `run(cluster.origin.clone(), config)` alongside its own accept loop; the
-//! bundled `moq-srt` binary instead serves the origin locally or forwards it to
-//! a remote relay (those paths need the `server` feature).
+//! Two entry points, depending on how much control you need over each request:
+//!
+//! - [`run`]: the unauthenticated convenience. Build a [`Config`] and hand it
+//!   plus an origin to [`run`]; it accepts every publisher and subscriber and
+//!   routes by prefix + resource name. A relay embeds this with
+//!   `run(cluster.origin.clone(), config)`.
+//! - [`Server`] / [`Request`]: bring your own auth. Loop on [`Server::accept`],
+//!   inspect [`Request::resource`] / [`Request::stream_id`] (treat the stream id
+//!   as a token if you like), then match on the [`Request`]: accept a [`Publish`]
+//!   into an origin, or accept a [`Subscribe`] out of one, at a path of your
+//!   choosing (or reject it). This is how an embedder (e.g. a relay verifying a
+//!   JWT and scoping the origin per token) plugs its policy in. It mirrors
+//!   `moq-native`'s `Server` / `Request`.
+//!
+//! The bundled `moq-srt` binary serves the origin locally or forwards it to a
+//! remote relay (those paths need the `server` feature).
 //!
 //! Pure Rust: SRT is provided by `srt-tokio`, with no libsrt or ffmpeg
 //! dependency.
 
 mod error;
 mod listen;
+mod server;
 mod ts;
 
 pub use error::{Error, Result};
 pub use listen::{Config, run};
+pub use server::{Publish, Request, Server, Subscribe};

--- a/rs/moq-srt/src/listen.rs
+++ b/rs/moq-srt/src/listen.rs
@@ -1,45 +1,38 @@
-//! SRT listener and stream-id routing.
+//! SRT listener configuration and the unauthenticated `run` convenience.
 //!
 //! SRT is a thin reliability/encryption layer over a UDP datagram stream whose
-//! payload, by overwhelming convention, is MPEG-TS. We run an SRT listener and
-//! route each incoming connection by its stream id, in one of two directions:
+//! payload, by overwhelming convention, is MPEG-TS. [`run`] drives a [`Server`]:
+//! it accepts every connection and routes each by its stream-id `m=` mode, in one
+//! of two directions:
 //!
-//! - `m=publish` (the default): ingest. Pump the caller's TS payload through
-//!   [`crate::ts::Publisher`] into the origin as a broadcast.
-//! - `m=request`: egress. Re-mux the requested broadcast back to MPEG-TS with
-//!   [`crate::ts::Subscriber`] and stream it to the caller, so VLC / ffmpeg can
-//!   play `srt://host:port?streamid=#!::r=<broadcast>,m=request`.
+//! - `m=publish` (the default): ingest. Pump the caller's TS payload into the
+//!   origin as a broadcast.
+//! - `m=request`: egress. Re-mux the requested broadcast back to MPEG-TS and
+//!   stream it to the caller, so VLC / ffmpeg can play
+//!   `srt://host:port?streamid=#!::r=<broadcast>,m=request`.
 //!
-//! Routing: SRT's recommended stream-id form is `#!::r=<resource>,m=<mode>`. We
-//! extract the `r=` resource when present and otherwise fall back to the raw
-//! stream-id string; the `m=` mode picks the direction (absent / non-`request`
-//! means ingest). The optional [`prefix`](Config::prefix) is prepended so a
-//! single listener can namespace all of its streams (e.g. prefix `live/` +
-//! stream id `cam0` -> broadcast `live/cam0`).
+//! Routing: SRT's recommended stream-id form is `#!::r=<resource>,m=<mode>`. The
+//! `r=` resource (or the raw stream id, for OBS-style clients) names the
+//! broadcast, and the optional [`prefix`](Config::prefix) is prepended so a
+//! single listener can namespace all of its streams (e.g. prefix `live/` + stream
+//! id `cam0` -> broadcast `live/cam0`).
 //!
-//! Auth: this listener is currently unauthenticated. Anyone who can reach the
-//! UDP port can publish or request any broadcast, so gate it with the host
-//! firewall / a private network. SRT passphrase encryption and token checks are
-//! the obvious next step (see `request.accept(Some(KeySettings))`).
+//! Auth: [`run`] is unauthenticated. Anyone who can reach the UDP port can
+//! publish or request any broadcast, so gate it with the host firewall / a
+//! private network. To gate access (e.g. verify the stream id as a JWT) or to
+//! scope the origin per client, drive [`Server`] directly: loop on
+//! [`Server::accept`], match the [`Request`], and call accept/reject after making
+//! your own decision.
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use futures::{SinkExt, StreamExt};
-use moq_net::{OriginConsumer, OriginProducer};
-use srt_tokio::SrtListener;
-use srt_tokio::access::{
-	AccessControlList, ConnectionMode, RejectReason, ServerRejectReason, StandardAccessControlEntry,
-};
-use srt_tokio::options::StreamId;
+use moq_net::OriginProducer;
 
-use crate::{Error, Result};
-
-/// SRT payload size for egress: 7 MPEG-TS packets (7 x 188), the de-facto
-/// standard for TS-over-SRT and a clean fit under the typical SRT MTU.
-const SRT_PAYLOAD: usize = 7 * 188;
+use crate::Result;
+use crate::server::{Request, Server};
 
 /// SRT gateway configuration.
 ///
@@ -76,6 +69,13 @@ impl Default for Config {
 /// Run the SRT gateway until it fails, publishing `m=publish` connections into
 /// `origin` and serving `m=request` connections out of it.
 ///
+/// This is the unauthenticated convenience entry point: it accepts every
+/// publisher and subscriber and routes by [`prefix`](Config::prefix) + resource
+/// name. Subscribe requests are served from `origin.consume()`, so anything in
+/// the origin (SRT ingests and otherwise) can be pulled back out over SRT. To
+/// gate access (e.g. verify the stream id as a JWT) or to scope the origin per
+/// client, drive [`Server`] directly.
+///
 /// Stays pending forever (rather than resolving) when SRT is disabled, so it
 /// composes cleanly inside a `tokio::select!` alongside a relay's other
 /// long-running tasks.
@@ -86,7 +86,7 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 		unreachable!("pending future never resolves");
 	};
 
-	let (_listener, mut incoming) = SrtListener::builder().latency(config.latency).bind(listen).await?;
+	let mut server = Server::bind(listen, config.latency).await?;
 	tracing::info!(%listen, prefix = %config.prefix, "SRT listening");
 
 	// Read side of the origin, used to serve `m=request` callers their broadcast.
@@ -97,75 +97,54 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 	// RTMP stream key) instead of being silently parked as a backup that could
 	// take over the path when the first publisher drops.
 	let active = ActivePaths::default();
+	let prefix = Arc::new(config.prefix);
 
-	while let Some(request) = incoming.incoming().next().await {
-		let remote = request.remote();
-		let Some(route) = resolve_route(&config.prefix, request.stream_id()) else {
-			tracing::warn!(%remote, stream_id = ?request.stream_id(), "rejecting SRT: no usable stream id");
-			reject(request, ServerRejectReason::BadRequest, remote).await;
-			continue;
-		};
-
-		// `m=request` reads a broadcast out; everything else publishes one in.
-		if route.mode == ConnectionMode::Request {
-			let path = route.path;
-			let consumer = consumer.clone();
-			tokio::spawn(async move {
-				let socket = match request.accept(None).await {
-					Ok(socket) => socket,
-					Err(err) => {
-						tracing::warn!(%remote, %err, "SRT accept failed");
+	while let Some(request) = server.accept().await {
+		let prefix = prefix.clone();
+		match request {
+			Request::Publish(publish) => {
+				let origin = origin.clone();
+				let active = active.clone();
+				// Each connection runs on its own task: `accept` pumps media for the
+				// whole connection lifetime, so handling it inline would serialize
+				// publishers.
+				tokio::spawn(async move {
+					let peer = publish.peer();
+					let path = format!("{prefix}{}", publish.resource());
+					// Claim the path before accepting; the guard releases it when the
+					// connection task ends (success, error, or panic).
+					let Some(_guard) = active.claim(&path) else {
+						tracing::warn!(%peer, %path, "rejecting SRT publish: path already being ingested");
+						let _ = publish.reject().await;
 						return;
+					};
+					if let Err(err) = publish.accept(&origin, &path).await {
+						tracing::warn!(%peer, %path, %err, "SRT ingest ended with error");
+					} else {
+						tracing::info!(%peer, %path, "SRT ingest ended");
 					}
-				};
-				tracing::info!(%remote, %path, "SRT request accepted");
-				if let Err(err) = serve_request(consumer, &path, socket).await {
-					tracing::warn!(%remote, %path, %err, "SRT request ended with error");
-				} else {
-					tracing::info!(%remote, %path, "SRT request ended");
-				}
-			});
-			continue;
-		}
-
-		// Claim the path before accepting; the guard releases it when the
-		// connection task ends (success, error, or panic).
-		let Some(guard) = active.claim(&route.path) else {
-			tracing::warn!(%remote, path = %route.path, "rejecting SRT: path already being ingested");
-			reject(request, ServerRejectReason::Forbidden, remote).await;
-			continue;
-		};
-
-		let path = route.path;
-		let origin = origin.clone();
-		tokio::spawn(async move {
-			let _guard = guard;
-			let socket = match request.accept(None).await {
-				Ok(socket) => socket,
-				Err(err) => {
-					tracing::warn!(%remote, %err, "SRT accept failed");
-					return;
-				}
-			};
-			tracing::info!(%remote, %path, "SRT connection accepted");
-			if let Err(err) = serve_publish(origin, &path, socket).await {
-				tracing::warn!(%remote, %path, %err, "SRT ingest ended with error");
-			} else {
-				tracing::info!(%remote, %path, "SRT ingest ended");
+				});
 			}
-		});
+			Request::Subscribe(subscribe) => {
+				let consumer = consumer.clone();
+				// Many viewers can request the same path concurrently, so subscribes
+				// don't claim an `ActivePaths` slot.
+				tokio::spawn(async move {
+					let peer = subscribe.peer();
+					let path = format!("{prefix}{}", subscribe.resource());
+					if let Err(err) = subscribe.accept(&consumer, &path).await {
+						tracing::warn!(%peer, %path, %err, "SRT request ended with error");
+					} else {
+						tracing::info!(%peer, %path, "SRT request ended");
+					}
+				});
+			}
+		}
 	}
 
-	Err(Error::from(anyhow::anyhow!(
+	Err(crate::Error::from(anyhow::anyhow!(
 		"SRT listener stopped accepting connections"
 	)))
-}
-
-/// Reject a connection request, logging (but not propagating) a send failure.
-async fn reject(request: srt_tokio::ConnectionRequest, reason: ServerRejectReason, remote: SocketAddr) {
-	if let Err(err) = request.reject(RejectReason::Server(reason)).await {
-		tracing::debug!(%remote, %err, "failed to send SRT rejection");
-	}
 }
 
 /// The set of broadcast paths with a live ingest, used to reject duplicate
@@ -200,167 +179,9 @@ impl Drop for PathGuard {
 	}
 }
 
-/// Pump one accepted SRT socket's MPEG-TS payload into the origin (`m=publish`).
-async fn serve_publish(origin: OriginProducer, path: &str, mut socket: srt_tokio::SrtSocket) -> Result<()> {
-	use futures::TryStreamExt;
-
-	let mut publisher = crate::ts::Publisher::new(&origin, path)?;
-	while let Some((_instant, bytes)) = socket.try_next().await? {
-		publisher.feed(bytes)?;
-	}
-	publisher.finish()?;
-	Ok(())
-}
-
-/// Mux the requested broadcast back to MPEG-TS and stream it to the SRT caller
-/// (`m=request`).
-///
-/// Waits for the broadcast to be announced (so a caller may connect before the
-/// publisher), then packs the muxer's output into [`SRT_PAYLOAD`]-sized SRT
-/// messages. Returns once the broadcast ends or the caller disconnects.
-async fn serve_request(origin: OriginConsumer, path: &str, mut socket: srt_tokio::SrtSocket) -> Result<()> {
-	// Resolve the broadcast, but watch the socket while we wait: `announced_broadcast`
-	// parks forever for a stream that is never published, and nothing else polls the
-	// socket during that wait, so without this a caller who requests a non-existent
-	// stream (or hangs up before it starts) would leak this task and its socket.
-	let subscriber = tokio::select! {
-		biased;
-		_ = wait_closed(&mut socket) => {
-			tracing::debug!(%path, "SRT request closed before its broadcast was available");
-			return Ok(());
-		}
-		subscriber = crate::ts::Subscriber::new(&origin, path) => subscriber?,
-	};
-
-	let Some(mut subscriber) = subscriber else {
-		tracing::warn!(%path, "SRT request for an unroutable broadcast");
-		return Ok(());
-	};
-
-	// MPEG-TS is a continuous byte stream, so we coalesce the muxer's per-frame
-	// chunks and slice them on a fixed boundary rather than preserving them.
-	let mut buffer = bytes::BytesMut::new();
-	while let Some(chunk) = subscriber.next().await? {
-		buffer.extend_from_slice(&chunk);
-		while buffer.len() >= SRT_PAYLOAD {
-			let payload = buffer.split_to(SRT_PAYLOAD).freeze();
-			socket.send((Instant::now(), payload)).await?;
-		}
-	}
-
-	if !buffer.is_empty() {
-		socket.send((Instant::now(), buffer.freeze())).await?;
-	}
-	socket.close().await?;
-
-	Ok(())
-}
-
-/// Resolve once the SRT caller hangs up (a clean close or an error), draining and
-/// ignoring any unexpected inbound packets. A request caller normally sends
-/// nothing, so this is purely a disconnect signal to race against the announce wait.
-async fn wait_closed(socket: &mut srt_tokio::SrtSocket) {
-	use futures::TryStreamExt;
-	while let Ok(Some(_)) = socket.try_next().await {}
-}
-
-/// A routing decision derived from an SRT connection's stream id.
-struct Route {
-	/// Broadcast path (with [`Config::prefix`] applied) to publish into or read from.
-	path: String,
-	/// Direction: `Request` serves a broadcast out, anything else ingests one in.
-	mode: ConnectionMode,
-}
-
-/// Derive a [`Route`] from an SRT stream id, applying `prefix`.
-///
-/// Prefers the standard `#!::r=<resource>,m=<mode>` form, then falls back to the
-/// raw stream-id string (always treated as ingest). Returns `None` when there's
-/// nothing usable to route on.
-fn resolve_route(prefix: &str, stream_id: Option<&StreamId>) -> Option<Route> {
-	let raw = stream_id?.as_str().trim();
-
-	// Standard SRT access-control form: `#!::r=<resource>,m=<mode>,...`. Absent
-	// `m=` defaults to publish, matching a bare stream id and OBS-style ingest.
-	let mut resource = None;
-	let mut mode = ConnectionMode::Publish;
-	if let Ok(acl) = raw.parse::<AccessControlList>() {
-		for entry in acl.0 {
-			match StandardAccessControlEntry::try_from(entry) {
-				Ok(StandardAccessControlEntry::ResourceName(name)) if !name.is_empty() => resource = Some(name),
-				Ok(StandardAccessControlEntry::Mode(m)) => mode = m,
-				_ => {}
-			}
-		}
-	}
-
-	// Fall back to the raw stream id (e.g. OBS-style `app/key`), but never to an
-	// unparsed `#!::` control string.
-	let name = match resource {
-		Some(name) => name,
-		None if raw.is_empty() || raw.starts_with("#!::") => return None,
-		None => raw.to_string(),
-	};
-
-	Some(Route {
-		path: format!("{prefix}{name}"),
-		mode,
-	})
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	fn sid(s: &str) -> StreamId {
-		StreamId::try_from(s.as_bytes().to_vec()).unwrap()
-	}
-
-	fn route(prefix: &str, s: &str) -> Option<Route> {
-		resolve_route(prefix, Some(&sid(s)))
-	}
-
-	#[test]
-	fn standard_resource_form() {
-		let r = route("", "#!::r=live/cam0,m=publish").unwrap();
-		assert_eq!(r.path, "live/cam0");
-		assert_eq!(r.mode, ConnectionMode::Publish);
-	}
-
-	#[test]
-	fn request_mode_is_egress() {
-		let r = route("", "#!::r=live/cam0,m=request").unwrap();
-		assert_eq!(r.path, "live/cam0");
-		assert_eq!(r.mode, ConnectionMode::Request);
-	}
-
-	#[test]
-	fn absent_mode_defaults_to_publish() {
-		// Both a bare stream id and an `r=`-only ACL ingest by default.
-		assert_eq!(route("", "app/key").unwrap().mode, ConnectionMode::Publish);
-		assert_eq!(route("", "#!::r=cam0").unwrap().mode, ConnectionMode::Publish);
-	}
-
-	#[test]
-	fn raw_stream_id() {
-		let r = route("", "app/key").unwrap();
-		assert_eq!(r.path, "app/key");
-		assert_eq!(r.mode, ConnectionMode::Publish);
-	}
-
-	#[test]
-	fn prefix_is_prepended() {
-		assert_eq!(route("live/", "cam0").unwrap().path, "live/cam0");
-		// Prefix applies to egress requests too.
-		assert_eq!(route("live/", "#!::r=cam0,m=request").unwrap().path, "live/cam0");
-	}
-
-	#[test]
-	fn missing_or_empty_is_rejected() {
-		assert!(resolve_route("", None).is_none());
-		assert!(route("", "").is_none());
-		assert!(route("", "#!::").is_none());
-	}
 
 	#[test]
 	fn active_paths_rejects_duplicates_and_releases_on_drop() {

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -1,0 +1,410 @@
+//! SRT server: accept connections, and hand each pending request to the caller
+//! as a [`Request`] to authorize.
+//!
+//! [`Server::accept`] yields a [`Request`] for each incoming SRT connection,
+//! before the handshake is finalized, classified by its stream-id `m=` mode into
+//! one of two directions. The caller inspects [`Request::resource`] /
+//! [`Request::stream_id`], makes an authorization decision, and either:
+//!
+//! - **[`Request::Publish`]**: [`Publish::accept`] (ingest the connection's
+//!   MPEG-TS into an origin at a path) or [`Publish::reject`]. This is the
+//!   contribution path (OBS, ffmpeg).
+//! - **[`Request::Subscribe`]**: [`Subscribe::accept`] (re-mux a broadcast from
+//!   an origin back to MPEG-TS and stream it down to the caller) or
+//!   [`Subscribe::reject`]. This is the egress path: a player (VLC, ffmpeg) pulls
+//!   `srt://host:port?streamid=#!::r=<broadcast>,m=request`.
+//!
+//! This mirrors `moq-native`'s `Server` / `Request`, so the gateway stays
+//! unopinionated about auth: the embedder (e.g. a relay verifying the stream id
+//! as a JWT) owns that policy. For the unauthenticated convenience that accepts
+//! everything and routes by prefix, use [`crate::run`].
+
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use futures::{SinkExt, StreamExt};
+use moq_net::{OriginConsumer, OriginProducer};
+use srt_tokio::access::{
+	AccessControlList, ConnectionMode, RejectReason, ServerRejectReason, StandardAccessControlEntry,
+};
+use srt_tokio::options::StreamId;
+use srt_tokio::{ConnectionRequest, SrtIncoming, SrtListener, SrtSocket};
+
+use crate::Result;
+
+/// Default SRT receive latency: the negotiated buffer that trades delay for loss
+/// recovery. Override per-server with [`Server::bind`]'s `latency` argument.
+const DEFAULT_LATENCY: Duration = Duration::from_millis(200);
+
+/// SRT payload size for egress: 7 MPEG-TS packets (7 x 188), the de-facto
+/// standard for TS-over-SRT and a clean fit under the typical SRT MTU.
+const SRT_PAYLOAD: usize = 7 * 188;
+
+/// An SRT server that yields each incoming connection's pending request as a
+/// [`Request`].
+///
+/// Build it with [`bind`](Self::bind), then loop on [`accept`](Self::accept).
+/// Each [`Request`] is produced before the SRT handshake is finalized, so the
+/// caller can authorize (and pick the broadcast path) before any media flows.
+pub struct Server {
+	/// Held to keep the listener (and its UDP socket) alive for the server's lifetime.
+	_listener: SrtListener,
+	incoming: SrtIncoming,
+}
+
+impl Server {
+	/// Bind an SRT listener on `addr` (SRT has no well-known port; 9000 is common).
+	///
+	/// `latency` is the SRT receive latency, negotiated at handshake time; pass
+	/// `None` for a sensible default (200ms).
+	pub async fn bind(addr: SocketAddr, latency: impl Into<Option<Duration>>) -> Result<Self> {
+		let latency = latency.into().unwrap_or(DEFAULT_LATENCY);
+		let (listener, incoming) = SrtListener::builder().latency(latency).bind(addr).await?;
+		Ok(Self {
+			_listener: listener,
+			incoming,
+		})
+	}
+
+	/// Wait for the next connection that wants to publish or subscribe.
+	///
+	/// Connections whose stream id can't be routed (no usable resource name) are
+	/// rejected internally and skipped, so every [`Request`] returned is
+	/// actionable. Returns `None` only if the listener stops accepting (it
+	/// currently never does).
+	pub async fn accept(&mut self) -> Option<Request> {
+		while let Some(request) = self.incoming.incoming().next().await {
+			let peer = request.remote();
+			let Some((resource, mode)) = parse_stream_id(request.stream_id()) else {
+				tracing::warn!(%peer, stream_id = ?request.stream_id(), "rejecting SRT: no usable stream id");
+				reject_log(request, ServerRejectReason::BadRequest, peer).await;
+				continue;
+			};
+
+			let stream_id = request.stream_id().map(|id| id.as_str().to_string());
+			let pending = Pending {
+				request,
+				resource,
+				stream_id,
+				peer,
+			};
+
+			// `m=request` reads a broadcast out; everything else publishes one in.
+			return Some(match mode {
+				ConnectionMode::Request => Request::Subscribe(Subscribe(pending)),
+				_ => Request::Publish(Publish(pending)),
+			});
+		}
+
+		None
+	}
+}
+
+/// Common state behind a pending [`Request`]: the SRT connection plus the
+/// routing info parsed from its stream id.
+struct Pending {
+	request: ConnectionRequest,
+	/// The resource name to route on: the stream id's `r=` value, or the raw
+	/// stream id when it carries no access-control list.
+	resource: String,
+	/// The raw stream id string, if any. Exposed so an embedder can parse its own
+	/// fields out of it (e.g. a token in `u=` or a custom key).
+	stream_id: Option<String>,
+	peer: SocketAddr,
+}
+
+/// What an accepted SRT connection wants: to contribute media ([`Publish`]) or to
+/// view it ([`Subscribe`]).
+///
+/// Yielded by [`Server::accept`], classified by the stream id's `m=` mode.
+/// Inspect [`resource`](Self::resource) / [`stream_id`](Self::stream_id), then
+/// match to authorize the right direction. Dropping it without accepting or
+/// rejecting drops the connection.
+#[non_exhaustive]
+pub enum Request {
+	/// A client pushing media in (OBS, ffmpeg). Ingest it with [`Publish::accept`].
+	Publish(Publish),
+	/// A client pulling media out (VLC, ffmpeg). Serve it with [`Subscribe::accept`].
+	Subscribe(Subscribe),
+}
+
+impl Request {
+	/// The resource name to route on: the stream id's `r=` value, or the raw
+	/// stream id when it carries no access-control list.
+	pub fn resource(&self) -> &str {
+		match self {
+			Request::Publish(r) => r.resource(),
+			Request::Subscribe(r) => r.resource(),
+		}
+	}
+
+	/// The raw SRT stream id, if the client supplied one.
+	pub fn stream_id(&self) -> Option<&str> {
+		match self {
+			Request::Publish(r) => r.stream_id(),
+			Request::Subscribe(r) => r.stream_id(),
+		}
+	}
+
+	/// The remote peer address.
+	pub fn peer(&self) -> SocketAddr {
+		match self {
+			Request::Publish(r) => r.peer(),
+			Request::Subscribe(r) => r.peer(),
+		}
+	}
+}
+
+/// A pending SRT publish (contribution), waiting on the caller to authorize it.
+///
+/// Inspect [`resource`](Self::resource) / [`stream_id`](Self::stream_id), then
+/// either [`accept`](Self::accept) the publish into an origin at a chosen
+/// broadcast path or [`reject`](Self::reject) it. Dropping it without either
+/// drops the connection.
+pub struct Publish(Pending);
+
+impl Publish {
+	/// The resource name to route on (the stream id's `r=` value, or the raw
+	/// stream id).
+	pub fn resource(&self) -> &str {
+		&self.0.resource
+	}
+
+	/// The raw SRT stream id, if the client supplied one.
+	///
+	/// Conventionally just a resource path, but an embedder can treat it (or a
+	/// field within it) as a token to authenticate the publish.
+	pub fn stream_id(&self) -> Option<&str> {
+		self.0.stream_id.as_deref()
+	}
+
+	/// The remote peer address.
+	pub fn peer(&self) -> SocketAddr {
+		self.0.peer
+	}
+
+	/// Accept the publish: announce a broadcast at `path` in `origin` and pump the
+	/// connection's MPEG-TS into it until the client disconnects.
+	///
+	/// `origin` is whatever the caller wants the media published into (e.g. a
+	/// relay's shared origin, optionally scoped per the authenticated token). This
+	/// future resolves when the connection ends, so callers usually run it on its
+	/// own task.
+	pub async fn accept(self, origin: &OriginProducer, path: &str) -> Result<()> {
+		let socket = self.0.request.accept(None).await?;
+		tracing::info!(peer = %self.0.peer, %path, "SRT publish accepted");
+		serve_publish(origin, path, socket).await
+	}
+
+	/// Reject the publish, sending the client a `Forbidden` rejection.
+	pub async fn reject(self) -> Result<()> {
+		Ok(self
+			.0
+			.request
+			.reject(RejectReason::Server(ServerRejectReason::Forbidden))
+			.await?)
+	}
+}
+
+/// A pending SRT subscribe (egress), waiting on the caller to authorize it.
+///
+/// The viewing counterpart of [`Publish`]: inspect [`resource`](Self::resource) /
+/// [`stream_id`](Self::stream_id), then [`accept`](Self::accept) to serve a
+/// broadcast from an origin down to the caller, or [`reject`](Self::reject) it.
+/// Dropping it without either drops the connection.
+pub struct Subscribe(Pending);
+
+impl Subscribe {
+	/// The resource name to route on (the stream id's `r=` value, or the raw
+	/// stream id).
+	pub fn resource(&self) -> &str {
+		&self.0.resource
+	}
+
+	/// The raw SRT stream id, if the client supplied one.
+	///
+	/// As with a publish, an embedder can treat this as a token to authorize the
+	/// viewer.
+	pub fn stream_id(&self) -> Option<&str> {
+		self.0.stream_id.as_deref()
+	}
+
+	/// The remote peer address.
+	pub fn peer(&self) -> SocketAddr {
+		self.0.peer
+	}
+
+	/// Accept the subscribe: resolve the broadcast at `path` in `origin`, re-mux
+	/// it to MPEG-TS, and stream it down to the caller until either side ends.
+	///
+	/// Waits for the broadcast to be announced (so a caller may connect before the
+	/// publisher), cancelling cleanly if the caller disconnects first. This future
+	/// resolves when playback ends, so callers usually run it on its own task.
+	pub async fn accept(self, origin: &OriginConsumer, path: &str) -> Result<()> {
+		let socket = self.0.request.accept(None).await?;
+		tracing::info!(peer = %self.0.peer, %path, "SRT subscribe accepted");
+		serve_subscribe(origin, path, socket).await
+	}
+
+	/// Reject the subscribe, sending the client a `Forbidden` rejection.
+	pub async fn reject(self) -> Result<()> {
+		Ok(self
+			.0
+			.request
+			.reject(RejectReason::Server(ServerRejectReason::Forbidden))
+			.await?)
+	}
+}
+
+/// Reject a connection request, logging (but not propagating) a send failure.
+/// Used for connections the server drops itself, before they reach the caller.
+async fn reject_log(request: ConnectionRequest, reason: ServerRejectReason, peer: SocketAddr) {
+	if let Err(err) = request.reject(RejectReason::Server(reason)).await {
+		tracing::debug!(%peer, %err, "failed to send SRT rejection");
+	}
+}
+
+/// Pump one accepted SRT socket's MPEG-TS payload into the origin (`m=publish`).
+async fn serve_publish(origin: &OriginProducer, path: &str, mut socket: SrtSocket) -> Result<()> {
+	use futures::TryStreamExt;
+
+	let mut publisher = crate::ts::Publisher::new(origin, path)?;
+	while let Some((_instant, bytes)) = socket.try_next().await? {
+		publisher.feed(bytes)?;
+	}
+	publisher.finish()?;
+	Ok(())
+}
+
+/// Mux the requested broadcast back to MPEG-TS and stream it to the SRT caller
+/// (`m=request`).
+///
+/// Waits for the broadcast to be announced (so a caller may connect before the
+/// publisher), then packs the muxer's output into [`SRT_PAYLOAD`]-sized SRT
+/// messages. Returns once the broadcast ends or the caller disconnects.
+async fn serve_subscribe(origin: &OriginConsumer, path: &str, mut socket: SrtSocket) -> Result<()> {
+	// Resolve the broadcast, but watch the socket while we wait: `announced_broadcast`
+	// parks forever for a stream that is never published, and nothing else polls the
+	// socket during that wait, so without this a caller who requests a non-existent
+	// stream (or hangs up before it starts) would leak this task and its socket.
+	let subscriber = tokio::select! {
+		biased;
+		_ = wait_closed(&mut socket) => {
+			tracing::debug!(%path, "SRT subscribe closed before its broadcast was available");
+			return Ok(());
+		}
+		subscriber = crate::ts::Subscriber::new(origin, path) => subscriber?,
+	};
+
+	let Some(mut subscriber) = subscriber else {
+		tracing::warn!(%path, "SRT subscribe for an unroutable broadcast");
+		return Ok(());
+	};
+
+	// MPEG-TS is a continuous byte stream, so we coalesce the muxer's per-frame
+	// chunks and slice them on a fixed boundary rather than preserving them.
+	let mut buffer = bytes::BytesMut::new();
+	while let Some(chunk) = subscriber.next().await? {
+		buffer.extend_from_slice(&chunk);
+		while buffer.len() >= SRT_PAYLOAD {
+			let payload = buffer.split_to(SRT_PAYLOAD).freeze();
+			socket.send((Instant::now(), payload)).await?;
+		}
+	}
+
+	if !buffer.is_empty() {
+		socket.send((Instant::now(), buffer.freeze())).await?;
+	}
+	socket.close().await?;
+
+	Ok(())
+}
+
+/// Resolve once the SRT caller hangs up (a clean close or an error), draining and
+/// ignoring any unexpected inbound packets. A subscribe caller normally sends
+/// nothing, so this is purely a disconnect signal to race against the announce wait.
+async fn wait_closed(socket: &mut SrtSocket) {
+	use futures::TryStreamExt;
+	while let Ok(Some(_)) = socket.try_next().await {}
+}
+
+/// Parse an SRT stream id into its resource name and connection mode.
+///
+/// Prefers the standard `#!::r=<resource>,m=<mode>` form, then falls back to the
+/// raw stream-id string (always treated as publish). Returns `None` when there's
+/// nothing usable to route on.
+fn parse_stream_id(stream_id: Option<&StreamId>) -> Option<(String, ConnectionMode)> {
+	let raw = stream_id?.as_str().trim();
+
+	// Standard SRT access-control form: `#!::r=<resource>,m=<mode>,...`. Absent
+	// `m=` defaults to publish, matching a bare stream id and OBS-style ingest.
+	let mut resource = None;
+	let mut mode = ConnectionMode::Publish;
+	if let Ok(acl) = raw.parse::<AccessControlList>() {
+		for entry in acl.0 {
+			match StandardAccessControlEntry::try_from(entry) {
+				Ok(StandardAccessControlEntry::ResourceName(name)) if !name.is_empty() => resource = Some(name),
+				Ok(StandardAccessControlEntry::Mode(m)) => mode = m,
+				_ => {}
+			}
+		}
+	}
+
+	// Fall back to the raw stream id (e.g. OBS-style `app/key`), but never to an
+	// unparsed `#!::` control string.
+	let name = match resource {
+		Some(name) => name,
+		None if raw.is_empty() || raw.starts_with("#!::") => return None,
+		None => raw.to_string(),
+	};
+
+	Some((name, mode))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn sid(s: &str) -> StreamId {
+		StreamId::try_from(s.as_bytes().to_vec()).unwrap()
+	}
+
+	fn parse(s: &str) -> Option<(String, ConnectionMode)> {
+		parse_stream_id(Some(&sid(s)))
+	}
+
+	#[test]
+	fn standard_resource_form() {
+		let (resource, mode) = parse("#!::r=live/cam0,m=publish").unwrap();
+		assert_eq!(resource, "live/cam0");
+		assert_eq!(mode, ConnectionMode::Publish);
+	}
+
+	#[test]
+	fn request_mode_is_egress() {
+		let (resource, mode) = parse("#!::r=live/cam0,m=request").unwrap();
+		assert_eq!(resource, "live/cam0");
+		assert_eq!(mode, ConnectionMode::Request);
+	}
+
+	#[test]
+	fn absent_mode_defaults_to_publish() {
+		// Both a bare stream id and an `r=`-only ACL ingest by default.
+		assert_eq!(parse("app/key").unwrap().1, ConnectionMode::Publish);
+		assert_eq!(parse("#!::r=cam0").unwrap().1, ConnectionMode::Publish);
+	}
+
+	#[test]
+	fn raw_stream_id() {
+		let (resource, mode) = parse("app/key").unwrap();
+		assert_eq!(resource, "app/key");
+		assert_eq!(mode, ConnectionMode::Publish);
+	}
+
+	#[test]
+	fn missing_or_empty_is_rejected() {
+		assert!(parse_stream_id(None).is_none());
+		assert!(parse("").is_none());
+		assert!(parse("#!::").is_none());
+	}
+}


### PR DESCRIPTION
## Summary

Both gateways were functional but unauthenticated with no embedder hook, so a relay couldn't gate them with subscribe tokens. This adds the auth seam to each, modeled on `moq-rtmp`'s `Server` / `Request` (which mirrors `moq-native`). The gateways stay **auth-agnostic** (no `moq-token` / `moq-relay` dependency): the embedder verifies the request and picks the broadcast path, then accepts or rejects.

### moq-srt: `Server` / `Request`

- New `rs/moq-srt/src/server.rs`: `Server::bind(addr, latency)` → loop on `Server::accept() -> Option<Request>`.
- `Request` (`#[non_exhaustive]`): `Publish` (ingest) / `Subscribe` (`m=request` egress). Named `Subscribe` rather than `Request` to avoid a `Request::Request` stutter.
- Inspect `resource()` / `stream_id()` / `peer()`, then `Publish::accept(&OriginProducer, path)` / `Subscribe::accept(&OriginConsumer, path)` / `.reject()`.
- `run()` is now the unauthenticated convenience, rebuilt on top of `Server` (still applies prefix + first-publisher-wins). Unroutable stream ids are rejected internally so every `Request` is actionable.

### moq-rtc: public `whep::accept`

- Add `whep::accept(server, broadcast, offer) -> Result<Response>` mirroring `whip::accept`, so an embedder can own the HTTP route and authorize WHEP egress instead of only using the unauthenticated `subscribe_router`.
- Promote the duplicated `Response { resource_id, answer }` struct into `server::Response` (re-exported from both `whip` and `whep`, so `whip::Response` still resolves).
- Drop a stale `#[allow(dead_code)]` + "gated until per-codec re-packetizers land" note on `Server::subscriber` — WHEP uses it now.

## Why

Follow-up to the SRT (#1828) and WHEP (#1827) merges, both of which shipped without an authenticated embed path. This gives a relay the hook to verify a JWT (e.g. the SRT stream id, or a WHIP/WHEP path resolved from a token) and scope the origin per request.

## Public API changes

- `moq-srt`: **new** `Server`, `Request`, `Publish`, `Subscribe` (additive). `run` / `Config` unchanged.
- `moq-rtc`: **new** `whep::accept`, `whep::Response`, `server::Response` (additive). `whip::Response` is now an alias of `server::Response` (same fields, source-compatible).

Targets `dev` per the breaking/library-API branch policy (additive public surface on library crates).

## Test plan

- [x] `cargo clippy -p moq-srt -p moq-rtc --all-targets` clean (nix toolchain)
- [x] `cargo test -p moq-srt -p moq-rtc` passes
- [x] `cargo doc -p moq-srt -p moq-rtc` with `-D warnings` (intra-doc links) clean
- [x] `cargo fmt --check` clean (nix)
- [x] `--no-default-features` (embedding build) compiles for both crates
- [ ] E2E: relay embeds `Server`/`whep::accept` and verifies a token (application-side follow-up; no in-repo relay embeds these gateways yet)

(Written by Claude)