### PR TITLE
ci: persistent cargo target dir + trim redundant compiles

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,43 +56,17 @@ jobs:
         uses: DeterminateSystems/flake-checker-action@9ee1c5473f1abdfb299f6c4f0fab813147c97fe3 # main
 
       # GitHub-hosted fallback caches Rust via the Actions cache. The self-hosted
-      # box runs the heavy Rust CI (clippy/doc/test) as crane derivations via
-      # `nix flake check`, so deps cache in /nix/store and there's no persistent
-      # CARGO_TARGET_DIR to manage -- the residual `cargo check`s use the
-      # workspace ./target, which the runner wipes per job.
+      # box runs the heavy Rust CI (clippy/doc/test) as plain cargo, reusing a
+      # persistent CARGO_TARGET_DIR set in the runner environment (not here), so
+      # unchanged crates are reused across jobs; the checkout's ./target is unused.
       - name: Rust Cache
         if: runner.environment == 'github-hosted'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
 
-      # Mark a baseline so the post-run assertion can tell whether anything wrote
-      # under the old persistent target dir (i.e. a CARGO_TARGET_DIR override
-      # leaked back in and would re-grow an unbounded tree).
-      - name: Target-dir baseline
-        if: runner.environment == 'self-hosted'
-        run: touch "$RUNNER_TEMP/target-baseline"
-
       # `just ci` calls `just changed` internally to skip unchanged scopes.
       # Login shell so /etc/profile.d puts Nix on PATH; Actions shells don't by
       # default. Harmless on the hosted fallback.
       - run: nix develop --command just ci
         shell: bash -leo pipefail {0}
-
-      # Invariant: nothing should write to the old persistent target dir anymore.
-      # Fails loudly if a CARGO_TARGET_DIR override sneaks back in. Scope it to
-      # *this* repo's old per-runner dir (moq-$RUNNER_NAME) -- the box's
-      # $HOME/cargo-target is shared with other repos (e.g. moq-pro) and runners,
-      # whose jobs may run concurrently and legitimately still write there.
-      - name: Assert the persistent target dir stayed unused
-        if: runner.environment == 'self-hosted'
-        run: |
-          target="$HOME/cargo-target/moq-$RUNNER_NAME"
-          mkdir -p "$target"
-          leaked=$(find "$target" -type f -newer "$RUNNER_TEMP/target-baseline" 2>/dev/null | head)
-          if [ -n "$leaked" ]; then
-            echo "::error::cargo wrote to $target; a CARGO_TARGET_DIR override leaked back in"
-            echo "$leaked"
-            exit 1
-          fi
-          echo "OK: $target untouched this run"

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,7 @@
             cargo-edit
             cargo-semver-checks
             cargo-deny
+            cargo-nextest
           ]
           ++ gstreamerDeps
           ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
@@ -238,10 +239,10 @@
         # build via crane `buildPackage` (see `packages` above / release-*.yml).
         #
         # On the self-hosted runner those cargo checks transparently reuse a
-        # per-crate compiler cache (rustc is wrapped by sccache via the runner
-        # environment), so a Cargo.lock change recompiles only the changed crate
-        # + its reverse-deps. That's a runner-side concern -- nothing here or in
-        # the workflows configures it.
+        # persistent CARGO_TARGET_DIR (set in the runner environment), so a
+        # Cargo.lock change recompiles only the changed crate + its reverse-deps
+        # and unchanged crates are reused across jobs. That's a runner-side
+        # concern -- nothing here or in the workflows configures it.
         checks = { };
       }
     );

--- a/rs/justfile
+++ b/rs/justfile
@@ -44,17 +44,25 @@ ci FILES="":
 
     # Compiles. The all-features clippy / doc / test were crane derivations built
     # by `nix flake check`; they now run here as plain cargo (flake.nix `checks`
-    # is unwired). The default / no-default-feature `cargo check`s cover feature
-    # edges the all-features run doesn't. Everything builds into the in-workspace
-    # ./target, which the runner wipes per job; on the self-hosted runner the
-    # heavy compilation is transparently cached per-crate by sccache (wired into
-    # the runner environment, not here), so there's no persistent target dir to
-    # bound. (Local devs still get the full cargo loop via `just rs check`.)
-    cargo check --workspace --all-targets
+    # is unwired). Each full-workspace compile below is expensive on the 4-core A1
+    # runner, so we run the minimum set that still covers every feature edge:
+    #   - clippy --all-targets --all-features is the gate and a superset of a plain
+    #     `cargo check --all-targets` (default features), so that redundant check
+    #     pass is intentionally omitted -- one fewer full workspace compile.
+    #   - --no-default-features stays: it's the only pass that exercises code behind
+    #     `#[cfg(not(feature = ...))]`, which the all-features run never compiles.
+    # The self-hosted runner sets a persistent CARGO_TARGET_DIR (in its env, not
+    # here), so unchanged crates are reused across jobs and a Cargo.lock change
+    # recompiles only the changed crate + its reverse-deps. (Local devs still get
+    # the full cargo loop via `just rs check`.)
     cargo check --workspace --no-default-features
     cargo clippy --workspace --all-targets --all-features -- -D warnings
     RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
-    cargo test --workspace --all-targets --all-features
+    # nextest compiles + runs the test binaries with real parallelism (faster than
+    # `cargo test`'s serial harness on the 4-core box). It does not build or run
+    # doctests, so the `/// ```` examples are no longer compile-checked in CI -- an
+    # accepted trade for speed (they still render in `cargo doc` output).
+    cargo nextest run --workspace --all-targets --all-features
 
 # Auto-fix clippy/format/shear/sort.
 fix:


### PR DESCRIPTION
## Why

The self-hosted A1 runner (4 ARM cores) was slow largely because every job recompiled from scratch: `./target` is wiped per job and sccache — the only cache — cannot cache build-script execution (ffmpeg/gstreamer `bindgen` ran every job), linking, or final codegen. On a single box a warm `CARGO_TARGET_DIR` beats sccache.

## What

- **`rs/justfile`**: drop the redundant `cargo check --workspace --all-targets` — `cargo clippy --all-targets --all-features` is a strict superset, so zero coverage loss and one fewer full-workspace compile. Switch `cargo test` → `cargo nextest run` for parallel test execution. ⚠️ nextest does **not** build/run doctests, so the `/// ```` examples are no longer compile-checked in CI (accepted trade for speed).
- **`flake.nix`**: add `cargo-nextest` to the dev shell (required by the justfile change — they must land together). Refresh the stale sccache comment.
- **`check.yml`**: remove the obsolete persistent-target *assertion* steps — the runner now deliberately uses a persistent `CARGO_TARGET_DIR`.

## Runner side (separate, already applied live)

The persistent target dir, `CARGO_PROFILE_DEV_DEBUG=0` (keeps artifacts small enough not to fill the disk), and a `cargo-sweep` GC timer are configured in the `oci` runner repo's cloud-init and have been applied to the box. The first job after this is still a cold build; the speedup shows from the second job onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)