### PR TITLE
feat(moq-video): H.264 hardware decode on Windows via Media Foundation

### DIFF
--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `decode::Consumer` (the counterpart to `moq-audio`'s `AudioConsumer`) that
   subscribes to an H.264 track and returns raw I420 frames. Backends are
   VideoToolbox (macOS) and openh264 (portable software fallback); no ffmpeg.
+- H.264 hardware decode on Windows via Media Foundation. The Microsoft decoder
+  MFT runs synchronously with a Direct3D11 device bound to it, so the decode
+  happens on the GPU through DXVA (NVDEC / Intel / AMD); output textures are
+  downloaded to I420. Requires a GPU: a GPU-less host falls back to openh264.
 - H.265 encode via the NVENC backend (Linux, `nvenc` feature). The codec is
   selected by `encode::Codec`; the NVENC HEVC path shares the H.264 preset / GOP
   / rate-control setup and emits Annex-B with inline VPS/SPS/PPS. Not yet

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -50,6 +50,14 @@ GPU-less builder and still starts on a GPU-less machine.
 ## Decode
 
 `decode::Consumer` (the mirror of `moq-audio`'s `AudioConsumer`) subscribes to an
-H.264 track and returns raw I420 frames. Backends are VideoToolbox (macOS) and
-openh264 (portable software fallback). H.264 only for now; a non-H.264 rendition
+H.264 track and returns raw I420 frames. Backends are tried hardware-first, like
+encode:
+
+| Codec | Software | macOS | Windows | Linux |
+|---|---|---|---|---|
+| H.264 | openh264 (vendored, static) | VideoToolbox | Media Foundation (DXVA) | openh264 |
+
+On Windows the Microsoft decoder MFT runs synchronously with a Direct3D11 device
+bound to it, so the decode happens on the GPU through DXVA (NVDEC / Intel / AMD);
+a GPU-less host falls back to openh264. H.264 only for now; a non-H.264 rendition
 yields `Error::UnsupportedCodec`.

--- a/rs/moq-video/src/capture/mediafoundation.rs
+++ b/rs/moq-video/src/capture/mediafoundation.rs
@@ -12,21 +12,15 @@ use std::ffi::c_void;
 use std::ptr;
 use std::slice;
 
-use windows::Win32::Foundation::HMODULE;
-use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
-use windows::Win32::Graphics::Direct3D10::ID3D10Multithread;
-use windows::Win32::Graphics::Direct3D11::{
-	D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_VIDEO_SUPPORT, D3D11_SDK_VERSION, D3D11CreateDevice,
-	ID3D11Device, ID3D11Texture2D,
-};
+use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
 use windows::Win32::Media::MediaFoundation::{
 	IMF2DBuffer, IMFActivate, IMFAttributes, IMFDXGIBuffer, IMFDXGIDeviceManager, IMFMediaSource, IMFSample,
 	IMFSourceReader, MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
 	MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_MAJOR_TYPE,
 	MF_MT_SUBTYPE, MF_SOURCE_READER_D3D_MANAGER, MF_SOURCE_READER_ENABLE_ADVANCED_VIDEO_PROCESSING,
 	MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, MF_SOURCE_READER_FIRST_VIDEO_STREAM, MF_SOURCE_READERF_ENDOFSTREAM,
-	MFCreateAttributes, MFCreateDXGIDeviceManager, MFCreateMediaType, MFCreateSourceReaderFromMediaSource,
-	MFEnumDeviceSources, MFMediaType_Video, MFVideoFormat_NV12,
+	MFCreateAttributes, MFCreateMediaType, MFCreateSourceReaderFromMediaSource, MFEnumDeviceSources, MFMediaType_Video,
+	MFVideoFormat_NV12,
 };
 use windows::Win32::System::Com::CoTaskMemFree;
 use windows::core::{Interface, PWSTR};
@@ -68,11 +62,7 @@ pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
 		Box::new(guard),
 	))
 }
-use crate::mf::{ComGuard, mf_err, pack_2x32};
-
-fn unpack_2x32(v: u64) -> (u32, u32) {
-	((v >> 32) as u32, v as u32)
-}
+use crate::mf::{ComGuard, create_d3d_device, mf_err, pack_2x32, unpack_2x32};
 
 /// An open camera, read frame-by-frame via [`read`](Self::read) on the pump thread.
 struct Camera {
@@ -317,49 +307,6 @@ impl Drop for Camera {
 			let _ = self.source.Shutdown();
 		}
 	}
-}
-
-/// Create a hardware Direct3D11 device plus a DXGI device manager wrapping it.
-/// The device is marked multithread-protected: the source reader's internal
-/// threads and our capture thread both touch it.
-fn create_d3d_device() -> Result<(ID3D11Device, IMFDXGIDeviceManager), Error> {
-	let mut device: Option<ID3D11Device> = None;
-	unsafe {
-		D3D11CreateDevice(
-			None,
-			D3D_DRIVER_TYPE_HARDWARE,
-			HMODULE::default(),
-			D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT,
-			None,
-			D3D11_SDK_VERSION,
-			Some(&mut device),
-			None,
-			None,
-		)
-		.map_err(|e| mf_err("D3D11CreateDevice", e))?;
-	}
-	let device = device.ok_or_else(|| Error::Codec(anyhow::anyhow!("D3D11CreateDevice returned null")))?;
-
-	let multithread = device
-		.cast::<ID3D10Multithread>()
-		.map_err(|e| mf_err("query ID3D10Multithread", e))?;
-	unsafe {
-		let _ = multithread.SetMultithreadProtected(true);
-	}
-
-	let mut token: u32 = 0;
-	let mut manager: Option<IMFDXGIDeviceManager> = None;
-	unsafe {
-		MFCreateDXGIDeviceManager(&mut token, &mut manager).map_err(|e| mf_err("MFCreateDXGIDeviceManager", e))?;
-	}
-	let manager = manager.ok_or_else(|| Error::Codec(anyhow::anyhow!("MFCreateDXGIDeviceManager returned null")))?;
-	unsafe {
-		manager
-			.ResetDevice(&device, token)
-			.map_err(|e| mf_err("ResetDevice", e))?;
-	}
-
-	Ok((device, manager))
 }
 
 fn create_attributes(capacity: u32) -> Result<IMFAttributes, Error> {

--- a/rs/moq-video/src/decode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/decode/backend/mediafoundation.rs
@@ -1,0 +1,420 @@
+//! Hardware H.264 decode backend via the Media Foundation decoder MFT + DXVA.
+//!
+//! The inverse of the encode Media Foundation backend, and the Windows
+//! counterpart to the macOS VideoToolbox decode backend. Unlike encoders, the
+//! GPU vendors (NVIDIA especially) don't ship standalone async hardware decoder
+//! MFTs; the portable hardware path is the Microsoft decoder MFT driven
+//! synchronously with a Direct3D11 device manager bound to it, which routes the
+//! actual decode to DXVA (NVDEC / Intel / AMD). We require that device: if it
+//! can't be created (a GPU-less host), `open` fails and the caller falls back to
+//! openh264, so this backend is always genuinely hardware.
+//!
+//! Each Annex-B access unit goes in as an `IMFSample`; decoded NV12 comes back as
+//! a GPU texture (the DXVA decoder owns the output pool) that we download and
+//! deinterleave to packed I420.
+//!
+//! The MFT learns the picture size from the bitstream, so unlike the encoder we
+//! don't know the dimensions up front: only after feeding the first access unit
+//! does the MFT offer an output type carrying the real frame size, so we set the
+//! NV12 output type (and read the size off it) right after that first input.
+//!
+//! Used only from the one decode task (the consumer's `read` loop), so the COM
+//! handles are wrapped in a thread-confined `Send` type.
+
+use std::ffi::c_void;
+use std::mem::ManuallyDrop;
+use std::ptr;
+
+use bytes::Bytes;
+use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
+use windows::Win32::Media::MediaFoundation::{
+	IMF2DBuffer, IMFDXGIBuffer, IMFDXGIDeviceManager, IMFMediaType, IMFSample, IMFTransform, MF_E_NO_MORE_TYPES,
+	MF_E_NOTACCEPTING, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE, MF_LOW_LATENCY, MF_MT_FRAME_SIZE,
+	MF_MT_MAJOR_TYPE, MF_MT_SUBTYPE, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video,
+	MFT_CATEGORY_VIDEO_DECODER, MFT_ENUM_FLAG_SORTANDFILTER, MFT_ENUM_FLAG_SYNCMFT, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
+	MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER,
+	MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_NV12,
+};
+use windows::core::{GUID, Interface};
+
+use super::Backend;
+use crate::Error;
+use crate::frame::I420;
+use crate::frame::d3d11::Texture;
+use crate::mf::{ComGuard, create_d3d_device, mf_err, unpack_2x32};
+
+pub(crate) const NAME: &str = "mediafoundation";
+
+/// Media Foundation time base (100ns units per second). The decoder doesn't need
+/// real timestamps (the container PTS is applied downstream), only monotonically
+/// increasing ones to keep input samples in order, so we space them by a nominal
+/// 30fps tick.
+const HNS_PER_SEC: i64 = 10_000_000;
+const NOMINAL_FPS: i64 = 30;
+
+pub(crate) struct MediaFoundation {
+	transform: IMFTransform,
+	/// The DXVA device backing the decoder; also the device the output textures
+	/// live on, so the I420 download runs on the device that owns them.
+	device: ID3D11Device,
+	/// Picture size, learned from the first output-type negotiation (0 until then).
+	width: u32,
+	height: u32,
+	/// True once the NV12 output type is set (after the initial stream change).
+	output_configured: bool,
+	/// Whether the MFT allocates its own output samples (true in DXVA mode: each
+	/// output is a GPU texture from the decoder's pool). Cached from
+	/// `GetOutputStreamInfo`.
+	provides_samples: bool,
+	/// Output buffer size to allocate when `provides_samples` is false.
+	output_size: u32,
+	sample_index: i64,
+	/// Kept alive for the MFT's lifetime; the MFT holds its own ref but we own the
+	/// pairing. Drops before `_com`.
+	_manager: IMFDXGIDeviceManager,
+	_com: ComGuard,
+}
+
+// The MFT and its COM handles are only ever touched from the one decode task (the
+// consumer's single-threaded `read` loop).
+unsafe impl Send for MediaFoundation {}
+
+impl MediaFoundation {
+	pub(crate) fn open() -> Result<Box<dyn Backend>, Error> {
+		let com = ComGuard::new()?;
+		let transform = enumerate_decoder(MFVideoFormat_H264)?;
+
+		// A hardware (DXVA) decode needs a D3D manager; failing here (no GPU) drops
+		// us to the openh264 fallback, keeping this backend hardware-only.
+		let (device, manager) = create_d3d_device()?;
+		unsafe {
+			transform
+				.ProcessMessage(MFT_MESSAGE_SET_D3D_MANAGER, manager.as_raw() as usize)
+				.map_err(|e| mf_err("set D3D manager", e))?;
+		}
+
+		// Disable the decoder's output-reorder buffer so each access unit produces
+		// its frame right away. Our streams carry no B-frames, so this adds no
+		// latency and avoids holding frames until an end-of-stream drain (which the
+		// per-access-unit `Backend` interface never signals).
+		let attrs = unsafe { transform.GetAttributes().map_err(|e| mf_err("MFT GetAttributes", e))? };
+		unsafe {
+			let _ = attrs.SetUINT32(&MF_LOW_LATENCY, 1);
+		}
+
+		let backend = Self {
+			transform,
+			device,
+			width: 0,
+			height: 0,
+			output_configured: false,
+			provides_samples: false,
+			output_size: 0,
+			sample_index: 0,
+			_manager: manager,
+			_com: com,
+		};
+
+		backend.set_input_type()?;
+		unsafe {
+			backend
+				.transform
+				.ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, 0)
+				.map_err(|e| mf_err("begin streaming", e))?;
+			// Async-model message; a synchronous decoder may not implement it, so
+			// don't let that reject an otherwise-working MFT.
+			let _ = backend.transform.ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0);
+		}
+
+		tracing::info!(decoder = NAME, "opened H.264 decoder");
+		Ok(Box::new(backend))
+	}
+
+	/// Describe the input as H.264; the MFT parses the bitstream for the rest
+	/// (the picture size shows up later on the output type).
+	fn set_input_type(&self) -> Result<(), Error> {
+		let media = unsafe { MFCreateMediaType().map_err(|e| mf_err("create input type", e))? };
+		unsafe {
+			media
+				.SetGUID(&MF_MT_MAJOR_TYPE, &MFMediaType_Video)
+				.map_err(|e| mf_err("input major type", e))?;
+			media
+				.SetGUID(&MF_MT_SUBTYPE, &MFVideoFormat_H264)
+				.map_err(|e| mf_err("input subtype", e))?;
+			self.transform
+				.SetInputType(0, &media, 0)
+				.map_err(|e| mf_err("SetInputType", e))?;
+		}
+		Ok(())
+	}
+
+	/// Pick the NV12 output type the MFT offers (now that it has parsed the
+	/// stream) and read the negotiated picture size off it. Called once after the
+	/// first access unit, and again if the MFT later reports a resolution change.
+	fn configure_output(&mut self) -> Result<(), Error> {
+		let mut index = 0;
+		loop {
+			let media = match unsafe { self.transform.GetOutputAvailableType(0, index) } {
+				Ok(media) => media,
+				Err(e) if e.code() == MF_E_NO_MORE_TYPES => {
+					return Err(Error::Codec(anyhow::anyhow!("decoder offers no NV12 output type")));
+				}
+				Err(e) => return Err(mf_err("GetOutputAvailableType", e)),
+			};
+
+			let subtype = unsafe { media.GetGUID(&MF_MT_SUBTYPE).map_err(|e| mf_err("output subtype", e))? };
+			if subtype == MFVideoFormat_NV12 {
+				unsafe {
+					self.transform
+						.SetOutputType(0, &media, 0)
+						.map_err(|e| mf_err("SetOutputType", e))?;
+				}
+				self.read_frame_size(&media)?;
+				self.read_output_info()?;
+				self.output_configured = true;
+				return Ok(());
+			}
+			index += 1;
+		}
+	}
+
+	fn read_frame_size(&mut self, media: &IMFMediaType) -> Result<(), Error> {
+		let packed = unsafe {
+			media
+				.GetUINT64(&MF_MT_FRAME_SIZE)
+				.map_err(|e| mf_err("frame size", e))?
+		};
+		let (width, height) = unpack_2x32(packed);
+		// I420 chroma is 2x2 subsampled, so the download needs even dimensions.
+		if width == 0 || height == 0 || width % 2 != 0 || height % 2 != 0 {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"decoder reported unusable frame size {width}x{height}"
+			)));
+		}
+		self.width = width;
+		self.height = height;
+		Ok(())
+	}
+
+	/// Cache whether the MFT provides its own output samples (true for a
+	/// DXVA-backed decoder: each output is a GPU texture it allocates) and, if
+	/// not, how big a buffer we must hand it.
+	fn read_output_info(&mut self) -> Result<(), Error> {
+		let info = unsafe {
+			self.transform
+				.GetOutputStreamInfo(0)
+				.map_err(|e| mf_err("GetOutputStreamInfo", e))?
+		};
+		self.provides_samples = info.dwFlags & MFT_OUTPUT_STREAM_PROVIDES_SAMPLES.0 as u32 != 0;
+		self.output_size = info.cbSize;
+		Ok(())
+	}
+
+	/// Wrap an Annex-B access unit as an input [`IMFSample`] in a fresh
+	/// system-memory buffer (the MFT uploads it to the GPU itself).
+	fn build_sample(&self, access_unit: &[u8]) -> Result<IMFSample, Error> {
+		let buffer = unsafe { MFCreateMemoryBuffer(access_unit.len() as u32).map_err(|e| mf_err("input buffer", e))? };
+		let mut ptr_out: *mut u8 = ptr::null_mut();
+		unsafe {
+			buffer
+				.Lock(&mut ptr_out, None, None)
+				.map_err(|e| mf_err("lock input buffer", e))?;
+		}
+		// SAFETY: the buffer was allocated with `access_unit.len()` bytes and we
+		// hold the lock until `Unlock`.
+		unsafe { std::slice::from_raw_parts_mut(ptr_out, access_unit.len()) }.copy_from_slice(access_unit);
+		unsafe {
+			let _ = buffer.Unlock();
+			buffer
+				.SetCurrentLength(access_unit.len() as u32)
+				.map_err(|e| mf_err("set input length", e))?;
+		}
+
+		let sample = unsafe { MFCreateSample().map_err(|e| mf_err("MFCreateSample", e))? };
+		unsafe {
+			sample.AddBuffer(&buffer).map_err(|e| mf_err("AddBuffer", e))?;
+			let tick = HNS_PER_SEC / NOMINAL_FPS;
+			sample
+				.SetSampleTime(self.sample_index * tick)
+				.map_err(|e| mf_err("SetSampleTime", e))?;
+			sample
+				.SetSampleDuration(tick)
+				.map_err(|e| mf_err("SetSampleDuration", e))?;
+		}
+		Ok(sample)
+	}
+
+	/// Pull every frame the MFT has ready, stopping when it asks for more input.
+	/// No-op until the output type is configured (the decoder rejects
+	/// `ProcessOutput` before then).
+	fn drain_output(&mut self, out: &mut Vec<I420>) -> Result<(), Error> {
+		if !self.output_configured {
+			return Ok(());
+		}
+		while self.process_output(out)? {}
+		Ok(())
+	}
+
+	/// One `ProcessOutput`. Returns `true` if it produced a frame or handled a
+	/// stream change (so the caller keeps draining), `false` on
+	/// `MF_E_TRANSFORM_NEED_MORE_INPUT` (the decoder wants the next access unit).
+	fn process_output(&mut self, out: &mut Vec<I420>) -> Result<bool, Error> {
+		// In DXVA mode the MFT provides its own texture-backed sample, so we pass a
+		// null slot; otherwise we hand it a system-memory buffer to fill.
+		let provided = if self.provides_samples {
+			None
+		} else {
+			let buffer = unsafe { MFCreateMemoryBuffer(self.output_size).map_err(|e| mf_err("output buffer", e))? };
+			let sample = unsafe { MFCreateSample().map_err(|e| mf_err("output sample", e))? };
+			unsafe { sample.AddBuffer(&buffer).map_err(|e| mf_err("output AddBuffer", e))? };
+			Some(sample)
+		};
+
+		let mut data = [MFT_OUTPUT_DATA_BUFFER {
+			dwStreamID: 0,
+			pSample: ManuallyDrop::new(provided),
+			dwStatus: 0,
+			pEvents: ManuallyDrop::new(None),
+		}];
+		let mut status = 0u32;
+		let result = unsafe { self.transform.ProcessOutput(0, &mut data, &mut status) };
+
+		let sample = ManuallyDrop::into_inner(unsafe { ptr::read(&data[0].pSample) });
+		let _events = ManuallyDrop::into_inner(unsafe { ptr::read(&data[0].pEvents) });
+
+		match result {
+			Ok(()) => {
+				if let Some(sample) = sample {
+					out.push(self.sample_to_i420(&sample)?);
+				}
+				Ok(true)
+			}
+			Err(e) if e.code() == MF_E_TRANSFORM_NEED_MORE_INPUT => Ok(false),
+			Err(e) if e.code() == MF_E_TRANSFORM_STREAM_CHANGE => {
+				self.configure_output()?;
+				Ok(true)
+			}
+			Err(e) => Err(mf_err("ProcessOutput", e)),
+		}
+	}
+
+	/// Download a decoded NV12 output sample to packed I420. The DXVA path hands
+	/// back a GPU texture (reusing the capture staging-copy); a system-memory
+	/// fallback deinterleaves the contiguous NV12 directly.
+	fn sample_to_i420(&self, sample: &IMFSample) -> Result<I420, Error> {
+		let buffer = unsafe { sample.GetBufferByIndex(0).map_err(|e| mf_err("get output buffer", e))? };
+
+		if let Ok(dxgi) = buffer.cast::<IMFDXGIBuffer>() {
+			// GetResource returns a fresh ref (`AddRef`) we take ownership of.
+			let mut raw: *mut c_void = ptr::null_mut();
+			unsafe {
+				dxgi.GetResource(&ID3D11Texture2D::IID, &mut raw)
+					.map_err(|e| mf_err("get DXGI resource", e))?;
+			}
+			let texture = unsafe { ID3D11Texture2D::from_raw(raw) };
+			let subresource = unsafe {
+				dxgi.GetSubresourceIndex()
+					.map_err(|e| mf_err("get subresource index", e))?
+			};
+			return Texture::new(self.device.clone(), texture, subresource, self.width, self.height).download_i420();
+		}
+
+		// System-memory NV12: prefer the 2D copy (strips per-row stride padding).
+		let buf2d = buffer
+			.cast::<IMF2DBuffer>()
+			.map_err(|e| mf_err("output buffer is neither DXGI nor 2D", e))?;
+		let len = unsafe {
+			buf2d
+				.GetContiguousLength()
+				.map_err(|e| mf_err("contiguous length", e))?
+		};
+		let mut nv12 = vec![0u8; len as usize];
+		unsafe {
+			buf2d
+				.ContiguousCopyTo(&mut nv12)
+				.map_err(|e| mf_err("contiguous copy", e))?;
+		}
+		I420::from_nv12(&nv12, self.width, self.height)
+	}
+}
+
+impl Backend for MediaFoundation {
+	fn decode(&mut self, access_unit: Bytes, _keyframe: bool) -> Result<Vec<I420>, Error> {
+		let mut out = Vec::new();
+
+		let sample = self.build_sample(&access_unit)?;
+		// The decoder accepts one access unit at a time. If it's still holding
+		// output it returns NOTACCEPTING; drain that, then the input goes in.
+		loop {
+			match unsafe { self.transform.ProcessInput(0, &sample, 0) } {
+				Ok(()) => break,
+				Err(e) if e.code() == MF_E_NOTACCEPTING => {
+					self.drain_output(&mut out)?;
+				}
+				Err(e) => return Err(mf_err("ProcessInput", e)),
+			}
+		}
+		self.sample_index += 1;
+
+		// The decoder only reports the picture size once it has parsed the first
+		// access unit's SPS, so the output type is configured here rather than at
+		// open time.
+		if !self.output_configured {
+			self.configure_output()?;
+		}
+
+		self.drain_output(&mut out)?;
+		Ok(out)
+	}
+
+	fn name(&self) -> &str {
+		NAME
+	}
+}
+
+/// Pick the first synchronous decoder MFT (`subtype` in, NV12 out). The Microsoft
+/// decoder it returns runs the actual decode on the GPU via DXVA once a D3D
+/// manager is bound.
+fn enumerate_decoder(subtype: GUID) -> Result<IMFTransform, Error> {
+	let input = MFT_REGISTER_TYPE_INFO {
+		guidMajorType: MFMediaType_Video,
+		guidSubtype: subtype,
+	};
+	let output = MFT_REGISTER_TYPE_INFO {
+		guidMajorType: MFMediaType_Video,
+		guidSubtype: MFVideoFormat_NV12,
+	};
+
+	let mut activates: *mut Option<windows::Win32::Media::MediaFoundation::IMFActivate> = ptr::null_mut();
+	let mut count: u32 = 0;
+	unsafe {
+		MFTEnumEx(
+			MFT_CATEGORY_VIDEO_DECODER,
+			MFT_ENUM_FLAG_SYNCMFT | MFT_ENUM_FLAG_SORTANDFILTER,
+			Some(&input),
+			Some(&output),
+			&mut activates,
+			&mut count,
+		)
+		.map_err(|e| mf_err("MFTEnumEx", e))?;
+	}
+	if count == 0 {
+		return Err(Error::Codec(anyhow::anyhow!("no decoder MFT found")));
+	}
+
+	let entries = unsafe { std::slice::from_raw_parts_mut(activates, count as usize) };
+	let mut transform: Option<IMFTransform> = None;
+	for slot in entries.iter_mut() {
+		let Some(activate) = slot.take() else { continue };
+		if transform.is_none() {
+			if let Ok(mft) = unsafe { activate.ActivateObject::<IMFTransform>() } {
+				transform = Some(mft);
+			}
+		}
+	}
+	unsafe {
+		windows::Win32::System::Com::CoTaskMemFree(Some(activates as *const c_void));
+	}
+
+	transform.ok_or_else(|| Error::Codec(anyhow::anyhow!("failed to activate decoder MFT")))
+}

--- a/rs/moq-video/src/decode/backend/mod.rs
+++ b/rs/moq-video/src/decode/backend/mod.rs
@@ -7,8 +7,8 @@
 //! keyframe) and returns zero or more decoded [`I420`] frames.
 //!
 //! [`open`] picks the best backend for a [`Kind`](super::Kind), trying hardware
-//! candidates (platform-gated) before the openh264 software fallback, exactly
-//! like the encode side.
+//! candidates (platform-gated: VideoToolbox on macOS, Media Foundation / DXVA on
+//! Windows) before the openh264 software fallback, exactly like the encode side.
 
 use bytes::Bytes;
 
@@ -20,6 +20,9 @@ mod openh264;
 
 #[cfg(target_os = "macos")]
 mod videotoolbox;
+
+#[cfg(target_os = "windows")]
+mod mediafoundation;
 
 /// An opened H.264 decoder. Feed it Annex-B access units in decode order; get
 /// back zero or more raw I420 frames (zero while the decoder is still buffering,
@@ -47,6 +50,11 @@ const HARDWARE: &[Candidate] = &[
 	Candidate {
 		name: videotoolbox::NAME,
 		open: videotoolbox::VideoToolbox::open,
+	},
+	#[cfg(target_os = "windows")]
+	Candidate {
+		name: mediafoundation::NAME,
+		open: mediafoundation::MediaFoundation::open,
 	},
 ];
 

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -169,11 +169,24 @@ mod tests {
 		}
 
 		assert!(!decoded.is_empty(), "decoder produced no frames");
+		let luma = 320 * 240;
 		for i420 in &decoded {
 			assert_eq!(i420.width, 320);
 			assert_eq!(i420.height, 240);
 			// Tightly-packed I420: luma + two quarter-size chroma planes.
-			assert_eq!(i420.data.len(), 320 * 240 * 3 / 2);
+			assert_eq!(i420.data.len(), luma * 3 / 2);
+
+			// Mid-gray RGBA (0x80) encodes to a flat picture: BT.601 limited-range
+			// luma near 125 and neutral chroma near 128. Averaging each plane
+			// catches plane swaps, stride bugs, and a misread Y/UV split that an
+			// exact size check would miss.
+			let avg = |plane: &[u8]| plane.iter().map(|&b| b as u32).sum::<u32>() / plane.len() as u32;
+			let y = avg(&i420.data[..luma]);
+			let u = avg(&i420.data[luma..luma + luma / 4]);
+			let v = avg(&i420.data[luma + luma / 4..]);
+			assert!((110..=140).contains(&y), "luma {y} off for a gray frame");
+			assert!((118..=138).contains(&u), "u {u} off for a gray frame");
+			assert!((118..=138).contains(&v), "v {v} off for a gray frame");
 		}
 	}
 
@@ -186,5 +199,17 @@ mod tests {
 	#[test]
 	fn videotoolbox_round_trip() {
 		round_trip(&super::Kind::Named("videotoolbox".into()), "videotoolbox");
+	}
+
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn mediafoundation_round_trip() {
+		// Requires a hardware decoder MFT (GPU). Skip on machines without one
+		// rather than fail: CI runners are often headless.
+		if backend::open(&super::Kind::Named("mediafoundation".into())).is_err() {
+			eprintln!("skipping: no Media Foundation hardware decoder available");
+			return;
+		}
+		round_trip(&super::Kind::Named("mediafoundation".into()), "mediafoundation");
 	}
 }

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -3,7 +3,8 @@
 //! The decode counterpart to [`encode`](crate::encode), and the mirror of
 //! `moq-audio`'s `AudioConsumer`. [`Consumer`] subscribes to a moq-mux H.264
 //! track and hands back decoded [`Frame`]s; a native backend does the work
-//! (VideoToolbox on macOS, openh264 everywhere as the software fallback).
+//! (VideoToolbox on macOS, Media Foundation / DXVA on Windows, openh264
+//! everywhere as the software fallback).
 //!
 //! Only H.264 is supported: it's symmetric with what [`encode`](crate::encode)
 //! produces. A non-H.264 rendition yields [`Error::UnsupportedCodec`](crate::Error).

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -19,8 +19,9 @@
 //!     released when the last one leaves.
 //!   - [`encode::Producer`] publishes packets you encoded yourself.
 //! - [`decode`] subscribes to an H.264 track and decodes it to raw I420 frames
-//!   with a native backend (VideoToolbox / openh264). [`decode::Consumer`] is the
-//!   mirror of `moq-audio`'s `AudioConsumer`.
+//!   with a native backend (VideoToolbox on macOS, Media Foundation / DXVA on
+//!   Windows, openh264 software fallback). [`decode::Consumer`] is the mirror of
+//!   `moq-audio`'s `AudioConsumer`.
 //!
 //! ## API stability
 //!

--- a/rs/moq-video/src/mf.rs
+++ b/rs/moq-video/src/mf.rs
@@ -1,8 +1,18 @@
-//! Shared Media Foundation / COM helpers used by both the capture source and the
-//! hardware encoder backend on Windows.
+//! Shared Media Foundation / COM helpers used by the capture source, the
+//! hardware encoder backend, and the hardware decoder backend on Windows.
 
-use windows::Win32::Media::MediaFoundation::{MF_VERSION, MFSTARTUP_FULL, MFShutdown, MFStartup};
+use windows::Win32::Foundation::HMODULE;
+use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
+use windows::Win32::Graphics::Direct3D10::ID3D10Multithread;
+use windows::Win32::Graphics::Direct3D11::{
+	D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_VIDEO_SUPPORT, D3D11_SDK_VERSION, D3D11CreateDevice,
+	ID3D11Device,
+};
+use windows::Win32::Media::MediaFoundation::{
+	IMFDXGIDeviceManager, MF_VERSION, MFCreateDXGIDeviceManager, MFSTARTUP_FULL, MFShutdown, MFStartup,
+};
 use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize};
+use windows::core::Interface;
 
 use crate::Error;
 
@@ -16,6 +26,58 @@ pub(crate) fn mf_err(ctx: &str, e: windows::core::Error) -> Error {
 /// (numerator/denominator).
 pub(crate) fn pack_2x32(hi: u32, lo: u32) -> u64 {
 	((hi as u64) << 32) | lo as u64
+}
+
+/// Split the high/low halves of a `pack_2x32` value back out, the inverse of
+/// [`pack_2x32`]. Used to read `MF_MT_FRAME_SIZE` / `MF_MT_FRAME_RATE` back off a
+/// negotiated media type.
+pub(crate) fn unpack_2x32(v: u64) -> (u32, u32) {
+	((v >> 32) as u32, v as u32)
+}
+
+/// Create a hardware Direct3D11 device plus a DXGI device manager wrapping it,
+/// the pairing every Media Foundation GPU path needs (a capture source reader, a
+/// hardware encoder MFT, or a hardware decoder MFT). The device is marked
+/// multithread-protected because Media Foundation's internal worker threads and
+/// our blocking thread both touch it.
+pub(crate) fn create_d3d_device() -> Result<(ID3D11Device, IMFDXGIDeviceManager), Error> {
+	let mut device: Option<ID3D11Device> = None;
+	unsafe {
+		D3D11CreateDevice(
+			None,
+			D3D_DRIVER_TYPE_HARDWARE,
+			HMODULE::default(),
+			D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT,
+			None,
+			D3D11_SDK_VERSION,
+			Some(&mut device),
+			None,
+			None,
+		)
+		.map_err(|e| mf_err("D3D11CreateDevice", e))?;
+	}
+	let device = device.ok_or_else(|| Error::Codec(anyhow::anyhow!("D3D11CreateDevice returned null")))?;
+
+	let multithread = device
+		.cast::<ID3D10Multithread>()
+		.map_err(|e| mf_err("query ID3D10Multithread", e))?;
+	unsafe {
+		let _ = multithread.SetMultithreadProtected(true);
+	}
+
+	let mut token: u32 = 0;
+	let mut manager: Option<IMFDXGIDeviceManager> = None;
+	unsafe {
+		MFCreateDXGIDeviceManager(&mut token, &mut manager).map_err(|e| mf_err("MFCreateDXGIDeviceManager", e))?;
+	}
+	let manager = manager.ok_or_else(|| Error::Codec(anyhow::anyhow!("MFCreateDXGIDeviceManager returned null")))?;
+	unsafe {
+		manager
+			.ResetDevice(&device, token)
+			.map_err(|e| mf_err("ResetDevice", e))?;
+	}
+
+	Ok((device, manager))
 }
 
 /// COM (MTA) + Media Foundation lifetime for the calling thread, balanced by


### PR DESCRIPTION
Closes the **H.264 hardware decode on Windows** item in #1837. Windows subscribers currently fall back to openh264 software; this adds a Media Foundation decode backend that runs the decode on the GPU.

## Approach

Unlike *encoders*, GPU vendors (NVIDIA especially) don't ship standalone async hardware *decoder* MFTs. The portable hardware decode path on Windows is the **Microsoft decoder MFT driven synchronously with a Direct3D11 device bound to it**, which routes the actual work through DXVA (NVDEC / Intel / AMD). I started with the symmetric async `MFT_ENUM_FLAG_HARDWARE` approach (mirroring the encoder) but enumeration returns nothing on the NVIDIA box, confirming the sync-MFT + DXVA route is the right one.

- Enumerate the sync decoder MFT (`MFT_CATEGORY_VIDEO_DECODER`, H.264 in / NV12 out), bind a fresh D3D11 device via `MFT_MESSAGE_SET_D3D_MANAGER`.
- The picture size isn't known up front (the encoder knows it; a decoder learns it from the bitstream), so the NV12 output type is configured right after the first access unit, reading the frame size off the negotiated type.
- Decoded NV12 comes back as a GPU texture; download + deinterleave to packed I420, reusing the capture path's staging copy (`frame::d3d11::Texture::download_i420`).
- `MF_LOW_LATENCY` disables the output-reorder buffer. Our streams have no B-frames, so each AU yields its frame immediately, avoiding holding frames until an end-of-stream drain (which the per-AU `Backend` interface never signals).
- **Hardware-only**: if the D3D11 device can't be created (GPU-less host), `open` fails and the caller falls back to openh264. No silent software MF path masking openh264.

Also factored `create_d3d_device` + `unpack_2x32` into the shared `mf` module (capture, encoder, and now decoder share them).

## Public API

No change. The new backend is `pub(crate)`; `decode::Consumer` is unchanged. Selection still happens through the existing `decode::Kind` (`Auto` picks the new backend ahead of openh264 on Windows).

## Test plan

- [x] `cargo test -p moq-video` (incl. a new `mediafoundation_round_trip`) — **passes on a real NVIDIA RTX 3070 Ti**: openh264 encode -> NVDEC decode round-trip, asserting both dimensions and plane content (a gray frame decodes back to near-neutral luma/chroma — catches plane-swap / stride bugs across all three decode backends).
- [x] Existing MF *encode* tests still pass on hardware (the `mf.rs` refactor).
- [x] `cargo clippy -p moq-video --all-targets -- -D warnings` clean.
- [x] Round-trip test skips cleanly on hosts without a hardware decoder.

Targets `dev` (builds on the just-landed `decode` module, still `[Unreleased]`).

Cross-package sync: this is the native-side mirror of work tracked in #1837; no wire/catalog/API change, so no paired JS/doc updates required. `rs/moq-video`'s own README + CHANGELOG are updated.

(Written by Claude)