### PR TITLE
feat(moq-video): H.265 decode + Media Foundation HEVC backend

### DIFF
--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   frame to a staging texture, and converts BGRA to I420. Whole-monitor capture;
   select one with a bare index or `display:{index}`. The read loop paces to the
   target frame rate and re-emits the last frame while the screen is static.
+- H.265 decode: the `decode` module now handles H.265 tracks (hvc1 and hev1)
+  alongside H.264, sharing the same length-prefixed -> Annex-B front end. The
+  Windows Media Foundation backend decodes it (DXVA) when an HEVC decoder MFT is
+  present. There is no software H.265 decoder, so H.265 has no fallback below the
+  hardware path. The HEVC decode path is unverified on hardware (the test box had
+  no HEVC decoder MFT installed); the shared front end is exercised by the H.264
+  hardware round-trip.
 - H.265 encode via the NVENC backend (Linux, `nvenc` feature). The codec is
   selected by `encode::Codec`; the NVENC HEVC path shares the H.264 preset / GOP
   / rate-control setup and emits Annex-B with inline VPS/SPS/PPS. Not yet

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -52,14 +52,16 @@ GPU-less builder and still starts on a GPU-less machine.
 ## Decode
 
 `decode::Consumer` (the mirror of `moq-audio`'s `AudioConsumer`) subscribes to an
-H.264 track and returns raw I420 frames. Backends are tried hardware-first, like
-encode:
+H.264 or H.265 track and returns raw I420 frames. Backends are tried
+hardware-first, like encode:
 
 | Codec | Software | macOS | Windows | Linux |
 |---|---|---|---|---|
 | H.264 | openh264 (vendored, static) | VideoToolbox | Media Foundation (DXVA) | openh264 |
+| H.265 | none | none | Media Foundation (DXVA) | none |
 
 On Windows the Microsoft decoder MFT runs synchronously with a Direct3D11 device
-bound to it, so the decode happens on the GPU through DXVA (NVDEC / Intel / AMD);
-a GPU-less host falls back to openh264. H.264 only for now; a non-H.264 rendition
-yields `Error::UnsupportedCodec`.
+bound to it, so the decode happens on the GPU through DXVA (NVDEC / Intel / AMD).
+H.264 falls back to openh264 on a GPU-less host; H.265 has no software decoder, so
+it needs the GPU path (and an HEVC decoder MFT: the inbox HEVC Video Extensions or
+a vendor one). A non-H.264/H.265 rendition yields `Error::UnsupportedCodec`.

--- a/rs/moq-video/src/decode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/decode/backend/mediafoundation.rs
@@ -1,4 +1,5 @@
-//! Hardware H.264 decode backend via the Media Foundation decoder MFT + DXVA.
+//! Hardware H.264 / H.265 decode backend via the Media Foundation decoder MFT +
+//! DXVA.
 //!
 //! The inverse of the encode Media Foundation backend, and the Windows
 //! counterpart to the macOS VideoToolbox decode backend. Unlike encoders, the
@@ -6,8 +7,10 @@
 //! MFTs; the portable hardware path is the Microsoft decoder MFT driven
 //! synchronously with a Direct3D11 device manager bound to it, which routes the
 //! actual decode to DXVA (NVDEC / Intel / AMD). We require that device: if it
-//! can't be created (a GPU-less host), `open` fails and the caller falls back to
-//! openh264, so this backend is always genuinely hardware.
+//! can't be created (a GPU-less host), `open` fails. H.265 additionally needs an
+//! HEVC decoder MFT present (the inbox HEVC Video Extensions or a vendor MFT);
+//! absent that, `open` fails too. For H.264 the caller then falls back to
+//! openh264; H.265 has no software fallback, so it simply has no decoder.
 //!
 //! Each Annex-B access unit goes in as an `IMFSample`; decoded NV12 comes back as
 //! a GPU texture (the DXVA decoder owns the output pool) that we download and
@@ -33,11 +36,12 @@ use windows::Win32::Media::MediaFoundation::{
 	MF_MT_MAJOR_TYPE, MF_MT_SUBTYPE, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video,
 	MFT_CATEGORY_VIDEO_DECODER, MFT_ENUM_FLAG_SORTANDFILTER, MFT_ENUM_FLAG_SYNCMFT, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
 	MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER,
-	MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_NV12,
+	MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_HEVC,
+	MFVideoFormat_NV12,
 };
 use windows::core::{GUID, Interface};
 
-use super::Backend;
+use super::{Backend, Codec};
 use crate::Error;
 use crate::frame::I420;
 use crate::frame::d3d11::Texture;
@@ -54,6 +58,9 @@ const NOMINAL_FPS: i64 = 30;
 
 pub(crate) struct MediaFoundation {
 	transform: IMFTransform,
+	/// The Media Foundation input subtype (`MFVideoFormat_H264` / `_HEVC`), kept
+	/// for `set_input_type`.
+	input_subtype: GUID,
 	/// The DXVA device backing the decoder; also the device the output textures
 	/// live on, so the I420 download runs on the device that owns them.
 	device: ID3D11Device,
@@ -80,9 +87,13 @@ pub(crate) struct MediaFoundation {
 unsafe impl Send for MediaFoundation {}
 
 impl MediaFoundation {
-	pub(crate) fn open() -> Result<Box<dyn Backend>, Error> {
+	pub(crate) fn open(codec: Codec) -> Result<Box<dyn Backend>, Error> {
+		let (input_subtype, label) = match codec {
+			Codec::H264 => (MFVideoFormat_H264, "H.264"),
+			Codec::H265 => (MFVideoFormat_HEVC, "H.265"),
+		};
 		let com = ComGuard::new()?;
-		let transform = enumerate_decoder(MFVideoFormat_H264)?;
+		let transform = enumerate_decoder(input_subtype)?;
 
 		// A hardware (DXVA) decode needs a D3D manager; failing here (no GPU) drops
 		// us to the openh264 fallback, keeping this backend hardware-only.
@@ -104,6 +115,7 @@ impl MediaFoundation {
 
 		let backend = Self {
 			transform,
+			input_subtype,
 			device,
 			width: 0,
 			height: 0,
@@ -126,12 +138,12 @@ impl MediaFoundation {
 			let _ = backend.transform.ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0);
 		}
 
-		tracing::info!(decoder = NAME, "opened H.264 decoder");
+		tracing::info!(decoder = NAME, codec = label, "opened decoder");
 		Ok(Box::new(backend))
 	}
 
-	/// Describe the input as H.264; the MFT parses the bitstream for the rest
-	/// (the picture size shows up later on the output type).
+	/// Describe the input as the coded format (H.264 / H.265); the MFT parses the
+	/// bitstream for the rest (the picture size shows up later on the output type).
 	fn set_input_type(&self) -> Result<(), Error> {
 		let media = unsafe { MFCreateMediaType().map_err(|e| mf_err("create input type", e))? };
 		unsafe {
@@ -139,7 +151,7 @@ impl MediaFoundation {
 				.SetGUID(&MF_MT_MAJOR_TYPE, &MFMediaType_Video)
 				.map_err(|e| mf_err("input major type", e))?;
 			media
-				.SetGUID(&MF_MT_SUBTYPE, &MFVideoFormat_H264)
+				.SetGUID(&MF_MT_SUBTYPE, &self.input_subtype)
 				.map_err(|e| mf_err("input subtype", e))?;
 			self.transform
 				.SetInputType(0, &media, 0)

--- a/rs/moq-video/src/decode/backend/mod.rs
+++ b/rs/moq-video/src/decode/backend/mod.rs
@@ -1,14 +1,18 @@
-//! Pluggable H.264 decoder backends.
+//! Pluggable H.264 / H.265 decoder backends.
 //!
 //! The mirror of [`encode::backend`](crate::encode). [`Backend`] is the seam
-//! between the access-unit prep (avc1 -> Annex-B conversion + keyframe gating,
-//! owned by [`Decoder`](super::Decoder)) and the codec itself. Every backend
-//! takes one **Annex-B** H.264 access unit (SPS/PPS inline ahead of each
-//! keyframe) and returns zero or more decoded [`I420`] frames.
+//! between the access-unit prep (length-prefixed -> Annex-B conversion + keyframe
+//! gating, owned by [`Decoder`](super::Decoder)) and the codec itself. Every
+//! backend takes one **Annex-B** access unit (parameter sets inline ahead of each
+//! keyframe: SPS/PPS for H.264, VPS/SPS/PPS for H.265) and returns zero or more
+//! decoded [`I420`] frames.
 //!
-//! [`open`] picks the best backend for a [`Kind`](super::Kind), trying hardware
-//! candidates (platform-gated: VideoToolbox on macOS, Media Foundation / DXVA on
-//! Windows) before the openh264 software fallback, exactly like the encode side.
+//! [`open`] picks the best backend for a ([`Codec`], [`Kind`](super::Kind)) pair,
+//! trying hardware candidates (platform-gated: VideoToolbox on macOS, Media
+//! Foundation / DXVA on Windows) before the openh264 software fallback, exactly
+//! like the encode side. Only backends that support the requested codec are
+//! considered: there is no software H.265 decoder, so an H.265 track has no
+//! fallback below the hardware path.
 
 use bytes::Bytes;
 
@@ -24,11 +28,28 @@ mod videotoolbox;
 #[cfg(target_os = "windows")]
 mod mediafoundation;
 
-/// An opened H.264 decoder. Feed it Annex-B access units in decode order; get
-/// back zero or more raw I420 frames (zero while the decoder is still buffering,
-/// e.g. before the first keyframe's parameter sets).
+/// The video codec a decoder handles. Derived from the catalog, not chosen by the
+/// caller.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Codec {
+	H264,
+	H265,
+}
+
+impl Codec {
+	fn label(self) -> &'static str {
+		match self {
+			Codec::H264 => "H.264",
+			Codec::H265 => "H.265",
+		}
+	}
+}
+
+/// An opened decoder. Feed it Annex-B access units in decode order; get back zero
+/// or more raw I420 frames (zero while the decoder is still buffering, e.g. before
+/// the first keyframe's parameter sets).
 pub(crate) trait Backend: Send {
-	/// Decode one Annex-B access unit. `keyframe` marks an IDR (parameter sets
+	/// Decode one Annex-B access unit. `keyframe` marks a keyframe (parameter sets
 	/// are inline ahead of it). Takes an owned [`Bytes`] so a backend can split
 	/// out NAL slices without copying.
 	fn decode(&mut self, access_unit: Bytes, keyframe: bool) -> Result<Vec<I420>, Error>;
@@ -37,10 +58,11 @@ pub(crate) trait Backend: Send {
 	fn name(&self) -> &str;
 }
 
-/// A backend constructor: name plus an opener that tries to start it.
+/// A backend constructor: name, the codecs it can decode, and an opener.
 struct Candidate {
 	name: &'static str,
-	open: fn() -> Result<Box<dyn Backend>, Error>,
+	supports: fn(Codec) -> bool,
+	open: fn(Codec) -> Result<Box<dyn Backend>, Error>,
 }
 
 /// Hardware backends, in priority order. Platform-gated so only the ones that
@@ -49,23 +71,27 @@ const HARDWARE: &[Candidate] = &[
 	#[cfg(target_os = "macos")]
 	Candidate {
 		name: videotoolbox::NAME,
+		supports: |c| matches!(c, Codec::H264),
 		open: videotoolbox::VideoToolbox::open,
 	},
 	#[cfg(target_os = "windows")]
 	Candidate {
 		name: mediafoundation::NAME,
+		supports: |_| true,
 		open: mediafoundation::MediaFoundation::open,
 	},
 ];
 
 const SOFTWARE: Candidate = Candidate {
 	name: openh264::NAME,
+	supports: |c| matches!(c, Codec::H264),
 	open: openh264::Openh264::open,
 };
 
-/// Open the best decoder for `kind`, trying candidates in priority order and
-/// falling back until one succeeds.
-pub(crate) fn open(kind: &Kind) -> Result<Box<dyn Backend>, Error> {
+/// Open the best decoder for `codec` and `kind`, trying candidates in priority
+/// order and falling back until one succeeds. Candidates that don't support the
+/// codec are skipped before they're even tried.
+pub(crate) fn open(codec: Codec, kind: &Kind) -> Result<Box<dyn Backend>, Error> {
 	let candidates: Vec<&Candidate> = match kind {
 		Kind::Auto => HARDWARE.iter().chain(std::iter::once(&SOFTWARE)).collect(),
 		Kind::Hardware => HARDWARE.iter().collect(),
@@ -78,12 +104,18 @@ pub(crate) fn open(kind: &Kind) -> Result<Box<dyn Backend>, Error> {
 
 	let mut tried = Vec::new();
 	for candidate in candidates {
+		if !(candidate.supports)(codec) {
+			continue;
+		}
 		tried.push(candidate.name);
-		match (candidate.open)() {
+		match (candidate.open)(codec) {
 			Ok(backend) => return Ok(backend),
 			Err(e) => tracing::debug!(decoder = candidate.name, error = %e, "decoder unavailable, trying next"),
 		}
 	}
 
+	if tried.is_empty() {
+		return Err(Error::NoDecoder(format!("none support {}", codec.label())));
+	}
 	Err(Error::NoDecoder(tried.join(", ")))
 }

--- a/rs/moq-video/src/decode/backend/openh264.rs
+++ b/rs/moq-video/src/decode/backend/openh264.rs
@@ -9,7 +9,7 @@ use openh264::OpenH264API;
 use openh264::decoder::{Decoder, DecoderConfig};
 use openh264::formats::YUVSource;
 
-use super::Backend;
+use super::{Backend, Codec};
 use crate::Error;
 use crate::frame::I420;
 
@@ -20,7 +20,9 @@ pub(crate) struct Openh264 {
 }
 
 impl Openh264 {
-	pub(crate) fn open() -> Result<Box<dyn Backend>, Error> {
+	/// openh264 decodes H.264 only; the backend selector never routes another
+	/// codec here, so `codec` is accepted for signature parity and ignored.
+	pub(crate) fn open(_codec: Codec) -> Result<Box<dyn Backend>, Error> {
 		let decoder = Decoder::with_api_config(OpenH264API::from_source(), DecoderConfig::new())
 			.map_err(|e| Error::Codec(anyhow::anyhow!("openh264 decoder init: {e}")))?;
 

--- a/rs/moq-video/src/decode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/decode/backend/videotoolbox.rs
@@ -32,7 +32,7 @@ use objc2_video_toolbox::{
 	VTDecodeFrameFlags, VTDecodeInfoFlags, VTDecompressionOutputCallbackRecord, VTDecompressionSession,
 };
 
-use super::Backend;
+use super::{Backend, Codec};
 use crate::Error;
 use crate::frame::I420;
 
@@ -69,7 +69,9 @@ pub(crate) struct VideoToolbox {
 unsafe impl Send for VideoToolbox {}
 
 impl VideoToolbox {
-	pub(crate) fn open() -> Result<Box<dyn Backend>, Error> {
+	/// The VideoToolbox decode backend handles H.264 only for now; the selector
+	/// never routes H.265 here, so `codec` is accepted for signature parity.
+	pub(crate) fn open(_codec: Codec) -> Result<Box<dyn Backend>, Error> {
 		tracing::info!(decoder = NAME, "opened H.264 decoder");
 		Ok(Box::new(Self {
 			session: None,

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -1,4 +1,4 @@
-//! Subscribe to an encoded H.264 track and emit raw I420 frames.
+//! Subscribe to an encoded H.264 or H.265 track and emit raw I420 frames.
 
 use std::collections::VecDeque;
 
@@ -9,7 +9,7 @@ use super::Frame;
 use super::decoder::{Config, Decoder};
 use crate::Error;
 
-/// Subscribe to a moq-mux H.264 track and emit decoded I420.
+/// Subscribe to a moq-mux H.264 or H.265 track and emit decoded I420.
 ///
 /// The codec/backend are fixed at construction; [`read`](Self::read) returns
 /// plain [`Frame`]s. The direct mirror of `moq_audio::AudioConsumer`.
@@ -24,7 +24,7 @@ pub struct Consumer {
 
 impl Consumer {
 	/// Subscribe to `name` in `broadcast`, decoding it per the catalog entry.
-	/// Errors if the rendition isn't H.264.
+	/// Errors if the rendition isn't H.264 or H.265.
 	pub async fn new(
 		broadcast: &moq_net::BroadcastConsumer,
 		catalog: &VideoConfig,

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -1,18 +1,19 @@
-//! H.264 decoder front end.
+//! H.264 / H.265 decoder front end.
 //!
 //! Prepares each container frame for a [`Backend`](super::backend::Backend):
-//! converts avc1 (length-prefixed, out-of-band avcC) payloads to Annex-B and
-//! injects the SPS/PPS ahead of keyframes, leaving avc3 (already Annex-B inline)
-//! payloads untouched. Gates output until the first keyframe so the backend
-//! never sees a delta frame it can't decode.
+//! converts out-of-band payloads (avc1 / hvc1: length-prefixed NALs with the
+//! parameter sets in the description) to Annex-B and injects those parameter sets
+//! ahead of keyframes, leaving in-band payloads (avc3 / hev1, already Annex-B
+//! inline) untouched. Gates output until the first keyframe so the backend never
+//! sees a delta frame it can't decode.
 
 use std::time::Duration;
 
 use bytes::Bytes;
 use hang::catalog::{VideoCodec, VideoConfig};
-use moq_mux::codec::{annexb, h264};
+use moq_mux::codec::{annexb, h264, h265};
 
-use super::backend::{self, Backend};
+use super::backend::{self, Backend, Codec};
 use crate::Error;
 use crate::frame::I420;
 
@@ -56,12 +57,13 @@ impl Config {
 
 /// How to turn a container payload into an Annex-B access unit for the backend.
 enum Conversion {
-	/// avc3: the payload is already Annex-B with SPS/PPS inline. Pass through.
+	/// avc3 / hev1: the payload is already Annex-B with parameter sets inline.
+	/// Pass through.
 	Annexb,
-	/// avc1: length-prefixed NALs with the avcC out-of-band. Replace the length
-	/// prefixes with start codes and prepend `keyframe_prefix` (SPS/PPS from the
-	/// avcC) ahead of every keyframe.
-	Avc1 { length_size: usize, keyframe_prefix: Bytes },
+	/// avc1 / hvc1: length-prefixed NALs with the parameter sets out-of-band (in
+	/// the avcC / hvcC description). Replace the length prefixes with start codes
+	/// and prepend `keyframe_prefix` (the parameter sets) ahead of every keyframe.
+	LengthPrefixed { length_size: usize, keyframe_prefix: Bytes },
 }
 
 /// Drives a [`Backend`] from container frames.
@@ -72,29 +74,47 @@ pub(crate) struct Decoder {
 }
 
 impl Decoder {
-	/// Build a decoder for the catalog's video config. Errors if the codec is not
-	/// H.264 (the only codec the native backends support).
+	/// Build a decoder for the catalog's video config. Errors if the codec is
+	/// neither H.264 nor H.265 (the codecs the native backends support).
 	pub(crate) fn new(catalog: &VideoConfig, kind: &Kind) -> Result<Self, Error> {
-		let VideoCodec::H264(h264) = &catalog.codec else {
-			return Err(Error::UnsupportedCodec(catalog.codec.to_string()));
-		};
-
-		let conversion = if h264.inline {
-			Conversion::Annexb
-		} else {
-			let avcc = catalog
-				.description
-				.as_ref()
-				.ok_or_else(|| Error::Codec(anyhow::anyhow!("avc1 H.264 track is missing its avcC description")))?;
-			let params = h264::parse_avcc_param_sets(avcc).map_err(moq_mux::Error::from)?;
-			let keyframe_prefix = annexb::build_prefix(params.sps.iter().chain(params.pps.iter()));
-			Conversion::Avc1 {
-				length_size: params.length_size,
-				keyframe_prefix,
+		let (codec, conversion) = match &catalog.codec {
+			VideoCodec::H264(h264) => {
+				let conversion = if h264.inline {
+					Conversion::Annexb
+				} else {
+					let avcc = catalog.description.as_ref().ok_or_else(|| {
+						Error::Codec(anyhow::anyhow!("avc1 H.264 track is missing its avcC description"))
+					})?;
+					let params = h264::parse_avcc_param_sets(avcc).map_err(moq_mux::Error::from)?;
+					let keyframe_prefix = annexb::build_prefix(params.sps.iter().chain(params.pps.iter()));
+					Conversion::LengthPrefixed {
+						length_size: params.length_size,
+						keyframe_prefix,
+					}
+				};
+				(Codec::H264, conversion)
 			}
+			VideoCodec::H265(h265) => {
+				let conversion = if h265.in_band {
+					Conversion::Annexb
+				} else {
+					let hvcc = catalog.description.as_ref().ok_or_else(|| {
+						Error::Codec(anyhow::anyhow!("hvc1 H.265 track is missing its hvcC description"))
+					})?;
+					let params = h265::parse_hvcc_param_sets(hvcc).map_err(moq_mux::Error::from)?;
+					let keyframe_prefix =
+						annexb::build_prefix(params.vps.iter().chain(params.sps.iter()).chain(params.pps.iter()));
+					Conversion::LengthPrefixed {
+						length_size: params.length_size,
+						keyframe_prefix,
+					}
+				};
+				(Codec::H265, conversion)
+			}
+			other => return Err(Error::UnsupportedCodec(other.to_string())),
 		};
 
-		let backend = backend::open(kind)?;
+		let backend = backend::open(codec, kind)?;
 		tracing::debug!(decoder = backend.name(), "opened video decoder");
 		Ok(Self {
 			backend,
@@ -122,7 +142,7 @@ impl Decoder {
 		let annexb = match &self.conversion {
 			// Cheap refcount bump; the backend splits NAL slices off this buffer.
 			Conversion::Annexb => payload.clone(),
-			Conversion::Avc1 {
+			Conversion::LengthPrefixed {
 				length_size,
 				keyframe_prefix,
 			} => {
@@ -137,26 +157,39 @@ impl Decoder {
 
 #[cfg(test)]
 mod tests {
-	use super::backend;
-	use crate::encode::{Config as EncodeConfig, Encoder, Kind as EncodeKind};
+	use super::backend::{self, Codec};
+	use crate::encode::{Codec as EncodeCodec, Config as EncodeConfig, Encoder, Kind as EncodeKind};
+	use crate::frame::I420;
 
 	/// A mid-gray RGBA frame: encodable without a camera.
 	fn gray_rgba(width: u32, height: u32) -> Vec<u8> {
 		vec![0x80u8; width as usize * height as usize * 4]
 	}
 
-	/// Encode synthetic frames to Annex-B, decode them back, and assert the
-	/// backend hands us a correctly-sized I420 picture. Exercises the whole
-	/// software path (openh264 encode -> openh264 decode), keyframe gating
-	/// included (the first packet is an IDR with inline SPS/PPS).
-	fn round_trip(decode_kind: &super::Kind, expect_name: &str) {
-		let mut encoder = Encoder::new(&EncodeConfig {
-			kind: EncodeKind::Software,
-			..EncodeConfig::new(320, 240, 30)
-		})
-		.expect("openh264 encoder");
+	/// Assert a decoded picture is the expected size and looks like the gray frame
+	/// we encoded. Mid-gray RGBA (0x80) is a flat picture: BT.601 limited-range
+	/// luma near 125 and neutral chroma near 128. Averaging each plane catches
+	/// plane swaps, stride bugs, and a misread Y/UV split that a size check misses.
+	fn assert_gray(i420: &I420, width: u32, height: u32) {
+		assert_eq!(i420.width, width);
+		assert_eq!(i420.height, height);
+		let luma = (width * height) as usize;
+		// Tightly-packed I420: luma + two quarter-size chroma planes.
+		assert_eq!(i420.data.len(), luma * 3 / 2);
 
-		let mut decoder = backend::open(decode_kind).expect("decoder available");
+		let avg = |plane: &[u8]| plane.iter().map(|&b| b as u32).sum::<u32>() / plane.len() as u32;
+		let y = avg(&i420.data[..luma]);
+		let u = avg(&i420.data[luma..luma + luma / 4]);
+		let v = avg(&i420.data[luma + luma / 4..]);
+		assert!((110..=140).contains(&y), "luma {y} off for a gray frame");
+		assert!((118..=138).contains(&u), "u {u} off for a gray frame");
+		assert!((118..=138).contains(&v), "v {v} off for a gray frame");
+	}
+
+	/// Encode 10 gray frames with `encoder`, decode them through `decoder`, and
+	/// assert each decoded picture round-trips. Keyframe gating is exercised (the
+	/// first packet is a keyframe with inline parameter sets).
+	fn round_trip(mut encoder: Encoder, mut decoder: Box<dyn backend::Backend>, expect_name: &str) {
 		assert_eq!(decoder.name(), expect_name);
 
 		let frame = gray_rgba(320, 240);
@@ -169,36 +202,32 @@ mod tests {
 		}
 
 		assert!(!decoded.is_empty(), "decoder produced no frames");
-		let luma = 320 * 240;
 		for i420 in &decoded {
-			assert_eq!(i420.width, 320);
-			assert_eq!(i420.height, 240);
-			// Tightly-packed I420: luma + two quarter-size chroma planes.
-			assert_eq!(i420.data.len(), luma * 3 / 2);
-
-			// Mid-gray RGBA (0x80) encodes to a flat picture: BT.601 limited-range
-			// luma near 125 and neutral chroma near 128. Averaging each plane
-			// catches plane swaps, stride bugs, and a misread Y/UV split that an
-			// exact size check would miss.
-			let avg = |plane: &[u8]| plane.iter().map(|&b| b as u32).sum::<u32>() / plane.len() as u32;
-			let y = avg(&i420.data[..luma]);
-			let u = avg(&i420.data[luma..luma + luma / 4]);
-			let v = avg(&i420.data[luma + luma / 4..]);
-			assert!((110..=140).contains(&y), "luma {y} off for a gray frame");
-			assert!((118..=138).contains(&u), "u {u} off for a gray frame");
-			assert!((118..=138).contains(&v), "v {v} off for a gray frame");
+			assert_gray(i420, 320, 240);
 		}
+	}
+
+	/// An openh264 (software H.264) encoder for the gray test stream.
+	fn h264_software_encoder() -> Encoder {
+		Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Software,
+			..EncodeConfig::new(320, 240, 30)
+		})
+		.expect("openh264 encoder")
 	}
 
 	#[test]
 	fn openh264_round_trip() {
-		round_trip(&super::Kind::Software, "openh264");
+		let decoder = backend::open(Codec::H264, &super::Kind::Software).expect("openh264 decoder");
+		round_trip(h264_software_encoder(), decoder, "openh264");
 	}
 
 	#[cfg(target_os = "macos")]
 	#[test]
 	fn videotoolbox_round_trip() {
-		round_trip(&super::Kind::Named("videotoolbox".into()), "videotoolbox");
+		let decoder =
+			backend::open(Codec::H264, &super::Kind::Named("videotoolbox".into())).expect("videotoolbox decoder");
+		round_trip(h264_software_encoder(), decoder, "videotoolbox");
 	}
 
 	#[cfg(target_os = "windows")]
@@ -206,10 +235,33 @@ mod tests {
 	fn mediafoundation_round_trip() {
 		// Requires a hardware decoder MFT (GPU). Skip on machines without one
 		// rather than fail: CI runners are often headless.
-		if backend::open(&super::Kind::Named("mediafoundation".into())).is_err() {
-			eprintln!("skipping: no Media Foundation hardware decoder available");
+		let Ok(decoder) = backend::open(Codec::H264, &super::Kind::Named("mediafoundation".into())) else {
+			eprintln!("skipping: no Media Foundation H.264 hardware decoder available");
 			return;
-		}
-		round_trip(&super::Kind::Named("mediafoundation".into()), "mediafoundation");
+		};
+		round_trip(h264_software_encoder(), decoder, "mediafoundation");
+	}
+
+	/// H.265 has no software encoder or decoder, so the HEVC round-trip rides the
+	/// Media Foundation hardware path on both ends: NVENC/QSV/AMF encode through an
+	/// HEVC encoder MFT, DXVA decode through an HEVC decoder MFT. Skips cleanly when
+	/// either is absent (no GPU, or no HEVC Video Extensions installed).
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn mediafoundation_hevc_round_trip() {
+		let encoder = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Named("mediafoundation".into()),
+			codec: EncodeCodec::H265,
+			..EncodeConfig::new(320, 240, 30)
+		});
+		let Ok(encoder) = encoder else {
+			eprintln!("skipping: no Media Foundation H.265 hardware encoder available");
+			return;
+		};
+		let Ok(decoder) = backend::open(Codec::H265, &super::Kind::Named("mediafoundation".into())) else {
+			eprintln!("skipping: no Media Foundation H.265 hardware decoder available");
+			return;
+		};
+		round_trip(encoder, decoder, "mediafoundation");
 	}
 }

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -158,7 +158,7 @@ impl Decoder {
 #[cfg(test)]
 mod tests {
 	use super::backend::{self, Codec};
-	use crate::encode::{Codec as EncodeCodec, Config as EncodeConfig, Encoder, Kind as EncodeKind};
+	use crate::encode::{Config as EncodeConfig, Encoder, Kind as EncodeKind};
 	use crate::frame::I420;
 
 	/// A mid-gray RGBA frame: encodable without a camera.
@@ -251,7 +251,7 @@ mod tests {
 	fn mediafoundation_hevc_round_trip() {
 		let encoder = Encoder::new(&EncodeConfig {
 			kind: EncodeKind::Named("mediafoundation".into()),
-			codec: EncodeCodec::H265,
+			codec: crate::encode::Codec::H265,
 			..EncodeConfig::new(320, 240, 30)
 		});
 		let Ok(encoder) = encoder else {

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -1,13 +1,14 @@
-//! Subscribe to an H.264 track and decode it to raw frames.
+//! Subscribe to an H.264 or H.265 track and decode it to raw frames.
 //!
 //! The decode counterpart to [`encode`](crate::encode), and the mirror of
-//! `moq-audio`'s `AudioConsumer`. [`Consumer`] subscribes to a moq-mux H.264
-//! track and hands back decoded [`Frame`]s; a native backend does the work
+//! `moq-audio`'s `AudioConsumer`. [`Consumer`] subscribes to a moq-mux H.264 or
+//! H.265 track and hands back decoded [`Frame`]s; a native backend does the work
 //! (VideoToolbox on macOS, Media Foundation / DXVA on Windows, openh264
-//! everywhere as the software fallback).
+//! everywhere as the software fallback for H.264).
 //!
-//! Only H.264 is supported: it's symmetric with what [`encode`](crate::encode)
-//! produces. A non-H.264 rendition yields [`Error::UnsupportedCodec`](crate::Error).
+//! H.264 and H.265 are supported, symmetric with what [`encode`](crate::encode)
+//! produces. H.265 is hardware-only (no software fallback). Any other codec
+//! yields [`Error::UnsupportedCodec`](crate::Error).
 
 use bytes::Bytes;
 

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -18,10 +18,10 @@
 //!     front, but the camera opens only while a subscriber is watching and is
 //!     released when the last one leaves.
 //!   - [`encode::Producer`] publishes packets you encoded yourself.
-//! - [`decode`] subscribes to an H.264 track and decodes it to raw I420 frames
-//!   with a native backend (VideoToolbox on macOS, Media Foundation / DXVA on
-//!   Windows, openh264 software fallback). [`decode::Consumer`] is the mirror of
-//!   `moq-audio`'s `AudioConsumer`.
+//! - [`decode`] subscribes to an H.264 or H.265 track and decodes it to raw I420
+//!   frames with a native backend (VideoToolbox on macOS, Media Foundation / DXVA
+//!   on Windows, openh264 software fallback for H.264). [`decode::Consumer`] is
+//!   the mirror of `moq-audio`'s `AudioConsumer`.
 //!
 //! ## API stability
 //!


### PR DESCRIPTION
Addresses the **H.265 hardware decode on Windows** item in #1837, and lays the H.265 decode groundwork shared with the macOS/Linux HEVC-decode items.

> #1853 (H.264 MF decode) has merged; this branch is rebased onto `dev` and targets it directly, so the diff here is just the H.265 delta.

## What changed

**Decode front end generalized to H.265.** The container -> Annex-B prep was H.264-only; it's now codec-neutral:
- `Conversion::Avc1` -> `Conversion::LengthPrefixed`, fed by either avcC (SPS/PPS) or hvcC (VPS/SPS/PPS) parameter sets. hev1/avc3 (in-band) still pass through untouched.
- `Decoder::new` matches `VideoCodec::H264 | H265` and derives a `Codec` for the backend; anything else is `UnsupportedCodec`.
- `backend::open` now takes that `Codec` and filters candidates by what each supports, so an H.265 track skips the H.264-only backends (openh264, today's VideoToolbox). **No software H.265 decoder** means H.265 has no fallback below the hardware path — by design (per #1837: don't add software HEVC decode).

**Media Foundation backend gains H.265.** It selects `MFVideoFormat_HEVC` for input and otherwise reuses the H.264 DXVA path verbatim (the decode is codec-agnostic once the input subtype is set). Needs an HEVC decoder MFT (inbox HEVC Video Extensions or a vendor one) on top of the GPU.

## Public API

No public surface change. New `Codec` is `pub(crate)`; `decode::Consumer` / `decode::Config` are unchanged. `decode::Consumer::new` now accepts H.265 catalogs that it previously rejected (additive).

## Test plan

- [x] `cargo test -p moq-video` passes on an NVIDIA RTX 3070 Ti. The H.264 hardware round-trip (which exercises the now-shared front end and selector) passes; all existing tests pass.
- [x] `cargo clippy -p moq-video --all-targets -- -D warnings` clean.
- [ ] **HEVC decode unverified on hardware.** The test box has no HEVC decoder MFT installed (the HEVC Video Extensions aren't present, and the Store source isn't reachable headlessly — confirmed `sync/async/hw/all = 0` HEVC decoder MFTs via `MFTEnumEx`). The new `mediafoundation_hevc_round_trip` (MF NVENC encode -> MF DXVA decode) **skips cleanly** there and will run on a box that has an HEVC decoder MFT. This matches the repo's existing pattern of landing unverified HW paths (NVENC HEVC encode, VAAPI).

The macOS VideoToolbox and software openh264 backends only gained an ignored `Codec` parameter for signature parity (they stay H.264-only; HEVC there is a separate #1837 item) — mechanical, not compile-tested on macOS from this Windows box.

Cross-package sync: native-side only, no wire/catalog/API change; `rs/moq-video` README + CHANGELOG updated.

(Written by Claude)
