### PR TITLE
feat(moq-video): Windows screen capture via DXGI Desktop Duplication

### DIFF
--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -55,7 +55,7 @@ pub struct CaptureArgs {
 	#[arg(long, conflicts_with = "screen")]
 	pub camera: Option<String>,
 
-	/// Capture a display (whole screen) instead of a camera. macOS only.
+	/// Capture a display (whole screen) instead of a camera. macOS and Windows.
 	#[arg(long)]
 	pub screen: bool,
 

--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MFT runs synchronously with a Direct3D11 device bound to it, so the decode
   happens on the GPU through DXVA (NVDEC / Intel / AMD); output textures are
   downloaded to I420. Requires a GPU: a GPU-less host falls back to openh264.
+- Windows screen capture (`capture::Source::Display`) via DXGI Desktop
+  Duplication. Duplicates a monitor on a Direct3D11 device, copies each desktop
+  frame to a staging texture, and converts BGRA to I420. Whole-monitor capture;
+  select one with a bare index or `display:{index}`. The read loop paces to the
+  target frame rate and re-emits the last frame while the screen is static.
 - H.265 encode via the NVENC backend (Linux, `nvenc` feature). The codec is
   selected by `encode::Codec`; the NVENC HEVC path shares the H.264 preset / GOP
   / rate-control setup and emits Annex-B with inline VPS/SPS/PPS. Not yet

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -17,7 +17,9 @@ Per-platform, picked at compile time:
 - **macOS**: AVFoundation (camera) and ScreenCaptureKit (display), yielding
   zero-copy `CVPixelBuffer` surfaces straight to VideoToolbox.
 - **Linux**: native V4L2 (camera; YUYV resampled, MJPEG via `zune-jpeg`).
-- **Windows**: native Media Foundation (`IMFSourceReader` -> CPU I420).
+- **Windows**: native Media Foundation (camera; `IMFSourceReader`) and DXGI
+  Desktop Duplication (display; BGRA -> CPU I420). Display capture is
+  whole-monitor; select one with a bare index or `display:{index}`.
 
 ## Encode
 

--- a/rs/moq-video/src/capture/desktopduplication.rs
+++ b/rs/moq-video/src/capture/desktopduplication.rs
@@ -1,0 +1,349 @@
+//! Native Windows display capture via DXGI Desktop Duplication.
+//!
+//! Duplicates a monitor's output on a Direct3D11 device and pulls each desktop
+//! frame off the GPU as a BGRA texture, copies it to a CPU staging texture, and
+//! converts it to packed [`I420`] for the encoder. Whole-monitor capture only
+//! (the Windows analogue of macOS ScreenCaptureKit display capture); per-window
+//! capture would need Windows.Graphics.Capture instead.
+//!
+//! Runs on the shared blocking [`pump`] thread: `AcquireNextFrame` is a blocking
+//! call with no async form, and the [`IDXGIOutputDuplication`] handle is `!Send`,
+//! so building and driving it on one thread is the natural fit. The read loop
+//! paces itself to the target frame rate, coalescing bursts of desktop updates
+//! into one frame and re-emitting the last frame while the screen is static, so a
+//! still desktop still produces a steady stream.
+
+use std::time::{Duration, Instant};
+
+use windows::Win32::Graphics::Direct3D11::{
+	D3D11_CPU_ACCESS_READ, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING,
+	ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D,
+};
+use windows::Win32::Graphics::Dxgi::{
+	DXGI_ERROR_ACCESS_LOST, DXGI_ERROR_WAIT_TIMEOUT, DXGI_OUTDUPL_FRAME_INFO, IDXGIAdapter, IDXGIDevice, IDXGIOutput1,
+	IDXGIOutputDuplication, IDXGIResource,
+};
+use windows::core::Interface;
+
+use super::channel::FrameChannel;
+use super::pump::{self, Geometry};
+use super::{Config, FrameStream};
+use crate::Error;
+use crate::frame::{Frame, I420, d3d11};
+
+const DEFAULT_FRAMERATE: u32 = 30;
+
+fn err(ctx: &str, e: windows::core::Error) -> Error {
+	Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
+}
+
+/// Open a display capture and stream its frames over a pump thread.
+pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
+	let config = config.clone();
+	let chan = FrameChannel::new();
+	let (geo, guard) = pump::spawn(
+		chan.clone(),
+		move || {
+			let cap = Duplicator::open(&config)?;
+			let geometry = Geometry {
+				width: cap.width,
+				height: cap.height,
+				framerate: Some(cap.framerate),
+				device: cap.device_name.clone(),
+			};
+			Ok((cap, geometry))
+		},
+		Duplicator::read,
+	)
+	.await?;
+
+	Ok(FrameStream::new(
+		chan,
+		geo.width,
+		geo.height,
+		geo.framerate,
+		geo.device,
+		None,
+		Box::new(guard),
+	))
+}
+
+/// An open monitor duplication, read frame-by-frame on the pump thread.
+struct Duplicator {
+	device: ID3D11Device,
+	context: ID3D11DeviceContext,
+	/// The duplicated output, kept so the duplication can be rebuilt after a
+	/// `DXGI_ERROR_ACCESS_LOST` (a mode switch or fullscreen transition).
+	output: IDXGIOutput1,
+	dupl: IDXGIOutputDuplication,
+	/// Reused CPU-readable copy of the desktop texture (constant size).
+	staging: Option<ID3D11Texture2D>,
+	/// Even-clamped capture size (I420 chroma is 2x2, so dimensions must be even).
+	width: u32,
+	height: u32,
+	framerate: u32,
+	interval: Duration,
+	/// When the next frame is due; paces `read` to `framerate`.
+	next_deadline: Option<Instant>,
+	/// Most recent decoded frame, re-emitted while the screen is static.
+	last: Option<I420>,
+	device_name: String,
+}
+
+impl Duplicator {
+	fn open(config: &Config) -> Result<Self, Error> {
+		let device = d3d11::create_device()?;
+		let context = unsafe {
+			device
+				.GetImmediateContext()
+				.map_err(|e| err("GetImmediateContext", e))?
+		};
+
+		let index = select_output(config)?;
+		let output = enumerate_output(&device, index)?;
+		let device_name = format!("display:{index}");
+		let dupl = duplicate(&output, &device)?;
+
+		let desc = unsafe { dupl.GetDesc() };
+		// I420 needs even dimensions; clamp down (drop the last odd row/column).
+		let width = desc.ModeDesc.Width & !1;
+		let height = desc.ModeDesc.Height & !1;
+		if width == 0 || height == 0 {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"display {index} reported an unusable size {}x{}",
+				desc.ModeDesc.Width,
+				desc.ModeDesc.Height
+			)));
+		}
+
+		let framerate = config.framerate.unwrap_or(DEFAULT_FRAMERATE).max(1);
+		let mut cap = Self {
+			device,
+			context,
+			output,
+			dupl,
+			staging: None,
+			width,
+			height,
+			framerate,
+			interval: Duration::from_micros(1_000_000 / framerate as u64),
+			next_deadline: None,
+			last: None,
+			device_name,
+		};
+
+		// Seed the first frame so a static screen still has something to emit, and
+		// so a broken duplication path fails here at open rather than mid-stream.
+		// The desktop image may not be ready instantly, so retry briefly.
+		for _ in 0..20 {
+			if cap.capture_once(100)? {
+				break;
+			}
+		}
+		if cap.last.is_none() {
+			return Err(Error::Codec(anyhow::anyhow!("no desktop frame within timeout")));
+		}
+
+		tracing::info!(
+			display = %cap.device_name,
+			width = cap.width,
+			height = cap.height,
+			framerate = cap.framerate,
+			"opened Desktop Duplication capture"
+		);
+		Ok(cap)
+	}
+
+	/// Rebuild the duplication after `DXGI_ERROR_ACCESS_LOST` (e.g. a resolution
+	/// change or a fullscreen exclusive app grabbing/releasing the output).
+	fn reduplicate(&mut self) -> Result<(), Error> {
+		self.dupl = duplicate(&self.output, &self.device)?;
+		self.staging = None;
+		Ok(())
+	}
+
+	/// Acquire at most one desktop frame, waiting up to `timeout_ms`. Returns
+	/// `true` if a frame was captured into `last`, `false` on timeout (no update).
+	fn capture_once(&mut self, timeout_ms: u32) -> Result<bool, Error> {
+		let mut info = DXGI_OUTDUPL_FRAME_INFO::default();
+		let mut resource: Option<IDXGIResource> = None;
+		match unsafe { self.dupl.AcquireNextFrame(timeout_ms, &mut info, &mut resource) } {
+			Ok(()) => {}
+			Err(e) if e.code() == DXGI_ERROR_WAIT_TIMEOUT => return Ok(false),
+			Err(e) if e.code() == DXGI_ERROR_ACCESS_LOST => {
+				self.reduplicate()?;
+				return Ok(false);
+			}
+			Err(e) => return Err(err("AcquireNextFrame", e)),
+		}
+
+		let resource = resource.ok_or_else(|| Error::Codec(anyhow::anyhow!("AcquireNextFrame returned no surface")))?;
+		let texture = resource
+			.cast::<ID3D11Texture2D>()
+			.map_err(|e| err("desktop surface is not a texture", e))?;
+
+		// Always release the frame, even if the copy fails, or the next acquire
+		// deadlocks (only one frame may be held at a time).
+		let result = self.copy_to_last(&texture);
+		unsafe {
+			let _ = self.dupl.ReleaseFrame();
+		}
+		result?;
+		Ok(true)
+	}
+
+	/// Copy the desktop texture to the staging texture and convert BGRA -> I420.
+	fn copy_to_last(&mut self, texture: &ID3D11Texture2D) -> Result<(), Error> {
+		let staging = self.ensure_staging(texture)?;
+		unsafe { self.context.CopyResource(&staging, texture) };
+
+		let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+		unsafe {
+			self.context
+				.Map(&staging, 0, D3D11_MAP_READ, 0, Some(&mut mapped))
+				.map_err(|e| err("Map (staging)", e))?;
+		}
+		let _guard = UnmapGuard {
+			context: &self.context,
+			resource: &staging,
+		};
+
+		let pitch = mapped.RowPitch;
+		let len = pitch as usize * self.height as usize;
+		let bgra = unsafe { std::slice::from_raw_parts(mapped.pData as *const u8, len) };
+		self.last = Some(I420::from_bgra(bgra, pitch, self.width, self.height)?);
+		Ok(())
+	}
+
+	/// Lazily create (and cache) a CPU-readable staging texture matching the
+	/// desktop texture's format and size.
+	fn ensure_staging(&mut self, texture: &ID3D11Texture2D) -> Result<ID3D11Texture2D, Error> {
+		if let Some(staging) = &self.staging {
+			return Ok(staging.clone());
+		}
+		let mut desc = D3D11_TEXTURE2D_DESC::default();
+		unsafe { texture.GetDesc(&mut desc) };
+		desc.Usage = D3D11_USAGE_STAGING;
+		desc.BindFlags = 0;
+		desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ.0 as u32;
+		desc.MiscFlags = 0;
+		desc.ArraySize = 1;
+		desc.MipLevels = 1;
+
+		let mut staging: Option<ID3D11Texture2D> = None;
+		unsafe {
+			self.device
+				.CreateTexture2D(&desc, None, Some(&mut staging))
+				.map_err(|e| err("CreateTexture2D (staging)", e))?;
+		}
+		let staging = staging.ok_or_else(|| Error::Codec(anyhow::anyhow!("CreateTexture2D returned null")))?;
+		self.staging = Some(staging.clone());
+		Ok(staging)
+	}
+
+	/// Capture the next frame, paced to the target frame rate. Coalesces a burst
+	/// of desktop updates into the latest frame, and re-emits the last frame when
+	/// the screen hasn't changed, so the output rate stays steady.
+	fn read(&mut self) -> Result<Option<Frame>, Error> {
+		let deadline = *self.next_deadline.get_or_insert_with(|| Instant::now() + self.interval);
+
+		loop {
+			let now = Instant::now();
+			if now >= deadline {
+				break;
+			}
+			let remaining = (deadline - now).as_millis().max(1) as u32;
+			// Blocks up to `remaining`; a new frame returns early, a static screen
+			// times out at the deadline. Either way we exit the loop at the deadline.
+			self.capture_once(remaining)?;
+		}
+
+		// Schedule the next frame; if we fell badly behind (a long stall), reset to
+		// now so we don't then burst to catch up.
+		let next = deadline + self.interval;
+		self.next_deadline = Some(next.max(Instant::now()));
+
+		Ok(self.last.clone().map(Frame::I420))
+	}
+}
+
+struct UnmapGuard<'a> {
+	context: &'a ID3D11DeviceContext,
+	resource: &'a ID3D11Texture2D,
+}
+
+impl Drop for UnmapGuard<'_> {
+	fn drop(&mut self) {
+		unsafe { self.context.Unmap(self.resource, 0) };
+	}
+}
+
+/// Which monitor to capture: a bare index or the `display:{index}` form that
+/// [`FrameStream::device`](super::FrameStream) reports; `None` is the first one.
+fn select_output(config: &Config) -> Result<u32, Error> {
+	match config.device.as_deref() {
+		None => Ok(0),
+		Some(spec) => spec
+			.strip_prefix("display:")
+			.unwrap_or(spec)
+			.parse::<u32>()
+			.map_err(|_| Error::Codec(anyhow::anyhow!("invalid display selector {spec:?}"))),
+	}
+}
+
+/// Get the `index`th output (monitor) attached to the device's adapter.
+fn enumerate_output(device: &ID3D11Device, index: u32) -> Result<IDXGIOutput1, Error> {
+	let dxgi = device
+		.cast::<IDXGIDevice>()
+		.map_err(|e| err("device is not a DXGI device", e))?;
+	let adapter: IDXGIAdapter = unsafe { dxgi.GetAdapter().map_err(|e| err("GetAdapter", e))? };
+	let output = unsafe {
+		adapter
+			.EnumOutputs(index)
+			.map_err(|_| Error::Codec(anyhow::anyhow!("no display at index {index}")))?
+	};
+	output
+		.cast::<IDXGIOutput1>()
+		.map_err(|e| err("output is not IDXGIOutput1", e))
+}
+
+/// Start duplicating `output` on `device`.
+fn duplicate(output: &IDXGIOutput1, device: &ID3D11Device) -> Result<IDXGIOutputDuplication, Error> {
+	unsafe { output.DuplicateOutput(device) }.map_err(|e| err("DuplicateOutput", e))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::capture::Config;
+	use crate::frame::Frame;
+
+	/// Open the primary display, grab a few frames, and check geometry + frame
+	/// size. Ignored because Desktop Duplication needs an interactive desktop
+	/// session with a GPU output; skips cleanly when that isn't available.
+	#[test]
+	#[ignore]
+	fn duplicates_primary_display() {
+		let mut cap = match Duplicator::open(&Config::default()) {
+			Ok(cap) => cap,
+			Err(e) => {
+				eprintln!("skipping: no Desktop Duplication available: {e}");
+				return;
+			}
+		};
+
+		assert!(cap.width >= 2 && cap.width % 2 == 0, "bad width {}", cap.width);
+		assert!(cap.height >= 2 && cap.height % 2 == 0, "bad height {}", cap.height);
+
+		for i in 0..5 {
+			let frame = cap.read().expect("read frame");
+			let Some(Frame::I420(i420)) = frame else {
+				panic!("frame {i} was not I420");
+			};
+			assert_eq!(i420.width, cap.width);
+			assert_eq!(i420.height, cap.height);
+			assert_eq!(i420.data.len(), I420::len(cap.width, cap.height));
+		}
+		eprintln!("captured 5 frames at {}x{}", cap.width, cap.height);
+	}
+}

--- a/rs/moq-video/src/capture/mod.rs
+++ b/rs/moq-video/src/capture/mod.rs
@@ -3,7 +3,8 @@
 //! - macOS camera -> AVFoundation, screen -> ScreenCaptureKit, both yielding
 //!   zero-copy `CVPixelBuffer` surfaces straight to VideoToolbox.
 //! - Linux camera -> native V4L2 (YUYV / MJPEG -> CPU I420).
-//! - Windows camera -> native Media Foundation (`IMFSourceReader` -> CPU I420).
+//! - Windows camera -> native Media Foundation (`IMFSourceReader`), screen ->
+//!   DXGI Desktop Duplication (BGRA -> CPU I420).
 //!
 //! [`encode::publish_capture`](crate::encode::publish_capture) consumes [`Config`].
 
@@ -30,6 +31,10 @@ mod v4l2;
 #[cfg(target_os = "windows")]
 mod mediafoundation;
 
+// DXGI Desktop Duplication screen capture on Windows.
+#[cfg(target_os = "windows")]
+mod desktopduplication;
+
 // Blocking-device -> async-channel bridge used by V4L2 / Media Foundation.
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 mod pump;
@@ -41,7 +46,7 @@ pub enum Source {
 	/// A camera / webcam.
 	#[default]
 	Camera,
-	/// A display (whole-screen capture). macOS only for now.
+	/// A display (whole-screen capture). macOS and Windows.
 	Display,
 }
 
@@ -165,10 +170,14 @@ pub(crate) async fn open(config: &Config) -> Result<FrameStream, Error> {
 			{
 				screencapture::open(config).await
 			}
-			#[cfg(not(target_os = "macos"))]
+			#[cfg(target_os = "windows")]
+			{
+				desktopduplication::open(config).await
+			}
+			#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 			{
 				Err(Error::Codec(anyhow::anyhow!(
-					"screen capture is only supported on macOS"
+					"screen capture is not supported on this platform"
 				)))
 			}
 		}

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -98,6 +98,27 @@ impl I420 {
 		Ok(Self::pack(&planar, width, height))
 	}
 
+	/// Convert BGRA to I420, BT.601 limited range. `stride` is the source row
+	/// pitch in bytes (>= `width * 4`), so a padded surface maps directly. Used by
+	/// the Windows Desktop Duplication screen-capture path, whose staging texture
+	/// is BGRA with a driver-chosen row pitch.
+	#[cfg(target_os = "windows")]
+	pub(crate) fn from_bgra(bgra: &[u8], stride: u32, width: u32, height: u32) -> Result<Self, Error> {
+		use yuv::bgra_to_yuv420;
+
+		let mut planar = YuvPlanarImageMut::alloc(width, height, YuvChromaSubsampling::Yuv420);
+		bgra_to_yuv420(
+			&mut planar,
+			bgra,
+			stride,
+			YuvRange::Limited,
+			YuvStandardMatrix::Bt601,
+			YuvConversionMode::Balanced,
+		)
+		.map_err(|e| Error::Codec(anyhow::anyhow!("bgra_to_yuv420 failed for {width}x{height}: {e}")))?;
+		Ok(Self::pack(&planar, width, height))
+	}
+
 	/// Pack strided Y/U/V planes (4:2:0, full-size luma, half-size chroma) into a
 	/// tightly-packed I420 buffer. `y_stride` / `uv_stride` are the source row
 	/// strides, which a decoder may pad wider than the visible width. Used by the
@@ -345,16 +366,52 @@ pub(crate) mod macos {
 pub(crate) mod d3d11 {
 	use std::ptr;
 
+	use windows::Win32::Foundation::HMODULE;
+	use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
+	use windows::Win32::Graphics::Direct3D10::ID3D10Multithread;
 	use windows::Win32::Graphics::Direct3D11::{
-		D3D11_CPU_ACCESS_READ, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING,
+		D3D11_CPU_ACCESS_READ, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_VIDEO_SUPPORT, D3D11_MAP_READ,
+		D3D11_MAPPED_SUBRESOURCE, D3D11_SDK_VERSION, D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING, D3D11CreateDevice,
 		ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D,
 	};
+	use windows::core::Interface;
 
 	use super::I420;
 	use crate::Error;
 
 	fn err(ctx: &str, e: windows::core::Error) -> Error {
 		Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
+	}
+
+	/// Create a hardware Direct3D11 device, multithread-protected (Media
+	/// Foundation's internal threads or DXGI duplication and our capture thread
+	/// both touch it). The shared low-level constructor behind the Media
+	/// Foundation device manager and the Desktop Duplication capture path.
+	pub(crate) fn create_device() -> Result<ID3D11Device, Error> {
+		let mut device: Option<ID3D11Device> = None;
+		unsafe {
+			D3D11CreateDevice(
+				None,
+				D3D_DRIVER_TYPE_HARDWARE,
+				HMODULE::default(),
+				D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT,
+				None,
+				D3D11_SDK_VERSION,
+				Some(&mut device),
+				None,
+				None,
+			)
+			.map_err(|e| err("D3D11CreateDevice", e))?;
+		}
+		let device = device.ok_or_else(|| Error::Codec(anyhow::anyhow!("D3D11CreateDevice returned null")))?;
+
+		let multithread = device
+			.cast::<ID3D10Multithread>()
+			.map_err(|e| err("query ID3D10Multithread", e))?;
+		unsafe {
+			let _ = multithread.SetMultithreadProtected(true);
+		}
+		Ok(device)
 	}
 
 	/// A captured GPU texture (NV12) on the Media Foundation source reader's

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! - [`capture`] describes a frame source ([`capture::Config`]) and grabs
 //!   frames per platform: AVFoundation/ScreenCaptureKit on macOS, native V4L2
-//!   on Linux, native Media Foundation on Windows. Today that's a webcam or
-//!   the screen.
+//!   on Linux, native Media Foundation (camera) and DXGI Desktop Duplication
+//!   (screen) on Windows. Today that's a webcam or the screen.
 //! - [`encode`] encodes frames with a native backend and publishes them through
 //!   the matching `moq_mux::codec` importer, which handles catalog registration
 //!   and framing. The codec is chosen via [`encode::Codec`]: H.264 (openh264 /

--- a/rs/moq-video/src/mf.rs
+++ b/rs/moq-video/src/mf.rs
@@ -1,20 +1,14 @@
 //! Shared Media Foundation / COM helpers used by the capture source, the
 //! hardware encoder backend, and the hardware decoder backend on Windows.
 
-use windows::Win32::Foundation::HMODULE;
-use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
-use windows::Win32::Graphics::Direct3D10::ID3D10Multithread;
-use windows::Win32::Graphics::Direct3D11::{
-	D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_VIDEO_SUPPORT, D3D11_SDK_VERSION, D3D11CreateDevice,
-	ID3D11Device,
-};
+use windows::Win32::Graphics::Direct3D11::ID3D11Device;
 use windows::Win32::Media::MediaFoundation::{
 	IMFDXGIDeviceManager, MF_VERSION, MFCreateDXGIDeviceManager, MFSTARTUP_FULL, MFShutdown, MFStartup,
 };
 use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize};
-use windows::core::Interface;
 
 use crate::Error;
+use crate::frame::d3d11;
 
 /// Wrap a `windows` error with context as a codec error.
 pub(crate) fn mf_err(ctx: &str, e: windows::core::Error) -> Error {
@@ -37,33 +31,11 @@ pub(crate) fn unpack_2x32(v: u64) -> (u32, u32) {
 
 /// Create a hardware Direct3D11 device plus a DXGI device manager wrapping it,
 /// the pairing every Media Foundation GPU path needs (a capture source reader, a
-/// hardware encoder MFT, or a hardware decoder MFT). The device is marked
-/// multithread-protected because Media Foundation's internal worker threads and
-/// our blocking thread both touch it.
+/// hardware encoder MFT, or a hardware decoder MFT). The device comes from the
+/// shared [`d3d11::create_device`] (multithread-protected); this adds the Media
+/// Foundation manager on top.
 pub(crate) fn create_d3d_device() -> Result<(ID3D11Device, IMFDXGIDeviceManager), Error> {
-	let mut device: Option<ID3D11Device> = None;
-	unsafe {
-		D3D11CreateDevice(
-			None,
-			D3D_DRIVER_TYPE_HARDWARE,
-			HMODULE::default(),
-			D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_VIDEO_SUPPORT,
-			None,
-			D3D11_SDK_VERSION,
-			Some(&mut device),
-			None,
-			None,
-		)
-		.map_err(|e| mf_err("D3D11CreateDevice", e))?;
-	}
-	let device = device.ok_or_else(|| Error::Codec(anyhow::anyhow!("D3D11CreateDevice returned null")))?;
-
-	let multithread = device
-		.cast::<ID3D10Multithread>()
-		.map_err(|e| mf_err("query ID3D10Multithread", e))?;
-	unsafe {
-		let _ = multithread.SetMultithreadProtected(true);
-	}
+	let device = d3d11::create_device()?;
 
 	let mut token: u32 = 0;
 	let mut manager: Option<IMFDXGIDeviceManager> = None;


### PR DESCRIPTION
Closes the **Screen/display capture on Windows** item in #1837. `capture::Source::Display` worked only on macOS (ScreenCaptureKit); this adds the Windows equivalent via DXGI Desktop Duplication.

> #1853 has merged; this branch is rebased onto `dev` and targets it directly. It carries the shared `frame::d3d11::create_device` refactor (factoring the D3D11 device creation #1853 moved into `mf`); the capture code itself is independent of the decode work and does not depend on the HEVC PR #1854.

## Approach

Desktop Duplication (not Windows.Graphics.Capture) because it's synchronous and `!Send`, which fits the existing blocking [`pump`] thread that V4L2 / Media Foundation capture already use — no WinRT async/dispatcher needed.

- Duplicate a monitor on a D3D11 device; `AcquireNextFrame` -> desktop BGRA texture -> `CopyResource` to a staging texture -> map -> `bgra_to_yuv420` to packed I420 (`Frame::I420`, same CPU path the camera fallback uses).
- **Paced read loop**: blocks in `AcquireNextFrame` until the next frame-interval deadline, coalescing a burst of desktop updates into the latest frame and re-emitting the last frame while the screen is static, so a still desktop still yields a steady stream at the target rate.
- **`DXGI_ERROR_ACCESS_LOST`** (mode switch, fullscreen exclusive app grabbing/releasing the output) rebuilds the duplication instead of ending capture.
- Whole-monitor only; select one with a bare index or `display:{index}` (mirrors the macOS display selector). Even-clamps dimensions for I420.

Factors the D3D11 device creation into `frame::d3d11::create_device` (used by both the MF device manager and this path).

## Public API

No public surface change. `capture::Source::Display` already existed (was macOS-only); it now works on Windows. `Source`'s doc updated, and the moq-cli `--screen` help no longer says "macOS only".

## Test plan

- [x] **Validated on an NVIDIA RTX 3070 Ti**: the new (ignored) `duplicates_primary_display` test captured frames at **2560x1440** from the live desktop and round-tripped BGRA -> I420 with correct geometry. It's `#[ignore]` because Desktop Duplication needs an interactive desktop session with a GPU output; it skips cleanly otherwise.
- [x] `cargo clippy -p moq-video --all-targets -- -D warnings` clean; `cargo build -p moq-cli` clean.
- [x] Existing moq-video tests pass.

Cross-package sync: `rs/moq-cli` `--screen` help updated (the only paired hit — `doc/bin/cli.md` documents only ffmpeg-pipe screen capture, not the native `--screen` flag, so nothing to change there). `rs/moq-video` README + CHANGELOG updated.

Follow-ups (out of scope): zero-copy GPU path (NV12 texture straight to the encoder instead of CPU I420), per-window capture via Windows.Graphics.Capture, cursor compositing.

(Written by Claude)
