### PR TITLE
feat(moq-mux): carry B-frame reorder depth as catalog jitter (exact DTS reserve)

### DIFF
--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -1,4 +1,4 @@
-use crate::container::jitter::MinFrameDuration;
+use crate::container::jitter::Jitter;
 
 use anyhow::Context;
 use bytes::BytesMut;
@@ -26,7 +26,7 @@ pub struct Import {
 	zero: Option<tokio::time::Instant>,
 
 	// Tracks the minimum frame duration and updates the catalog `jitter` field.
-	jitter: MinFrameDuration,
+	jitter: Jitter,
 }
 
 #[derive(Default)]
@@ -45,7 +45,7 @@ impl Import {
 			config: None,
 			current: Default::default(),
 			zero: None,
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 
@@ -57,7 +57,7 @@ impl Import {
 			config: None,
 			current: Default::default(),
 			zero: None,
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -14,7 +14,7 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 use super::Sps;
 use crate::catalog::hang::CatalogExt;
 use crate::codec::annexb::{NalIterator, START_CODE};
-use crate::container::jitter::MinFrameDuration;
+use crate::container::jitter::Jitter;
 
 /// The wire shape an [`Import`] is processing.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -37,7 +37,7 @@ pub struct Import<E: CatalogExt = ()> {
 	config: Option<hang::catalog::VideoConfig>,
 	state: State,
 	zero: Option<tokio::time::Instant>,
-	jitter: MinFrameDuration,
+	jitter: Jitter,
 }
 
 enum State {
@@ -78,7 +78,7 @@ impl<E: CatalogExt> Import<E> {
 			config: None,
 			state: State::Pending { mode_hint: None },
 			zero: None,
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 
@@ -90,7 +90,7 @@ impl<E: CatalogExt> Import<E> {
 			config: None,
 			state: State::Pending { mode_hint: None },
 			zero: None,
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 
@@ -258,6 +258,22 @@ impl<E: CatalogExt> Import<E> {
 		}
 	}
 
+	/// Record a frame's reorder delay (`PTS - DTS`) so the catalog `jitter` reflects the
+	/// B-frame reorder depth (the decode buffer a transmuxer/player must hold). The container
+	/// supplies this since the elementary stream alone carries no decode time. No-op until the
+	/// track exists.
+	pub fn observe_reorder(&mut self, reorder: crate::container::Timestamp) {
+		let Some(jitter) = self.jitter.observe_reorder(reorder) else {
+			return;
+		};
+		let Some(track) = self.track.as_ref() else {
+			return;
+		};
+		if let Some(c) = self.catalog.lock().video.renditions.get_mut(&track.name) {
+			c.jitter = Some(jitter);
+		}
+	}
+
 	fn decode_avc1<T: Buf + AsRef<[u8]>>(
 		&mut self,
 		buf: &mut T,
@@ -407,7 +423,13 @@ impl<E: CatalogExt> Import<E> {
 				// The avc3 track was created eagerly in initialize_avc3; just publish
 				// (or republish) the catalog rendition with the latest config.
 				let track_name = self.track.as_ref().context("avc3 track not created")?.name.clone();
-				self.catalog.lock().video.renditions.insert(track_name, config.clone());
+				// Seed jitter from whatever has accumulated: a dirty start feeds frames before
+				// this first rendition exists, so those per-frame updates would otherwise be
+				// lost. Keep the cached `config` jitter-free so a later jitter change is not
+				// mistaken for a codec reconfiguration.
+				let mut published = config.clone();
+				published.jitter = self.jitter.current();
+				self.catalog.lock().video.renditions.insert(track_name, published);
 				self.config = Some(config);
 				Ok(reconfigured)
 			}

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -1,6 +1,6 @@
 use crate::catalog::hang::CatalogExt;
 use crate::codec::annexb::{NalIterator, START_CODE};
-use crate::container::jitter::MinFrameDuration;
+use crate::container::jitter::Jitter;
 
 use anyhow::Context;
 use bytes::{Buf, Bytes, BytesMut};
@@ -37,7 +37,7 @@ pub struct Import<E: CatalogExt = ()> {
 	pps: Vec<Bytes>,
 
 	// Tracks the minimum frame duration and updates the catalog `jitter` field.
-	jitter: MinFrameDuration,
+	jitter: Jitter,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -52,7 +52,7 @@ impl<E: CatalogExt> Import<E> {
 			vps: Vec::new(),
 			sps: Vec::new(),
 			pps: Vec::new(),
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 
@@ -67,7 +67,7 @@ impl<E: CatalogExt> Import<E> {
 			vps: Vec::new(),
 			sps: Vec::new(),
 			pps: Vec::new(),
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 
@@ -101,6 +101,11 @@ impl<E: CatalogExt> Import<E> {
 		}
 
 		let reconfigured = self.config.is_some();
+		// Seed jitter from whatever has accumulated: a dirty start feeds frames before this
+		// first rendition exists, so those per-frame updates would otherwise be lost. The
+		// cached `config` stays jitter-free so a later jitter change is not mistaken for a
+		// codec reconfiguration.
+		let jitter = self.jitter.current();
 		let mut catalog = self.catalog.lock();
 
 		if self.track.is_some() && self.tracks.is_fixed() {
@@ -114,7 +119,9 @@ impl<E: CatalogExt> Import<E> {
 
 		let track = self.tracks.create()?;
 		tracing::debug!(name = ?track.name, ?config, "starting track");
-		catalog.video.renditions.insert(track.name.clone(), config.clone());
+		let mut published = config.clone();
+		published.jitter = jitter;
+		catalog.video.renditions.insert(track.name.clone(), published);
 
 		self.config = Some(config);
 		self.track =
@@ -173,6 +180,22 @@ impl<E: CatalogExt> Import<E> {
 	/// This can also be used when EOF is detected to flush the final frame.
 	///
 	/// NOTE: The next decode will fail if it doesn't begin with a start code.
+	/// Record a frame's reorder delay (`PTS - DTS`) so the catalog `jitter` reflects the
+	/// B-frame reorder depth (the decode buffer a transmuxer/player must hold). The container
+	/// supplies this since the elementary stream alone carries no decode time. No-op until the
+	/// track exists.
+	pub fn observe_reorder(&mut self, reorder: crate::container::Timestamp) {
+		let Some(jitter) = self.jitter.observe_reorder(reorder) else {
+			return;
+		};
+		let Some(track) = self.track.as_ref() else {
+			return;
+		};
+		if let Some(c) = self.catalog.lock().video.renditions.get_mut(&track.name) {
+			c.jitter = Some(jitter);
+		}
+	}
+
 	pub fn decode_frame<T: Buf + AsRef<[u8]>>(
 		&mut self,
 		buf: &mut T,

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use bytes::Buf;
 
-use crate::container::jitter::MinFrameDuration;
+use crate::container::jitter::Jitter;
 
 use super::FrameHeader;
 
@@ -28,7 +28,7 @@ pub struct Import {
 	zero: Option<tokio::time::Instant>,
 
 	// Tracks the minimum frame duration and updates the catalog `jitter` field.
-	jitter: MinFrameDuration,
+	jitter: Jitter,
 }
 
 impl Import {
@@ -39,7 +39,7 @@ impl Import {
 			track: None,
 			config: None,
 			zero: None,
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 
@@ -50,7 +50,7 @@ impl Import {
 			track: None,
 			config: None,
 			zero: None,
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use bytes::Buf;
 
-use crate::container::jitter::MinFrameDuration;
+use crate::container::jitter::Jitter;
 
 use super::FrameHeader;
 
@@ -28,7 +28,7 @@ pub struct Import {
 	zero: Option<tokio::time::Instant>,
 
 	// Tracks the minimum frame duration and updates the catalog `jitter` field.
-	jitter: MinFrameDuration,
+	jitter: Jitter,
 }
 
 impl Import {
@@ -39,7 +39,7 @@ impl Import {
 			track: None,
 			config: None,
 			zero: None,
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 
@@ -50,7 +50,7 @@ impl Import {
 			track: None,
 			config: None,
 			zero: None,
-			jitter: MinFrameDuration::new(),
+			jitter: Jitter::new(),
 		}
 	}
 

--- a/rs/moq-mux/src/container/jitter.rs
+++ b/rs/moq-mux/src/container/jitter.rs
@@ -1,36 +1,71 @@
 use crate::container::Timestamp;
 
-/// Tracks the minimum duration between consecutive frames.
+/// Tracks the catalog `jitter` for a video/audio track: the maximum delay before a frame can
+/// be emitted, so a player sizes its buffer to at least this much.
 ///
-/// This is the value reported as `jitter` in the catalog: a player should
-/// buffer at least this much before emitting frames. Despite the name "jitter",
-/// what we actually record is the *minimum frame duration* observed so far.
+/// It reports whichever is larger of two contributions:
+/// - the minimum frame duration (the steady inter-frame spacing), and
+/// - the reorder delay (`max(PTS - DTS)`), which is non-zero only for reordered (B-frame)
+///   streams and which a transmuxer also reuses as the decode-clock reserve.
+///
+/// A non-reordered stream reports the frame duration; a B-frame stream reports the deeper
+/// reorder delay (e.g. up to 3 consecutive B-frames is 3x the frame duration).
 #[derive(Default)]
-pub struct MinFrameDuration {
+pub struct Jitter {
 	last_timestamp: Option<Timestamp>,
 	min_duration: Option<Timestamp>,
+	max_reorder: Timestamp,
+	/// Last value handed back from [`observe`](Self::observe) /
+	/// [`observe_reorder`](Self::observe_reorder), so they only report on a change.
+	reported: Option<Timestamp>,
 }
 
-impl MinFrameDuration {
+impl Jitter {
 	pub fn new() -> Self {
 		Self::default()
 	}
 
-	/// Record a new frame timestamp.
-	///
-	/// Returns the new minimum-frame-duration as a `moq_net::Time` if it
-	/// changed, so the caller can persist it on the catalog rendition. Returns
-	/// `None` when this is the first observation, the timestamps are
-	/// non-monotonic, or the new gap is no smaller than the recorded minimum.
+	/// Record a frame's presentation timestamp (decode order), updating the minimum frame
+	/// duration. Returns the new jitter as a [`moq_net::Time`] if it changed, else `None`.
+	/// The first observation and non-monotonic timestamps (B-frames) only update state.
 	pub fn observe(&mut self, ts: Timestamp) -> Option<moq_net::Time> {
-		let last = self.last_timestamp.replace(ts)?;
-		let duration = ts.checked_sub(last).ok()?;
+		if let Some(last) = self.last_timestamp.replace(ts)
+			&& let Ok(duration) = ts.checked_sub(last)
+			&& !duration.is_zero()
+			&& duration < self.min_duration.unwrap_or(Timestamp::MAX)
+		{
+			self.min_duration = Some(duration);
+		}
+		self.report()
+	}
 
-		if duration >= self.min_duration.unwrap_or(Timestamp::MAX) {
+	/// Record a frame's reorder delay (`PTS - DTS`), updating the maximum. Returns the new
+	/// jitter as a [`moq_net::Time`] if it changed, else `None`.
+	pub fn observe_reorder(&mut self, reorder: Timestamp) -> Option<moq_net::Time> {
+		self.max_reorder = self.max_reorder.max(reorder);
+		self.report()
+	}
+
+	/// The current jitter (the larger of the frame duration and the reorder delay), without
+	/// the change-detection of [`observe`](Self::observe). Used to seed a freshly created
+	/// catalog rendition with whatever has accumulated, since per-frame updates before the
+	/// rendition exists would otherwise be lost.
+	pub fn current(&self) -> Option<moq_net::Time> {
+		let jitter = self.combined();
+		(!jitter.is_zero()).then(|| jitter.convert().ok()).flatten()
+	}
+
+	fn combined(&self) -> Timestamp {
+		self.min_duration.unwrap_or(Timestamp::ZERO).max(self.max_reorder)
+	}
+
+	/// Report the current jitter only when it changes.
+	fn report(&mut self) -> Option<moq_net::Time> {
+		let jitter = self.combined();
+		if jitter.is_zero() || self.reported == Some(jitter) {
 			return None;
 		}
-
-		self.min_duration = Some(duration);
-		duration.convert().ok()
+		self.reported = Some(jitter);
+		jitter.convert().ok()
 	}
 }

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -77,6 +77,10 @@ struct Track {
 	/// Last decode timestamp (continuous 90 kHz ticks) authored for this track, keeping the
 	/// decode clock monotonic across reordered (B-frame) video. Only video uses it.
 	last_dts: Option<u64>,
+	/// Decode-clock reserve (90 kHz ticks): how far ahead of its PTS each frame decodes. Taken
+	/// from the catalog `jitter` (the reorder depth) so it is large enough for `DTS <= PTS`,
+	/// or [`DEFAULT_DTS_RESERVE`] when the catalog declares none. Only video uses it.
+	dts_reserve: u64,
 }
 
 #[derive(Clone)]
@@ -337,16 +341,20 @@ impl<E: catalog::Catalog> Export<E> {
 			let kind = video_kind(config, name)?;
 			let descriptors = track_descriptors(&mpegts, name);
 			let pid = pids[name];
+			// The catalog `jitter` carries the reorder depth (max PTS - DTS), so use it as the
+			// decode-clock reserve; it may arrive in a later snapshot, so refresh it each time.
+			let reserve = dts_reserve(config);
 			match old.remove(name) {
 				Some(mut track) => {
 					track.pid = pid;
 					track.kind = kind;
 					track.descriptors = descriptors;
+					track.dts_reserve = reserve;
 					self.tracks.insert(name.clone(), track);
 				}
 				None => {
 					let source = ExportSource::for_video(&self.broadcast, name, config, self.latency)?;
-					self.insert_track(name, source, pid, kind, descriptors);
+					self.insert_track(name, source, pid, kind, descriptors, reserve);
 				}
 			}
 		}
@@ -363,7 +371,7 @@ impl<E: catalog::Catalog> Export<E> {
 				}
 				None => {
 					let source = ExportSource::for_audio(&self.broadcast, name, config, self.latency)?;
-					self.insert_track(name, source, pid, kind, descriptors);
+					self.insert_track(name, source, pid, kind, descriptors, DEFAULT_DTS_RESERVE);
 				}
 			}
 		}
@@ -387,7 +395,7 @@ impl<E: catalog::Catalog> Export<E> {
 				}
 				None => {
 					let source = ExportSource::for_stream(&self.broadcast, name, self.latency)?;
-					self.insert_track(name, source, pid, kind, descriptors);
+					self.insert_track(name, source, pid, kind, descriptors, DEFAULT_DTS_RESERVE);
 				}
 			}
 		}
@@ -402,6 +410,7 @@ impl<E: catalog::Catalog> Export<E> {
 		pid: u16,
 		kind: Kind,
 		descriptors: Vec<catalog::Descriptor>,
+		dts_reserve: u64,
 	) {
 		self.tracks.insert(
 			name.to_string(),
@@ -413,6 +422,7 @@ impl<E: catalog::Catalog> Export<E> {
 				kind,
 				descriptors,
 				last_dts: None,
+				dts_reserve,
 			},
 		);
 	}
@@ -604,7 +614,8 @@ impl<E: catalog::Catalog> Export<E> {
 		// never reorder, so DTS == PTS and the PES stays PTS-only.
 		let dts = if is_video {
 			let pts = to_ticks(frame.timestamp);
-			author_dts(pts, &mut self.tracks.get_mut(name).context("missing track")?.last_dts)
+			let track = self.tracks.get_mut(name).context("missing track")?;
+			author_dts(pts, track.dts_reserve, &mut track.last_dts)
 		} else {
 			None
 		};
@@ -813,14 +824,13 @@ impl<E: catalog::Catalog> Export<E> {
 const PES_OPTIONAL_LEN: usize = 3 + 5;
 /// Extra bytes when the optional region also carries a DTS (5 DTS bytes).
 const PES_DTS_LEN: usize = 5;
-/// Decode-clock reserve in 90 kHz ticks: each video frame is scheduled to decode this far
-/// before its PTS. At 16 ticks (~0.18 ms) this is effectively just a strict-monotonic nudge:
-/// it keeps DTS strictly increasing across reordered (B-frame) decode order, which is what
-/// players need to schedule decoding (the `ffplay -fflags +igndts` fix). It does NOT keep
-/// `DTS <= PTS` for B-frames, since covering the reorder span would need a frame-scale reserve
-/// (and the matching decode lead); exact `DTS <= PTS` is the faithful wire-DTS follow-up.
-/// See [`author_dts`].
-const DTS_RESERVE: u64 = 16;
+/// Fallback decode-clock reserve in 90 kHz ticks when the catalog declares no `jitter`. At
+/// 16 ticks (~0.18 ms) it is just a strict-monotonic nudge: it keeps DTS strictly increasing
+/// across reordered (B-frame) decode order (the `ffplay -fflags +igndts` fix) but does not
+/// keep `DTS <= PTS`. When the catalog carries `jitter` (the reorder depth, populated on
+/// import), the track uses that instead, which is large enough to keep `DTS <= PTS`. See
+/// [`author_dts`] and [`Track::dts_reserve`].
+const DEFAULT_DTS_RESERVE: u64 = 16;
 
 fn psi_interval() -> crate::container::Timestamp {
 	crate::container::Timestamp::try_from(PSI_INTERVAL).unwrap_or(crate::container::Timestamp::ZERO)
@@ -948,12 +958,13 @@ fn ensure_raw(container: &Container, kind: &str, name: &str) -> anyhow::Result<(
 /// the small reserve this keeps DTS monotonic but lets it sit above a B-frame's own PTS; a
 /// frame-scale reserve (or the faithful wire DTS) would be needed for `DTS <= PTS`.
 ///
-/// `pts` and `last` are continuous (unwrapped) 90 kHz ticks, so the clock never wraps
-/// mid-stream; the 33-bit wire wrap happens once at emission in [`write_pes`]. `last` is the
-/// previous DTS, updated in place. Returns `None` when the DTS equals the PTS (PES stays
+/// `reserve` is how far behind the PTS to run the clock (the catalog reorder depth, or the
+/// fallback). `pts` and `last` are continuous (unwrapped) 90 kHz ticks, so the clock never
+/// wraps mid-stream; the 33-bit wire wrap happens once at emission in [`write_pes`]. `last` is
+/// the previous DTS, updated in place. Returns `None` when the DTS equals the PTS (PES stays
 /// PTS-only).
-fn author_dts(pts: u64, last: &mut Option<u64>) -> Option<u64> {
-	let mut dts = pts.saturating_sub(DTS_RESERVE);
+fn author_dts(pts: u64, reserve: u64, last: &mut Option<u64>) -> Option<u64> {
+	let mut dts = pts.saturating_sub(reserve);
 	if let Some(prev) = *last
 		&& dts <= prev
 	{
@@ -963,15 +974,27 @@ fn author_dts(pts: u64, last: &mut Option<u64>) -> Option<u64> {
 	(dts != pts).then_some(dts)
 }
 
+/// The decode-clock reserve for a video rendition: its catalog `jitter` (the reorder depth)
+/// in 90 kHz ticks, or [`DEFAULT_DTS_RESERVE`] when none is declared.
+fn dts_reserve(config: &VideoConfig) -> u64 {
+	config
+		.jitter
+		.map(|t| t.as_scale(90_000) as u64)
+		.filter(|&ticks| ticks > 0)
+		.unwrap_or(DEFAULT_DTS_RESERVE)
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{DTS_RESERVE, author_dts, is_complete_section};
+	use super::{DEFAULT_DTS_RESERVE, author_dts, is_complete_section};
 
-	/// Push a decode-order PTS stream (90 kHz) through the decode clock and return the
-	/// effective DTS per frame (the authored DTS, or the PTS when none is authored).
-	fn run_clock(pts: &[u64]) -> Vec<u64> {
+	/// Push a decode-order PTS stream (90 kHz) through the decode clock with a given reserve and
+	/// return the effective DTS per frame (the authored DTS, or the PTS when none is authored).
+	fn run_clock(pts: &[u64], reserve: u64) -> Vec<u64> {
 		let mut last = None;
-		pts.iter().map(|&p| author_dts(p, &mut last).unwrap_or(p)).collect()
+		pts.iter()
+			.map(|&p| author_dts(p, reserve, &mut last).unwrap_or(p))
+			.collect()
 	}
 
 	/// Decode-order PTS for a constant-frame-rate display timeline with `b` B-frames between
@@ -994,17 +1017,35 @@ mod tests {
 
 	#[test]
 	fn dts_is_monotonic_across_reorder() {
-		// 25 fps, 10 s offset; a few B-frame depths. The small reserve guarantees a strictly
-		// increasing decode timeline (the `+igndts` fix); it does not keep DTS <= PTS.
+		// 25 fps, 10 s offset. Even with the tiny fallback reserve the decode timeline is
+		// strictly increasing (the `+igndts` fix); it just may sit above PTS for B-frames.
 		for b in [1, 3, 5] {
 			let pts = decode_order(40, b, 3_600, 10_000_000);
-			let dts = run_clock(&pts);
+			let dts = run_clock(&pts, DEFAULT_DTS_RESERVE);
 
 			// The fixture genuinely reorders (PTS dips in decode order).
 			assert!(pts.windows(2).any(|w| w[1] < w[0]), "b={b}: stream must reorder PTS");
-			// The decode timeline is strictly increasing.
 			for (i, win) in dts.windows(2).enumerate() {
 				assert!(win[1] > win[0], "b={b}: DTS not strictly increasing at {i}: {win:?}");
+			}
+		}
+	}
+
+	#[test]
+	fn sufficient_reserve_keeps_dts_under_pts() {
+		// With a reserve covering the reorder span (the catalog `jitter` carries it), the decode
+		// timeline is both strictly increasing and never after the PTS.
+		let dur = 3_600;
+		for b in [1, 3, 5] {
+			let reserve = (b as u64 + 1) * dur; // one frame past the b-frame run
+			let pts = decode_order(40, b, dur, 10_000_000);
+			let dts = run_clock(&pts, reserve);
+
+			for (i, win) in dts.windows(2).enumerate() {
+				assert!(win[1] > win[0], "b={b}: DTS not strictly increasing at {i}: {win:?}");
+			}
+			for (i, (&d, &p)) in dts.iter().zip(pts.iter()).enumerate() {
+				assert!(d <= p, "b={b}: DTS {d} after PTS {p} at {i}");
 			}
 		}
 	}
@@ -1016,7 +1057,7 @@ mod tests {
 		// only at emission, so here the authored DTS keeps climbing past 1 << 33.
 		let wrap = 1u64 << 33;
 		let pts = decode_order(40, 3, 3_600, wrap - 20 * 3_600);
-		let dts = run_clock(&pts);
+		let dts = run_clock(&pts, DEFAULT_DTS_RESERVE);
 
 		assert!(pts.iter().any(|&p| p >= wrap), "test must cross the wrap boundary");
 		for (i, win) in dts.windows(2).enumerate() {
@@ -1029,17 +1070,15 @@ mod tests {
 
 	#[test]
 	fn dts_without_reorder_trails_pts_by_the_reserve() {
-		// A monotonic (no-B) stream stays strictly increasing and one reserve under its PTS,
-		// which at 16 ticks is a negligible decode nudge (and not added latency: presentation
-		// is still at the PTS).
+		// A monotonic (no-B) stream stays strictly increasing and one reserve under its PTS.
 		let pts: Vec<u64> = (0..40).map(|i| 10_000_000 + i * 3_600).collect();
-		let dts = run_clock(&pts);
+		let dts = run_clock(&pts, DEFAULT_DTS_RESERVE);
 
 		for (i, win) in dts.windows(2).enumerate() {
 			assert!(win[1] > win[0], "DTS not strictly increasing at {i}: {win:?}");
 		}
 		for (i, (&d, &p)) in dts.iter().zip(pts.iter()).enumerate() {
-			assert_eq!(d, p - DTS_RESERVE, "DTS should trail PTS by exactly the reserve at {i}");
+			assert_eq!(d, p - DEFAULT_DTS_RESERVE, "DTS should trail PTS by the reserve at {i}");
 		}
 	}
 

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -335,10 +335,10 @@ async fn export_avc1_out_of_band_reassembles() {
 }
 
 /// A real broadcast contribution feed (Ateme Kyrion, H.264 1080i with ~86 B-frames)
-/// must come out of the exporter with an authored decode timeline. Without it players
-/// see PTS-only video and choke on the out-of-order decode times (`ffplay +igndts`).
-/// Assert the video PES carry a strictly increasing DTS in decode order (the fix), and
-/// that the reorder was real (some authored DTS, non-monotonic PTS in the source).
+/// must come out of the exporter with an authored decode timeline. The importer publishes
+/// the reorder depth as the catalog `jitter`, and the exporter sizes its decode-clock reserve
+/// from it, so the video PES carry a DTS that is both strictly increasing and never after the
+/// PTS in decode order. Also assert the reorder was real (non-monotonic PTS in the source).
 #[tokio::test(start_paused = true)]
 async fn export_bframe_video_authors_dts() {
 	let data = include_bytes!("test_data/scte35/kyrion_dirtystart.ts");
@@ -393,9 +393,13 @@ async fn export_bframe_video_authors_dts() {
 	);
 	// The exporter authored a decode timeline (the decode clock trails the PTS).
 	assert!(authored > 0, "no DTS authored for a B-frame stream");
-	// That timeline is strictly increasing, which is what removes the `+igndts` requirement.
+	// Strictly increasing (removes the `+igndts` requirement) and never after presentation
+	// (the catalog jitter sized the reserve to the reorder depth).
 	for (i, win) in effective.windows(2).enumerate() {
 		assert!(win[1] > win[0], "DTS not strictly increasing at frame {i}: {win:?}");
+	}
+	for (i, (&d, &p)) in effective.iter().zip(pts.iter()).enumerate() {
+		assert!(d <= p, "DTS {d} after PTS {p} at frame {i}");
 	}
 }
 

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -472,6 +472,7 @@ impl<E: catalog::Catalog> Import<E> {
 		let data_len = pes_data_len(&pes.header, pes.pes_packet_len);
 		let mut pending = Pending {
 			pts: pes.header.pts.map(|t| t.as_u64()),
+			dts: pes.header.dts.map(|t| t.as_u64()),
 			stream_id: pes.header.stream_id.as_u8(),
 			data: Vec::with_capacity(pes.data.len()),
 			data_len,
@@ -586,6 +587,9 @@ impl<E: catalog::Catalog> Import<E> {
 struct Pending {
 	/// Raw 90 kHz PTS, before wrap-unwrapping.
 	pts: Option<u64>,
+	/// Raw 90 kHz DTS, before wrap-unwrapping. Present on reordered (B-frame) video; its
+	/// distance below the PTS is the reorder delay published as the catalog jitter.
+	dts: Option<u64>,
 	/// PES stream_id, preserved for verbatim PES carriage.
 	stream_id: u8,
 	data: Vec<u8>,
@@ -981,12 +985,23 @@ impl<E: catalog::Catalog> Stream<E> {
 	fn write(&mut self, pending: Pending, burst: Option<u64>) -> anyhow::Result<()> {
 		match self {
 			Stream::H264 { import, unwrap } => {
+				let reorder = reorder_delay(pending.pts, pending.dts);
 				let pts = unwrap_pts(unwrap, pending.pts)?;
-				import.decode_frame(&mut pending.data.as_slice(), pts)
+				import.decode_frame(&mut pending.data.as_slice(), pts)?;
+				// After decode_frame, so the track (and its catalog rendition) exists.
+				if let Some(reorder) = reorder {
+					import.observe_reorder(reorder);
+				}
+				Ok(())
 			}
 			Stream::H265 { import, unwrap } => {
+				let reorder = reorder_delay(pending.pts, pending.dts);
 				let pts = unwrap_pts(unwrap, pending.pts)?;
-				import.decode_frame(&mut pending.data.as_slice(), pts)
+				import.decode_frame(&mut pending.data.as_slice(), pts)?;
+				if let Some(reorder) = reorder {
+					import.observe_reorder(reorder);
+				}
+				Ok(())
 			}
 			Stream::Aac(stream) => stream.write(pending, burst),
 			Stream::Legacy(stream) => stream.write(pending),
@@ -1296,6 +1311,22 @@ fn unwrap_pts(unwrap: &mut PtsUnwrap, pts: Option<u64>) -> anyhow::Result<Option
 	};
 	let extended = unwrap.unwrap(raw);
 	Ok(Some(Timestamp::from_scale(extended, 90_000)?))
+}
+
+/// The reorder delay `PTS - DTS` for one PES, as a microsecond [`Timestamp`]. `None` unless
+/// both stamps are present and the gap is a plausible reorder (a few seconds); a larger or
+/// negative gap is a discontinuity or bad DTS, ignored so it can't inflate the jitter. Both
+/// are raw 90 kHz, so the subtraction is done modulo the 33-bit field to stay correct across
+/// the wrap.
+fn reorder_delay(pts: Option<u64>, dts: Option<u64>) -> Option<Timestamp> {
+	const FIELD: u64 = 1 << 33;
+	const MAX_REORDER_TICKS: u64 = 90_000 * 2; // 2 s; broadcast reorder is well under this.
+	let (pts, dts) = (pts?, dts?);
+	let delay = pts.wrapping_sub(dts) & (FIELD - 1);
+	if delay == 0 || delay > MAX_REORDER_TICKS {
+		return None;
+	}
+	Timestamp::from_scale(delay, 90_000).ok()
 }
 
 /// Tracks the wrap-around of the 33-bit, 90 kHz PTS field so timestamps stay

--- a/rs/moq-mux/src/container/ts/import_test.rs
+++ b/rs/moq-mux/src/container/ts/import_test.rs
@@ -45,6 +45,24 @@ fn import_bbb_catalog() {
 	assert!(audio.description.is_some(), "AAC track missing AudioSpecificConfig");
 }
 
+/// The Kyrion capture is H.264 1080i with B-frames (open-GOP, ~5-frame reorder despite only
+/// 3 consecutive B-frames). Its video rendition's `jitter` must capture that reorder delay
+/// (the source `PTS - DTS`), not just the ~33 ms frame interval, so a transmuxer/player sizes
+/// its decode buffer correctly. The stream is ~30 fps, so the reorder is ~5 * 33 ms.
+#[test]
+fn import_kyrion_video_jitter_captures_reorder() {
+	let data = include_bytes!("test_data/scte35/kyrion_dirtystart.ts");
+	let catalog = import_ts(data);
+
+	let video = catalog.video.renditions.values().next().expect("a video track");
+	let jitter = video.jitter.expect("B-frame stream must publish jitter").as_millis();
+	// ~5 frames of reorder at ~30 fps is ~167 ms, far above the ~33 ms frame interval.
+	assert!(
+		(150..=200).contains(&jitter),
+		"jitter {jitter} ms should reflect the ~5-frame reorder, not the frame interval"
+	);
+}
+
 /// The Kyrion capture carries two real MP2 programs (stream_type 0x03, 48 kHz
 /// stereo, 192 kbps). Both must surface as catalog renditions with the
 /// header-derived config and no description (verbatim carriage).


### PR DESCRIPTION
Stacked on #1843. Makes the exporter's decode-clock reserve **exact** instead of a fixed guess, so `DTS ≤ PTS` holds for real B-frame feeds — by carrying the reorder depth the source already knows through the catalog.

## What

- **TS import** now reads the PES **DTS** (previously discarded), computes the reorder delay (`max(PTS − DTS)`), and folds it into the video rendition's catalog **`jitter`**. The `jitter` field already documents this exact case ("up to 3 b-frames in a row → 3 × 1000/fps") — this finally populates it. The jitter estimator now reports `max(min frame duration, max reorder)`, and a freshly created rendition is **seeded** from it so a *dirty start* (frames before the first SPS, as in the kyrion capture) doesn't lose the value.
- **TS export** sizes its decode-clock reserve from the catalog `jitter`, falling back to the small monotonic-only nudge (#1843) when none is declared. With the reorder depth known, the authored DTS is both strictly increasing **and** `≤ PTS`.

This rides through the relay via the catalog, so it survives `pub | relay | sub` with **no per-frame wire change**, and **no catalog format change** (`jitter` already existed — only its population and consumption change).

## Why this over the fixed reserve

#1843 keeps DTS monotonic (fixes `+igndts`) but can't guarantee `DTS ≤ PTS` without either over-buffering (large fixed reserve = latency) or guessing. The source TS states the exact reorder (`PTS − DTS`); this carries it, so the reserve equals the *actual* reorder depth — minimal latency, exact, and B-frame-free streams are unaffected (reserve ≈ one frame).

## Notes / decisions for the reviewer

- **Final branch:** I based this on the #1843 branch (not `dev`) only to keep the diff to one commit — `dev` is currently ~35 commits behind `main`, so a direct `dev` PR would show all of that. It's **not** a catalog format change, so it can land on `main` together with #1843, or be retargeted to `dev` if you'd rather batch it there. Your call at merge time.
- Behavior change: B-frame streams now report a larger `jitter` (the reorder delay, e.g. ~167 ms for kyrion) instead of just the frame interval — which is the field's documented meaning, and correctly sizes the browser player's buffer too.
- Re-import unaffected: the importer still delivers frames in decode order with PTS; the DTS is only used to derive the reserve.

## Test plan

- [x] `author_dts`: monotonic across reorder with the fallback; **`DTS ≤ PTS`** once the reserve covers the reorder span.
- [x] Import: `import_kyrion_video_jitter_captures_reorder` asserts the video `jitter` reflects the ~5-frame reorder (~167 ms), not the ~33 ms frame interval.
- [x] End-to-end: the kyrion export test now asserts the video PES carry a strictly increasing **`DTS ≤ PTS`** timeline (the whole import → jitter → export chain).
- [x] Full `moq-mux` suite (249 tests), `cargo clippy`, `cargo fmt` clean (via nix).

(Written by Claude)