### PR TITLE
feat(moq-video): H.265 hardware decode on macOS (VideoToolbox)

### DIFF
--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -23,12 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   select one with a bare index or `display:{index}`. The read loop paces to the
   target frame rate and re-emits the last frame while the screen is static.
 - H.265 decode: the `decode` module now handles H.265 tracks (hvc1 and hev1)
-  alongside H.264, sharing the same length-prefixed -> Annex-B front end. The
-  Windows Media Foundation backend decodes it (DXVA) when an HEVC decoder MFT is
-  present. There is no software H.265 decoder, so H.265 has no fallback below the
-  hardware path. The HEVC decode path is unverified on hardware (the test box had
-  no HEVC decoder MFT installed); the shared front end is exercised by the H.264
-  hardware round-trip.
+  alongside H.264, sharing the same length-prefixed -> Annex-B front end.
+  VideoToolbox (macOS) and Media Foundation (Windows, DXVA) decode it on
+  hardware, pulling VPS/SPS/PPS out of each keyframe to build the format
+  description. There is no software H.265 decoder, so H.265 has no fallback below
+  the hardware path. The macOS VideoToolbox path is verified by an end-to-end
+  HEVC encode -> decode round-trip on Apple silicon; the Windows path is
+  unverified on hardware (the test box had no HEVC decoder MFT installed).
 - H.265 encode via the NVENC backend (Linux, `nvenc` feature). The codec is
   selected by `encode::Codec`; the NVENC HEVC path shares the H.264 preset / GOP
   / rate-control setup and emits Annex-B with inline VPS/SPS/PPS. Not yet

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -58,10 +58,13 @@ hardware-first, like encode:
 | Codec | Software | macOS | Windows | Linux |
 |---|---|---|---|---|
 | H.264 | openh264 (vendored, static) | VideoToolbox | Media Foundation (DXVA) | openh264 |
-| H.265 | none | none | Media Foundation (DXVA) | none |
+| H.265 | none | VideoToolbox | Media Foundation (DXVA) | none |
 
-On Windows the Microsoft decoder MFT runs synchronously with a Direct3D11 device
-bound to it, so the decode happens on the GPU through DXVA (NVDEC / Intel / AMD).
-H.264 falls back to openh264 on a GPU-less host; H.265 has no software decoder, so
-it needs the GPU path (and an HEVC decoder MFT: the inbox HEVC Video Extensions or
-a vendor one). A non-H.264/H.265 rendition yields `Error::UnsupportedCodec`.
+On macOS VideoToolbox decodes both codecs on hardware, pulling the parameter sets
+(SPS/PPS, plus VPS for H.265) out of each keyframe to build the format
+description. On Windows the Microsoft decoder MFT runs synchronously with a
+Direct3D11 device bound to it, so the decode happens on the GPU through DXVA
+(NVDEC / Intel / AMD). H.264 falls back to openh264 on a GPU-less host; H.265 has
+no software decoder, so it needs the GPU path (on Windows, an HEVC decoder MFT:
+the inbox HEVC Video Extensions or a vendor one). A non-H.264/H.265 rendition
+yields `Error::UnsupportedCodec`.

--- a/rs/moq-video/src/decode/backend/mod.rs
+++ b/rs/moq-video/src/decode/backend/mod.rs
@@ -71,7 +71,7 @@ const HARDWARE: &[Candidate] = &[
 	#[cfg(target_os = "macos")]
 	Candidate {
 		name: videotoolbox::NAME,
-		supports: |c| matches!(c, Codec::H264),
+		supports: |c| matches!(c, Codec::H264 | Codec::H265),
 		open: videotoolbox::VideoToolbox::open,
 	},
 	#[cfg(target_os = "windows")]

--- a/rs/moq-video/src/decode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/decode/backend/videotoolbox.rs
@@ -1,10 +1,13 @@
-//! Hardware H.264 decode backend via Apple VideoToolbox (`VTDecompressionSession`).
+//! Hardware H.264 / H.265 decode backend via Apple VideoToolbox
+//! (`VTDecompressionSession`).
 //!
 //! The inverse of the encode VideoToolbox backend. We receive Annex-B access
-//! units (SPS/PPS inline ahead of each keyframe), so we:
-//! - pull SPS/PPS out of the stream and build a `CMVideoFormatDescription`,
-//!   (re)creating the decompression session whenever the parameter sets change;
-//! - repackage the slice NALs as AVCC (4-byte length-prefixed) in a
+//! units (parameter sets inline ahead of each keyframe: SPS/PPS for H.264,
+//! VPS/SPS/PPS for H.265), so we:
+//! - pull the parameter sets out of the stream and build a
+//!   `CMVideoFormatDescription`, (re)creating the decompression session whenever
+//!   they change;
+//! - repackage the slice NALs as AVCC/HVCC (4-byte length-prefixed) in a
 //!   `CMSampleBuffer`, the form VideoToolbox decodes;
 //! - request NV12 output and download it to packed I420 (reusing the same
 //!   `CVPixelBuffer` download as the capture path).
@@ -22,7 +25,7 @@ use moq_mux::codec::annexb::NalIterator;
 use objc2_core_foundation::{CFDictionary, CFNumber, CFNumberType, CFRetained, CFString};
 use objc2_core_media::{
 	CMBlockBuffer, CMFormatDescription, CMSampleBuffer, CMTime, CMVideoFormatDescriptionCreateFromH264ParameterSets,
-	kCMBlockBufferAssureMemoryNowFlag,
+	CMVideoFormatDescriptionCreateFromHEVCParameterSets, kCMBlockBufferAssureMemoryNowFlag,
 };
 use objc2_core_video::{
 	CVImageBuffer, CVPixelBuffer, CVPixelBufferGetHeight, CVPixelBufferGetWidth, kCVPixelBufferPixelFormatTypeKey,
@@ -38,8 +41,14 @@ use crate::frame::I420;
 
 pub(crate) const NAME: &str = "videotoolbox";
 
-const NAL_TYPE_SPS: u8 = 7;
-const NAL_TYPE_PPS: u8 = 8;
+/// A parameter-set NAL we pull out of the stream to (re)build the format
+/// description; `Slice` is everything else (the coded picture data we decode).
+enum NalKind {
+	Vps,
+	Sps,
+	Pps,
+	Slice,
+}
 
 /// Where the C output callback drops decoded frames, drained after each
 /// `decode_frame`. Boxed so its address is a stable refcon for the session.
@@ -50,17 +59,21 @@ struct Sink {
 }
 
 pub(crate) struct VideoToolbox {
-	/// Built lazily once the first SPS+PPS arrive, rebuilt if they change.
+	/// Which codec's parameter sets and format description to build (H.264 needs
+	/// SPS+PPS; H.265 also needs VPS).
+	codec: Codec,
+	/// Built lazily once the parameter sets first arrive, rebuilt if they change.
 	session: Option<CFRetained<VTDecompressionSession>>,
 	/// Format description the current session + samples use (kept in lockstep
 	/// with `session`).
 	format: Option<CFRetained<CMFormatDescription>>,
-	/// Latest SPS/PPS seen, persisted across access units (a delta frame carries
-	/// neither). `built_from` records which pair the live session was built from,
-	/// so a mid-stream parameter-set change triggers a rebuild.
+	/// Latest parameter sets seen, persisted across access units (a delta frame
+	/// carries none). `built_from` records the exact ordered set the live session
+	/// was built from, so a mid-stream parameter-set change triggers a rebuild.
+	vps: Option<Bytes>,
 	sps: Option<Bytes>,
 	pps: Option<Bytes>,
-	built_from: Option<(Bytes, Bytes)>,
+	built_from: Option<Vec<Bytes>>,
 	sink: Box<Sink>,
 }
 
@@ -69,13 +82,15 @@ pub(crate) struct VideoToolbox {
 unsafe impl Send for VideoToolbox {}
 
 impl VideoToolbox {
-	/// The VideoToolbox decode backend handles H.264 only for now; the selector
-	/// never routes H.265 here, so `codec` is accepted for signature parity.
-	pub(crate) fn open(_codec: Codec) -> Result<Box<dyn Backend>, Error> {
-		tracing::info!(decoder = NAME, "opened H.264 decoder");
+	/// Open a decoder for `codec` (H.264 or H.265). The session is built lazily
+	/// once the first keyframe's parameter sets arrive.
+	pub(crate) fn open(codec: Codec) -> Result<Box<dyn Backend>, Error> {
+		tracing::info!(decoder = NAME, codec = ?codec, "opened video decoder");
 		Ok(Box::new(Self {
+			codec,
 			session: None,
 			format: None,
+			vps: None,
 			sps: None,
 			pps: None,
 			built_from: None,
@@ -83,25 +98,40 @@ impl VideoToolbox {
 		}))
 	}
 
+	/// The ordered parameter sets the format description needs, or `None` if any
+	/// required one hasn't been seen yet. H.264: `[SPS, PPS]`; H.265: `[VPS, SPS,
+	/// PPS]`.
+	fn param_sets(&self) -> Option<Vec<Bytes>> {
+		let sps = self.sps.clone()?;
+		let pps = self.pps.clone()?;
+		match self.codec {
+			Codec::H264 => Some(vec![sps, pps]),
+			Codec::H265 => Some(vec![self.vps.clone()?, sps, pps]),
+		}
+	}
+
 	/// (Re)build the decompression session when the parameter sets first appear
-	/// or change. Returns `false` if we still don't have both SPS and PPS.
-	fn ensure_session(&mut self, sps: Option<Bytes>, pps: Option<Bytes>) -> Result<bool, Error> {
+	/// or change. Returns `false` if we still don't have a complete set.
+	fn ensure_session(&mut self, vps: Option<Bytes>, sps: Option<Bytes>, pps: Option<Bytes>) -> Result<bool, Error> {
+		if let Some(vps) = vps {
+			self.vps = Some(vps);
+		}
 		if let Some(sps) = sps {
 			self.sps = Some(sps);
 		}
 		if let Some(pps) = pps {
 			self.pps = Some(pps);
 		}
-		let (Some(sps), Some(pps)) = (self.sps.clone(), self.pps.clone()) else {
+		let Some(params) = self.param_sets() else {
 			return Ok(false);
 		};
 
 		// Reuse the existing session if it was built from these exact sets.
-		if self.session.is_some() && self.built_from.as_ref() == Some(&(sps.clone(), pps.clone())) {
+		if self.session.is_some() && self.built_from.as_ref() == Some(&params) {
 			return Ok(true);
 		}
 
-		let format = create_format_description(&sps, &pps)?;
+		let format = create_format_description(self.codec, &params)?;
 		let attrs = nv12_output_attributes()?;
 
 		let refcon = (&mut *self.sink as *mut Sink).cast::<c_void>();
@@ -128,7 +158,7 @@ impl VideoToolbox {
 
 		self.session = Some(session);
 		self.format = Some(format);
-		self.built_from = Some((sps, pps));
+		self.built_from = Some(params);
 		Ok(true)
 	}
 }
@@ -136,16 +166,19 @@ impl VideoToolbox {
 impl Backend for VideoToolbox {
 	fn decode(&mut self, access_unit: Bytes, _keyframe: bool) -> Result<Vec<I420>, Error> {
 		// Split the Annex-B access unit, pull out any parameter sets, and gather
-		// the VCL slices into AVCC (4-byte length-prefixed) form. `NalIterator`
-		// yields the parameter-set NALs as zero-copy `Bytes` (sub-slices of
-		// `access_unit`), so SPS/PPS need no copy.
+		// the slices into length-prefixed (4-byte) form. `NalIterator` yields the
+		// parameter-set NALs as zero-copy `Bytes` (sub-slices of `access_unit`), so
+		// they need no copy.
+		let codec = self.codec;
+		let mut vps = None;
 		let mut sps = None;
 		let mut pps = None;
 		let mut avcc: Vec<u8> = Vec::with_capacity(access_unit.len());
-		let mut handle = |nal: Bytes| match nal_unit_type(&nal) {
-			NAL_TYPE_SPS => sps = Some(nal),
-			NAL_TYPE_PPS => pps = Some(nal),
-			_ => {
+		let mut handle = |nal: Bytes| match nal_kind(&nal, codec) {
+			NalKind::Vps => vps = Some(nal),
+			NalKind::Sps => sps = Some(nal),
+			NalKind::Pps => pps = Some(nal),
+			NalKind::Slice => {
 				avcc.extend_from_slice(&(nal.len() as u32).to_be_bytes());
 				avcc.extend_from_slice(&nal);
 			}
@@ -162,7 +195,7 @@ impl Backend for VideoToolbox {
 			handle(nal);
 		}
 
-		if !self.ensure_session(sps, pps)? {
+		if !self.ensure_session(vps, sps, pps)? {
 			// No parameter sets yet (e.g. a delta frame before the first keyframe).
 			return Ok(Vec::new());
 		}
@@ -231,31 +264,53 @@ unsafe extern "C-unwind" fn output_callback(
 	}
 }
 
-/// Build a `CMVideoFormatDescription` from raw SPS and PPS NAL units.
-fn create_format_description(sps: &[u8], pps: &[u8]) -> Result<CFRetained<CMFormatDescription>, Error> {
-	let pointers: [NonNull<u8>; 2] = [
-		NonNull::new(sps.as_ptr() as *mut u8).ok_or_else(|| Error::Codec(anyhow::anyhow!("empty SPS")))?,
-		NonNull::new(pps.as_ptr() as *mut u8).ok_or_else(|| Error::Codec(anyhow::anyhow!("empty PPS")))?,
-	];
-	let sizes: [usize; 2] = [sps.len(), pps.len()];
+/// Build a `CMVideoFormatDescription` from the ordered parameter-set NAL units
+/// (`[SPS, PPS]` for H.264; `[VPS, SPS, PPS]` for H.265).
+fn create_format_description(codec: Codec, params: &[Bytes]) -> Result<CFRetained<CMFormatDescription>, Error> {
+	let pointers: Vec<NonNull<u8>> = params
+		.iter()
+		.map(|p| {
+			NonNull::new(p.as_ptr() as *mut u8).ok_or_else(|| Error::Codec(anyhow::anyhow!("empty parameter set")))
+		})
+		.collect::<Result<_, _>>()?;
+	let sizes: Vec<usize> = params.iter().map(|p| p.len()).collect();
+	let count = params.len();
+	// `pointers` / `sizes` must outlive the call below; keep them named so they're
+	// not dropped while the C function reads through these raw pointers.
+	let pointers_ptr = NonNull::new(pointers.as_ptr() as *mut NonNull<u8>).unwrap();
+	let sizes_ptr = NonNull::new(sizes.as_ptr() as *mut usize).unwrap();
 
 	let mut format_ptr: *const CMFormatDescription = ptr::null();
-	let status = unsafe {
-		CMVideoFormatDescriptionCreateFromH264ParameterSets(
-			None,
-			2,
-			NonNull::new(pointers.as_ptr() as *mut NonNull<u8>).unwrap(),
-			NonNull::new(sizes.as_ptr() as *mut usize).unwrap(),
-			4, // 4-byte NAL length prefixes (AVCC), matching make_sample_buffer
-			NonNull::new(&mut format_ptr).unwrap(),
-		)
+	// 4-byte NAL length prefixes (AVCC/HVCC), matching make_sample_buffer.
+	let status = match codec {
+		Codec::H264 => unsafe {
+			CMVideoFormatDescriptionCreateFromH264ParameterSets(
+				None,
+				count,
+				pointers_ptr,
+				sizes_ptr,
+				4,
+				NonNull::new(&mut format_ptr).unwrap(),
+			)
+		},
+		Codec::H265 => unsafe {
+			CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+				None,
+				count,
+				pointers_ptr,
+				sizes_ptr,
+				4,
+				None, // no extensions
+				NonNull::new(&mut format_ptr).unwrap(),
+			)
+		},
 	};
 	NonNull::new(format_ptr as *mut CMFormatDescription)
 		.filter(|_| status == 0)
 		.map(|p| unsafe { CFRetained::from_raw(p) })
 		.ok_or_else(|| {
 			Error::Codec(anyhow::anyhow!(
-				"CMVideoFormatDescriptionCreateFromH264ParameterSets failed: {status}"
+				"CMVideoFormatDescriptionCreateFrom*ParameterSets failed: {status}"
 			))
 		})
 }
@@ -341,6 +396,24 @@ fn nv12_output_attributes() -> Result<CFRetained<CFDictionary>, Error> {
 	.ok_or_else(|| Error::Codec(anyhow::anyhow!("failed to build NV12 attributes dictionary")))
 }
 
-fn nal_unit_type(nal: &[u8]) -> u8 {
-	nal.first().map_or(0, |b| b & 0x1f)
+/// Classify a NAL by its header so the parameter sets can be split out. H.264
+/// carries the type in the low 5 bits of one header byte (SPS 7, PPS 8); H.265
+/// uses bits 1..=6 of a two-byte header (VPS 32, SPS 33, PPS 34).
+fn nal_kind(nal: &[u8], codec: Codec) -> NalKind {
+	let Some(&b) = nal.first() else {
+		return NalKind::Slice;
+	};
+	match codec {
+		Codec::H264 => match b & 0x1f {
+			7 => NalKind::Sps,
+			8 => NalKind::Pps,
+			_ => NalKind::Slice,
+		},
+		Codec::H265 => match (b >> 1) & 0x3f {
+			32 => NalKind::Vps,
+			33 => NalKind::Sps,
+			34 => NalKind::Pps,
+			_ => NalKind::Slice,
+		},
+	}
 }

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -230,6 +230,27 @@ mod tests {
 		round_trip(h264_software_encoder(), decoder, "videotoolbox");
 	}
 
+	/// H.265 has no software path, so the HEVC round-trip rides VideoToolbox on
+	/// both ends: hardware HEVC encode emitting hev1 (inline VPS/SPS/PPS) and
+	/// hardware HEVC decode. Skips cleanly on a Mac without HEVC hardware (older
+	/// Intel models predating the HEVC encoder).
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn videotoolbox_hevc_round_trip() {
+		let encoder = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Named("videotoolbox".into()),
+			codec: crate::encode::Codec::H265,
+			..EncodeConfig::new(320, 240, 30)
+		});
+		let Ok(encoder) = encoder else {
+			eprintln!("skipping: no VideoToolbox H.265 hardware encoder available");
+			return;
+		};
+		let decoder =
+			backend::open(Codec::H265, &super::Kind::Named("videotoolbox".into())).expect("videotoolbox H.265 decoder");
+		round_trip(encoder, decoder, "videotoolbox");
+	}
+
 	#[cfg(target_os = "windows")]
 	#[test]
 	fn mediafoundation_round_trip() {


### PR DESCRIPTION
## Summary

The decode front end already handled H.265 (catalog parse, length-prefixed -> Annex-B conversion, keyframe gating), but the macOS VideoToolbox backend hard-rejected it, so an `hvc1`/`hev1` track had no decoder on macOS even though we can already *encode* HEVC there. This teaches the VideoToolbox decode backend H.265, closing one box on #1837 ("we can already encode hev1 on macOS/Windows but can't natively consume it").

Changes, all in `rs/moq-video/src/decode/`:

- **`backend/videotoolbox.rs`**: carry the `Codec`; classify NALs per codec (`nal_kind` — H.264 reads the low 5 bits of one header byte, H.265 bits 1..=6 of a two-byte header; VPS 32 / SPS 33 / PPS 34) and pull VPS out alongside SPS/PPS; build the format description via `CMVideoFormatDescriptionCreateFromHEVCParameterSets` (parameter sets ordered VPS, SPS, PPS). The session, sample-buffer packaging, output callback, and NV12 -> I420 download are codec-agnostic and unchanged.
- **`backend/mod.rs`**: the macOS VideoToolbox candidate now advertises `Codec::H264 | Codec::H265`.

## Public API

No public API change. `decode::Consumer` / `decode::Config` are untouched. The only externally visible behavior change is additive: a macOS consumer subscribing to an H.265 track now decodes instead of erroring with `NoDecoder`. Not a breaking change.

## Test plan

- [x] New `videotoolbox_hevc_round_trip` test: encodes gray frames through the VideoToolbox HEVC encoder (`hev1`, inline VPS/SPS/PPS) and decodes them back, asserting each picture round-trips. Skips cleanly on a Mac without HEVC hardware.
- [x] Verified on **Apple M4**: `cargo test -p moq-video` — all 20 tests pass, including the new HEVC round-trip and the existing H.264 / openh264 round-trips.
- [x] `cargo fmt` + `cargo clippy -p moq-video --all-targets -- -D warnings` clean (via nix).
- [x] CHANGELOG `[Unreleased]` and README capability matrix updated (the H.265 decode row now lists VideoToolbox for macOS and notes the macOS path is HW-verified).

## Cross-package sync

moq-video decode is native-only (no JS mirror; browsers use WebCodecs), so no paired package needs updating.

(Written by Claude)