### PR TITLE
feat(moq-video): opt-out nvenc/vaapi features (default-on) + correct libva docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,10 @@ moq-net = { version = "0.1", path = "rs/moq-net" }
 moq-token = { version = "0.6", path = "rs/moq-token" }
 # Standalone crate (moq-dev/vaapi); vendored from cros-libva + cros-codecs.
 moq-vaapi = "0.0.2"
-moq-video = { version = "0.0.4", path = "rs/moq-video" }
+# default-features off (the `nvenc` / `vaapi` hardware encoders) so each consumer
+# opts in: binaries (libmoq, moq-boy, moq-cli) enable them, but a self-compiler can
+# leave them off to drop the CUDA / libva deps. moq-video itself still defaults them on.
+moq-video = { version = "0.0.4", path = "rs/moq-video", default-features = false }
 qmux = { version = "0.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 tokio = "1.48"

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -107,6 +107,16 @@ moq-cli publish --url https://relay.example.com --broadcast cam.hang capture --n
 moq-cli publish --url https://relay.example.com --broadcast cam.hang capture --codec h265
 ```
 
+On Linux the NVENC (NVIDIA) and VAAPI (Intel/AMD) encoders are compiled in by
+default and link the CUDA / libva system libraries. To build `capture` without
+them (software openh264 + V4L2 capture only, no CUDA/libva dependency), drop the
+default features:
+
+```bash
+cargo build --release -p moq-cli --no-default-features \
+    --features "iroh quinn websocket capture"
+```
+
 Video capture uses a native per-platform backend (AVFoundation on macOS, V4L2 on
 Linux, Media Foundation on Windows). The codec is chosen with `--codec`
 (`h264` default, or `h265`). For H.264 it picks a hardware encoder

--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -24,7 +24,8 @@ moq-audio = { workspace = true }
 moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = true }
 moq-net = { workspace = true, features = ["serde"] }
-moq-video = { workspace = true }
+# Enable the NVENC / VAAPI hardware encoders (default-off at the workspace level).
+moq-video = { workspace = true, features = ["nvenc", "vaapi"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["macros"] }
 tracing = "0.1"

--- a/rs/moq-boy/Cargo.toml
+++ b/rs/moq-boy/Cargo.toml
@@ -28,7 +28,8 @@ moq-json = { workspace = true }
 moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
 moq-net = { workspace = true }
-moq-video = { workspace = true }
+# Enable the NVENC / VAAPI hardware encoders (default-off at the workspace level).
+moq-video = { workspace = true, features = ["nvenc", "vaapi"] }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = "0.1"

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
 [features]
-default = ["iroh", "quinn", "websocket"]
+default = ["iroh", "quinn", "websocket", "nvenc", "vaapi"]
 iroh = ["moq-native/iroh"]
 quinn = ["moq-native/quinn"]
 quiche = ["moq-native/quiche"]
@@ -25,6 +25,12 @@ websocket = ["moq-native/websocket"]
 # extra install. H.264 is vendored static (openh264), so no system ffmpeg/libav.
 # Enable with `cargo build -p moq-cli --features capture`.
 capture = ["dep:moq-video", "dep:moq-audio", "moq-audio/capture"]
+# NVENC / VAAPI hardware encoders for `capture` (Linux), on by default. Each just
+# turns on the matching moq-video feature, and only bites when `capture` pulls in
+# moq-video. For a `capture` build with no CUDA / libva system deps, drop them, e.g.
+#   cargo build -p moq-cli --no-default-features --features "iroh quinn websocket capture"
+nvenc = ["moq-video?/nvenc"]
+vaapi = ["moq-video?/vaapi"]
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -15,6 +15,21 @@ categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 [lib]
 doctest = false
 
+[features]
+# Hardware encoders are enabled by default. Disable them (e.g. `--no-default-features`)
+# for a slimmer self-compiled Linux build that drops the CUDA / libva deps: openh264
+# stays as the always-compiled software fallback and V4L2 capture is unaffected. Both
+# features are no-ops off Linux (their deps are Linux-only).
+default = ["nvenc", "vaapi"]
+# NVIDIA NVENC hardware encoder (Linux). dlopen'd at runtime (cudarc + the SDK's
+# `dynamic-loading`), with a libloading probe for the driver libs, so an nvenc build
+# still links GPU-less and starts driverless, falling back to the next encoder.
+nvenc = ["dep:cudarc", "dep:nvidia-video-codec-sdk", "dep:libloading"]
+# Intel/AMD VAAPI hardware encoder (Linux). moq-vaapi 0.0.2 hard-links libva (the
+# binary carries NEEDED libva.so.2 / libva-drm.so.2), so disable this feature for a
+# build with no libva dependency. See #1837.
+vaapi = ["dep:moq-vaapi"]
+
 [dependencies]
 anyhow = "1"
 bytes = "1"
@@ -34,28 +49,30 @@ tracing = "0.1"
 yuv = "0.8.14"
 
 [target.'cfg(target_os="linux")'.dependencies]
-# NVENC hardware encoder, always-on for Linux. Everything is dlopen'd at runtime:
-# cudarc loads CUDA, and nvidia-video-codec-sdk's `dynamic-loading` (a fork
-# feature, see the root [patch.crates-io]) loads libnvidia-encode. So the binary
-# links on a GPU-less builder and still starts on machines without the NVIDIA
-# driver, falling back to the next encoder (see backend::open). `cuda-12020` pins
-# the CUDA API version so the build needs no CUDA toolkit.
-cudarc = { version = "0.19", default-features = false, features = ["driver", "fallback-dynamic-loading", "cuda-12020"] }
+# NVENC hardware encoder, behind the default-on `nvenc` feature. Everything is
+# dlopen'd at runtime: cudarc loads CUDA, and nvidia-video-codec-sdk's
+# `dynamic-loading` (a fork feature, see the root [patch.crates-io]) loads
+# libnvidia-encode. So the binary links on a GPU-less builder and still starts on
+# machines without the NVIDIA driver, falling back to the next encoder (see
+# backend::open). `cuda-12020` pins the CUDA API version so the build needs no
+# CUDA toolkit.
+cudarc = { version = "0.19", optional = true, default-features = false, features = ["driver", "fallback-dynamic-loading", "cuda-12020"] }
 # Probe for the NVIDIA driver libraries before calling cudarc / the NVENC SDK,
 # which panic (process-abort under release `panic = "abort"`) if their library is
 # absent. Lets a GPU-less host fall back to the next encoder instead of crashing.
-libloading = "0.8"
-# Intel/AMD VAAPI hardware encoder, always-on for Linux. As of moq-vaapi 0.0.2
-# libva is dynamically linked via pkg-config (the binary carries NEEDED
-# libva.so.2 / libva-drm.so.2), so a Linux build needs libva at build time and
-# the binary needs it at runtime: a libva-less host fails to load rather than
-# falling back. Switching moq-vaapi to dlopen libva (one portable binary that
-# falls back like the NVENC backend) is tracked in #1837.
-moq-vaapi = { workspace = true }
+libloading = { version = "0.8", optional = true }
+# Intel/AMD VAAPI hardware encoder, behind the default-on `vaapi` feature. As of
+# moq-vaapi 0.0.2 libva is dynamically linked via pkg-config (the binary carries
+# NEEDED libva.so.2 / libva-drm.so.2), so an enabled-vaapi Linux build needs libva
+# at build time and the binary needs it at runtime: a libva-less host fails to load
+# rather than falling back. Disable the `vaapi` feature for a libva-free build, or
+# switch moq-vaapi to dlopen libva (one portable binary that falls back like the
+# NVENC backend); the latter is tracked in #1837.
+moq-vaapi = { workspace = true, optional = true }
 # default-features off so the crate's `cuda-version-from-build-system` default
 # stays off: we pin the CUDA version via our own cudarc dep (cuda-12020) instead,
 # so the build needs no CUDA toolkit.
-nvidia-video-codec-sdk = { version = "0.4", default-features = false, features = ["dynamic-loading"] }
+nvidia-video-codec-sdk = { version = "0.4", optional = true, default-features = false, features = ["dynamic-loading"] }
 # Native V4L2 webcam capture (replaces nokhwa). `v4l` streams MMAP buffers;
 # MJPEG cameras are decoded with the pure-Rust `zune-jpeg` (no libjpeg/IJG).
 v4l = "0.14"

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -45,10 +45,12 @@ cudarc = { version = "0.19", default-features = false, features = ["driver", "fa
 # which panic (process-abort under release `panic = "abort"`) if their library is
 # absent. Lets a GPU-less host fall back to the next encoder instead of crashing.
 libloading = "0.8"
-# Intel/AMD VAAPI hardware encoder, always-on for Linux. Builds against its own
-# vendored libva headers and dlopen's libva at runtime, so it builds without
-# system libva-dev and still loads on machines without libva, falling back to the
-# next encoder (see backend::open).
+# Intel/AMD VAAPI hardware encoder, always-on for Linux. As of moq-vaapi 0.0.2
+# libva is dynamically linked via pkg-config (the binary carries NEEDED
+# libva.so.2 / libva-drm.so.2), so a Linux build needs libva at build time and
+# the binary needs it at runtime: a libva-less host fails to load rather than
+# falling back. Switching moq-vaapi to dlopen libva (one portable binary that
+# falls back like the NVENC backend) is tracked in #1837.
 moq-vaapi = { workspace = true }
 # default-features off so the crate's `cuda-version-from-build-system` default
 # stays off: we pin the CUDA version via our own cudarc dep (cuda-12020) instead,

--- a/rs/moq-video/DESIGN-native-codecs.md
+++ b/rs/moq-video/DESIGN-native-codecs.md
@@ -43,7 +43,7 @@ capture still pulls in `libav*`. This proposal replaces encode **and** capture.
 |---|---|---|---|
 | VideoToolbox (macOS) | [`objc2-video-toolbox`](https://docs.rs/objc2-video-toolbox/) + `objc2-core-media` / `objc2-core-video` | Raw FFI. We hand-write the `VTCompressionSession` glue. | System frameworks, always present. Zero external runtime deps. |
 | NVENC (NVIDIA) | [`nvidia-video-codec-sdk`](https://crates.io/crates/nvidia-video-codec-sdk) (0.4) | Safe `Encoder` wrapper. | NVENC API lives in the driver (`libnvidia-encode.so`), loaded at runtime. No build-time SDK linking. |
-| VAAPI (Intel/AMD) | [`moq-vaapi`](../moq-vaapi) (in-tree; vendored+trimmed from cros-libva + discord/cros-codecs) | VAAPI H.264 encoder (Google/ChromeOS, ships in crosvm). | `dlopen`s `libva` at runtime; libva `dlopen`s the GPU driver. Build needs libva headers for bindgen. |
+| VAAPI (Intel/AMD) | [`moq-vaapi`](https://crates.io/crates/moq-vaapi) `0.0.2` (published; vendored+trimmed from cros-libva + discord/cros-codecs) | VAAPI H.264 encoder (Google/ChromeOS, ships in crosvm). | As of 0.0.2 *links* `libva` (`NEEDED libva.so.2`), build needs libva-dev; `dlopen` (no NEEDED, no build dep) is intended but not yet realized, see #1837. |
 | Software fallback | [`openh264`](https://crates.io/crates/openh264) | Pure fallback when no GPU. | Vendored build -> static, zero runtime deps. |
 
 Decisions and rationale:
@@ -259,7 +259,9 @@ A backend "fails to open" (driver missing, no device) the same way an ffmpeg
 - **Linux**: one binary that
 
   - `dlopen`s `libnvidia-encode` if an NVIDIA driver is present (no build dep),
-  - `dlopen`s `libva` for Intel/AMD (no build dep on libva-dev),
+  - `dlopen`s `libva` for Intel/AMD (no build dep on libva-dev) — *intended*;
+    moq-vaapi 0.0.2 currently links libva instead, so this isn't realized yet
+    (see #1837),
   - falls back to the always-compiled-in openh264 when no GPU encoder is usable.
 
   That single artifact runs across Ubuntu 20.04 -> 24.04, Debian, Fedora, etc.,
@@ -391,6 +393,13 @@ actively-maintained fork (Discord ships it for Go Live) that bumps to cros-libva
 links on a libva-less builder and loads on a libva-less machine, falling back to
 software (see `backend::open`). The build still needs libva *headers* for
 cros-libva's bindgen, so `libva` is in the nix devShell.
+
+> **Status (moq-vaapi 0.0.2): not yet realized.** The published `moq-vaapi` crate
+> we depend on today *links* libva via `pkg_config` (its `build.rs` probes `libva`
+> and `libva-drm`), so the binary carries `NEEDED libva.so.2` / `libva-drm.so.2`
+> and needs libva at both build and run time; a libva-less host fails to load
+> rather than falling back. Restoring the `dlopen` path in `moq-vaapi` (so this
+> section holds) is tracked in #1837.
 
 **Input is an NV12 surface upload, not zero-copy dmabuf.** The encoder wants an
 NV12 VA surface, but UVC webcams deliver YUYV/MJPEG (decoded to CPU I420); they

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -26,10 +26,10 @@ mod videotoolbox;
 #[cfg(target_os = "windows")]
 mod mediafoundation;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "nvenc"))]
 mod nvenc;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "vaapi"))]
 mod vaapi;
 
 /// An opened video encoder. Feed it frames at the configured resolution; get
@@ -68,13 +68,13 @@ const HARDWARE: &[Candidate] = &[
 		codecs: &[Codec::H264, Codec::H265],
 		open: mediafoundation::MediaFoundation::open,
 	},
-	#[cfg(target_os = "linux")]
+	#[cfg(all(target_os = "linux", feature = "nvenc"))]
 	Candidate {
 		name: nvenc::NAME,
 		codecs: &[Codec::H264, Codec::H265],
 		open: nvenc::Nvenc::open,
 	},
-	#[cfg(target_os = "linux")]
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
 	Candidate {
 		name: vaapi::NAME,
 		codecs: &[Codec::H264],

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -2,9 +2,16 @@
 //!
 //! `moq-vaapi` is a focused VA-API H.264 encoder vendored and trimmed from
 //! cros-libva + discord/cros-codecs. It takes tightly-packed NV12 and emits an
-//! Annex-B elementary stream with in-band SPS/PPS, matching avc3 mode. libva is
-//! dlopen'd at runtime, so this links without libva and the binary loads on
-//! machines without it, falling back to software (see [`backend::open`]).
+//! Annex-B elementary stream with in-band SPS/PPS, matching avc3 mode.
+//!
+//! As of moq-vaapi 0.0.2 libva is dynamically *linked* (the binary carries
+//! `NEEDED libva.so.2` / `libva-drm.so.2`), so a VAAPI-enabled Linux build needs
+//! libva present at runtime: a libva-less host fails to load the binary, before
+//! [`backend::open`](super::open) can fall back. A present-but-unusable VA stack
+//! (no render node, no usable driver) *does* fall back: `Encoder::new` returns an
+//! error and `backend::open` moves on to openh264. Making moq-vaapi `dlopen` libva
+//! (one portable binary that loads and falls back on a libva-less box, like the
+//! NVENC backend) is tracked in #1837.
 //!
 //! Our captures hand us CPU I420 (webcams deliver YUYV/MJPEG, decoded to I420),
 //! so each frame is interleaved to NV12 before encoding.


### PR DESCRIPTION
## Summary

Two related changes around how the Linux hardware encoders (NVENC / VAAPI) pull in system deps. Came out of the #1837 "VAAPI driver-probe" box.

### 1. Default-on `nvenc` / `vaapi` features (the opt-out)

#1819 made NVENC/VAAPI always-on for Linux, which also made **libva a hard runtime dependency of every Linux `moq-video` binary** — `moq-vaapi 0.0.2` links libva (`NEEDED libva.so.2` / `libva-drm.so.2`), so a libva-less host can't even load the binary. We're keeping that default (libva is near-universal on Linux GPU boxes), but giving **self-compilers** a way to drop the CUDA / libva deps.

- **moq-video**: reintroduce `nvenc` and `vaapi` features (the Linux deps become `optional`), both in `default`. Backend modules + candidates gated with `#[cfg(all(target_os = "linux", feature = ...))]`. openh264 stays the always-compiled software fallback; V4L2 capture is unaffected. Features are no-ops off Linux.
- **Consumers**: the workspace `moq-video` dep is now `default-features = false` (mirroring the existing `moq-native` pattern), so each binary opts in. `libmoq` / `moq-boy` enable both; **`moq-cli`** exposes default-on `nvenc`/`vaapi` passthroughs so a `capture` build can drop them:
  ```
  cargo build -p moq-cli --no-default-features --features "iroh quinn websocket capture"
  ```

Default builds everywhere are byte-for-byte the same as before — this is purely additive (a new way to turn things *off*).

### 2. Correct the libva docs (no code change)

The `vaapi.rs` + `Cargo.toml` comments and `DESIGN-native-codecs.md` claimed moq-vaapi **dlopens** libva ("builds without system libva-dev", "loads on machines without libva"). That's false for `moq-vaapi 0.0.2`, which **links** it. Corrected to describe the real behavior + the now-default-on feature.

## Evidence (podman, `rust:latest`)

- `moq-vaapi 0.0.2` without libva-dev → build fails at `pkg-config ... libva`; with it, the binary carries `NEEDED libva.so.2` + `libva-drm.so.2` (`readelf -d`). So it links, not dlopens.
- `cargo check -p moq-video --no-default-features` → **succeeds without libva-dev** (the opt-out works); the default (nvenc+vaapi) compiles with libva-dev.

## Why this isn't the NVENC-style "driver-probe" from #1837

moq-vaapi links libva and its `Encoder::new` returns a `Result` (no panic), so — unlike NVENC (which dlopens + `panic!`s, hence the #1844 probe) — a libva-less box fails at *process load*, before any probe could run, and the no-GPU case already falls back cleanly. The real "dlopen libva" fix lives in the `moq-dev/vaapi` crate; this PR makes the dep *optional* in the meantime. Issue #1837 reframed accordingly.

## Test plan

- [x] macOS: `cargo check` for moq-video / moq-cli (default + `--features capture`) / libmoq / moq-boy all pass; `cargo test -p moq-video` green.
- [x] Linux (container): `moq-video --no-default-features` builds with no libva-dev; default builds with it.
- [x] `cargo tree` confirms feature resolution: `moq-cli --features capture` → moq-video `nvenc,vaapi`; `--no-default-features ... capture` → none; `... capture nvenc` → `nvenc` only; libmoq/moq-boy → `nvenc,vaapi`.
- [x] `cargo fmt` + `taplo format --check` clean (via nix).

## Cross-package sync

No JS mirror (native-only). Docs touched: `DESIGN-native-codecs.md`. The `moq-cli` flags doc may want a note about the new `--no-default-features` opt-out, but no example invocation changed.

(Written by Claude)