### PR TITLE
fix(moq-net,moq-mux): don't block forever on an evicted/missing group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1981,7 +1981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3498,7 +3498,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4852,7 +4852,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6081,9 +6081,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -6552,7 +6552,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6611,7 +6611,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6632,7 +6632,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6871,7 +6871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7316,7 +7316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7646,7 +7646,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7655,7 +7655,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9008,7 +9008,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -54,9 +54,9 @@ pub struct Broadcaster {
 	/// Current rendition count, bumped on every catalog sync so handlers can wait
 	/// for the catalog to populate before rendering a playlist.
 	ready: watch::Sender<usize>,
-	/// Pause flag shared with every rendition pump. While true, the pumps stop
-	/// draining the broadcast; renditions discovered later inherit the current
-	/// value (they `subscribe()` to this sender).
+	/// Pause flag shared with every rendition pump. While true the pumps stop
+	/// reading; renditions discovered later inherit the current value (they
+	/// `subscribe()` to this sender).
 	paused: watch::Sender<bool>,
 }
 
@@ -76,12 +76,14 @@ impl Broadcaster {
 
 	/// Pause or resume pulling media from the broadcast.
 	///
-	/// While paused, every rendition's pump stops draining the source, so live
-	/// media produced during the pause is dropped (not buffered); resuming
-	/// continues the SAME playlists, with the first post-resume segment of each
-	/// rendition marked `#EXT-X-DISCONTINUITY`. Segment numbering and the init
-	/// segment persist across the pause, so a paused-then-resumed export is one
-	/// continuous recording with a gap, not a restart. Idempotent.
+	/// While paused, every rendition's pump stops reading its track, so the relay
+	/// stops sending and the live media produced during the pause is dropped from the
+	/// recording (not buffered, and the publisher isn't kept ingesting). Resuming
+	/// continues the SAME playlists from the next group still in the relay cache (the
+	/// evicted span is skipped, then it reads forward -- it does NOT jump to live),
+	/// marking the first post-resume segment `#EXT-X-DISCONTINUITY`. CMAF sequence
+	/// numbers and the init segment persist, so it's one continuous recording with a
+	/// gap, not a restart. Idempotent.
 	pub fn set_paused(&self, paused: bool) {
 		let _ = self.paused.send(paused);
 	}

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -134,15 +134,14 @@ async fn run_pump(
 		.with_fragment_duration(cfg.part_target)
 		.with_latency(cfg.latency);
 
-	// Whether we just resumed, so the first post-resume segment opens a new
+	// Whether we just resumed, so the first post-resume fragment opens a new
 	// continuity region (`#EXT-X-DISCONTINUITY`).
 	let mut resumed = false;
 
 	loop {
-		// Park while paused: stop draining the source entirely. The live media
-		// produced during the pause is dropped by the relay (the exporter's latency
-		// budget skips stale groups on resume), NOT buffered here, so a long pause
-		// costs no memory -- it just leaves a gap in the recording.
+		// While paused, stop reading the track entirely: the relay stops sending, so
+		// nothing is buffered here and the publisher isn't kept ingesting for a
+		// receiver that isn't recording.
 		while *paused.borrow_and_update() {
 			resumed = true;
 			tokio::select! {
@@ -158,15 +157,19 @@ async fn run_pump(
 		}
 
 		if resumed {
-			// The media timeline jumped across the dropped span; tag the next segment.
+			// The media dropped while paused is a real gap, so tag the seam. The export
+			// recovers on its own: the group it was mid-read on aged out of the relay
+			// cache while we weren't reading, and reading an evicted (or now-missing)
+			// group errors instead of blocking (moq-net aborts it with `Error::Old`), so
+			// the consumer skips the evicted span and resumes from the NEXT group still in
+			// the cache (`recv_group`), reading forward -- not jumping to live.
 			store.mark_discontinuity();
 			resumed = false;
 		}
 
-		// Pull exactly one fragment uninterrupted (next_fragment isn't cancel-safe),
-		// then re-check the pause flag at the top of the loop. So entering a pause
-		// costs at most one extra fragment (~part_target), which records right up to
-		// the pause point.
+		// Pull one fragment uninterrupted (next_fragment isn't cancel-safe), then
+		// re-check the pause flag at the top of the loop -- so entering a pause costs at
+		// most one extra fragment (~part_target), recording right up to the pause point.
 		match export.next_fragment().await? {
 			Some(fragment) => store.push(fragment),
 			None => break,

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -120,14 +120,21 @@ impl<F: Container> Consumer<F> {
 					// Still blocked on this group, don't skip it yet.
 					Poll::Pending => break,
 					Poll::Ready(Err(e)) => {
-						tracing::warn!(error = ?e, "error reading current group, skipping");
+						// The group was dropped/aborted -- typically it aged out of the relay
+						// cache (`Error::Old`) while we weren't reading it. Any sequences
+						// between it and the next buffered group were evicted alongside it, so
+						// jump straight to that group instead of stepping one-by-one and then
+						// blocking on a sequence gap of groups that will never arrive.
+						tracing::warn!(error = ?e, "current group dropped; skipping to next buffered group");
+						self.pending.pop_front();
+						self.current = self.pending.front().map_or(self.current + 1, |g| g.sequence);
 					}
-					// No more frames, advance to next group.
-					Poll::Ready(Ok(None)) => {}
+					// Cleanly finished group: advance to the next sequence.
+					Poll::Ready(Ok(None)) => {
+						self.pending.pop_front();
+						self.current += 1;
+					}
 				}
-
-				self.pending.pop_front();
-				self.current += 1
 			}
 
 			// Get the current group's min timestamp (the reference for latency
@@ -179,9 +186,13 @@ impl<F: Container> Consumer<F> {
 					let covered = current_end.is_some_and(|end| end >= next_start);
 					over_latency || covered
 				} else {
-					// Sequence gap: current group consumed but next sequence missing.
-					// Only skip if track is fully received (no more groups coming).
-					finished
+					// The current group can't produce a timestamp: either it's missing
+					// entirely -- a lower sequence the cache evicted, so `front` is already
+					// past `current` -- or it's finished/empty. With a newer group buffered,
+					// skip if the track is done OR the current sequence is simply gone. On a
+					// live track a buffered higher sequence means the missing one was evicted
+					// (the relay delivers in order), not merely late, so waiting is futile.
+					finished || self.pending.front().is_some_and(|g| g.sequence > self.current)
 				}
 			} else {
 				false
@@ -887,6 +898,86 @@ mod tests {
 
 		let frames = read_all(&mut consumer).await.unwrap();
 		assert!(frames.len() >= 4, "Expected >= 4 frames, got {}", frames.len());
+	}
+
+	// ---- Eviction recovery (pause/resume) ----
+
+	/// A group that aged out of the relay cache (aborted with `Error::Old`) while the
+	/// consumer was parked on it must not hang the consumer: reading it errors, and
+	/// the consumer skips the gap to the next live group even though the track is NOT
+	/// finished. This is the resume-from-pause path (the recorder stops reading, the
+	/// group + the sequences after it evict, then it resumes).
+	#[tokio::test]
+	async fn evicted_group_with_gap_skips_to_live() {
+		let mut track = moq_net::TrackProducer::new(
+			"test",
+			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+		);
+		let consumer_track = track.subscribe(None);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+
+		// Group 0: a frame the consumer reads, positioning it there.
+		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		Container::Legacy
+			.write(
+				&mut group0,
+				&[Frame {
+					timestamp: ts(0),
+					payload: Bytes::from_static(&[0xDE, 0xAD]),
+					keyframe: false,
+					duration: None,
+				}],
+			)
+			.unwrap();
+		let first = consumer.read().await.unwrap().unwrap();
+		assert_eq!(first.timestamp, ts(0));
+
+		// A live group arrives far ahead -- sequences 1..4 never come (evicted). The
+		// track stays OPEN (not finished), the failure mode that used to hang.
+		write_group(&mut track, 5, &[ts(150_000)]);
+
+		// Group 0 ages out of the cache (the relay aborts it on eviction).
+		group0.abort(moq_net::Error::Old).unwrap();
+
+		// Must skip the evicted group + the gap and reach the live group, without
+		// hanging on a track that never finishes.
+		let next = tokio::time::timeout(Duration::from_secs(1), consumer.read())
+			.await
+			.expect("consumer hung on an evicted group / gap")
+			.unwrap()
+			.unwrap();
+		assert_eq!(next.timestamp, ts(150_000), "skipped the evicted gap to the live group");
+	}
+
+	/// A missing (evicted) sequence with a newer group buffered must be skipped even
+	/// while the track is still LIVE -- not only once it's finished. This is the
+	/// recorder resume stall: `current` points at a sequence the cache dropped, a
+	/// higher group is buffered, and the track never finishes.
+	#[tokio::test]
+	async fn missing_sequence_skips_on_live_track() {
+		let mut track = moq_net::TrackProducer::new(
+			"test",
+			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+		);
+		let consumer_track = track.subscribe(None);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
+
+		// Group 0, then group 2 -- sequence 1 is missing (evicted) and never arrives.
+		// The track is NOT finished (live), the case that used to hang.
+		write_group(&mut track, 0, &[ts(0), ts(20_000)]);
+		write_group(&mut track, 2, &[ts(200_000)]);
+
+		// Reading must reach group 2 across the gap instead of waiting forever for 1.
+		let reached = tokio::time::timeout(Duration::from_secs(1), async {
+			loop {
+				let frame = consumer.read().await.unwrap().unwrap();
+				if frame.timestamp == ts(200_000) {
+					return;
+				}
+			}
+		})
+		.await;
+		assert!(reached.is_ok(), "consumer hung on a missing sequence on a live track");
 	}
 
 	// ---- Frame Decoding ----

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -403,6 +403,12 @@ impl TrackState {
 			}
 
 			self.duplicates.remove(&group.sequence);
+			// Abort the group before dropping it so any consumer still reading it
+			// surfaces `Error::Old` instead of blocking forever on a frame that will
+			// never arrive (the cached producer is about to be gone). Without this a
+			// reader parked on an aged-out group hangs indefinitely, since the group
+			// was never finished or aborted -- it just silently disappeared.
+			let _ = group.abort(Error::Old);
 			*slot = None;
 		}
 


### PR DESCRIPTION
## Problem

A consumer that stops reading and later resumes — the moq-pro VOD recorder pausing/resuming, or any slow reader catching up after a stall — could **hang forever**. #1862's export pause hit this: after resume the recording produced one more segment and froze. Two root causes, both "wait indefinitely for media the relay cache already dropped":

1. **moq-net** — `TrackState::evict_expired` tombstoned an aged-out group's slot (`*slot = None`) **without aborting it**, so a `GroupConsumer` still parked on that group saw `fin=false`/`abort=None` and `poll_get_frame` returned `Pending` forever.
2. **moq-mux `container::Consumer`** — even with (1) fixed, the common case is a pure **sequence gap**: `current` points at a sequence the cache evicted (`DEFAULT_CACHE` is 5s) while a newer group is already buffered, but the gap-skip only fired once the track was `finished` — so a *live* track hung.

## Fix

- **moq-net**: eviction now `abort()`s the group with `Error::Old`, so reading an expired group errors instead of blocking.
- **moq-mux `Consumer`**:
  - a group read error skips straight to the next buffered group (the evicted group and any sequences before the next buffer were evicted together);
  - the sequence-gap skip also fires when `current` is simply gone — a buffered higher sequence on a live track means it was evicted, not merely late.

**On resume the consumer resumes from the next group still in the cache** (`recv_group`) and reads forward — it does **not** jump to live. With the recorder's latency budget (10s) larger than the cache (5s), nothing cached is dropped, so it captures everything the cache still holds (just the evicted span before it is lost).

moq-hls's #1862 pause (`tokio::watch`, park the pump, mark the discontinuity on resume) is **unchanged** and now works against the fixed consumer — only its resume comments are clarified. `Broadcaster::set_paused(bool)` is unchanged for the downstream recorder.

## Verification

- New consumer tests: an evicted group with a gap, and a missing sequence on a **live** track (the exact stall) — both now skip instead of hanging. `cargo test -p moq-net -p moq-mux -p moq-hls` passes (396 / 281 / 7).
- End to end (moq-pro VOD recorder, live publisher, instrumented to confirm the stall signature `current=N front=N+1 finished=false`): pause holds production flat; **resume continues from the cached backlog (a brief catch-up burst, then realtime) with no stall**; `#EXT-X-DISCONTINUITY` lands at the seam.

## Notes

- Based on `dev` (has #1862). Fixes #1862's resume stall without touching its pause mechanism.
- The eviction-abort is a general correctness fix: any consumer of an aged-out group now errors instead of hanging (moq-mux's `Consumer` already had a `Ready(Err)` arm that skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)