### PR TITLE
feat(moq-rtc): single shared-UDP-port mux for WHIP/WHEP servers

### DIFF
--- a/rs/moq-rtc/bin/moq-rtc.rs
+++ b/rs/moq-rtc/bin/moq-rtc.rs
@@ -71,6 +71,12 @@ enum Role {
 		#[arg(long, env = "MOQ_RTC_LISTEN", default_value = "[::]:8088")]
 		listen: SocketAddr,
 
+		/// UDP socket the shared WebRTC media mux binds to. All WHIP/WHEP
+		/// sessions share this one port (demuxed by ICE ufrag), so open just
+		/// this in the firewall. `0.0.0.0:0` lets the OS pick (loopback/dev).
+		#[arg(long, env = "MOQ_RTC_UDP_BIND", default_value = "0.0.0.0:0")]
+		udp_bind: SocketAddr,
+
 		/// Optional TLS cert (PEM). Requires `--tls-key`.
 		#[arg(long, env = "MOQ_RTC_TLS_CERT", requires = "tls_key")]
 		tls_cert: Option<PathBuf>,
@@ -145,18 +151,33 @@ async fn run_role(
 	match role {
 		Role::Server {
 			listen,
+			udp_bind,
 			tls_cert,
 			tls_key,
 			direction,
-		} => run_server(public_addr, publisher, subscriber, listen, tls_cert, tls_key, direction).await,
+		} => {
+			run_server(
+				public_addr,
+				udp_bind,
+				publisher,
+				subscriber,
+				listen,
+				tls_cert,
+				tls_key,
+				direction,
+			)
+			.await
+		}
 		Role::Client { url, direction } => {
 			run_client(broadcast, public_addr, publisher, subscriber, url, direction).await
 		}
 	}
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_server(
 	public_addr: Vec<SocketAddr>,
+	udp_bind: SocketAddr,
 	publisher: moq_net::OriginProducer,
 	subscriber: moq_net::OriginConsumer,
 	listen: SocketAddr,
@@ -166,6 +187,7 @@ async fn run_server(
 ) -> anyhow::Result<()> {
 	let config = moq_rtc::server::Config {
 		ice_candidates: public_addr,
+		udp_bind,
 	};
 	let server = Server::new(config, publisher, subscriber);
 

--- a/rs/moq-rtc/src/client/whep.rs
+++ b/rs/moq-rtc/src/client/whep.rs
@@ -60,7 +60,12 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::Broadcas
 	rtc.sdp_api().accept_answer(pending, answer).map_err(Error::Rtc)?;
 	tracing::info!(%url, "whep client connected");
 
-	let session = session::Session::ingest(rtc, socket, sink);
+	// 1:1 socket (no demux on the client): pump its datagrams into the session.
+	// Report the first advertised candidate as the local address (str0m matches
+	// each datagram's destination against a host candidate, not the socket bind).
+	let local = candidates[0];
+	let inbound = session::spawn_socket_reader(socket.clone());
+	let session = session::Session::ingest(rtc, socket, local, inbound, sink);
 	tokio::spawn(async move {
 		if let Err(err) = session.run().await {
 			tracing::warn!(%err, "whep client session ended");

--- a/rs/moq-rtc/src/client/whip.rs
+++ b/rs/moq-rtc/src/client/whip.rs
@@ -66,7 +66,12 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::Broadcas
 	rtc.sdp_api().accept_answer(pending, answer).map_err(Error::Rtc)?;
 	tracing::info!(%url, "whip client connected");
 
-	let session = session::Session::egress(rtc, socket, source);
+	// 1:1 socket (no demux on the client): pump its datagrams into the session.
+	// Report the first advertised candidate as the local address (str0m matches
+	// each datagram's destination against a host candidate, not the socket bind).
+	let local = candidates[0];
+	let inbound = session::spawn_socket_reader(socket.clone());
+	let session = session::Session::egress(rtc, socket, local, inbound, source);
 	tokio::spawn(async move {
 		if let Err(err) = session.run().await {
 			tracing::warn!(%err, "whip client session ended");

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -9,10 +9,16 @@
 pub mod whep;
 pub mod whip;
 
+mod mux;
+
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::Router;
+use tokio::sync::OnceCell;
+
+use crate::Result;
+use mux::Mux;
 
 /// The result of a WHIP/WHEP [`whip::accept`] / [`whep::accept`]: the SDP answer
 /// to return to the client, plus an opaque resource id for the `Location` header
@@ -26,16 +32,30 @@ pub struct Response {
 }
 
 /// Configuration shared by both `server publish` and `server subscribe`.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Config {
 	/// Public UDP socket addresses that should be advertised as ICE host
 	/// candidates. Each is sent as a separate `candidate` line in the SDP
 	/// answer so a remote peer can reach us.
 	///
-	/// If empty, the session loop binds an ephemeral port and uses whatever
-	/// address the OS picks. That works for loopback testing but not behind
-	/// NAT.
+	/// If empty, the mux advertises whatever address the OS picked for the
+	/// shared socket. That works for loopback testing but not behind NAT.
 	pub ice_candidates: Vec<SocketAddr>,
+
+	/// Address the shared WebRTC media socket binds to. Every WHIP/WHEP session
+	/// shares this one UDP port (demuxed by ICE ufrag), so a deployment opens
+	/// exactly one media port in its firewall. `0.0.0.0:0` (the default) lets
+	/// the OS pick a port, which is fine for dev/loopback; production pins it.
+	pub udp_bind: SocketAddr,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			ice_candidates: Vec::new(),
+			udp_bind: SocketAddr::from(([0, 0, 0, 0], 0)),
+		}
+	}
 }
 
 /// Glue that owns the moq-net origin pair and hands axum routers to the caller.
@@ -53,6 +73,9 @@ struct Inner {
 	publisher: moq_net::OriginProducer,
 	/// Source for `server subscribe` (WHEP) egress.
 	subscriber: moq_net::OriginConsumer,
+	/// The shared media socket + demux, bound lazily on the first accept so
+	/// `Server::new` can stay synchronous (and an idle server binds no port).
+	mux: OnceCell<Mux>,
 }
 
 impl Server {
@@ -64,8 +87,17 @@ impl Server {
 				config,
 				publisher,
 				subscriber,
+				mux: OnceCell::new(),
 			}),
 		}
+	}
+
+	/// The shared media mux, bound (and its demux task spawned) on first use.
+	pub(crate) async fn mux(&self) -> Result<&Mux> {
+		self.inner
+			.mux
+			.get_or_try_init(|| Mux::bind(self.inner.config.udp_bind, &self.inner.config.ice_candidates))
+			.await
 	}
 
 	/// Router for `server publish` (WHIP). Mount under whichever HTTP path
@@ -88,10 +120,6 @@ impl Server {
 	/// call [`whep::accept`] directly from your own handler.
 	pub fn subscribe_router(&self) -> Router {
 		whep::router(self.clone())
-	}
-
-	pub(crate) fn config(&self) -> &Config {
-		&self.inner.config
 	}
 
 	pub(crate) fn publisher(&self) -> &moq_net::OriginProducer {

--- a/rs/moq-rtc/src/server/mux.rs
+++ b/rs/moq-rtc/src/server/mux.rs
@@ -1,0 +1,202 @@
+//! Single-UDP-port media mux for the WHIP/WHEP servers.
+//!
+//! str0m is sans-IO, so each [`Session`](crate::session::Session) needs UDP
+//! datagrams fed to it. The naive approach (one ephemeral socket per session)
+//! makes the media port unpredictable, so a deployment behind a firewall would
+//! have to open the whole ephemeral range. Instead every server session shares
+//! **one** UDP socket bound to a configured port; a demux task reads that socket
+//! and routes each datagram to the right session.
+//!
+//! Routing key: ICE. A session is registered under the local ICE ufrag we mint
+//! for it ([`IceCreds::new`]). The peer's first packets are STUN binding
+//! requests whose USERNAME is `<our-ufrag>:<their-ufrag>`, so we parse the local
+//! ufrag out of the STUN message and look the session up. Once we've seen a
+//! source address we cache `addr -> session`, so subsequent DTLS/RTP/RTCP (which
+//! carry no ufrag) route by address on the fast path.
+//!
+//! Backpressure mirrors a UDP socket buffer: each session has a bounded inbox
+//! and a full inbox drops the datagram (WebRTC tolerates loss). A closed inbox
+//! (session ended) evicts the address-cache entry; the ufrag entry is removed by
+//! the [`Registration`] guard the accept path holds for the session's lifetime.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use str0m::ice::{IceCreds, StunMessage};
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+
+use crate::Result;
+use crate::session::{Packet, SESSION_INBOX};
+
+/// Per-session routing table, shared between the demux task and the accept path.
+#[derive(Default)]
+struct Registry {
+	/// Local ICE ufrag -> session inbox. Populated at registration, the only
+	/// way a brand-new peer (STUN binding request) finds its session.
+	by_ufrag: HashMap<String, mpsc::Sender<Packet>>,
+	/// Source address -> session inbox. Cached after first contact so non-STUN
+	/// packets (DTLS/RTP/RTCP, which carry no ufrag) route without parsing.
+	by_addr: HashMap<SocketAddr, mpsc::Sender<Packet>>,
+}
+
+/// The shared media socket plus its demux routing table.
+///
+/// One per [`Server`](crate::server::Server), bound lazily on the first
+/// WHIP/WHEP accept so `Server::new` can stay synchronous.
+pub(crate) struct Mux {
+	socket: Arc<UdpSocket>,
+	registry: Arc<Mutex<Registry>>,
+	/// ICE host candidates to advertise: the configured public IP(s) (or the
+	/// bound address if none) paired with the shared socket's actual port.
+	candidates: Vec<SocketAddr>,
+}
+
+/// Removes a session's ufrag entry (and sweeps any dead address entries) when
+/// dropped. The accept path hands this to the session task, so the registration
+/// lives exactly as long as the session.
+pub(crate) struct Registration {
+	ufrag: String,
+	registry: Arc<Mutex<Registry>>,
+}
+
+impl Drop for Registration {
+	fn drop(&mut self) {
+		let mut registry = self.registry.lock().unwrap();
+		registry.by_ufrag.remove(&self.ufrag);
+		// Sweep address-cache entries whose session inbox has closed (this one,
+		// and any other session that ended without another inbound packet to
+		// trigger the per-packet eviction below).
+		registry.by_addr.retain(|_, tx| !tx.is_closed());
+	}
+}
+
+impl Mux {
+	/// Bind the shared socket to `udp_bind` and spawn the demux task. The
+	/// advertised candidates are `ice_candidates` (each reusing the socket's
+	/// real port), or the bound address itself when none are configured.
+	pub(crate) async fn bind(udp_bind: SocketAddr, ice_candidates: &[SocketAddr]) -> Result<Self> {
+		let socket = Arc::new(UdpSocket::bind(udp_bind).await?);
+		let port = socket.local_addr()?.port();
+		let candidates = if ice_candidates.is_empty() {
+			vec![socket.local_addr()?]
+		} else {
+			// str0m's ICE agent sends to the candidate's port, so reuse the one
+			// real bound port across each advertised IP.
+			ice_candidates
+				.iter()
+				.map(|addr| SocketAddr::new(addr.ip(), port))
+				.collect()
+		};
+
+		let registry = Arc::new(Mutex::new(Registry::default()));
+		tokio::spawn(demux(socket.clone(), registry.clone()));
+
+		tracing::info!(?candidates, bound = %socket.local_addr()?, "webrtc media mux listening");
+		Ok(Self {
+			socket,
+			registry,
+			candidates,
+		})
+	}
+
+	/// Mint ICE credentials for a new session and register its inbox. Returns
+	/// the credentials (set on the session's [`Rtc`](str0m::Rtc) so the demux's
+	/// ufrag lookup matches), the inbox receiver the session reads from, and a
+	/// [`Registration`] guard the session task must hold for its lifetime.
+	pub(crate) fn register(&self) -> (IceCreds, mpsc::Receiver<Packet>, Registration) {
+		let creds = IceCreds::new();
+		let (tx, rx) = mpsc::channel(SESSION_INBOX);
+		self.registry.lock().unwrap().by_ufrag.insert(creds.ufrag.clone(), tx);
+		let registration = Registration {
+			ufrag: creds.ufrag.clone(),
+			registry: self.registry.clone(),
+		};
+		(creds, rx, registration)
+	}
+
+	/// The shared socket, handed to each session for sending.
+	pub(crate) fn socket(&self) -> Arc<UdpSocket> {
+		self.socket.clone()
+	}
+
+	/// ICE host candidates to advertise in the SDP answer.
+	pub(crate) fn candidates(&self) -> &[SocketAddr] {
+		&self.candidates
+	}
+
+	/// The local address to report to str0m as each datagram's destination. str0m
+	/// requires it to match an advertised host candidate (it drops STUN whose
+	/// destination is an "unknown interface"), and the shared socket binds a
+	/// wildcard, so report the first advertised candidate rather than the bind. The
+	/// candidate list is never empty (it falls back to the bound address).
+	pub(crate) fn local(&self) -> SocketAddr {
+		self.candidates[0]
+	}
+}
+
+/// Read the shared socket forever, routing each datagram to its session.
+async fn demux(socket: Arc<UdpSocket>, registry: Arc<Mutex<Registry>>) {
+	let mut buf = vec![0u8; 65_535];
+	loop {
+		let (len, src) = match socket.recv_from(&mut buf).await {
+			Ok(v) => v,
+			// recv errors on UDP are typically transient (e.g. an ICMP
+			// port-unreachable surfacing as ECONNREFUSED); keep serving.
+			Err(err) => {
+				tracing::warn!(%err, "webrtc media mux recv failed");
+				continue;
+			}
+		};
+		let data = &buf[..len];
+
+		// Fast path: a source we've already paired with a session.
+		let sender = registry.lock().unwrap().by_addr.get(&src).cloned();
+		let sender = match sender {
+			Some(sender) => Some(sender),
+			// New source: only a STUN binding request (carrying the local
+			// ufrag) can introduce one. Parse outside the lock.
+			None => match local_ufrag(data) {
+				Some(ufrag) => {
+					let mut registry = registry.lock().unwrap();
+					match registry.by_ufrag.get(&ufrag).cloned() {
+						// Cache addr -> session so this peer's later non-STUN
+						// packets route without re-parsing.
+						Some(sender) => {
+							registry.by_addr.insert(src, sender.clone());
+							Some(sender)
+						}
+						None => None,
+					}
+				}
+				None => None,
+			},
+		};
+
+		let Some(sender) = sender else {
+			// Unknown source and no matching ufrag: not our session, drop it.
+			continue;
+		};
+
+		// Bounded like a socket buffer: drop on full (WebRTC tolerates loss),
+		// evict on closed (the session ended).
+		match sender.try_send((data.to_vec(), src)) {
+			Ok(()) => {}
+			Err(mpsc::error::TrySendError::Full(_)) => {}
+			Err(mpsc::error::TrySendError::Closed(_)) => {
+				registry.lock().unwrap().by_addr.remove(&src);
+			}
+		}
+	}
+}
+
+/// Extract the local ICE ufrag from a STUN binding request, if `data` is one.
+/// The USERNAME is `<local-ufrag>:<remote-ufrag>`; we route on the local half.
+fn local_ufrag(data: &[u8]) -> Option<String> {
+	let msg = StunMessage::parse(data).ok()?;
+	if !msg.is_binding_request() {
+		return None;
+	}
+	msg.split_username().map(|(local, _remote)| local.to_string())
+}

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -47,32 +47,41 @@ async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: By
 		return Err(Error::InvalidSdp("expected Content-Type: application/sdp".into()));
 	}
 	let offer = std::str::from_utf8(&body).map_err(|err| Error::InvalidSdp(err.to_string()))?;
-	accept(server, path, offer).await
+	accept(server, server.subscriber(), path, offer).await
 }
 
 /// Accept a WHEP SDP offer and egress the MoQ broadcast `broadcast` (a path
-/// relative to the subscribe origin's root) to the negotiated WebRTC peer.
+/// relative to `subscriber`'s root) to the negotiated WebRTC peer.
 ///
 /// This is the negotiation core behind [`router`], exposed so an embedder can own
 /// the HTTP route and authentication: verify the request, resolve the authorized
-/// broadcast name, then hand the raw SDP offer here. It parses the offer, resolves
-/// the broadcast on the subscribe origin, restricts the answer to the codecs the
-/// catalog actually has, binds the ICE socket, spawns the MoQ->RTP session, and
-/// returns the SDP answer plus an opaque `resource_id` for the WHEP `Location`
-/// header. Mirrors [`whip::accept`](super::whip::accept).
+/// broadcast name, scope `subscriber` to the caller's grants, then hand the raw
+/// SDP offer here. Taking the consumer explicitly (rather than using the server's)
+/// lets the embedder egress through a *scoped* origin, so the subscribe scope is
+/// enforced by moq-net exactly as for a native session; the bundled [`router`]
+/// passes the server's own (unauthenticated) consumer. It parses the offer,
+/// resolves the broadcast on `subscriber`, restricts the answer to the codecs the
+/// catalog actually has, registers a media session on the shared mux, spawns the
+/// MoQ->RTP session, and returns the SDP answer plus an opaque `resource_id` for
+/// the WHEP `Location` header. Mirrors [`whip::accept`](super::whip::accept).
 ///
 /// `offer` is the raw SDP body; the caller is responsible for checking the
 /// `Content-Type: application/sdp` request header. Fails with [`Error::InvalidSdp`]
 /// on a malformed offer, and surfaces a not-announced broadcast (or one outside
-/// the subscribe origin's scope) as [`Error::Other`].
-pub async fn accept(server: &Server, broadcast: impl moq_net::AsPath, offer: &str) -> Result<Response> {
+/// `subscriber`'s scope) as [`Error::Other`].
+pub async fn accept(
+	server: &Server,
+	subscriber: &moq_net::OriginConsumer,
+	broadcast: impl moq_net::AsPath,
+	offer: &str,
+) -> Result<Response> {
 	let offer = sdp::parse_offer(offer)?;
 
-	// Look up the MoQ broadcast on the subscriber origin. `request_broadcast` resolves an
+	// Look up the MoQ broadcast on the subscribe origin. `request_broadcast` resolves an
 	// already-announced broadcast immediately and falls back to a dynamic handler if the
 	// origin has one; with neither, it fails fast and the WHEP client retries (typical).
 	let broadcast = broadcast.as_path().to_string();
-	let consumer = async { server.subscriber().request_broadcast(&broadcast)?.await }
+	let consumer = async { subscriber.request_broadcast(&broadcast)?.await }
 		.await
 		.map_err(|_| Error::Other(anyhow::anyhow!("broadcast {broadcast} not announced")))?;
 
@@ -84,21 +93,27 @@ pub async fn accept(server: &Server, broadcast: impl moq_net::AsPath, offer: &st
 		)));
 	}
 
-	let (socket, candidates) = session::bind_udp(&server.config().ice_candidates).await?;
-	// Restrict our CodecConfig before accept_offer so the answer intersects
-	// the peer's offer with what the catalog actually has, instead of
-	// agreeing to a codec we can't fulfil.
-	let mut rtc = session::rtc_with_codecs(&codecs);
-	for addr in &candidates {
+	// Register a session on the shared media mux (see whip::accept). Restrict our
+	// CodecConfig before accept_offer so the answer intersects the peer's offer
+	// with what the catalog actually has, instead of agreeing to a codec we can't
+	// fulfil; set the mux's known ICE credentials on the same config.
+	let mux = server.mux().await?;
+	let (creds, inbound, registration) = mux.register();
+	let mut rtc = session::rtc_config_with_codecs(&codecs)
+		.set_local_ice_credentials(creds)
+		.build(std::time::Instant::now());
+	for addr in mux.candidates() {
 		let cand = Candidate::host(*addr, "udp").map_err(str0m::RtcError::from)?;
 		rtc.add_local_candidate(cand);
 	}
 
 	let answer = rtc.sdp_api().accept_offer(offer).map_err(Error::Rtc)?;
 	let resource_id = sdp::new_resource_id();
-	let session = session::Session::egress(rtc, socket, source);
+	let session = session::Session::egress(rtc, mux.socket(), mux.local(), inbound, source);
 
 	tokio::spawn(async move {
+		// Hold the mux registration for the session's lifetime (unregisters on exit).
+		let _registration = registration;
 		if let Err(err) = session.run().await {
 			tracing::warn!(%err, "whep session ended");
 		}

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -12,7 +12,7 @@ use axum::{
 	response::{IntoResponse, Response as HttpResponse},
 	routing::post,
 };
-use str0m::{Candidate, Rtc};
+use str0m::{Candidate, RtcConfig};
 
 use crate::{Error, Result, ingest::IngestSink, sdp, server::Server, session};
 
@@ -52,27 +52,35 @@ async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: By
 		return Err(Error::InvalidSdp("expected Content-Type: application/sdp".into()));
 	}
 	let offer = std::str::from_utf8(&body).map_err(|err| Error::InvalidSdp(err.to_string()))?;
-	accept(server, path, offer).await
+	accept(server, server.publisher(), path, offer).await
 }
 
-/// Accept a WHIP SDP offer and publish the negotiated WebRTC media into the
-/// server's configured publish origin under `broadcast` (a path relative to the
-/// origin's root).
+/// Accept a WHIP SDP offer and publish the negotiated WebRTC media into
+/// `publisher` under `broadcast` (a path relative to that producer's root).
 ///
 /// This is the negotiation core behind [`router`], exposed so an embedder can
 /// own the HTTP route and authentication: verify the request, resolve the
-/// authorized broadcast name, then hand the raw SDP offer here. It parses the
+/// authorized broadcast name, scope `publisher` to the caller's grants, then hand
+/// the raw SDP offer here. Taking the producer explicitly (rather than using the
+/// server's) lets the embedder publish through a *scoped* origin, so the publish
+/// scope is enforced by moq-net exactly as for a native session; the bundled
+/// [`router`] passes the server's own (unauthenticated) producer. It parses the
 /// offer, registers the broadcast (so a fast subscriber doesn't 404 in the gap
-/// before the first RTP packet), binds the ICE socket, spawns the RTP->MoQ
-/// session, and returns the SDP answer plus an opaque `resource_id` for the WHIP
-/// `Location` header.
+/// before the first RTP packet), registers a media session on the shared mux,
+/// spawns the RTP->MoQ session, and returns the SDP answer plus an opaque
+/// `resource_id` for the WHIP `Location` header.
 ///
 /// `offer` is the raw SDP body; the caller is responsible for checking the
 /// `Content-Type: application/sdp` request header. Fails with
 /// [`Error::InvalidSdp`] on a malformed offer and surfaces
 /// [`moq_net::Error::Unauthorized`] (as [`Error::Other`]) if `broadcast` is
-/// outside the publish origin's scope.
-pub async fn accept(server: &Server, broadcast: impl moq_net::AsPath, offer: &str) -> Result<Response> {
+/// outside `publisher`'s scope.
+pub async fn accept(
+	server: &Server,
+	publisher: &moq_net::OriginProducer,
+	broadcast: impl moq_net::AsPath,
+	offer: &str,
+) -> Result<Response> {
 	let offer = sdp::parse_offer(offer)?;
 
 	// Register the broadcast on the publish origin before negotiating, so a
@@ -80,27 +88,34 @@ pub async fn accept(server: &Server, broadcast: impl moq_net::AsPath, offer: &st
 	// and the first RTP packet.
 	let producer = moq_net::BroadcastInfo::new().produce();
 	let consumer = producer.consume();
-	let publish = server
-		.publisher()
+	let publish = publisher
 		.publish_broadcast(broadcast, &consumer)
 		.map_err(|err| Error::Other(anyhow::anyhow!("failed to publish broadcast: {err}")))?;
 
 	let sink = Box::new(IngestSink::new(producer)?);
 
-	let (socket, candidates) = session::bind_udp(&server.config().ice_candidates).await?;
-	let mut rtc = Rtc::new(std::time::Instant::now());
-	for addr in &candidates {
+	// Register a session on the shared media mux: known ICE credentials (so the
+	// demux routes this peer's STUN by ufrag), an inbox to read datagrams from,
+	// and a guard the session task holds for its lifetime (unregisters on exit).
+	let mux = server.mux().await?;
+	let (creds, inbound, registration) = mux.register();
+	let mut rtc = RtcConfig::new()
+		.set_local_ice_credentials(creds)
+		.build(std::time::Instant::now());
+	for addr in mux.candidates() {
 		let cand = Candidate::host(*addr, "udp").map_err(str0m::RtcError::from)?;
 		rtc.add_local_candidate(cand);
 	}
 
 	let answer = rtc.sdp_api().accept_offer(offer).map_err(Error::Rtc)?;
 	let resource_id = sdp::new_resource_id();
-	let session = session::Session::ingest(rtc, socket, sink);
+	let session = session::Session::ingest(rtc, mux.socket(), mux.local(), inbound, sink);
 
 	tokio::spawn(async move {
-		// Hold the announcement guard for the session's lifetime; unannounces on exit.
+		// Hold the announcement guard + mux registration for the session's
+		// lifetime; both release (unannounce / unregister) on exit.
 		let _publish = publish;
+		let _registration = registration;
 		if let Err(err) = session.run().await {
 			tracing::warn!(%err, "whip session ended");
 		}

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::Instant;
 
 use str0m::{Event, IceConnectionState, Input, Output, Rtc, net::Receive};
@@ -20,6 +21,17 @@ use tokio::sync::mpsc;
 
 use crate::egress::{EgressSource, WriteRequest};
 use crate::{Error, Result, codec};
+
+/// One inbound UDP datagram plus its source address, the unit fed to a session.
+/// The [`server`](crate::server) paths get these from the shared-socket demux
+/// (`crate::server::mux`); the client paths get them from a 1:1 reader
+/// ([`spawn_socket_reader`]).
+pub(crate) type Packet = (Vec<u8>, SocketAddr);
+
+/// Bound on a session's inbound datagram queue, sized like a socket buffer:
+/// past this, datagrams are dropped rather than buffered (WebRTC tolerates loss
+/// and a stalled session must not grow memory without limit).
+pub(crate) const SESSION_INBOX: usize = 256;
 
 /// Receives `MediaData` events from str0m and dispatches to the right codec
 /// [`Bridge`](codec::Bridge). Used as the per-session sink in [`Session::run`]
@@ -49,13 +61,27 @@ pub enum MediaRole {
 	Egress(Box<EgressSource>),
 }
 
-/// Drives a [`Rtc`] instance on a UDP socket until it ends.
+/// Drives a [`Rtc`] instance until it ends.
 ///
-/// The caller pre-populates the `Rtc` with whatever SDP exchange they need;
-/// this just owns the socket and the media role.
+/// The caller pre-populates the `Rtc` with whatever SDP exchange they need.
+/// Sends go out the (possibly shared) `socket`; inbound datagrams arrive on
+/// `inbound` rather than being read off the socket directly, so several
+/// sessions can share one socket behind the `crate::server::mux`.
 pub struct Session {
 	rtc: Rtc,
-	socket: UdpSocket,
+	/// Send side. Shared across sessions on the server (the mux socket); owned
+	/// 1:1 on the client. Receiving happens via `inbound`, not this socket.
+	socket: Arc<UdpSocket>,
+	/// The local address to report to str0m as each datagram's destination. MUST
+	/// equal one of the local ICE candidates we advertised, not the socket's bind
+	/// address: str0m drops a STUN binding request whose destination doesn't match
+	/// a host candidate ("unknown interface"), and the shared mux socket binds a
+	/// wildcard (`0.0.0.0`) while advertising a concrete IP.
+	local: SocketAddr,
+	/// Inbound datagrams routed to this session (demux on the server, a 1:1
+	/// reader on the client). `None` from `recv` means every sender dropped, so
+	/// the session is done.
+	inbound: mpsc::Receiver<Packet>,
 	role: MediaRole,
 	/// Egress write requests. `Some` only for [`MediaRole::Egress`]
 	/// sessions; pumps send frames here, the main loop forwards them into
@@ -64,30 +90,49 @@ pub struct Session {
 }
 
 impl Session {
-	/// Convenience for the ingest case (WHIP server, WHEP client).
-	pub fn ingest(rtc: Rtc, socket: UdpSocket, sink: Box<dyn MediaSink>) -> Self {
+	/// Convenience for the ingest case (WHIP server, WHEP client). `local` is the
+	/// advertised ICE candidate address (see the field docs), not the socket bind.
+	pub fn ingest(
+		rtc: Rtc,
+		socket: Arc<UdpSocket>,
+		local: SocketAddr,
+		inbound: mpsc::Receiver<Packet>,
+		sink: Box<dyn MediaSink>,
+	) -> Self {
 		Self {
 			rtc,
 			socket,
+			local,
+			inbound,
 			role: MediaRole::Ingest(sink),
 			writes_rx: None,
 		}
 	}
 
-	/// Convenience for the egress case (WHEP server, WHIP client).
-	pub fn egress(rtc: Rtc, socket: UdpSocket, mut source: EgressSource) -> Self {
+	/// Convenience for the egress case (WHEP server, WHIP client). `local` is the
+	/// advertised ICE candidate address (see the field docs), not the socket bind.
+	pub fn egress(
+		rtc: Rtc,
+		socket: Arc<UdpSocket>,
+		local: SocketAddr,
+		inbound: mpsc::Receiver<Packet>,
+		mut source: EgressSource,
+	) -> Self {
 		let writes_rx = source.take_writes();
 		Self {
 			rtc,
 			socket,
+			local,
+			inbound,
 			role: MediaRole::Egress(Box::new(source)),
 			writes_rx: Some(writes_rx),
 		}
 	}
 
 	pub async fn run(mut self) -> Result<()> {
-		// Buffer for one UDP datagram (max v4/v6 payload size).
-		let mut buf = vec![0u8; 65_535];
+		// The local address str0m tags each inbound packet with -- the advertised
+		// ICE candidate, NOT the socket bind (see the `local` field docs).
+		let local = self.local;
 
 		loop {
 			let timeout = match self.rtc.poll_output().map_err(Error::Rtc)? {
@@ -127,16 +172,17 @@ impl Session {
 					crate::egress::dispatch(&mut self.rtc, req, Instant::now());
 				}
 
-				read = self.socket.recv_from(&mut buf) => {
-					match read {
-						Ok((len, src)) => {
-							let local = self.socket.local_addr()?;
+				packet = self.inbound.recv() => {
+					match packet {
+						Some((data, src)) => {
 							let now = Instant::now();
-							let recv = Receive::new(str0m::net::Protocol::Udp, src, local, &buf[..len])
+							let recv = Receive::new(str0m::net::Protocol::Udp, src, local, &data)
 								.map_err(Error::RtcInput)?;
 							self.rtc.handle_input(Input::Receive(now, recv)).map_err(Error::Rtc)?;
 						}
-						Err(err) => return Err(err.into()),
+						// Every sender dropped: the demux unregistered us (or the
+						// 1:1 reader stopped). Nothing more will arrive, so end.
+						None => return Err(Error::SessionClosed),
 					}
 				}
 
@@ -255,7 +301,7 @@ impl Bridges {
 /// can't fulfil (WHEP server). For both, the negotiated SDP intersects with
 /// what we can actually deliver, so `MediaAdded` only fires for codecs that
 /// [`crate::egress::EgressSource`] can match to a rendition.
-pub fn rtc_with_codecs(codecs: &[str0m::format::Codec]) -> Rtc {
+pub fn rtc_config_with_codecs(codecs: &[str0m::format::Codec]) -> str0m::RtcConfig {
 	use str0m::format::Codec;
 	let mut config = str0m::RtcConfig::new().clear_codecs();
 	for c in codecs {
@@ -270,16 +316,26 @@ pub fn rtc_with_codecs(codecs: &[str0m::format::Codec]) -> Rtc {
 			_ => config,
 		};
 	}
-	config.build(std::time::Instant::now())
+	config
 }
 
-/// Bind a UDP socket on `0.0.0.0:0` and return both the socket and the
-/// listed ICE candidates the caller should advertise.
+/// Build a codec-restricted [`Rtc`] for the client egress path (which lets
+/// str0m mint its own ICE credentials). The server egress path uses
+/// [`rtc_config_with_codecs`] directly so it can inject the mux's known
+/// credentials before building.
+pub fn rtc_with_codecs(codecs: &[str0m::format::Codec]) -> Rtc {
+	rtc_config_with_codecs(codecs).build(std::time::Instant::now())
+}
+
+/// Bind an ephemeral UDP socket for a single client session and return it
+/// (shared with its [reader task](spawn_socket_reader)) plus the ICE candidates
+/// to advertise.
 ///
-/// If `advertise` is non-empty, those addresses are used verbatim as
-/// ICE host candidates (typically the gateway's public IPs). Otherwise we
-/// fall back to whatever the OS picked.
-pub async fn bind_udp(advertise: &[SocketAddr]) -> Result<(UdpSocket, Vec<SocketAddr>)> {
+/// The client paths are 1:1 (one socket per dialed session, no demux); the
+/// server paths share one socket via `crate::server::mux` instead. `advertise`
+/// IPs are used verbatim (reusing the bound port); empty falls back to whatever
+/// address the OS picked (loopback only).
+pub async fn bind_udp(advertise: &[SocketAddr]) -> Result<(Arc<UdpSocket>, Vec<SocketAddr>)> {
 	let socket = UdpSocket::bind(("0.0.0.0", 0)).await?;
 	let local = socket.local_addr()?;
 	let candidates = if advertise.is_empty() {
@@ -293,5 +349,31 @@ pub async fn bind_udp(advertise: &[SocketAddr]) -> Result<(UdpSocket, Vec<Socket
 			.map(|addr| SocketAddr::new(addr.ip(), local.port()))
 			.collect()
 	};
-	Ok((socket, candidates))
+	Ok((Arc::new(socket), candidates))
+}
+
+/// Spawn a 1:1 reader pumping every datagram from `socket` into a channel, for
+/// the client paths (one socket per session, so no demux is needed). Mirrors the
+/// inbound side of `crate::server::mux` for a single session.
+pub fn spawn_socket_reader(socket: Arc<UdpSocket>) -> mpsc::Receiver<Packet> {
+	let (tx, rx) = mpsc::channel(SESSION_INBOX);
+	tokio::spawn(async move {
+		let mut buf = vec![0u8; 65_535];
+		loop {
+			match socket.recv_from(&mut buf).await {
+				// Bounded like a socket buffer: drop on full, stop once the
+				// session's receiver is gone.
+				Ok((len, src)) => {
+					if let Err(mpsc::error::TrySendError::Closed(_)) = tx.try_send((buf[..len].to_vec(), src)) {
+						break;
+					}
+				}
+				Err(err) => {
+					tracing::warn!(%err, "webrtc client socket recv failed");
+					break;
+				}
+			}
+		}
+	});
+	rx
 }


### PR DESCRIPTION
## What

WHIP/WHEP server sessions each bound their own ephemeral UDP socket, so the WebRTC media port was unpredictable — a deployment behind a firewall would have to open the whole ephemeral range. This routes every server session through **one** shared UDP socket, demultiplexed by ICE ufrag, so a deployment opens exactly one media port.

## How

- **`server/mux.rs`** (new): a shared `Arc<UdpSocket>` + a demux task that routes each datagram to the right session. A new peer is matched by the local ICE ufrag parsed from its STUN binding request (`USERNAME = <local>:<remote>`); once seen, the source address is cached so non-STUN packets (DTLS/RTP/RTCP) route without parsing. Per-session inboxes are bounded (drop on full like a socket buffer, evict on close); a `Registration` guard removes the ufrag entry when the session ends.
- **`session.rs`**: `Session` reads inbound datagrams from an `mpsc` channel instead of owning the socket, and reports an explicit `local` address — the advertised ICE candidate, **not** the socket bind. str0m discards a STUN binding request whose destination doesn't match a host candidate, and the shared socket binds a wildcard (`0.0.0.0`) while advertising a concrete IP, so the two are reported separately.
- **`server::{whip,whep}::accept`** now take the (scoped) origin explicitly and set known ICE credentials via `RtcConfig::set_local_ice_credentials`, so an embedder can enforce its publish/subscribe scope through moq-net and the demux can find the session by ufrag. The bundled routers pass the server's own origin (behaviour unchanged).
- **`server::Config`** gains `udp_bind`; the `Server` binds the mux lazily on first accept (`OnceCell`) so `Server::new` stays sync.
- **`client/{whip,whep}`**: keep their 1:1 socket but feed the session via a small reader task, matching the new channel input.
- **bin**: `--udp-bind` / `MOQ_RTC_UDP_BIND` for the shared media port.

## Testing

Verified end-to-end over loopback by embedding the gateway in a relay: a browser WHIP publish and a browser WHEP pull run **concurrently through the one shared port** (demuxed by ufrag), with media flowing both directions (WHIP video packets in, WHEP packets out). `cargo check` / `clippy -D warnings` / `rustdoc -D warnings` / `fmt` clean on the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
