### PR TITLE
docs: prioritize simple, type-safe public API design in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,18 @@ A function with 4+ args, or a call site passing the same 3+ values into multiple
 
 ## Public API Scrutiny
 
-Before exposing a new public type, function, or field, stop and ask: how will consumers actually call this, and what are we likely to add later? Default to the smallest surface that does the job. Prefer one insulated high-level entry point (plain config in, plain result out) over exposing every building block. Then future-proof what you do expose so additions don't force a breaking change:
+Before exposing a new public type, function, or field, stop and ask: how will consumers actually call this, and what are we likely to add later? Default to the smallest surface that does the job. A simpler long-term API is worth a refactor now: reshaping today is cheaper than living with a confusing surface forever, so don't preserve an awkward shape just to avoid churn. Prefer one insulated high-level entry point (plain config in, plain result out) over exposing every building block.
+
+Favor composable building blocks over one-off functions. A handful of orthogonal primitives that snap together beats a pile of bespoke `do_the_specific_thing()` helpers that each cover one caller and invite misuse when a caller's needs drift slightly. Each building block should do one thing and be hard to hold wrong.
+
+**Let the type system do the heavy lifting; make misuse unrepresentable rather than merely documented.** A compile error beats a runtime check beats a doc-comment warning. Encode the rules in types so the wrong call simply doesn't compile:
+
+- **Make terminal operations consume `self`** (e.g. `fn close(self)`) so use-after-close can't be expressed, rather than taking `&mut self` and tracking a `closed` flag.
+- Prefer enums/newtypes over stringly-typed or primitive args so invalid combinations don't typecheck.
+- Use the typestate / builder pattern when an object is only valid in certain states, so a half-built or out-of-order call is a compile error.
+- Return owned handles whose `Drop` does the cleanup instead of asking callers to remember a teardown call.
+
+Then future-proof what you do expose so additions don't force a breaking change:
 
 - **Config structs consumers construct**: add `#[non_exhaustive]` and a `Default` or constructor. New optional fields then stay additive (callers build via `default()`/`new()` + field set, not struct literals). Prefer adding a field to an existing `#[non_exhaustive]` config over adding a function parameter.
 - **Public enums that may gain variants**: add `#[non_exhaustive]` so external `match`es keep compiling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ A function with 4+ args, or a call site passing the same 3+ values into multiple
 
 ## Public API Scrutiny
 
+**API design is the single most important thing to get right, ahead of fixing functionality.** We expose a huge surface area across many languages and bindings, and every public shape is something consumers build on and we have to live with. A bug can be fixed in a point release; a bad API shape costs a breaking change, a migration, and ripples through every wrapper and doc. So when functionality and API cleanliness pull in different directions, bias toward the clean API: get the shape right first, then make it work. A slightly less capable but well-shaped surface beats a feature-complete one that's easy to misuse.
+
 Before exposing a new public type, function, or field, stop and ask: how will consumers actually call this, and what are we likely to add later? Default to the smallest surface that does the job. A simpler long-term API is worth a refactor now: reshaping today is cheaper than living with a confusing surface forever, so don't preserve an awkward shape just to avoid churn. Prefer one insulated high-level entry point (plain config in, plain result out) over exposing every building block.
 
 Favor composable building blocks over one-off functions. A handful of orthogonal primitives that snap together beats a pile of bespoke `do_the_specific_thing()` helpers that each cover one caller and invite misuse when a caller's needs drift slightly. Each building block should do one thing and be hard to hold wrong.


### PR DESCRIPTION
## Summary

Strengthens the **Public API Scrutiny** section of `CLAUDE.md` to make API design a first-class priority and push harder on simple, hard-to-misuse public APIs:

- **Lead with priority**: API design is the single most important thing to get right, ahead of fixing functionality. Given the large multi-language surface area, a bad API shape costs a breaking change across every binding, whereas a bug is a point-release fix. When the two conflict, bias toward the clean shape.
- A simpler long-term API is worth a refactor now, so we don't preserve an awkward shape just to avoid churn.
- Favor composable building blocks (orthogonal primitives that snap together) over one-off `do_the_specific_thing()` helpers that invite misuse.
- Add a dedicated principle to **let the type system do the heavy lifting and make misuse unrepresentable rather than merely documented**, with concrete patterns:
  - terminal operations consume `self` (e.g. `fn close(self)`) so use-after-close can't compile
  - enums/newtypes over stringly-typed args
  - typestate/builder for state-dependent validity
  - `Drop`-based cleanup over remember-to-teardown calls

## Test plan

Docs-only change. No code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)