### PR TITLE
fix(moq-rtmp): reap half-open connections with TCP keepalive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,6 +4316,7 @@ dependencies = [
  "rml_rtmp",
  "rustls",
  "sd-notify",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",

--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -53,6 +53,10 @@ moq-net = { workspace = true }
 # server-session state machine. RTMP carries FLV, demuxed by moq-mux.
 rml_rtmp = "0.8"
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"], optional = true }
+# TCP keepalive on accepted sockets, so a half-open connection (a peer that
+# vanished without a FIN/RST) is reaped instead of pinning a broadcast and its
+# stream-key slot forever.
+socket2 = "0.6"
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }
 # RTMPS: TLS-terminate accepted connections. Mirrors moq-relay's pinning so the

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -39,6 +39,7 @@ use moq_net::{BroadcastInfo, OriginConsumer, OriginProducer, OriginPublish};
 use rml_rtmp::handshake::{Handshake, HandshakeProcessResult, PeerType};
 use rml_rtmp::sessions::{ServerSession, ServerSessionConfig, ServerSessionEvent, ServerSessionResult};
 use rml_rtmp::time::RtmpTimestamp;
+use socket2::{SockRef, TcpKeepalive};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
 
@@ -54,6 +55,17 @@ const READ_BUFFER: usize = 16 * 1024;
 /// connections can't accumulate without limit. With TLS this also covers the TLS
 /// handshake.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// TCP keepalive idle period before the kernel starts probing a silent peer, and
+/// the interval between probes. Once a connection is publishing or playing it can
+/// block in a `read` indefinitely, so without keepalive a half-open connection (a
+/// peer that vanished without sending a FIN/RST, e.g. a yanked network cable)
+/// would pin its broadcast (and its first-publisher stream-key slot) forever.
+/// Keepalive lets the kernel surface the dead peer as a read error, tearing the
+/// session down. The values are generous enough not to disturb a healthy but
+/// momentarily quiet connection.
+const KEEPALIVE_IDLE: Duration = Duration::from_secs(30);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 
 /// A bidirectional byte stream carrying an RTMP session.
 ///
@@ -179,10 +191,7 @@ impl Server {
 				// A new TCP connection: start its (TLS +) handshake concurrently.
 				res = self.listener.accept() => match res {
 					Ok((stream, peer)) => {
-						// Nagle off: RTMP is latency-sensitive and we write whole packets.
-						if let Err(err) = stream.set_nodelay(true) {
-							tracing::debug!(%peer, %err, "failed to set TCP_NODELAY");
-						}
+						configure_socket(&stream, peer);
 						#[cfg(feature = "server")]
 						let tls = self.tls.clone();
 						self.pending.push(Box::pin(async move {
@@ -226,6 +235,24 @@ impl Server {
 				},
 			}
 		}
+	}
+}
+
+/// Tune a freshly accepted RTMP socket: Nagle off for latency, keepalive on so a
+/// dead peer is reaped rather than pinning a broadcast forever.
+///
+/// Both are best-effort: a failure to set either is logged and ignored rather
+/// than dropping an otherwise healthy connection.
+fn configure_socket(stream: &TcpStream, peer: SocketAddr) {
+	// Nagle off: RTMP is latency-sensitive and we write whole packets.
+	if let Err(err) = stream.set_nodelay(true) {
+		tracing::debug!(%peer, %err, "failed to set TCP_NODELAY");
+	}
+	let keepalive = TcpKeepalive::new()
+		.with_time(KEEPALIVE_IDLE)
+		.with_interval(KEEPALIVE_INTERVAL);
+	if let Err(err) = SockRef::from(stream).set_tcp_keepalive(&keepalive) {
+		tracing::debug!(%peer, %err, "failed to set TCP keepalive");
 	}
 }
 


### PR DESCRIPTION
Production-readiness pass over `moq-rtmp` (the gateway from #1824 + the play/egress path from #1829, now on `dev`). One fix, plus a review of the rest.

## Fix: reap half-open connections

Once an RTMP connection is past the handshake and into `publish` (ingest) or `play` (egress), `pump` / `play_pump` block in a `read` with no timeout. A peer that disappears **without** a clean FIN/RST (yanked cable, crashed encoder, NAT idle-eviction) leaves that read pending forever, which means:

- the publisher's broadcast stays announced (a phantom live stream), and
- its `ActivePaths` slot stays claimed, so **nobody can republish that stream key** until the process restarts.

The handshake/request phase was already bounded by `REQUEST_TIMEOUT` (15s); the long-lived media phase was not.

This enables **TCP keepalive** on every accepted socket (idle 30s, probe every 10s), so the kernel surfaces a dead peer as a read error and the session tears down. I folded the existing `TCP_NODELAY` setup and the new keepalive into one `configure_socket` helper.

Why keepalive rather than an app-level idle read timeout: it covers **both** directions from one place, and it does **not** misfire on a healthy-but-quiet connection. An idle read timeout on the play path would wrongly kill a viewer who is just watching (the server is the one sending); keepalive probes work regardless of which side has data to send. `socket2` (already in the workspace via `moq-native`) is the only new dependency.

## Review of the rest (no changes needed)

Read the whole crate and the `moq-mux` FLV import it depends on:

- **No panics/unwraps in production paths** — every `unwrap`/`expect` is in tests or a genuine invariant (mutex-poison, crypto-provider install).
- **Demux atomicity claim holds.** `pump` drops a frame that fails to demux instead of tearing down the publish, because `Import::decode` consumes whole tags atomically. Confirmed: `import.rs` advances its buffer past the tag *before* parsing, so a bad frame can't desync the next one.
- **Egress chunk size is fine.** `rml_rtmp`'s `ServerSessionConfig` defaults to 4096 and sends `SetChunkSize` on connect, so large keyframes aren't death-by-128-byte-chunks.
- **Play wait is cancellation-safe.** The `biased` select over `feed_input` vs. `announced_broadcast` only awaits a `read` and feeds (not discards) client bytes through the session, keeping the deserializer in sync for `play_pump`.
- **Body-size guard** against FLV's 24-bit tag size is correct (oversized message dropped, not truncated).
- Builds clean with **default** and **`--no-default-features`**; `clippy --all-targets --all-features` and `fmt --check` are clean (the one clippy warning is pre-existing in `moq-native`, unrelated).

## Flakiness assessment

- The 4 networked unit tests bind `127.0.0.1:0` and drive a real `rml_rtmp` client over loopback with 5s safety-net timeouts. Correctly **not** time-paused (real socket I/O, not simulated sleeps). Robust; passed repeatedly.
- All 15 tests pass.

## Flagged for a follow-up (intentionally not done here)

- **An ffmpeg/OBS round-trip smoke test.** There's no test against a real external encoder yet (the existing tests drive the in-process `rml_rtmp` client). Being handled in a separate PR by the maintainer.
- **Connection-flood backpressure.** `Server`'s `pending` `FuturesUnordered` is unbounded: every accepted TCP connection pushes a handshake future (each capped at 15s). A real cap is a policy decision (max in-flight? reject vs. throttle? per-IP?), so I left it for a deliberate call.
- **Embedding claim.** The lib/docs say a relay can run the gateway in-process via `moq_rtmp::run`, but no relay wires it up yet. The API supports it; it's just not exercised.

## Test plan

- [x] `cargo test -p moq-rtmp --all-features` (15 pass)
- [x] `cargo clippy -p moq-rtmp --all-targets --all-features` clean (moq-rtmp)
- [x] `cargo fmt -p moq-rtmp --check` clean
- [x] `cargo build -p moq-rtmp` and `--no-default-features` both compile

Targets `dev` per the branch-targeting rules (work lives in the `moq-rtmp` crate on `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)