### PR TITLE
moq-rtc production hardening: A/V sync, DELETE teardown, dual-stack ICE, VP9, NACK

### DIFF
--- a/doc/bin/rtc.md
+++ b/doc/bin/rtc.md
@@ -25,11 +25,14 @@ and are the same shape regardless of HTTP role.
 
 ### Keyframe latency on the egress side
 
-WebRTC subscribers expect a keyframe within ~2 s of joining. If the
-upstream MoQ broadcast uses long GOPs, freshly-connected WHEP / WHIP-out
-peers see a black screen until the next natural keyframe arrives.
-`KeyframeRequest` events from the peer are logged but not propagated
-upstream; PLI-to-MoQ back-pressure is a future enhancement.
+A freshly-connected WHEP / WHIP-out peer subscribes at the *current*
+(in-progress) MoQ group, which begins at a keyframe, so it gets a
+decodable start without waiting for the next GOP boundary. If the peer
+loses keyframe packets, str0m fulfils its NACK retransmissions from the
+video send buffer, which is sized to cover a large keyframe plus the rest
+of the current group. MoQ has no PLI path back to the publisher, so
+`KeyframeRequest` (PLI/FIR) events from the peer are logged but not
+propagated upstream.
 
 The egress paths (WHEP server, WHIP client) negotiate H.264, H.265, VP8,
 VP9, AV1, and Opus. The ingest paths (WHIP server, WHEP client) currently
@@ -82,6 +85,15 @@ moq-rtc --relay https://relay.example.com --broadcast my-stream \
 ### Client flags
 
 - `--url`: remote WHIP or WHEP resource URL.
+
+### Session teardown
+
+The bundled WHIP/WHEP servers honor an HTTP `DELETE` to the resource URL
+returned in the `Location` header (`/<broadcast>/<resource-id>`), per
+RFC 9725. It ends the session promptly, releasing its broadcast
+announcement and shared-media-port registration instead of waiting for the
+ICE disconnect timeout. Embedders that own their own routing can call
+`Server::terminate(resource_id)` to do the same.
 
 ## Codec mapping
 

--- a/doc/bin/rtc.md
+++ b/doc/bin/rtc.md
@@ -70,6 +70,12 @@ moq-rtc --relay https://relay.example.com --broadcast my-stream \
 ### Server flags
 
 - `--listen`: HTTP bind address (default `[::]:8088`).
+- `--udp-bind`: UDP address the shared WebRTC media socket binds to
+  (default `0.0.0.0:0`, i.e. an OS-picked port for dev/loopback). Every
+  WHIP/WHEP session shares this one port (demuxed by ICE ufrag), so a
+  deployment behind a firewall pins it (e.g. `0.0.0.0:8089`) and opens just
+  that one media port. Pair it with `--public-addr` so the advertised ICE
+  candidate uses the pinned port.
 - `--tls-cert` / `--tls-key`: serve HTTPS instead. Most WHIP clients
   require it in practice.
 

--- a/rs/moq-rtc/src/client/whep.rs
+++ b/rs/moq-rtc/src/client/whep.rs
@@ -61,11 +61,10 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::Broadcas
 	tracing::info!(%url, "whep client connected");
 
 	// 1:1 socket (no demux on the client): pump its datagrams into the session.
-	// Report the first advertised candidate as the local address (str0m matches
-	// each datagram's destination against a host candidate, not the socket bind).
-	let local = candidates[0];
+	// The session tags each datagram with the advertised candidate matching its
+	// family (str0m matches the destination against a host candidate, not the bind).
 	let inbound = session::spawn_socket_reader(socket.clone());
-	let session = session::Session::ingest(rtc, socket, local, inbound, sink);
+	let session = session::Session::ingest(rtc, socket, candidates, inbound, sink);
 	tokio::spawn(async move {
 		if let Err(err) = session.run().await {
 			tracing::warn!(%err, "whep client session ended");

--- a/rs/moq-rtc/src/client/whep.rs
+++ b/rs/moq-rtc/src/client/whep.rs
@@ -66,9 +66,7 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::Broadcas
 	let inbound = session::spawn_socket_reader(socket.clone());
 	let session = session::Session::ingest(rtc, socket, candidates, inbound, sink);
 	tokio::spawn(async move {
-		if let Err(err) = session.run().await {
-			tracing::warn!(%err, "whep client session ended");
-		}
+		session::log_session_end("whep client", session.run().await);
 	});
 
 	Ok(())

--- a/rs/moq-rtc/src/client/whip.rs
+++ b/rs/moq-rtc/src/client/whip.rs
@@ -72,9 +72,7 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::Broadcas
 	let inbound = session::spawn_socket_reader(socket.clone());
 	let session = session::Session::egress(rtc, socket, candidates, inbound, source);
 	tokio::spawn(async move {
-		if let Err(err) = session.run().await {
-			tracing::warn!(%err, "whip client session ended");
-		}
+		session::log_session_end("whip client", session.run().await);
 	});
 
 	Ok(())

--- a/rs/moq-rtc/src/client/whip.rs
+++ b/rs/moq-rtc/src/client/whip.rs
@@ -67,11 +67,10 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::Broadcas
 	tracing::info!(%url, "whip client connected");
 
 	// 1:1 socket (no demux on the client): pump its datagrams into the session.
-	// Report the first advertised candidate as the local address (str0m matches
-	// each datagram's destination against a host candidate, not the socket bind).
-	let local = candidates[0];
+	// The session tags each datagram with the advertised candidate matching its
+	// family (str0m matches the destination against a host candidate, not the bind).
 	let inbound = session::spawn_socket_reader(socket.clone());
-	let session = session::Session::egress(rtc, socket, local, inbound, source);
+	let session = session::Session::egress(rtc, socket, candidates, inbound, source);
 	tokio::spawn(async move {
 		if let Err(err) = session.run().await {
 			tracing::warn!(%err, "whip client session ended");

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -82,6 +82,9 @@ impl Track {
 	/// Audio track for an Opus rendition.
 	pub async fn opus(broadcast: &moq_net::BroadcastConsumer, name: &str) -> Result<Self> {
 		let container = moq_mux::catalog::hang::Container::Legacy;
+		// `None` subscription => start at the latest (in-progress) group. Groups
+		// begin at a keyframe, so a late joiner gets a decodable start immediately
+		// rather than waiting for the next group boundary.
 		let track = broadcast.track(name)?.subscribe(None)?.await?;
 		let consumer = moq_mux::container::Consumer::new(track, container);
 		Ok(Self {
@@ -96,6 +99,8 @@ impl Track {
 	/// `config.description` (avc1/hvc1 vs avc3/hev1).
 	pub async fn video(broadcast: &moq_net::BroadcastConsumer, name: &str, config: &VideoConfig) -> Result<Self> {
 		let container: moq_mux::catalog::hang::Container = (&config.container).try_into()?;
+		// `None` subscription => start at the latest (in-progress) group, which
+		// begins at a keyframe, so a late-joining peer gets a decodable start.
 		let track = broadcast.track(name)?.subscribe(None)?.await?;
 		let consumer = moq_mux::container::Consumer::new(track, container);
 

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -45,8 +45,7 @@ impl codec::Bridge for Bridge {
 		self.announce();
 		let pts = moq_net::Timestamp::from_micros(frame.timestamp_us)
 			.map_err(|err| crate::Error::Other(anyhow::anyhow!("invalid timestamp: {err}")))?;
-		// VP9 uncompressed header: bit 2 is frame_type (0 = keyframe).
-		let keyframe = frame.payload.first().map(|b| (b & 0b0000_0100) == 0).unwrap_or(false);
+		let keyframe = is_keyframe(&frame.payload);
 		self.track
 			.write(moq_mux::container::Frame {
 				timestamp: pts,
@@ -59,8 +58,64 @@ impl codec::Bridge for Bridge {
 	}
 }
 
+/// Detect a VP9 keyframe from the uncompressed header's first byte (VP9 spec
+/// §6.2), reading bits MSB-first: `frame_marker(2)`, `profile_low(1)`,
+/// `profile_high(1)`, a `reserved(1)` bit only when profile == 3,
+/// `show_existing_frame(1)`, then `frame_type(1)` (0 == KEY_FRAME). A
+/// show-existing frame carries no frame_type and is never a keyframe.
+fn is_keyframe(payload: &[u8]) -> bool {
+	let Some(&b) = payload.first() else {
+		return false;
+	};
+	let profile = (((b >> 4) & 1) << 1) | ((b >> 5) & 1); // (high << 1) | low
+	// Bits consumed from the MSB: 2 (marker) + 2 (profile), plus profile 3's reserved bit.
+	let mut pos = 4;
+	if profile == 3 {
+		pos += 1;
+	}
+	let show_existing_frame = (b >> (7 - pos)) & 1;
+	if show_existing_frame == 1 {
+		return false;
+	}
+	pos += 1;
+	let frame_type = (b >> (7 - pos)) & 1;
+	frame_type == 0
+}
+
 impl Drop for Bridge {
 	fn drop(&mut self) {
 		self.catalog.lock().video.renditions.remove(self.track.track().name());
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::is_keyframe;
+
+	// frame_marker = 0b10 in the top two bits for every well-formed header.
+	#[test]
+	fn profile0_keyframe_and_interframe() {
+		// profile 0, show_existing_frame = 0, frame_type = 0 (key) / 1 (inter).
+		assert!(is_keyframe(&[0b1000_0010]));
+		assert!(!is_keyframe(&[0b1000_0110]));
+	}
+
+	#[test]
+	fn profile0_show_existing_frame_is_not_keyframe() {
+		// profile 0, show_existing_frame = 1: no frame_type follows.
+		assert!(!is_keyframe(&[0b1000_1000]));
+	}
+
+	#[test]
+	fn profile3_keyframe_and_interframe() {
+		// profile 3 (both profile bits set) inserts a reserved bit before
+		// show_existing_frame, shifting frame_type one position right.
+		assert!(is_keyframe(&[0b1011_0000])); // reserved=0, show=0, frame_type=0
+		assert!(!is_keyframe(&[0b1011_0010])); // frame_type=1
+	}
+
+	#[test]
+	fn empty_payload_is_not_keyframe() {
+		assert!(!is_keyframe(&[]));
 	}
 }

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -11,11 +11,14 @@ pub mod whip;
 
 mod mux;
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use axum::Router;
-use tokio::sync::OnceCell;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use tokio::sync::{OnceCell, oneshot};
 
 use crate::Result;
 use mux::Mux;
@@ -76,6 +79,10 @@ struct Inner {
 	/// The shared media socket + demux, bound lazily on the first accept so
 	/// `Server::new` can stay synchronous (and an idle server binds no port).
 	mux: OnceCell<Mux>,
+	/// Live sessions keyed by resource id, each holding a cancel sender the
+	/// session task selects on. Lets [`Server::terminate`] (and the bundled
+	/// `DELETE` route) end a session by its `Location` id.
+	sessions: Mutex<HashMap<String, oneshot::Sender<()>>>,
 }
 
 impl Server {
@@ -88,6 +95,7 @@ impl Server {
 				publisher,
 				subscriber,
 				mux: OnceCell::new(),
+				sessions: Mutex::new(HashMap::new()),
 			}),
 		}
 	}
@@ -128,5 +136,78 @@ impl Server {
 
 	pub(crate) fn subscriber(&self) -> &moq_net::OriginConsumer {
 		&self.inner.subscriber
+	}
+
+	/// Register a session under its resource id, returning the cancel receiver
+	/// the session task selects on. Called by [`whip::accept`] / [`whep::accept`]
+	/// before spawning the session.
+	pub(crate) fn register_session(&self, resource_id: String) -> oneshot::Receiver<()> {
+		let (tx, rx) = oneshot::channel();
+		self.inner.sessions.lock().unwrap().insert(resource_id, tx);
+		rx
+	}
+
+	/// Drop a session's registry entry once it has ended on its own.
+	pub(crate) fn unregister_session(&self, resource_id: &str) {
+		self.inner.sessions.lock().unwrap().remove(resource_id);
+	}
+
+	/// Terminate a negotiated session by its resource id (the `Location` path
+	/// component from the WHIP/WHEP response). Returns `true` if a live session
+	/// was found and signalled to stop; the session task then releases its
+	/// broadcast announcement and mux registration. Embedders that own their own
+	/// HTTP routing call this to honor a WHIP/WHEP `DELETE`; the bundled routers
+	/// already wire it to the `DELETE` method.
+	pub fn terminate(&self, resource_id: &str) -> bool {
+		if let Some(cancel) = self.inner.sessions.lock().unwrap().remove(resource_id) {
+			let _ = cancel.send(());
+			true
+		} else {
+			false
+		}
+	}
+}
+
+/// Shared `DELETE` handler for both bundled routers: parse the resource id from
+/// the trailing path segment and terminate the matching session.
+pub(crate) async fn delete(State(server): State<Server>, Path(path): Path<String>) -> StatusCode {
+	match crate::sdp::parse_resource_id(&path) {
+		Ok(id) if server.terminate(&id.to_string()) => StatusCode::OK,
+		Ok(_) => StatusCode::NOT_FOUND,
+		Err(_) => StatusCode::BAD_REQUEST,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn server() -> Server {
+		let publisher = moq_net::Origin::random().produce();
+		let subscriber = moq_net::Origin::random().produce().consume();
+		Server::new(Config::default(), publisher, subscriber)
+	}
+
+	#[test]
+	fn terminate_unknown_session_is_false() {
+		assert!(!server().terminate("00000000-0000-0000-0000-000000000000"));
+	}
+
+	#[test]
+	fn terminate_registered_session_once() {
+		let server = server();
+		let id = "11111111-1111-1111-1111-111111111111";
+		let _cancel = server.register_session(id.to_string());
+		assert!(server.terminate(id), "first terminate finds the session");
+		assert!(!server.terminate(id), "second terminate is a no-op");
+	}
+
+	#[test]
+	fn unregister_drops_the_entry() {
+		let server = server();
+		let id = "22222222-2222-2222-2222-222222222222";
+		let _cancel = server.register_session(id.to_string());
+		server.unregister_session(id);
+		assert!(!server.terminate(id), "unregistered session can't be terminated");
 	}
 }

--- a/rs/moq-rtc/src/server/mux.rs
+++ b/rs/moq-rtc/src/server/mux.rs
@@ -121,18 +121,11 @@ impl Mux {
 		self.socket.clone()
 	}
 
-	/// ICE host candidates to advertise in the SDP answer.
+	/// ICE host candidates to advertise in the SDP answer. The session tags each
+	/// inbound datagram with the family-matching candidate; never empty (falls
+	/// back to the bound address).
 	pub(crate) fn candidates(&self) -> &[SocketAddr] {
 		&self.candidates
-	}
-
-	/// The local address to report to str0m as each datagram's destination. str0m
-	/// requires it to match an advertised host candidate (it drops STUN whose
-	/// destination is an "unknown interface"), and the shared socket binds a
-	/// wildcard, so report the first advertised candidate rather than the bind. The
-	/// candidate list is never empty (it falls back to the bound address).
-	pub(crate) fn local(&self) -> SocketAddr {
-		self.candidates[0]
 	}
 }
 

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -19,7 +19,9 @@ pub use crate::server::Response;
 
 /// Build the WHEP axum router.
 pub fn router(server: Server) -> Router {
-	Router::new().route("/{*path}", post(handle)).with_state(server)
+	Router::new()
+		.route("/{*path}", post(handle).delete(crate::server::delete))
+		.with_state(server)
 }
 
 async fn handle(server: State<Server>, path: Path<String>, headers: HeaderMap, body: Bytes) -> HttpResponse {
@@ -109,14 +111,23 @@ pub async fn accept(
 
 	let answer = rtc.sdp_api().accept_offer(offer).map_err(Error::Rtc)?;
 	let resource_id = sdp::new_resource_id();
-	let session = session::Session::egress(rtc, mux.socket(), mux.local(), inbound, source);
+	let session = session::Session::egress(rtc, mux.socket(), mux.candidates().to_vec(), inbound, source);
 
+	// Register before spawning so a DELETE that races startup still finds the
+	// session; the task unregisters itself when it ends.
+	let cancel = server.register_session(resource_id.clone());
+	let task_server = server.clone();
+	let task_resource = resource_id.clone();
 	tokio::spawn(async move {
 		// Hold the mux registration for the session's lifetime (unregisters on exit).
 		let _registration = registration;
-		if let Err(err) = session.run().await {
-			tracing::warn!(%err, "whep session ended");
+		tokio::select! {
+			res = session.run() => if let Err(err) = res {
+				tracing::warn!(%err, "whep session ended");
+			},
+			_ = cancel => tracing::debug!("whep session terminated by DELETE"),
 		}
+		task_server.unregister_session(&task_resource);
 	});
 
 	Ok(Response {

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -122,9 +122,7 @@ pub async fn accept(
 		// Hold the mux registration for the session's lifetime (unregisters on exit).
 		let _registration = registration;
 		tokio::select! {
-			res = session.run() => if let Err(err) = res {
-				tracing::warn!(%err, "whep session ended");
-			},
+			res = session.run() => session::log_session_end("whep server", res),
 			_ = cancel => tracing::debug!("whep session terminated by DELETE"),
 		}
 		task_server.unregister_session(&task_resource);

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -20,7 +20,9 @@ pub use crate::server::Response;
 
 /// Build the WHIP axum router.
 pub fn router(server: Server) -> Router {
-	Router::new().route("/{*path}", post(handle)).with_state(server)
+	Router::new()
+		.route("/{*path}", post(handle).delete(crate::server::delete))
+		.with_state(server)
 }
 
 async fn handle(
@@ -109,16 +111,25 @@ pub async fn accept(
 
 	let answer = rtc.sdp_api().accept_offer(offer).map_err(Error::Rtc)?;
 	let resource_id = sdp::new_resource_id();
-	let session = session::Session::ingest(rtc, mux.socket(), mux.local(), inbound, sink);
+	let session = session::Session::ingest(rtc, mux.socket(), mux.candidates().to_vec(), inbound, sink);
 
+	// Register before spawning so a DELETE that races the first packet still
+	// finds the session; the task unregisters itself when it ends.
+	let cancel = server.register_session(resource_id.clone());
+	let task_server = server.clone();
+	let task_resource = resource_id.clone();
 	tokio::spawn(async move {
 		// Hold the announcement guard + mux registration for the session's
 		// lifetime; both release (unannounce / unregister) on exit.
 		let _publish = publish;
 		let _registration = registration;
-		if let Err(err) = session.run().await {
-			tracing::warn!(%err, "whip session ended");
+		tokio::select! {
+			res = session.run() => if let Err(err) = res {
+				tracing::warn!(%err, "whip session ended");
+			},
+			_ = cancel => tracing::debug!("whip session terminated by DELETE"),
 		}
+		task_server.unregister_session(&task_resource);
 	});
 
 	Ok(Response {

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -124,9 +124,7 @@ pub async fn accept(
 		let _publish = publish;
 		let _registration = registration;
 		tokio::select! {
-			res = session.run() => if let Err(err) = res {
-				tracing::warn!(%err, "whip session ended");
-			},
+			res = session.run() => session::log_session_end("whip server", res),
 			_ = cancel => tracing::debug!("whip session terminated by DELETE"),
 		}
 		task_server.unregister_session(&task_resource);

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -226,11 +226,12 @@ impl Session {
 			}
 			Event::MediaAdded(added) => self.handle_media_added(added)?,
 			Event::MediaData(data) => {
-				// Rebase off the raw (random, per-track) RTP base before borrowing
-				// the sink, so the clock and the role are disjoint borrows.
-				let media_us = media_time_to_micros(&data.time);
-				let timestamp_us = self.clock.normalize(data.mid, data.network_time, media_us);
+				// `clock` and `role` are disjoint fields, so the borrow checker lets
+				// us rebase the (random, per-track) RTP base and feed the sink in one
+				// block; egress sessions never get here so the clock stays untouched.
 				if let MediaRole::Ingest(sink) = &mut self.role {
+					let media_us = media_time_to_micros(&data.time);
+					let timestamp_us = self.clock.normalize(data.mid, data.network_time, media_us);
 					sink.on_frame(
 						data.mid,
 						codec::Frame {
@@ -310,10 +311,29 @@ impl IngestClock {
 	fn normalize(&mut self, mid: str0m::media::Mid, arrival: Instant, media_us: u64) -> u64 {
 		let epoch = *self.epoch.get_or_insert(arrival);
 		let offset = *self.offsets.entry(mid).or_insert_with(|| {
-			let wall_us = arrival.saturating_duration_since(epoch).as_micros() as i64;
+			// Signed wall delta from the epoch: a track whose first frame we dequeue
+			// after the epoch frame may have actually arrived *before* it, and that
+			// lead must pull its timeline earlier (not clamp to the epoch via an
+			// unsigned subtraction) so it stays in sync.
+			let wall_us = if arrival >= epoch {
+				arrival.duration_since(epoch).as_micros() as i64
+			} else {
+				-(epoch.duration_since(arrival).as_micros() as i64)
+			};
 			wall_us - media_us as i64
 		});
 		(media_us as i64 + offset).max(0) as u64
+	}
+}
+
+/// Log a finished session at the right level: an ordinary peer disconnect
+/// ([`Error::SessionClosed`]) is debug, a genuine failure is a warning. Keeps
+/// normal WebRTC churn out of the warning stream. `role` labels the path
+/// (e.g. `"whip server"`).
+pub(crate) fn log_session_end(role: &str, result: Result<()>) {
+	match result {
+		Ok(()) | Err(Error::SessionClosed) => tracing::debug!(role, "session ended"),
+		Err(err) => tracing::warn!(%err, role, "session ended"),
 	}
 }
 
@@ -513,6 +533,25 @@ mod tests {
 		assert_eq!(
 			clock.normalize(video, video_arrival + Duration::from_millis(33), 8_000_033_000),
 			38_000
+		);
+	}
+
+	#[test]
+	fn ingest_clock_handles_track_arriving_before_epoch() {
+		let mut clock = IngestClock::default();
+		let audio = Mid::from("0");
+		let video = Mid::from("1");
+		let t0 = Instant::now();
+		// Audio's MediaData is dequeued first and sets the epoch at t0.
+		assert_eq!(clock.normalize(audio, t0, 1_000_000), 0);
+		// Video's first frame actually arrived 5 ms *before* the epoch. Its lead
+		// pulls the start below zero (clamped to 0), and a frame 33 ms into video
+		// lands 28 ms onto the shared timeline (33 ms - the 5 ms head start).
+		let video_arrival = t0 - Duration::from_millis(5);
+		assert_eq!(clock.normalize(video, video_arrival, 8_000_000), 0);
+		assert_eq!(
+			clock.normalize(video, video_arrival + Duration::from_millis(33), 8_033_000),
+			28_000
 		);
 	}
 }

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -33,6 +33,12 @@ pub(crate) type Packet = (Vec<u8>, SocketAddr);
 /// and a stalled session must not grow memory without limit).
 pub(crate) const SESSION_INBOX: usize = 256;
 
+/// str0m's outbound video buffer depth (packets), which also backs NACK resends.
+/// Raised above the str0m default (1000) so a late-joining peer can recover a
+/// large keyframe and the rest of the current group via NACK; see
+/// [`rtc_config_with_codecs`].
+const EGRESS_SEND_BUFFER_VIDEO: usize = 3000;
+
 /// Receives `MediaData` events from str0m and dispatches to the right codec
 /// [`Bridge`](codec::Bridge). Used as the per-session sink in [`Session::run`]
 /// for any flow where RTP arrives from the peer (`server publish` / WHIP
@@ -72,12 +78,15 @@ pub struct Session {
 	/// Send side. Shared across sessions on the server (the mux socket); owned
 	/// 1:1 on the client. Receiving happens via `inbound`, not this socket.
 	socket: Arc<UdpSocket>,
-	/// The local address to report to str0m as each datagram's destination. MUST
-	/// equal one of the local ICE candidates we advertised, not the socket's bind
-	/// address: str0m drops a STUN binding request whose destination doesn't match
-	/// a host candidate ("unknown interface"), and the shared mux socket binds a
-	/// wildcard (`0.0.0.0`) while advertising a concrete IP.
-	local: SocketAddr,
+	/// The local ICE candidates we advertised. Each inbound datagram is tagged
+	/// (for str0m) with the candidate whose address family matches the packet's
+	/// source, so a dual-stack peer reaching us over IPv6 isn't told the packet
+	/// arrived on an IPv4 host candidate. MUST be the advertised candidates, not
+	/// the socket's bind address: str0m drops a STUN binding request whose
+	/// destination doesn't match a host candidate ("unknown interface"), and the
+	/// shared mux socket binds a wildcard (`0.0.0.0`) while advertising concrete
+	/// IPs. Never empty (falls back to the bound address).
+	locals: Vec<SocketAddr>,
 	/// Inbound datagrams routed to this session (demux on the server, a 1:1
 	/// reader on the client). `None` from `recv` means every sender dropped, so
 	/// the session is done.
@@ -93,19 +102,19 @@ pub struct Session {
 }
 
 impl Session {
-	/// Convenience for the ingest case (WHIP server, WHEP client). `local` is the
-	/// advertised ICE candidate address (see the field docs), not the socket bind.
+	/// Convenience for the ingest case (WHIP server, WHEP client). `locals` are the
+	/// advertised ICE candidates (see the field docs), not the socket bind.
 	pub fn ingest(
 		rtc: Rtc,
 		socket: Arc<UdpSocket>,
-		local: SocketAddr,
+		locals: Vec<SocketAddr>,
 		inbound: mpsc::Receiver<Packet>,
 		sink: Box<dyn MediaSink>,
 	) -> Self {
 		Self {
 			rtc,
 			socket,
-			local,
+			locals,
 			inbound,
 			role: MediaRole::Ingest(sink),
 			writes_rx: None,
@@ -113,12 +122,12 @@ impl Session {
 		}
 	}
 
-	/// Convenience for the egress case (WHEP server, WHIP client). `local` is the
-	/// advertised ICE candidate address (see the field docs), not the socket bind.
+	/// Convenience for the egress case (WHEP server, WHIP client). `locals` are the
+	/// advertised ICE candidates (see the field docs), not the socket bind.
 	pub fn egress(
 		rtc: Rtc,
 		socket: Arc<UdpSocket>,
-		local: SocketAddr,
+		locals: Vec<SocketAddr>,
 		inbound: mpsc::Receiver<Packet>,
 		mut source: EgressSource,
 	) -> Self {
@@ -126,7 +135,7 @@ impl Session {
 		Self {
 			rtc,
 			socket,
-			local,
+			locals,
 			inbound,
 			role: MediaRole::Egress(Box::new(source)),
 			writes_rx: Some(writes_rx),
@@ -135,10 +144,6 @@ impl Session {
 	}
 
 	pub async fn run(mut self) -> Result<()> {
-		// The local address str0m tags each inbound packet with -- the advertised
-		// ICE candidate, NOT the socket bind (see the `local` field docs).
-		let local = self.local;
-
 		loop {
 			// A dead Rtc (DTLS/SDP failure, explicit disconnect) makes poll_output
 			// return a never-firing timeout instead of erroring, which would hang
@@ -189,6 +194,9 @@ impl Session {
 					match packet {
 						Some((data, src)) => {
 							let now = Instant::now();
+							// Tag the packet with the advertised candidate matching its
+							// address family, not the socket bind (see the `locals` docs).
+							let local = pick_local(&self.locals, src);
 							let recv = Receive::new(str0m::net::Protocol::Udp, src, local, &data)
 								.map_err(Error::RtcInput)?;
 							self.rtc.handle_input(Input::Receive(now, recv)).map_err(Error::Rtc)?;
@@ -309,6 +317,18 @@ impl IngestClock {
 	}
 }
 
+/// Pick the advertised local candidate to tag an inbound packet with: the first
+/// one whose address family matches `src`, falling back to the first candidate
+/// (the list is never empty). Keeps a dual-stack peer's packets tagged with a
+/// same-family host candidate so str0m's ICE pairing stays consistent.
+fn pick_local(locals: &[SocketAddr], src: SocketAddr) -> SocketAddr {
+	locals
+		.iter()
+		.find(|l| l.is_ipv4() == src.is_ipv4())
+		.copied()
+		.unwrap_or(locals[0])
+}
+
 /// Convert a str0m [`MediaTime`](str0m::media::MediaTime) to microseconds.
 fn media_time_to_micros(time: &str0m::media::MediaTime) -> u64 {
 	// MediaTime stores `numer / denom` seconds; cast through i128 so the
@@ -354,7 +374,14 @@ impl Bridges {
 /// [`crate::egress::EgressSource`] can match to a rendition.
 pub fn rtc_config_with_codecs(codecs: &[str0m::format::Codec]) -> str0m::RtcConfig {
 	use str0m::format::Codec;
-	let mut config = str0m::RtcConfig::new().clear_codecs();
+	// str0m fulfils NACK resends from the video send buffer (default 1000
+	// packets). MoQ has no PLI path back to the publisher, so a late joiner's
+	// recovery is whatever the peer can NACK out of this buffer while the current
+	// group is still in flight. Widen it so a large keyframe plus the rest of the
+	// group stays recoverable instead of aging out after ~1000 packets.
+	let mut config = str0m::RtcConfig::new()
+		.clear_codecs()
+		.set_send_buffer_video(EGRESS_SEND_BUFFER_VIDEO);
 	for c in codecs {
 		config = match c {
 			Codec::Opus => config.enable_opus(true),
@@ -436,6 +463,19 @@ mod tests {
 	use str0m::media::Mid;
 
 	use super::*;
+
+	#[test]
+	fn pick_local_matches_address_family() {
+		let v4: SocketAddr = "1.2.3.4:5000".parse().unwrap();
+		let v6: SocketAddr = "[2001:db8::1]:5000".parse().unwrap();
+		let locals = vec![v4, v6];
+		let src_v4: SocketAddr = "9.9.9.9:1".parse().unwrap();
+		let src_v6: SocketAddr = "[2001:db8::2]:1".parse().unwrap();
+		assert_eq!(pick_local(&locals, src_v4), v4);
+		assert_eq!(pick_local(&locals, src_v6), v6);
+		// No same-family candidate falls back to the first.
+		assert_eq!(pick_local(&[v4], src_v6), v4);
+	}
 
 	#[test]
 	fn ingest_clock_rebases_first_frame_to_zero() {

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -87,6 +87,9 @@ pub struct Session {
 	/// sessions; pumps send frames here, the main loop forwards them into
 	/// str0m's [`Writer`](str0m::media::Writer).
 	writes_rx: Option<mpsc::Receiver<WriteRequest>>,
+	/// Rebases each ingested track's raw RTP timestamps onto one session
+	/// timeline so audio and video stay in sync. Unused by egress sessions.
+	clock: IngestClock,
 }
 
 impl Session {
@@ -106,6 +109,7 @@ impl Session {
 			inbound,
 			role: MediaRole::Ingest(sink),
 			writes_rx: None,
+			clock: IngestClock::default(),
 		}
 	}
 
@@ -126,6 +130,7 @@ impl Session {
 			inbound,
 			role: MediaRole::Egress(Box::new(source)),
 			writes_rx: Some(writes_rx),
+			clock: IngestClock::default(),
 		}
 	}
 
@@ -135,6 +140,14 @@ impl Session {
 		let local = self.local;
 
 		loop {
+			// A dead Rtc (DTLS/SDP failure, explicit disconnect) makes poll_output
+			// return a never-firing timeout instead of erroring, which would hang
+			// this task forever holding the broadcast announcement + mux
+			// registration. Bail so those release.
+			if !self.rtc.is_alive() {
+				return Err(Error::SessionClosed);
+			}
+
 			let timeout = match self.rtc.poll_output().map_err(Error::Rtc)? {
 				Output::Timeout(t) => t,
 				Output::Transmit(t) => {
@@ -205,8 +218,11 @@ impl Session {
 			}
 			Event::MediaAdded(added) => self.handle_media_added(added)?,
 			Event::MediaData(data) => {
+				// Rebase off the raw (random, per-track) RTP base before borrowing
+				// the sink, so the clock and the role are disjoint borrows.
+				let media_us = media_time_to_micros(&data.time);
+				let timestamp_us = self.clock.normalize(data.mid, data.network_time, media_us);
 				if let MediaRole::Ingest(sink) = &mut self.role {
-					let timestamp_us = media_time_to_micros(&data.time);
 					sink.on_frame(
 						data.mid,
 						codec::Frame {
@@ -255,6 +271,41 @@ impl Session {
 			}
 		}
 		Ok(())
+	}
+}
+
+/// Per-session clock that rebases each ingested track's raw RTP timestamps onto
+/// one timeline so audio and video stay in sync.
+///
+/// str0m hands us the RTP header timestamp verbatim
+/// ([`MediaData::time`](str0m::media::MediaData::time)). Per RFC 3550 that base
+/// is random and independent for each track, and str0m applies no RTCP
+/// sender-report correlation, so publishing the values as-is would desync audio
+/// from video (their bases differ by hours) and start the broadcast at an
+/// arbitrary offset. We anchor each track on its first frame to that packet's
+/// arrival time (relative to the first frame seen in the whole session), then
+/// advance within the track by the RTP delta (str0m extends the 32-bit RTP
+/// timestamp with a roll-over counter, so the delta is wrap-safe). The first
+/// frame of the session maps to 0.
+#[derive(Default)]
+pub(crate) struct IngestClock {
+	/// Arrival time of the first frame seen in the session; the timeline origin.
+	epoch: Option<Instant>,
+	/// Per-track additive offset (microseconds) applied to the raw RTP time.
+	offsets: HashMap<str0m::media::Mid, i64>,
+}
+
+impl IngestClock {
+	/// Map a raw RTP-derived microsecond timestamp onto the session timeline.
+	/// `arrival` is the packet's network time
+	/// ([`MediaData::network_time`](str0m::media::MediaData::network_time)).
+	fn normalize(&mut self, mid: str0m::media::Mid, arrival: Instant, media_us: u64) -> u64 {
+		let epoch = *self.epoch.get_or_insert(arrival);
+		let offset = *self.offsets.entry(mid).or_insert_with(|| {
+			let wall_us = arrival.saturating_duration_since(epoch).as_micros() as i64;
+			wall_us - media_us as i64
+		});
+		(media_us as i64 + offset).max(0) as u64
 	}
 }
 
@@ -376,4 +427,52 @@ pub fn spawn_socket_reader(socket: Arc<UdpSocket>) -> mpsc::Receiver<Packet> {
 		}
 	});
 	rx
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::Duration;
+
+	use str0m::media::Mid;
+
+	use super::*;
+
+	#[test]
+	fn ingest_clock_rebases_first_frame_to_zero() {
+		let mut clock = IngestClock::default();
+		let mid = Mid::from("0");
+		let t0 = Instant::now();
+		// Raw RTP base is a large random value; the first frame must map to 0.
+		assert_eq!(clock.normalize(mid, t0, 5_000_000_000), 0);
+	}
+
+	#[test]
+	fn ingest_clock_tracks_rtp_delta_within_track() {
+		let mut clock = IngestClock::default();
+		let mid = Mid::from("0");
+		let t0 = Instant::now();
+		assert_eq!(clock.normalize(mid, t0, 5_000_000_000), 0);
+		// A later frame advances by the RTP delta, not by arrival jitter.
+		let arrival = t0 + Duration::from_millis(17); // jittered arrival, ignored after anchor
+		assert_eq!(clock.normalize(mid, arrival, 5_000_020_000), 20_000);
+	}
+
+	#[test]
+	fn ingest_clock_keeps_tracks_in_sync_via_arrival() {
+		let mut clock = IngestClock::default();
+		let audio = Mid::from("0");
+		let video = Mid::from("1");
+		let t0 = Instant::now();
+		// Audio anchors the session at 0 with its own random RTP base.
+		assert_eq!(clock.normalize(audio, t0, 1_000_000_000), 0);
+		// Video's first frame arrives 5 ms later with an unrelated RTP base; it
+		// must land at +5 ms on the shared timeline, not at video's raw base.
+		let video_arrival = t0 + Duration::from_millis(5);
+		assert_eq!(clock.normalize(video, video_arrival, 8_000_000_000), 5_000);
+		// And then track its own RTP delta.
+		assert_eq!(
+			clock.normalize(video, video_arrival + Duration::from_millis(33), 8_000_033_000),
+			38_000
+		);
+	}
 }


### PR DESCRIPTION
## Production-readiness review of `moq-rtc`

A review + hardening pass on the WebRTC (WHIP/WHEP) gateway on `dev` (through #1864, the shared-UDP-port mux). The crate was already in good shape (clean module split, embeddable library boundary, `#[non_exhaustive]` configs/errors, good docs). This PR fixes the correctness/robustness issues found. Clippy is clean (only a pre-existing `moq-native` warning) and tests pass (22: 17 unit + 5 integration).

### Fixes

1. **A/V desync on ingest (the headline bug).** str0m hands the *raw* RTP header timestamp per `MediaData`. Per RFC 3550 that base is random and **independent per track**, with no RTCP sender-report correlation, so WHIP-server / WHEP-client ingest was publishing audio and video on unrelated, multi-hour-offset timelines (broken lip-sync, arbitrary start offset). Added a per-session `IngestClock` that anchors each track on its first frame to that packet's arrival time (relative to the first frame in the session) and advances by the wrap-safe extended RTP delta. First frame maps to `0` and audio/video share one timeline.

2. **Dead-session leak backstop.** A dead `Rtc` makes `poll_output` return a never-firing timeout instead of erroring, hanging the task forever holding the broadcast announcement + mux registration. Added an `rtc.is_alive()` guard so those release.

3. **WHIP/WHEP `DELETE` / session teardown (RFC 9725).** The bundled routers now honor `DELETE` on the resource URL, ending a session promptly and releasing its announcement + shared-media-port registration instead of waiting for the ICE disconnect timeout. `Server` keeps a `resource_id -> cancel-sender` registry; the session task selects on it and unregisters on exit. Exposed as `Server::terminate` for embedders that own their routing. Wires up the previously-unused `sdp::parse_resource_id` / `Error::SessionNotFound`.

4. **Dual-stack ICE candidate tagging.** The session tags each inbound datagram with the advertised candidate whose address family matches the packet source, instead of always `candidates[0]`, so an IPv6 peer on a v4+v6 deployment isn't told its packet arrived on an IPv4 host candidate.

5. **VP9 keyframe detection** now parses the uncompressed header properly: profile 3's extra reserved bit and `show_existing_frame` (which carries no `frame_type`), not just profile 0-2.

6. **Late joiners.** A fresh WHEP subscriber already starts at the current (in-progress) MoQ group, which begins at a keyframe (now documented at the subscribe call). MoQ has no PLI path upstream, so str0m's egress video send buffer is widened above the default (1000 -> 3000 packets) so the peer can NACK-recover a large keyframe and the rest of the current group while it's still in flight.

7. **Log hygiene.** Ordinary peer disconnects (`Error::SessionClosed`) now log at debug, not warn, via a shared `session::log_session_end` helper, so normal WebRTC churn stays out of the warning stream.

8. **Docs.** `doc/bin/rtc.md`: documented `--udp-bind`, the updated keyframe/NACK behavior, and `DELETE` teardown.

### Public API changes (on `dev`, breaking allowed)

- **Added** `Server::terminate(&str) -> bool`.
- **Changed** `session::Session::ingest` / `egress`: `local: SocketAddr` -> `locals: Vec<SocketAddr>`. (Documented embedder path is `whip::accept` / `whep::accept` / `Client`, which are unaffected.)
- **Removed** `Mux::local()` (was `pub(crate)`).

### Still flagged (not in this PR)

- PLI propagation upstream to MoQ: by design there is no MoQ PLI mechanism; mitigated via current-group start + the wider NACK buffer above. A true keyframe-on-demand path would be a larger cross-crate feature.

### Test plan

- [x] `cargo clippy -p moq-rtc --all-targets --all-features` (clean)
- [x] `cargo test -p moq-rtc --all-features` (22 passed: 17 unit + 5 integration)
- [x] `cargo fmt --check -p moq-rtc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)