### PR TITLE
test: add in-tree cross-language interop smoke test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,72 @@
+name: Smoke
+
+# Cross-language interop smoke test built from THIS checkout (not the published
+# packages, unlike the moq-dev/smoke repo). Stands up a relay and runs the
+# publish x subscribe matrix across rust / python / browser / native-js / c.
+on:
+  # Manual on-demand runs.
+  workflow_dispatch:
+  # Nightly: catch an interop regression in the current tree before a user does.
+  schedule:
+    - cron: "0 8 * * *"
+  # On PRs that touch the harness itself, so a change to the smoke test is
+  # validated before it merges. Source regressions still surface nightly.
+  pull_request:
+    paths:
+      - "test/smoke/**"
+      - ".github/workflows/smoke.yml"
+
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  smoke:
+    name: Smoke
+    runs-on: ubuntu-latest
+    # The matrix runs in real time (ffmpeg -re pacing + per-subscriber timeouts);
+    # this is a safety net against a hung relay/client plus a cold first build.
+    timeout-minutes: 60
+
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+        with:
+          tool-cache: false
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        with:
+          determinate: false
+      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
+
+      # Reuse ~/.cargo + ./target across nightly runs so only changed crates
+      # recompile (the relay, cli, moq-ffi, and libmoq all build from source).
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      # Playwright's Chromium isn't in the nix devShell. Install it plus its apt
+      # runtime libs (`--with-deps` needs the host package manager) so the
+      # browser client can launch headless Chromium. smoke.sh's own
+      # `playwright install` then no-ops.
+      - name: Playwright Chromium
+        run: nix develop --command bash -c "bun install && bunx playwright install --with-deps chromium"
+        shell: bash -leo pipefail {0}
+
+      - name: Smoke (full matrix)
+        run: nix develop --command just test smoke-full
+        shell: bash -leo pipefail {0}
+
+      - name: Negative control
+        run: nix develop --command just test smoke-negative
+        shell: bash -leo pipefail {0}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     paths:
       - "test/smoke/**"
+      # The smoke job also depends on the recipe that invokes it and the
+      # workspace membership that links the JS clients to source.
+      - "test/justfile"
+      - "package.json"
       - ".github/workflows/smoke.yml"
 
 concurrency:

--- a/bun.lock
+++ b/bun.lock
@@ -260,6 +260,30 @@
         "vite": "^8.0.16",
       },
     },
+    "test/smoke/clients/js": {
+      "name": "@moq/smoke-browser",
+      "dependencies": {
+        "@moq/publish": "workspace:*",
+        "@moq/watch": "workspace:*",
+      },
+      "devDependencies": {
+        "esbuild": "^0.28.0",
+        "playwright": "^1.61.0",
+        "vite": "^8.0.16",
+      },
+    },
+    "test/smoke/clients/js-native": {
+      "name": "@moq/smoke-native",
+      "dependencies": {
+        "@moq/hang": "workspace:*",
+        "@moq/net": "workspace:*",
+        "@moq/web-transport": "^0.1.2",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "tsx": "^4.0.0",
+      },
+    },
   },
   "trustedDependencies": [
     "@fails-components/webtransport-transport-http3-quiche",
@@ -541,9 +565,25 @@
 
     "@moq/signals": ["@moq/signals@workspace:js/signals"],
 
+    "@moq/smoke-browser": ["@moq/smoke-browser@workspace:test/smoke/clients/js"],
+
+    "@moq/smoke-native": ["@moq/smoke-native@workspace:test/smoke/clients/js-native"],
+
     "@moq/token": ["@moq/token@workspace:js/token"],
 
     "@moq/watch": ["@moq/watch@workspace:js/watch"],
+
+    "@moq/web-transport": ["@moq/web-transport@0.1.2", "", { "optionalDependencies": { "@moq/web-transport-darwin-arm64": "0.1.2", "@moq/web-transport-darwin-x64": "0.1.2", "@moq/web-transport-linux-arm64-gnu": "0.1.2", "@moq/web-transport-linux-x64-gnu": "0.1.2", "@moq/web-transport-win32-x64-msvc": "0.1.2" } }, "sha512-cJE0B+T5a8ey1ZgFUIBTWkIWfhCAYGAUgAw8XYeOPsKPjFhtW9M/C+XV8Yu0IeUS4nnrbBPw4sEc+TvMybV4IQ=="],
+
+    "@moq/web-transport-darwin-arm64": ["@moq/web-transport-darwin-arm64@0.1.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-waCy1fIyUg0WDwP+rI5Jg7Mw5efsJjImGZzyIDvCXM98O/nWoybPmh8Cka6VP+8xUBeclRpWmlC6phYXtYqPyw=="],
+
+    "@moq/web-transport-darwin-x64": ["@moq/web-transport-darwin-x64@0.1.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-MWllJfxoZ5ncFxuWpcrwIEMpNjvixt7ycCZQDoW9yjfqsMzfPVRaunvJ8kW0zp0IXrGpC/RFeecFSaE7PmzHpg=="],
+
+    "@moq/web-transport-linux-arm64-gnu": ["@moq/web-transport-linux-arm64-gnu@0.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cjVoLj/SGjetlJx3tbVt0fhzYIN195L9JQ/UkZqpvkhIfWEopPX7MzCWUPRK72mzH7kCyWr0dUGSu7B3pD1j1w=="],
+
+    "@moq/web-transport-linux-x64-gnu": ["@moq/web-transport-linux-x64-gnu@0.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ExZbJFdUeL2G0FkBY7mw/tZTq6+lZfYgIWkjDRa4YkifcGjMevEgpsby5QXlxhs+Og1y5q/x2Xgzd/bAG3TkRQ=="],
+
+    "@moq/web-transport-win32-x64-msvc": ["@moq/web-transport-win32-x64-msvc@0.1.2", "", { "os": "win32", "cpu": "x64" }, "sha512-iypZ2WVoqEDB4dt7qG/wRj3zWAEqpoPP1Lj44L3o23g60UGuqsrGgbpy85qmejBkjMmDrWHr0Phx6pYJNAj/TA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -1321,6 +1361,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+
+    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
+
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
@@ -1553,6 +1597,8 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
+
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-fest": ["type-fest@3.13.1", "", {}, "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="],
@@ -1752,6 +1798,8 @@
     "npm-pick-manifest/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
 		"js/signals",
 		"demo/boy",
 		"demo/web",
-		"js/moq-boy"
+		"js/moq-boy",
+		"test/smoke/clients/js",
+		"test/smoke/clients/js-native"
 	]
 }

--- a/test/justfile
+++ b/test/justfile
@@ -3,8 +3,11 @@
 # Tests that span more than one language. Per-language unit tests live in each
 # language's own justfile; this module aggregates them.
 #
-# The cross-language interop smoke test against the published packages now lives
-# in its own repo: https://github.com/moq-dev/smoke
+# Two cross-language interop smoke tests exist:
+#   - https://github.com/moq-dev/smoke installs each client from its PUBLIC
+#     package registry to catch packaging breakage in a release.
+#   - `just test smoke` (smoke/, below) builds every client from THIS checkout
+#     to catch interop regressions before anything is published.
 
 # Fall back to the root justfile so `just js test` (etc.) resolve from here.
 set fallback
@@ -15,3 +18,21 @@ default *args:
     just js test
     just rs test {{ args }}
     if command -v uv &> /dev/null; then just py test; fi
+
+# Cross-language media interop smoke test, built from this checkout. Stands up a
+# relay and runs the publisher x subscriber matrix. Default: rust only. Pass
+# flags through, e.g.
+# just test smoke --publishers rust,python,js --subscribers rust,c
+smoke *args:
+    ./smoke/smoke.sh {{ args }}
+
+# Full interop matrix: rust + python + browser publish; everyone subscribes
+# (incl. native node/bun JS, the C libmoq client, and the GStreamer moqsrc
+# plugin). --timeout 30 gives headless Chromium cold-start headroom.
+smoke-full:
+    ./smoke/smoke.sh --publishers rust,python,js --subscribers rust,python,js,js-native-node,js-native-bun,c,gst --timeout 30
+
+# Negative control: no publisher, every subscriber must time out (proves the
+# harness can actually report failure).
+smoke-negative *args:
+    ./smoke/smoke.sh --negative {{ args }}

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -1,0 +1,88 @@
+# In-tree smoke test
+
+Cross-language interop smoke test that builds every client from **this checkout**
+and runs them against each other.
+
+This is the in-tree companion to [moq-dev/smoke](https://github.com/moq-dev/smoke).
+That repo installs each client from its public package registry (crates.io, PyPI,
+npm, ...) to catch *packaging* breakage in a release. This one builds each client
+from the workspace source (`cargo`, `bun`, `uv`, `cc`) to catch *interop*
+regressions before anything is published. No apt/brew/npm/PyPI, and no
+distribution-mechanism matrix.
+
+It stands up a `moq-relay`, then for each publisher language publishes an H.264
+broadcast and confirms every subscriber sees data flowing (a non-empty frame
+before the timeout). We check that bytes move end-to-end across implementations,
+not that H.264 decodes.
+
+## Clients
+
+| Client | Source under test | Built with | Roles |
+|---|---|---|---|
+| Rust | `rs/moq-relay` + `rs/moq-cli` | `cargo build` | publish + subscribe |
+| Python | `py/moq-rs` (+ `rs/moq-ffi`, import `moq`) | `just py build` (maturin editable into `.venv`) | publish + subscribe |
+| Browser | `js/watch` + `js/publish` | `vite build` + headless Chromium (Playwright) | publish + subscribe |
+| Native JS | `js/net` + `js/hang` + the npm `@moq/web-transport` polyfill | `node` (tsx) and `bun` | subscribe |
+| C | `rs/libmoq` | `cargo build -p libmoq` + `cc` | subscribe |
+| GStreamer | `rs/moq-gst` (`moqsrc`) | `cargo build -p moq-gst` + `gst-launch-1.0` | subscribe |
+
+The browser, native JS, C, and GStreamer clients subscribe only by choice
+(publishing media needs an encoder the native JS runtimes lack, the C client is
+intentionally minimal, and `moqsink` publishing needs request-pad muxing this
+client doesn't drive). Rust, Python, and the browser publish.
+
+The GStreamer client builds the `moqsrc` plugin from `rs/moq-gst` and points
+`GST_PLUGIN_PATH` at it, then reads a broadcast with
+`gst-launch-1.0 moqsrc ... ! filesink`. The plugin dynamic-links the host's
+GStreamer, so this cell needs `gst-launch-1.0` + the core plugins on the system.
+The `nix develop` shell ships them; a bare shell without GStreamer marks the cell
+unavailable rather than failing it.
+
+The `@moq/web-transport` polyfill is the one dependency that comes from npm rather
+than this checkout: it's a prebuilt NAPI QUIC/HTTP3 addon, not part of the moq
+source tree. Everything else (`@moq/net`, `@moq/hang`, ...) resolves to the
+workspace packages, because the JS clients here are bun workspace members.
+
+## Running locally
+
+You need the workspace toolchain on `PATH` (cargo, ffmpeg, bun, uv, a C
+compiler). `nix develop` provides all of it except Playwright's Chromium, which
+`smoke.sh` fetches on first run (`bunx playwright install chromium`).
+
+```bash
+# Default: rust publishes, rust subscribes (a fast sanity check).
+just test smoke
+
+# Full matrix: rust/python/browser publish; everyone subscribes.
+just test smoke-full
+
+# Pick your own axes:
+just test smoke --publishers rust,python --subscribers rust,c,js-native-bun
+
+# Negative control: no publisher, every subscriber must time out.
+just test smoke-negative
+```
+
+Subscriber names: `rust`, `python`, `js` (browser), `js-native-node`,
+`js-native-bun`, `c`, `gst`. Publisher names: `rust`, `python`, `js`.
+
+A client whose source build fails fails only its own matrix cells (see
+`mark_broken` in `smoke.sh`); it never aborts the rest of the run.
+
+## Layout
+
+```
+smoke.sh                  orchestrator: build clients, run the relay + matrix
+smoke.toml                relay config (anonymous, self-signed localhost)
+clients/
+  python/smoke.py         publish/subscribe via py/moq-rs (import moq)
+  js/                      headless-Chromium publish/subscribe via @moq/watch + @moq/publish
+  js-native/subscribe.ts  subscribe via @moq/net + @moq/hang + the WebTransport polyfill
+  c/subscribe.c           subscribe via rs/libmoq
+```
+
+## CI
+
+`.github/workflows/smoke.yml` runs the full matrix nightly (and on demand, and on
+PRs that touch `test/smoke/`). A red cell means a real interop break in the
+current tree.

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -71,7 +71,7 @@ A client whose source build fails fails only its own matrix cells (see
 
 ## Layout
 
-```
+```text
 smoke.sh                  orchestrator: build clients, run the relay + matrix
 smoke.toml                relay config (anonymous, self-signed localhost)
 clients/

--- a/test/smoke/clients/c/subscribe.c
+++ b/test/smoke/clients/c/subscribe.c
@@ -1,0 +1,149 @@
+// Subscribe-only cross-language interop client for the smoke test, linked
+// against the workspace libmoq (the C bindings, built by `cargo build -p libmoq`).
+//
+// libmoq is a handle + callback API: connect, consume a broadcast, get a
+// catalog snapshot via callback, start the video track, and a frame callback
+// fires as frames arrive. We exit 0 the moment a non-empty frame lands, 1 on
+// timeout. Publishing isn't wired up: the raw-stream importer that the other
+// clients use to publish isn't part of this subscribe-only client.
+//
+//   c-smoke subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+#include <moq.h>
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+typedef struct {
+    pthread_mutex_t mu;
+    pthread_cond_t cv;
+    int got;           // a non-empty frame arrived
+    int video_started; // guard: start the video track only once
+} ctx_t;
+
+// Callbacks run on libmoq's runtime thread; main waits on the condvar. ctx
+// lives on main's stack and outlives the callbacks (main blocks until got/
+// timeout, then the process exits), so there's no use-after-free.
+static void on_status(void *ud, int32_t code) {
+    (void)ud;
+    fprintf(stderr, "session status: %d\n", code);
+}
+
+static void on_frame(void *ud, int32_t frame) {
+    ctx_t *c = (ctx_t *)ud;
+    if (frame <= 0) return; // 0 = ended, negative = error
+    moq_frame f;
+    memset(&f, 0, sizeof(f));
+    if (moq_consume_frame((uint32_t)frame, &f) == 0 && f.payload_size > 0) {
+        pthread_mutex_lock(&c->mu);
+        c->got = 1;
+        pthread_cond_signal(&c->cv);
+        pthread_mutex_unlock(&c->mu);
+    }
+    moq_consume_frame_close((uint32_t)frame);
+}
+
+static void on_catalog(void *ud, int32_t catalog) {
+    ctx_t *c = (ctx_t *)ud;
+    if (catalog <= 0) return;
+
+    pthread_mutex_lock(&c->mu);
+    int start = !c->video_started;
+    pthread_mutex_unlock(&c->mu);
+
+    if (start) {
+        // A lazy publisher may announce video in a later catalog update, so this
+        // just no-ops (config returns < 0) until a video track exists at index 0.
+        moq_video_config vcfg;
+        memset(&vcfg, 0, sizeof(vcfg));
+        if (moq_consume_video_config((uint32_t)catalog, 0, &vcfg) == 0) {
+            int32_t track = moq_consume_video_ordered((uint32_t)catalog, 0, 1000, on_frame, ud);
+            if (track > 0) {
+                pthread_mutex_lock(&c->mu);
+                c->video_started = 1;
+                pthread_mutex_unlock(&c->mu);
+            }
+        }
+    }
+    moq_consume_catalog_free((uint32_t)catalog);
+}
+
+int main(int argc, char **argv) {
+    const char *url = NULL, *broadcast = NULL;
+    double timeout_s = 20.0;
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--url") && i + 1 < argc) url = argv[++i];
+        else if (!strcmp(argv[i], "--broadcast") && i + 1 < argc) broadcast = argv[++i];
+        else if (!strcmp(argv[i], "--timeout") && i + 1 < argc) timeout_s = atof(argv[++i]);
+        // a leading "subscribe" positional (and anything else) is ignored.
+    }
+    if (!url || !broadcast) {
+        fprintf(stderr, "usage: c-smoke subscribe --url U --broadcast B [--timeout S]\n");
+        return 2;
+    }
+
+    ctx_t c;
+    pthread_mutex_init(&c.mu, NULL);
+    pthread_cond_init(&c.cv, NULL);
+    c.got = 0;
+    c.video_started = 0;
+
+    int32_t origin = moq_origin_create();
+    if (origin <= 0) {
+        fprintf(stderr, "error: moq_origin_create failed: %d\n", origin);
+        return 1;
+    }
+
+    // origin_publish = 0 disables publishing; consume via our origin.
+    int32_t session = moq_session_connect(url, strlen(url), 0, (uint32_t)origin, on_status, &c);
+    if (session <= 0) {
+        fprintf(stderr, "error: moq_session_connect failed: %d\n", session);
+        return 1;
+    }
+
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += (time_t)timeout_s;
+
+    // moq_origin_consume is a synchronous lookup, but the broadcast arrives over
+    // the network after connect. Retry until it's announced (or we run out of
+    // time). We don't enable libmoq logging, so the misses stay quiet.
+    int32_t bc = -1;
+    while (1) {
+        bc = moq_origin_consume((uint32_t)origin, broadcast, strlen(broadcast));
+        if (bc > 0) break;
+        struct timespec now;
+        clock_gettime(CLOCK_REALTIME, &now);
+        if (now.tv_sec >= deadline.tv_sec) break;
+        usleep(150 * 1000);
+    }
+    if (bc <= 0) {
+        fprintf(stderr, "error: broadcast never announced (moq_origin_consume: %d)\n", bc);
+        return 1;
+    }
+
+    int32_t cat = moq_consume_catalog((uint32_t)bc, on_catalog, &c);
+    if (cat <= 0) {
+        fprintf(stderr, "error: moq_consume_catalog failed: %d\n", cat);
+        return 1;
+    }
+
+    pthread_mutex_lock(&c.mu);
+    while (!c.got) {
+        if (pthread_cond_timedwait(&c.cv, &c.mu, &deadline) != 0) break; // timed out
+    }
+    int got = c.got;
+    pthread_mutex_unlock(&c.mu);
+
+    if (got) {
+        fprintf(stderr, "received a frame from %s\n", broadcast);
+        moq_session_close((uint32_t)session);
+        return 0;
+    }
+    fprintf(stderr, "error: timed out waiting for data\n");
+    return 1;
+}

--- a/test/smoke/clients/js-native/package.json
+++ b/test/smoke/clients/js-native/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@moq/smoke-native",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@moq/hang": "workspace:*",
+		"@moq/net": "workspace:*",
+		"@moq/web-transport": "^0.1.2",
+		"zod": "^4.0.0"
+	},
+	"devDependencies": {
+		"tsx": "^4.0.0"
+	}
+}

--- a/test/smoke/clients/js-native/subscribe.ts
+++ b/test/smoke/clients/js-native/subscribe.ts
@@ -1,15 +1,16 @@
-// Native-JS (non-browser) subscriber: run the workspace @moq/net + @moq/hang
-// packages under a JS runtime that has no native WebTransport, using moq's own
-// @moq/web-transport polyfill (a prebuilt NAPI QUIC/HTTP3 addon, the one piece
-// that comes from npm rather than this checkout). Runs under both node and bun.
-//
-// Connect, read the .hang catalog to find the video track, subscribe it, and
-// exit 0 as soon as any non-empty frame arrives (1 on timeout).
-//
-//   node --import tsx subscribe.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
-//
-// Subscribe-only: publishing media needs a WebCodecs encoder, which a native JS
-// runtime doesn't have. Reading raw container frames needs no codec.
+/**
+ * Native-JS (non-browser) smoke subscriber: run the workspace `@moq/net` +
+ * `@moq/hang` under a runtime with no native WebTransport, via moq's own
+ * `@moq/web-transport` polyfill (a prebuilt NAPI QUIC/HTTP3 addon, the one piece
+ * that comes from npm rather than this checkout). Runs under both node and bun.
+ * Connect, find the video track in the .hang catalog, subscribe, and exit 0 as
+ * soon as a non-empty frame arrives (1 on timeout). Subscribe-only: publishing
+ * media needs a WebCodecs encoder a native JS runtime lacks.
+ *
+ *     node --import tsx subscribe.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+ *
+ * @module
+ */
 import { parseArgs } from "node:util";
 import * as Catalog from "@moq/hang/catalog";
 import * as Moq from "@moq/net";

--- a/test/smoke/clients/js-native/subscribe.ts
+++ b/test/smoke/clients/js-native/subscribe.ts
@@ -34,8 +34,8 @@ const role = positionals[0];
 const url = values.url;
 const broadcast = values.broadcast;
 const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
-if (role !== "subscribe" || !url || !broadcast) {
-	console.error("usage: subscribe.ts subscribe --url U --broadcast B [--timeout S]");
+if (role !== "subscribe" || !url || !broadcast || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+	console.error("usage: subscribe.ts subscribe --url U --broadcast B [--timeout S>0]");
 	process.exit(2);
 }
 

--- a/test/smoke/clients/js-native/subscribe.ts
+++ b/test/smoke/clients/js-native/subscribe.ts
@@ -1,0 +1,110 @@
+// Native-JS (non-browser) subscriber: run the workspace @moq/net + @moq/hang
+// packages under a JS runtime that has no native WebTransport, using moq's own
+// @moq/web-transport polyfill (a prebuilt NAPI QUIC/HTTP3 addon, the one piece
+// that comes from npm rather than this checkout). Runs under both node and bun.
+//
+// Connect, read the .hang catalog to find the video track, subscribe it, and
+// exit 0 as soon as any non-empty frame arrives (1 on timeout).
+//
+//   node --import tsx subscribe.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+//
+// Subscribe-only: publishing media needs a WebCodecs encoder, which a native JS
+// runtime doesn't have. Reading raw container frames needs no codec.
+import { parseArgs } from "node:util";
+import * as Catalog from "@moq/hang/catalog";
+import * as Moq from "@moq/net";
+import { install } from "@moq/web-transport";
+
+// globalThis.WebTransport = the polyfill (no-op if a native one already exists).
+// @moq/net's connect() reads globalThis.WebTransport at call time, so this just
+// has to run before run() below.
+install();
+
+const { positionals, values } = parseArgs({
+	allowPositionals: true,
+	options: {
+		url: { type: "string" },
+		broadcast: { type: "string" },
+		timeout: { type: "string", default: "20" },
+	},
+});
+
+const role = positionals[0];
+const url = values.url;
+const broadcast = values.broadcast;
+const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
+if (role !== "subscribe" || !url || !broadcast) {
+	console.error("usage: subscribe.ts subscribe --url U --broadcast B [--timeout S]");
+	process.exit(2);
+}
+
+async function run(): Promise<void> {
+	const connection = await Moq.Connection.connect(new URL(url as string));
+	try {
+		const path = Moq.Path.from(broadcast as string);
+
+		// Wait for the broadcast to be announced before subscribing. Subscribing to a
+		// track on a broadcast the publisher hasn't announced yet races the relay,
+		// which resets the catalog stream (RESET_STREAM). The Rust API folds this
+		// wait into consume(); the JS API leaves it to the caller. The outer timeout
+		// below bounds how long we wait.
+		const announced = connection.announced(path);
+		try {
+			for (;;) {
+				const entry = await announced.next();
+				if (!entry) throw new Error("connection closed before broadcast was announced");
+				if (entry.active && Moq.Path.hasPrefix(path, entry.path)) break;
+			}
+		} finally {
+			announced.close();
+		}
+
+		const bc = connection.consume(path);
+
+		// The .hang catalog lives on the "catalog.json" track. A lazy publisher may
+		// announce video in a later update, so keep reading frames until one has it.
+		const catalog = bc.subscribe("catalog.json", Catalog.PRIORITY.catalog);
+		let videoTrack: string | undefined;
+		while (!videoTrack) {
+			const root = await Catalog.fetch(catalog);
+			if (!root) throw new Error("catalog ended without a video track");
+			const renditions = root.video?.renditions;
+			if (renditions) videoTrack = Object.keys(renditions)[0];
+		}
+
+		const video = bc.subscribe(videoTrack, 0);
+		let total = 0;
+		for (;;) {
+			const group = await video.recvGroup();
+			if (!group) break;
+			for (;;) {
+				const frame = await group.readFrame();
+				if (!frame) break;
+				total += frame.byteLength;
+				if (total > 0) {
+					// The harness judges success by this marker, not the exit code: the
+					// @moq/web-transport NAPI addon can segfault during the runtime's exit
+					// teardown after a frame has arrived (an upstream bug, seen under bun),
+					// which would turn a real success into a signal exit.
+					console.error(`received ${total} bytes from ${broadcast}`);
+					return;
+				}
+			}
+		}
+		throw new Error("no frame data received");
+	} finally {
+		connection.close(); // returns void, not a promise
+	}
+}
+
+const timeout = new Promise<never>((_, reject) =>
+	setTimeout(() => reject(new Error("timed out waiting for data")), timeoutMs),
+);
+
+try {
+	await Promise.race([run(), timeout]);
+	process.exit(0);
+} catch (err) {
+	console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+	process.exit(1);
+}

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -1,0 +1,93 @@
+// Drives a headless Chromium (channel "chromium" for WebTransport + WebCodecs)
+// against the vite-built page (dist/). publish streams a fake camera until
+// killed; subscribe exits 0 once the watch element decodes a frame.
+//
+//   bun driver.ts publish   --url http://127.0.0.1:4443 --broadcast b.hang
+//   bun driver.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { chromium } from "playwright";
+
+const { positionals, values } = parseArgs({
+	allowPositionals: true,
+	options: {
+		url: { type: "string" },
+		broadcast: { type: "string" },
+		timeout: { type: "string", default: "20" },
+	},
+});
+
+const role = positionals[0];
+const url = values.url;
+const broadcast = values.broadcast;
+if ((role !== "publish" && role !== "subscribe") || !url || !broadcast) {
+	console.error("usage: driver.ts publish|subscribe --url U --broadcast B [--timeout S]");
+	process.exit(2);
+}
+const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
+
+// Serve the prebuilt page on localhost (a secure context, so WebTransport /
+// WebCodecs are enabled).
+const root = join(new URL(".", import.meta.url).pathname, "dist");
+const server = Bun.serve({
+	port: 0,
+	async fetch(req) {
+		let path = new URL(req.url).pathname;
+		if (path === "/") path = "/index.html";
+		const file = Bun.file(join(root, path));
+		if (await file.exists()) return new Response(file);
+		return new Response(Bun.file(join(root, "index.html"))); // SPA fallback
+	},
+});
+const pageUrl = `http://localhost:${server.port}/?role=${role}&url=${encodeURIComponent(url)}&broadcast=${encodeURIComponent(broadcast)}`;
+
+const browser = await chromium.launch({
+	channel: "chromium", // full Chromium (new headless); the headless shell lacks these APIs
+	headless: true,
+	args: [
+		"--use-fake-device-for-media-stream",
+		"--use-fake-ui-for-media-stream",
+		"--autoplay-policy=no-user-gesture-required",
+	],
+});
+
+let code = 1;
+try {
+	const page = await browser.newPage();
+	page.on("console", (m) => console.error(`[page] ${m.text()}`));
+	page.on("pageerror", (e) => console.error(`[page error] ${e.message}`));
+	await page.goto(pageUrl, { waitUntil: "load" });
+
+	if (role === "publish") {
+		console.error(`publishing ${broadcast} (fake camera) to ${url}`);
+		await new Promise(() => {}); // stream until the orchestrator kills us
+	} else {
+		const start = Date.now();
+		const deadline = start + timeoutMs;
+		let frames = 0;
+		let reloaded = false;
+		while (Date.now() < deadline) {
+			frames = await page.evaluate(() => {
+				const w = document.querySelector("moq-watch") as unknown as {
+					backend?: { video?: { stats?: { peek(): { frameCount?: number } | undefined } } };
+				} | null;
+				return w?.backend?.video?.stats?.peek()?.frameCount ?? 0;
+			});
+			if (frames > 0) break;
+			// The watch element gives up if it subscribes to the catalog before the
+			// publisher has announced it (RESET_STREAM). If nothing has decoded by the
+			// halfway mark, reload once to re-subscribe now that the publisher is up.
+			if (!reloaded && Date.now() - start > timeoutMs / 2) {
+				reloaded = true;
+				await page.reload({ waitUntil: "load" }).catch(() => {});
+			}
+			await new Promise((r) => setTimeout(r, 250));
+		}
+		console.error(`decoded ${frames} frames from ${broadcast}`);
+		code = frames > 0 ? 0 : 1;
+	}
+} finally {
+	await browser.close().catch(() => {});
+	server.stop(true);
+}
+process.exit(code);

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -24,11 +24,17 @@ const { positionals, values } = parseArgs({
 const role = positionals[0];
 const url = values.url;
 const broadcast = values.broadcast;
-if ((role !== "publish" && role !== "subscribe") || !url || !broadcast) {
-	console.error("usage: driver.ts publish|subscribe --url U --broadcast B [--timeout S]");
+const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
+if (
+	(role !== "publish" && role !== "subscribe") ||
+	!url ||
+	!broadcast ||
+	!Number.isFinite(timeoutMs) ||
+	timeoutMs <= 0
+) {
+	console.error("usage: driver.ts publish|subscribe --url U --broadcast B [--timeout S>0]");
 	process.exit(2);
 }
-const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
 
 // Serve the prebuilt page on localhost (a secure context, so WebTransport /
 // WebCodecs are enabled).

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -1,9 +1,13 @@
-// Drives a headless Chromium (channel "chromium" for WebTransport + WebCodecs)
-// against the vite-built page (dist/). publish streams a fake camera until
-// killed; subscribe exits 0 once the watch element decodes a frame.
-//
-//   bun driver.ts publish   --url http://127.0.0.1:4443 --broadcast b.hang
-//   bun driver.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+/**
+ * Drives a headless Chromium (channel "chromium" for WebTransport + WebCodecs)
+ * against the vite-built page (dist/). publish streams a fake camera until
+ * killed; subscribe exits 0 once the watch element decodes a frame.
+ *
+ *     bun driver.ts publish   --url http://127.0.0.1:4443 --broadcast b.hang
+ *     bun driver.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+ *
+ * @module
+ */
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { chromium } from "playwright";

--- a/test/smoke/clients/js/index.html
+++ b/test/smoke/clients/js/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>moq smoke</title>
+  </head>
+  <body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/test/smoke/clients/js/package.json
+++ b/test/smoke/clients/js/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@moq/smoke-browser",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@moq/publish": "workspace:*",
+		"@moq/watch": "workspace:*"
+	},
+	"devDependencies": {
+		"esbuild": "^0.28.0",
+		"playwright": "^1.61.0",
+		"vite": "^8.0.16"
+	}
+}

--- a/test/smoke/clients/js/src/main.ts
+++ b/test/smoke/clients/js/src/main.ts
@@ -1,5 +1,9 @@
-// Browser entry point. Registers the public custom elements from the workspace
-// @moq/publish + @moq/watch packages, then runs the shared role logic.
+/**
+ * Browser entry point: register the `@moq/publish` + `@moq/watch` custom elements
+ * from the workspace, then run the shared role logic.
+ *
+ * @module
+ */
 import "@moq/publish/element";
 import "@moq/watch/element";
 import "./setup.ts";

--- a/test/smoke/clients/js/src/main.ts
+++ b/test/smoke/clients/js/src/main.ts
@@ -1,0 +1,5 @@
+// Browser entry point. Registers the public custom elements from the workspace
+// @moq/publish + @moq/watch packages, then runs the shared role logic.
+import "@moq/publish/element";
+import "@moq/watch/element";
+import "./setup.ts";

--- a/test/smoke/clients/js/src/setup.ts
+++ b/test/smoke/clients/js/src/setup.ts
@@ -1,0 +1,28 @@
+// Role logic for the browser client: read ?role= and wire up a <moq-publish> or
+// <moq-watch> element. The Playwright driver (driver.ts) polls the watch
+// element's decoded-frame stats to decide pass/fail.
+const params = new URLSearchParams(location.search);
+const role = params.get("role");
+const url = params.get("url") ?? "";
+const broadcast = params.get("broadcast") ?? "";
+
+if (role === "publish") {
+	const el = document.createElement("moq-publish");
+	el.setAttribute("url", url);
+	el.setAttribute("name", broadcast);
+	el.setAttribute("muted", ""); // video only; keep the audio encoder out of it
+	// Chromium's --use-fake-device-for-media-stream feeds getUserMedia a pattern.
+	el.setAttribute("source", "camera");
+	document.body.appendChild(el);
+} else if (role === "subscribe") {
+	const el = document.createElement("moq-watch");
+	el.setAttribute("url", url);
+	el.setAttribute("name", broadcast);
+	// A render target is what makes <moq-watch> actually subscribe to and decode
+	// the video track. @moq/publish only encodes on subscriber demand, so without
+	// this the publisher never produces frames.
+	el.appendChild(document.createElement("canvas"));
+	document.body.appendChild(el);
+} else {
+	throw new Error("missing ?role=publish|subscribe");
+}

--- a/test/smoke/clients/js/vite.config.ts
+++ b/test/smoke/clients/js/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+// @moq/publish is consumed here as workspace *source*, not the prebuilt npm
+// package, so its audio capture worklet (`./capture-worklet.ts?worklet`) is not
+// pre-inlined. The same plugin @moq/publish uses for its own build compiles and
+// inlines it as a blob URL here too.
+import { workletInline } from "../../../../js/common/vite-plugin-worklet";
+
+// esnext keeps WebCodecs / WebTransport syntax intact for headless Chromium.
+export default defineConfig({
+	plugins: [workletInline()],
+	build: { target: "esnext", outDir: "dist" },
+});

--- a/test/smoke/clients/js/vite.config.ts
+++ b/test/smoke/clients/js/vite.config.ts
@@ -1,11 +1,15 @@
+/**
+ * Vite config for the browser smoke client. `@moq/publish` is consumed here as
+ * workspace *source*, not the prebuilt npm package, so its audio capture worklet
+ * (`./capture-worklet.ts?worklet`) is not pre-inlined; the same plugin
+ * `@moq/publish` uses for its own build inlines it as a blob URL here too.
+ *
+ * @module
+ */
 import { defineConfig } from "vite";
-// @moq/publish is consumed here as workspace *source*, not the prebuilt npm
-// package, so its audio capture worklet (`./capture-worklet.ts?worklet`) is not
-// pre-inlined. The same plugin @moq/publish uses for its own build compiles and
-// inlines it as a blob URL here too.
 import { workletInline } from "../../../../js/common/vite-plugin-worklet";
 
-// esnext keeps WebCodecs / WebTransport syntax intact for headless Chromium.
+/** esnext keeps WebCodecs / WebTransport syntax intact for headless Chromium. */
 export default defineConfig({
 	plugins: [workletInline()],
 	build: { target: "esnext", outDir: "dist" },

--- a/test/smoke/clients/python/smoke.py
+++ b/test/smoke/clients/python/smoke.py
@@ -1,0 +1,106 @@
+"""Cross-language interop client for the smoke test (workspace py/moq-rs, import `moq`).
+
+publish:   read raw Annex-B H.264 from stdin (e.g. piped from ffmpeg) and feed
+           it to a streaming importer, which infers frame boundaries.
+subscribe: connect, find the video track in the catalog, and exit 0 as soon as
+           any non-empty frame arrives (exit 1 on timeout / no data).
+
+    ffmpeg ... -f h264 - | python smoke.py publish --url http://localhost:4443 --broadcast b.hang
+    python smoke.py subscribe --url http://localhost:4443 --broadcast b.hang --timeout 20
+"""
+
+import argparse
+import asyncio
+import sys
+
+import moq
+
+READ_CHUNK = 64 * 1024
+MAX_LATENCY_MS = 1_000  # subscribe_media congestion-control / lookahead window
+
+
+async def publish(url: str, broadcast: str) -> None:
+    producer = moq.BroadcastProducer()
+    media = producer.publish_media_stream("avc3")
+
+    async with moq.Client(url, tls_verify=False) as client:
+        client.publish(broadcast, producer)
+        print(f"publishing {broadcast!r} (Annex-B H.264 from stdin) to {url}")
+
+        loop = asyncio.get_running_loop()
+        stdin = sys.stdin.buffer
+        # read1 returns as soon as any bytes are available (read() would block
+        # for a full chunk and batch up ffmpeg's real-time output). getattr both
+        # keeps pyright happy (BinaryIO doesn't declare read1) and falls back if
+        # the stream lacks it.
+        read = getattr(stdin, "read1", stdin.read)
+        while True:
+            # Blocking read off the event loop so the client keeps flushing.
+            chunk = await loop.run_in_executor(None, read, READ_CHUNK)
+            if not chunk:
+                break
+            media.write(chunk)
+        media.finish()
+
+
+async def _catalog_with_video(consumer: moq.BroadcastConsumer) -> moq.Catalog:
+    # The catalog is a live track. A lazy publisher (e.g. the browser, which only
+    # encodes on demand) may announce video in a *later* update, not the first
+    # snapshot, so wait for a catalog that actually has a video track.
+    async for catalog in consumer.subscribe_catalog():
+        if catalog.video:
+            return catalog
+    raise RuntimeError("catalog stream ended without a video track")
+
+
+async def subscribe(url: str, broadcast: str, timeout: float) -> None:
+    async with moq.Client(url, tls_verify=False) as client:
+        consumer = await asyncio.wait_for(client.announced_broadcast(broadcast), timeout)
+        catalog = await asyncio.wait_for(_catalog_with_video(consumer), timeout)
+
+        track_name = next(iter(catalog.video))
+        video = catalog.video[track_name]
+
+        media = consumer.subscribe_media(track_name, video.container, MAX_LATENCY_MS)
+
+        total = 0
+
+        async def drain() -> None:
+            nonlocal total
+            async for frame in media:
+                total += len(frame.payload)
+                if total > 0:
+                    return
+
+        await asyncio.wait_for(drain(), timeout)
+
+    if total <= 0:
+        raise RuntimeError("no frame data received")
+    print(f"received {total} bytes from {broadcast!r}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("role", choices=["publish", "subscribe"])
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--broadcast", required=True)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    args = parser.parse_args()
+
+    try:
+        if args.role == "publish":
+            asyncio.run(publish(args.url, args.broadcast))
+        else:
+            asyncio.run(subscribe(args.url, args.broadcast, args.timeout))
+    except KeyboardInterrupt:
+        pass
+    except (TimeoutError, asyncio.TimeoutError):
+        print("error: timed out waiting for data", file=sys.stderr)
+        sys.exit(1)
+    except Exception as err:  # noqa: BLE001 - smoke client: any failure is a failure
+        print(f"error: {err}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -73,6 +73,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Numeric guards so a fat-fingered --timeout / SMOKE_PORT fails clearly here
+# instead of surfacing later as a cryptic `timeout` or relay-bind error.
+[[ "$TIMEOUT" =~ ^[0-9]+(\.[0-9]+)?$ ]] || {
+    echo "error: timeout must be a positive number (got '$TIMEOUT')" >&2
+    exit 2
+}
+[[ "$PORT" =~ ^[0-9]+$ ]] || {
+    echo "error: port must be numeric (got '$PORT')" >&2
+    exit 2
+}
+
 IFS=',' read -r -a PUB_LIST <<<"$PUBLISHERS"
 IFS=',' read -r -a SUB_LIST <<<"$SUBSCRIBERS"
 

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -1,0 +1,502 @@
+#!/usr/bin/env bash
+# Cross-language media interop smoke test against THIS checkout.
+#
+# Unlike the standalone moq-dev/smoke repo (which installs each client from its
+# public registry to catch packaging breakage), this builds every client from
+# the workspace source. It proves the code in the tree interoperates across
+# implementations before anything is published: a relay built from rs/moq-relay,
+# clients built from rs/moq-cli, py/, js/, and rs/libmoq, all talking to each
+# other. There's no apt/brew/npm/PyPI here, just cargo/bun/uv/cc.
+#
+# It stands up a moq-relay, then for each publisher language publishes an H.264
+# broadcast and confirms every subscriber sees data flowing (a non-empty frame
+# before the timeout). We check that bytes move end-to-end across
+# implementations, not that H.264 decodes.
+set -euo pipefail
+
+SMOKE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORKSPACE=$(cd "$SMOKE_DIR/../.." && pwd)
+CLIENTS="$SMOKE_DIR/clients"
+
+PUBLISHERS="rust"
+SUBSCRIBERS="rust"
+TIMEOUT="${SMOKE_TIMEOUT:-20}"
+FPS="${SMOKE_FPS:-30}"
+SIZE="${SMOKE_SIZE:-320x240}"
+PORT="${SMOKE_PORT:-4443}"
+URL="http://127.0.0.1:${PORT}"
+NEGATIVE=0
+
+# Cargo profile for the relay/cli/libmoq builds. Debug compiles faster, which is
+# what a smoke test wants; the workload (320x240@30) is trivial either way.
+PROFILE="${SMOKE_PROFILE:-debug}"
+
+# Binaries under test. Built from source below unless overridden to point at a
+# prebuilt (mirrors the standalone smoke repo's RELAY_BIN/MOQ_BIN escape hatch).
+RELAY="${RELAY_BIN:-}"
+MOQ="${MOQ_BIN:-}"
+
+require_value() {
+    # require_value <flag> "$@": the flag plus the rest of the argv. Ensures a
+    # non-flag value follows, so `set -u` doesn't abort on a bare `--timeout`.
+    if [[ $# -lt 2 || -z "${2:-}" || "$2" == -* ]]; then
+        echo "error: $1 requires a value" >&2
+        exit 2
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --publishers)
+            require_value "$@"
+            PUBLISHERS="$2"
+            shift 2
+            ;;
+        --subscribers)
+            require_value "$@"
+            SUBSCRIBERS="$2"
+            shift 2
+            ;;
+        --timeout)
+            require_value "$@"
+            TIMEOUT="$2"
+            shift 2
+            ;;
+        --negative)
+            NEGATIVE=1
+            shift
+            ;;
+        *)
+            echo "unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+IFS=',' read -r -a PUB_LIST <<<"$PUBLISHERS"
+IFS=',' read -r -a SUB_LIST <<<"$SUBSCRIBERS"
+
+needs() {
+    # needs <lang>: true if <lang> appears in either list.
+    local lang="$1" x
+    for x in "${PUB_LIST[@]}" "${SUB_LIST[@]}"; do [[ "$x" == "$lang" ]] && return 0; done
+    return 1
+}
+
+# True if any browser/native JS client is in play (they share one bun install).
+needs_js() {
+    needs js || needs js-native-node || needs js-native-bun
+}
+
+TMP=$(mktemp -d)
+RELAY_PID=""
+TARGET_BASE=""    # cargo target dir (resolved in require_tools)
+PY=""             # python interpreter with the workspace moq build (set in prepare)
+C_SMOKE=""        # compiled C client binary (set in prepare)
+GST_PLUGIN_DIR="" # dir holding the built moq-gst plugin (set in prepare)
+BROKEN_LANGS=""   # clients whose source build failed
+
+mark_broken() {
+    # A client whose source build fails fails only its own matrix cells instead
+    # of aborting the whole run, so one broken binding still lets the rest report.
+    BROKEN_LANGS="$BROKEN_LANGS $1"
+    echo "  WARN  $1 client unavailable: $2"
+}
+
+is_broken() {
+    local lang="$1" x
+    for x in $BROKEN_LANGS; do [[ "$x" == "$lang" ]] && return 0; done
+    return 1
+}
+
+kill_tree() {
+    # SIGKILL, depth-first. moq-cli ignores SIGTERM (handles only SIGINT), so a
+    # polite kill would leak it; these are ephemeral test processes, so -9 is fine.
+    local pid="$1" child
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do kill_tree "$child"; done
+    kill -KILL "$pid" 2>/dev/null || true
+}
+
+# shellcheck disable=SC2329  # invoked indirectly via 'trap cleanup EXIT'
+cleanup() {
+    # Reap the last publisher too; subscribers self-terminate via their timeouts.
+    [[ -n "${PUB_PID:-}" ]] && kill_tree "$PUB_PID"
+    [[ -n "$RELAY_PID" ]] && kill_tree "$RELAY_PID"
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+require_tools() {
+    # The relay, CLI, ffmpeg, and harness essentials are hard requirements. A
+    # missing per-client toolchain (uv / bun / node / cc) just marks that client
+    # broken in prepare, so it fails its own cells instead of the whole run.
+    local missing=() t
+    for t in cargo ffmpeg curl pgrep timeout; do
+        have "$t" || missing+=("$t")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "error: missing required tools: ${missing[*]}" >&2
+        exit 1
+    fi
+    # Resolve the cargo target dir once (honors a custom CARGO_TARGET_DIR, which
+    # the self-hosted CI runner sets), so the built binaries and libmoq's header
+    # are found wherever cargo actually writes them.
+    TARGET_BASE=$(cargo metadata --format-version 1 --manifest-path "$WORKSPACE/Cargo.toml" --no-deps |
+        sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+    [[ -n "$TARGET_BASE" ]] || {
+        echo "error: could not resolve cargo target directory" >&2
+        exit 1
+    }
+}
+
+# Build moq-relay + moq-cli from the workspace. The relay is the spine of the
+# test, so a failure here aborts rather than marking a single client broken.
+build_relay_cli() {
+    local flag=()
+    [[ "$PROFILE" == "release" ]] && flag=(--release)
+    echo "building moq-relay + moq-cli ($PROFILE)..."
+    # ${arr[@]+...} guard: bash 3.2 (macOS /bin/bash) errors on "${flag[@]}" for
+    # an empty (debug) array under `set -u`.
+    (cd "$WORKSPACE" && cargo build ${flag[@]+"${flag[@]}"} -p moq-relay -p moq-cli) || {
+        echo "error: failed to build moq-relay / moq-cli" >&2
+        exit 1
+    }
+    [[ -n "$RELAY" ]] || RELAY="$TARGET_BASE/$PROFILE/moq-relay"
+    # `cargo build -p moq-cli` names the binary after the crate (moq-cli); the
+    # apt/rpm packages rename it to `moq`, but from source it's moq-cli.
+    [[ -n "$MOQ" ]] || MOQ="$TARGET_BASE/$PROFILE/moq-cli"
+}
+
+# Editable-install the workspace Python build (maturin builds rs/moq-ffi, then
+# the moq-rs wrapper installs on top) into the repo-root .venv. `import moq`
+# then resolves to this checkout, not a PyPI wheel.
+prepare_python() {
+    have uv || {
+        mark_broken python "uv not found"
+        return
+    }
+    echo "building python client (workspace moq via maturin)..."
+    if (cd "$WORKSPACE" && just py build) >"$TMP/py-build.log" 2>&1; then
+        PY="$WORKSPACE/.venv/bin/python"
+        [[ -x "$PY" ]] || {
+            mark_broken python "workspace .venv python not found after build"
+            sed 's/^/        /' "$TMP/py-build.log" >&2 || true
+        }
+    else
+        mark_broken python "just py build failed"
+        sed 's/^/        /' "$TMP/py-build.log" >&2 || true
+    fi
+}
+
+# Link the JS workspace (the smoke clients are bun workspace members, so the
+# @moq/* packages resolve to this checkout's source) and build the browser page.
+prepare_js() {
+    have bun || {
+        for v in js js-native-node js-native-bun; do needs "$v" && mark_broken "$v" "bun not found"; done
+        return
+    }
+    echo "installing js clients (workspace @moq/* via bun)..."
+    if ! (cd "$WORKSPACE" && bun install) >"$TMP/js-install.log" 2>&1; then
+        for v in js js-native-node js-native-bun; do needs "$v" && mark_broken "$v" "bun install failed"; done
+        sed 's/^/        /' "$TMP/js-install.log" >&2 || true
+        return
+    fi
+    if needs js; then
+        # Nix provides Chromium via PLAYWRIGHT_BROWSERS_PATH; otherwise fetch it.
+        if [[ -z "${PLAYWRIGHT_BROWSERS_PATH:-}" ]] && ! (cd "$CLIENTS/js" && bunx playwright install chromium) >"$TMP/js-chromium.log" 2>&1; then
+            mark_broken js "playwright chromium install failed"
+            sed 's/^/        /' "$TMP/js-chromium.log" >&2 || true
+        elif ! (cd "$CLIENTS/js" && bunx vite build) >"$TMP/js-vite.log" 2>&1; then
+            mark_broken js "vite build failed"
+            sed 's/^/        /' "$TMP/js-vite.log" >&2 || true
+        fi
+    fi
+    if needs js-native-node && ! have node; then
+        mark_broken js-native-node "node not found"
+    fi
+}
+
+# Build libmoq (the C staticlib + cbindgen header) and compile the C subscriber
+# against it. cargo writes moq.h to $TARGET_BASE/include and libmoq.a to the
+# profile dir.
+prepare_c() {
+    local cc="${CC:-cc}" header lib os_libs
+    have "$cc" || {
+        mark_broken c "no C compiler ($cc) on PATH"
+        return
+    }
+    echo "building c client (workspace libmoq + cc)..."
+    local flag=()
+    [[ "$PROFILE" == "release" ]] && flag=(--release)
+    if ! (cd "$WORKSPACE" && cargo build ${flag[@]+"${flag[@]}"} -p libmoq) >"$TMP/c-build.log" 2>&1; then
+        mark_broken c "cargo build -p libmoq failed"
+        sed 's/^/        /' "$TMP/c-build.log" >&2 || true
+        return
+    fi
+    header="$TARGET_BASE/include/moq.h"
+    lib="$TARGET_BASE/$PROFILE/libmoq.a"
+    [[ -f "$header" && -f "$lib" ]] || {
+        mark_broken c "libmoq artifacts missing ($header / $lib)"
+        return
+    }
+    case "$(uname -s)" in
+        Darwin) os_libs=(-framework CoreFoundation -framework Security -framework CoreServices) ;;
+        *) os_libs=(-ldl -lm -lpthread) ;;
+    esac
+    C_SMOKE="$TMP/c-smoke"
+    if ! "$cc" "$CLIENTS/c/subscribe.c" -I"$TARGET_BASE/include" -L"$TARGET_BASE/$PROFILE" -lmoq "${os_libs[@]}" -o "$C_SMOKE" >"$TMP/c-compile.log" 2>&1; then
+        mark_broken c "cc compile failed"
+        sed 's/^/        /' "$TMP/c-compile.log" >&2 || true
+    fi
+}
+
+# Build the moq-gst plugin and confirm it loads against the GStreamer in the
+# environment. moqsrc links the host's libgstreamer, so this wants a real
+# GStreamer with the core plugins (the nix devShell ships gstreamer + base/good;
+# a bare shell without it marks gst unavailable). Sets GST_PLUGIN_DIR to the dir
+# holding libgstmoq.{so,dylib}. Subscribe only: moqsink publishing needs an
+# encoder + request-pad muxing this client doesn't drive.
+prepare_gst() {
+    have gst-launch-1.0 || {
+        mark_broken gst "gst-launch-1.0 not on PATH (needs a system GStreamer)"
+        return
+    }
+    have gst-inspect-1.0 || {
+        mark_broken gst "gst-inspect-1.0 not on PATH"
+        return
+    }
+    echo "building gstreamer client (workspace moq-gst plugin)..."
+    local flag=()
+    [[ "$PROFILE" == "release" ]] && flag=(--release)
+    if ! (cd "$WORKSPACE" && cargo build ${flag[@]+"${flag[@]}"} -p moq-gst) >"$TMP/gst-build.log" 2>&1; then
+        mark_broken gst "cargo build -p moq-gst failed"
+        sed 's/^/        /' "$TMP/gst-build.log" >&2 || true
+        return
+    fi
+    GST_PLUGIN_DIR="$TARGET_BASE/$PROFILE"
+    # gst-inspect exits 0 even when the .so fails to load, so grep for the
+    # factory. Isolate discovery to our dir + a temp registry so a system-wide moq
+    # plugin can't shadow it (mirrors rs/moq-gst/smoke.sh).
+    if ! GST_PLUGIN_PATH_1_0="$GST_PLUGIN_DIR" GST_PLUGIN_SYSTEM_PATH_1_0="" \
+        GST_REGISTRY_1_0="$TMP/gst-registry.bin" \
+        gst-inspect-1.0 moq 2>/dev/null | grep -qE '^[[:space:]]+moqsrc:'; then
+        mark_broken gst "moqsrc not exposed (plugin failed to load against this GStreamer)"
+    fi
+}
+
+# ── setup ───────────────────────────────────────────────────────────────────
+require_tools
+build_relay_cli
+
+echo "relay:   $RELAY"
+echo "moq-cli: $MOQ"
+
+needs python && prepare_python
+needs_js && prepare_js
+needs c && prepare_c
+needs gst && prepare_gst
+
+if curl -sf "$URL/certificate.sha256" >/dev/null 2>&1; then
+    echo "error: something is already listening on 127.0.0.1:${PORT} (stale relay?)" >&2
+    exit 1
+fi
+
+echo "starting relay on 127.0.0.1:${PORT}..."
+# smoke.toml is the source of truth; rewrite its port into a scratch copy so a
+# busy 4443 (a dev relay, a parallel run) doesn't require editing the committed file.
+sed "s/4443/${PORT}/g" "$SMOKE_DIR/smoke.toml" >"$TMP/relay.toml"
+"$RELAY" "$TMP/relay.toml" >"$TMP/relay.log" 2>&1 &
+RELAY_PID=$!
+for _ in $(seq 1 60); do
+    curl -sf "$URL/certificate.sha256" >/dev/null 2>&1 && break
+    sleep 0.5
+done
+if ! curl -sf "$URL/certificate.sha256" >/dev/null 2>&1; then
+    echo "relay never became ready" >&2
+    sed 's/^/  relay: /' "$TMP/relay.log" >&2 || true
+    exit 1
+fi
+
+# ── client dispatch ─────────────────────────────────────────────────────────
+# Encode an endless H.264 Annex-B stream from a synthetic source to stdout.
+# Paced with -re so the broadcast streams in real time until the reader closes.
+# Baseline + repeat-headers re-emits SPS/PPS before every keyframe so a late
+# subscriber (or the stream importer) can initialize without the first packet.
+ffmpeg_h264() {
+    ffmpeg -hide_banner -loglevel error -re -f lavfi -i "testsrc=size=${SIZE}:rate=${FPS}" \
+        -an -c:v libx264 -profile:v baseline -preset ultrafast -pix_fmt yuv420p \
+        -x264-params "keyint=${FPS}:min-keyint=${FPS}:scenecut=0:repeat-headers=1" \
+        -f h264 -
+}
+
+# Sets global PUB_PID. Called in the current shell (no command substitution) so
+# $! refers to the backgrounded job and kill_tree can reap the whole pipeline.
+# Every non-browser publisher consumes the same ffmpeg Annex-B stream on stdin;
+# the client frames it (moq-cli / the FFI importers only frame-and-forward).
+PUB_PID=""
+start_publisher() {
+    local lang="$1" broadcast="$2" log="$TMP/pub-$1.log"
+    case "$lang" in
+        rust)
+            (ffmpeg_h264 | "$MOQ" publish --url "$URL" --broadcast "$broadcast" avc3) >"$log" 2>&1 &
+            ;;
+        python)
+            (ffmpeg_h264 | "$PY" "$CLIENTS/python/smoke.py" \
+                publish --url "$URL" --broadcast "$broadcast") >"$log" 2>&1 &
+            ;;
+        js)
+            # Headless Chromium encodes its own H.264 from a fake camera via
+            # WebCodecs (lazily, once a subscriber creates demand).
+            (cd "$CLIENTS/js" && bun driver.ts publish \
+                --url "$URL" --broadcast "$broadcast") >"$log" 2>&1 &
+            ;;
+        *)
+            echo "unknown publisher: $lang" >&2
+            return 1
+            ;;
+    esac
+    PUB_PID=$!
+}
+
+# Run a native-JS subscriber and judge it by the "received N bytes" marker it
+# prints, not its exit code. The @moq/web-transport NAPI addon can segfault
+# during the runtime's exit teardown *after* a frame has arrived (an upstream bug
+# under bun), which would turn a real success into a signal exit. The data path
+# is what we test, so a printed marker is the verdict; the crash is swallowed.
+run_native() {
+    local out
+    out=$( (cd "$CLIENTS/js-native" && "$@") 2>&1) || true
+    printf '%s\n' "$out" >&2
+    printf '%s\n' "$out" | grep -q '^received '
+}
+
+run_subscriber() {
+    local lang="$1" broadcast="$2"
+    case "$lang" in
+        rust)
+            # moq-cli only handles SIGINT, so -k forces SIGKILL if it ignores the
+            # SIGTERM that fires when no data arrives within the timeout.
+            local n
+            n=$(timeout -k 3 "$TIMEOUT" "$MOQ" subscribe --url "$URL" --broadcast "$broadcast" \
+                --format fmp4 2>/dev/null | head -c 1 | wc -c | tr -d ' ' || true)
+            [[ "${n:-0}" -ge 1 ]]
+            ;;
+        python)
+            "$PY" "$CLIENTS/python/smoke.py" \
+                subscribe --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
+            ;;
+        c)
+            "$C_SMOKE" subscribe --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
+            ;;
+        gst)
+            # moqsrc exposes the broadcast's video as a Sometimes pad (video_%u);
+            # gst-launch links it to filesink once it appears. We grab one byte,
+            # the same "bytes moved" bar as the rust subscriber (no decode). head
+            # closing the pipe SIGPIPEs gst-launch, so success returns at once; no
+            # data just runs out the timeout. Our plugin dir rides on top of the
+            # system path (which provides filesink); a private registry keeps the
+            # scan off the user's cache. buffer-mode=2 makes filesink unbuffered so
+            # the first frame reaches head immediately.
+            local n
+            n=$(GST_PLUGIN_PATH_1_0="$GST_PLUGIN_DIR" GST_REGISTRY_1_0="$TMP/gst-run-registry.bin" \
+                timeout -k 3 "$TIMEOUT" gst-launch-1.0 -q \
+                moqsrc url="$URL" broadcast="$broadcast" ! filesink location=/dev/stdout buffer-mode=2 \
+                2>/dev/null | head -c 1 | wc -c | tr -d ' ' || true)
+            [[ "${n:-0}" -ge 1 ]]
+            ;;
+        js)
+            # Headless Chromium decodes via WebCodecs; exits 0 once a frame lands.
+            (cd "$CLIENTS/js" && bun driver.ts subscribe \
+                --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT")
+            ;;
+        js-native-bun)
+            # Native @moq/net via moq's WebTransport polyfill, under bun.
+            run_native bun subscribe.ts subscribe \
+                --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
+            ;;
+        js-native-node)
+            # Same, under node (tsx runs the TS directly).
+            run_native node --import tsx subscribe.ts subscribe \
+                --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT"
+            ;;
+        *)
+            echo "unknown subscriber: $lang" >&2
+            return 1
+            ;;
+    esac
+}
+
+# ── matrix ──────────────────────────────────────────────────────────────────
+overall=0
+
+run_round() {
+    local pub="$1" broadcast="$2" pub_pid="$3"
+    local pids=() names=() i sub
+    for sub in "${SUB_LIST[@]}"; do
+        if is_broken "$sub"; then
+            echo "  FAIL  $pub -> $sub (subscriber client unavailable)"
+            overall=1
+            continue
+        fi
+        (run_subscriber "$sub" "$broadcast") >"$TMP/$pub-$sub.log" 2>&1 &
+        pids+=("$!")
+        names+=("$sub")
+    done
+    # A publisher that streams forever should still be alive; if it died, the
+    # subscriber failures below are a publisher bug, so surface its log.
+    if [[ -n "$pub_pid" ]] && ! kill -0 "$pub_pid" 2>/dev/null; then
+        echo "  WARN  publisher '$pub' exited early:"
+        sed 's/^/        /' "$TMP/pub-$pub.log" 2>/dev/null || true
+    fi
+    local want_pass=1 got
+    [[ "$NEGATIVE" -eq 1 ]] && want_pass=0
+    # ${arr[@]+...} guard: a round may have no live subscribers (all broken),
+    # and bash 3.2 (macOS) errors on "${!pids[@]}" for an empty array under `set -u`.
+    for i in ${pids[@]+"${!pids[@]}"}; do
+        if wait "${pids[$i]}"; then got=1; else got=0; fi
+        if [[ "$got" -eq "$want_pass" ]]; then
+            echo "  PASS  $pub -> ${names[$i]}"
+        else
+            echo "  FAIL  $pub -> ${names[$i]}"
+            sed 's/^/        /' "$TMP/$pub-${names[$i]}.log" 2>/dev/null || true
+            overall=1
+        fi
+    done
+    if [[ -n "$pub_pid" ]]; then
+        kill_tree "$pub_pid"
+        wait "$pub_pid" 2>/dev/null || true
+        # Don't let cleanup() later signal this now-reaped (possibly recycled) PID.
+        [[ "${PUB_PID:-}" == "$pub_pid" ]] && PUB_PID=""
+    fi
+    return 0
+}
+
+if [[ "$NEGATIVE" -eq 1 ]]; then
+    # Negative control: no publisher. Every subscriber must FAIL (time out with
+    # no data), proving the harness can actually report failure.
+    echo "=== negative control: subscribers expect NO data ==="
+    run_round "none" "smoke-missing-$$-$RANDOM.hang" ""
+else
+    for pub in "${PUB_LIST[@]}"; do
+        broadcast="smoke-${pub}-$$-${RANDOM}.hang"
+        echo "=== publisher: $pub  broadcast: $broadcast ==="
+        if is_broken "$pub"; then
+            for sub in "${SUB_LIST[@]}"; do
+                echo "  FAIL  $pub -> $sub (publisher client unavailable)"
+            done
+            overall=1
+            continue
+        fi
+        start_publisher "$pub" "$broadcast"
+        run_round "$pub" "$broadcast" "$PUB_PID"
+    done
+fi
+
+if [[ "$overall" -eq 0 ]]; then
+    echo "smoke: all checks passed"
+else
+    echo "smoke: FAILURES detected" >&2
+fi
+exit "$overall"

--- a/test/smoke/smoke.toml
+++ b/test/smoke/smoke.toml
@@ -1,0 +1,18 @@
+# Relay config for the cross-language interop smoke test.
+# Anonymous access, self-signed localhost cert, QUIC + WebSocket on 127.0.0.1:4443.
+
+[log]
+level = "info"
+
+[server]
+# QUIC on UDP. 127.0.0.1 avoids IPv6 flakiness on CI runners.
+listen = "127.0.0.1:4443"
+tls.generate = ["localhost", "127.0.0.1"]
+
+[web.http]
+# HTTP + WebSocket on TCP, also serving /certificate.sha256 for cert pinning.
+listen = "127.0.0.1:4443"
+
+[auth]
+# Allow anonymous access to everything.
+public = ""


### PR DESCRIPTION
## Summary

An in-tree cross-language interop smoke test under `test/smoke/` that builds **every client from this checkout** and runs a publish × subscribe matrix against a local relay. It proves the code in the tree interoperates across implementations *before* anything is published.

This is the in-tree companion to [moq-dev/smoke](https://github.com/moq-dev/smoke): that repo installs each client from its public registry (crates.io, PyPI, npm, ...) to catch *packaging* breakage in a release; this one builds from source (`cargo`/`bun`/`uv`/`cc`/`gst`) to catch *interop* regressions in the current commit. No apt/brew/npm/PyPI, no distribution-mechanism matrix. It lives under `test/`, wired through the existing `mod test`, next to where `test/justfile` already points at the standalone repo.

## What's here

- **`test/smoke/smoke.sh`** — the orchestrator. Same matrix engine as the upstream repo (`mark_broken` isolation, `kill_tree`, negative control), but every client builds from the workspace: `cargo build` for the relay/cli/libmoq/moq-gst, `just py build` (maturin editable into `.venv`) for Python, the bun workspace for JS.
- **Clients** — rust, python, browser (vite + headless Chromium), native JS (node + bun), C (libmoq), GStreamer (`moqsrc`). Rust/python/browser publish; everyone subscribes.
- **`just test smoke`** / **`smoke-full`** / **`smoke-negative`** (in `test/justfile`).
- **`.github/workflows/smoke.yml`** — nightly + on-demand + on PRs that touch `test/smoke/`, running `just test smoke-full` inside `nix develop` on `ubuntu-latest`.
- The two JS clients join the bun workspace (`package.json` + `bun.lock`) as private members, so `@moq/*` resolve to this checkout's source. The browser page reuses the in-repo `workletInline()` vite plugin since `@moq/publish` is consumed as source.

## Why a few things look the way they do

- **GStreamer needs no extra CI setup**: the nix devShell already ships gstreamer + base/good/bad plugins, so `cargo build -p moq-gst` and `gst-launch-1.0` run against one consistent GStreamer inside `nix develop`.
- **Native-JS subscribers are judged by the `received N bytes` marker, not the exit code.** The `@moq/web-transport` NAPI addon can segfault during bun's exit teardown *after* a frame has arrived, which would turn a real success into a signal exit. The data path (frame bytes arrived) is exactly our success criterion, so the harness reads the marker; the negative control confirms it still reports failure when there's genuinely no data.

## Scope notes

- **No public API or wire changes.** Pure additive test infrastructure (the only non-test change is registering two private bun-workspace members), so this targets `main`.
- **FFI trio (go/swift/kotlin) intentionally not added.** moq-ffi's interop is already proven by the python client (`moq-rs` wraps the `moq_ffi` bindings), and each binding is built + tested by `just go/swift/kt check`. Adding them to the smoke would need toolchains absent from the devShell (`go`+`uniffi-bindgen-go`, `java`+`gradle`) and a macOS runner for swift — low marginal value. Easy to add later via `mark_broken`'s per-client isolation.

## Test plan

Verified locally on macOS via `nix develop`:

- [x] `just test smoke-full` — **21/21 PASS** (3 publishers × 7 subscribers), exit 0
- [x] `just test smoke-negative` (incl. `js-native-bun`) — every subscriber correctly fails (negative pass)
- [x] Native-JS segfault tolerance stress-tested 30/30 after the marker fix
- [x] `shfmt` / `shellcheck` / `biome` / `remark` / `actionlint` / `just --fmt` all clean
- [x] `just js check/build/test` cleanly skip the new workspace members; no build artifacts leak into git

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)