### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5553,9 +5553,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What

Bumps `quinn-proto` from 0.11.14 to 0.11.15 in `Cargo.lock` to patch **RUSTSEC-2026-0185**: a remote memory-exhaustion vulnerability (unbounded out-of-order stream reassembly) in quinn-proto 0.11.14. It reaches us purely transitively (`quinn` -> `web-transport-quinn` -> `moq-native`); no `Cargo.toml` is touched.

## Why this diff is only two lines

`cargo update -p quinn-proto --precise 0.11.15` also re-normalized a batch of unrelated entries (`windows-sys 0.61.2` down to `0.59.0`/`0.60.2` across ~12 crates, `syn 2.0.118` down to `1.0.109`). That churn is the local cargo's preferred re-resolution under `rust-version = "1.85"`, not anything the quinn-proto patch requires. A security bump should not quietly downgrade a dozen Windows-only deps, so the lockfile was hand-edited to touch only the two quinn-proto lines (version + checksum).

## Validation

- `cargo metadata --locked` accepts the lockfile as-is (0.11.15 has the same dependency set as 0.11.14, and `--locked`/`--frozen` CI builds will not demand the windows-sys churn).
- `cargo check --locked -p moq-native` compiles clean, building quinn-proto 0.11.15 through to `moq-native`.

## Branch / sync

Lockfile-only security patch that preserves public and wire behavior, so it targets `main`. The Cross-Package Sync table is N/A (no source, API, wire, or doc surface changed).

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
