### PR TITLE
fix: link macOS CoreServices for the bundled notify/FSEvents backend

### DIFF
--- a/go/moq/cgo.go
+++ b/go/moq/cgo.go
@@ -13,8 +13,8 @@ package moq
 /*
 #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/lib/linux_amd64 -lmoq_ffi -ldl -lm -lpthread
 #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/lib/linux_arm64 -lmoq_ffi -ldl -lm -lpthread
-#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/lib/darwin_amd64 -lmoq_ffi -framework Security -framework SystemConfiguration -framework CoreFoundation
-#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/lib/darwin_arm64 -lmoq_ffi -framework Security -framework SystemConfiguration -framework CoreFoundation
+#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/lib/darwin_amd64 -lmoq_ffi -framework Security -framework SystemConfiguration -framework CoreFoundation -framework CoreServices
+#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/lib/darwin_arm64 -lmoq_ffi -framework Security -framework SystemConfiguration -framework CoreFoundation -framework CoreServices
 #cgo windows,amd64 LDFLAGS: -L${SRCDIR}/lib/windows_amd64 -lmoq_ffi -lws2_32 -luserenv -lbcrypt -lntdll
 */
 import "C"

--- a/go/moq/link_test.go
+++ b/go/moq/link_test.go
@@ -1,0 +1,13 @@
+package moq
+
+import "testing"
+
+// TestLink is a link smoke test. The moq package is a cgo library, so
+// `go build ./...` compiles it without ever linking an executable. That lets a
+// missing system library in the per-platform LDFLAGS (see cgo.go) pass the
+// build and only fail when a downstream consumer links a binary, off-platform
+// from CI. `go test` does link a real test binary against the static archive,
+// and the package's generated init references the FFI symbols, so the archive
+// and its transitive system deps (e.g. CoreServices, which the bundled
+// FSEvents backend needs on macOS) are pulled in and resolved here instead.
+func TestLink(t *testing.T) {}

--- a/rs/libmoq/CMakeLists.txt
+++ b/rs/libmoq/CMakeLists.txt
@@ -54,7 +54,7 @@ target_link_libraries(moq INTERFACE "${RUST_LIB}")
 
 # Link required system frameworks on macOS
 if(APPLE)
-    target_link_options(moq INTERFACE "LINKER:-framework,CoreFoundation" "LINKER:-framework,Security")
+    target_link_options(moq INTERFACE "LINKER:-framework,CoreFoundation" "LINKER:-framework,Security" "LINKER:-framework,CoreServices")
 endif()
 
 # System libraries Rust std/deps pull in on Windows (from

--- a/rs/libmoq/cmake/moq-config.cmake.in
+++ b/rs/libmoq/cmake/moq-config.cmake.in
@@ -25,7 +25,7 @@ if(NOT TARGET moq::moq)
     # Link required system frameworks on macOS
     if(APPLE)
         set_property(TARGET moq::moq APPEND PROPERTY
-            INTERFACE_LINK_LIBRARIES "-framework CoreFoundation" "-framework Security"
+            INTERFACE_LINK_LIBRARIES "-framework CoreFoundation" "-framework Security" "-framework CoreServices"
         )
     endif()
 


### PR DESCRIPTION
## Summary

The Go bindings (`github.com/moq-dev/moq-go`) and any C/CMake consumer of `libmoq` failed to link on macOS with undefined `_FSEventStream*` / `_FSEvents*` symbols:

```
Undefined symbols for architecture arm64:
  "_FSEventStreamCreate", referenced from:
      notify::fsevent::FsEventWatcher::run ... in libmoq_ffi.a
  ...
ld: symbol(s) not found for architecture arm64
```

**Root cause:** `moq-native`'s default features enable `quinn`, which implies the `watch` feature and pulls in `notify`. Both `moq-ffi` and `libmoq` link `moq-native` with default features, so `libmoq_ffi.a` and `libmoq.a` bundle `notify`'s FSEvents backend. Those symbols live in the macOS **CoreServices** framework, which the Go cgo flags and the libmoq CMake config did not link. Only `build.rs`'s pkg-config already listed it (`rs/libmoq/build.rs:33`), so the three link configs were inconsistent. Linux uses inotify and needs no extra framework, which is why the Linux-only CI never caught it.

## Changes

- **`go/moq/cgo.go`**: add `-framework CoreServices` to both `darwin,amd64` and `darwin,arm64` LDFLAGS.
- **`rs/libmoq/CMakeLists.txt`** + **`rs/libmoq/cmake/moq-config.cmake.in`**: add CoreServices, bringing the CMake / `find_package(moq)` path in line with `build.rs`. Confirmed `libmoq.a` carries the same undefined FSEvents symbols.
- **`go/moq/link_test.go`**: a link smoke test. `go build ./...` compiles the cgo library but never links a binary, so a missing framework slips through compilation; `go test ./...` (already run by `go/scripts/check.sh`) now links a real test binary and surfaces it.

## Test plan

- [x] `nm` confirms `libmoq_ffi.a` and `libmoq.a` both carry the 9 undefined `_FSEvent*` symbols.
- [x] On darwin/arm64, a consumer binary **fails** to link without the framework (exact bug-report error) and **links + runs** with it.
- [x] `just go check` green; the new `link_test.go` is staged and `go test ./...` passes. A/B confirmed the test fails the build without CoreServices and passes with it.
- [x] Swift checked (`just swift check`): unaffected, links and tests pass without declaring the framework (Apple-toolchain autolink). Kotlin/Python load the dynamic lib (rustc links it self-contained), so they are unaffected.

Targets `main`: a build/link fix, with no public API or wire-protocol change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
