### PR TITLE
fix(moq-net): enforce MAX_FRAME_SIZE at the frame allocation chokepoint

### DIFF
--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, hash_map::Entry};
 use std::sync::Arc;
 
 use crate::{
-	BroadcastDynamic, BroadcastInfo, Error, Frame, FrameProducer, Group, GroupProducer, MAX_FRAME_SIZE, OriginProducer,
-	OriginPublish, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer, TrackRequest,
+	BroadcastDynamic, BroadcastInfo, Error, Frame, FrameProducer, Group, GroupProducer, OriginProducer, OriginPublish,
+	Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer, TrackRequest,
 	coding::{Reader, Stream},
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
 	model::BroadcastProducer,
@@ -826,9 +826,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					return Err(Error::Unsupported);
 				}
 			} else {
-				if size > MAX_FRAME_SIZE {
-					return Err(Error::FrameTooLarge);
-				}
+				// `create_frame` is the allocation chokepoint and rejects an oversized
+				// `size` before allocating, so no pre-check is needed.
 				let mut frame = producer.create_frame(Frame { size, timestamp: None })?;
 				track_stats.frame();
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -642,12 +642,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let Some(size) = stream.decode_maybe::<u64>().await? else {
 				break;
 			};
-			if size > MAX_FRAME_SIZE {
-				return Err(Error::FrameTooLarge);
-			}
 
 			match compression {
 				Compression::None => {
+					// `create_frame` is the allocation chokepoint and rejects an
+					// oversized `size` before allocating, so no pre-check is needed.
 					let mut frame = group.create_frame(Frame { size, timestamp })?;
 					track_stats.frame();
 
@@ -659,8 +658,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					frame.finish()?;
 				}
 				compression => {
-					// `size` is the compressed length; pull it off the wire, then
-					// inflate. The frame the consumer sees carries the original size.
+					// Here `size` is the compressed wire length, not the frame size, so
+					// it never reaches the `create_frame` chokepoint. Bound it directly
+					// so a peer can't make us buffer an unbounded blob before decoding.
+					if size > MAX_FRAME_SIZE {
+						return Err(Error::FrameTooLarge);
+					}
+					// Pull the compressed bytes off the wire, then inflate. The frame
+					// the consumer sees carries the original (decompressed) size.
 					let packed = stream.read_exact(size as usize).await?;
 					track_stats.frame();
 					track_stats.bytes(size);

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -7,19 +7,18 @@ use bytes::{BufMut, Bytes};
 
 use crate::{Error, Result, Timestamp};
 
-/// Maximum payload size accepted for a single frame on the wire.
+/// Maximum payload size accepted for a single frame.
 ///
 /// The receive path preallocates a buffer from the declared frame size, so an
 /// untrusted peer could otherwise request a multi-gigabyte allocation with a
-/// single varint. Subscribers reject frames whose declared size exceeds this.
+/// single varint. [`FrameProducer::new`] enforces this for every frame: it's the
+/// sole allocation chokepoint (reached via [`Frame::produce`] and
+/// [`crate::GroupProducer::create_frame`]) and rejects an oversized declared size
+/// with [`Error::FrameTooLarge`] before allocating.
 ///
 /// Matches the per-group cache cap (`MAX_GROUP_CACHE`), so a single frame may fill
 /// a group. 16 MiB was too tight for a high-bitrate CMAF fragment carried as one
 /// frame; 32 MiB covers that while keeping the per-frame preallocation bounded.
-///
-// TODO enforce this in [Frame::produce] / [FrameProducer::new] so the limit is
-// guaranteed for every caller, not just the wire decode paths. Blocked on
-// making the constructor fallible (returning [Result]), which is an API break.
 pub(crate) const MAX_FRAME_SIZE: u64 = 32 * 1024 * 1024;
 
 /// A chunk of data with an upfront size and optional presentation timestamp.
@@ -46,8 +45,9 @@ impl Frame {
 	///
 	/// Crate-private: frames are only constructed via
 	/// [`crate::GroupProducer::create_frame`], which validates the timestamp
-	/// against the parent track's timescale.
-	pub(crate) fn produce(self) -> FrameProducer {
+	/// against the parent track's timescale. Returns [`Error::FrameTooLarge`] if the
+	/// declared [`Frame::size`] exceeds [`MAX_FRAME_SIZE`].
+	pub(crate) fn produce(self) -> Result<FrameProducer> {
 		FrameProducer::new(self)
 	}
 }
@@ -196,13 +196,20 @@ impl std::ops::Deref for FrameProducer {
 
 impl FrameProducer {
 	/// Create a new frame producer for the given frame header.
-	pub(crate) fn new(info: Frame) -> Self {
+	///
+	/// The single allocation chokepoint: rejects a frame whose declared
+	/// [`Frame::size`] exceeds [`MAX_FRAME_SIZE`] with [`Error::FrameTooLarge`]
+	/// before allocating the (untrusted) buffer.
+	pub(crate) fn new(info: Frame) -> Result<Self> {
+		if info.size > MAX_FRAME_SIZE {
+			return Err(Error::FrameTooLarge);
+		}
 		let buf = FrameBuf::new(info.size as usize);
-		Self {
+		Ok(Self {
 			info,
 			state: kio::Producer::new(FrameState::default()),
 			buf,
-		}
+		})
 	}
 
 	/// Write a chunk of data to the frame.
@@ -471,7 +478,8 @@ mod test {
 			size: 5,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		producer.write(Bytes::from_static(b"hello")).unwrap();
 		producer.finish().unwrap();
 
@@ -486,7 +494,8 @@ mod test {
 			size: 10,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		producer.write(Bytes::from_static(b"hello")).unwrap();
 		producer.write(Bytes::from_static(b"world")).unwrap();
 		producer.finish().unwrap();
@@ -502,7 +511,8 @@ mod test {
 			size: 10,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		producer.write(Bytes::from_static(b"hello")).unwrap();
 		// Each read_chunk returns whatever is new since the last call,
 		// which may span multiple writes.
@@ -525,7 +535,8 @@ mod test {
 			size: 10,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		producer.write(Bytes::from_static(b"hello")).unwrap();
 		producer.write(Bytes::from_static(b"world")).unwrap();
 		producer.finish().unwrap();
@@ -542,7 +553,8 @@ mod test {
 			size: 5,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		producer.write(Bytes::from_static(b"hi")).unwrap();
 		let err = producer.finish().unwrap_err();
 		assert!(matches!(err, Error::WrongSize));
@@ -554,9 +566,22 @@ mod test {
 			size: 3,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		let err = producer.write(Bytes::from_static(b"toolong")).unwrap_err();
 		assert!(matches!(err, Error::WrongSize));
+	}
+
+	#[test]
+	fn rejects_oversized_frame() {
+		// The allocation chokepoint refuses an oversized declared size before any
+		// buffer is allocated, so a single varint can't request a huge allocation.
+		let result = Frame {
+			size: MAX_FRAME_SIZE + 1,
+			timestamp: None,
+		}
+		.produce();
+		assert!(matches!(result, Err(Error::FrameTooLarge)));
 	}
 
 	#[test]
@@ -565,7 +590,8 @@ mod test {
 			size: 5,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		let mut consumer = producer.consume();
 		producer.abort(Error::Cancel).unwrap();
 
@@ -579,7 +605,8 @@ mod test {
 			size: 0,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
@@ -593,7 +620,8 @@ mod test {
 			size: 5,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		let mut consumer = producer.consume();
 
 		// Consumer blocks because no data yet.
@@ -613,7 +641,8 @@ mod test {
 			size: 12,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		assert_eq!(producer.remaining_mut(), 12);
 		producer.put_slice(b"hello");
 		assert_eq!(producer.remaining_mut(), 7);
@@ -633,7 +662,8 @@ mod test {
 			size: 4,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		// Safety violation on purpose: cnt > remaining_mut().
 		unsafe { producer.advance_mut(5) };
 	}
@@ -644,7 +674,8 @@ mod test {
 			size: 6,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		let mut consumer = producer.consume();
 
 		producer.write(Bytes::from_static(b"foo")).unwrap();
@@ -668,7 +699,8 @@ mod test {
 			size: 10,
 			timestamp: None,
 		}
-		.produce();
+		.produce()
+		.unwrap();
 		let mut c1 = producer.consume();
 		producer.write(Bytes::from_static(b"hello")).unwrap();
 

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -197,9 +197,12 @@ impl GroupProducer {
 		Ok(())
 	}
 
-	/// Create a frame with an upfront size
+	/// Create a frame with an upfront size.
+	///
+	/// Returns [`Error::FrameTooLarge`] if the declared size exceeds the per-frame
+	/// limit, refused before the buffer is allocated.
 	pub fn create_frame(&mut self, info: impl Into<Frame>) -> Result<FrameProducer> {
-		let frame = info.into().produce();
+		let frame = info.into().produce()?;
 		self.append_frame(frame.clone())?;
 		Ok(frame)
 	}
@@ -741,5 +744,14 @@ mod test {
 		let mut writer = producer.create_frame(frame).unwrap();
 		writer.write(Bytes::from_static(b"x")).unwrap();
 		writer.finish().unwrap();
+	}
+
+	/// The per-frame size cap is enforced at allocation, so create_frame surfaces
+	/// it as FrameTooLarge before allocating the buffer.
+	#[test]
+	fn create_frame_rejects_oversized() {
+		let mut producer = Group { sequence: 0 }.produce();
+		let result = producer.create_frame(crate::MAX_FRAME_SIZE + 1);
+		assert!(matches!(result, Err(Error::FrameTooLarge)));
 	}
 }


### PR DESCRIPTION
## Summary

Make the frame producer construction fallible so `MAX_FRAME_SIZE` is enforced at the allocation chokepoint, not just on the wire-decode paths.

`FrameProducer::new` is the only place that allocates the declared frame size (`vec![0u8; size]`). It now checks `size > MAX_FRAME_SIZE` and returns `Error::FrameTooLarge` before allocating, making it the single chokepoint. A direct caller can no longer allocate an attacker-controlled size before any check.

- `FrameProducer::new(info) -> Result<Self>` (was `-> Self`): the size guard lives here, before the allocation.
- `Frame::produce(self) -> Result<FrameProducer>` (was `-> FrameProducer`).
- `GroupProducer::create_frame` becomes `info.into().produce()?`; its doc notes the `FrameTooLarge` path.
- IETF subscriber pre-check removed (now redundant); lite subscriber's check relocated into the compression branch (see below).
- `MAX_FRAME_SIZE` doc updated; the old TODO pointing at this follow-up is gone.
- Added a reject test at both the frame and group layers.

## Notes / deviations from the deferring PR

This was deferred from #1870, which was based on `main`. `dev` has since moved, so two things differ from that PR's framing:

1. **Not a public API break on `dev`.** `Frame::produce` and `FrameProducer::new` are already `pub(crate)` here (from the per-frame timestamp work), and `From<Frame> for FrameProducer` is already gone. `create_frame` / `append_frame` keep their existing `Result` signatures, so this is an internal change that only tightens `create_frame`'s behavior (oversized now returns the existing `FrameTooLarge` variant). There were also no `create_frame` / `append_frame` size checks to remove (those are `main`/#1870-only). Targeting `dev` anyway, per the original instruction and because it builds on the dev-only frame/compression code.

2. **The lite compression path keeps its bound.** In `lite/subscriber.rs` the compression branch reads `size` as the *compressed* wire length and feeds it to `read_exact(size)`, which never reaches `produce()`. Removing that check outright would reintroduce an unbounded read, so it was moved into the compression branch; the uncompressed path now relies on the `produce()` chokepoint. The IETF path has no compression branch, so its check was purely redundant and was removed (along with its now-unused `MAX_FRAME_SIZE` import).

## Test plan

Run via `nix develop` (pinned toolchain):

- [x] `just rs check` (cargo check, clippy `-D warnings`, fmt `--check`, doc `-D warnings`, shear, sort)
- [x] `cargo test -p moq-net` — 398 unit + doctests pass, incl. new `rejects_oversized_frame` / `create_frame_rejects_oversized`
- [x] `cargo test -p moq-native -p hang -p moq-mux -p moq-relay` — all pass

## Cross-package sync

No `js/net` or `doc/concept` changes: the wire format and public API are unchanged. This is a receiver-side allocation guard only.

(Written by Claude)
