### PR TITLE
fix(moq-net): bound frame size in create_frame/append_frame

### DIFF
--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -17,9 +17,11 @@ use crate::{Error, Result};
 /// a group. 16 MiB was too tight for a high-bitrate CMAF fragment carried as one
 /// frame; 32 MiB covers that while keeping the per-frame preallocation bounded.
 ///
-// TODO enforce this in [Frame::produce] / [FrameProducer::new] so the limit is
-// guaranteed for every caller, not just the wire decode paths. Blocked on
-// making the constructor fallible (returning [Result]), which is an API break.
+/// Enforced on the wire decode (above) and in
+/// [`GroupProducer::create_frame`](super::group::GroupProducer::create_frame), which rejects an
+/// oversized frame *before* `produce()` allocates its buffer. A direct `FrameProducer::new` still
+/// allocates ahead of the [`append_frame`](super::group::GroupProducer::append_frame) backstop;
+/// closing that gap means a fallible constructor, which is a breaking change left to a separate `dev` PR.
 pub(crate) const MAX_FRAME_SIZE: u64 = 32 * 1024 * 1024;
 
 /// A chunk of data with an upfront size.

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -12,7 +12,7 @@ use std::task::{Poll, ready};
 
 use bytes::Bytes;
 
-use crate::{Error, Result};
+use crate::{Error, MAX_FRAME_SIZE, Result};
 
 use super::{Frame, FrameConsumer, FrameProducer};
 
@@ -179,6 +179,11 @@ impl GroupProducer {
 
 	/// Create a frame with an upfront size
 	pub fn create_frame(&mut self, info: Frame) -> Result<FrameProducer> {
+		// Reject before `produce()`: `FrameProducer::new` preallocates `size` bytes, so an oversized
+		// frame must be caught here or it triggers the very allocation the limit exists to prevent.
+		if info.size > MAX_FRAME_SIZE {
+			return Err(Error::FrameTooLarge);
+		}
 		let frame = info.produce();
 		self.append_frame(frame.clone())?;
 		Ok(frame)
@@ -186,6 +191,11 @@ impl GroupProducer {
 
 	/// Append a frame producer to the group.
 	pub fn append_frame(&mut self, frame: FrameProducer) -> Result<()> {
+		// Backstop for direct callers (the buffer is already allocated by the time we hold a
+		// FrameProducer); `create_frame` is the path that rejects before allocating.
+		if frame.size > MAX_FRAME_SIZE {
+			return Err(Error::FrameTooLarge);
+		}
 		let mut state = modify(&self.state)?;
 		if state.fin {
 			return Err(Error::Closed);
@@ -439,6 +449,20 @@ mod test {
 		let chunks = consumer.read_frame_chunks().now_or_never().unwrap().unwrap().unwrap();
 		assert_eq!(chunks.len(), 1);
 		assert_eq!(chunks[0], Bytes::from_static(b"helloworld"));
+	}
+
+	#[test]
+	fn append_rejects_oversized_frame() {
+		let mut producer = Group { sequence: 0 }.produce();
+		let err = producer.create_frame(Frame {
+			size: MAX_FRAME_SIZE + 1,
+		});
+		assert!(
+			matches!(err, Err(Error::FrameTooLarge)),
+			"a frame over the limit is rejected"
+		);
+		// A frame at the limit is still accepted.
+		assert!(producer.create_frame(Frame { size: MAX_FRAME_SIZE }).is_ok());
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

Bound the declared frame size at the `GroupProducer` level so an oversized frame is rejected before `FrameProducer::new` preallocates its buffer.

- `create_frame` rejects `size > MAX_FRAME_SIZE` with `Error::FrameTooLarge` *before* `produce()` allocates.
- `append_frame` carries the same check as a backstop for direct callers (the buffer is already allocated by then, but it keeps an oversized frame out of the group cache).
- `MAX_FRAME_SIZE` doc updated to describe where the limit is enforced and the remaining `FrameProducer::new` gap.
- Test: `append_rejects_oversized_frame` (over the limit rejected, at the limit accepted).

This is **non-breaking**: `create_frame` / `append_frame` already return `Result`, and `FrameTooLarge` is an existing `#[non_exhaustive]` variant. It guarantees the limit for local callers, not just the wire-decode paths (which already checked).

## Relationship to other PRs

- **Extracted verbatim from [#1870](https://github.com/moq-dev/moq/pull/1870)** (the moqsink GstAggregator rewrite), which currently bundles this guard. The `frame.rs` / `group.rs` hunks here are byte-identical to #1870's, so once this lands #1870 can rebase and those hunks drop out cleanly. **#1870 should drop its copy** (or just rebase) to avoid a conflict.
- The breaking follow-up that makes `FrameProducer::new` itself fallible (closing the direct-constructor gap, the true single chokepoint) is **[#1881](https://github.com/moq-dev/moq/pull/1881)**, on `dev`. This PR is the non-breaking guard for `main`.

## Test plan

Run via `nix develop`:

- [x] `just rs check` (check, clippy `-D warnings`, fmt `--check`, doc `-D warnings`, shear, sort)
- [x] `cargo test -p moq-net` — 347 unit + doctests pass, incl. new `append_rejects_oversized_frame`
- [x] `cargo test -p moq-native -p hang -p moq-mux -p moq-relay` — all pass

## Cross-package sync

None needed: the wire format and public API signatures are unchanged.

(Written by Claude)
