### PR TITLE
fix(moq-relay): serve the WebSocket fallback at the root path

### DIFF
--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -131,10 +131,18 @@ impl Web {
 			.route("/announced/{*prefix}", get(serve_announced))
 			.route("/fetch/{*path}", get(serve_fetch));
 
-		// If WebSocket is enabled, add the WebSocket route.
+		// If WebSocket is enabled, add the WebSocket route. Both `/` and
+		// `/{*path}` map to the same handler so a client that dials a bare
+		// `host:port` with no path (e.g. `moqsink url="https://host:4443"`)
+		// still gets a WebSocket upgrade at the empty (root) auth scope. Without
+		// the root route, axum's wildcard never matches `/`, the request falls
+		// through to the landing page, and the client's WS fallback is silently
+		// dead.
 		#[cfg(feature = "websocket")]
 		let app = match self.config.ws {
-			true => app.route("/{*path}", axum::routing::any(crate::websocket::serve_ws)),
+			true => app
+				.route("/", axum::routing::any(crate::websocket::serve_ws))
+				.route("/{*path}", axum::routing::any(crate::websocket::serve_ws)),
 			false => app,
 		};
 

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -8,8 +8,7 @@ use std::{
 
 use axum::{
 	extract::{
-		Extension, Path, Query, State, WebSocketUpgrade,
-		rejection::{PathRejection, QueryRejection},
+		Extension, Path, Query, State, WebSocketUpgrade, rejection::QueryRejection,
 		ws::rejection::WebSocketUpgradeRejection,
 	},
 	http::StatusCode,
@@ -21,16 +20,20 @@ use crate::{AuthParams, AuthToken, WebState, web::AuthQuery, web::MtlsPeer, web:
 
 pub(crate) async fn serve_ws(
 	ws: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
-	path: Result<Path<String>, PathRejection>,
+	path: Option<Path<String>>,
 	query: Result<Query<AuthQuery>, QueryRejection>,
 	mtls: Option<Extension<MtlsPeer>>,
 	State(state): State<Arc<WebState>>,
 ) -> axum::response::Result<Response> {
 	// If this isn't a WebSocket upgrade (e.g. a plain browser visit), serve
 	// the informational landing page instead of an error response.
-	let (Ok(ws), Ok(Path(path)), Ok(Query(query))) = (ws, path, query) else {
+	let (Ok(ws), Ok(Query(query))) = (ws, query) else {
 		return Ok(landing_response());
 	};
+
+	// The `/{*path}` route captures the path; the bare `/` route captures none,
+	// which is the empty (root) auth scope. Mirrors `serve_announced`.
+	let path = path.map_or_else(String::new, |Path(path)| path);
 
 	// Advertise the full qmux × moq-net subprotocol matrix, with bare qmux
 	// fallbacks last. axum picks the first entry that the client also offered,

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -185,6 +185,71 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	web_handle.abort();
 }
 
+/// A client that dials a bare `host:port` with no path must still get a
+/// WebSocket upgrade at the root, not the landing page. The empty path is the
+/// root auth scope (same as the internal listener). Regression for the
+/// `/{*path}`-only route, which left bare-URL clients (e.g.
+/// `moqsink url="https://host:4443"`) with a silently dead WS fallback.
+#[tokio::test]
+async fn relay_websocket_root_path_upgrades() {
+	let (port, web_handle) = spawn_relay().await;
+	// No path: the URL is just host:port, so the WS handshake targets "/".
+	let url: url::Url = format!("ws://127.0.0.1:{port}").parse().expect("parse url");
+
+	// ── publisher ───────────────────────────────────────────────────
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	let mut track = broadcast.create_track(Track::new("video")).expect("create track");
+	let mut group = track.append_group().expect("append group");
+	group.write_frame(b"hello".as_ref()).expect("write frame");
+	group.finish().expect("finish group");
+
+	let pub_session = tokio::time::timeout(
+		TIMEOUT,
+		client().with_publish(pub_origin.consume()).connect(url.clone()),
+	)
+	.await
+	.expect("publisher connect timeout")
+	.expect("publisher connect failed (root-path WS upgrade)");
+
+	// ── subscriber ──────────────────────────────────────────────────
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume();
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_consume(sub_origin).connect(url))
+		.await
+		.expect("subscriber connect timeout")
+		.expect("subscriber connect failed (root-path WS upgrade)");
+
+	// ── data path ───────────────────────────────────────────────────
+	// The root auth scope is the empty path, so the broadcast announces at its
+	// own name with no prefix.
+	let (path, bc) = tokio::time::timeout(TIMEOUT, announcements.announced())
+		.await
+		.expect("announcement timeout")
+		.expect("origin closed");
+	assert_eq!(path.as_str(), "test");
+	let bc = bc.expect("expected announce, got unannounce");
+
+	let mut track_sub = bc.subscribe_track(&Track::new("video")).expect("subscribe_track");
+	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
+		.await
+		.expect("recv_group timeout")
+		.expect("recv_group failed")
+		.expect("track closed prematurely");
+	let frame = tokio::time::timeout(TIMEOUT, group_sub.read_frame())
+		.await
+		.expect("read_frame timeout")
+		.expect("read_frame failed")
+		.expect("group closed prematurely");
+	assert_eq!(&*frame, b"hello");
+
+	drop(track);
+	drop(broadcast);
+	drop(pub_session);
+	drop(sub_session);
+	web_handle.abort();
+}
+
 /// Two publish-only clients (each `with_publish`, no `with_consume`) coexist on one relay;
 /// a single subscriber sees broadcasts forwarded from both. Verifies that multiple
 /// publish-only connections don't interfere with each other or get torn down.


### PR DESCRIPTION
## Summary

The relay only routed the WebSocket upgrade at `/{*path}`, an axum/matchit catch-all that **does not match the bare root `/`**. A client that dials a bare `host:port` with no path (e.g. `moqsink url="https://host:4443"`) had its WebSocket handshake fall through to `.fallback(serve_landing)` and receive a `404 + HTML landing page` instead of a `101 Switching Protocols`. The WebSocket fallback was therefore **silently dead** for bare-host URLs.

WebTransport over QUIC was unaffected: it takes a completely separate code path (`server.accept()` → `connection.rs` → `AuthParams::from_url`) that has no path *routing* and already maps `/` to the empty root scope. So we assume both transports are served at the root, but only WebTransport actually was.

## What changed

- **`web.rs`**: register `serve_ws` at both `/` and `/{*path}`.
- **`websocket.rs`**: switch the path extractor from `Result<Path<String>, PathRejection>` to `Option<Path<String>>`, defaulting `None` (the captureless root route) to `""`. Adding the route alone isn't enough: `Path<String>` extraction *fails* on a route with no `{path}` capture, so a root upgrade would still bail to the landing page. This mirrors the existing `serve_announced` dual-route idiom (`/announced` and `/announced/{*prefix}`) and matches the QUIC side's `/` → `""` mapping.
- **`smoke.rs`**: new `relay_websocket_root_path_upgrades` test that round-trips a frame over `ws://host:port` (no path) through the real router.

| Transport | path `/` → scope | Before | After |
|---|---|---|---|
| WebTransport (QUIC) | `""` | ✅ works | ✅ works |
| WebSocket (axum) | `""` | ❌ 404 landing | ✅ upgrades |

Browser GETs to `/` are unchanged: `serve_ws` returns `landing_response()` for any non-upgrade request, which is byte-identical to the old `serve_landing` fallback.

## Context

Found while investigating a customer report (gst `moqsink` works against a `0.11.3` relay but not `0.12.12`). Their `moqsink url=` has no path, so when QUIC has trouble the WebSocket fallback can't upgrade. This route gap is the same on both versions (not the `0.11.3` → `0.12.12` regression itself), but it's a real footgun: a bare-host client has no working fallback. The underlying "why does their QUIC fail on `0.12.12`" question is still open and needs the customer's full logs / relay config.

## API / wire impact

None. `serve_ws` is `pub(crate)`; no public API, config flag, or wire behavior changes. Targets `main` per the branch-targeting rules (small additive bug fix, preserves wire/public behavior).

## Test plan

- [x] `cargo test -p moq-relay --test smoke` — 6/6 pass (incl. new root-path test)
- [x] `cargo test -p moq-relay --lib` — 125/125 pass (incl. existing `serve_ws` websocket tests)
- [x] `cargo clippy -p moq-relay --all-targets` (nix toolchain) clean; `cargo fmt` applied
- [x] Manually verified with the customer's exact client (old `moq-clock` built from `7eeb3195`): WebSocket + empty path went BROKEN → WORKS; with-path case still works

(Written by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)