### PR TITLE
fix(moq-mux): begin TS export at the first video keyframe

### DIFF
--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -405,9 +405,12 @@ mod tests {
 			.tracks
 			.insert(section.name().to_string(), section_track);
 		let mut section_producer = Producer::new(section, Container::Legacy);
+		// bbb's first video keyframe is at 1.4 s; stamp the ancillary streams just after
+		// it so they clear the export's keyframe alignment (anything before the first
+		// keyframe is dropped on tune-in).
 		section_producer
 			.write(Frame {
-				timestamp: Timestamp::from_millis(40).unwrap(),
+				timestamp: Timestamp::from_millis(1410).unwrap(),
 				duration: None,
 				payload: bytes::Bytes::from_static(CUE),
 				keyframe: true,
@@ -432,7 +435,7 @@ mod tests {
 		let mut pes_producer = Producer::new(pes, Container::Legacy);
 		pes_producer
 			.write(Frame {
-				timestamp: Timestamp::from_millis(40).unwrap(),
+				timestamp: Timestamp::from_millis(1410).unwrap(),
 				duration: None,
 				payload: bytes::Bytes::from_static(PES_PAYLOAD),
 				keyframe: true,

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -68,6 +68,18 @@ pub struct Export<E: catalog::Catalog = ()> {
 	psi: Option<Psi>,
 	/// Media timestamp of the last PAT/PMT emission.
 	last_psi: Option<Timestamp>,
+	/// Tune-in point: the first video keyframe's timestamp, captured when the program
+	/// tables are built. Non-video frames before it are dropped so the keyframe leads
+	/// the stream.
+	///
+	/// MPEG-TS carries the H.264/H.265 parameter sets in-band on the keyframe (unlike
+	/// RTMP/CMAF, which carry the codec config out-of-band in the header). On a
+	/// mid-stream join the audio source can start over a second before the oldest
+	/// cached video keyframe; emitting that lead audio first would bury the parameter
+	/// sets behind an audio-only preamble, and a live decoder probing the stream gives
+	/// up before it ever configures video. `None` until the tables are built, and for
+	/// programs with no video track (nothing to align to).
+	video_start: Option<Timestamp>,
 }
 
 struct Track {
@@ -180,6 +192,7 @@ impl<E: catalog::Catalog> Export<E> {
 			program_descriptors: Vec::new(),
 			psi: None,
 			last_psi: None,
+			video_start: None,
 		})
 	}
 
@@ -221,14 +234,23 @@ impl<E: catalog::Catalog> Export<E> {
 		// can't use them, and parking them would stop us polling for the keyframe
 		// that carries the parameter sets.
 		let waiting_for_header = self.psi.is_none();
+		let video_start = self.video_start;
 		for track in self.tracks.values_mut() {
 			if track.pending.is_some() || track.finished {
 				continue;
 			}
+			let is_video = matches!(track.kind, Kind::Video(_));
 			loop {
 				match track.source.poll_read(waiter) {
 					Poll::Ready(Ok(Some(frame))) => {
 						if waiting_for_header && !track.source.header_ready() {
+							continue;
+						}
+						// Tune-in alignment: drop non-video frames before the first video
+						// keyframe (see `video_start`) so the in-band SPS/PPS leads the stream.
+						if let Some(start) = video_start
+							&& !is_video && frame.timestamp < start
+						{
 							continue;
 						}
 						track.pending = Some(frame);
@@ -256,15 +278,30 @@ impl<E: catalog::Catalog> Export<E> {
 				}
 				return Poll::Pending;
 			}
-			if !self.header_ready() {
-				// Still waiting on codec configs. If every track finished without
-				// producing one, the broadcast can't be muxed.
+			if !self.header_ready() || !self.video_ready() {
+				// Hold all output (tables and audio alike) until codec configs resolve
+				// and, when the program has a video rendition, its first keyframe is
+				// buffered: the stream must begin on that keyframe so the in-band
+				// parameter sets lead it. An audio-only program has nothing to wait for.
+				// If every track finished without producing a config, it can't be muxed.
 				if self.catalog.is_none() && self.tracks.values().all(|t| t.finished) {
 					return Poll::Ready(Ok(None));
 				}
 				return Poll::Pending;
 			}
 			self.build_psi()?;
+			// Anchor tune-in to the first video keyframe and drop any non-video frame
+			// already buffered ahead of it (see `video_start`).
+			self.video_start = self.first_video_pts();
+			if let Some(start) = self.video_start {
+				for track in self.tracks.values_mut() {
+					if !matches!(track.kind, Kind::Video(_))
+						&& track.pending.as_ref().is_some_and(|f| f.timestamp < start)
+					{
+						track.pending = None;
+					}
+				}
+			}
 		}
 
 		// 4. Emit the smallest-timestamp pending frame as a PES packet (the first
@@ -447,6 +484,28 @@ impl<E: catalog::Catalog> Export<E> {
 	/// codec config (from the catalog `description`, or built by the transform).
 	fn header_ready(&self) -> bool {
 		self.tracks.values().all(|t| t.source.header_ready())
+	}
+
+	/// Every video track has buffered its first frame (the keyframe) or finished.
+	/// The tables wait for this so the tune-in point ([`Self::video_start`]) can be
+	/// read from the keyframe before any audio is emitted ahead of it. A program
+	/// with no video track is trivially ready.
+	fn video_ready(&self) -> bool {
+		self.tracks
+			.values()
+			.filter(|t| matches!(t.kind, Kind::Video(_)))
+			.all(|t| t.pending.is_some() || t.finished)
+	}
+
+	/// The smallest timestamp among the video tracks' buffered frames: the first
+	/// video keyframe, since pre-keyframe video frames are dropped before the tables
+	/// are built. `None` when no video track has a buffered frame (audio-only program).
+	fn first_video_pts(&self) -> Option<Timestamp> {
+		self.tracks
+			.values()
+			.filter(|t| matches!(t.kind, Kind::Video(_)))
+			.filter_map(|t| t.pending.as_ref().map(|f| f.timestamp))
+			.min()
 	}
 
 	/// Build the PAT/PMT once every track's PID and codec is known.

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -165,6 +165,140 @@ async fn export_aac_roundtrip() {
 	}
 }
 
+/// Collect PES presentation timestamps per elementary stream (video H.264, audio AAC),
+/// keyed off the PMT's PID assignments.
+fn collect_pes_pts(ts: &[u8]) -> (Vec<u64>, Vec<u64>) {
+	let mut reader = TsPacketReader::new(Cursor::new(ts));
+	let (mut video_pid, mut audio_pid) = (None, None);
+	let (mut video, mut audio) = (Vec::new(), Vec::new());
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		match packet.payload {
+			Some(TsPayload::Pmt(pmt)) => {
+				for es in &pmt.es_info {
+					match es.stream_type {
+						StreamType::H264 => video_pid = Some(es.elementary_pid),
+						StreamType::AdtsAac => audio_pid = Some(es.elementary_pid),
+						_ => {}
+					}
+				}
+			}
+			Some(TsPayload::PesStart(pes)) => {
+				if let Some(pts) = pes.header.pts {
+					let pid = Some(packet.header.pid);
+					if pid == video_pid {
+						video.push(pts.as_u64());
+					} else if pid == audio_pid {
+						audio.push(pts.as_u64());
+					}
+				}
+			}
+			_ => {}
+		}
+	}
+	(video, audio)
+}
+
+/// Build a broadcast whose audio begins before the first video keyframe (the shape a
+/// mid-stream tune-in produces: the audio source is cached further back than the oldest
+/// retained video keyframe), then export it to TS.
+async fn export_lead_audio() -> BytesMut {
+	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	// In-band avc3 video (SPS/PPS inline on keyframes; no out-of-band description).
+	let vtrack = broadcast
+		.create_track(
+			broadcast.unique_name(".avc3"),
+			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+		)
+		.unwrap();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		cfg.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(vtrack.name().to_string(), cfg);
+	}
+	let mut video = Producer::new(vtrack, HangContainer::Legacy);
+
+	let atrack = broadcast
+		.create_track(
+			broadcast.unique_name(".aac"),
+			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+		)
+		.unwrap();
+	{
+		let mut cfg = AudioConfig::new(AAC { profile: 2 }, 48_000, 2);
+		cfg.container = Container::Legacy;
+		catalog.lock().audio.renditions.insert(atrack.name().to_string(), cfg);
+	}
+	let mut audio = Producer::new(atrack, HangContainer::Legacy);
+
+	let audio_frame = |ms: u64| Frame {
+		timestamp: Timestamp::from_micros(ms * 1_000).unwrap(),
+		duration: None,
+		payload: Bytes::from(vec![0xAAu8; 16]),
+		keyframe: true,
+	};
+	// Lead audio (0..80 ms) precedes the first video keyframe at 100 ms; both continue after.
+	for ms in [0, 20, 40, 60, 80] {
+		audio.write(audio_frame(ms)).unwrap();
+		audio.finish_group().unwrap();
+	}
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xAB, 200));
+	video
+		.write(Frame {
+			timestamp: Timestamp::from_micros(100_000).unwrap(),
+			duration: None,
+			payload: annexb(&[SPS, PPS, &idr]),
+			keyframe: true,
+		})
+		.unwrap();
+	video.finish_group().unwrap();
+	for ms in [100, 120, 140] {
+		audio.write(audio_frame(ms)).unwrap();
+		audio.finish_group().unwrap();
+	}
+	video.finish().unwrap();
+	audio.finish().unwrap();
+
+	let exporter = Export::new(consumer).await.unwrap();
+	// The producers stay alive through the drain so the retained tracks are readable.
+	drain_with(exporter).await
+}
+
+/// The exported stream must begin at the first video keyframe. On a mid-stream tune-in the
+/// audio source can lead the first cached video keyframe by over a second; emitting that
+/// audio first buries the in-band SPS/PPS behind an audio-only preamble, and a live decoder
+/// probing the stream gives up before it ever configures video (RTMP/CMAF carry the codec
+/// config out-of-band, so they don't hit this). The muxer drops the lead audio so the
+/// keyframe leads. Audio from the keyframe onward is still carried.
+#[tokio::test(start_paused = true)]
+async fn export_starts_at_video_keyframe() {
+	// 100 ms (the keyframe PTS) in 90 kHz ticks.
+	const KEYFRAME_PTS: u64 = 100 * 90;
+
+	let ts = export_lead_audio().await;
+	assert_packet_aligned(&ts);
+	let (video, audio) = collect_pes_pts(&ts);
+
+	assert_eq!(
+		video.first(),
+		Some(&KEYFRAME_PTS),
+		"the stream must begin at the video keyframe"
+	);
+	assert!(
+		audio.iter().all(|&p| p >= KEYFRAME_PTS),
+		"lead audio before the first keyframe must be dropped, got {audio:?}"
+	);
+	assert!(!audio.is_empty(), "audio from the keyframe onward is still carried");
+}
+
 /// Re-parse a TS byte stream: assert the single video stream type, that the
 /// keyframe carries random-access + PCR in an unbounded PES, and return the
 /// reassembled Annex-B elementary stream.
@@ -461,9 +595,11 @@ async fn export_scte35_roundtrip() {
 		catalog.lock().mpegts.tracks.insert(scte_name.clone(), track);
 	}
 	let mut scte_producer = Producer::new(scte, HangContainer::Legacy);
+	// bbb's first video keyframe is at 1.4 s; stamp the cue just after it so it survives
+	// the tune-in alignment (a cue before the first keyframe is dropped with the lead).
 	scte_producer
 		.write(Frame {
-			timestamp: Timestamp::from_millis(40).unwrap(),
+			timestamp: Timestamp::from_millis(1410).unwrap(),
 			duration: None,
 			payload: Bytes::from_static(CUE),
 			keyframe: true,
@@ -607,7 +743,9 @@ async fn read_frames(consumer: &moq_net::BroadcastConsumer, name: &str) -> Vec<V
 
 /// Both real Kyrion MP2 programs must survive TS -> MoQ -> TS byte-for-byte, and
 /// the PMT must re-announce them as MPEG-1 audio (0x03): the capture is 48 kHz,
-/// so the half-rate type (0x04) would be unfaithful.
+/// so the half-rate type (0x04) would be unfaithful. This capture is a dirty start
+/// (begins mid-GOP), so the export's keyframe alignment drops the MP2 ahead of the
+/// first video keyframe; what remains is a byte-exact suffix of each program.
 #[tokio::test(start_paused = true)]
 async fn mp2_kyrion_roundtrip_byte_exact() {
 	let data = include_bytes!("test_data/scte35/kyrion_dirtystart.ts");
@@ -662,10 +800,16 @@ async fn mp2_kyrion_roundtrip_byte_exact() {
 		roundtripped.push(read_frames(&consumer2, name).await);
 	}
 
-	// Track discovery order is not stable across imports; compare as sorted sets.
-	ingested.sort();
-	roundtripped.sort();
-	assert_eq!(roundtripped, ingested, "MP2 frames must survive byte-for-byte");
+	// Keyframe alignment drops the MP2 ahead of the first video keyframe (the dirty-start
+	// lead), so each program's surviving frames are a byte-exact suffix of what was
+	// ingested. Track discovery order is not stable across imports, so match by content.
+	for rt in &roundtripped {
+		assert!(!rt.is_empty(), "a program lost all of its MP2 frames");
+		assert!(
+			ingested.iter().any(|ing| ing.ends_with(rt)),
+			"round-tripped MP2 must be a byte-exact suffix of an ingested program"
+		);
+	}
 }
 
 /// The ffmpeg AC-3 fixture must survive TS -> MoQ -> TS byte-for-byte in an


### PR DESCRIPTION
## Problem

A viewer tuning into a live MPEG-TS egress mid-broadcast decodes **0 video frames** — ffmpeg connects, sees a valid-looking stream, but reports `unspecified size` for the H.264 track and decodes nothing. This is the `Import/Export: SRT` check that moq-pro's `just dev smoke` keeps as a tracked SKIP. It reproduces with a synthetic clip (`testsrc2` + `libx264 -preset ultrafast -tune zerolatency`) but not with `bbb.ts`.

## Root cause

Audio and video are separate MoQ tracks with independent groups. On a mid-stream join the two `ExportSource`s land at different points in the live edge: video keyframes are ~1 GOP apart, so the oldest *deliverable* video keyframe can sit ~1s after the oldest cached audio (their matching video GOP has already evicted). The muxer emits frames in timestamp order, so it sent ~1.2s of audio-only PES before the first video keyframe.

MPEG-TS carries the H.264/H.265 parameter sets (SPS/PPS) **in-band on the keyframe**, unlike RTMP/FLV and fMP4/CMAF which carry the codec config out-of-band in a header the decoder reads immediately. So a live decoder, probing a bounded window at the start of the stream, gives up before it ever reaches the keyframe — hence 0 frames. The bytes aren't corrupt (a full file decode finds everything); the config just arrives too late for a live probe. That's why it's TS-specific: TS is the only egress where what's emitted before the first keyframe decides whether video decodes at all.

A file round-trip never reproduced it, because a finished/retained broadcast delivers from group 0 (no preamble); it needs a true mid-stream join.

## Fix

`ts::Export` now begins the stream at the first video keyframe. It holds **all** output (PAT/PMT and audio alike) until codec configs resolve and — when the program has a video rendition — its first keyframe is buffered, then drops any non-video frame (audio and ancillary streams) ahead of that keyframe. Groups therefore start at keyframe boundaries, and the in-band parameter sets lead the stream. Audio-only programs are unaffected (nothing to wait for or align to).

No public API change and no egress-crate change: this is the default behavior, so moq-srt and moq-cli `subscribe ts` get it through plain `Export::new`.

## Tests

- New `export_starts_at_video_keyframe`: builds a broadcast with audio ahead of the first keyframe (the mid-stream shape) and asserts the stream begins at the keyframe with the lead audio dropped.
- Three round-trip tests moved their pre-keyframe content past the first keyframe, since it's now dropped on export: `export_scte35_roundtrip` and moq-cli `ts_verbatim_streams_round_trip_through_cli` (cue / verbatim PES 40 ms → 1410 ms, after `bbb.ts`'s 1.4 s keyframe); `mp2_kyrion_roundtrip_byte_exact` now asserts the surviving MP2 is a byte-exact *suffix* (the dirty-start lead is dropped).

`cargo test -p moq-mux` (288), `-p moq-cli`, `-p moq-srt`; clippy + fmt clean.

## Verification

Reproduced end-to-end with `moq-srt serve` plus an in-process mid-stream tap: a live-like restricted-probe decode (`ffmpeg -analyzeduration 100000`) of the real egress went **0 → 302 frames**, with the audio preamble cut from 1.19 s to ~16 ms.

## Branch

Targets `dev`: the affected exporter (the H.264 `split.rs` refactor, async `Export::new`) and the moq-srt / moq-cli egress paths are dev-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)