### PR TITLE
feat(moq-ffi): expose broadcast hop chain on announcements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "moq-ffi"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "bytes",
  "hang",

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -131,11 +131,14 @@ Missing track subscriptions are accepted while the `BroadcastDynamic` object is 
 ```python
 async for announcement in client.announced("live/"):
     print(announcement.path)
+    print(announcement.hops)  # relay origin ids the broadcast traversed, oldest first
     ...
 
 # Or wait for a specific path:
 broadcast = await client.announced_broadcast("live/cam1")
 ```
+
+`announcement.hops` is the chain of relay origin ids (as `list[int]`) the broadcast passed through to reach you, oldest first. It is useful for routing decisions such as preferring a nearby edge or detecting how many relays a broadcast crossed.
 
 ## Examples
 

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -19,6 +19,11 @@ class Announcement:
         return self._inner.path()
 
     @property
+    def hops(self) -> list[int]:
+        """Origin ids of the relay hops this broadcast traversed, oldest first."""
+        return self._inner.hops()
+
+    @property
     def broadcast(self) -> BroadcastConsumer:
         return BroadcastConsumer(self._inner.broadcast())
 

--- a/py/moq-rs/pyproject.toml
+++ b/py/moq-rs/pyproject.toml
@@ -14,7 +14,7 @@ name = "moq-rs"
 # isn't already there (no tag needed; the registry is the gate).
 # Starts at 0.3.0 to open a new line above the old lockstep 0.2.x releases that
 # bundled the bindings.
-version = "0.3.0"
+version = "0.3.1"
 description = "Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization, with a Pythonic API. Import as `moq`."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/py/moq-rs/pyproject.toml
+++ b/py/moq-rs/pyproject.toml
@@ -30,8 +30,9 @@ classifiers = [
 ]
 # Compatible-release pin: floats to the latest 0.2.x moq-ffi patch without a
 # wrapper re-release. A moq-ffi minor bump (0.3) is the only thing that forces
-# bumping this constraint.
-dependencies = ["moq-ffi ~= 0.2.16"]
+# bumping this constraint. Floor is 0.2.24, the first release exposing
+# MoqAnnouncement.hops() that Announcement.hops depends on.
+dependencies = ["moq-ffi ~= 0.2.24"]
 
 [project.urls]
 Homepage = "https://github.com/moq-dev/moq"

--- a/py/moq-rs/tests/test_server.py
+++ b/py/moq-rs/tests/test_server.py
@@ -165,6 +165,36 @@ async def test_serve_helper_accepts_clients():
             broadcast.finish()
 
 
+async def test_announcement_hops_over_wire():
+    """An announcement received over the wire exposes its relay hop chain as a list of ints."""
+    async with moq.Server("127.0.0.1:0", tls_generate=["localhost"]) as server:
+        broadcast = moq.BroadcastProducer()
+        server.publish("with-hops", broadcast)
+
+        serve_task = asyncio.create_task(server.serve())
+        try:
+            async with moq.Client(
+                f"https://{server.local_addr}",
+                tls_verify=False,
+                bind="127.0.0.1:0",
+            ) as client:
+                async for announcement in client.announced():
+                    assert announcement.path == "with-hops"
+                    hops = announcement.hops
+                    assert isinstance(hops, list)
+                    assert all(isinstance(h, int) for h in hops)
+                    # A broadcast crossing at least one session carries a non-empty hop chain.
+                    assert len(hops) >= 1
+                    break
+        finally:
+            serve_task.cancel()
+            try:
+                await serve_task
+            except asyncio.CancelledError:
+                pass
+            broadcast.finish()
+
+
 async def test_serve_helper_with_on_request_rejection():
     """on_request returning False causes Server.serve() to reject the request."""
     async with moq.Server("127.0.0.1:0", tls_generate=["localhost"]) as server:

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>", "Brian Medley <bpm@bmedley.org>"
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.2.23"
+version = "0.2.24"
 edition = "2024"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -29,8 +29,10 @@ impl Announced {
 		loop {
 			match self.inner.announced().await {
 				Some((path, Some(broadcast))) => {
+					let hops = broadcast.hops.iter().map(|origin| origin.id).collect();
 					return Ok(Some(Arc::new(MoqAnnouncement {
 						path: path.to_string(),
+						hops,
 						broadcast: Arc::new(MoqBroadcastConsumer::new(broadcast)),
 					})));
 				}
@@ -59,6 +61,7 @@ impl Announced {
 #[derive(uniffi::Object)]
 pub struct MoqAnnouncement {
 	path: String,
+	hops: Vec<u64>,
 	broadcast: Arc<MoqBroadcastConsumer>,
 }
 
@@ -147,6 +150,11 @@ impl MoqAnnouncement {
 	/// The path of the announced broadcast.
 	pub fn path(&self) -> String {
 		self.path.clone()
+	}
+
+	/// The origin ids of the relay hops this broadcast traversed, oldest first.
+	pub fn hops(&self) -> Vec<u64> {
+		self.hops.clone()
 	}
 
 	/// The broadcast consumer.

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ source = { editable = "py/moq-ffi" }
 
 [[package]]
 name = "moq-rs"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "py/moq-rs" }
 dependencies = [
     { name = "moq-ffi" },


### PR DESCRIPTION
## Summary

Adds a way to read a broadcast's relay hop chain from an announcement, surfaced through the Python `moq` package.

- **`rs/moq-ffi`**: `MoqAnnouncement::hops() -> Vec<u64>` returns the broadcast's origin-id hop chain, oldest first. The ids are read from the subscribed broadcast (`BroadcastConsumer` derefs to `Broadcast`, whose `hops: OriginList` is populated from the wire `Announce`). The announce itself (`OriginAnnounce = (PathOwned, Option<BroadcastConsumer>)`) doesn't carry hops, so they're captured off the broadcast at construction.
- **`py/moq-rs`**: new `Announcement.hops -> list[int]` property mirroring `path`/`broadcast`. `Vec<u64>` maps to `list[int]` via uniffi.
- **`doc/lib/py/moq-rs.md`**: documents `announcement.hops` in the discovery section (Cross-Package Sync).

## Why

A downstream voice-agent worker self-elects which relay edge answers a client by inspecting the hop chain (counting how many hops share the fleet's internal-relay prefix). The Python `Announcement` previously exposed only `.path` and `.broadcast`, so the worker couldn't see hops. The worker reads it as `getattr(ann, "hops", None)`, so the property is named `hops` and returns a `list[int]` of u64 origin ids, oldest first.

## Release / versioning

This rides the next `moq-rs` release, so the version bumps are included:

- `moq-ffi` `0.2.23` -> `0.2.24` (the first release carrying `hops()`). This is exactly the patch release-plz would compute from an additive `feat`, so it should reconcile and generate the `0.2.24` CHANGELOG on merge. `moq-ffi`'s deps are all at versions already published in #1795, so there's no stale-dependency hazard.
- `moq-rs` `0.3.0` -> `0.3.1` (republishes the wrapper; `0.3.0` is already on PyPI and `release-py.yml` gates on the registry).
- `moq-rs` dependency floor tightened `moq-ffi ~= 0.2.16` -> `~= 0.2.24` so the `Announcement.hops` property can't resolve against a `moq-ffi` that lacks `hops()`.

## Cross-Package Sync

- `swift`/`kt`/`go` get `hops()` automatically — they're uniffi-generated from `moq-ffi` and re-mirrored on the next `moq-ffi-v*` tag, no manual edit.
- `rs/libmoq` (hand-written C API) intentionally left out of scope to keep this minimal and Python-focused; the C `moq_announced` struct can grow a hops accessor as a follow-up if a C consumer needs it.

## Test plan

- [x] `cargo check -p moq-ffi` / `cargo clippy -p moq-ffi` clean (`moq-ffi v0.2.24`).
- [x] `just py check`: ruff + format + pyright (0 errors); the tightened `~= 0.2.24` floor resolves against the workspace `moq-ffi 0.2.24`.
- [x] `just py test`: 38 passed, including the new `test_announcement_hops_over_wire` (Server + Client over loopback TLS).
- [x] Verified against a local relay: `ann.hops` returns `[1840552095890056]` — a `list` of `int`; `getattr(ann, "hops", None)` returns it.

Note: fmt/clippy ran on the system toolchain (`rustfmt 1.9.0`) since the nix dev shell can't be entered in this environment; flag for CI's pinned toolchain.

(Written by Claude)