### PR TITLE
refactor(moq-net): make request_broadcast/subscribe/fetch_group infallible

### DIFF
--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -53,7 +53,7 @@ async fn run_subscribe(consumer: moq_net::OriginConsumer) -> anyhow::Result<()> 
 	// Read the catalog to discover available tracks.
 	let catalog_track = broadcast
 		.track(hang::Catalog::DEFAULT_NAME)?
-		.subscribe(hang::Catalog::default_subscription())?
+		.subscribe(hang::Catalog::default_subscription())
 		.await?;
 	let mut catalog = moq_mux::catalog::hang::Consumer::<()>::new(catalog_track);
 
@@ -81,7 +81,7 @@ async fn run_subscribe(consumer: moq_net::OriginConsumer) -> anyhow::Result<()> 
 		.subscribe(moq_net::Subscription {
 			priority: 1,
 			..Default::default()
-		})?
+		})
 		.await?;
 	let mut ordered = moq_mux::container::Consumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)
 		.with_latency(Duration::from_millis(500));

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -70,7 +70,7 @@ impl Consume {
 			let res = async move {
 				let catalog = broadcast
 					.track(hang::catalog::Catalog::DEFAULT_NAME)?
-					.subscribe(hang::catalog::Catalog::default_subscription())?
+					.subscribe(hang::catalog::Catalog::default_subscription())
 					.await?;
 				Self::run_catalog(on_catalog, broadcast.clone(), catalog.into(), channel.1).await
 			}
@@ -254,7 +254,7 @@ impl Consume {
 					.subscribe(moq_net::Subscription {
 						priority: 1,
 						..Default::default()
-					})?
+					})
 					.await?;
 				let track = moq_mux::container::Consumer::new(track, moq_mux::catalog::hang::Container::Legacy)
 					.with_latency(latency);
@@ -306,7 +306,7 @@ impl Consume {
 					.subscribe(moq_net::Subscription {
 						priority: 2,
 						..Default::default()
-					})?
+					})
 					.await?;
 				let track = moq_mux::container::Consumer::new(track, moq_mux::catalog::hang::Container::Legacy)
 					.with_latency(latency);
@@ -407,7 +407,7 @@ impl Consume {
 		// `subscribe` blocks on SUBSCRIBE_OK, so run it inside the task.
 		tokio::spawn(async move {
 			let res = async move {
-				let track = broadcast.track(&name)?.subscribe(None)?.await?;
+				let track = broadcast.track(&name)?.subscribe(None).await?;
 				Self::run_raw(on_frame, track, channel.1).await
 			}
 			.await;

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -220,9 +220,9 @@ impl Origin {
 		path: String,
 		mut close: oneshot::Receiver<()>,
 	) -> Result<(), Error> {
-		// Registration is synchronous; this errors immediately if the path can never be served
-		// (not announced and no dynamic handler).
-		let pending = consumer.request_broadcast(path.as_str())?;
+		// Resolves to an error if the path can never be served (not announced and no dynamic
+		// handler), otherwise once a handler serves it.
+		let pending = consumer.request_broadcast(path.as_str());
 
 		// `biased` so a pending close always wins over a ready broadcast.
 		let broadcast = tokio::select! {

--- a/rs/moq-audio/src/consumer.rs
+++ b/rs/moq-audio/src/consumer.rs
@@ -53,7 +53,7 @@ impl AudioConsumer {
 		};
 
 		let name = name.into();
-		let track = broadcast.track(&name)?.subscribe(None)?.await?;
+		let track = broadcast.track(&name)?.subscribe(None).await?;
 		let mut track = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 		if let Some(latency) = output.latency_max {
 			track = track.with_latency(latency);

--- a/rs/moq-audio/src/producer.rs
+++ b/rs/moq-audio/src/producer.rs
@@ -224,7 +224,7 @@ mod tests {
 		let mut producer =
 			AudioProducer::new(&mut broadcast, catalog, "audio", input, EncoderOutput::default()).unwrap();
 
-		let track = consumer.track("audio").unwrap().subscribe(None).unwrap().await.unwrap();
+		let track = consumer.track("audio").unwrap().subscribe(None).await.unwrap();
 		let mut reader = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 
 		let mut pts = Vec::new();

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -275,7 +275,7 @@ async fn subscribe(
 async fn drain(broadcast: BroadcastConsumer, stats: &Stats) -> anyhow::Result<()> {
 	let _gauge = Gauge::inc(&stats.subscriptions);
 
-	let mut track = broadcast.track(TRACK)?.subscribe(None)?.await?;
+	let mut track = broadcast.track(TRACK)?.subscribe(None).await?;
 	let mut gaps = GapTracker::new(stats);
 	let mut learned_shape = false;
 
@@ -428,7 +428,7 @@ mod tests {
 		// Advance past one full group (keyframe + 2 payload) into the next.
 		tokio::time::advance(Duration::from_millis(350)).await;
 
-		let mut sub = consumer.track(TRACK).unwrap().subscribe(None).unwrap().await.unwrap();
+		let mut sub = consumer.track(TRACK).unwrap().subscribe(None).await.unwrap();
 		let mut group = sub.next_group().await.unwrap().expect("a group");
 
 		let keyframe = group.read_frame().await.unwrap().expect("keyframe");
@@ -463,7 +463,7 @@ mod tests {
 		let task = tokio::spawn(produce(0, "bench/test".into(), rolled(10, 4, 0), track, stats.clone()));
 		tokio::time::advance(Duration::from_millis(250)).await;
 
-		let mut sub = consumer.track(TRACK).unwrap().subscribe(None).unwrap().await.unwrap();
+		let mut sub = consumer.track(TRACK).unwrap().subscribe(None).await.unwrap();
 		let mut group = sub.next_group().await.unwrap().expect("a group");
 
 		// Just the keyframe, then the group ends.

--- a/rs/moq-boy/src/input.rs
+++ b/rs/moq-boy/src/input.rs
@@ -99,7 +99,7 @@ async fn handle_viewer_commands(
 	broadcast: moq_net::BroadcastConsumer,
 	cmd_tx: &tokio::sync::mpsc::Sender<Command>,
 ) -> anyhow::Result<()> {
-	let track = broadcast.track("command")?.subscribe(None)?.await?;
+	let track = broadcast.track("command")?.subscribe(None).await?;
 	let mut commands = moq_json::Consumer::<RawCommand>::new(track);
 
 	loop {

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -548,7 +548,7 @@ mod tests {
 
 	/// Read the first frame of a verbatim track back as raw bytes.
 	async fn read_frame(consumer: &moq_net::BroadcastConsumer, name: &str) -> Vec<u8> {
-		let track = consumer.track(name).unwrap().subscribe(None).unwrap().await.unwrap();
+		let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
 		let mut reader = Consumer::new(track, Container::Legacy).with_latency(Duration::ZERO);
 		let frame = tokio::time::timeout(Duration::from_secs(1), reader.read())
 			.await

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -120,7 +120,7 @@ impl MoqBroadcastConsumer {
 		let track = self
 			.inner
 			.track(hang::catalog::Catalog::DEFAULT_NAME)?
-			.subscribe(hang::catalog::Catalog::default_subscription())?
+			.subscribe(hang::catalog::Catalog::default_subscription())
 			.await?;
 		let consumer = moq_mux::catalog::hang::Consumer::from(track);
 		Ok(Arc::new(MoqCatalogConsumer {
@@ -138,7 +138,7 @@ impl MoqBroadcastConsumer {
 		subscription: Option<MoqSubscription>,
 	) -> Result<Arc<MoqTrackConsumer>, MoqError> {
 		let subscription = subscription.map(moq_net::Subscription::from);
-		let track = self.inner.track(&name)?.subscribe(subscription)?.await?;
+		let track = self.inner.track(&name)?.subscribe(subscription).await?;
 		Ok(Arc::new(MoqTrackConsumer::new(track)))
 	}
 
@@ -161,7 +161,7 @@ impl MoqBroadcastConsumer {
 			.try_into()
 			.map_err(|e| MoqError::Codec(format!("invalid container: {e}")))?;
 		let subscription = subscription.map(moq_net::Subscription::from);
-		let track = self.inner.track(&name)?.subscribe(subscription)?.await?;
+		let track = self.inner.track(&name)?.subscribe(subscription).await?;
 		let latency = std::time::Duration::from_millis(max_latency_ms);
 		let consumer = moq_mux::container::Consumer::new(track, media).with_latency(latency);
 		Ok(Arc::new(MoqMediaConsumer {

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -160,7 +160,7 @@ impl MoqOriginConsumer {
 	/// indefinitely for a future announcement: it resolves or fails based on what is
 	/// announced now plus any dynamic fallback. Drop the returned future to cancel.
 	pub async fn request_broadcast(&self, path: String) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
-		let broadcast = self.inner.request_broadcast(path.as_str())?.await?;
+		let broadcast = self.inner.request_broadcast(path.as_str()).await?;
 		Ok(Arc::new(MoqBroadcastConsumer::new(broadcast)))
 	}
 }

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -300,7 +300,7 @@ async fn run_session(
 
 	let catalog_track = broadcast
 		.track(hang::catalog::Catalog::DEFAULT_NAME)?
-		.subscribe(hang::catalog::Catalog::default_subscription())?
+		.subscribe(hang::catalog::Catalog::default_subscription())
 		.await?;
 	let mut catalog_consumer = moq_mux::catalog::hang::Consumer::new(catalog_track);
 
@@ -427,7 +427,7 @@ async fn reconcile(
 		}
 		.fetch_add(1, Ordering::Relaxed);
 
-		let track_subscriber = broadcast.track(&name)?.subscribe(None)?.await?;
+		let track_subscriber = broadcast.track(&name)?.subscribe(None).await?;
 		let track = moq_mux::container::Consumer::new(track_subscriber, container).with_latency(Duration::from_secs(1));
 
 		let descriptor = TrackDescriptor {

--- a/rs/moq-mux/src/catalog/consumer.rs
+++ b/rs/moq-mux/src/catalog/consumer.rs
@@ -27,12 +27,12 @@ impl<E: CatalogExt> Consumer<E> {
 			CatalogFormat::Hang => {
 				let track = broadcast
 					.track(hang::Catalog::DEFAULT_NAME)?
-					.subscribe(hang::Catalog::default_subscription())?
+					.subscribe(hang::Catalog::default_subscription())
 					.await?;
 				Self::Hang(super::hang::Consumer::new(track))
 			}
 			CatalogFormat::Msf => {
-				let track = broadcast.track(moq_msf::DEFAULT_NAME)?.subscribe(None)?.await?;
+				let track = broadcast.track(moq_msf::DEFAULT_NAME)?.subscribe(None).await?;
 				Self::Msf(super::msf::Consumer::new(track))
 			}
 		})

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -113,13 +113,7 @@ async fn import_emits_frames() {
 	let video_name = snap.video.renditions.keys().next().unwrap().clone();
 
 	// Decode the video track back through the Legacy container.
-	let track = consumer
-		.track(&video_name)
-		.unwrap()
-		.subscribe(None)
-		.unwrap()
-		.await
-		.unwrap();
+	let track = consumer.track(&video_name).unwrap().subscribe(None).await.unwrap();
 	let mut decoder = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy)
 		.with_latency(std::time::Duration::from_secs(1));
 	let frame = decoder.read().await.unwrap().expect("a video frame");

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -185,7 +185,6 @@ async fn test_seek_sets_initial_sequence() {
 		.track(&video_name)
 		.unwrap()
 		.subscribe(None)
-		.unwrap()
 		.await
 		.expect("video track should exist");
 
@@ -227,7 +226,6 @@ async fn test_msf_catalog_roundtrip() {
 		.track(moq_msf::DEFAULT_NAME)
 		.unwrap()
 		.subscribe(None)
-		.unwrap()
 		.await
 		.expect("MSF catalog track should exist");
 	let mut msf = crate::catalog::msf::Consumer::new(track);

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -82,7 +82,7 @@ impl ExportSource {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
 		Ok(Self {
-			state: SourceState::Subscribing(broadcast.track(name)?.subscribe(None)?),
+			state: SourceState::Subscribing(broadcast.track(name)?.subscribe(None)),
 			media: Some(media),
 			latency,
 			transform,
@@ -104,7 +104,7 @@ impl ExportSource {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
 		Ok(Self {
-			state: SourceState::Subscribing(broadcast.track(name)?.subscribe(None)?),
+			state: SourceState::Subscribing(broadcast.track(name)?.subscribe(None)),
 			media: Some(media),
 			latency,
 			transform: None,
@@ -124,7 +124,7 @@ impl ExportSource {
 		let description = config.description.as_ref().filter(|b| !b.is_empty()).cloned();
 
 		Ok(Self {
-			state: SourceState::Subscribing(broadcast.track(name)?.subscribe(None)?),
+			state: SourceState::Subscribing(broadcast.track(name)?.subscribe(None)),
 			media: Some(media),
 			latency,
 			transform: None,
@@ -141,7 +141,7 @@ impl ExportSource {
 		latency: Duration,
 	) -> Result<Self, crate::Error> {
 		Ok(Self {
-			state: SourceState::Subscribing(broadcast.track(name)?.subscribe(None)?),
+			state: SourceState::Subscribing(broadcast.track(name)?.subscribe(None)),
 			media: Some(HangContainer::Legacy),
 			latency,
 			transform: None,

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -660,7 +660,7 @@ async fn export_scte35_roundtrip() {
 	assert_eq!(verbatim, 1, "round-trip lost the SCTE-35 track");
 	let name = scte_track(&snapshot).expect("a scte35 track");
 
-	let track = consumer2.track(&name).unwrap().subscribe(None).unwrap().await.unwrap();
+	let track = consumer2.track(&name).unwrap().subscribe(None).await.unwrap();
 	let mut scte_reader = crate::container::Consumer::new(track, HangContainer::Legacy);
 	let frame = scte_reader
 		.read()
@@ -731,7 +731,7 @@ async fn scte35_without_video_export_is_rejected() {
 
 /// Subscribe to a track and read every retained frame payload it holds.
 async fn read_frames(consumer: &moq_net::BroadcastConsumer, name: &str) -> Vec<Vec<u8>> {
-	let track = consumer.track(name).unwrap().subscribe(None).unwrap().await.unwrap();
+	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
 	let mut reader = crate::container::Consumer::new(track, HangContainer::Legacy);
 	let mut frames = Vec::new();
 	while let Ok(res) = tokio::time::timeout(std::time::Duration::from_millis(50), reader.read()).await {
@@ -1047,7 +1047,7 @@ fn scte_track(snap: &crate::catalog::hang::Catalog<tscat::Ext>) -> Option<String
 
 /// Subscribe to a cue track and read every retained `splice_info_section` it holds.
 async fn read_cues(consumer: &moq_net::BroadcastConsumer, name: &str) -> Vec<(Vec<u8>, Timestamp)> {
-	let track = consumer.track(name).unwrap().subscribe(None).unwrap().await.unwrap();
+	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
 	let mut reader = crate::container::Consumer::new(track, HangContainer::Legacy);
 	let mut cues = Vec::new();
 	while let Ok(res) = tokio::time::timeout(std::time::Duration::from_millis(50), reader.read()).await {

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -1733,7 +1733,7 @@ mod test {
 		);
 
 		let name = catalog.snapshot().mpegts.tracks.keys().next().unwrap().clone();
-		let track = consumer.track(&name).unwrap().subscribe(None).unwrap().await.unwrap();
+		let track = consumer.track(&name).unwrap().subscribe(None).await.unwrap();
 		let mut reader = Consumer::new(track, Container::Legacy).with_latency(std::time::Duration::ZERO);
 		let frame = tokio::time::timeout(std::time::Duration::from_secs(1), reader.read())
 			.await
@@ -1908,7 +1908,7 @@ mod test {
 			.next()
 			.expect("an audio track")
 			.clone();
-		let track = consumer.track(&name).unwrap().subscribe(None).unwrap().await.unwrap();
+		let track = consumer.track(&name).unwrap().subscribe(None).await.unwrap();
 		let mut reader = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy);
 		let mut frames = Vec::new();
 		while let Ok(Ok(Some(frame))) = tokio::time::timeout(std::time::Duration::from_millis(50), reader.read()).await
@@ -2039,7 +2039,7 @@ mod test {
 		import.finish().unwrap();
 
 		let name = catalog.snapshot().mpegts.tracks.keys().next().unwrap().clone();
-		let track = consumer.track(&name).unwrap().subscribe(None).unwrap().await.unwrap();
+		let track = consumer.track(&name).unwrap().subscribe(None).await.unwrap();
 		let mut reader = Consumer::new(track, Container::Legacy).with_latency(std::time::Duration::ZERO);
 		let frame = tokio::time::timeout(std::time::Duration::from_secs(1), reader.read())
 			.await
@@ -2170,13 +2170,7 @@ mod test {
 		assert_eq!(verbatim.stream_id, Some(0xC0), "recorded the PES stream_id");
 		assert_eq!(track.pid, DATA_PID, "recorded the original PID");
 
-		let track = consumer
-			.track(name.as_str())
-			.unwrap()
-			.subscribe(None)
-			.unwrap()
-			.await
-			.unwrap();
+		let track = consumer.track(name.as_str()).unwrap().subscribe(None).await.unwrap();
 		let mut reader = Consumer::new(track, Container::Legacy).with_latency(std::time::Duration::ZERO);
 		let frame = tokio::time::timeout(std::time::Duration::from_secs(1), reader.read())
 			.await

--- a/rs/moq-mux/src/container/ts/import_test.rs
+++ b/rs/moq-mux/src/container/ts/import_test.rs
@@ -278,7 +278,7 @@ async fn survives_midstream_join() {
 
 	// The track resumes at the keyframe: the leading delta was dropped, the IDR
 	// anchors the one and only group.
-	let track = consumer.track(&name).unwrap().subscribe(None).unwrap().await.unwrap();
+	let track = consumer.track(&name).unwrap().subscribe(None).await.unwrap();
 	let mut reader = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy);
 	let mut frames = Vec::new();
 	while let Ok(Ok(Some(frame))) = tokio::time::timeout(std::time::Duration::from_millis(50), reader.read()).await {
@@ -322,7 +322,7 @@ async fn kyrion_dirtystart_extracts_real_cues() {
 		.find(|(_, t)| t.verbatim.as_ref().is_some_and(|v| v.stream_type == 0x86))
 		.map(|(name, _)| name.clone())
 		.expect("scte35 track");
-	let track = consumer.track(&name).unwrap().subscribe(None).unwrap().await.unwrap();
+	let track = consumer.track(&name).unwrap().subscribe(None).await.unwrap();
 	let mut reader = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy);
 	let mut cues = Vec::new();
 	while let Ok(Ok(Some(frame))) = tokio::time::timeout(std::time::Duration::from_millis(50), reader.read()).await {

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -104,8 +104,7 @@ async fn main() -> anyhow::Result<()> {
 						Some(broadcast) => {
 							tracing::info!(broadcast = %path, "broadcast is online, subscribing to track");
 							let track = broadcast
-								.track(&track)?.subscribe(None)?
-								.await?;
+								.track(&track)?.subscribe(None).await?;
 							clock = Some(Subscriber::new(track));
 						}
 						None => {

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -71,7 +71,6 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 		.track("video")
 		.unwrap()
 		.subscribe(None)
-		.unwrap()
 		.await
 		.expect("consume_track failed");
 
@@ -342,7 +341,6 @@ async fn iroh_connect() {
 		.track("video")
 		.unwrap()
 		.subscribe(None)
-		.unwrap()
 		.await
 		.expect("consume_track failed");
 

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -89,7 +89,6 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 		.track("video")
 		.unwrap()
 		.subscribe(None)
-		.unwrap()
 		.await
 		.expect("consume_track failed");
 
@@ -191,7 +190,6 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 		.track("video")
 		.unwrap()
 		.subscribe(None)
-		.unwrap()
 		.await
 		.expect("consume_track failed");
 
@@ -306,12 +304,10 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 
 	// Fetch group 0 directly, without subscribing. No live producer holds the group
 	// on the client, so this issues a wire FETCH upstream.
-	let mut group_sub = tokio::time::timeout(TIMEOUT, async {
-		bc.track("video").unwrap().fetch_group(0, None).unwrap().await
-	})
-	.await
-	.expect("fetch timed out")
-	.expect("fetch failed");
+	let mut group_sub = tokio::time::timeout(TIMEOUT, async { bc.track("video").unwrap().fetch_group(0, None).await })
+		.await
+		.expect("fetch timed out")
+		.expect("fetch failed");
 	assert_eq!(group_sub.sequence, 0);
 
 	for &expected_us in &frames {
@@ -428,12 +424,10 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 
 	// Subscribe (starts at the latest group) and read the live group, which
 	// establishes the upstream subscription and leaves it active.
-	let mut track_sub = tokio::time::timeout(TIMEOUT, async {
-		bc.track("video").unwrap().subscribe(None).unwrap().await
-	})
-	.await
-	.expect("subscribe timed out")
-	.expect("subscribe failed");
+	let mut track_sub = tokio::time::timeout(TIMEOUT, async { bc.track("video").unwrap().subscribe(None).await })
+		.await
+		.expect("subscribe timed out")
+		.expect("subscribe failed");
 	let mut live = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
 		.expect("recv_group timed out")
@@ -450,12 +444,10 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	// While the subscription is still held and active, fetch the older group. The
 	// relay doesn't have it cached (subscription started at the latest), so this
 	// must issue a wire FETCH concurrently with the live subscription.
-	let mut fetched = tokio::time::timeout(TIMEOUT, async {
-		bc.track("video").unwrap().fetch_group(0, None).unwrap().await
-	})
-	.await
-	.expect("fetch timed out")
-	.expect("fetch failed");
+	let mut fetched = tokio::time::timeout(TIMEOUT, async { bc.track("video").unwrap().fetch_group(0, None).await })
+		.await
+		.expect("fetch timed out")
+		.expect("fetch failed");
 	assert_eq!(fetched.sequence, 0);
 	let frame = tokio::time::timeout(TIMEOUT, fetched.read_frame())
 		.await
@@ -533,7 +525,6 @@ async fn broadcast_moq_lite_05_without_timescale() {
 		.track("video")
 		.unwrap()
 		.subscribe(None)
-		.unwrap()
 		.await
 		.expect("consume_track failed");
 
@@ -947,7 +938,6 @@ async fn broadcast_websocket() {
 		.track("video")
 		.unwrap()
 		.subscribe(None)
-		.unwrap()
 		.await
 		.expect("consume_track failed");
 
@@ -1056,7 +1046,6 @@ async fn broadcast_websocket_fallback() {
 		.track("video")
 		.unwrap()
 		.subscribe(None)
-		.unwrap()
 		.await
 		.expect("consume_track failed");
 
@@ -1293,13 +1282,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	let bc = bc.broadcast().expect("expected announce");
 
 	// First subscription: receive group 0.
-	let mut sub1 = bc
-		.track("video")
-		.unwrap()
-		.subscribe(None)
-		.unwrap()
-		.await
-		.expect("subscribe1");
+	let mut sub1 = bc.track("video").unwrap().subscribe(None).await.expect("subscribe1");
 	let mut g = tokio::time::timeout(TIMEOUT, sub1.recv_group())
 		.await
 		.expect("recv group 0 timeout")
@@ -1323,13 +1306,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	tokio::time::sleep(Duration::from_millis(20)).await;
 
 	// Resubscribe well inside the 5s linger window.
-	let mut sub2 = bc
-		.track("video")
-		.unwrap()
-		.subscribe(None)
-		.unwrap()
-		.await
-		.expect("subscribe2");
+	let mut sub2 = bc.track("video").unwrap().subscribe(None).await.expect("subscribe2");
 
 	// A new group published after the resubscribe must reach the consumer
 	// regardless of which linger branch fired.
@@ -1557,7 +1534,6 @@ async fn publish_only_client_to_subscribe_only_server() {
 			.track("video")
 			.unwrap()
 			.subscribe(None)
-			.unwrap()
 			.await
 			.expect("consume_track failed");
 		let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -133,7 +133,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// We just received a subscribe for this exact namespace, so the peer must have already
 		// seen the announcement. `request_broadcast` resolves it immediately, or falls back to
 		// an `OriginDynamic` handler if one is registered.
-		let broadcast = match async { self.origin.request_broadcast(&msg.track_namespace)?.await }.await {
+		let broadcast = match self.origin.request_broadcast(&msg.track_namespace).await {
 			Ok(broadcast) => broadcast,
 			Err(_) => {
 				self.write_subscribe_error(&mut stream.writer, request_id, 404, "Broadcast not found")
@@ -147,7 +147,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			..Default::default()
 		};
 
-		let track = match async { broadcast.track(&msg.track_name)?.subscribe(subscription)?.await }.await {
+		let track = match async { broadcast.track(&msg.track_name)?.subscribe(subscription).await }.await {
 			Ok(track) => track,
 			Err(err) => {
 				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -448,7 +448,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// The peer requested this exact path, so it has already seen an announcement for it.
 		// `request_broadcast` resolves it immediately, or falls back to an `OriginDynamic`
 		// handler (as in recv_subscribe).
-		let broadcast = self.origin.request_broadcast(&request.broadcast)?.await?;
+		let broadcast = self.origin.request_broadcast(&request.broadcast).await?;
 		let info = broadcast.track(&request.track)?.info().await?;
 
 		// Same negotiation as a subscription, just answered once: codec only when
@@ -491,7 +491,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// We just received a subscribe for this exact path, so by definition the peer has
 		// already seen an announcement for it. `request_broadcast` resolves an announced
 		// broadcast immediately; if it isn't announced it falls back to an `OriginDynamic`
-		// handler (or fails fast when there is none). Registration is synchronous.
+		// handler (or resolves to an error when there is none).
 		let broadcast = self.origin.request_broadcast(&subscribe.broadcast);
 
 		// Per-track subscription guard (bumps `subscriptions`). The per-(session,
@@ -532,7 +532,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		session: S,
 		stream: &mut Stream<S, Version>,
 		subscribe: &lite::Subscribe<'_>,
-		broadcast: Result<kio::Pending<crate::BroadcastRequested>, Error>,
+		broadcast: kio::Pending<crate::BroadcastRequested>,
 		priority: PriorityQueue,
 		// The track guard (bumps `subscriptions`), the per-session broadcast
 		// tracker, and the broadcast path. The `broadcasts` sentinel is taken
@@ -550,9 +550,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		};
 
 		// Awaits the dynamic fallback if the broadcast wasn't announced; resolves
-		// immediately otherwise.
-		let broadcast = broadcast?.await?;
-		let track = broadcast.track(&subscribe.track)?.subscribe(subscription)?.await?;
+		// immediately otherwise (including an unroutable/dropped error).
+		let broadcast = broadcast.await?;
+		let track = broadcast.track(&subscribe.track)?.subscribe(subscription).await?;
 
 		// Compress only when the producer marked the track worth it and the
 		// negotiated draft can carry a codec. Older drafts (lite-04 and below) get
@@ -669,11 +669,11 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	async fn run_fetch(
 		stream: &mut Stream<S, Version>,
 		fetch: &lite::Fetch<'_>,
-		broadcast: Result<kio::Pending<crate::BroadcastRequested>, Error>,
+		broadcast: kio::Pending<crate::BroadcastRequested>,
 		track_stats: crate::PublisherTrack,
 		version: Version,
 	) -> Result<(), Error> {
-		let broadcast = broadcast?.await?;
+		let broadcast = broadcast.await?;
 		let track = broadcast.track(&fetch.track)?;
 
 		let group = track
@@ -682,7 +682,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				crate::Fetch {
 					priority: fetch.priority,
 				},
-			)?
+			)
 			.await?;
 
 		// FETCH is gated to lite-05+, which always carries timestamps when the track

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -483,7 +483,7 @@ mod test {
 	/// a publisher accepts). Returns the pending subscription to resolve after accepting.
 	macro_rules! subscribe_pending {
 		($consumer:expr, $name:expr) => {{
-			let pending = $consumer.track($name).unwrap().subscribe(None).unwrap();
+			let pending = $consumer.track($name).unwrap().subscribe(None);
 			assert!(
 				pending.poll_ok(&kio::Waiter::noop()).is_pending(),
 				"subscribe should stay pending until the request is accepted"
@@ -504,26 +504,14 @@ mod test {
 		let consumer = producer.consume();
 
 		// The track already exists, so subscribe resolves immediately.
-		let mut track1_sub = consumer
-			.track("track1")
-			.unwrap()
-			.subscribe(None)
-			.unwrap()
-			.await
-			.unwrap();
+		let mut track1_sub = consumer.track("track1").unwrap().subscribe(None).await.unwrap();
 		track1_sub.assert_group();
 
 		let mut track2 = TrackProducer::new("track2", None);
 		producer.assert_insert_track(&track2);
 
 		let consumer2 = producer.consume();
-		let mut track2_consumer = consumer2
-			.track("track2")
-			.unwrap()
-			.subscribe(None)
-			.unwrap()
-			.await
-			.unwrap();
+		let mut track2_consumer = consumer2.track("track2").unwrap().subscribe(None).await.unwrap();
 		track2_consumer.assert_no_group();
 
 		track2.append_group().unwrap();
@@ -541,13 +529,7 @@ mod test {
 
 		// Create a new track and insert it into the broadcast (resolves immediately).
 		let track1 = producer.assert_create_track("track1", None);
-		let track1c = consumer
-			.track("track1")
-			.unwrap()
-			.subscribe(None)
-			.unwrap()
-			.await
-			.unwrap();
+		let track1c = consumer.track("track1").unwrap().subscribe(None).await.unwrap();
 
 		// A track nobody publishes stays pending until accepted.
 		let track2_fut = subscribe_pending!(consumer, "track2");
@@ -651,13 +633,7 @@ mod test {
 		);
 
 		// A second subscriber reuses the live producer (fast path / dedup).
-		let consumer2 = bc
-			.track("unknown_track")
-			.unwrap()
-			.subscribe(None)
-			.unwrap()
-			.await
-			.unwrap();
+		let consumer2 = bc.track("unknown_track").unwrap().subscribe(None).await.unwrap();
 		consumer2.assert_is_clone(&consumer1);
 
 		drop(consumer1);
@@ -675,13 +651,7 @@ mod test {
 		// While the producer is still alive, re-subscribing to the same name reuses
 		// it (no new request) — this is what lets the relay linger upstream
 		// subscriptions across transient consumer churn.
-		let consumer3 = bc
-			.track("unknown_track")
-			.unwrap()
-			.subscribe(None)
-			.unwrap()
-			.await
-			.unwrap();
+		let consumer3 = bc.track("unknown_track").unwrap().subscribe(None).await.unwrap();
 		consumer3.assert_is_clone(&producer1.subscribe(None));
 		broadcast.assert_no_request();
 		drop(consumer3);

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1184,6 +1184,9 @@ pub struct BroadcastRequested {
 enum Requested {
 	// Already announced: resolves immediately with a clone of this broadcast.
 	Ready(BroadcastConsumer),
+	// Unroutable at request time, or the origin was already dropped: resolves immediately
+	// with this error. Baked in so `request_broadcast` itself stays infallible.
+	Failed(Error),
 	// Awaiting a handler: resolves when the request's result channel is written.
 	Pending(kio::Consumer<PendingBroadcast>),
 }
@@ -1192,6 +1195,12 @@ impl BroadcastRequested {
 	fn ready(broadcast: BroadcastConsumer) -> Self {
 		Self {
 			inner: Requested::Ready(broadcast),
+		}
+	}
+
+	fn failed(error: Error) -> Self {
+		Self {
+			inner: Requested::Failed(error),
 		}
 	}
 
@@ -1205,6 +1214,7 @@ impl BroadcastRequested {
 	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<BroadcastConsumer, Error>> {
 		match &self.inner {
 			Requested::Ready(broadcast) => Poll::Ready(Ok(broadcast.clone())),
+			Requested::Failed(error) => Poll::Ready(Err(error.clone())),
 			Requested::Pending(consumer) => Poll::Ready(
 				match ready!(consumer.poll(waiter, |state| match &state.resolved {
 					Some(result) => Poll::Ready(result.clone()),
@@ -1423,31 +1433,33 @@ impl OriginConsumer {
 	/// [`reject`](BroadcastRequest::reject)s or every handler drops). Concurrent requests for
 	/// the same unannounced path coalesce onto one handler request.
 	///
-	/// Fails synchronously with [`Error::Unroutable`] when the path is not announced and no
+	/// The returned future resolves to [`Error::Unroutable`] when the path is not announced and no
 	/// dynamic handler exists, or [`Error::Dropped`] once the origin is gone. A request that is
 	/// registered while a handler is live but then loses every handler before being served also
 	/// resolves to [`Error::Unroutable`]. Unlike an announced broadcast, a dynamically served one
 	/// is never visible to [`Self::announced`].
-	pub fn request_broadcast(&self, path: impl AsPath) -> Result<kio::Pending<BroadcastRequested>, Error> {
+	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<BroadcastRequested> {
 		let path = path.as_path();
 
 		// Prefer a live announcement when one is present; the dynamic queue is only a fallback.
 		if let Some(broadcast) = self.get_broadcast(&path) {
-			return Ok(kio::Pending::new(BroadcastRequested::ready(broadcast)));
+			return kio::Pending::new(BroadcastRequested::ready(broadcast));
 		}
 
 		// Key requests by absolute path so a scoped/rooted consumer and the handler
 		// (which may have a different root) agree on the same entry.
 		let absolute = self.root.join(&path).to_owned();
 
-		let mut state = self.dynamic.write().map_err(|_| Error::Dropped)?;
+		let Ok(mut state) = self.dynamic.write() else {
+			return kio::Pending::new(BroadcastRequested::failed(Error::Dropped));
+		};
 
 		// Coalesce onto a queued request for the same path; otherwise register a new one.
 		let consumer = if let Some(producer) = state.requests.get(&absolute) {
 			producer.consume()
 		} else {
 			if state.dynamic == 0 {
-				return Err(Error::Unroutable);
+				return kio::Pending::new(BroadcastRequested::failed(Error::Unroutable));
 			}
 
 			let producer = kio::Producer::<PendingBroadcast>::default();
@@ -1457,7 +1469,7 @@ impl OriginConsumer {
 			consumer
 		};
 
-		Ok(kio::Pending::new(BroadcastRequested::pending(consumer)))
+		kio::Pending::new(BroadcastRequested::pending(consumer))
 	}
 
 	/// Returns a new OriginConsumer that automatically strips out the provided prefix.
@@ -2963,12 +2975,15 @@ mod tests {
 		assert_eq!(paths, ["test1", "test2"]);
 	}
 
-	// With no OriginDynamic handler, an unannounced path fails fast (synchronously).
+	// With no OriginDynamic handler, an unannounced path resolves to Unroutable.
 	#[tokio::test]
 	async fn dynamic_request_unroutable_without_handler() {
 		let origin = Origin::random().produce();
 		let consumer = origin.consume();
-		assert!(matches!(consumer.request_broadcast("missing"), Err(Error::Unroutable)));
+		assert!(matches!(
+			consumer.request_broadcast("missing").await,
+			Err(Error::Unroutable)
+		));
 	}
 
 	// A dynamically served broadcast resolves the requester and serves tracks, but is
@@ -2984,8 +2999,8 @@ mod tests {
 		announced.assert_next_wait();
 
 		// Request a path that nobody announced; the future stays pending until served.
-		// Registration is synchronous, so the handler sees the request immediately.
-		let request_fut = consumer.request_broadcast("fallback").unwrap();
+		// Registration happens up front, so the handler sees the request immediately.
+		let request_fut = consumer.request_broadcast("fallback");
 
 		// The handler serves it with a live broadcast it keeps producing into.
 		let served = BroadcastInfo::new().produce();
@@ -2999,7 +3014,7 @@ mod tests {
 		assert!(broadcast.is_clone(&served.consume()));
 
 		// The served broadcast is live: a track subscription resolves via its handler.
-		let track_fut = broadcast.track("video").unwrap().subscribe(None).unwrap();
+		let track_fut = broadcast.track("video").unwrap().subscribe(None);
 		let mut producer = served_dynamic.requested_track().await.unwrap().accept(None);
 		let mut track = track_fut.await.unwrap();
 		producer.append_group().unwrap();
@@ -3016,9 +3031,9 @@ mod tests {
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
-		// Both register synchronously before the handler drains either.
-		let f1 = consumer.request_broadcast("dup").unwrap();
-		let f2 = consumer.request_broadcast("dup").unwrap();
+		// Both register before the handler drains either.
+		let f1 = consumer.request_broadcast("dup");
+		let f2 = consumer.request_broadcast("dup");
 
 		// Exactly one request reaches the handler.
 		let request = dynamic.requested_broadcast().await.unwrap();
@@ -3042,7 +3057,7 @@ mod tests {
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
-		let request_fut = consumer.request_broadcast("fallback").unwrap();
+		let request_fut = consumer.request_broadcast("fallback");
 
 		let request = dynamic.requested_broadcast().await.unwrap();
 		request.reject(Error::Cancel);
@@ -3051,19 +3066,22 @@ mod tests {
 	}
 
 	// Dropping the last handler resolves queued requests with an error and reverts to
-	// failing fast.
+	// resolving Unroutable.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_handler_dropped() {
 		let origin = Origin::random().produce();
 		let dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
-		let request_fut = consumer.request_broadcast("fallback").unwrap();
+		let request_fut = consumer.request_broadcast("fallback");
 		drop(dynamic);
 		assert!(matches!(request_fut.await, Err(Error::Unroutable)));
 
-		// With no handler left, a fresh request fails fast.
-		assert!(matches!(consumer.request_broadcast("again"), Err(Error::Unroutable)));
+		// With no handler left, a fresh request resolves Unroutable.
+		assert!(matches!(
+			consumer.request_broadcast("again").await,
+			Err(Error::Unroutable)
+		));
 	}
 
 	// `accept` is decoupled from the dynamic count: once a handler has picked a request up,
@@ -3075,7 +3093,7 @@ mod tests {
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
-		let request_fut = consumer.request_broadcast("fallback").unwrap();
+		let request_fut = consumer.request_broadcast("fallback");
 
 		// The handler picks the request up, then every handler drops (count -> 0).
 		let request = dynamic.requested_broadcast().await.unwrap();
@@ -3097,7 +3115,7 @@ mod tests {
 		let broadcast = BroadcastInfo::new().produce();
 		let _publish = origin.publish_broadcast("live", &broadcast).unwrap();
 
-		let got = consumer.request_broadcast("live").unwrap().await.unwrap();
+		let got = consumer.request_broadcast("live").await.unwrap();
 		assert!(
 			got.is_clone(&broadcast.consume()),
 			"should return the announced broadcast"
@@ -3118,11 +3136,10 @@ mod tests {
 		drop(dynamic.clone());
 
 		// The original handle is still live, so the request registers (stays pending)
-		// instead of failing fast.
+		// instead of resolving Unroutable.
 		let request_fut = consumer.request_broadcast("fallback");
-		assert!(request_fut.is_ok(), "request should register, not fail");
 		assert!(
-			request_fut.unwrap().now_or_never().is_none(),
+			request_fut.now_or_never().is_none(),
 			"request should stay pending until served"
 		);
 	}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -986,19 +986,24 @@ impl TrackConsumer {
 	}
 
 	/// Open a live subscription.
-	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> Result<kio::Pending<TrackSubscribe>> {
+	///
+	/// Registers the subscription on the track and returns a [`kio::Pending`] that resolves to the
+	/// [`TrackSubscriber`] once the track info is available, or the track's abort error (or
+	/// [`Error::Dropped`]) if it is already closed.
+	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> kio::Pending<TrackSubscribe> {
 		let subscription = kio::Producer::new(subscription.into().unwrap_or_default());
 
-		match self.state.write() {
-			Ok(mut state) => state.subscriptions.push(subscription.consume()),
-			Err(state) => return Err(state.abort.clone().unwrap_or(Error::Dropped)),
-		};
+		// Register the subscription if the track is live. If it is already closed, the returned
+		// future resolves to the abort error via `TrackSubscribe::poll_ok`.
+		if let Ok(mut state) = self.state.write() {
+			state.subscriptions.push(subscription.consume());
+		}
 
-		Ok(kio::Pending::new(TrackSubscribe {
+		kio::Pending::new(TrackSubscribe {
 			name: self.name.clone(),
 			state: self.state.clone(),
 			subscription,
-		}))
+		})
 	}
 
 	/// Return a cached group by sequence without blocking, or `None` if it isn't in
@@ -1015,33 +1020,28 @@ impl TrackConsumer {
 	/// the request (a wire FETCH for a relay). `options` accepts `None`, a [`Fetch`],
 	/// or `Fetch::default()`.
 	///
-	/// Fails synchronously with [`Error::NotFound`] when the group can never be served
-	/// (past the final sequence, or no [`TrackDynamic`] on the track), or the track's
-	/// abort error if it's already closed.
-	pub fn fetch_group(&self, sequence: u64, options: impl Into<Option<Fetch>>) -> Result<kio::Pending<TrackFetch>> {
+	/// The returned future resolves to [`Error::NotFound`] when the group can never be served
+	/// (past the final sequence, or no [`TrackDynamic`] on the track), or the track's abort error
+	/// if it's already closed.
+	pub fn fetch_group(&self, sequence: u64, options: impl Into<Option<Fetch>>) -> kio::Pending<TrackFetch> {
 		let options = options.into().unwrap_or_default();
 
-		let mut state = self
-			.state
-			.write()
-			.map_err(|s| s.abort.clone().unwrap_or(Error::Dropped))?;
-		match state.poll_fetch(sequence) {
-			// Cached: the pending resolves immediately, no handler needed.
-			Poll::Ready(Ok(_)) => {}
-			// Unservable (NotFound) or already aborted: report it synchronously.
-			Poll::Ready(Err(err)) => return Err(err),
-			// A handler exists but the group isn't cached yet: queue it.
-			Poll::Pending => state.fetches.push_back(GroupRequested {
-				sequence,
-				priority: options.priority,
-			}),
+		// Queue a request only when a handler can serve it but the group isn't cached yet. A cached
+		// group, an unservable sequence (NotFound), or a closed track all resolve through
+		// `TrackFetch::poll` without a queue entry.
+		if let Ok(mut state) = self.state.write() {
+			if state.poll_fetch(sequence).is_pending() {
+				state.fetches.push_back(GroupRequested {
+					sequence,
+					priority: options.priority,
+				});
+			}
 		}
-		drop(state);
 
-		Ok(kio::Pending::new(TrackFetch {
+		kio::Pending::new(TrackFetch {
 			state: self.state.clone(),
 			sequence,
-		}))
+		})
 	}
 
 	pub fn info(&self) -> kio::Pending<TrackInfoQuery> {
@@ -2349,7 +2349,7 @@ mod test {
 		let dynamic = producer.dynamic();
 		let consumer = producer.consume();
 		assert!(consumer.get_group(0).is_some());
-		let mut g = consumer.fetch_group(0, None).unwrap().await.unwrap();
+		let mut g = consumer.fetch_group(0, None).await.unwrap();
 		assert_eq!(g.sequence, 0);
 		assert_eq!(&g.read_frame().await.unwrap().unwrap()[..], b"hello");
 
@@ -2367,7 +2367,7 @@ mod test {
 		// `fetch_group` stays pending and queues a request. `*pending` derefs the
 		// wrapper to the inner `TrackFetch` (a `kio::Future`).
 		assert!(consumer.get_group(5).is_none());
-		let pending = consumer.fetch_group(5, Fetch::default().with_priority(7)).unwrap();
+		let pending = consumer.fetch_group(5, Fetch::default().with_priority(7));
 		assert!(kio::Future::poll(&*pending, &kio::Waiter::noop()).is_pending());
 
 		let req = dynamic
@@ -2391,11 +2391,11 @@ mod test {
 	#[tokio::test]
 	async fn fetch_miss_no_dynamic_not_found() {
 		// A track with no `TrackDynamic` can't serve old content, so a cache miss
-		// fails fast (synchronously) instead of blocking forever.
+		// resolves to NotFound instead of blocking forever.
 		let mut producer = TrackProducer::new("test", None);
 		producer.append_group().unwrap(); // seq 0, but we miss on seq 5
 		let consumer = producer.consume();
-		assert!(matches!(consumer.fetch_group(5, None), Err(Error::NotFound)));
+		assert!(matches!(consumer.fetch_group(5, None).await, Err(Error::NotFound)));
 	}
 
 	#[tokio::test]
@@ -2405,10 +2405,10 @@ mod test {
 		producer.finish().unwrap(); // final_sequence = 1
 
 		// A group at or past the final sequence can never exist, even with a handler,
-		// so it fails fast synchronously.
+		// so it resolves to NotFound.
 		let dynamic = producer.dynamic();
 		let consumer = producer.consume();
-		assert!(matches!(consumer.fetch_group(5, None), Err(Error::NotFound)));
+		assert!(matches!(consumer.fetch_group(5, None).await, Err(Error::NotFound)));
 
 		// And it doesn't signal the dynamic handler.
 		assert!(dynamic.poll_requested_group(&kio::Waiter::noop()).is_pending());
@@ -2420,7 +2420,7 @@ mod test {
 		let dynamic = producer.dynamic();
 		let consumer = producer.consume();
 
-		let pending = consumer.fetch_group(3, None).unwrap();
+		let pending = consumer.fetch_group(3, None);
 		assert!(kio::Future::poll(&*pending, &kio::Waiter::noop()).is_pending());
 
 		producer.abort(Error::Cancel).unwrap();

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -1456,7 +1456,6 @@ mod tests {
 			.track("publisher.json")
 			.unwrap()
 			.subscribe(None)
-			.unwrap()
 			.await
 			.expect("subscribe");
 		let frame = read_frame(track).await;
@@ -1485,7 +1484,6 @@ mod tests {
 			.track("publisher.json")
 			.unwrap()
 			.subscribe(None)
-			.unwrap()
 			.await
 			.expect("subscribe");
 		let frame = read_frame(track).await;
@@ -1522,7 +1520,6 @@ mod tests {
 			.track("publisher.json")
 			.unwrap()
 			.subscribe(None)
-			.unwrap()
 			.await
 			.expect("subscribe");
 		let frame = read_frame(track).await;
@@ -1651,7 +1648,6 @@ mod tests {
 			.track("sessions.json")
 			.unwrap()
 			.subscribe(None)
-			.unwrap()
 			.await
 			.expect("subscribe");
 		let frame = read_session_frame(track).await;
@@ -1667,7 +1663,6 @@ mod tests {
 			.track("internal/sessions.json")
 			.unwrap()
 			.subscribe(None)
-			.unwrap()
 			.await
 			.expect("subscribe");
 		let snap = *read_session_frame(int_track).await.get("peer").expect("internal entry");
@@ -1719,7 +1714,6 @@ mod tests {
 			.track("publisher.json")
 			.unwrap()
 			.subscribe(None)
-			.unwrap()
 			.await
 			.expect("subscribe");
 		assert!(
@@ -1730,13 +1724,7 @@ mod tests {
 		// The other three slots had zero activity. The first frame on
 		// each must be `{}`, not `{"foo/bar": {all zeros}}`.
 		for name in ["subscriber.json", "internal/publisher.json", "internal/subscriber.json"] {
-			let t = broadcast
-				.track(name)
-				.unwrap()
-				.subscribe(None)
-				.unwrap()
-				.await
-				.expect("subscribe");
+			let t = broadcast.track(name).unwrap().subscribe(None).await.expect("subscribe");
 			let frame = read_frame(t).await;
 			assert!(
 				frame.is_empty(),

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -592,7 +592,7 @@ async fn serve_fetch(
 		let group = match params.group {
 			// "latest" needs a live subscription to learn the newest sequence;
 			// fetch only retrieves a specified past group.
-			FetchGroup::Latest => match async { broadcast.track(&track)?.subscribe(None)?.await }.await {
+			FetchGroup::Latest => match async { broadcast.track(&track)?.subscribe(None).await }.await {
 				Ok(mut sub) => match sub.latest() {
 					Some(sequence) => sub.get_group(sequence).await,
 					None => sub.recv_group().await,
@@ -600,7 +600,7 @@ async fn serve_fetch(
 				Err(err) => Err(err),
 			},
 			// A one-shot fetch, no subscription required.
-			FetchGroup::Num(sequence) => async { broadcast.track(&track)?.fetch_group(sequence, None)?.await }
+			FetchGroup::Num(sequence) => async { broadcast.track(&track)?.fetch_group(sequence, None).await }
 				.await
 				.map(Some),
 		};

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -149,13 +149,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	assert_eq!(path.as_str(), "test");
 	let bc = bc.broadcast().expect("expected announce, got unannounce");
 
-	let mut track_sub = bc
-		.track("video")
-		.unwrap()
-		.subscribe(None)
-		.unwrap()
-		.await
-		.expect("consume_track");
+	let mut track_sub = bc.track("video").unwrap().subscribe(None).await.expect("consume_track");
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
 		.expect("recv_group timeout")
@@ -332,13 +326,7 @@ async fn internal_tcp_round_trip() {
 	assert_eq!(path.as_str(), "test");
 	let bc = bc.broadcast().expect("expected announce, got unannounce");
 
-	let mut track_sub = bc
-		.track("video")
-		.unwrap()
-		.subscribe(None)
-		.unwrap()
-		.await
-		.expect("consume_track");
+	let mut track_sub = bc.track("video").unwrap().subscribe(None).await.expect("consume_track");
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
 		.expect("recv_group timeout")
@@ -440,13 +428,7 @@ async fn internal_unix_round_trip() {
 	assert_eq!(announced_path.as_str(), "test");
 	let bc = bc.broadcast().expect("expected announce, got unannounce");
 
-	let mut track_sub = bc
-		.track("video")
-		.unwrap()
-		.subscribe(None)
-		.unwrap()
-		.await
-		.expect("consume_track");
+	let mut track_sub = bc.track("video").unwrap().subscribe(None).await.expect("consume_track");
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
 		.await
 		.expect("recv_group timeout")

--- a/rs/moq-rtc/bin/moq-rtc.rs
+++ b/rs/moq-rtc/bin/moq-rtc.rs
@@ -229,7 +229,8 @@ async fn run_client(
 			// Once the per-codec re-packetizer lands, this should poll
 			// `subscriber.announced()` to await the broadcast rather than
 			// erroring on first-miss.
-			let broadcast = async { subscriber.request_broadcast(broadcast_name)?.await }
+			let broadcast = subscriber
+				.request_broadcast(broadcast_name)
 				.await
 				.map_err(|_| anyhow::anyhow!("broadcast {} not announced", broadcast_name))?;
 			client.publish(url, broadcast).await?;

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -85,7 +85,7 @@ impl Track {
 		// `None` subscription => start at the latest (in-progress) group. Groups
 		// begin at a keyframe, so a late joiner gets a decodable start immediately
 		// rather than waiting for the next group boundary.
-		let track = broadcast.track(name)?.subscribe(None)?.await?;
+		let track = broadcast.track(name)?.subscribe(None).await?;
 		let consumer = moq_mux::container::Consumer::new(track, container);
 		Ok(Self {
 			consumer,
@@ -101,7 +101,7 @@ impl Track {
 		let container: moq_mux::catalog::hang::Container = (&config.container).try_into()?;
 		// `None` subscription => start at the latest (in-progress) group, which
 		// begins at a keyframe, so a late-joining peer gets a decodable start.
-		let track = broadcast.track(name)?.subscribe(None)?.await?;
+		let track = broadcast.track(name)?.subscribe(None).await?;
 		let consumer = moq_mux::container::Consumer::new(track, container);
 
 		let (codec, convert) = match &config.codec {

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -53,7 +53,7 @@ impl EgressSource {
 	pub async fn new(broadcast: moq_net::BroadcastConsumer) -> Result<Self> {
 		let catalog_track = broadcast
 			.track(hang::Catalog::DEFAULT_NAME)?
-			.subscribe(hang::Catalog::default_subscription())?
+			.subscribe(hang::Catalog::default_subscription())
 			.await?;
 		let mut consumer = moq_mux::catalog::hang::Consumer::new(catalog_track);
 		let catalog = consumer

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -81,9 +81,10 @@ pub async fn accept(
 
 	// Look up the MoQ broadcast on the subscribe origin. `request_broadcast` resolves an
 	// already-announced broadcast immediately and falls back to a dynamic handler if the
-	// origin has one; with neither, it fails fast and the WHEP client retries (typical).
+	// origin has one; with neither, it resolves to an error and the WHEP client retries (typical).
 	let broadcast = broadcast.as_path().to_string();
-	let consumer = async { subscriber.request_broadcast(&broadcast)?.await }
+	let consumer = subscriber
+		.request_broadcast(&broadcast)
 		.await
 		.map_err(|_| Error::Other(anyhow::anyhow!("broadcast {broadcast} not announced")))?;
 

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -34,7 +34,7 @@ impl Consumer {
 		let decoder = Decoder::new(catalog, &config.kind)?;
 
 		let name = name.into();
-		let track = broadcast.track(&name)?.subscribe(None)?.await?;
+		let track = broadcast.track(&name)?.subscribe(None).await?;
 		let mut track = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 		if let Some(latency) = config.latency_max {
 			track = track.with_latency(latency);

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -103,7 +103,7 @@ impl Broadcast {
 	/// Subscribe to a track by name, resolving once the publisher accepts.
 	pub async fn subscribe(&self, name: String) -> Result<Track, JsValue> {
 		let track = self.inner.track(&name).map_err(js_err)?;
-		let subscriber = track.subscribe(None).map_err(js_err)?.await.map_err(js_err)?;
+		let subscriber = track.subscribe(None).await.map_err(js_err)?;
 		Ok(Track {
 			inner: Rc::new(RefCell::new(Some(subscriber))),
 		})


### PR DESCRIPTION
## Summary

Three consumer-side lookups in `rs/moq-net` each returned `Result<kio::Pending<…>>` — a synchronous `Result` wrapping a future that *itself* resolves to a `Result`. That double layer forced every caller into either `x()?.await?` or, when the synchronous error had to be translated into a wire/HTTP response rather than propagated, the awkward `async { x()?.await }.await` dance:

```rust
let broadcast = match async { self.origin.request_broadcast(&ns)?.await }.await { … };
```

The synchronous error was never useful on its own: callers await the result anyway, and even the one register-then-`select!` caller (`libmoq`) just `?`s it. So this collapses all three to return a bare `kio::Pending<…>` and bakes the former synchronous errors into the future, resolved on `.await` like every other outcome:

- **`OriginConsumer::request_broadcast`** — new internal `Requested::Failed(Error)` variant carries `Unroutable` / `Dropped`.
- **`TrackConsumer::subscribe`** — the closed-track error already surfaces via `TrackSubscribe::poll_ok`, so registration simply skips when the track is closed.
- **`TrackConsumer::fetch_group`** — `TrackFetch::poll` already reports `NotFound` / abort, so the synchronous `poll_fetch` check was a pure duplicate; it now only decides whether to queue a request.

`TrackConsumer::info()` already worked this way, so this just makes the set consistent.

The gross call sites become a single `.await`:

```rust
let broadcast = match self.origin.request_broadcast(&ns).await { … };
```

## Public API changes (breaking)

In `rs/moq-net`:

- `OriginConsumer::request_broadcast` → `kio::Pending<BroadcastRequested>` (was `Result<…, Error>`)
- `TrackConsumer::subscribe` → `kio::Pending<TrackSubscribe>` (was `Result<…>`)
- `TrackConsumer::fetch_group` → `kio::Pending<TrackFetch>` (was `Result<…>`)

These are breaking, hence the **dev** base per the branch-targeting rules.

The remaining `broadcast.track(name)?` stays a plain `?` — it is a synchronous accessor returning a handle, not a future-in-a-Result, so a single `?` is idiomatic and not the wart being removed. The few surviving `async { … }` blocks (ietf publisher, relay `serve_fetch`) are now justified: they flatten a genuine `track()?` lookup *plus* a separate `.await`, not one call's double-`Result`.

## Call-site sweep

Mechanical `?.await?` → `.await?` (and tests `.unwrap().await` → `.await`) across: moq-net, moq-relay, moq-rtc, moq-ffi, libmoq, moq-mux, moq-audio, moq-boy, moq-gst, moq-bench, moq-native, hang.

## Cross-package sync

- `js/net` mirrors the `rs/moq-net` consumer surface (`requestBroadcast` / `subscribe` / `fetchGroup`). **Not** updated in this PR — flagging for a follow-up so the JS side can decide whether to reshape to match.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p moq-net` — 389 passed
- [x] `cargo test -p moq-mux -p moq-relay --lib` — green
- [ ] Re-run `just fix` against the pinned nix toolchain before merge — this branch was formatted with the system `cargo fmt` because `nix develop` couldn't allocate a pty in the dev environment.

(Written by Claude)