### PR TITLE
docs: base new worktrees on the freshly-fetched remote branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ Two long-lived branches:
 
 When making changes to the codebase:
 
-1. Pick the base branch per [Branch Targeting](#branch-targeting) above
+1. Pick the base branch per [Branch Targeting](#branch-targeting) above. **When creating a new worktree, base it on the freshly-fetched remote branch** (`git fetch origin` first, then branch off `origin/main` / `origin/dev`), not on whatever local `main`/`dev` the repo happens to be sitting on. A local branch can lag the remote by many commits (or carry a stale local merge), which produces a massive conflicting PR diff against the real base at merge time.
 2. Make your code changes
 3. Run `just fix` to auto-format and fix linting issues
 4. Run `just check` to verify everything passes


### PR DESCRIPTION
Adds a note to the root `CLAUDE.md` workflow steps: when creating a new worktree, fetch and base it on `origin/main` / `origin/dev`, not on whatever local `main`/`dev` the repo is sitting on.

### Why

A worktree cut from a stale local base (lagging the remote by many commits, or carrying a local merge commit) produces a massive conflicting PR diff against the real base at merge time. Hit exactly this on #1891, where the branch carried a stale local `Merge main into dev` and the PR showed a 360/342 conflicting diff until rebased onto the real `origin/dev`.

Docs-only, targeting `main`.

(Written by Claude)