### PR TITLE
feat(moq-net): mandatory timestamps for moq-lite-05

### DIFF
--- a/js/clock/src/main.ts
+++ b/js/clock/src/main.ts
@@ -162,7 +162,7 @@ async function subscribe(config: Config) {
 			continue;
 		}
 
-		const base = new TextDecoder().decode(baseFrame);
+		const base = new TextDecoder().decode(baseFrame.data);
 
 		// Read individual second frames
 		for (;;) {

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -138,7 +138,7 @@ function encodeLegacy(timestamp: Time.Micro): Uint8Array {
 function writeGroupWithLegacyFrames(track: TrackProducer, sequence: number, timestamps: Time.Micro[]) {
 	const group = new Group(sequence);
 	for (const ts of timestamps) {
-		group.writeFrame(encodeLegacy(ts));
+		group.writeFrame({ data: encodeLegacy(ts) });
 	}
 	group.close();
 	track.writeGroup(group);
@@ -205,8 +205,8 @@ test("Consumer index spans MoQ frames for keyframe detection", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: multiFormat, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
-	group.writeFrame(new Uint8Array([0x01])); // first MoQ frame → 3 samples
-	group.writeFrame(new Uint8Array([0x02])); // second MoQ frame → 3 samples
+	group.writeFrame({ data: new Uint8Array([0x01]) }); // first MoQ frame → 3 samples
+	group.writeFrame({ data: new Uint8Array([0x02]) }); // second MoQ frame → 3 samples
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -234,15 +234,15 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 
 	// Group 0: 2 valid frames then a tail-truncating error.
 	const g0 = new Group(0);
-	g0.writeFrame(new Uint8Array([0x01]));
-	g0.writeFrame(new Uint8Array([0x02]));
-	g0.writeFrame(new Uint8Array([0xff]));
+	g0.writeFrame({ data: new Uint8Array([0x01]) });
+	g0.writeFrame({ data: new Uint8Array([0x02]) });
+	g0.writeFrame({ data: new Uint8Array([0xff]) });
 	g0.close();
 	track.writeGroup(g0);
 
 	// Group 1 decodes cleanly.
 	const g1 = new Group(1);
-	g1.writeFrame(new Uint8Array([0x04]));
+	g1.writeFrame({ data: new Uint8Array([0x04]) });
 	g1.close();
 	track.writeGroup(g1);
 
@@ -430,8 +430,8 @@ test("Consumer handles empty decode result without deadlock", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: emptyThenValid, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
-	group.writeFrame(new Uint8Array([0x01])); // empty decode
-	group.writeFrame(new Uint8Array([0x02])); // valid decode
+	group.writeFrame({ data: new Uint8Array([0x01]) }); // empty decode
+	group.writeFrame({ data: new Uint8Array([0x02]) }); // valid decode
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -456,24 +456,24 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 	});
 
 	const group = new Group(0);
-	group.writeFrame(
-		encodeDataSegment({
+	group.writeFrame({
+		data: encodeDataSegment({
 			data: new Uint8Array([0xca, 0xfe]),
 			timestamp: 0,
 			duration: 3000,
 			keyframe: true,
 			sequence: 0,
 		}),
-	);
-	group.writeFrame(
-		encodeDataSegment({
+	});
+	group.writeFrame({
+		data: encodeDataSegment({
 			data: new Uint8Array([0xbe, 0xef]),
 			timestamp: 3000,
 			duration: 3000,
 			keyframe: false,
 			sequence: 0,
 		}),
-	);
+	});
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -525,11 +525,11 @@ test("Consumer duration-skips a stalled group once it is covered", async () => {
 
 	// Group 0: one frame at ts=0 lasting 33ms, never closed (stalled).
 	const g0 = new Group(0);
-	g0.writeFrame(new Uint8Array([0]));
+	g0.writeFrame({ data: new Uint8Array([0]) });
 
 	// Group 1: closed, starts exactly where group 0's frame ends.
 	const g1 = new Group(1);
-	g1.writeFrame(new Uint8Array([33]));
+	g1.writeFrame({ data: new Uint8Array([33]) });
 	g1.close();
 
 	track.writeGroup(g0);
@@ -563,10 +563,10 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 	// Group 0 stays open and later receives a second frame; nothing covers the gap,
 	// so that late frame must survive rather than being skipped.
 	const g0 = new Group(0);
-	g0.writeFrame(new Uint8Array([0]));
+	g0.writeFrame({ data: new Uint8Array([0]) });
 
 	const g1 = new Group(1);
-	g1.writeFrame(new Uint8Array([33]));
+	g1.writeFrame({ data: new Uint8Array([33]) });
 	g1.close();
 
 	track.writeGroup(g0);
@@ -574,7 +574,7 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 
 	// Let the consumer settle on group 0, then extend it before closing.
 	await new Promise((resolve) => setTimeout(resolve, 20));
-	g0.writeFrame(new Uint8Array([20]));
+	g0.writeFrame({ data: new Uint8Array([20]) });
 	g0.close();
 	track.close();
 

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -138,7 +138,7 @@ function encodeLegacy(timestamp: Time.Micro): Uint8Array {
 function writeGroupWithLegacyFrames(track: TrackProducer, sequence: number, timestamps: Time.Micro[]) {
 	const group = new Group(sequence);
 	for (const ts of timestamps) {
-		group.writeFrameNow(encodeLegacy(ts));
+		group.writeFrame(encodeLegacy(ts));
 	}
 	group.close();
 	track.writeGroup(group);
@@ -205,8 +205,8 @@ test("Consumer index spans MoQ frames for keyframe detection", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: multiFormat, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
-	group.writeFrameNow(new Uint8Array([0x01])); // first MoQ frame → 3 samples
-	group.writeFrameNow(new Uint8Array([0x02])); // second MoQ frame → 3 samples
+	group.writeFrame(new Uint8Array([0x01])); // first MoQ frame → 3 samples
+	group.writeFrame(new Uint8Array([0x02])); // second MoQ frame → 3 samples
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -234,15 +234,15 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 
 	// Group 0: 2 valid frames then a tail-truncating error.
 	const g0 = new Group(0);
-	g0.writeFrameNow(new Uint8Array([0x01]));
-	g0.writeFrameNow(new Uint8Array([0x02]));
-	g0.writeFrameNow(new Uint8Array([0xff]));
+	g0.writeFrame(new Uint8Array([0x01]));
+	g0.writeFrame(new Uint8Array([0x02]));
+	g0.writeFrame(new Uint8Array([0xff]));
 	g0.close();
 	track.writeGroup(g0);
 
 	// Group 1 decodes cleanly.
 	const g1 = new Group(1);
-	g1.writeFrameNow(new Uint8Array([0x04]));
+	g1.writeFrame(new Uint8Array([0x04]));
 	g1.close();
 	track.writeGroup(g1);
 
@@ -430,8 +430,8 @@ test("Consumer handles empty decode result without deadlock", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: emptyThenValid, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
-	group.writeFrameNow(new Uint8Array([0x01])); // empty decode
-	group.writeFrameNow(new Uint8Array([0x02])); // valid decode
+	group.writeFrame(new Uint8Array([0x01])); // empty decode
+	group.writeFrame(new Uint8Array([0x02])); // valid decode
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -456,7 +456,7 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 	});
 
 	const group = new Group(0);
-	group.writeFrameNow(
+	group.writeFrame(
 		encodeDataSegment({
 			data: new Uint8Array([0xca, 0xfe]),
 			timestamp: 0,
@@ -465,7 +465,7 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 			sequence: 0,
 		}),
 	);
-	group.writeFrameNow(
+	group.writeFrame(
 		encodeDataSegment({
 			data: new Uint8Array([0xbe, 0xef]),
 			timestamp: 3000,
@@ -525,11 +525,11 @@ test("Consumer duration-skips a stalled group once it is covered", async () => {
 
 	// Group 0: one frame at ts=0 lasting 33ms, never closed (stalled).
 	const g0 = new Group(0);
-	g0.writeFrameNow(new Uint8Array([0]));
+	g0.writeFrame(new Uint8Array([0]));
 
 	// Group 1: closed, starts exactly where group 0's frame ends.
 	const g1 = new Group(1);
-	g1.writeFrameNow(new Uint8Array([33]));
+	g1.writeFrame(new Uint8Array([33]));
 	g1.close();
 
 	track.writeGroup(g0);
@@ -563,10 +563,10 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 	// Group 0 stays open and later receives a second frame; nothing covers the gap,
 	// so that late frame must survive rather than being skipped.
 	const g0 = new Group(0);
-	g0.writeFrameNow(new Uint8Array([0]));
+	g0.writeFrame(new Uint8Array([0]));
 
 	const g1 = new Group(1);
-	g1.writeFrameNow(new Uint8Array([33]));
+	g1.writeFrame(new Uint8Array([33]));
 	g1.close();
 
 	track.writeGroup(g0);
@@ -574,7 +574,7 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 
 	// Let the consumer settle on group 0, then extend it before closing.
 	await new Promise((resolve) => setTimeout(resolve, 20));
-	g0.writeFrameNow(new Uint8Array([20]));
+	g0.writeFrame(new Uint8Array([20]));
 	g0.close();
 	track.close();
 

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { Group, type Time, TrackProducer, Varint } from "@moq/net";
+import { Group, Time, TrackProducer, Varint } from "@moq/net";
 import type { InitSegment } from "./cmaf/decode.ts";
 import { encodeDataSegment } from "./cmaf/encode.ts";
 import { Format as CmafFormat } from "./cmaf/format.ts";
@@ -138,7 +138,7 @@ function encodeLegacy(timestamp: Time.Micro): Uint8Array {
 function writeGroupWithLegacyFrames(track: TrackProducer, sequence: number, timestamps: Time.Micro[]) {
 	const group = new Group(sequence);
 	for (const ts of timestamps) {
-		group.writeFrame({ data: encodeLegacy(ts) });
+		group.writeFrame({ data: encodeLegacy(ts), timestamp: Time.Timestamp.now() });
 	}
 	group.close();
 	track.writeGroup(group);
@@ -205,8 +205,8 @@ test("Consumer index spans MoQ frames for keyframe detection", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: multiFormat, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
-	group.writeFrame({ data: new Uint8Array([0x01]) }); // first MoQ frame → 3 samples
-	group.writeFrame({ data: new Uint8Array([0x02]) }); // second MoQ frame → 3 samples
+	group.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // first MoQ frame → 3 samples
+	group.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // second MoQ frame → 3 samples
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -234,15 +234,15 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 
 	// Group 0: 2 valid frames then a tail-truncating error.
 	const g0 = new Group(0);
-	g0.writeFrame({ data: new Uint8Array([0x01]) });
-	g0.writeFrame({ data: new Uint8Array([0x02]) });
-	g0.writeFrame({ data: new Uint8Array([0xff]) });
+	g0.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() });
+	g0.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() });
+	g0.writeFrame({ data: new Uint8Array([0xff]), timestamp: Time.Timestamp.now() });
 	g0.close();
 	track.writeGroup(g0);
 
 	// Group 1 decodes cleanly.
 	const g1 = new Group(1);
-	g1.writeFrame({ data: new Uint8Array([0x04]) });
+	g1.writeFrame({ data: new Uint8Array([0x04]), timestamp: Time.Timestamp.now() });
 	g1.close();
 	track.writeGroup(g1);
 
@@ -430,8 +430,8 @@ test("Consumer handles empty decode result without deadlock", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: emptyThenValid, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
-	group.writeFrame({ data: new Uint8Array([0x01]) }); // empty decode
-	group.writeFrame({ data: new Uint8Array([0x02]) }); // valid decode
+	group.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // empty decode
+	group.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // valid decode
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -464,6 +464,7 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 			keyframe: true,
 			sequence: 0,
 		}),
+		timestamp: Time.Timestamp.now(),
 	});
 	group.writeFrame({
 		data: encodeDataSegment({
@@ -473,6 +474,7 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 			keyframe: false,
 			sequence: 0,
 		}),
+		timestamp: Time.Timestamp.now(),
 	});
 	group.close();
 	track.writeGroup(group);
@@ -525,11 +527,11 @@ test("Consumer duration-skips a stalled group once it is covered", async () => {
 
 	// Group 0: one frame at ts=0 lasting 33ms, never closed (stalled).
 	const g0 = new Group(0);
-	g0.writeFrame({ data: new Uint8Array([0]) });
+	g0.writeFrame({ data: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
 
 	// Group 1: closed, starts exactly where group 0's frame ends.
 	const g1 = new Group(1);
-	g1.writeFrame({ data: new Uint8Array([33]) });
+	g1.writeFrame({ data: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
 	g1.close();
 
 	track.writeGroup(g0);
@@ -563,10 +565,10 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 	// Group 0 stays open and later receives a second frame; nothing covers the gap,
 	// so that late frame must survive rather than being skipped.
 	const g0 = new Group(0);
-	g0.writeFrame({ data: new Uint8Array([0]) });
+	g0.writeFrame({ data: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
 
 	const g1 = new Group(1);
-	g1.writeFrame({ data: new Uint8Array([33]) });
+	g1.writeFrame({ data: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
 	g1.close();
 
 	track.writeGroup(g0);
@@ -574,7 +576,7 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 
 	// Let the consumer settle on group 0, then extend it before closing.
 	await new Promise((resolve) => setTimeout(resolve, 20));
-	g0.writeFrame({ data: new Uint8Array([20]) });
+	g0.writeFrame({ data: new Uint8Array([20]), timestamp: Time.Timestamp.now() });
 	g0.close();
 	track.close();
 

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -138,7 +138,7 @@ function encodeLegacy(timestamp: Time.Micro): Uint8Array {
 function writeGroupWithLegacyFrames(track: TrackProducer, sequence: number, timestamps: Time.Micro[]) {
 	const group = new Group(sequence);
 	for (const ts of timestamps) {
-		group.writeFrame(encodeLegacy(ts));
+		group.writeFrameNow(encodeLegacy(ts));
 	}
 	group.close();
 	track.writeGroup(group);
@@ -205,8 +205,8 @@ test("Consumer index spans MoQ frames for keyframe detection", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: multiFormat, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
-	group.writeFrame(new Uint8Array([0x01])); // first MoQ frame → 3 samples
-	group.writeFrame(new Uint8Array([0x02])); // second MoQ frame → 3 samples
+	group.writeFrameNow(new Uint8Array([0x01])); // first MoQ frame → 3 samples
+	group.writeFrameNow(new Uint8Array([0x02])); // second MoQ frame → 3 samples
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -234,15 +234,15 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 
 	// Group 0: 2 valid frames then a tail-truncating error.
 	const g0 = new Group(0);
-	g0.writeFrame(new Uint8Array([0x01]));
-	g0.writeFrame(new Uint8Array([0x02]));
-	g0.writeFrame(new Uint8Array([0xff]));
+	g0.writeFrameNow(new Uint8Array([0x01]));
+	g0.writeFrameNow(new Uint8Array([0x02]));
+	g0.writeFrameNow(new Uint8Array([0xff]));
 	g0.close();
 	track.writeGroup(g0);
 
 	// Group 1 decodes cleanly.
 	const g1 = new Group(1);
-	g1.writeFrame(new Uint8Array([0x04]));
+	g1.writeFrameNow(new Uint8Array([0x04]));
 	g1.close();
 	track.writeGroup(g1);
 
@@ -430,8 +430,8 @@ test("Consumer handles empty decode result without deadlock", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: emptyThenValid, latency: 500 as Time.Milli });
 
 	const group = new Group(0);
-	group.writeFrame(new Uint8Array([0x01])); // empty decode
-	group.writeFrame(new Uint8Array([0x02])); // valid decode
+	group.writeFrameNow(new Uint8Array([0x01])); // empty decode
+	group.writeFrameNow(new Uint8Array([0x02])); // valid decode
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -456,7 +456,7 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 	});
 
 	const group = new Group(0);
-	group.writeFrame(
+	group.writeFrameNow(
 		encodeDataSegment({
 			data: new Uint8Array([0xca, 0xfe]),
 			timestamp: 0,
@@ -465,7 +465,7 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 			sequence: 0,
 		}),
 	);
-	group.writeFrame(
+	group.writeFrameNow(
 		encodeDataSegment({
 			data: new Uint8Array([0xbe, 0xef]),
 			timestamp: 3000,
@@ -525,11 +525,11 @@ test("Consumer duration-skips a stalled group once it is covered", async () => {
 
 	// Group 0: one frame at ts=0 lasting 33ms, never closed (stalled).
 	const g0 = new Group(0);
-	g0.writeFrame(new Uint8Array([0]));
+	g0.writeFrameNow(new Uint8Array([0]));
 
 	// Group 1: closed, starts exactly where group 0's frame ends.
 	const g1 = new Group(1);
-	g1.writeFrame(new Uint8Array([33]));
+	g1.writeFrameNow(new Uint8Array([33]));
 	g1.close();
 
 	track.writeGroup(g0);
@@ -563,10 +563,10 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 	// Group 0 stays open and later receives a second frame; nothing covers the gap,
 	// so that late frame must survive rather than being skipped.
 	const g0 = new Group(0);
-	g0.writeFrame(new Uint8Array([0]));
+	g0.writeFrameNow(new Uint8Array([0]));
 
 	const g1 = new Group(1);
-	g1.writeFrame(new Uint8Array([33]));
+	g1.writeFrameNow(new Uint8Array([33]));
 	g1.close();
 
 	track.writeGroup(g0);
@@ -574,7 +574,7 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 
 	// Let the consumer settle on group 0, then extend it before closing.
 	await new Promise((resolve) => setTimeout(resolve, 20));
-	g0.writeFrame(new Uint8Array([20]));
+	g0.writeFrameNow(new Uint8Array([20]));
 	g0.close();
 	track.close();
 

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -97,7 +97,7 @@ export class Consumer {
 				const next = await group.consumer.readFrame();
 				if (!next) break;
 
-				const decoded = this.#format.decode(next);
+				const decoded = this.#format.decode(next.data);
 
 				for (const sample of decoded) {
 					const frame: Frame = {

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -57,7 +57,7 @@ export class Producer {
 			throw new Error("must start with a keyframe");
 		}
 
-		this.#group?.writeFrame(encodeFrame(data, timestamp), Time.Milli.fromMicro(timestamp));
+		this.#group?.writeFrame({ data: encodeFrame(data, timestamp), timestamp: Time.Milli.fromMicro(timestamp) });
 	}
 
 	/** Close the track and current group, optionally with an error. */

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -57,7 +57,10 @@ export class Producer {
 			throw new Error("must start with a keyframe");
 		}
 
-		this.#group?.writeFrame({ data: encodeFrame(data, timestamp), timestamp: Time.Milli.fromMicro(timestamp) });
+		this.#group?.writeFrame({
+			data: encodeFrame(data, timestamp),
+			timestamp: Time.Timestamp.fromMicros(timestamp),
+		});
 	}
 
 	/** Close the track and current group, optionally with an error. */

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -1,5 +1,5 @@
-import type { Time } from "@moq/net";
 import * as Moq from "@moq/net";
+import { Time } from "@moq/net";
 
 export type { BufferedRange, BufferedRanges, Frame } from "./types";
 
@@ -57,7 +57,7 @@ export class Producer {
 			throw new Error("must start with a keyframe");
 		}
 
-		this.#group?.writeFrame(timestamp, encodeFrame(data, timestamp));
+		this.#group?.writeFrame(encodeFrame(data, timestamp), Time.Milli.fromMicro(timestamp));
 	}
 
 	/** Close the track and current group, optionally with an error. */

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -57,7 +57,7 @@ export class Producer {
 			throw new Error("must start with a keyframe");
 		}
 
-		this.#group?.writeFrame(encodeFrame(data, timestamp));
+		this.#group?.writeFrame(timestamp, encodeFrame(data, timestamp));
 	}
 
 	/** Close the track and current group, optionally with an error. */

--- a/js/json/src/consumer.ts
+++ b/js/json/src/consumer.ts
@@ -33,7 +33,7 @@ export class Consumer<T> {
 				this.#framesRead = 0;
 			}
 
-			let frame: Uint8Array | undefined;
+			let frame: Moq.Frame | undefined;
 			try {
 				frame = await this.#group.readFrame();
 			} catch {
@@ -50,7 +50,7 @@ export class Consumer<T> {
 				continue;
 			}
 
-			return this.#apply(frame);
+			return this.#apply(frame.data);
 		}
 	}
 

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -53,7 +53,7 @@ export class Producer<T> {
 		const snapshot = new TextEncoder().encode(text);
 		const delta = this.#delta(json, snapshot.length);
 		if (delta && this.#group) {
-			this.#group.writeFrame(delta);
+			this.#group.writeFrame({ data: delta });
 			this.#groupBytes += delta.length;
 			this.#groupFrames += 1;
 		} else {
@@ -122,7 +122,7 @@ export class Producer<T> {
 		this.#group?.close();
 
 		const group = this.#track.appendGroup();
-		group.writeFrame(snapshot);
+		group.writeFrame({ data: snapshot });
 		this.#groupBytes = snapshot.length;
 		this.#groupFrames = 1;
 

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -53,7 +53,7 @@ export class Producer<T> {
 		const snapshot = new TextEncoder().encode(text);
 		const delta = this.#delta(json, snapshot.length);
 		if (delta && this.#group) {
-			this.#group.writeFrameNow(delta);
+			this.#group.writeFrame(delta);
 			this.#groupBytes += delta.length;
 			this.#groupFrames += 1;
 		} else {
@@ -122,7 +122,7 @@ export class Producer<T> {
 		this.#group?.close();
 
 		const group = this.#track.appendGroup();
-		group.writeFrameNow(snapshot);
+		group.writeFrame(snapshot);
 		this.#groupBytes = snapshot.length;
 		this.#groupFrames = 1;
 

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -1,4 +1,5 @@
 import type * as Moq from "@moq/net";
+import { Time } from "@moq/net";
 import type * as z from "zod/mini";
 
 import { deepEqual, diff } from "./diff.ts";
@@ -53,7 +54,7 @@ export class Producer<T> {
 		const snapshot = new TextEncoder().encode(text);
 		const delta = this.#delta(json, snapshot.length);
 		if (delta && this.#group) {
-			this.#group.writeFrame({ data: delta });
+			this.#group.writeFrame({ data: delta, timestamp: Time.Timestamp.now() });
 			this.#groupBytes += delta.length;
 			this.#groupFrames += 1;
 		} else {
@@ -122,7 +123,7 @@ export class Producer<T> {
 		this.#group?.close();
 
 		const group = this.#track.appendGroup();
-		group.writeFrame({ data: snapshot });
+		group.writeFrame({ data: snapshot, timestamp: Time.Timestamp.now() });
 		this.#groupBytes = snapshot.length;
 		this.#groupFrames = 1;
 

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -53,7 +53,7 @@ export class Producer<T> {
 		const snapshot = new TextEncoder().encode(text);
 		const delta = this.#delta(json, snapshot.length);
 		if (delta && this.#group) {
-			this.#group.writeFrame(delta);
+			this.#group.writeFrameNow(delta);
 			this.#groupBytes += delta.length;
 			this.#groupFrames += 1;
 		} else {
@@ -122,7 +122,7 @@ export class Producer<T> {
 		this.#group?.close();
 
 		const group = this.#track.appendGroup();
-		group.writeFrame(snapshot);
+		group.writeFrameNow(snapshot);
 		this.#groupBytes = snapshot.length;
 		this.#groupFrames = 1;
 

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -116,7 +116,7 @@ export class Producer {
 			throw new Error("must start with a keyframe");
 		}
 
-		this.#group?.writeFrame(this.#encode(data, timestamp));
+		this.#group?.writeFrame(timestamp, this.#encode(data, timestamp));
 	}
 
 	#encode(source: Uint8Array | Source, timestamp: Time.Micro): Uint8Array {

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -117,7 +117,7 @@ export class Producer {
 			throw new Error("must start with a keyframe");
 		}
 
-		this.#group?.writeFrame(this.#encode(data, timestamp), Time.Milli.fromMicro(timestamp));
+		this.#group?.writeFrame({ data: this.#encode(data, timestamp), timestamp: Time.Milli.fromMicro(timestamp) });
 	}
 
 	#encode(source: Uint8Array | Source, timestamp: Time.Micro): Uint8Array {

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -4,8 +4,9 @@
  *
  * @module
  */
-import type { Time } from "@moq/net";
+
 import * as Moq from "@moq/net";
+import { Time } from "@moq/net";
 
 /** A decoded LOC frame: the codec bitstream plus its timing metadata. */
 export interface Frame {
@@ -116,7 +117,7 @@ export class Producer {
 			throw new Error("must start with a keyframe");
 		}
 
-		this.#group?.writeFrame(timestamp, this.#encode(data, timestamp));
+		this.#group?.writeFrame(this.#encode(data, timestamp), Time.Milli.fromMicro(timestamp));
 	}
 
 	#encode(source: Uint8Array | Source, timestamp: Time.Micro): Uint8Array {

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -117,7 +117,10 @@ export class Producer {
 			throw new Error("must start with a keyframe");
 		}
 
-		this.#group?.writeFrame({ data: this.#encode(data, timestamp), timestamp: Time.Milli.fromMicro(timestamp) });
+		this.#group?.writeFrame({
+			data: this.#encode(data, timestamp),
+			timestamp: Time.Timestamp.fromMicros(timestamp),
+		});
 	}
 
 	#encode(source: Uint8Array | Source, timestamp: Time.Micro): Uint8Array {

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -64,12 +64,12 @@ test("a read throws CacheFull on a gap, then resyncs to the next group", async (
 
 	// Group 0 overflows its frame cap without being read, evicting the front: a gap.
 	const g0 = producer.appendGroup();
-	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) g0.writeFrame(new Uint8Array([i & 0xff]));
+	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) g0.writeFrameNow(new Uint8Array([i & 0xff]));
 	g0.close();
 
 	// Group 1 is clean.
 	const g1 = producer.appendGroup();
-	g1.writeFrame(new TextEncoder().encode("ok"));
+	g1.writeFrameNow(new TextEncoder().encode("ok"));
 	g1.close();
 
 	// The reader hits the gap in group 0 (error, not a silent skip), then the next

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -64,12 +64,12 @@ test("a read throws CacheFull on a gap, then resyncs to the next group", async (
 
 	// Group 0 overflows its frame cap without being read, evicting the front: a gap.
 	const g0 = producer.appendGroup();
-	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) g0.writeFrameNow(new Uint8Array([i & 0xff]));
+	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) g0.writeFrame(new Uint8Array([i & 0xff]));
 	g0.close();
 
 	// Group 1 is clean.
 	const g1 = producer.appendGroup();
-	g1.writeFrameNow(new TextEncoder().encode("ok"));
+	g1.writeFrame(new TextEncoder().encode("ok"));
 	g1.close();
 
 	// The reader hits the gap in group 0 (error, not a silent skip), then the next

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -1,6 +1,7 @@
 import { expect, setSystemTime, test } from "bun:test";
 import { Broadcast } from "./broadcast.ts";
 import { CacheFull, MAX_GROUP_FRAMES } from "./group.ts";
+import { Timestamp } from "./time.ts";
 import { TrackProducer } from "./track.ts";
 
 test("subscribe serves a statically inserted track without a request", async () => {
@@ -64,12 +65,13 @@ test("a read throws CacheFull on a gap, then resyncs to the next group", async (
 
 	// Group 0 overflows its frame cap without being read, evicting the front: a gap.
 	const g0 = producer.appendGroup();
-	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) g0.writeFrame({ data: new Uint8Array([i & 0xff]) });
+	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++)
+		g0.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
 	g0.close();
 
 	// Group 1 is clean.
 	const g1 = producer.appendGroup();
-	g1.writeFrame({ data: new TextEncoder().encode("ok") });
+	g1.writeFrame({ data: new TextEncoder().encode("ok"), timestamp: Timestamp.now() });
 	g1.close();
 
 	// The reader hits the gap in group 0 (error, not a silent skip), then the next

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -64,12 +64,12 @@ test("a read throws CacheFull on a gap, then resyncs to the next group", async (
 
 	// Group 0 overflows its frame cap without being read, evicting the front: a gap.
 	const g0 = producer.appendGroup();
-	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) g0.writeFrame(new Uint8Array([i & 0xff]));
+	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) g0.writeFrame({ data: new Uint8Array([i & 0xff]) });
 	g0.close();
 
 	// Group 1 is clean.
 	const g1 = producer.appendGroup();
-	g1.writeFrame(new TextEncoder().encode("ok"));
+	g1.writeFrame({ data: new TextEncoder().encode("ok") });
 	g1.close();
 
 	// The reader hits the gap in group 0 (error, not a silent skip), then the next

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "bun:test";
 import { CacheFull, Group, MAX_GROUP_CACHE_BYTES, MAX_GROUP_FRAMES } from "./group.ts";
+import { Timestamp } from "./time.ts";
 
 test("a group caps its frame count, dropping from the front", () => {
 	const group = new Group(0);
 
 	const extra = 100;
 	for (let i = 0; i < MAX_GROUP_FRAMES + extra; i++) {
-		group.writeFrame({ data: new Uint8Array([i & 0xff]) });
+		group.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
 	}
 
 	const frames = group.state.frames.peek();
@@ -23,7 +24,7 @@ test("a group caps its byte size, dropping from the front", () => {
 	// 40 x 1 MiB = 40 MiB, over the 32 MiB cap.
 	const oneMiB = 1024 * 1024;
 	for (let i = 0; i < 40; i++) {
-		group.writeFrame({ data: new Uint8Array(oneMiB) });
+		group.writeFrame({ data: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
 	}
 
 	const frames = group.state.frames.peek();
@@ -37,7 +38,7 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 	// Overflow the frame cap without reading, so the front frames are evicted.
 	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) {
-		group.writeFrame({ data: new Uint8Array([i & 0xff]) });
+		group.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
 	}
 
 	// The reader fell behind the eviction window: it must error, not skip the gap.
@@ -46,8 +47,8 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 test("a group with no eviction reads every frame without error", async () => {
 	const group = new Group(0);
-	group.writeFrame({ data: new Uint8Array([1]) });
-	group.writeFrame({ data: new Uint8Array([2]) });
+	group.writeFrame({ data: new Uint8Array([1]), timestamp: Timestamp.now() });
+	group.writeFrame({ data: new Uint8Array([2]), timestamp: Timestamp.now() });
 	group.close();
 
 	expect((await group.readFrame())?.data[0]).toBe(1);

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -6,7 +6,7 @@ test("a group caps its frame count, dropping from the front", () => {
 
 	const extra = 100;
 	for (let i = 0; i < MAX_GROUP_FRAMES + extra; i++) {
-		group.writeFrame(new Uint8Array([i & 0xff]));
+		group.writeFrameNow(new Uint8Array([i & 0xff]));
 	}
 
 	const frames = group.state.frames.peek();
@@ -14,7 +14,7 @@ test("a group caps its frame count, dropping from the front", () => {
 	// `total` still counts every frame written, so frame indices stay consistent.
 	expect(group.state.total.peek()).toBe(MAX_GROUP_FRAMES + extra);
 	// The oldest `extra` frames were dropped: the front is now frame `extra`.
-	expect(frames[0][0]).toBe(extra & 0xff);
+	expect(frames[0].data[0]).toBe(extra & 0xff);
 });
 
 test("a group caps its byte size, dropping from the front", () => {
@@ -23,11 +23,11 @@ test("a group caps its byte size, dropping from the front", () => {
 	// 40 x 1 MiB = 40 MiB, over the 32 MiB cap.
 	const oneMiB = 1024 * 1024;
 	for (let i = 0; i < 40; i++) {
-		group.writeFrame(new Uint8Array(oneMiB));
+		group.writeFrameNow(new Uint8Array(oneMiB));
 	}
 
 	const frames = group.state.frames.peek();
-	const bytes = frames.reduce((sum, f) => sum + f.byteLength, 0);
+	const bytes = frames.reduce((sum, f) => sum + f.data.byteLength, 0);
 	expect(bytes).toBeLessThanOrEqual(MAX_GROUP_CACHE_BYTES);
 	expect(frames.length).toBe(MAX_GROUP_CACHE_BYTES / oneMiB);
 });
@@ -37,7 +37,7 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 	// Overflow the frame cap without reading, so the front frames are evicted.
 	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) {
-		group.writeFrame(new Uint8Array([i & 0xff]));
+		group.writeFrameNow(new Uint8Array([i & 0xff]));
 	}
 
 	// The reader fell behind the eviction window: it must error, not skip the gap.
@@ -46,8 +46,8 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 test("a group with no eviction reads every frame without error", async () => {
 	const group = new Group(0);
-	group.writeFrame(new Uint8Array([1]));
-	group.writeFrame(new Uint8Array([2]));
+	group.writeFrameNow(new Uint8Array([1]));
+	group.writeFrameNow(new Uint8Array([2]));
 	group.close();
 
 	expect((await group.readFrame())?.[0]).toBe(1);

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -6,7 +6,7 @@ test("a group caps its frame count, dropping from the front", () => {
 
 	const extra = 100;
 	for (let i = 0; i < MAX_GROUP_FRAMES + extra; i++) {
-		group.writeFrame(new Uint8Array([i & 0xff]));
+		group.writeFrame({ data: new Uint8Array([i & 0xff]) });
 	}
 
 	const frames = group.state.frames.peek();
@@ -23,7 +23,7 @@ test("a group caps its byte size, dropping from the front", () => {
 	// 40 x 1 MiB = 40 MiB, over the 32 MiB cap.
 	const oneMiB = 1024 * 1024;
 	for (let i = 0; i < 40; i++) {
-		group.writeFrame(new Uint8Array(oneMiB));
+		group.writeFrame({ data: new Uint8Array(oneMiB) });
 	}
 
 	const frames = group.state.frames.peek();
@@ -37,7 +37,7 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 	// Overflow the frame cap without reading, so the front frames are evicted.
 	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) {
-		group.writeFrame(new Uint8Array([i & 0xff]));
+		group.writeFrame({ data: new Uint8Array([i & 0xff]) });
 	}
 
 	// The reader fell behind the eviction window: it must error, not skip the gap.
@@ -46,8 +46,8 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 test("a group with no eviction reads every frame without error", async () => {
 	const group = new Group(0);
-	group.writeFrame(new Uint8Array([1]));
-	group.writeFrame(new Uint8Array([2]));
+	group.writeFrame({ data: new Uint8Array([1]) });
+	group.writeFrame({ data: new Uint8Array([2]) });
 	group.close();
 
 	expect((await group.readFrame())?.data[0]).toBe(1);

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -6,7 +6,7 @@ test("a group caps its frame count, dropping from the front", () => {
 
 	const extra = 100;
 	for (let i = 0; i < MAX_GROUP_FRAMES + extra; i++) {
-		group.writeFrameNow(new Uint8Array([i & 0xff]));
+		group.writeFrame(new Uint8Array([i & 0xff]));
 	}
 
 	const frames = group.state.frames.peek();
@@ -23,7 +23,7 @@ test("a group caps its byte size, dropping from the front", () => {
 	// 40 x 1 MiB = 40 MiB, over the 32 MiB cap.
 	const oneMiB = 1024 * 1024;
 	for (let i = 0; i < 40; i++) {
-		group.writeFrameNow(new Uint8Array(oneMiB));
+		group.writeFrame(new Uint8Array(oneMiB));
 	}
 
 	const frames = group.state.frames.peek();
@@ -37,7 +37,7 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 	// Overflow the frame cap without reading, so the front frames are evicted.
 	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) {
-		group.writeFrameNow(new Uint8Array([i & 0xff]));
+		group.writeFrame(new Uint8Array([i & 0xff]));
 	}
 
 	// The reader fell behind the eviction window: it must error, not skip the gap.
@@ -46,11 +46,11 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 test("a group with no eviction reads every frame without error", async () => {
 	const group = new Group(0);
-	group.writeFrameNow(new Uint8Array([1]));
-	group.writeFrameNow(new Uint8Array([2]));
+	group.writeFrame(new Uint8Array([1]));
+	group.writeFrame(new Uint8Array([2]));
 	group.close();
 
-	expect((await group.readFrame())?.[0]).toBe(1);
-	expect((await group.readFrame())?.[0]).toBe(2);
+	expect((await group.readFrame())?.data[0]).toBe(1);
+	expect((await group.readFrame())?.data[0]).toBe(2);
 	expect(await group.readFrame()).toBeUndefined();
 });

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -8,11 +8,10 @@ export const MAX_GROUP_CACHE_BYTES = 32 * 1024 * 1024;
 export const MAX_GROUP_FRAMES = 1024;
 
 /**
- * A frame buffered in a {@link Group}: its presentation timestamp and payload bytes.
+ * A frame buffered in a {@link Group}: its presentation {@link Timestamp} and payload bytes.
  *
- * The timestamp is in milliseconds; wall-clock accuracy doesn't warrant finer units for
- * transport-level timing, and the wire layer converts it into the track's timescale.
- * A future `Timestamp` type (mirroring Rust) will let a track pick its own scale.
+ * The timestamp carries its own scale, so a track can pick its units; the wire layer
+ * converts it into the track's negotiated timescale.
  */
 export interface Frame {
 	/** The frame payload. */

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -1,5 +1,5 @@
 import { Signal } from "@moq/signals";
-import { Micro } from "./time.ts";
+import { Milli } from "./time.ts";
 
 /** Maximum bytes of frames cached in a group before old frames are evicted from the front. */
 export const MAX_GROUP_CACHE_BYTES = 32 * 1024 * 1024;
@@ -10,13 +10,13 @@ export const MAX_GROUP_FRAMES = 1024;
 /**
  * A frame buffered in a {@link Group}: its presentation timestamp and payload bytes.
  *
- * The timestamp is in microseconds (the unit the hang container and WebCodecs use); the
- * wire layer converts it into the track's timescale. Frames written without an explicit
- * timestamp (catalogs, JSON state) are stamped with wall-clock now.
+ * The timestamp is in milliseconds; wall-clock accuracy doesn't warrant finer units for
+ * transport-level timing, and the wire layer converts it into the track's timescale.
+ * A future `Timestamp` type (mirroring Rust) will let a track pick its own scale.
  */
 export interface Frame {
-	/** Presentation timestamp in microseconds. */
-	timestamp: Micro;
+	/** Presentation timestamp in milliseconds. */
+	timestamp: Milli;
 	/** The frame payload. */
 	data: Uint8Array;
 }
@@ -77,11 +77,12 @@ export class Group {
 	}
 
 	/**
-	 * Writes a frame to the group at the given presentation timestamp (microseconds).
-	 * @param timestamp - Presentation time in microseconds
+	 * Writes a frame to the group.
 	 * @param data - The frame payload
+	 * @param timestamp - Presentation time in milliseconds; defaults to wall-clock now
+	 *   (`performance.now()`) for data with no presentation time of its own.
 	 */
-	writeFrame(timestamp: Micro, data: Uint8Array) {
+	writeFrame(data: Uint8Array, timestamp: Milli = Milli.now()) {
 		if (this.state.closed.peek()) throw new Error("group is closed");
 
 		this.#cacheBytes += data.byteLength;
@@ -104,17 +105,9 @@ export class Group {
 		if (this.#mirrors) {
 			for (const mirror of this.#mirrors) {
 				if (mirror.state.closed.peek()) this.#mirrors.delete(mirror);
-				else mirror.writeFrame(timestamp, data);
+				else mirror.writeFrame(data, timestamp);
 			}
 		}
-	}
-
-	/**
-	 * Writes a frame stamped with wall-clock now, for data with no presentation time of
-	 * its own (a JSON catalog, control state) or a source whose protocol can't carry one.
-	 */
-	writeFrameNow(data: Uint8Array) {
-		this.writeFrame(Micro.now(), data);
 	}
 
 	/**
@@ -126,7 +119,7 @@ export class Group {
 	 */
 	mirror(): Group {
 		const dst = new Group(this.sequence);
-		for (const frame of this.state.frames.peek()) dst.writeFrame(frame.timestamp, frame.data);
+		for (const frame of this.state.frames.peek()) dst.writeFrame(frame.data, frame.timestamp);
 		// Inherit the evicted prefix: frames dropped before this copy was made are a gap
 		// for its reader too, so reading them throws CacheFull.
 		dst.state.offset = this.state.offset;
@@ -144,7 +137,7 @@ export class Group {
 
 	/** Write a string as a single UTF-8 encoded frame, stamped with wall-clock now. */
 	writeString(str: string) {
-		this.writeFrameNow(new TextEncoder().encode(str));
+		this.writeFrame(new TextEncoder().encode(str));
 	}
 
 	/** Write a value as a single JSON-encoded frame, stamped with wall-clock now. */
@@ -154,19 +147,14 @@ export class Group {
 
 	/** Write a boolean as a single one-byte frame, stamped with wall-clock now. */
 	writeBool(bool: boolean) {
-		this.writeFrameNow(new Uint8Array([bool ? 1 : 0]));
+		this.writeFrame(new Uint8Array([bool ? 1 : 0]));
 	}
 
 	/**
-	 * Reads the next frame's payload from the group.
-	 * @returns A promise that resolves to the next payload or undefined
+	 * Reads the next frame (timestamp + payload) from the group.
+	 * @returns A promise that resolves to the next frame or undefined
 	 */
-	async readFrame(): Promise<Uint8Array | undefined> {
-		return (await this.readFrameTimed())?.data;
-	}
-
-	/** Reads the next frame, including its presentation timestamp. */
-	async readFrameTimed(): Promise<Frame | undefined> {
+	async readFrame(): Promise<Frame | undefined> {
 		for (;;) {
 			if (this.state.offset > 0) throw new CacheFull();
 
@@ -199,22 +187,22 @@ export class Group {
 		}
 	}
 
-	/** Reads the next frame and decodes it as a UTF-8 string. */
+	/** Reads the next frame and decodes its payload as a UTF-8 string. */
 	async readString(): Promise<string | undefined> {
 		const frame = await this.readFrame();
-		return frame ? new TextDecoder().decode(frame) : undefined;
+		return frame ? new TextDecoder().decode(frame.data) : undefined;
 	}
 
-	/** Reads the next frame and parses it as JSON. */
+	/** Reads the next frame and parses its payload as JSON. */
 	async readJson(): Promise<unknown | undefined> {
 		const frame = await this.readString();
 		return frame ? JSON.parse(frame) : undefined;
 	}
 
-	/** Reads the next frame and decodes it as a one-byte boolean. */
+	/** Reads the next frame and decodes its payload as a one-byte boolean. */
 	async readBool(): Promise<boolean | undefined> {
 		const frame = await this.readFrame();
-		return frame ? frame[0] === 1 : undefined;
+		return frame ? frame.data[0] === 1 : undefined;
 	}
 
 	/** Closes the group, optionally with an error to abort readers. */

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -15,10 +15,14 @@ export const MAX_GROUP_FRAMES = 1024;
  * A future `Timestamp` type (mirroring Rust) will let a track pick its own scale.
  */
 export interface Frame {
-	/** Presentation timestamp in milliseconds. */
-	timestamp: Milli;
 	/** The frame payload. */
 	data: Uint8Array;
+	/**
+	 * Presentation timestamp in milliseconds. Optional on write: omit it for data with
+	 * no presentation time of its own (a JSON catalog, control state) and it defaults to
+	 * wall-clock now (`performance.now()`). Always populated on a frame read back.
+	 */
+	timestamp?: Milli;
 }
 
 /**
@@ -77,17 +81,18 @@ export class Group {
 	}
 
 	/**
-	 * Writes a frame to the group.
-	 * @param data - The frame payload
-	 * @param timestamp - Presentation time in milliseconds; defaults to wall-clock now
-	 *   (`performance.now()`) for data with no presentation time of its own.
+	 * Writes a frame to the group. A frame with no `timestamp` is stamped with
+	 * wall-clock now (`performance.now()`).
 	 */
-	writeFrame(data: Uint8Array, timestamp: Milli = Milli.now()) {
+	writeFrame(frame: Frame) {
 		if (this.state.closed.peek()) throw new Error("group is closed");
+
+		const data = frame.data;
+		const timestamp = frame.timestamp ?? Milli.now();
 
 		this.#cacheBytes += data.byteLength;
 		this.state.frames.mutate((frames) => {
-			frames.push({ timestamp, data });
+			frames.push({ data, timestamp });
 
 			// Bound an unbounded (e.g. never-closed) group: drop the oldest frames once
 			// over either cap. A consumer too far behind silently skips them.
@@ -105,7 +110,7 @@ export class Group {
 		if (this.#mirrors) {
 			for (const mirror of this.#mirrors) {
 				if (mirror.state.closed.peek()) this.#mirrors.delete(mirror);
-				else mirror.writeFrame(data, timestamp);
+				else mirror.writeFrame({ data, timestamp });
 			}
 		}
 	}
@@ -119,7 +124,7 @@ export class Group {
 	 */
 	mirror(): Group {
 		const dst = new Group(this.sequence);
-		for (const frame of this.state.frames.peek()) dst.writeFrame(frame.data, frame.timestamp);
+		for (const frame of this.state.frames.peek()) dst.writeFrame(frame);
 		// Inherit the evicted prefix: frames dropped before this copy was made are a gap
 		// for its reader too, so reading them throws CacheFull.
 		dst.state.offset = this.state.offset;
@@ -137,7 +142,7 @@ export class Group {
 
 	/** Write a string as a single UTF-8 encoded frame, stamped with wall-clock now. */
 	writeString(str: string) {
-		this.writeFrame(new TextEncoder().encode(str));
+		this.writeFrame({ data: new TextEncoder().encode(str) });
 	}
 
 	/** Write a value as a single JSON-encoded frame, stamped with wall-clock now. */
@@ -147,7 +152,7 @@ export class Group {
 
 	/** Write a boolean as a single one-byte frame, stamped with wall-clock now. */
 	writeBool(bool: boolean) {
-		this.writeFrame(new Uint8Array([bool ? 1 : 0]));
+		this.writeFrame({ data: new Uint8Array([bool ? 1 : 0]) });
 	}
 
 	/**

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -1,5 +1,5 @@
 import { Signal } from "@moq/signals";
-import { Milli } from "./time.ts";
+import { Timestamp } from "./time.ts";
 
 /** Maximum bytes of frames cached in a group before old frames are evicted from the front. */
 export const MAX_GROUP_CACHE_BYTES = 32 * 1024 * 1024;
@@ -18,11 +18,10 @@ export interface Frame {
 	/** The frame payload. */
 	data: Uint8Array;
 	/**
-	 * Presentation timestamp in milliseconds. Optional on write: omit it for data with
-	 * no presentation time of its own (a JSON catalog, control state) and it defaults to
-	 * wall-clock now (`performance.now()`). Always populated on a frame read back.
+	 * Presentation timestamp. Required: for data with no presentation time of its own
+	 * (a JSON catalog, control state) pass {@link Timestamp.now} explicitly.
 	 */
-	timestamp?: Milli;
+	timestamp: Timestamp;
 }
 
 /**
@@ -80,19 +79,15 @@ export class Group {
 		});
 	}
 
-	/**
-	 * Writes a frame to the group. A frame with no `timestamp` is stamped with
-	 * wall-clock now (`performance.now()`).
-	 */
+	/** Writes a frame to the group. */
 	writeFrame(frame: Frame) {
 		if (this.state.closed.peek()) throw new Error("group is closed");
 
-		const data = frame.data;
-		const timestamp = frame.timestamp ?? Milli.now();
+		const { data } = frame;
 
 		this.#cacheBytes += data.byteLength;
 		this.state.frames.mutate((frames) => {
-			frames.push({ data, timestamp });
+			frames.push(frame);
 
 			// Bound an unbounded (e.g. never-closed) group: drop the oldest frames once
 			// over either cap. A consumer too far behind silently skips them.
@@ -110,7 +105,7 @@ export class Group {
 		if (this.#mirrors) {
 			for (const mirror of this.#mirrors) {
 				if (mirror.state.closed.peek()) this.#mirrors.delete(mirror);
-				else mirror.writeFrame({ data, timestamp });
+				else mirror.writeFrame(frame);
 			}
 		}
 	}
@@ -142,7 +137,7 @@ export class Group {
 
 	/** Write a string as a single UTF-8 encoded frame, stamped with wall-clock now. */
 	writeString(str: string) {
-		this.writeFrame({ data: new TextEncoder().encode(str) });
+		this.writeFrame({ data: new TextEncoder().encode(str), timestamp: Timestamp.now() });
 	}
 
 	/** Write a value as a single JSON-encoded frame, stamped with wall-clock now. */
@@ -152,7 +147,7 @@ export class Group {
 
 	/** Write a boolean as a single one-byte frame, stamped with wall-clock now. */
 	writeBool(bool: boolean) {
-		this.writeFrame({ data: new Uint8Array([bool ? 1 : 0]) });
+		this.writeFrame({ data: new Uint8Array([bool ? 1 : 0]), timestamp: Timestamp.now() });
 	}
 
 	/**

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -1,10 +1,25 @@
 import { Signal } from "@moq/signals";
+import { Micro } from "./time.ts";
 
 /** Maximum bytes of frames cached in a group before old frames are evicted from the front. */
 export const MAX_GROUP_CACHE_BYTES = 32 * 1024 * 1024;
 
 /** Maximum number of frames cached in a group before old frames are evicted from the front. */
 export const MAX_GROUP_FRAMES = 1024;
+
+/**
+ * A frame buffered in a {@link Group}: its presentation timestamp and payload bytes.
+ *
+ * The timestamp is in microseconds (the unit the hang container and WebCodecs use); the
+ * wire layer converts it into the track's timescale. Frames written without an explicit
+ * timestamp (catalogs, JSON state) are stamped with wall-clock now.
+ */
+export interface Frame {
+	/** Presentation timestamp in microseconds. */
+	timestamp: Micro;
+	/** The frame payload. */
+	data: Uint8Array;
+}
 
 /**
  * Thrown by a frame read when the reader fell behind the group's eviction window: frames
@@ -21,7 +36,7 @@ export class CacheFull extends Error {
 
 /** Reactive backing state for a {@link Group}: buffered frames, a closed flag, and the running frame count. */
 export class GroupState {
-	frames = new Signal<Uint8Array[]>([]);
+	frames = new Signal<Frame[]>([]);
 	closed = new Signal<boolean | Error>(false);
 	total = new Signal<number>(0); // The total number of frames in the group thus far
 
@@ -62,22 +77,23 @@ export class Group {
 	}
 
 	/**
-	 * Writes a frame to the group.
-	 * @param frame - The frame to write
+	 * Writes a frame to the group at the given presentation timestamp (microseconds).
+	 * @param timestamp - Presentation time in microseconds
+	 * @param data - The frame payload
 	 */
-	writeFrame(frame: Uint8Array) {
+	writeFrame(timestamp: Micro, data: Uint8Array) {
 		if (this.state.closed.peek()) throw new Error("group is closed");
 
-		this.#cacheBytes += frame.byteLength;
+		this.#cacheBytes += data.byteLength;
 		this.state.frames.mutate((frames) => {
-			frames.push(frame);
+			frames.push({ timestamp, data });
 
 			// Bound an unbounded (e.g. never-closed) group: drop the oldest frames once
 			// over either cap. A consumer too far behind silently skips them.
 			while (frames.length > MAX_GROUP_FRAMES || this.#cacheBytes > MAX_GROUP_CACHE_BYTES) {
 				const evicted = frames.shift();
 				if (!evicted) break;
-				this.#cacheBytes -= evicted.byteLength;
+				this.#cacheBytes -= evicted.data.byteLength;
 				this.state.offset++;
 			}
 		});
@@ -88,9 +104,17 @@ export class Group {
 		if (this.#mirrors) {
 			for (const mirror of this.#mirrors) {
 				if (mirror.state.closed.peek()) this.#mirrors.delete(mirror);
-				else mirror.writeFrame(frame);
+				else mirror.writeFrame(timestamp, data);
 			}
 		}
+	}
+
+	/**
+	 * Writes a frame stamped with wall-clock now, for data with no presentation time of
+	 * its own (a JSON catalog, control state) or a source whose protocol can't carry one.
+	 */
+	writeFrameNow(data: Uint8Array) {
+		this.writeFrame(Micro.now(), data);
 	}
 
 	/**
@@ -102,7 +126,7 @@ export class Group {
 	 */
 	mirror(): Group {
 		const dst = new Group(this.sequence);
-		for (const frame of this.state.frames.peek()) dst.writeFrame(frame);
+		for (const frame of this.state.frames.peek()) dst.writeFrame(frame.timestamp, frame.data);
 		// Inherit the evicted prefix: frames dropped before this copy was made are a gap
 		// for its reader too, so reading them throws CacheFull.
 		dst.state.offset = this.state.offset;
@@ -118,26 +142,31 @@ export class Group {
 		return dst;
 	}
 
-	/** Write a string as a single UTF-8 encoded frame. */
+	/** Write a string as a single UTF-8 encoded frame, stamped with wall-clock now. */
 	writeString(str: string) {
-		this.writeFrame(new TextEncoder().encode(str));
+		this.writeFrameNow(new TextEncoder().encode(str));
 	}
 
-	/** Write a value as a single JSON-encoded frame. */
+	/** Write a value as a single JSON-encoded frame, stamped with wall-clock now. */
 	writeJson(json: unknown) {
 		this.writeString(JSON.stringify(json));
 	}
 
-	/** Write a boolean as a single one-byte frame. */
+	/** Write a boolean as a single one-byte frame, stamped with wall-clock now. */
 	writeBool(bool: boolean) {
-		this.writeFrame(new Uint8Array([bool ? 1 : 0]));
+		this.writeFrameNow(new Uint8Array([bool ? 1 : 0]));
 	}
 
 	/**
-	 * Reads the next frame from the group.
-	 * @returns A promise that resolves to the next frame or undefined
+	 * Reads the next frame's payload from the group.
+	 * @returns A promise that resolves to the next payload or undefined
 	 */
 	async readFrame(): Promise<Uint8Array | undefined> {
+		return (await this.readFrameTimed())?.data;
+	}
+
+	/** Reads the next frame, including its presentation timestamp. */
+	async readFrameTimed(): Promise<Frame | undefined> {
 		for (;;) {
 			if (this.state.offset > 0) throw new CacheFull();
 
@@ -153,14 +182,14 @@ export class Group {
 		}
 	}
 
-	/** Reads the next frame along with its sequence number within the group. */
+	/** Reads the next frame's payload along with its sequence number within the group. */
 	async readFrameSequence(): Promise<{ sequence: number; data: Uint8Array } | undefined> {
 		for (;;) {
 			if (this.state.offset > 0) throw new CacheFull();
 
 			const frames = this.state.frames.peek();
 			const frame = frames.shift();
-			if (frame) return { sequence: this.state.total.peek() - frames.length - 1, data: frame };
+			if (frame) return { sequence: this.state.total.peek() - frames.length - 1, data: frame.data };
 
 			const closed = this.state.closed.peek();
 			if (closed instanceof Error) throw closed;

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -231,7 +231,7 @@ export class Publisher {
 					const frame = await Promise.race([group.readFrame(), stream.closed]);
 					if (!frame) break;
 
-					const obj = new Frame({ payload: frame });
+					const obj = new Frame({ payload: frame.data });
 					await obj.encode(stream, header.flags);
 				}
 

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -3,6 +3,7 @@ import { Broadcast, type TrackRequest } from "../broadcast.ts";
 import { Group } from "../group.ts";
 import * as Path from "../path.ts";
 import type { Reader, Stream } from "../stream.ts";
+import { Timestamp } from "../time.ts";
 import type { TrackProducer } from "../track.ts";
 import { error } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
@@ -487,7 +488,7 @@ export class Subscriber {
 				const frame = await Frame.decode(stream, group.flags);
 				if (frame.payload === undefined) break;
 
-				producer.writeFrame({ data: frame.payload });
+				producer.writeFrame({ data: frame.payload, timestamp: Timestamp.now() });
 			}
 
 			producer.close();

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -487,7 +487,7 @@ export class Subscriber {
 				const frame = await Frame.decode(stream, group.flags);
 				if (frame.payload === undefined) break;
 
-				producer.writeFrame(frame.payload);
+				producer.writeFrameNow(frame.payload);
 			}
 
 			producer.close();

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -487,7 +487,7 @@ export class Subscriber {
 				const frame = await Frame.decode(stream, group.flags);
 				if (frame.payload === undefined) break;
 
-				producer.writeFrame(frame.payload);
+				producer.writeFrame({ data: frame.payload });
 			}
 
 			producer.close();

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -487,7 +487,7 @@ export class Subscriber {
 				const frame = await Frame.decode(stream, group.flags);
 				if (frame.payload === undefined) break;
 
-				producer.writeFrameNow(frame.payload);
+				producer.writeFrame(frame.payload);
 			}
 
 			producer.close();

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -4,6 +4,7 @@ import { Compression, compress } from "../compression.ts";
 import type { Group } from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
+import { Milli } from "../time.ts";
 import type { TrackSubscriber } from "../track.ts";
 import { error } from "../util/error.ts";
 import { AnnounceBroadcast, AnnounceInit, AnnounceOk, type AnnounceRequest, epochNow } from "./announce.ts";
@@ -24,6 +25,14 @@ import { Version } from "./version.ts";
 const PROBE_INTERVAL = 100; // ms
 const PROBE_MAX_AGE = 10_000; // ms
 const PROBE_MAX_DELTA = 0.25;
+
+/** Wire timescale (units per second) the publisher advertises: milliseconds. */
+const MILLI_TIMESCALE = 1000;
+
+/** Map a signed delta to an unsigned zigzag varint value (mirrors Rust `VarInt::from_zigzag`). */
+function zigzag(delta: bigint): bigint {
+	return delta >= 0n ? delta << 1n : (-delta << 1n) - 1n;
+}
 
 // The TRACK stream, implicit SUBSCRIBE acceptance, and SUBSCRIBE_START/END are
 // all lite-05+.
@@ -374,8 +383,10 @@ export class Publisher {
 			return new TrackInfoMessage({
 				priority: info.priority,
 				ordered: info.ordered,
-				// This implementation doesn't produce per-frame timestamps yet.
-				timescale: 0,
+				// Lite05 mandates per-frame timestamps. The JS model frames carry no
+				// presentation time of their own, so we stamp wall-clock milliseconds
+				// (the default timescale) in `#runGroup`.
+				timescale: MILLI_TIMESCALE,
 				compression: info.compress ? Compression.Deflate : Compression.None,
 			});
 		})();
@@ -400,10 +411,22 @@ export class Publisher {
 			await stream.u8(0); // stream type
 			await msg.encode(stream);
 
+			// Lite05+ prefixes every frame with a zigzag-delta timestamp at the track's
+			// timescale; older drafts omit it. The model has no per-frame time, so each
+			// frame is stamped with wall-clock milliseconds (matching MILLI_TIMESCALE).
+			const timestamps = supportsTrackStream(this.version);
+			let prevTs = 0n;
+
 			try {
 				for (;;) {
 					const frame = await Promise.race([group.readFrame(), stream.closed]);
 					if (!frame) break;
+
+					if (timestamps) {
+						const ts = BigInt(Math.round(Milli.now()));
+						await stream.u62(zigzag(ts - prevTs));
+						prevTs = ts;
+					}
 
 					// On a compressed track the wire size is the compressed length;
 					// the subscriber inflates it back from the SUBSCRIBE_OK codec.

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -25,9 +25,9 @@ const PROBE_INTERVAL = 100; // ms
 const PROBE_MAX_AGE = 10_000; // ms
 const PROBE_MAX_DELTA = 0.25;
 
-/** Wire timescale (units per second) the publisher advertises: microseconds, matching
+/** Wire timescale (units per second) the publisher advertises: milliseconds, matching
  * the model frame timestamp unit. */
-const MICRO_TIMESCALE = 1_000_000;
+const MILLI_TIMESCALE = 1000;
 
 /** Map a signed delta to an unsigned zigzag varint value (mirrors Rust `VarInt::from_zigzag`). */
 function zigzag(delta: bigint): bigint {
@@ -383,10 +383,10 @@ export class Publisher {
 			return new TrackInfoMessage({
 				priority: info.priority,
 				ordered: info.ordered,
-				// Lite05 mandates per-frame timestamps. Model frames carry a microsecond
+				// Lite05 mandates per-frame timestamps. Model frames carry a millisecond
 				// timestamp (the app's, or wall-clock for timeless data), so we advertise
-				// microseconds and emit each frame's own timestamp in `#runGroup`.
-				timescale: MICRO_TIMESCALE,
+				// milliseconds and emit each frame's own timestamp in `#runGroup`.
+				timescale: MILLI_TIMESCALE,
 				compression: info.compress ? Compression.Deflate : Compression.None,
 			});
 		})();
@@ -412,13 +412,13 @@ export class Publisher {
 			await msg.encode(stream);
 
 			// Lite05+ prefixes every frame with a zigzag-delta timestamp at the track's
-			// timescale (microseconds here); older drafts omit it.
+			// timescale (milliseconds here); older drafts omit it.
 			const timestamps = supportsTrackStream(this.version);
 			let prevTs = 0n;
 
 			try {
 				for (;;) {
-					const frame = await Promise.race([group.readFrameTimed(), stream.closed]);
+					const frame = await Promise.race([group.readFrame(), stream.closed]);
 					if (!frame) break;
 
 					if (timestamps) {

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -4,7 +4,7 @@ import { Compression, compress } from "../compression.ts";
 import type { Group } from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
-import { Milli } from "../time.ts";
+import { Timescale } from "../time.ts";
 import type { TrackSubscriber } from "../track.ts";
 import { error } from "../util/error.ts";
 import { AnnounceBroadcast, AnnounceInit, AnnounceOk, type AnnounceRequest, epochNow } from "./announce.ts";
@@ -423,8 +423,9 @@ export class Publisher {
 					if (!frame) break;
 
 					if (timestamps) {
-						// A frame read back always carries a timestamp; guard the type anyway.
-						const ts = BigInt(Math.round(frame.timestamp ?? Milli.now()));
+						// Emit at the advertised (millisecond) timescale, converting from
+						// whatever scale the frame carries.
+						const ts = BigInt(Math.round(frame.timestamp.as(Timescale.MILLI)));
 						await stream.u62(zigzag(ts - prevTs));
 						prevTs = ts;
 					}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -4,7 +4,6 @@ import { Compression, compress } from "../compression.ts";
 import type { Group } from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
-import { Milli } from "../time.ts";
 import type { TrackSubscriber } from "../track.ts";
 import { error } from "../util/error.ts";
 import { AnnounceBroadcast, AnnounceInit, AnnounceOk, type AnnounceRequest, epochNow } from "./announce.ts";
@@ -26,8 +25,9 @@ const PROBE_INTERVAL = 100; // ms
 const PROBE_MAX_AGE = 10_000; // ms
 const PROBE_MAX_DELTA = 0.25;
 
-/** Wire timescale (units per second) the publisher advertises: milliseconds. */
-const MILLI_TIMESCALE = 1000;
+/** Wire timescale (units per second) the publisher advertises: microseconds, matching
+ * the model frame timestamp unit. */
+const MICRO_TIMESCALE = 1_000_000;
 
 /** Map a signed delta to an unsigned zigzag varint value (mirrors Rust `VarInt::from_zigzag`). */
 function zigzag(delta: bigint): bigint {
@@ -383,10 +383,10 @@ export class Publisher {
 			return new TrackInfoMessage({
 				priority: info.priority,
 				ordered: info.ordered,
-				// Lite05 mandates per-frame timestamps. The JS model frames carry no
-				// presentation time of their own, so we stamp wall-clock milliseconds
-				// (the default timescale) in `#runGroup`.
-				timescale: MILLI_TIMESCALE,
+				// Lite05 mandates per-frame timestamps. Model frames carry a microsecond
+				// timestamp (the app's, or wall-clock for timeless data), so we advertise
+				// microseconds and emit each frame's own timestamp in `#runGroup`.
+				timescale: MICRO_TIMESCALE,
 				compression: info.compress ? Compression.Deflate : Compression.None,
 			});
 		})();
@@ -412,25 +412,24 @@ export class Publisher {
 			await msg.encode(stream);
 
 			// Lite05+ prefixes every frame with a zigzag-delta timestamp at the track's
-			// timescale; older drafts omit it. The model has no per-frame time, so each
-			// frame is stamped with wall-clock milliseconds (matching MILLI_TIMESCALE).
+			// timescale (microseconds here); older drafts omit it.
 			const timestamps = supportsTrackStream(this.version);
 			let prevTs = 0n;
 
 			try {
 				for (;;) {
-					const frame = await Promise.race([group.readFrame(), stream.closed]);
+					const frame = await Promise.race([group.readFrameTimed(), stream.closed]);
 					if (!frame) break;
 
 					if (timestamps) {
-						const ts = BigInt(Math.round(Milli.now()));
+						const ts = BigInt(Math.round(frame.timestamp));
 						await stream.u62(zigzag(ts - prevTs));
 						prevTs = ts;
 					}
 
 					// On a compressed track the wire size is the compressed length;
 					// the subscriber inflates it back from the SUBSCRIBE_OK codec.
-					const payload = await compress(compression, frame);
+					const payload = await compress(compression, frame.data);
 					await stream.u53(payload.byteLength);
 					await stream.write(payload);
 				}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -26,10 +26,6 @@ const PROBE_INTERVAL = 100; // ms
 const PROBE_MAX_AGE = 10_000; // ms
 const PROBE_MAX_DELTA = 0.25;
 
-/** Wire timescale (units per second) the publisher advertises: milliseconds, matching
- * the model frame timestamp unit. */
-const MILLI_TIMESCALE = 1000;
-
 /** Map a signed delta to an unsigned zigzag varint value (mirrors Rust `VarInt::from_zigzag`). */
 function zigzag(delta: bigint): bigint {
 	return delta >= 0n ? delta << 1n : (-delta << 1n) - 1n;
@@ -244,19 +240,21 @@ export class Publisher {
 
 		try {
 			let compression: Compression = Compression.None;
+			let timescale: Timescale = Timescale.MILLI;
 
 			if (supportsTrackStream(this.version)) {
 				// Lite-05+ accepts implicitly: no SUBSCRIBE_OK (the immutable
 				// properties live in TRACK_INFO), and the resolved range arrives as
 				// SUBSCRIBE_START / SUBSCRIBE_END emitted from #runTrack.
 				//
-				// The frame codec is one of those immutable properties, so serving
+				// The frame codec and timescale are immutable properties, so serving
 				// MUST use exactly what TRACK_INFO advertised. Both come from the
 				// producer's accept(), so they always agree. Awaiting info() also
 				// surfaces a rejected track (accept never called, track closed) as an
 				// error here, which resets the stream.
 				const info = await track.info();
 				compression = info.compress ? Compression.Deflate : Compression.None;
+				timescale = info.timescale;
 			} else {
 				// Older drafts acknowledge with SUBSCRIBE_OK and stream frames verbatim.
 				const ok = new SubscribeOk({ priority: msg.priority });
@@ -265,7 +263,7 @@ export class Publisher {
 
 			console.debug(`publish ok: broadcast=${msg.broadcast} track=${track.name}`);
 
-			const serving = this.#runTrack(msg.id, msg.broadcast, track, stream.writer, compression);
+			const serving = this.#runTrack(msg.id, msg.broadcast, track, stream.writer, compression, timescale);
 
 			for (;;) {
 				const decode = SubscribeUpdate.decodeMaybe(stream.reader, this.version);
@@ -307,6 +305,7 @@ export class Publisher {
 		track: TrackSubscriber,
 		stream: Writer,
 		compression: Compression,
+		timescale: Timescale,
 	) {
 		// Lite-05+ resolves the range on the subscribe stream: SUBSCRIBE_START once the
 		// first group is known, SUBSCRIBE_END when the track finishes.
@@ -329,7 +328,7 @@ export class Publisher {
 				}
 				lastSequence = group.sequence;
 
-				void this.#runGroup(sub, group, compression);
+				void this.#runGroup(sub, group, compression, timescale);
 			}
 
 			if (emitRange) {
@@ -384,10 +383,9 @@ export class Publisher {
 			return new TrackInfoMessage({
 				priority: info.priority,
 				ordered: info.ordered,
-				// Lite05 mandates per-frame timestamps. Model frames carry a millisecond
-				// timestamp (the app's, or wall-clock for timeless data), so we advertise
-				// milliseconds and emit each frame's own timestamp in `#runGroup`.
-				timescale: MILLI_TIMESCALE,
+				// Lite05 mandates per-frame timestamps. Advertise the track's timescale;
+				// `#runGroup` emits each frame converted to it.
+				timescale: info.timescale,
 				compression: info.compress ? Compression.Deflate : Compression.None,
 			});
 		})();
@@ -405,7 +403,7 @@ export class Publisher {
 	 *
 	 * @internal
 	 */
-	async #runGroup(sub: bigint, group: Group, compression: Compression) {
+	async #runGroup(sub: bigint, group: Group, compression: Compression, timescale: Timescale) {
 		const msg = new GroupMessage(sub, group.sequence);
 		try {
 			const stream = await Writer.open(this.#quic);
@@ -413,7 +411,7 @@ export class Publisher {
 			await msg.encode(stream);
 
 			// Lite05+ prefixes every frame with a zigzag-delta timestamp at the track's
-			// timescale (milliseconds here); older drafts omit it.
+			// advertised timescale; older drafts omit it.
 			const timestamps = supportsTrackStream(this.version);
 			let prevTs = 0n;
 
@@ -423,9 +421,8 @@ export class Publisher {
 					if (!frame) break;
 
 					if (timestamps) {
-						// Emit at the advertised (millisecond) timescale, converting from
-						// whatever scale the frame carries.
-						const ts = BigInt(Math.round(frame.timestamp.as(Timescale.MILLI)));
+						// Convert each frame to the track's advertised timescale.
+						const ts = BigInt(Math.round(frame.timestamp.as(timescale)));
 						await stream.u62(zigzag(ts - prevTs));
 						prevTs = ts;
 					}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -4,6 +4,7 @@ import { Compression, compress } from "../compression.ts";
 import type { Group } from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
+import { Milli } from "../time.ts";
 import type { TrackSubscriber } from "../track.ts";
 import { error } from "../util/error.ts";
 import { AnnounceBroadcast, AnnounceInit, AnnounceOk, type AnnounceRequest, epochNow } from "./announce.ts";
@@ -422,7 +423,8 @@ export class Publisher {
 					if (!frame) break;
 
 					if (timestamps) {
-						const ts = BigInt(Math.round(frame.timestamp));
+						// A frame read back always carries a timestamp; guard the type anyway.
+						const ts = BigInt(Math.round(frame.timestamp ?? Milli.now()));
 						await stream.u62(zigzag(ts - prevTs));
 						prevTs = ts;
 					}

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -501,9 +501,8 @@ export class Subscriber {
 
 			// timescale resolves together with compression (from TRACK_INFO). A non-zero
 			// scale means every frame is prefixed with a zigzag-delta timestamp (the
-			// lite-05 FRAME format), which we decode and convert to milliseconds (the
-			// model's unit). Scale 0 (pre-lite-05) carries no timestamp, so writeFrame
-			// falls back to wall-clock.
+			// lite-05 FRAME format), which we decode into a Timestamp at that scale.
+			// Scale 0 (pre-lite-05) carries no timestamp, so we wall-clock-stamp.
 			const scale = timescale.peek() ?? 0;
 			let prevTs = 0n;
 
@@ -511,10 +510,12 @@ export class Subscriber {
 				const done = await Promise.race([stream.done(), track.closed, producer.closed]);
 				if (done !== false) break;
 
-				let timestamp: Time.Milli | undefined;
+				let timestamp: Time.Timestamp;
 				if (scale !== 0) {
 					prevTs += unzigzag(await stream.u62());
-					timestamp = Time.Milli((Number(prevTs) * 1000) / scale);
+					timestamp = new Time.Timestamp(Number(prevTs), Time.Timescale(scale));
+				} else {
+					timestamp = Time.Timestamp.now();
 				}
 
 				const size = await stream.u53();

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -524,7 +524,7 @@ export class Subscriber {
 				// On a compressed track the wire size is the compressed length;
 				// inflate it back to the original frame the consumer sees.
 				const data = codec === Compression.None ? payload : await decompress(codec, payload);
-				producer.writeFrame(data, timestamp);
+				producer.writeFrame({ data, timestamp });
 			}
 
 			producer.close();

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -501,8 +501,9 @@ export class Subscriber {
 
 			// timescale resolves together with compression (from TRACK_INFO). A non-zero
 			// scale means every frame is prefixed with a zigzag-delta timestamp (the
-			// lite-05 FRAME format), which we decode and convert to microseconds (the
-			// model's unit). Scale 0 (pre-lite-05) carries no timestamp, so we wall-clock.
+			// lite-05 FRAME format), which we decode and convert to milliseconds (the
+			// model's unit). Scale 0 (pre-lite-05) carries no timestamp, so writeFrame
+			// falls back to wall-clock.
 			const scale = timescale.peek() ?? 0;
 			let prevTs = 0n;
 
@@ -510,10 +511,10 @@ export class Subscriber {
 				const done = await Promise.race([stream.done(), track.closed, producer.closed]);
 				if (done !== false) break;
 
-				let timestamp: Time.Micro | undefined;
+				let timestamp: Time.Milli | undefined;
 				if (scale !== 0) {
 					prevTs += unzigzag(await stream.u62());
-					timestamp = Time.Micro((Number(prevTs) * 1_000_000) / scale);
+					timestamp = Time.Milli((Number(prevTs) * 1000) / scale);
 				}
 
 				const size = await stream.u53();
@@ -523,8 +524,7 @@ export class Subscriber {
 				// On a compressed track the wire size is the compressed length;
 				// inflate it back to the original frame the consumer sees.
 				const data = codec === Compression.None ? payload : await decompress(codec, payload);
-				if (timestamp !== undefined) producer.writeFrame(timestamp, data);
-				else producer.writeFrameNow(data);
+				producer.writeFrame(data, timestamp);
 			}
 
 			producer.close();

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -234,6 +234,7 @@ export class Subscriber {
 			const info = await this.#trackInfo(path, name);
 			return {
 				compress: info.compression !== Compression.None,
+				timescale: Time.Timescale(info.timescale),
 				// The wire no longer carries a cache hint (retention is best-effort),
 				// so the local retention window falls back to the model default.
 				cache: DEFAULT_CACHE_MS,
@@ -353,6 +354,7 @@ export class Subscriber {
 			const info = await this.#trackInfo(msg.broadcast, msg.track);
 			producer = request.accept({
 				compress: info.compression !== Compression.None,
+				timescale: Time.Timescale(info.timescale),
 				// The wire no longer carries a cache hint (retention is best-effort),
 				// so the local retention window falls back to the model default.
 				cache: DEFAULT_CACHE_MS,

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -26,6 +26,11 @@ import { Version } from "./version.ts";
 // The timeout turns that into a clear error.
 const SUBSCRIBE_SETUP_TIMEOUT_MS = 10_000;
 
+/** Decode an unsigned zigzag varint back to a signed delta (mirrors Rust `VarInt::to_zigzag`). */
+function unzigzag(v: bigint): bigint {
+	return (v >> 1n) ^ -(v & 1n);
+}
+
 // The TRACK stream and implicit SUBSCRIBE acceptance are lite-05+.
 function supportsTrackStream(version: Version): boolean {
 	switch (version) {
@@ -494,20 +499,21 @@ export class Subscriber {
 				codec = compression.peek();
 			}
 
-			// timescale resolves together with compression (from TRACK_INFO). A
-			// non-zero scale means every frame is prefixed with a zigzag-delta
-			// timestamp (see the lite-05 FRAME format). We don't surface it to the
-			// application yet, but we must still read the varint to keep the frame
-			// framing in sync with the publisher.
+			// timescale resolves together with compression (from TRACK_INFO). A non-zero
+			// scale means every frame is prefixed with a zigzag-delta timestamp (the
+			// lite-05 FRAME format), which we decode and convert to microseconds (the
+			// model's unit). Scale 0 (pre-lite-05) carries no timestamp, so we wall-clock.
 			const scale = timescale.peek() ?? 0;
+			let prevTs = 0n;
 
 			for (;;) {
 				const done = await Promise.race([stream.done(), track.closed, producer.closed]);
 				if (done !== false) break;
 
+				let timestamp: Time.Micro | undefined;
 				if (scale !== 0) {
-					// Consume (and discard) the per-frame timestamp delta.
-					await stream.u62();
+					prevTs += unzigzag(await stream.u62());
+					timestamp = Time.Micro((Number(prevTs) * 1_000_000) / scale);
 				}
 
 				const size = await stream.u53();
@@ -516,7 +522,9 @@ export class Subscriber {
 
 				// On a compressed track the wire size is the compressed length;
 				// inflate it back to the original frame the consumer sees.
-				producer.writeFrame(codec === Compression.None ? payload : await decompress(codec, payload));
+				const data = codec === Compression.None ? payload : await decompress(codec, payload);
+				if (timestamp !== undefined) producer.writeFrame(timestamp, data);
+				else producer.writeFrameNow(data);
 			}
 
 			producer.close();

--- a/js/net/src/lite/track.ts
+++ b/js/net/src/lite/track.ts
@@ -61,8 +61,9 @@ export class TrackInfo {
 	priority: number;
 	ordered: boolean;
 	/**
-	 * Per-frame timestamp scale (units per second). `0` means frames carry no
-	 * per-frame timestamps on the wire.
+	 * Per-frame timestamp scale (units per second). Mandatory on Lite05: a real
+	 * (non-zero) scale, and every frame on the wire is prefixed with a zigzag-delta
+	 * timestamp at this scale.
 	 */
 	timescale: number;
 	/** Codec applied to every frame payload on this track. */

--- a/js/net/src/lite/track.ts
+++ b/js/net/src/lite/track.ts
@@ -97,6 +97,9 @@ export class TrackInfo {
 		const priority = await r.u8();
 		const ordered = await r.bool();
 		const timescale = await r.u53();
+		// Mandatory on Lite05: a zero scale is invalid (mirrors Rust's Timescale::new rejection),
+		// and would otherwise throw later when wrapped in Timescale().
+		if (timescale === 0) throw new Error("track timescale must be non-zero");
 		const compression = compressionFromCode(await r.u53());
 		return new TrackInfo({ priority, ordered, timescale, compression });
 	}

--- a/js/net/src/time.ts
+++ b/js/net/src/time.ts
@@ -67,6 +67,78 @@ export const Milli = Object.assign((value: number): Milli => value as Milli, {
 	min: (a: Milli, b: Milli): Milli => Math.min(a, b) as Milli,
 });
 
+/** Units per second for a {@link Timestamp}'s value, e.g. `1000` for milliseconds. */
+export type Timescale = number & { readonly _brand: "timescale" };
+
+/** Named timescales and a checked constructor (rejects non-positive / non-integer values). */
+export const Timescale = Object.assign(
+	(unitsPerSecond: number): Timescale => {
+		if (!Number.isInteger(unitsPerSecond) || unitsPerSecond <= 0) {
+			throw new Error(`invalid timescale: ${unitsPerSecond}`);
+		}
+		return unitsPerSecond as Timescale;
+	},
+	{
+		/** One unit per second. */
+		SECOND: 1 as Timescale,
+		/** 1,000 units per second. */
+		MILLI: 1_000 as Timescale,
+		/** 1,000,000 units per second. */
+		MICRO: 1_000_000 as Timescale,
+		/** 1,000,000,000 units per second. */
+		NANO: 1_000_000_000 as Timescale,
+	},
+);
+
+/**
+ * A presentation timestamp: a raw value in a given {@link Timescale}.
+ *
+ * Mirrors the Rust `Timestamp`. Unlike the bare `Milli`/`Micro` aliases it carries its
+ * own scale, so a track can pick its units and conversions can't silently mix them up.
+ */
+export class Timestamp {
+	/** The raw value, in `scale` units. */
+	readonly value: number;
+	/** Units per second the {@link value} is measured in. */
+	readonly scale: Timescale;
+
+	/** Build a timestamp of `value` units at `scale`. */
+	constructor(value: number, scale: Timescale) {
+		this.value = value;
+		this.scale = scale;
+	}
+
+	/** Wall-clock now, in milliseconds (`performance.now()`). */
+	static now(): Timestamp {
+		return new Timestamp(performance.now(), Timescale.MILLI);
+	}
+
+	/** A timestamp of `ms` milliseconds. */
+	static fromMillis(ms: number): Timestamp {
+		return new Timestamp(ms, Timescale.MILLI);
+	}
+
+	/** A timestamp of `us` microseconds. */
+	static fromMicros(us: number): Timestamp {
+		return new Timestamp(us, Timescale.MICRO);
+	}
+
+	/** This timestamp's value re-expressed at `scale` (a raw number, not a new Timestamp). */
+	as(scale: Timescale): number {
+		return scale === this.scale ? this.value : (this.value * scale) / this.scale;
+	}
+
+	/** The value in milliseconds. */
+	asMillis(): number {
+		return this.as(Timescale.MILLI);
+	}
+
+	/** The value in microseconds. */
+	asMicros(): number {
+		return this.as(Timescale.MICRO);
+	}
+}
+
 /** A duration in seconds, branded so it can't be mixed with other units. */
 export type Second = number & { readonly _brand: "second" };
 

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1,5 +1,6 @@
 import { Signal } from "@moq/signals";
 import { CacheFull, Group } from "./group.ts";
+import type { Micro } from "./time.ts";
 
 /** Default {@link TrackInfo.cache} window (milliseconds) when the publisher doesn't set one. */
 export const DEFAULT_CACHE_MS = 5000;
@@ -261,10 +262,17 @@ export class TrackProducer extends TrackHandle {
 		this.#sinks.clear();
 	}
 
-	/** Append a frame as its own single-frame group. */
-	writeFrame(frame: Uint8Array) {
+	/** Append a frame as its own single-frame group, at the given presentation timestamp (µs). */
+	writeFrame(timestamp: Micro, frame: Uint8Array) {
 		const group = this.appendGroup();
-		group.writeFrame(frame);
+		group.writeFrame(timestamp, frame);
+		group.close();
+	}
+
+	/** Append a frame stamped with wall-clock now, as its own single-frame group. */
+	writeFrameNow(frame: Uint8Array) {
+		const group = this.appendGroup();
+		group.writeFrameNow(frame);
 		group.close();
 	}
 
@@ -363,7 +371,7 @@ export class TrackSubscriber extends TrackHandle {
 				const next = frames.shift();
 				if (next) {
 					const frame = groups[0].state.total.peek() - frames.length - 1;
-					return { group: groups[0].sequence, frame, data: next };
+					return { group: groups[0].sequence, frame, data: next.data };
 				}
 
 				// Skip this old group
@@ -393,7 +401,7 @@ export class TrackSubscriber extends TrackHandle {
 			const next = frames.shift();
 			if (next) {
 				const frame = group.state.total.peek() - frames.length - 1;
-				return { group: group.sequence, frame, data: next };
+				return { group: group.sequence, frame, data: next.data };
 			}
 
 			// If the track is closed, return undefined.

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1,6 +1,5 @@
 import { Signal } from "@moq/signals";
-import { CacheFull, Group } from "./group.ts";
-import type { Milli } from "./time.ts";
+import { CacheFull, type Frame, Group } from "./group.ts";
 
 /** Default {@link TrackInfo.cache} window (milliseconds) when the publisher doesn't set one. */
 export const DEFAULT_CACHE_MS = 5000;
@@ -262,10 +261,10 @@ export class TrackProducer extends TrackHandle {
 		this.#sinks.clear();
 	}
 
-	/** Append a frame as its own single-frame group; `timestamp` (ms) defaults to wall-clock now. */
-	writeFrame(frame: Uint8Array, timestamp?: Milli) {
+	/** Append a frame as its own single-frame group; a frame with no timestamp uses wall-clock now. */
+	writeFrame(frame: Frame) {
 		const group = this.appendGroup();
-		group.writeFrame(frame, timestamp);
+		group.writeFrame(frame);
 		group.close();
 	}
 

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1,6 +1,6 @@
 import { Signal } from "@moq/signals";
 import { CacheFull, Group } from "./group.ts";
-import type { Micro } from "./time.ts";
+import type { Milli } from "./time.ts";
 
 /** Default {@link TrackInfo.cache} window (milliseconds) when the publisher doesn't set one. */
 export const DEFAULT_CACHE_MS = 5000;
@@ -262,17 +262,10 @@ export class TrackProducer extends TrackHandle {
 		this.#sinks.clear();
 	}
 
-	/** Append a frame as its own single-frame group, at the given presentation timestamp (µs). */
-	writeFrame(timestamp: Micro, frame: Uint8Array) {
+	/** Append a frame as its own single-frame group; `timestamp` (ms) defaults to wall-clock now. */
+	writeFrame(frame: Uint8Array, timestamp?: Milli) {
 		const group = this.appendGroup();
-		group.writeFrame(timestamp, frame);
-		group.close();
-	}
-
-	/** Append a frame stamped with wall-clock now, as its own single-frame group. */
-	writeFrameNow(frame: Uint8Array) {
-		const group = this.appendGroup();
-		group.writeFrameNow(frame);
+		group.writeFrame(frame, timestamp);
 		group.close();
 	}
 

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1,5 +1,6 @@
 import { Signal } from "@moq/signals";
 import { CacheFull, type Frame, Group } from "./group.ts";
+import { Timescale } from "./time.ts";
 
 /** Default {@link TrackInfo.cache} window (milliseconds) when the publisher doesn't set one. */
 export const DEFAULT_CACHE_MS = 5000;
@@ -14,6 +15,12 @@ export const DEFAULT_CACHE_MS = 5000;
 export interface TrackInfo {
 	/** Hint that frames are worth compressing (e.g. a JSON catalog). */
 	compress: boolean;
+	/**
+	 * Units per second for this track's frame timestamps (reported in TRACK_INFO on
+	 * Lite05+). Defaults to milliseconds; set it finer (e.g. {@link Timescale.MICRO})
+	 * for media that needs sub-millisecond timing.
+	 */
+	timescale: Timescale;
 	/** How long (milliseconds) old groups stay available before eviction. */
 	cache: number;
 	/** Tie-break priority between subscriptions of equal subscriber priority. */
@@ -26,6 +33,7 @@ export interface TrackInfo {
 export function trackInfoDefaults(info: Partial<TrackInfo> = {}): TrackInfo {
 	return {
 		compress: info.compress ?? false,
+		timescale: info.timescale ?? Timescale.MILLI,
 		cache: info.cache ?? DEFAULT_CACHE_MS,
 		priority: info.priority ?? 0,
 		ordered: info.ordered ?? true,

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -294,10 +294,10 @@ export class Encoder {
 
 					// Each audio frame is its own group so the relay can forward it without
 					// waiting for a group boundary. Loss is handled by the codec's PLC.
-					track.writeFrame(
-						Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
-						Time.Milli.fromMicro(frame.timestamp as Time.Micro),
-					);
+					track.writeFrame({
+						data: Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
+						timestamp: Time.Milli.fromMicro(frame.timestamp as Time.Micro),
+					});
 				},
 				error: (err) => {
 					console.error("encoder error", err);

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -294,7 +294,10 @@ export class Encoder {
 
 					// Each audio frame is its own group so the relay can forward it without
 					// waiting for a group boundary. Loss is handled by the codec's PLC.
-					track.writeFrame(Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro));
+					track.writeFrame(
+						frame.timestamp as Time.Micro,
+						Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
+					);
 				},
 				error: (err) => {
 					console.error("encoder error", err);

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -295,8 +295,8 @@ export class Encoder {
 					// Each audio frame is its own group so the relay can forward it without
 					// waiting for a group boundary. Loss is handled by the codec's PLC.
 					track.writeFrame(
-						frame.timestamp as Time.Micro,
 						Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
+						Time.Milli.fromMicro(frame.timestamp as Time.Micro),
 					);
 				},
 				error: (err) => {

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -296,7 +296,7 @@ export class Encoder {
 					// waiting for a group boundary. Loss is handled by the codec's PLC.
 					track.writeFrame({
 						data: Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
-						timestamp: Time.Milli.fromMicro(frame.timestamp as Time.Micro),
+						timestamp: Time.Timestamp.fromMicros(frame.timestamp as Time.Micro),
 					});
 				},
 				error: (err) => {

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -78,7 +78,7 @@ fn create_track(broadcast: &mut moq_net::BroadcastProducer) -> anyhow::Result<mo
 	// Publish the catalog as a "catalog.json" track in the broadcast.
 	let mut catalog_track = broadcast.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())?;
 	let mut group = catalog_track.append_group()?;
-	group.write_frame(catalog.to_string()?)?;
+	group.write_frame_now(catalog.to_string()?)?;
 	group.finish()?;
 
 	// Actually create the media track now.

--- a/rs/hang/src/container/frame.rs
+++ b/rs/hang/src/container/frame.rs
@@ -51,17 +51,11 @@ impl Frame {
 		let size = (header.len() + self.payload.len()) as u64;
 
 		// Stamp the moq-net frame timestamp too so Lite05+ can delta-encode it on the
-		// wire independently of the container-level prefix, but only when the track
-		// advertises a timescale. Untimed tracks (e.g. an on-demand TrackRequest
-		// accepted with default info) carry the timestamp in the container prefix
-		// alone, matching the timeless net frames LOC/CMAF already produce.
-		let net_timestamp = group
-			.timescale()
-			.map(|scale| self.timestamp.convert(scale))
-			.transpose()?;
+		// wire independently of the container-level prefix. `create_frame` converts it
+		// into the track's timescale; older drafts simply don't put it on the wire.
 		let net_frame = moq_net::Frame {
 			size,
-			timestamp: net_timestamp,
+			timestamp: Some(self.timestamp),
 		};
 		let mut chunked = group.create_frame(net_frame)?;
 		chunked.write(header.freeze())?;

--- a/rs/hang/src/container/frame.rs
+++ b/rs/hang/src/container/frame.rs
@@ -55,7 +55,7 @@ impl Frame {
 		// into the track's timescale; older drafts simply don't put it on the wire.
 		let net_frame = moq_net::Frame {
 			size,
-			timestamp: Some(self.timestamp),
+			timestamp: self.timestamp,
 		};
 		let mut chunked = group.create_frame(net_frame)?;
 		chunked.write(header.freeze())?;

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -161,7 +161,7 @@ impl Publish {
 	/// one-frame-per-group pattern (e.g. status/command tracks).
 	pub fn track_frame(&mut self, track: Id, payload: &[u8]) -> Result<(), Error> {
 		let track = self.tracks.get_mut(track).ok_or(Error::TrackNotFound)?;
-		track.write_frame(bytes::Bytes::copy_from_slice(payload))?;
+		track.write_frame_now(bytes::Bytes::copy_from_slice(payload))?;
 		Ok(())
 	}
 
@@ -175,7 +175,7 @@ impl Publish {
 	/// Write a frame into a raw group.
 	pub fn group_frame(&mut self, group: Id, payload: &[u8]) -> Result<(), Error> {
 		let group = self.groups.get_mut(group).ok_or(Error::GroupNotFound)?;
-		group.write_frame(bytes::Bytes::copy_from_slice(payload))?;
+		group.write_frame_now(bytes::Bytes::copy_from_slice(payload))?;
 		Ok(())
 	}
 

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -210,13 +210,13 @@ async fn produce(
 				.as_millis(),
 		};
 		let header = Bytes::from(serde_json::to_vec(&header)?);
-		group.write_frame(header.clone())?;
+		group.write_frame_now(header.clone())?;
 		stats.frame_sent(header.len());
 
 		// The remaining frames in the group are zeroed payload.
 		for _ in 0..rolled.group_size {
 			ticker.tick().await;
-			group.write_frame(zeros.clone())?;
+			group.write_frame_now(zeros.clone())?;
 			stats.frame_sent(zeros.len());
 		}
 

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -22,8 +22,9 @@ pub struct MoqTrackInfo {
 	/// How long the relay should cache past groups, in milliseconds. Null uses the default.
 	#[uniffi(default = None)]
 	pub cache_ms: Option<u64>,
-	/// Per-frame timescale in ticks per second. Null leaves the track untimed; set it only
-	/// when writing timestamped frames, since raw `write_frame` is untimed and would mismatch.
+	/// Per-frame timescale in ticks per second. Null uses the default (milliseconds);
+	/// set it to match the scale of the timestamps you write. Frames written without an
+	/// explicit timestamp are stamped with wall-clock time at this scale.
 	#[uniffi(default = None)]
 	pub timescale: Option<u64>,
 }

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -7,7 +7,7 @@ use crate::ffi::Task;
 /// Publisher-side track properties, mirroring [`moq_net::TrackInfo`].
 ///
 /// Construct with the fields you care about; the rest default to moq-net's defaults
-/// (priority 0, ordered, uncompressed, default cache, untimed).
+/// (priority 0, ordered, uncompressed, default cache, millisecond timescale).
 #[derive(Clone, uniffi::Record)]
 pub struct MoqTrackInfo {
 	/// Priority, used only to break ties between subscriptions of equal subscriber priority.
@@ -431,7 +431,7 @@ impl MoqTrackProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.as_mut().ok_or(MoqError::Closed)?;
-		track.write_frame(payload)?;
+		track.write_frame_now(payload)?;
 		Ok(())
 	}
 
@@ -480,7 +480,7 @@ impl MoqGroupProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.inner.lock().unwrap();
 		let group = guard.as_mut().ok_or_else(|| MoqError::Closed)?;
-		group.write_frame(payload)?;
+		group.write_frame_now(payload)?;
 		Ok(())
 	}
 

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -224,7 +224,7 @@ impl Inner {
 			Some(delta) => {
 				let group = self.group.as_mut().expect("delta requires an open group");
 				let len = delta.len() as u64;
-				group.write_frame(delta)?;
+				group.write_frame_now(delta)?;
 				self.delta_bytes += len;
 				self.group_frames += 1;
 			}
@@ -273,7 +273,7 @@ impl Inner {
 		}
 
 		let mut group = self.track.append_group()?;
-		group.write_frame(snapshot)?;
+		group.write_frame_now(snapshot)?;
 		self.delta_bytes = 0;
 		self.group_frames = 1;
 

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -80,7 +80,7 @@ mod test {
 		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 
 		let (catalog, payload) = catalog_payload("pending");
-		group.write_frame(payload).expect("catalog frame should write");
+		group.write_frame_now(payload).expect("catalog frame should write");
 		group.finish().expect("catalog group should finish");
 
 		assert_eq!(expect_catalog(consumer.poll_next(&waiter)), catalog);
@@ -98,7 +98,7 @@ mod test {
 		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 
 		let (catalog, payload) = catalog_payload("finished");
-		group.write_frame(payload).expect("catalog frame should write");
+		group.write_frame_now(payload).expect("catalog frame should write");
 		group.finish().expect("catalog group should finish");
 
 		assert_eq!(expect_catalog(consumer.poll_next(&waiter)), catalog);
@@ -115,13 +115,13 @@ mod test {
 
 		let mut old_group = track.append_group().expect("old catalog group should append");
 		old_group
-			.write_frame(old_payload)
+			.write_frame_now(old_payload)
 			.expect("old catalog frame should write");
 		old_group.finish().expect("old catalog group should finish");
 
 		let mut latest_group = track.append_group().expect("latest catalog group should append");
 		latest_group
-			.write_frame(latest_payload)
+			.write_frame_now(latest_payload)
 			.expect("latest catalog frame should write");
 		latest_group.finish().expect("latest catalog group should finish");
 		track.finish().expect("catalog track should finish");
@@ -141,7 +141,7 @@ mod test {
 
 		let mut old_group = track.append_group().expect("old catalog group should append");
 		old_group
-			.write_frame(old_payload)
+			.write_frame_now(old_payload)
 			.expect("old catalog frame should write");
 		old_group.finish().expect("old catalog group should finish");
 
@@ -150,7 +150,7 @@ mod test {
 		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 
 		latest_group
-			.write_frame(latest_payload)
+			.write_frame_now(latest_payload)
 			.expect("latest catalog frame should write");
 		latest_group.finish().expect("latest catalog group should finish");
 
@@ -172,7 +172,7 @@ mod test {
 
 		let mut latest_group = track.append_group().expect("latest catalog group should append");
 		latest_group
-			.write_frame(latest_payload)
+			.write_frame_now(latest_payload)
 			.expect("latest catalog frame should write");
 		latest_group.finish().expect("latest catalog group should finish");
 		track.finish().expect("catalog track should finish");
@@ -180,7 +180,7 @@ mod test {
 		assert_eq!(expect_catalog(consumer.poll_next(&waiter)), latest);
 
 		old_group
-			.write_frame(old_payload)
+			.write_frame_now(old_payload)
 			.expect("old catalog frame should write");
 		old_group.finish().expect("old catalog group should finish");
 

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -168,7 +168,7 @@ impl<E: CatalogExt> Drop for Guard<'_, E> {
 		// Publish the MSF catalog, derived from the base media sections.
 		let msf = to_msf(&self.catalog.media());
 		if let Ok(mut group) = self.msf_track.append_group() {
-			let _ = group.write_frame(msf.to_string().expect("invalid MSF catalog"));
+			let _ = group.write_frame_now(msf.to_string().expect("invalid MSF catalog"));
 			let _ = group.finish();
 		}
 	}

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -443,7 +443,7 @@ mod tests {
 			// The duration tests write frames directly via `write_duration_frame`;
 			// this path just preserves the timestamp with an unknown duration.
 			for frame in frames {
-				group.write_frame(encode_duration_frame(frame.timestamp, ts(0)))?;
+				group.write_frame(frame.timestamp, encode_duration_frame(frame.timestamp, ts(0)))?;
 			}
 			Ok(())
 		}
@@ -474,7 +474,9 @@ mod tests {
 
 	/// Write one DurationWire frame (timestamp and duration in µs) into a group.
 	fn write_duration_frame(group: &mut moq_net::GroupProducer, timestamp: Timestamp, duration: Timestamp) {
-		group.write_frame(encode_duration_frame(timestamp, duration)).unwrap();
+		group
+			.write_frame(timestamp, encode_duration_frame(timestamp, duration))
+			.unwrap();
 	}
 
 	/// Write a finished group with explicit sequence and timestamps (Container::Legacy format).

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -612,7 +612,7 @@ impl Import {
 			let timestamp = min_timestamp.ok_or(Error::MissingTrun)?;
 			let mut frame = g.create_frame(moq_net::Frame {
 				size: fragment_bytes.len() as u64,
-				timestamp: Some(timestamp),
+				timestamp,
 			})?;
 			frame.write(fragment_bytes)?;
 			frame.finish()?;

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -287,7 +287,12 @@ pub(crate) fn encode(
 
 	let sequence_number = group.frame_count() as u32;
 	let bytes = encode_fragment(track_id, timescale, sequence_number, frames)?;
-	let mut writer = group.create_frame(bytes.len())?;
+	// The fragment may carry several samples; the net frame's timestamp is the
+	// fragment's earliest presentation time so a relay can order it.
+	let mut writer = group.create_frame(moq_net::Frame {
+		size: bytes.len() as u64,
+		timestamp: frames[0].timestamp,
+	})?;
 	writer.write(bytes)?;
 	writer.finish()?;
 

--- a/rs/moq-mux/src/container/loc/mod.rs
+++ b/rs/moq-mux/src/container/loc/mod.rs
@@ -29,7 +29,12 @@ impl Container for Wire {
 			let timestamp = frame.timestamp.convert(DEFAULT_TIMESCALE).map_err(hang::Error::from)?;
 			let data = moq_loc::encode(timestamp.value(), &frame.payload)?;
 
-			let mut chunked = group.create_frame(data.len())?;
+			// Carry the timestamp on the net frame too (converted to the track's
+			// timescale), so a relay sees it without parsing the LOC payload.
+			let mut chunked = group.create_frame(moq_net::Frame {
+				size: data.len() as u64,
+				timestamp: frame.timestamp,
+			})?;
 			chunked.write(data)?;
 			chunked.finish()?;
 		}

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -58,8 +58,8 @@ async fn run_broadcast(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 
 	// Write frames to the group.
 	// Each frame is dependent on the previous frame, so older frames are prioritized.
-	group.write_frame(bytes::Bytes::from_static(b"Hello"))?;
-	group.write_frame(bytes::Bytes::from_static(b"World"))?;
+	group.write_frame_now(bytes::Bytes::from_static(b"Hello"))?;
+	group.write_frame_now(bytes::Bytes::from_static(b"World"))?;
 	group.finish()?;
 
 	tracing::info!("wrote hello + world");
@@ -68,7 +68,7 @@ async fn run_broadcast(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 	tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
 
 	// There's also a helper method to create a group with a single frame.
-	track.write_frame(bytes::Bytes::from_static(b"foobarbaz"))?;
+	track.write_frame_now(bytes::Bytes::from_static(b"foobarbaz"))?;
 	tracing::info!("wrote foobarbaz");
 
 	// Sleep before exiting and closing the broadcast.

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -161,11 +161,11 @@ impl Publisher {
 		// Everything but the second.
 		let base = now.format("%Y-%m-%d %H:%M:").to_string();
 
-		segment.write_frame(base.clone())?;
+		segment.write_frame_now(base.clone())?;
 
 		loop {
 			let delta = now.format("%S").to_string();
-			segment.write_frame(delta.clone())?;
+			segment.write_frame_now(delta.clone())?;
 
 			let next = now + chrono::Duration::try_seconds(1).unwrap();
 			let next = next.with_nanosecond(0).unwrap();

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -19,7 +19,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -259,7 +259,7 @@ async fn iroh_connect() {
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	// Create server iroh endpoint

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -205,7 +205,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 			.expect("next_frame failed")
 			.expect("group closed prematurely");
 
-		let ts = frame_sub.timestamp.expect("Lite05 must carry per-frame timestamps");
+		let ts = frame_sub.timestamp;
 		assert_eq!(ts.scale(), Timescale::MICRO);
 		assert_eq!(ts.value(), expected_us);
 
@@ -316,9 +316,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 			.expect("next_frame failed")
 			.expect("group closed prematurely");
 
-		let ts = frame_sub
-			.timestamp
-			.expect("Lite05 fetch must carry per-frame timestamps");
+		let ts = frame_sub.timestamp;
 		assert_eq!(ts.scale(), Timescale::MICRO);
 		assert_eq!(ts.value(), expected_us);
 
@@ -541,7 +539,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 		.expect("next_frame failed")
 		.expect("group closed");
 
-	let ts = frame_sub.timestamp.expect("Lite05 frames always carry a timestamp");
+	let ts = frame_sub.timestamp;
 	assert_eq!(ts.scale(), Timescale::MILLI, "default timescale is milliseconds");
 
 	drop(session);

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -29,7 +29,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 
 	// Write a group containing a single frame.
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -137,7 +137,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 		let payload = format!("frame@{us}").into_bytes();
 		let frame = moq_native::moq_net::Frame {
 			size: payload.len() as u64,
-			timestamp: Some(Timestamp::new(us, Timescale::MICRO).unwrap()),
+			timestamp: Timestamp::new(us, Timescale::MICRO).unwrap(),
 		};
 		let mut writer = group.create_frame(frame).expect("failed to create frame");
 		writer
@@ -253,7 +253,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 		let payload = format!("frame@{us}").into_bytes();
 		let frame = moq_native::moq_net::Frame {
 			size: payload.len() as u64,
-			timestamp: Some(Timestamp::new(us, Timescale::MICRO).unwrap()),
+			timestamp: Timestamp::new(us, Timescale::MICRO).unwrap(),
 		};
 		let mut writer = group.create_frame(frame).expect("failed to create frame");
 		writer
@@ -359,7 +359,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	fn timestamped_frame(us: u64, payload: &str) -> moq_net::Frame {
 		moq_net::Frame {
 			size: payload.len() as u64,
-			timestamp: Some(Timestamp::new(us, Timescale::MICRO).unwrap()),
+			timestamp: Timestamp::new(us, Timescale::MICRO).unwrap(),
 		}
 	}
 
@@ -482,7 +482,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 	let mut track = broadcast.create_track("video", None).expect("create track");
 
 	let mut group = track.append_group().expect("append group");
-	group.write_frame(b"hello".as_ref()).expect("write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("write frame");
 	group.finish().expect("finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -874,7 +874,7 @@ async fn broadcast_websocket() {
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	// Server with both QUIC (required) and WebSocket listeners.
@@ -979,7 +979,7 @@ async fn broadcast_websocket_fallback() {
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	// QUIC binds on its own port; WebSocket on a different port.
@@ -1088,7 +1088,7 @@ async fn broadcast_websocket_uses_newest_version() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -1154,7 +1154,7 @@ async fn broadcast_race_quic_wins() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	// Bind WebSocket TCP first to pick a random port, then bind QUIC UDP to
@@ -1241,7 +1241,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	let mut track = broadcast.create_track("video", None).expect("create track");
 
 	let mut group0 = track.append_group().expect("append group 0");
-	group0.write_frame(b"a".as_ref()).expect("write frame 0");
+	group0.write_frame_now(b"a".as_ref()).expect("write frame 0");
 	group0.finish().expect("finish group 0");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -1310,7 +1310,7 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	// A new group published after the resubscribe must reach the consumer
 	// regardless of which linger branch fired.
 	let mut group1 = track.append_group().expect("append group 1");
-	group1.write_frame(b"b".as_ref()).expect("write frame 1");
+	group1.write_frame_now(b"b".as_ref()).expect("write frame 1");
 	group1.finish().expect("finish group 1");
 
 	let mut saw_group1 = false;
@@ -1433,7 +1433,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 		.expect("failed to create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let publish = pub_origin
@@ -1565,7 +1565,7 @@ async fn publish_only_client_to_subscribe_only_server() {
 		.expect("failed to create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame(b"hello".as_ref()).expect("failed to write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let publish = pub_origin

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -124,8 +124,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
 
-	// Track with an advertised microsecond timescale. Without it, Lite05 publish
-	// fails with ProtocolViolation.
+	// Track with an explicit microsecond timescale (the default is milliseconds).
 	let mut track = broadcast
 		.create_track("video", moq_net::TrackInfo::default().with_timescale(Timescale::MICRO))
 		.expect("failed to create track");
@@ -470,12 +469,14 @@ async fn broadcast_moq_lite_05_fetch_during_subscribe_webtransport() {
 	lite05_fetch_during_subscribe("https").await;
 }
 
-/// On Lite05 a publisher that doesn't advertise a timescale still works:
-/// SUBSCRIBE_OK carries `timescale = 0` and neither side encodes a
-/// per-frame timestamp byte. Subscribers receive `frame.timestamp = None`.
+/// On Lite05 timestamps are mandatory: a publisher that doesn't set a timescale gets
+/// the default (milliseconds), and frames written without an explicit timestamp are
+/// stamped with wall-clock time. The subscriber receives `Some(ts)` at that scale.
 #[tracing_test::traced_test]
 #[tokio::test]
-async fn broadcast_moq_lite_05_without_timescale() {
+async fn broadcast_moq_lite_05_default_timescale() {
+	use moq_native::moq_net::Timescale;
+
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("create track");
@@ -540,10 +541,8 @@ async fn broadcast_moq_lite_05_without_timescale() {
 		.expect("next_frame failed")
 		.expect("group closed");
 
-	assert_eq!(
-		frame_sub.timestamp, None,
-		"no timescale negotiated, no per-frame timestamp"
-	);
+	let ts = frame_sub.timestamp.expect("Lite05 frames always carry a timestamp");
+	assert_eq!(ts.scale(), Timescale::MILLI, "default timescale is milliseconds");
 
 	drop(session);
 	server_handle

--- a/rs/moq-net/src/coding/reader.rs
+++ b/rs/moq-net/src/coding/reader.rs
@@ -128,25 +128,6 @@ impl<S: web_transport_trait::RecvStream, V> Reader<S, V> {
 		Ok(buf.into_inner().freeze())
 	}
 
-	/// Skip the given number of bytes from the stream.
-	pub async fn skip(&mut self, mut size: usize) -> Result<(), Error> {
-		let buffered = self.buffer.len().min(size);
-		self.buffer.advance(buffered);
-		size -= buffered;
-
-		while size > 0 {
-			let chunk = self
-				.stream
-				.read_chunk(size)
-				.await
-				.map_err(Error::from_transport)?
-				.ok_or(DecodeError::Short)?;
-			size -= chunk.len();
-		}
-
-		Ok(())
-	}
-
 	/// Wait until the stream is closed, erroring if there are any additional bytes.
 	pub async fn closed(&mut self) -> Result<(), Error> {
 		if self.has_more().await? {

--- a/rs/moq-net/src/ietf/group.rs
+++ b/rs/moq-net/src/ietf/group.rs
@@ -1,4 +1,4 @@
-use crate::coding::{Decode, DecodeError, Encode, EncodeError};
+use crate::coding::{Decode, DecodeError, Encode, EncodeError, VarInt};
 use crate::{Timescale, Timestamp};
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -12,19 +12,26 @@ const PROP_TIMESTAMP: u64 = 0x06;
 const PROP_TIMESCALE: u64 = 0x08;
 
 /// Encode a frame's presentation timestamp as moq-transport Object Properties:
-/// Timestamp (0x06, absolute) in Timescale (0x08) units. Matches the LOC encoding
-/// of the same registry ids so a relay or LOC-aware peer reads the same bytes.
+/// Timestamp (0x06) in Timescale (0x08) units.
 ///
-/// Writes the raw KVP bytes (no outer length prefix); the caller frames the
-/// extension block with its byte length.
+/// The Timestamp is a zigzag delta against `*prev` (the previous object's raw value
+/// in this subgroup; pass `&mut 0` for the first object), so out-of-order PTS (e.g.
+/// B-frames) stay compact. The Timescale is the absolute units-per-second. Writes the
+/// raw KVP bytes (no outer length prefix); the caller frames the block with its length.
 pub fn encode_object_time<W: bytes::BufMut>(
 	w: &mut W,
 	timestamp: Timestamp,
+	prev: &mut u64,
 	version: Version,
 ) -> Result<(), EncodeError> {
 	// KVP type ids are delta-encoded ascending: 0x06 then 0x08 (delta 0x02).
 	PROP_TIMESTAMP.encode(w, version)?;
-	timestamp.value().encode(w, version)?;
+	let delta: i64 = (timestamp.value() as i128 - *prev as i128)
+		.try_into()
+		.map_err(|_| EncodeError::from(crate::coding::BoundsExceeded))?;
+	VarInt::from_zigzag(delta)?.encode(w, version)?;
+	*prev = timestamp.value();
+
 	(PROP_TIMESCALE - PROP_TIMESTAMP).encode(w, version)?;
 	u64::from(timestamp.scale()).encode(w, version)?;
 	Ok(())
@@ -33,28 +40,37 @@ pub fn encode_object_time<W: bytes::BufMut>(
 /// Decode the Timestamp (0x06) + Timescale (0x08) Object Properties from an object's
 /// extension block, skipping any other properties. Returns `None` when no Timestamp
 /// property is present; a missing Timescale defaults to microseconds (the registry default).
-pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Option<Timestamp>, DecodeError> {
-	let mut timestamp: Option<u64> = None;
+///
+/// The Timestamp is a zigzag delta against `*prev`, which is advanced to the decoded
+/// raw value. Mirrors [`encode_object_time`].
+pub fn decode_object_time<R: bytes::Buf>(
+	r: &mut R,
+	prev: &mut u64,
+	version: Version,
+) -> Result<Option<Timestamp>, DecodeError> {
+	let mut delta: Option<i64> = None;
 	let mut timescale: Option<u64> = None;
 	let mut prev_type: u64 = 0;
 	let mut first = true;
 
 	while r.has_remaining() {
-		let delta = u64::decode(r, version)?;
+		let step = u64::decode(r, version)?;
 		let abs = if first {
-			delta
+			step
 		} else {
-			prev_type.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?
+			prev_type.checked_add(step).ok_or(DecodeError::BoundsExceeded)?
 		};
 		first = false;
 		prev_type = abs;
 
 		if abs % 2 == 0 {
-			let value = u64::decode(r, version)?;
+			// Even type: a single varint value. 0x06 carries a zigzag delta.
 			match abs {
-				PROP_TIMESTAMP => timestamp = Some(value),
-				PROP_TIMESCALE => timescale = Some(value),
-				_ => {}
+				PROP_TIMESTAMP => delta = Some(VarInt::decode(r, version)?.to_zigzag()),
+				PROP_TIMESCALE => timescale = Some(u64::decode(r, version)?),
+				_ => {
+					let _ = u64::decode(r, version)?;
+				}
 			}
 		} else {
 			// Odd type: length-prefixed bytes we don't care about.
@@ -66,9 +82,14 @@ pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<
 		}
 	}
 
-	let Some(value) = timestamp else {
+	let Some(delta) = delta else {
 		return Ok(None);
 	};
+	let value: u64 = (*prev as i128 + delta as i128)
+		.try_into()
+		.map_err(|_| DecodeError::BoundsExceeded)?;
+	*prev = value;
+
 	let scale = match timescale {
 		Some(s) => Timescale::new(s).map_err(|_| DecodeError::InvalidValue)?,
 		None => Timescale::MICRO,
@@ -310,30 +331,52 @@ mod tests {
 
 	use bytes::Buf;
 
-	/// Object Property timestamp round-trips through encode/decode at its own scale.
+	/// A sequence of object timestamps round-trips through the zigzag-delta encoding,
+	/// including a backwards step (B-frame ordering) that yields a negative delta.
 	#[test]
 	fn test_object_time_roundtrip() {
-		let ts = Timestamp::new(96_000, Timescale::MICRO).unwrap();
-		let mut buf = bytes::BytesMut::new();
-		encode_object_time(&mut buf, ts, Version::Draft18).unwrap();
+		// Each object's extension block is length-framed on the wire and decoded on its
+		// own, so encode/decode one block per object while threading `prev`.
+		let values = [10_000u64, 30_000, 20_000];
+		let mut enc_prev = 0u64;
+		let blocks: Vec<bytes::Bytes> = values
+			.iter()
+			.map(|&v| {
+				let ts = Timestamp::new(v, Timescale::MICRO).unwrap();
+				let mut buf = bytes::BytesMut::new();
+				encode_object_time(&mut buf, ts, &mut enc_prev, Version::Draft18).unwrap();
+				buf.freeze()
+			})
+			.collect();
 
-		let mut bytes = buf.freeze();
-		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
-		assert_eq!(decoded.value(), 96_000);
-		assert_eq!(decoded.scale(), Timescale::MICRO);
-		assert!(!bytes.has_remaining());
+		let mut dec_prev = 0u64;
+		for (&v, block) in values.iter().zip(&blocks) {
+			let mut bytes = block.clone();
+			let decoded = decode_object_time(&mut bytes, &mut dec_prev, Version::Draft18)
+				.unwrap()
+				.unwrap();
+			assert_eq!(decoded.value(), v);
+			assert_eq!(decoded.scale(), Timescale::MICRO);
+			assert!(!bytes.has_remaining());
+		}
 	}
 
 	/// A timescale-less extension block falls back to microseconds (registry default).
 	#[test]
 	fn test_object_time_defaults_to_micros() {
 		let mut buf = bytes::BytesMut::new();
-		// Just a 0x06 Timestamp property, no 0x08.
+		// Just a 0x06 Timestamp property (zigzag delta from 0 = 1234), no 0x08.
 		PROP_TIMESTAMP.encode(&mut buf, Version::Draft18).unwrap();
-		1234u64.encode(&mut buf, Version::Draft18).unwrap();
+		VarInt::from_zigzag(1234)
+			.unwrap()
+			.encode(&mut buf, Version::Draft18)
+			.unwrap();
 
 		let mut bytes = buf.freeze();
-		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
+		let mut prev = 0u64;
+		let decoded = decode_object_time(&mut bytes, &mut prev, Version::Draft18)
+			.unwrap()
+			.unwrap();
 		assert_eq!(decoded.value(), 1234);
 		assert_eq!(decoded.scale(), Timescale::MICRO);
 	}
@@ -342,7 +385,12 @@ mod tests {
 	#[test]
 	fn test_object_time_absent() {
 		let mut empty = bytes::Bytes::new();
-		assert!(decode_object_time(&mut empty, Version::Draft18).unwrap().is_none());
+		let mut prev = 0u64;
+		assert!(
+			decode_object_time(&mut empty, &mut prev, Version::Draft18)
+				.unwrap()
+				.is_none()
+		);
 	}
 
 	// Test table from draft-ietf-moq-transport-14 Section 10.4.2 Table 7

--- a/rs/moq-net/src/ietf/group.rs
+++ b/rs/moq-net/src/ietf/group.rs
@@ -1,9 +1,82 @@
 use crate::coding::{Decode, DecodeError, Encode, EncodeError};
+use crate::{Timescale, Timestamp};
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use super::Version;
 use crate::ietf::Param;
+
+/// MOQ Object Property IDs (the MOQ Object Properties registry, shared with
+/// draft-ietf-moq-loc). Even type ids carry a single varint value.
+const PROP_TIMESTAMP: u64 = 0x06;
+const PROP_TIMESCALE: u64 = 0x08;
+
+/// Encode a frame's presentation timestamp as moq-transport Object Properties:
+/// Timestamp (0x06, absolute) in Timescale (0x08) units. Matches the LOC encoding
+/// of the same registry ids so a relay or LOC-aware peer reads the same bytes.
+///
+/// Writes the raw KVP bytes (no outer length prefix); the caller frames the
+/// extension block with its byte length.
+pub fn encode_object_time<W: bytes::BufMut>(
+	w: &mut W,
+	timestamp: Timestamp,
+	version: Version,
+) -> Result<(), EncodeError> {
+	// KVP type ids are delta-encoded ascending: 0x06 then 0x08 (delta 0x02).
+	PROP_TIMESTAMP.encode(w, version)?;
+	timestamp.value().encode(w, version)?;
+	(PROP_TIMESCALE - PROP_TIMESTAMP).encode(w, version)?;
+	u64::from(timestamp.scale()).encode(w, version)?;
+	Ok(())
+}
+
+/// Decode the Timestamp (0x06) + Timescale (0x08) Object Properties from an object's
+/// extension block, skipping any other properties. Returns `None` when no Timestamp
+/// property is present; a missing Timescale defaults to microseconds (the registry default).
+pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Option<Timestamp>, DecodeError> {
+	let mut timestamp: Option<u64> = None;
+	let mut timescale: Option<u64> = None;
+	let mut prev_type: u64 = 0;
+	let mut first = true;
+
+	while r.has_remaining() {
+		let delta = u64::decode(r, version)?;
+		let abs = if first {
+			delta
+		} else {
+			prev_type.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?
+		};
+		first = false;
+		prev_type = abs;
+
+		if abs % 2 == 0 {
+			let value = u64::decode(r, version)?;
+			match abs {
+				PROP_TIMESTAMP => timestamp = Some(value),
+				PROP_TIMESCALE => timescale = Some(value),
+				_ => {}
+			}
+		} else {
+			// Odd type: length-prefixed bytes we don't care about.
+			let len = u64::decode(r, version)? as usize;
+			if r.remaining() < len {
+				return Err(DecodeError::Short);
+			}
+			r.advance(len);
+		}
+	}
+
+	let Some(value) = timestamp else {
+		return Ok(None);
+	};
+	let scale = match timescale {
+		Some(s) => Timescale::new(s).map_err(|_| DecodeError::InvalidValue)?,
+		None => Timescale::MICRO,
+	};
+	Ok(Some(
+		Timestamp::new(value, scale).map_err(|_| DecodeError::InvalidValue)?,
+	))
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
 #[repr(u8)]
@@ -234,6 +307,43 @@ impl Decode<Version> for GroupHeader {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	use bytes::Buf;
+
+	/// Object Property timestamp round-trips through encode/decode at its own scale.
+	#[test]
+	fn test_object_time_roundtrip() {
+		let ts = Timestamp::new(96_000, Timescale::MICRO).unwrap();
+		let mut buf = bytes::BytesMut::new();
+		encode_object_time(&mut buf, ts, Version::Draft18).unwrap();
+
+		let mut bytes = buf.freeze();
+		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
+		assert_eq!(decoded.value(), 96_000);
+		assert_eq!(decoded.scale(), Timescale::MICRO);
+		assert!(!bytes.has_remaining());
+	}
+
+	/// A timescale-less extension block falls back to microseconds (registry default).
+	#[test]
+	fn test_object_time_defaults_to_micros() {
+		let mut buf = bytes::BytesMut::new();
+		// Just a 0x06 Timestamp property, no 0x08.
+		PROP_TIMESTAMP.encode(&mut buf, Version::Draft18).unwrap();
+		1234u64.encode(&mut buf, Version::Draft18).unwrap();
+
+		let mut bytes = buf.freeze();
+		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
+		assert_eq!(decoded.value(), 1234);
+		assert_eq!(decoded.scale(), Timescale::MICRO);
+	}
+
+	/// No Timestamp property at all yields None (the caller wall-clock-stamps).
+	#[test]
+	fn test_object_time_absent() {
+		let mut empty = bytes::Bytes::new();
+		assert!(decode_object_time(&mut empty, Version::Draft18).unwrap().is_none());
+	}
 
 	// Test table from draft-ietf-moq-transport-14 Section 10.4.2 Table 7
 	#[test]

--- a/rs/moq-net/src/ietf/group.rs
+++ b/rs/moq-net/src/ietf/group.rs
@@ -1,4 +1,4 @@
-use crate::coding::{Decode, DecodeError, Encode, EncodeError, VarInt};
+use crate::coding::{Decode, DecodeError, Encode, EncodeError};
 use crate::{Timescale, Timestamp};
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -12,26 +12,20 @@ const PROP_TIMESTAMP: u64 = 0x06;
 const PROP_TIMESCALE: u64 = 0x08;
 
 /// Encode a frame's presentation timestamp as moq-transport Object Properties:
-/// Timestamp (0x06) in Timescale (0x08) units.
+/// Timestamp (0x06) in Timescale (0x08) units, both absolute varints.
 ///
-/// The Timestamp is a zigzag delta against `*prev` (the previous object's raw value
-/// in this subgroup; pass `&mut 0` for the first object), so out-of-order PTS (e.g.
-/// B-frames) stay compact. The Timescale is the absolute units-per-second. Writes the
-/// raw KVP bytes (no outer length prefix); the caller frames the block with its length.
+/// Matches the LOC encoding of the same registry ids so a relay or LOC-aware peer
+/// reads the same bytes. (moq-lite delta-compresses its per-frame timestamps; the
+/// moq-transport object property is the absolute value.) Writes the raw KVP bytes
+/// (no outer length prefix); the caller frames the block with its byte length.
 pub fn encode_object_time<W: bytes::BufMut>(
 	w: &mut W,
 	timestamp: Timestamp,
-	prev: &mut u64,
 	version: Version,
 ) -> Result<(), EncodeError> {
 	// KVP type ids are delta-encoded ascending: 0x06 then 0x08 (delta 0x02).
 	PROP_TIMESTAMP.encode(w, version)?;
-	let delta: i64 = (timestamp.value() as i128 - *prev as i128)
-		.try_into()
-		.map_err(|_| EncodeError::from(crate::coding::BoundsExceeded))?;
-	VarInt::from_zigzag(delta)?.encode(w, version)?;
-	*prev = timestamp.value();
-
+	timestamp.value().encode(w, version)?;
 	(PROP_TIMESCALE - PROP_TIMESTAMP).encode(w, version)?;
 	u64::from(timestamp.scale()).encode(w, version)?;
 	Ok(())
@@ -40,15 +34,8 @@ pub fn encode_object_time<W: bytes::BufMut>(
 /// Decode the Timestamp (0x06) + Timescale (0x08) Object Properties from an object's
 /// extension block, skipping any other properties. Returns `None` when no Timestamp
 /// property is present; a missing Timescale defaults to microseconds (the registry default).
-///
-/// The Timestamp is a zigzag delta against `*prev`, which is advanced to the decoded
-/// raw value. Mirrors [`encode_object_time`].
-pub fn decode_object_time<R: bytes::Buf>(
-	r: &mut R,
-	prev: &mut u64,
-	version: Version,
-) -> Result<Option<Timestamp>, DecodeError> {
-	let mut delta: Option<i64> = None;
+pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Option<Timestamp>, DecodeError> {
+	let mut timestamp: Option<u64> = None;
 	let mut timescale: Option<u64> = None;
 	let mut prev_type: u64 = 0;
 	let mut first = true;
@@ -64,13 +51,12 @@ pub fn decode_object_time<R: bytes::Buf>(
 		prev_type = abs;
 
 		if abs % 2 == 0 {
-			// Even type: a single varint value. 0x06 carries a zigzag delta.
+			// Even type: a single varint value.
+			let value = u64::decode(r, version)?;
 			match abs {
-				PROP_TIMESTAMP => delta = Some(VarInt::decode(r, version)?.to_zigzag()),
-				PROP_TIMESCALE => timescale = Some(u64::decode(r, version)?),
-				_ => {
-					let _ = u64::decode(r, version)?;
-				}
+				PROP_TIMESTAMP => timestamp = Some(value),
+				PROP_TIMESCALE => timescale = Some(value),
+				_ => {}
 			}
 		} else {
 			// Odd type: length-prefixed bytes we don't care about.
@@ -82,14 +68,9 @@ pub fn decode_object_time<R: bytes::Buf>(
 		}
 	}
 
-	let Some(delta) = delta else {
+	let Some(value) = timestamp else {
 		return Ok(None);
 	};
-	let value: u64 = (*prev as i128 + delta as i128)
-		.try_into()
-		.map_err(|_| DecodeError::BoundsExceeded)?;
-	*prev = value;
-
 	let scale = match timescale {
 		Some(s) => Timescale::new(s).map_err(|_| DecodeError::InvalidValue)?,
 		None => Timescale::MICRO,
@@ -331,52 +312,30 @@ mod tests {
 
 	use bytes::Buf;
 
-	/// A sequence of object timestamps round-trips through the zigzag-delta encoding,
-	/// including a backwards step (B-frame ordering) that yields a negative delta.
+	/// Object Property timestamp round-trips through encode/decode at its own scale.
 	#[test]
 	fn test_object_time_roundtrip() {
-		// Each object's extension block is length-framed on the wire and decoded on its
-		// own, so encode/decode one block per object while threading `prev`.
-		let values = [10_000u64, 30_000, 20_000];
-		let mut enc_prev = 0u64;
-		let blocks: Vec<bytes::Bytes> = values
-			.iter()
-			.map(|&v| {
-				let ts = Timestamp::new(v, Timescale::MICRO).unwrap();
-				let mut buf = bytes::BytesMut::new();
-				encode_object_time(&mut buf, ts, &mut enc_prev, Version::Draft18).unwrap();
-				buf.freeze()
-			})
-			.collect();
+		let ts = Timestamp::new(96_000, Timescale::MICRO).unwrap();
+		let mut buf = bytes::BytesMut::new();
+		encode_object_time(&mut buf, ts, Version::Draft18).unwrap();
 
-		let mut dec_prev = 0u64;
-		for (&v, block) in values.iter().zip(&blocks) {
-			let mut bytes = block.clone();
-			let decoded = decode_object_time(&mut bytes, &mut dec_prev, Version::Draft18)
-				.unwrap()
-				.unwrap();
-			assert_eq!(decoded.value(), v);
-			assert_eq!(decoded.scale(), Timescale::MICRO);
-			assert!(!bytes.has_remaining());
-		}
+		let mut bytes = buf.freeze();
+		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
+		assert_eq!(decoded.value(), 96_000);
+		assert_eq!(decoded.scale(), Timescale::MICRO);
+		assert!(!bytes.has_remaining());
 	}
 
 	/// A timescale-less extension block falls back to microseconds (registry default).
 	#[test]
 	fn test_object_time_defaults_to_micros() {
 		let mut buf = bytes::BytesMut::new();
-		// Just a 0x06 Timestamp property (zigzag delta from 0 = 1234), no 0x08.
+		// Just a 0x06 Timestamp property, no 0x08.
 		PROP_TIMESTAMP.encode(&mut buf, Version::Draft18).unwrap();
-		VarInt::from_zigzag(1234)
-			.unwrap()
-			.encode(&mut buf, Version::Draft18)
-			.unwrap();
+		1234u64.encode(&mut buf, Version::Draft18).unwrap();
 
 		let mut bytes = buf.freeze();
-		let mut prev = 0u64;
-		let decoded = decode_object_time(&mut bytes, &mut prev, Version::Draft18)
-			.unwrap()
-			.unwrap();
+		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
 		assert_eq!(decoded.value(), 1234);
 		assert_eq!(decoded.scale(), Timescale::MICRO);
 	}
@@ -385,12 +344,7 @@ mod tests {
 	#[test]
 	fn test_object_time_absent() {
 		let mut empty = bytes::Bytes::new();
-		let mut prev = 0u64;
-		assert!(
-			decode_object_time(&mut empty, &mut prev, Version::Draft18)
-				.unwrap()
-				.is_none()
-		);
+		assert!(decode_object_time(&mut empty, Version::Draft18).unwrap().is_none());
 	}
 
 	// Test table from draft-ietf-moq-transport-14 Section 10.4.2 Table 7

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -277,7 +277,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				group_id: sequence,
 				sub_group_id: 0,
 				publisher_priority: 0,
-				flags: Default::default(),
+				// Carry per-object timestamps as extension headers (Timestamp/Timescale
+				// Object Properties) so moq-transport peers get the real PTS.
+				flags: ietf::GroupFlags {
+					has_extensions: true,
+					..Default::default()
+				},
 			};
 
 			let priority = track.subscription().priority;
@@ -326,9 +331,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			// object id delta is always 0.
 			stream.encode(&0u64).await?;
 
-			// not using extensions.
+			// Per-object extension headers carry the frame's presentation timestamp.
 			if msg.flags.has_extensions {
-				stream.encode(&0u64).await?;
+				let mut ext = bytes::BytesMut::new();
+				ietf::encode_object_time(&mut ext, frame.timestamp, version)?;
+				stream.encode(&(ext.len() as u64)).await?;
+				let mut ext = ext.freeze();
+				stream.write_all(&mut ext).await?;
 			}
 
 			// Write the size of the frame.

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -316,9 +316,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		stream.encode(&msg).await?;
 		track_stats.group();
 
-		// Previous object's raw timestamp value, for the zigzag-delta extension header.
-		let mut prev_ts = 0u64;
-
 		loop {
 			let frame = tokio::select! {
 				biased;
@@ -337,7 +334,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			// Per-object extension headers carry the frame's presentation timestamp.
 			if msg.flags.has_extensions {
 				let mut ext = bytes::BytesMut::new();
-				ietf::encode_object_time(&mut ext, frame.timestamp, &mut prev_ts, version)?;
+				ietf::encode_object_time(&mut ext, frame.timestamp, version)?;
 				stream.encode(&(ext.len() as u64)).await?;
 				let mut ext = ext.freeze();
 				stream.write_all(&mut ext).await?;

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -316,6 +316,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		stream.encode(&msg).await?;
 		track_stats.group();
 
+		// Previous object's raw timestamp value, for the zigzag-delta extension header.
+		let mut prev_ts = 0u64;
+
 		loop {
 			let frame = tokio::select! {
 				biased;
@@ -334,7 +337,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			// Per-object extension headers carry the frame's presentation timestamp.
 			if msg.flags.has_extensions {
 				let mut ext = bytes::BytesMut::new();
-				ietf::encode_object_time(&mut ext, frame.timestamp, version)?;
+				ietf::encode_object_time(&mut ext, frame.timestamp, &mut prev_ts, version)?;
 				stream.encode(&(ext.len() as u64)).await?;
 				let mut ext = ext.freeze();
 				stream.write_all(&mut ext).await?;

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, hash_map::Entry};
 use std::sync::Arc;
 
 use crate::{
-	BroadcastDynamic, BroadcastInfo, Error, Frame, FrameProducer, Group, GroupProducer, OriginProducer, OriginPublish,
-	Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer, TrackRequest,
+	BroadcastDynamic, BroadcastInfo, Error, FrameProducer, Group, GroupProducer, OriginProducer, OriginPublish, Path,
+	PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer, TrackRequest,
 	coding::{Reader, Stream},
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
 	model::BroadcastProducer,
@@ -814,10 +814,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			if size == 0 {
 				let status: u64 = stream.decode().await?;
 				if status == 0 {
-					let mut frame = producer.create_frame(Frame {
-						size: 0,
-						timestamp: None,
-					})?;
+					// moq-transport doesn't yet decode per-object timestamps, so frames
+					// fall back to wall-clock at receive (the track's default timescale).
+					let mut frame = producer.create_frame_now(0)?;
 					track_stats.frame();
 					frame.finish()?;
 				} else if status == 3 && !group.flags.has_end {
@@ -826,9 +825,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					return Err(Error::Unsupported);
 				}
 			} else {
-				// `create_frame` is the allocation chokepoint and rejects an oversized
-				// `size` before allocating, so no pre-check is needed.
-				let mut frame = producer.create_frame(Frame { size, timestamp: None })?;
+				// `create_frame_now` is the allocation chokepoint and rejects an oversized
+				// `size` before allocating, so no pre-check is needed. moq-transport
+				// doesn't yet decode per-object timestamps, so this is wall-clock.
+				let mut frame = producer.create_frame_now(size)?;
 				track_stats.frame();
 
 				if let Err(err) = self.run_frame(stream, frame.clone(), &track_stats).await {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -799,6 +799,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		mut producer: GroupProducer,
 		track_stats: Arc<SubscriberTrack>,
 	) -> Result<(), Error> {
+		// Previous object's raw timestamp value, for the zigzag-delta extension header.
+		let mut prev_ts = 0u64;
+
 		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
 			if id_delta != 0 {
 				tracing::warn!(id_delta = %id_delta, "object ID delta is not supported, dropping stream");
@@ -810,7 +813,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let timestamp = if group.flags.has_extensions {
 				let size: usize = stream.decode().await?;
 				let mut ext = stream.read_exact(size).await?;
-				ietf::decode_object_time(&mut ext, self.version)?
+				ietf::decode_object_time(&mut ext, &mut prev_ts, self.version)?
 			} else {
 				None
 			};

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -799,9 +799,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		mut producer: GroupProducer,
 		track_stats: Arc<SubscriberTrack>,
 	) -> Result<(), Error> {
-		// Previous object's raw timestamp value, for the zigzag-delta extension header.
-		let mut prev_ts = 0u64;
-
 		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
 			if id_delta != 0 {
 				tracing::warn!(id_delta = %id_delta, "object ID delta is not supported, dropping stream");
@@ -813,7 +810,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let timestamp = if group.flags.has_extensions {
 				let size: usize = stream.decode().await?;
 				let mut ext = stream.read_exact(size).await?;
-				ietf::decode_object_time(&mut ext, &mut prev_ts, self.version)?
+				ietf::decode_object_time(&mut ext, self.version)?
 			} else {
 				None
 			};

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, hash_map::Entry};
 use std::sync::Arc;
 
 use crate::{
-	BroadcastDynamic, BroadcastInfo, Error, FrameProducer, Group, GroupProducer, OriginProducer, OriginPublish, Path,
-	PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer, TrackRequest,
+	BroadcastDynamic, BroadcastInfo, Error, Frame, FrameProducer, Group, GroupProducer, OriginProducer, OriginPublish,
+	Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer, TrackRequest,
 	coding::{Reader, Stream},
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
 	model::BroadcastProducer,
@@ -805,18 +805,24 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				return Err(Error::Unsupported);
 			}
 
-			if group.flags.has_extensions {
+			// Per-object extension headers may carry the frame's presentation timestamp
+			// (Timestamp/Timescale Object Properties). Absent it, we wall-clock-stamp.
+			let timestamp = if group.flags.has_extensions {
 				let size: usize = stream.decode().await?;
-				stream.skip(size).await?;
-			}
+				let mut ext = stream.read_exact(size).await?;
+				ietf::decode_object_time(&mut ext, self.version)?
+			} else {
+				None
+			};
 
 			let size: u64 = stream.decode().await?;
 			if size == 0 {
 				let status: u64 = stream.decode().await?;
 				if status == 0 {
-					// moq-transport doesn't yet decode per-object timestamps, so frames
-					// fall back to wall-clock at receive (the track's default timescale).
-					let mut frame = producer.create_frame_now(0)?;
+					let mut frame = match timestamp {
+						Some(ts) => producer.create_frame(Frame { size: 0, timestamp: ts })?,
+						None => producer.create_frame_now(0)?,
+					};
 					track_stats.frame();
 					frame.finish()?;
 				} else if status == 3 && !group.flags.has_end {
@@ -825,10 +831,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					return Err(Error::Unsupported);
 				}
 			} else {
-				// `create_frame_now` is the allocation chokepoint and rejects an oversized
-				// `size` before allocating, so no pre-check is needed. moq-transport
-				// doesn't yet decode per-object timestamps, so this is wall-clock.
-				let mut frame = producer.create_frame_now(size)?;
+				// `create_frame*` is the allocation chokepoint and rejects an oversized
+				// `size` before allocating, so no pre-check is needed.
+				let mut frame = match timestamp {
+					Some(ts) => producer.create_frame(Frame { size, timestamp: ts })?,
+					None => producer.create_frame_now(size)?,
+				};
 				track_stats.frame();
 
 				if let Err(err) = self.run_frame(stream, frame.clone(), &track_stats).await {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -586,7 +586,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// Accept right away: IETF group data can arrive before SubscribeOk, so we
 		// need the producer in place to route it. This also unblocks the
 		// downstream subscriber's `consume_track`.
-		let mut track = request.accept(None);
+		//
+		// Set the track timescale to microseconds: IETF object timestamps default to
+		// microseconds, and `create_frame` normalizes each frame into the track scale.
+		// Accepting at milliseconds (the default) would truncate microsecond precision.
+		let info = crate::TrackInfo::default().with_timescale(crate::Timescale::MICRO);
+		let mut track = request.accept(info);
 
 		let request_id = match self.control.next_request_id().await {
 			Ok(id) => id,

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -459,18 +459,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		} else {
 			Compression::None
 		};
-		let timescale = if self.version.has_timestamps() {
-			info.timescale
-		} else {
-			None
-		};
-
+		// TRACK_INFO only flows on Lite05+ (the encode errors otherwise), where every
+		// track is timed, so the model's timescale goes on the wire verbatim.
 		stream
 			.writer
 			.encode(&lite::TrackInfo {
 				priority: info.priority,
 				ordered: info.ordered,
-				timescale,
+				timescale: info.timescale,
 				compression,
 			})
 			.await?;
@@ -565,12 +561,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			Compression::None
 		};
 
-		// Per-frame timestamps require both a publisher-advertised timescale and
-		// a wire format that carries it. Older drafts ignore `track.timescale`
-		// (the field never lands on the wire) and stream untimed frames; Lite05+
-		// honors `Some(_)` and skips the timestamp byte for `None`.
+		// Per-frame timestamps require a wire format that carries them. Lite05+ prefixes
+		// every frame with a zigzag-delta timestamp at the track's timescale; older
+		// drafts have no wire field, so `None` here means "don't emit the prefix" (the
+		// frames still carry timestamps in the model, just not on this wire).
 		let timescale = if version.has_timestamps() {
-			track.info().timescale
+			Some(track.info().timescale)
 		} else {
 			None
 		};
@@ -685,10 +681,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			)
 			.await?;
 
-		// FETCH is gated to lite-05+, which always carries timestamps when the track
-		// advertised a timescale; `None` means an untimed track (frames omit them).
+		// FETCH is gated to lite-05+, which always prefixes frames with a timestamp at
+		// the track's timescale.
 		let timescale = if version.has_timestamps() {
-			group.timescale()
+			Some(group.timescale())
 		} else {
 			None
 		};

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -731,9 +731,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 /// (catalogs, control channels, IETF transport).
 ///
 /// `prev_ts` carries the running baseline, so the first frame deltas against 0. The
-/// model layer (`GroupProducer::append_frame`) already validated the timestamp
-/// against the track timescale, so the `expect` below is infallible. Mirrors the
-/// decode in the subscriber's `run_group`.
+/// The model layer (`GroupProducer::create_frame`) already converted the timestamp
+/// into the track timescale, so its raw value goes straight onto the wire. Mirrors
+/// the decode in the subscriber's `run_group`.
 async fn encode_frame_timing<W: web_transport_trait::SendStream>(
 	writer: &mut Writer<W, Version>,
 	frame: &FrameConsumer,
@@ -744,10 +744,7 @@ async fn encode_frame_timing<W: web_transport_trait::SendStream>(
 		return Ok(());
 	}
 
-	let ts = frame
-		.timestamp
-		.expect("model layer validated timestamp presence")
-		.value();
+	let ts = frame.timestamp.value();
 	encode_zigzag_delta(writer, ts, prev_ts).await?;
 
 	Ok(())

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -731,7 +731,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 /// (catalogs, control channels, IETF transport).
 ///
 /// `prev_ts` carries the running baseline, so the first frame deltas against 0. The
-/// The model layer (`GroupProducer::create_frame`) already converted the timestamp
+/// model layer (`GroupProducer::create_frame`) already converted the timestamp
 /// into the track timescale, so its raw value goes straight onto the wire. Mirrors
 /// the decode in the subscriber's `run_group`.
 async fn encode_frame_timing<W: web_transport_trait::SendStream>(

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -832,7 +832,9 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		let (mut track, compression, timescale) = if self.subscriber.version.has_timestamps() {
 			match self.track_info().await {
 				Ok((info, compression)) => {
-					let timescale = info.timescale;
+					// Lite05 carries per-frame timestamps on the wire at this scale; `Some`
+					// tells `run_group` to decode them (vs. wall-clock-stamping locally).
+					let timescale = Some(info.timescale);
 					(Some(Track::Active(request.accept(info))), compression, timescale)
 				}
 				Err(err) => {
@@ -1241,7 +1243,9 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// TrackInfo only takes effect if the track isn't accepted yet (a fetch with no
 		// live subscription); otherwise the group inherits the accepted timescale.
 		let group_info = TrackInfo {
-			timescale,
+			// FETCH is lite-05+, so `timescale` is `Some`; fall back to the default scale
+			// defensively rather than panicking.
+			timescale: timescale.unwrap_or_default(),
 			..Default::default()
 		};
 		let mut producer = match request.accept(group_info) {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -647,7 +647,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				Compression::None => {
 					// `create_frame` is the allocation chokepoint and rejects an
 					// oversized `size` before allocating, so no pre-check is needed.
-					let mut frame = group.create_frame(Frame { size, timestamp })?;
+					// No wire timestamp (pre-lite-05) means wall-clock at receive.
+					let mut frame = match timestamp {
+						Some(ts) => group.create_frame(Frame { size, timestamp: ts })?,
+						None => group.create_frame_now(size)?,
+					};
 					track_stats.frame();
 
 					if let Err(err) = self.run_frame(stream, &mut frame, &track_stats).await {
@@ -671,10 +675,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					track_stats.bytes(size);
 
 					let payload = compression.decompress(&packed)?;
-					let mut frame = group.create_frame(Frame {
-						size: payload.len() as u64,
-						timestamp,
-					})?;
+					let size = payload.len() as u64;
+					let mut frame = match timestamp {
+						Some(ts) => group.create_frame(Frame { size, timestamp: ts })?,
+						None => group.create_frame_now(size)?,
+					};
 					frame.write(bytes::Bytes::from(payload))?;
 					frame.finish()?;
 				}

--- a/rs/moq-net/src/lite/track.rs
+++ b/rs/moq-net/src/lite/track.rs
@@ -51,9 +51,9 @@ pub struct TrackInfo {
 	pub priority: u8,
 	/// The publisher's group ordering preference (newest-first when `false`).
 	pub ordered: bool,
-	/// Per-frame timestamp scale, or `None` if frames carry no timestamps. On the
-	/// wire `None` is `0` and `Some(n)` is `n`.
-	pub timescale: Option<Timescale>,
+	/// Per-frame timestamp scale (units per second). Mandatory on Lite05+: every track
+	/// is timed, so this is always a real scale on the wire (never zero).
+	pub timescale: Timescale,
 	/// Codec applied to every frame payload on this track.
 	pub compression: Compression,
 }
@@ -66,7 +66,7 @@ impl Message for TrackInfo {
 
 		let priority = u8::decode(r, version)?;
 		let ordered = u8::decode(r, version)? != 0;
-		let timescale = Timescale::new(u64::decode(r, version)?).ok();
+		let timescale = Timescale::new(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)?;
 		let compression = Compression::from_code(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)?;
 
 		Ok(Self {
@@ -84,7 +84,7 @@ impl Message for TrackInfo {
 
 		self.priority.encode(w, version)?;
 		(self.ordered as u8).encode(w, version)?;
-		self.timescale.map(u64::from).unwrap_or(0).encode(w, version)?;
+		u64::from(self.timescale).encode(w, version)?;
 		self.compression.to_code().encode(w, version)?;
 		Ok(())
 	}
@@ -98,7 +98,7 @@ mod test {
 		TrackInfo {
 			priority: 7,
 			ordered: false,
-			timescale: Some(Timescale::MICRO),
+			timescale: Timescale::MICRO,
 			compression: Compression::Deflate,
 		}
 	}
@@ -115,15 +115,15 @@ mod test {
 		let got = info_roundtrip(Version::Lite05Wip, &info_sample());
 		assert_eq!(got.priority, 7);
 		assert!(!got.ordered);
-		assert_eq!(got.timescale, Some(Timescale::MICRO));
+		assert_eq!(got.timescale, Timescale::MICRO);
 		assert_eq!(got.compression, Compression::Deflate);
 	}
 
 	#[test]
-	fn track_info_timescale_none_roundtrips() {
+	fn track_info_default_timescale_roundtrips() {
 		let mut info = info_sample();
-		info.timescale = None;
-		assert_eq!(info_roundtrip(Version::Lite05Wip, &info).timescale, None);
+		info.timescale = Timescale::default();
+		assert_eq!(info_roundtrip(Version::Lite05Wip, &info).timescale, Timescale::MILLI);
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -21,66 +21,34 @@ use crate::{Error, Result, Timestamp};
 /// frame; 32 MiB covers that while keeping the per-frame preallocation bounded.
 pub(crate) const MAX_FRAME_SIZE: u64 = 32 * 1024 * 1024;
 
-/// A chunk of data with an upfront size and optional presentation timestamp.
+/// A chunk of data with an upfront size and a presentation timestamp.
 ///
 /// Note that this is just the header.
 /// You use [FrameProducer] and [FrameConsumer] to deal with the frame payload, potentially chunked.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Frame {
 	/// Total payload size in bytes. Declared up front so consumers can preallocate.
 	pub size: u64,
-	/// Presentation timestamp in the parent track's timescale.
+	/// Presentation timestamp.
 	///
-	/// `None` on input asks [`crate::GroupProducer::create_frame`] to stamp the frame
-	/// with wall-clock now; a `Some` at any scale is converted to the track's timescale.
-	/// After `create_frame` (and on every frame a consumer receives) this is always
-	/// `Some` at the track's [`crate::TrackInfo::timescale`].
-	pub timestamp: Option<Timestamp>,
+	/// [`crate::GroupProducer::create_frame`] converts it into the parent track's
+	/// timescale, so the scale you build it with doesn't have to match the track.
+	/// Use [`crate::GroupProducer::create_frame_now`] /
+	/// [`crate::GroupProducer::write_frame_now`] to stamp wall-clock time instead of
+	/// supplying one explicitly.
+	pub timestamp: Timestamp,
 }
 
 impl Frame {
 	/// Create a producer for the frame.
 	///
 	/// Crate-private: frames are only constructed via
-	/// [`crate::GroupProducer::create_frame`], which validates the timestamp
-	/// against the parent track's timescale. Returns [`Error::FrameTooLarge`] if the
-	/// declared [`Frame::size`] exceeds [`MAX_FRAME_SIZE`].
+	/// [`crate::GroupProducer::create_frame`], which converts the timestamp into the
+	/// parent track's timescale. Returns [`Error::FrameTooLarge`] if the declared
+	/// [`Frame::size`] exceeds [`MAX_FRAME_SIZE`].
 	pub(crate) fn produce(self) -> Result<FrameProducer> {
 		FrameProducer::new(self)
-	}
-}
-
-impl From<usize> for Frame {
-	fn from(size: usize) -> Self {
-		Self {
-			size: size as u64,
-			timestamp: None,
-		}
-	}
-}
-
-impl From<u64> for Frame {
-	fn from(size: u64) -> Self {
-		Self { size, timestamp: None }
-	}
-}
-
-impl From<u32> for Frame {
-	fn from(size: u32) -> Self {
-		Self {
-			size: size as u64,
-			timestamp: None,
-		}
-	}
-}
-
-impl From<u16> for Frame {
-	fn from(size: u16) -> Self {
-		Self {
-			size: size as u64,
-			timestamp: None,
-		}
 	}
 }
 
@@ -475,7 +443,7 @@ mod test {
 	fn single_chunk_roundtrip() {
 		let mut producer = Frame {
 			size: 5,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -491,7 +459,7 @@ mod test {
 	fn multi_chunk_read_all() {
 		let mut producer = Frame {
 			size: 10,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -508,7 +476,7 @@ mod test {
 	fn read_chunk_sequential() {
 		let mut producer = Frame {
 			size: 10,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -532,7 +500,7 @@ mod test {
 	fn read_all_chunks() {
 		let mut producer = Frame {
 			size: 10,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -550,7 +518,7 @@ mod test {
 	fn finish_checks_remaining() {
 		let mut producer = Frame {
 			size: 5,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -563,7 +531,7 @@ mod test {
 	fn write_too_many_bytes() {
 		let mut producer = Frame {
 			size: 3,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -577,7 +545,7 @@ mod test {
 		// buffer is allocated, so a single varint can't request a huge allocation.
 		let result = Frame {
 			size: MAX_FRAME_SIZE + 1,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce();
 		assert!(matches!(result, Err(Error::FrameTooLarge)));
@@ -587,7 +555,7 @@ mod test {
 	fn abort_propagates() {
 		let mut producer = Frame {
 			size: 5,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -602,7 +570,7 @@ mod test {
 	fn empty_frame() {
 		let mut producer = Frame {
 			size: 0,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -617,7 +585,7 @@ mod test {
 	async fn pending_then_ready() {
 		let mut producer = Frame {
 			size: 5,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -638,7 +606,7 @@ mod test {
 		// Exercise the BufMut path that the receive loop uses via `read_buf`.
 		let mut producer = Frame {
 			size: 12,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -659,7 +627,7 @@ mod test {
 	fn buf_mut_advance_past_capacity_panics() {
 		let mut producer = Frame {
 			size: 4,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -671,7 +639,7 @@ mod test {
 	fn read_chunk_streams_partial_writes() {
 		let mut producer = Frame {
 			size: 6,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();
@@ -696,7 +664,7 @@ mod test {
 	fn cloned_consumer_independent_cursor() {
 		let mut producer = Frame {
 			size: 10,
-			timestamp: None,
+			timestamp: Timestamp::ZERO,
 		}
 		.produce()
 		.unwrap();

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -32,11 +32,10 @@ pub struct Frame {
 	pub size: u64,
 	/// Presentation timestamp in the parent track's timescale.
 	///
-	/// `None` means no timestamp is attached to this frame, which is the case for
-	/// pre-Lite05 moq-lite streams and IETF moq-transport streams that haven't
-	/// negotiated a timescale. On Lite05+, producers must set `Some(ts)` whose
-	/// scale matches the track's [`crate::TrackInfo::timescale`]; the publisher
-	/// surfaces a `ProtocolViolation` otherwise.
+	/// `None` on input asks [`crate::GroupProducer::create_frame`] to stamp the frame
+	/// with wall-clock now; a `Some` at any scale is converted to the track's timescale.
+	/// After `create_frame` (and on every frame a consumer receives) this is always
+	/// `Some` at the track's [`crate::TrackInfo::timescale`].
 	pub timestamp: Option<Timestamp>,
 }
 

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -186,48 +186,66 @@ impl GroupProducer {
 	///
 	/// If you want to write multiple chunks, use [Self::create_frame] to get a frame producer.
 	/// But an upfront size is required.
-	pub fn write_frame<B: Into<Bytes>>(&mut self, frame: B) -> Result<()> {
-		let data = frame.into();
-		let mut frame = self.create_frame(data.len())?;
+	///
+	/// `timestamp` is converted into the parent track's timescale. Use
+	/// [Self::write_frame_now] to stamp wall-clock time instead of supplying one.
+	pub fn write_frame<B: Into<Bytes>>(&mut self, timestamp: Timestamp, data: B) -> Result<()> {
+		let data = data.into();
+		let mut frame = self.create_frame(Frame {
+			size: data.len() as u64,
+			timestamp,
+		})?;
 		frame.write(data)?;
 		frame.finish()?;
 		Ok(())
 	}
 
-	/// Create a frame with an upfront size, normalizing its timestamp into the parent
-	/// track's timescale.
-	///
-	/// A frame whose `timestamp` is at a different scale is converted; a frame with no
-	/// timestamp is stamped with wall-clock now ([`Timestamp::now`]), which is how
-	/// protocols whose wire can't carry a timestamp end up with millisecond wall-clock
-	/// timing. Returns [`Error::FrameTooLarge`] if the declared size exceeds the
-	/// per-frame limit (refused before the buffer is allocated) or
-	/// [`Error::TimestampMismatch`] if the timestamp can't be converted (overflow).
-	pub fn create_frame(&mut self, info: impl Into<Frame>) -> Result<FrameProducer> {
-		let mut info = info.into();
-		let normalized = match info.timestamp {
-			Some(ts) => ts.convert(self.timescale),
-			None => Timestamp::now().convert(self.timescale),
-		};
-		info.timestamp = Some(normalized.map_err(|_| Error::TimestampMismatch)?);
+	/// Like [Self::write_frame] but stamps the frame with wall-clock now
+	/// ([`Timestamp::now`]). For data with no real presentation time of its own
+	/// (catalogs, JSON state) or sources whose protocol can't carry one.
+	pub fn write_frame_now<B: Into<Bytes>>(&mut self, data: B) -> Result<()> {
+		self.write_frame(Timestamp::now(), data)
+	}
 
-		let frame = info.produce()?;
+	/// Create a frame with an upfront size and presentation timestamp.
+	///
+	/// The `timestamp` is converted into the parent track's timescale, so the scale you
+	/// build it with doesn't have to match the track. Returns [`Error::FrameTooLarge`]
+	/// if the declared size exceeds the per-frame limit (refused before the buffer is
+	/// allocated) or [`Error::TimestampMismatch`] if the timestamp can't be converted
+	/// (overflow).
+	pub fn create_frame(&mut self, frame: Frame) -> Result<FrameProducer> {
+		let mut frame = frame;
+		frame.timestamp = frame
+			.timestamp
+			.convert(self.timescale)
+			.map_err(|_| Error::TimestampMismatch)?;
+
+		let frame = frame.produce()?;
 		self.append_frame(frame.clone())?;
 		Ok(frame)
+	}
+
+	/// Like [Self::create_frame] but stamps the frame with wall-clock now
+	/// ([`Timestamp::now`]).
+	pub fn create_frame_now(&mut self, size: u64) -> Result<FrameProducer> {
+		self.create_frame(Frame {
+			size,
+			timestamp: Timestamp::now(),
+		})
 	}
 
 	/// Append a frame producer to the group.
 	///
 	/// Lower-level than [`Self::create_frame`]: the frame's `timestamp` must already be
-	/// `Some` at the parent track's timescale (use [`Self::create_frame`] to normalize).
+	/// at the parent track's timescale (use [`Self::create_frame`] to convert).
 	/// Returns [`Error::TimestampMismatch`] otherwise.
 	pub fn append_frame(&mut self, frame: FrameProducer) -> Result<()> {
 		// Catch the contract violation here, at the model layer, so peers that
 		// downstream-encode (e.g. the lite publisher's `serve_frame`) can rely
 		// on the invariant instead of re-validating per byte.
-		match frame.timestamp {
-			Some(ts) if ts.scale() == self.timescale => {}
-			_ => return Err(Error::TimestampMismatch),
+		if frame.timestamp.scale() != self.timescale {
+			return Err(Error::TimestampMismatch);
 		}
 
 		let mut state = modify(&self.state)?;
@@ -464,8 +482,8 @@ mod test {
 	#[test]
 	fn basic_frame_reading() {
 		let mut producer = Group { sequence: 0 }.produce();
-		producer.write_frame(Bytes::from_static(b"frame0")).unwrap();
-		producer.write_frame(Bytes::from_static(b"frame1")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"frame0")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"frame1")).unwrap();
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
@@ -480,7 +498,7 @@ mod test {
 	#[test]
 	fn read_frame_all_at_once() {
 		let mut producer = Group { sequence: 0 }.produce();
-		producer.write_frame(Bytes::from_static(b"hello")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"hello")).unwrap();
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
@@ -491,7 +509,7 @@ mod test {
 	#[test]
 	fn read_frame_chunks() {
 		let mut producer = Group { sequence: 0 }.produce();
-		let mut frame = producer.create_frame(10u64).unwrap();
+		let mut frame = producer.create_frame_now(10).unwrap();
 		frame.write(Bytes::from_static(b"hello")).unwrap();
 		frame.write(Bytes::from_static(b"world")).unwrap();
 		frame.finish().unwrap();
@@ -508,8 +526,8 @@ mod test {
 	#[test]
 	fn get_frame_by_index() {
 		let mut producer = Group { sequence: 0 }.produce();
-		producer.write_frame(Bytes::from_static(b"a")).unwrap();
-		producer.write_frame(Bytes::from_static(b"bb")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"a")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"bb")).unwrap();
 		producer.finish().unwrap();
 
 		let consumer = producer.consume();
@@ -544,7 +562,7 @@ mod test {
 	#[test]
 	fn abort_clears_cached_frames() {
 		let mut producer = Group { sequence: 0 }.produce();
-		producer.write_frame(Bytes::from_static(b"data")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"data")).unwrap();
 
 		// A stale consumer that never reads must not pin the cached frames.
 		let _consumer = producer.consume();
@@ -561,7 +579,7 @@ mod test {
 	fn drop_unfinished_clears_cached_frames() {
 		let producer = Group { sequence: 0 }.produce();
 		let mut writer = producer.clone();
-		writer.write_frame(Bytes::from_static(b"data")).unwrap();
+		writer.write_frame_now(Bytes::from_static(b"data")).unwrap();
 
 		// A stale consumer keeps the channel (and thus the cache) alive.
 		let mut consumer = producer.consume();
@@ -578,7 +596,7 @@ mod test {
 	#[test]
 	fn drop_finished_keeps_cached_frames() {
 		let mut producer = Group { sequence: 0 }.produce();
-		producer.write_frame(Bytes::from_static(b"data")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"data")).unwrap();
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
@@ -597,7 +615,7 @@ mod test {
 		// Consumer blocks because no frames yet.
 		assert!(consumer.next_frame().now_or_never().is_none());
 
-		producer.write_frame(Bytes::from_static(b"data")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"data")).unwrap();
 		producer.finish().unwrap();
 
 		let frame = consumer.next_frame().now_or_never().unwrap().unwrap().unwrap();
@@ -610,8 +628,8 @@ mod test {
 
 		// Write frames that total more than MAX_GROUP_CACHE.
 		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
-		producer.write_frame(big.clone()).unwrap();
-		producer.write_frame(big).unwrap();
+		producer.write_frame_now(big.clone()).unwrap();
+		producer.write_frame_now(big).unwrap();
 
 		// The first frame should have been evicted.
 		let consumer = producer.consume();
@@ -626,8 +644,8 @@ mod test {
 	#[test]
 	fn no_eviction_under_limit() {
 		let mut producer = Group { sequence: 0 }.produce();
-		producer.write_frame(Bytes::from_static(b"small")).unwrap();
-		producer.write_frame(Bytes::from_static(b"frames")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"small")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"frames")).unwrap();
 		producer.finish().unwrap();
 
 		let consumer = producer.consume();
@@ -643,7 +661,7 @@ mod test {
 
 		// Write more than MAX_GROUP_FRAMES frames.
 		for _ in 0..=MAX_GROUP_FRAMES {
-			producer.write_frame(Bytes::from_static(b"x")).unwrap();
+			producer.write_frame_now(Bytes::from_static(b"x")).unwrap();
 		}
 
 		// The first frame should have been evicted.
@@ -666,8 +684,8 @@ mod test {
 		let mut producer = Group { sequence: 0 }.produce();
 
 		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
-		producer.write_frame(big.clone()).unwrap();
-		producer.write_frame(big).unwrap();
+		producer.write_frame_now(big.clone()).unwrap();
+		producer.write_frame_now(big).unwrap();
 
 		let mut consumer = producer.consume();
 		// First frame was evicted, next_frame should return CacheFull.
@@ -678,7 +696,7 @@ mod test {
 	#[test]
 	fn clone_consumer_independent() {
 		let mut producer = Group { sequence: 0 }.produce();
-		producer.write_frame(Bytes::from_static(b"a")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"a")).unwrap();
 
 		let mut c1 = producer.consume();
 		// Read one frame from c1
@@ -687,7 +705,7 @@ mod test {
 		// Clone c1 — inherits index (past first frame)
 		let mut c2 = c1.clone();
 
-		producer.write_frame(Bytes::from_static(b"b")).unwrap();
+		producer.write_frame_now(Bytes::from_static(b"b")).unwrap();
 		producer.finish().unwrap();
 
 		// c2 should get the second frame (inherited index)
@@ -699,7 +717,7 @@ mod test {
 	}
 
 	/// A frame whose timestamp is at a different scale is converted to the group's
-	/// scale by `create_frame`, not rejected.
+	/// scale by `create_frame`.
 	#[test]
 	fn create_frame_converts_mismatched_scale() {
 		use crate::{Timescale, Timestamp};
@@ -707,28 +725,22 @@ mod test {
 		let mut producer = GroupProducer::new(Group { sequence: 0 }, Timescale::MICRO);
 		let frame = Frame {
 			size: 3,
-			timestamp: Some(Timestamp::from_millis(1).unwrap()), // 1ms -> 1000µs
+			timestamp: Timestamp::from_millis(1).unwrap(), // 1ms -> 1000µs
 		};
 		let writer = producer.create_frame(frame).unwrap();
-		let ts = writer.timestamp.unwrap();
-		assert_eq!(ts.scale(), Timescale::MICRO);
-		assert_eq!(ts.value(), 1000);
+		assert_eq!(writer.timestamp.scale(), Timescale::MICRO);
+		assert_eq!(writer.timestamp.value(), 1000);
 	}
 
-	/// A frame with no timestamp is stamped with wall-clock now, at the group's scale.
+	/// `create_frame_now` stamps wall-clock now, at the group's scale.
 	#[tokio::test]
-	async fn create_frame_stamps_wall_clock_when_missing() {
+	async fn create_frame_now_stamps_wall_clock() {
 		use crate::Timescale;
 
 		let mut producer = GroupProducer::new(Group { sequence: 0 }, Timescale::MICRO);
-		let frame = Frame {
-			size: 3,
-			timestamp: None,
-		};
-		let writer = producer.create_frame(frame).unwrap();
-		let ts = writer.timestamp.expect("stamped");
-		assert_eq!(ts.scale(), Timescale::MICRO);
-		assert!(!ts.is_zero(), "wall clock should be non-zero");
+		let writer = producer.create_frame_now(3).unwrap();
+		assert_eq!(writer.timestamp.scale(), Timescale::MICRO);
+		assert!(!writer.timestamp.is_zero(), "wall clock should be non-zero");
 	}
 
 	/// A matching scale passes through unchanged; bytes can be written normally.
@@ -739,10 +751,10 @@ mod test {
 		let mut producer = GroupProducer::new(Group { sequence: 0 }, Timescale::MICRO);
 		let frame = Frame {
 			size: 1,
-			timestamp: Some(Timestamp::from_micros(7).unwrap()),
+			timestamp: Timestamp::from_micros(7).unwrap(),
 		};
 		let mut writer = producer.create_frame(frame).unwrap();
-		assert_eq!(writer.timestamp.unwrap().value(), 7);
+		assert_eq!(writer.timestamp.value(), 7);
 		writer.write(Bytes::from_static(b"x")).unwrap();
 		writer.finish().unwrap();
 	}
@@ -752,7 +764,7 @@ mod test {
 	#[test]
 	fn create_frame_rejects_oversized() {
 		let mut producer = Group { sequence: 0 }.produce();
-		let result = producer.create_frame(crate::MAX_FRAME_SIZE + 1);
+		let result = producer.create_frame_now(crate::MAX_FRAME_SIZE + 1);
 		assert!(matches!(result, Err(Error::FrameTooLarge)));
 	}
 }

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -12,7 +12,7 @@ use std::task::{Poll, ready};
 
 use bytes::Bytes;
 
-use crate::{Error, Result, Timescale};
+use crate::{Error, Result, Timescale, Timestamp};
 
 use super::{Frame, FrameConsumer, FrameProducer};
 
@@ -43,7 +43,7 @@ impl Group {
 	/// tests that don't exercise timestamps.
 	#[cfg(test)]
 	pub(crate) fn produce(self) -> GroupProducer {
-		GroupProducer::new(self, None)
+		GroupProducer::new(self, Timescale::default())
 	}
 }
 
@@ -149,12 +149,10 @@ pub struct GroupProducer {
 	// The group header containing the sequence number.
 	info: Group,
 
-	// Parent track's negotiated timescale, used by [`Self::create_frame`] to
-	// validate per-frame timestamps before they enter the stream. `None` means
-	// frames on this group must have `Frame::timestamp = None`; `Some(scale)`
-	// requires `Frame::timestamp = Some(ts)` with `ts.scale() == scale`.
-	// Populated by [`crate::TrackProducer::create_group`] / `append_group`.
-	timescale: Option<Timescale>,
+	// Parent track's timescale, used by [`Self::create_frame`] to normalize every
+	// frame's timestamp into this scale before it enters the stream. Populated by
+	// [`crate::TrackProducer::create_group`] / `append_group`.
+	timescale: Timescale,
 }
 
 impl std::ops::Deref for GroupProducer {
@@ -168,11 +166,10 @@ impl std::ops::Deref for GroupProducer {
 impl GroupProducer {
 	/// Create a group producer bound to its parent track's timescale.
 	///
-	/// Crate-private: groups are only constructed via [`crate::TrackProducer`],
-	/// which supplies the negotiated timescale. `None` means the parent track is
-	/// untimed and added frames must have `timestamp = None`; `Some(scale)`
-	/// requires every frame's `timestamp` to be `Some(ts)` with `ts.scale() == scale`.
-	pub(crate) fn new(info: Group, timescale: Option<Timescale>) -> Self {
+	/// Crate-private: groups are only constructed via [`crate::TrackProducer`], which
+	/// supplies the track's timescale. Every frame added to this group is normalized to
+	/// that scale by [`Self::create_frame`].
+	pub(crate) fn new(info: Group, timescale: Timescale) -> Self {
 		Self {
 			info,
 			state: kio::Producer::default(),
@@ -180,8 +177,8 @@ impl GroupProducer {
 		}
 	}
 
-	/// The parent track's negotiated timescale, or `None` for untimed tracks.
-	pub fn timescale(&self) -> Option<Timescale> {
+	/// The parent track's timescale.
+	pub fn timescale(&self) -> Timescale {
 		self.timescale
 	}
 
@@ -197,28 +194,39 @@ impl GroupProducer {
 		Ok(())
 	}
 
-	/// Create a frame with an upfront size.
+	/// Create a frame with an upfront size, normalizing its timestamp into the parent
+	/// track's timescale.
 	///
-	/// Returns [`Error::FrameTooLarge`] if the declared size exceeds the per-frame
-	/// limit, refused before the buffer is allocated.
+	/// A frame whose `timestamp` is at a different scale is converted; a frame with no
+	/// timestamp is stamped with wall-clock now ([`Timestamp::now`]), which is how
+	/// protocols whose wire can't carry a timestamp end up with millisecond wall-clock
+	/// timing. Returns [`Error::FrameTooLarge`] if the declared size exceeds the
+	/// per-frame limit (refused before the buffer is allocated) or
+	/// [`Error::TimestampMismatch`] if the timestamp can't be converted (overflow).
 	pub fn create_frame(&mut self, info: impl Into<Frame>) -> Result<FrameProducer> {
-		let frame = info.into().produce()?;
+		let mut info = info.into();
+		let normalized = match info.timestamp {
+			Some(ts) => ts.convert(self.timescale),
+			None => Timestamp::now().convert(self.timescale),
+		};
+		info.timestamp = Some(normalized.map_err(|_| Error::TimestampMismatch)?);
+
+		let frame = info.produce()?;
 		self.append_frame(frame.clone())?;
 		Ok(frame)
 	}
 
 	/// Append a frame producer to the group.
 	///
-	/// Returns [`Error::TimestampMismatch`] if the frame's timing doesn't match the
-	/// parent track's timescale: a `timestamp` missing on a timed track, present on
-	/// an untimed track, or at a different scale.
+	/// Lower-level than [`Self::create_frame`]: the frame's `timestamp` must already be
+	/// `Some` at the parent track's timescale (use [`Self::create_frame`] to normalize).
+	/// Returns [`Error::TimestampMismatch`] otherwise.
 	pub fn append_frame(&mut self, frame: FrameProducer) -> Result<()> {
 		// Catch the contract violation here, at the model layer, so peers that
 		// downstream-encode (e.g. the lite publisher's `serve_frame`) can rely
 		// on the invariant instead of re-validating per byte.
-		match (self.timescale, frame.timestamp) {
-			(Some(track_scale), Some(ts)) if ts.scale() == track_scale => {}
-			(None, None) => {}
+		match frame.timestamp {
+			Some(ts) if ts.scale() == self.timescale => {}
 			_ => return Err(Error::TimestampMismatch),
 		}
 
@@ -322,9 +330,9 @@ pub struct GroupConsumer {
 	// Immutable stream state.
 	info: Group,
 
-	// Parent track's negotiated timescale, copied from the producer. Lets the
-	// wire publisher decide whether to emit per-frame timestamps for a fetched group.
-	timescale: Option<Timescale>,
+	// Parent track's timescale, copied from the producer. Lets the wire publisher
+	// emit per-frame timestamps at the right scale for a fetched group.
+	timescale: Timescale,
 
 	// The number of frames we've read.
 	// NOTE: Cloned readers inherit this offset, but then run in parallel.
@@ -340,8 +348,8 @@ impl std::ops::Deref for GroupConsumer {
 }
 
 impl GroupConsumer {
-	/// The parent track's negotiated timescale, or `None` for untimed tracks.
-	pub fn timescale(&self) -> Option<Timescale> {
+	/// The parent track's timescale.
+	pub fn timescale(&self) -> Timescale {
 		self.timescale
 	}
 
@@ -690,58 +698,51 @@ mod test {
 		assert!(end.is_none());
 	}
 
-	/// An untimed group (timescale = None) accepts only frames with no
-	/// timestamp. A timestamped frame triggers [`Error::TimestampMismatch`]
-	/// at the model layer, before any wire encoding happens.
+	/// A frame whose timestamp is at a different scale is converted to the group's
+	/// scale by `create_frame`, not rejected.
 	#[test]
-	fn append_frame_rejects_timestamp_on_untimed_group() {
-		use crate::Timestamp;
+	fn create_frame_converts_mismatched_scale() {
+		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, None);
+		let mut producer = GroupProducer::new(Group { sequence: 0 }, Timescale::MICRO);
 		let frame = Frame {
 			size: 3,
-			timestamp: Some(Timestamp::from_micros(42).unwrap()),
+			timestamp: Some(Timestamp::from_millis(1).unwrap()), // 1ms -> 1000µs
 		};
-		assert!(matches!(producer.create_frame(frame), Err(Error::TimestampMismatch)));
+		let writer = producer.create_frame(frame).unwrap();
+		let ts = writer.timestamp.unwrap();
+		assert_eq!(ts.scale(), Timescale::MICRO);
+		assert_eq!(ts.value(), 1000);
 	}
 
-	/// A timed group rejects frames that are missing a timestamp.
-	#[test]
-	fn append_frame_rejects_missing_timestamp_on_timed_group() {
+	/// A frame with no timestamp is stamped with wall-clock now, at the group's scale.
+	#[tokio::test]
+	async fn create_frame_stamps_wall_clock_when_missing() {
 		use crate::Timescale;
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
+		let mut producer = GroupProducer::new(Group { sequence: 0 }, Timescale::MICRO);
 		let frame = Frame {
 			size: 3,
 			timestamp: None,
 		};
-		assert!(matches!(producer.create_frame(frame), Err(Error::TimestampMismatch)));
+		let writer = producer.create_frame(frame).unwrap();
+		let ts = writer.timestamp.expect("stamped");
+		assert_eq!(ts.scale(), Timescale::MICRO);
+		assert!(!ts.is_zero(), "wall clock should be non-zero");
 	}
 
-	/// A timed group rejects a frame whose timestamp scale doesn't match.
+	/// A matching scale passes through unchanged; bytes can be written normally.
 	#[test]
-	fn append_frame_rejects_scale_mismatch() {
+	fn create_frame_accepts_matching_scale() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
-		let frame = Frame {
-			size: 3,
-			timestamp: Some(Timestamp::from_millis(1).unwrap()), // millis, not micros
-		};
-		assert!(matches!(producer.create_frame(frame), Err(Error::TimestampMismatch)));
-	}
-
-	/// A matching scale passes through; bytes can be written normally.
-	#[test]
-	fn append_frame_accepts_matching_scale() {
-		use crate::{Timescale, Timestamp};
-
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
+		let mut producer = GroupProducer::new(Group { sequence: 0 }, Timescale::MICRO);
 		let frame = Frame {
 			size: 1,
 			timestamp: Some(Timestamp::from_micros(7).unwrap()),
 		};
 		let mut writer = producer.create_frame(frame).unwrap();
+		assert_eq!(writer.timestamp.unwrap().value(), 7);
 		writer.write(Bytes::from_static(b"x")).unwrap();
 		writer.finish().unwrap();
 	}

--- a/rs/moq-net/src/model/time.rs
+++ b/rs/moq-net/src/model/time.rs
@@ -427,8 +427,7 @@ static TIME_ANCHOR: LazyLock<(std::time::Instant, SystemTime)> = LazyLock::new(|
 
 impl From<std::time::Instant> for Timestamp {
 	/// Convert an [`std::time::Instant`] into a millisecond-scale timestamp (the default
-	/// timescale), anchored at 2020 (see [`ANCHOR_EPOCH_SECS`]) plus a per-process jitter
-	/// (see `TIME_ANCHOR`).
+	/// timescale), anchored at 2020-01-01 plus a per-process jitter (see `TIME_ANCHOR`).
 	///
 	/// One-way only: there is no inverse, since the anchor is jittered to keep a
 	/// [`Timestamp`] from being read back as a clock.

--- a/rs/moq-net/src/model/time.rs
+++ b/rs/moq-net/src/model/time.rs
@@ -92,6 +92,15 @@ impl From<Timescale> for NonZero<u64> {
 	}
 }
 
+impl Default for Timescale {
+	/// Milliseconds ([`Self::MILLI`]). Every track has a timescale; this is the one
+	/// used when a producer doesn't pick one and the fallback for protocols whose wire
+	/// can't carry a timescale (pre-Lite05 moq-lite, IETF moq-transport).
+	fn default() -> Self {
+		Self::MILLI
+	}
+}
+
 impl std::fmt::Debug for Timescale {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match *self {
@@ -293,8 +302,13 @@ impl Timestamp {
 		}
 	}
 
-	/// Current time, expressed in microseconds ([`Timescale::MICRO`]). Uses
-	/// [`tokio::time::Instant::now`] so it honors `tokio::time::pause` in tests.
+	/// Wall-clock now, expressed in the default timescale ([`Timescale::MILLI`]).
+	///
+	/// This is the one-way bridge from wall-clock time to a track timestamp: there is
+	/// deliberately no inverse (a [`Timestamp`] is relative and jittered, never a clock).
+	/// Used to stamp frames that arrive without one, e.g. on protocols whose wire can't
+	/// carry a timestamp. Uses [`tokio::time::Instant::now`] so it honors
+	/// `tokio::time::pause` in tests.
 	pub fn now() -> Self {
 		tokio::time::Instant::now().into()
 	}
@@ -405,8 +419,11 @@ static TIME_ANCHOR: LazyLock<(std::time::Instant, SystemTime)> = LazyLock::new(|
 });
 
 impl From<std::time::Instant> for Timestamp {
-	/// Convert an [`std::time::Instant`] into a microsecond-scale timestamp anchored to a
-	/// jittered wall-clock reference (see `TIME_ANCHOR`).
+	/// Convert an [`std::time::Instant`] into a millisecond-scale timestamp (the default
+	/// timescale) anchored to a jittered wall-clock reference (see `TIME_ANCHOR`).
+	///
+	/// One-way only: there is no inverse, since the anchor is jittered to keep a
+	/// [`Timestamp`] from being read back as a clock.
 	fn from(instant: std::time::Instant) -> Self {
 		let (anchor_instant, anchor_system) = *TIME_ANCHOR;
 
@@ -419,7 +436,7 @@ impl From<std::time::Instant> for Timestamp {
 			.duration_since(UNIX_EPOCH)
 			.expect("dude your clock is earlier than 1970");
 
-		Self::from_micros(duration.as_micros() as u64).expect("dude your clock is later than 2116")
+		Self::from_millis(duration.as_millis() as u64).expect("dude your clock is later than 2116")
 	}
 }
 

--- a/rs/moq-net/src/model/time.rs
+++ b/rs/moq-net/src/model/time.rs
@@ -409,6 +409,13 @@ impl std::ops::SubAssign for Timestamp {
 	}
 }
 
+/// Epoch the wall-clock timestamps are measured from: 2020-01-01T00:00:00Z.
+///
+/// A [`Timestamp`] isn't a real clock, it just needs to be non-negative and roughly
+/// monotonic with wall time. Anchoring 50 years after the Unix epoch keeps the value
+/// ~1.5e12 ms smaller, trimming a byte or two off the first frame's varint.
+const ANCHOR_EPOCH_SECS: u64 = 1_577_836_800;
+
 // There's no zero Instant, so we need to use a reference point.
 static TIME_ANCHOR: LazyLock<(std::time::Instant, SystemTime)> = LazyLock::new(|| {
 	// To deter nerds trying to use timestamp as wall clock time, we subtract a random amount of time from the anchor.
@@ -420,7 +427,8 @@ static TIME_ANCHOR: LazyLock<(std::time::Instant, SystemTime)> = LazyLock::new(|
 
 impl From<std::time::Instant> for Timestamp {
 	/// Convert an [`std::time::Instant`] into a millisecond-scale timestamp (the default
-	/// timescale) anchored to a jittered wall-clock reference (see `TIME_ANCHOR`).
+	/// timescale), anchored at 2020 (see [`ANCHOR_EPOCH_SECS`]) plus a per-process jitter
+	/// (see `TIME_ANCHOR`).
 	///
 	/// One-way only: there is no inverse, since the anchor is jittered to keep a
 	/// [`Timestamp`] from being read back as a clock.
@@ -432,11 +440,10 @@ impl From<std::time::Instant> for Timestamp {
 			None => anchor_system - anchor_instant.duration_since(instant),
 		};
 
-		let duration = system
-			.duration_since(UNIX_EPOCH)
-			.expect("dude your clock is earlier than 1970");
+		let epoch = UNIX_EPOCH + std::time::Duration::from_secs(ANCHOR_EPOCH_SECS);
+		let duration = system.duration_since(epoch).expect("clock is earlier than 2020");
 
-		Self::from_millis(duration.as_millis() as u64).expect("dude your clock is later than 2116")
+		Self::from_millis(duration.as_millis() as u64).expect("clock is somehow past the year 2300")
 	}
 }
 

--- a/rs/moq-net/src/model/time.rs
+++ b/rs/moq-net/src/model/time.rs
@@ -440,7 +440,9 @@ impl From<std::time::Instant> for Timestamp {
 		};
 
 		let epoch = UNIX_EPOCH + std::time::Duration::from_secs(ANCHOR_EPOCH_SECS);
-		let duration = system.duration_since(epoch).expect("clock is earlier than 2020");
+		// Saturate to zero rather than panic if the wall clock is before 2020 (an unsynced
+		// clock on a peer-driven path), since the only requirement is a non-negative start.
+		let duration = system.duration_since(epoch).unwrap_or(std::time::Duration::ZERO);
 
 		Self::from_millis(duration.as_millis() as u64).expect("clock is somehow past the year 2300")
 	}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -13,7 +13,7 @@
 //!
 //! The track is closed with [Error] when all writers or readers are dropped.
 
-use crate::{Error, Result, Subscription, Timescale, coding};
+use crate::{Error, Result, Subscription, Timescale, Timestamp, coding};
 
 use super::{Fetch, Group, GroupConsumer, GroupProducer};
 
@@ -548,10 +548,22 @@ impl TrackProducer {
 		Ok(group)
 	}
 
-	/// Create a group with a single frame.
-	pub fn write_frame<B: Into<bytes::Bytes>>(&mut self, frame: B) -> Result<()> {
+	/// Create a group with a single frame, at the given presentation timestamp.
+	///
+	/// The timestamp is converted into the track's timescale. Use
+	/// [`Self::write_frame_now`] to stamp wall-clock time instead.
+	pub fn write_frame<B: Into<bytes::Bytes>>(&mut self, timestamp: Timestamp, frame: B) -> Result<()> {
 		let mut group = self.append_group()?;
-		group.write_frame(frame.into())?;
+		group.write_frame(timestamp, frame.into())?;
+		group.finish()?;
+		Ok(())
+	}
+
+	/// Like [`Self::write_frame`] but stamps the frame with wall-clock now
+	/// ([`Timestamp::now`]).
+	pub fn write_frame_now<B: Into<bytes::Bytes>>(&mut self, frame: B) -> Result<()> {
+		let mut group = self.append_group()?;
+		group.write_frame_now(frame.into())?;
 		group.finish()?;
 		Ok(())
 	}
@@ -2155,8 +2167,8 @@ mod test {
 		let mut producer = TrackProducer::new("test", None);
 		let mut consumer = producer.subscribe(None);
 
-		producer.write_frame(b"hello".as_slice()).unwrap();
-		producer.write_frame(b"world".as_slice()).unwrap();
+		producer.write_frame_now(b"hello".as_slice()).unwrap();
+		producer.write_frame_now(b"world".as_slice()).unwrap();
 
 		let frame = consumer
 			.read_frame()
@@ -2184,7 +2196,7 @@ mod test {
 		let _stalled = producer.create_group(Group { sequence: 3 }).unwrap();
 		// Seq 5: fully-written group with a frame.
 		let mut g5 = producer.create_group(Group { sequence: 5 }).unwrap();
-		g5.write_frame(bytes::Bytes::from_static(b"later")).unwrap();
+		g5.write_frame_now(bytes::Bytes::from_static(b"later")).unwrap();
 		g5.finish().unwrap();
 
 		// read_frame should not block on the stalled seq 3 — it returns seq 5's frame.
@@ -2204,12 +2216,12 @@ mod test {
 
 		// Group 0 has two frames; only the first is returned.
 		let mut g0 = producer.create_group(Group { sequence: 0 }).unwrap();
-		g0.write_frame(bytes::Bytes::from_static(b"one")).unwrap();
-		g0.write_frame(bytes::Bytes::from_static(b"two")).unwrap();
+		g0.write_frame_now(bytes::Bytes::from_static(b"one")).unwrap();
+		g0.write_frame_now(bytes::Bytes::from_static(b"two")).unwrap();
 		g0.finish().unwrap();
 
 		// Group 1 is a normal single-frame group.
-		producer.write_frame(b"next".as_slice()).unwrap();
+		producer.write_frame_now(b"next".as_slice()).unwrap();
 
 		let frame = consumer
 			.read_frame()
@@ -2246,7 +2258,7 @@ mod test {
 		);
 
 		// A late frame on the pending group is still delivered.
-		g0.write_frame(bytes::Bytes::from_static(b"late")).unwrap();
+		g0.write_frame_now(bytes::Bytes::from_static(b"late")).unwrap();
 		let frame = consumer
 			.read_frame()
 			.now_or_never()
@@ -2266,11 +2278,11 @@ mod test {
 
 		// Seq 3 has a frame but is below min_sequence — must be skipped.
 		let mut g3 = producer.create_group(Group { sequence: 3 }).unwrap();
-		g3.write_frame(bytes::Bytes::from_static(b"skip-me")).unwrap();
+		g3.write_frame_now(bytes::Bytes::from_static(b"skip-me")).unwrap();
 		g3.finish().unwrap();
 
 		let mut g5 = producer.create_group(Group { sequence: 5 }).unwrap();
-		g5.write_frame(bytes::Bytes::from_static(b"keep")).unwrap();
+		g5.write_frame_now(bytes::Bytes::from_static(b"keep")).unwrap();
 		g5.finish().unwrap();
 
 		let frame = consumer
@@ -2287,7 +2299,7 @@ mod test {
 		let mut producer = TrackProducer::new("test", None);
 		let mut consumer = producer.subscribe(None);
 
-		producer.write_frame(b"only".as_slice()).unwrap();
+		producer.write_frame_now(b"only".as_slice()).unwrap();
 		producer.finish().unwrap();
 
 		let frame = consumer
@@ -2346,7 +2358,7 @@ mod test {
 
 		// Produce a cached group.
 		let mut group = producer.append_group().unwrap(); // seq 0
-		group.write_frame(bytes::Bytes::from_static(b"hello")).unwrap();
+		group.write_frame_now(bytes::Bytes::from_static(b"hello")).unwrap();
 		group.finish().unwrap();
 
 		// A cached group resolves immediately and never queues a request. `get_group`
@@ -2385,7 +2397,7 @@ mod test {
 
 		// Serve it by accepting the request; the fetch then resolves.
 		let mut group = req.accept(None).unwrap();
-		group.write_frame(bytes::Bytes::from_static(b"hi")).unwrap();
+		group.write_frame_now(bytes::Bytes::from_static(b"hi")).unwrap();
 		group.finish().unwrap();
 
 		let mut g = pending.await.unwrap();

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -47,7 +47,7 @@ pub struct TrackInfo {
 	/// reported in TRACK_INFO and the publisher zigzag-delta encodes per-frame
 	/// timestamps at this scale on the wire. Protocols whose wire can't carry it
 	/// (pre-Lite05 moq-lite, IETF moq-transport) fall back to wall-clock milliseconds.
-	#[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "is_default_timescale"))]
+	#[cfg_attr(feature = "serde", serde(default))]
 	pub timescale: Timescale,
 	/// How long the publisher keeps old groups available before evicting them
 	/// (the newest group is always retained). A subscriber's
@@ -82,11 +82,6 @@ fn default_cache() -> Duration {
 #[cfg(feature = "serde")]
 fn is_default_cache(cache: &Duration) -> bool {
 	*cache == DEFAULT_CACHE
-}
-
-#[cfg(feature = "serde")]
-fn is_default_timescale(timescale: &Timescale) -> bool {
-	*timescale == Timescale::default()
 }
 
 /// Serialize [`TrackInfo::cache`] as a bare integer of milliseconds, matching the

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -43,13 +43,12 @@ pub struct TrackInfo {
 	pub compress: bool,
 	/// Units per second for per-frame timestamps on this track.
 	///
-	/// `None` means the publisher hasn't advertised a timescale; subscribers
-	/// receive frames with `timestamp: None`. On Lite05+ a `Some(_)` value is
-	/// reported in TRACK_INFO and the publisher zigzag-delta encodes
-	/// per-frame timestamps at that scale on the wire; rejecting a frame at
-	/// the wrong scale prevents silent corruption.
-	#[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
-	pub timescale: Option<Timescale>,
+	/// Every track is timed; this defaults to [`Timescale::MILLI`]. On Lite05+ it is
+	/// reported in TRACK_INFO and the publisher zigzag-delta encodes per-frame
+	/// timestamps at this scale on the wire. Protocols whose wire can't carry it
+	/// (pre-Lite05 moq-lite, IETF moq-transport) fall back to wall-clock milliseconds.
+	#[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "is_default_timescale"))]
+	pub timescale: Timescale,
 	/// How long the publisher keeps old groups available before evicting them
 	/// (the newest group is always retained). A subscriber's
 	/// [`Subscription::stale`] window is clamped to this, since a group can't be
@@ -85,6 +84,11 @@ fn is_default_cache(cache: &Duration) -> bool {
 	*cache == DEFAULT_CACHE
 }
 
+#[cfg(feature = "serde")]
+fn is_default_timescale(timescale: &Timescale) -> bool {
+	*timescale == Timescale::default()
+}
+
 /// Serialize [`TrackInfo::cache`] as a bare integer of milliseconds, matching the
 /// catalog's other durations (and the wire), rather than serde's `{secs, nanos}`.
 #[cfg(feature = "serde")]
@@ -104,7 +108,7 @@ impl Default for TrackInfo {
 	fn default() -> Self {
 		Self {
 			compress: false,
-			timescale: None,
+			timescale: Timescale::default(),
 			cache: DEFAULT_CACHE,
 			priority: 0,
 			ordered: true,
@@ -121,9 +125,10 @@ impl TrackInfo {
 
 	/// Set the per-frame timestamp scale, returning `self` for chaining.
 	///
-	/// Required for Lite05+ peers to encode per-frame timestamps on the wire.
+	/// Defaults to [`Timescale::MILLI`]. On Lite05+ this scale is reported in TRACK_INFO
+	/// and used to encode per-frame timestamps on the wire.
 	pub fn with_timescale(mut self, timescale: Timescale) -> Self {
-		self.timescale = Some(timescale);
+		self.timescale = timescale;
 		self
 	}
 

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -1046,7 +1046,7 @@ fn flush_track<T: Serialize>(track: &mut TrackProducer, frame: &T, last: &mut Ve
 	if &json == last {
 		return;
 	}
-	if let Err(err) = track.write_frame(json.clone()) {
+	if let Err(err) = track.write_frame_now(json.clone()) {
 		tracing::debug!(?err, name, "stats: failed to write frame");
 		return;
 	}

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -113,7 +113,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
-	group.write_frame(b"hello".as_ref()).expect("write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("write frame");
 	group.finish().expect("finish group");
 
 	let pub_session = tokio::time::timeout(TIMEOUT, client().with_publisher(&pub_origin).connect(url.clone()))
@@ -187,7 +187,7 @@ async fn two_publish_only_clients_coexist() {
 	track_a
 		.append_group()
 		.expect("append group a")
-		.write_frame(b"a".as_ref())
+		.write_frame_now(b"a".as_ref())
 		.expect("write frame a");
 
 	let pub_b = Origin::random().produce();
@@ -196,7 +196,7 @@ async fn two_publish_only_clients_coexist() {
 	track_b
 		.append_group()
 		.expect("append group b")
-		.write_frame(b"b".as_ref())
+		.write_frame_now(b"b".as_ref())
 		.expect("write frame b");
 
 	let sess_a = tokio::time::timeout(TIMEOUT, client().with_publisher(pub_a.consume()).connect(url.clone()))
@@ -292,7 +292,7 @@ async fn internal_tcp_round_trip() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
-	group.write_frame(b"hello".as_ref()).expect("write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("write frame");
 	group.finish().expect("finish group");
 
 	let pub_session = tokio::time::timeout(
@@ -396,7 +396,7 @@ async fn internal_unix_round_trip() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
-	group.write_frame(b"hello".as_ref()).expect("write frame");
+	group.write_frame_now(b"hello".as_ref()).expect("write frame");
 	group.finish().expect("finish group");
 
 	let pub_session = tokio::time::timeout(


### PR DESCRIPTION
## Summary

Makes per-track **timescale** and per-frame **timestamps** mandatory on moq-lite-05, gives both Rust and JS a proper timestamp type, and wires real timestamps through the media/transport paths.

Behavioral contract:

- **Every track is timed.** `TrackInfo.timescale` defaults to **milliseconds** (Rust and JS).
- **moq-lite-05 always carries timestamps**: `TRACK_INFO` encodes the timescale as a mandatory non-zero varint, and every frame is prefixed with a zigzag-delta timestamp at the track's scale.
- **moq-transport carries timestamps** as per-object extension headers — Timestamp (`0x06`, absolute) in Timescale (`0x08`) units, the MOQ Object Properties registry ids shared with draft-ietf-moq-loc — decoded on receive and emitted on send.
- **Timeless sources** (a peer/track with no real presentation time) fall back to wall-clock: Rust `write_frame_now`/`create_frame_now`, JS `Timestamp.now()`.
- **Timestamps auto-convert** into the track's timescale.

### Rust

- `Timescale` (default `MILLI`) and `Timestamp` (value + scale) carry their own scale; `Timestamp::now()` / `From<Instant>` are millisecond-scale and anchored at **2020-01-01** (a timestamp is non-negative + roughly monotonic, not a real clock — the smaller magnitude trims the first frame's varint).
- `Frame.timestamp` is a required `Timestamp`; `GroupProducer::create_frame` / `write_frame` (and `TrackProducer::write_frame`) require it, with `create_frame_now` / `write_frame_now` for the wall-clock case.
- `TrackInfo.timescale` and `lite::TrackInfo.timescale` are non-optional.
- Surfaced a real bug: the moq-mux **LOC** and **fMP4** export paths wrote the net frame with size only (wall-clock), dropping the media PTS — both now pass it through.
- IETF publisher/subscriber encode/decode the Timestamp/Timescale object properties (`ietf::{encode,decode}_object_time`).

### JS (@moq/net + consumers)

- New `Timestamp` (value + scale) and `Timescale` types mirroring Rust; `Timestamp.now()` is `performance.now()` ms.
- `Frame.timestamp` is required; `writeFrame(frame)` / `readFrame()` both use the `Frame` type (symmetric). No `writeFrameNow` — timeless callers pass `Timestamp.now()`.
- Model `TrackInfo` gains a `timescale` (default ms): the lite publisher advertises it and emits each frame converted to it; the subscriber reconstructs a `Timestamp` at the wire scale and carries it into the accepted track (so a relay re-publishes at the same scale). hang/loc/publish pass `Timestamp.fromMicros`.

## Public API changes (`rs/moq-net`, breaking — targets `dev`)

- `Frame.timestamp`: `Option<Timestamp>` → `Timestamp`; size-only `From<uN>` shortcuts removed.
- `GroupProducer`: `create_frame(Frame)` requires a timestamp; new `create_frame_now(size)`; `write_frame(timestamp, data)` + `write_frame_now(data)`; `timescale()` → `Timescale`.
- `GroupConsumer::timescale()` → `Timescale`; `TrackProducer::write_frame(timestamp, data)` + `write_frame_now(data)`.
- `TrackInfo.timescale` / `lite::TrackInfo.timescale`: `Option<Timescale>` → `Timescale`.
- `Timescale`: `Default` = `MILLI`; `Timestamp::now()` / `From<Instant>` now millisecond-scale, 2020-anchored.
- `ietf::{encode_object_time, decode_object_time}` added.

## Test plan

- [x] `cargo test -p moq-net -p moq-mux --lib` (400 + 288), incl. `ietf::group` object-property round-trips; `cargo clippy` + `cargo doc -D warnings` clean.
- [x] `@moq/net` 189 / `@moq/json` 32 / hang container 26 / `@moq/loc` 6; `tsc` + biome clean across net/hang/loc/json/publish/watch.
- [ ] moq-native integration tests can't *run* in the sandbox (no IPv6 → `[::]:0` bind), but pass in CI.

## Follow-ups

- `doc/concept` note on the lite-05 mandatory timestamp + moq-transport object properties.
- Optional: drop the per-process wall-clock jitter on the Rust anchor if epoch-obfuscation is no longer wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)