### PR TITLE
feat(moq-net): shared RAM LRU group cache

### DIFF
--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{Error, TrackConsumer, TrackProducer, model::track::TrackWeak};
 
-use super::{OriginList, Track};
+use super::{Cache, OriginList, Track};
 
 /// A collection of media tracks that can be published and subscribed to.
 ///
@@ -44,6 +44,10 @@ struct State {
 	// If this is 0, requests must be empty.
 	dynamic: usize,
 
+	// Shared cache cascaded onto every track produced by this broadcast (created statically or
+	// served on demand). A track-level cache overrides it. `None` keeps tracks latest-only.
+	cache: Option<Cache>,
+
 	// The error that caused the broadcast to be aborted, if any.
 	abort: Option<Error>,
 }
@@ -63,6 +67,14 @@ impl State {
 		};
 		entry.insert(weak);
 		Ok(())
+	}
+
+	/// Apply the broadcast's cascaded cache to a freshly produced track, if one is set.
+	fn apply_cache(&self, track: TrackProducer) -> TrackProducer {
+		match &self.cache {
+			Some(cache) => track.with_cache(cache.clone()),
+			None => track,
+		}
 	}
 }
 
@@ -93,6 +105,16 @@ impl BroadcastProducer {
 		}
 	}
 
+	/// Attach a shared [`Cache`] cascaded onto every track this broadcast produces (created
+	/// statically or served on demand). A track-level [`TrackProducer::with_cache`] overrides it.
+	/// Clone the same [`Cache`] across broadcasts to share one budget. Returns `self` for chaining.
+	pub fn with_cache(self, cache: Cache) -> Self {
+		if let Ok(mut state) = self.state.write() {
+			state.cache = Some(cache);
+		}
+		self
+	}
+
 	/// Insert a track into the lookup, returning an error on duplicate.
 	///
 	/// Stores a weak handle to the track. The caller (or the owner of the
@@ -112,9 +134,11 @@ impl BroadcastProducer {
 	}
 
 	/// Produce a new track and insert it into the broadcast.
+	///
+	/// The track inherits the broadcast's [`with_cache`](Self::with_cache) cache, if any.
 	pub fn create_track(&mut self, track: Track) -> Result<TrackProducer, Error> {
-		let track = TrackProducer::new(track);
 		let mut state = modify(&self.state)?;
+		let track = state.apply_cache(TrackProducer::new(track));
 		state.insert_track(track.weak())?;
 		drop(state);
 		Ok(track)
@@ -404,7 +428,7 @@ impl BroadcastConsumer {
 		}
 
 		// Otherwise we have never seen this track before and need to create a new producer.
-		let producer = track.clone().produce();
+		let producer = state.apply_cache(track.clone().produce());
 		let consumer = producer.consume();
 
 		if state.dynamic == 0 {
@@ -486,6 +510,44 @@ impl BroadcastConsumer {
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::cache;
+
+	#[tokio::test]
+	async fn cache_cascades_to_created_track() {
+		let cache = Cache::new(cache::Config::default().with_max_bytes(u64::MAX));
+		let mut broadcast = Broadcast::new().produce().with_cache(cache);
+
+		let mut track = broadcast.assert_create_track(&Track::new("video"));
+
+		// Without the cascaded cache the track would keep only its latest group; with it, the
+		// earlier group survives.
+		track.append_group().unwrap(); // seq 0
+		track.append_group().unwrap(); // seq 1
+
+		let consumer = track.consume();
+		assert!(
+			consumer.get_group(0).now_or_never().unwrap().unwrap().is_some(),
+			"the broadcast's cache retained the superseded group on its track"
+		);
+	}
+
+	#[tokio::test]
+	async fn cache_cascades_to_dynamic_track() {
+		let cache = Cache::new(cache::Config::default().with_max_bytes(u64::MAX));
+		let mut broadcast = Broadcast::new().produce().with_cache(cache).dynamic();
+
+		// A consumer-driven (dynamic) track also inherits the broadcast cache.
+		let _consumer = broadcast.consume().assert_subscribe_track(&Track::new("audio"));
+		let mut track = broadcast.assert_request();
+
+		track.append_group().unwrap(); // seq 0
+		track.append_group().unwrap(); // seq 1
+
+		assert!(
+			track.consume().get_group(0).now_or_never().unwrap().unwrap().is_some(),
+			"a dynamically served track inherits the broadcast cache"
+		);
+	}
 
 	#[tokio::test]
 	async fn insert() {

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -1,0 +1,319 @@
+//! A shared RAM LRU cache for groups, attachable at the origin, broadcast, or track level.
+//!
+//! By default a track keeps only its latest group: a live subscriber can always grab the
+//! current group, but nothing older is retained. Attach a [`Cache`] to keep more history in
+//! RAM, bounded by a byte budget and a wall-clock age. The budget is shared: clone the same
+//! [`Cache`] handle across many tracks (or whole broadcasts / origins) and they all draw from
+//! one `max_bytes` total and one `max_age`. Two distinct [`Cache`] instances have independent
+//! budgets.
+//!
+//! Eviction is LRU by wall-clock last-access time (when a group was last read), not by media
+//! timestamp or arrival order. A group is evicted once it is older than `max_age` since its
+//! last access, or once the shared total exceeds `max_bytes` (least-recently-accessed first).
+//! A track's current latest group is never handed to the cache, so it is never evicted out
+//! from under a live subscriber.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+use super::GroupProducer;
+use crate::Error;
+
+/// Configuration for a [`Cache`]: the shared byte budget and the wall-clock age bound.
+///
+/// Construct via [`Config::default`] (an empty, do-nothing budget) and the `with_*` setters,
+/// then build a handle with [`Cache::new`]. New fields stay additive, so build via `default()`
+/// plus setters rather than a struct literal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Config {
+	/// Maximum total bytes retained across every track sharing this cache. Summed over all
+	/// cached (non-latest) groups; the least-recently-accessed groups are evicted once the
+	/// total would exceed this. Defaults to `0` (retain nothing beyond the latest group).
+	pub max_bytes: u64,
+
+	/// Maximum wall-clock age since a group was last accessed before it is evicted. Measured
+	/// with [`tokio::time::Instant`], so `tokio::time::pause` controls it in tests. Defaults
+	/// to [`Duration::MAX`] (no age bound; eviction is by `max_bytes` alone).
+	pub max_age: Duration,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			max_bytes: 0,
+			max_age: Duration::MAX,
+		}
+	}
+}
+
+impl Config {
+	/// Set the shared byte budget, returning `self` for chaining.
+	pub fn with_max_bytes(mut self, max_bytes: u64) -> Self {
+		self.max_bytes = max_bytes;
+		self
+	}
+
+	/// Set the wall-clock age bound, returning `self` for chaining.
+	pub fn with_max_age(mut self, max_age: Duration) -> Self {
+		self.max_age = max_age;
+		self
+	}
+}
+
+/// A shared, cheaply cloneable handle to a RAM LRU group cache.
+///
+/// Everything attached with the *same* handle (clones share it) draws from one budget. Attach
+/// it via [`OriginProducer::with_cache`](crate::OriginProducer::with_cache),
+/// [`BroadcastProducer::with_cache`](crate::BroadcastProducer::with_cache), or
+/// [`TrackProducer::with_cache`](crate::TrackProducer::with_cache); the most specific attach
+/// point wins (track over broadcast over origin). Clone the handle to share a single budget
+/// across many of them.
+///
+/// See the [module docs](self) for the eviction policy.
+#[derive(Clone)]
+pub struct Cache {
+	state: Arc<Mutex<State>>,
+}
+
+impl Cache {
+	/// Create a cache with the given [`Config`].
+	pub fn new(config: Config) -> Self {
+		Self {
+			state: Arc::new(Mutex::new(State {
+				max_bytes: config.max_bytes,
+				max_age: config.max_age,
+				total_bytes: 0,
+				next_id: 0,
+				entries: HashMap::new(),
+				lru: BTreeMap::new(),
+			})),
+		}
+	}
+
+	/// Whether two handles share the same underlying budget (one is a clone of the other).
+	pub fn is_clone(&self, other: &Self) -> bool {
+		Arc::ptr_eq(&self.state, &other.state)
+	}
+
+	/// Register a group with the cache, recording its byte size and an initial access time of
+	/// `now`, then evict anything now over budget. Returns a [`Token`] identifying the entry.
+	///
+	/// Called by a track when a group stops being the latest (a newer group arrived), handing
+	/// the now-evictable group to the shared budget.
+	pub(crate) fn insert(&self, group: GroupProducer, bytes: u64, now: Instant) -> Token {
+		let mut state = self.state.lock().unwrap();
+		let id = state.next_id;
+		state.next_id += 1;
+		state.total_bytes += bytes;
+		state.lru.insert(Key { last_access: now, id }, ());
+		state.entries.insert(
+			id,
+			Entry {
+				group,
+				bytes,
+				last_access: now,
+			},
+		);
+		state.evict(now);
+		Token(id)
+	}
+
+	/// Bump a registered group's last-access time to `now`. A no-op if it was already evicted.
+	pub(crate) fn touch(&self, token: Token, now: Instant) {
+		let mut state = self.state.lock().unwrap();
+		let Some(entry) = state.entries.get_mut(&token.0) else {
+			return;
+		};
+		let old = entry.last_access;
+		entry.last_access = now;
+		state.lru.remove(&Key {
+			last_access: old,
+			id: token.0,
+		});
+		state.lru.insert(
+			Key {
+				last_access: now,
+				id: token.0,
+			},
+			(),
+		);
+	}
+
+	/// Remove a registered group from the cache without aborting it (the track is dropping it
+	/// for its own reasons, e.g. the track is closing).
+	pub(crate) fn remove(&self, token: Token) {
+		let mut state = self.state.lock().unwrap();
+		state.drop_id(token.0, false);
+	}
+
+	/// Evict groups over budget, aborting each so any reader unblocks with [`Error::Old`].
+	/// `now` is the current wall clock. Called by a track on insert.
+	pub(crate) fn evict(&self, now: Instant) {
+		let mut state = self.state.lock().unwrap();
+		state.evict(now);
+	}
+}
+
+/// Identifies a track's group within the shared cache. The track holds one per cached group.
+#[derive(Clone, Copy)]
+pub(crate) struct Token(u64);
+
+/// Ordering key for the LRU index: least-recently-accessed sorts first. `id` is a monotonic
+/// tie-breaker so two groups accessed at the same instant stay distinct and ordered.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Key {
+	last_access: Instant,
+	id: u64,
+}
+
+struct Entry {
+	/// A clone of the group's producer, held so its frame buffers stay in memory while cached.
+	/// Aborting it on eviction frees the buffers and unblocks any waiting reader.
+	group: GroupProducer,
+	bytes: u64,
+	last_access: Instant,
+}
+
+struct State {
+	max_bytes: u64,
+	max_age: Duration,
+	total_bytes: u64,
+	/// Monotonic id counter feeding each entry's tie-breaker.
+	next_id: u64,
+	/// Entries by id, the source of truth for bytes and last-access.
+	entries: HashMap<u64, Entry>,
+	/// LRU index into `entries`, ordered least-recently-accessed first.
+	lru: BTreeMap<Key, ()>,
+}
+
+impl State {
+	fn evict(&mut self, now: Instant) {
+		// Age first: drop anything not accessed within max_age.
+		if self.max_age != Duration::MAX {
+			while let Some((key, _)) = self.lru.iter().next() {
+				let key = *key;
+				if now.saturating_duration_since(key.last_access) <= self.max_age {
+					break;
+				}
+				self.drop_id(key.id, true);
+			}
+		}
+
+		// Then byte budget: drop least-recently-accessed until within max_bytes.
+		while self.total_bytes > self.max_bytes {
+			let Some((key, _)) = self.lru.iter().next() else {
+				break;
+			};
+			let id = key.id;
+			self.drop_id(id, true);
+		}
+	}
+
+	/// Remove an entry by id, optionally aborting its group. Keeps `lru` and `total_bytes`
+	/// in sync with `entries`.
+	fn drop_id(&mut self, id: u64, abort: bool) {
+		let Some(mut entry) = self.entries.remove(&id) else {
+			return;
+		};
+		self.total_bytes -= entry.bytes;
+		self.lru.remove(&Key {
+			last_access: entry.last_access,
+			id,
+		});
+		if abort {
+			// Surface `Error::Old` to a parked reader rather than letting it hang, matching the
+			// track-local eviction path.
+			let _ = entry.group.abort(Error::Old);
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::Group;
+
+	fn group(seq: u64) -> GroupProducer {
+		Group { sequence: seq }.produce()
+	}
+
+	#[tokio::test]
+	async fn bytes_evicts_least_recently_accessed() {
+		tokio::time::pause();
+		let cache = Cache::new(Config::default().with_max_bytes(100));
+
+		let now = Instant::now();
+		let g0 = group(0);
+		let g1 = group(1);
+		let _t0 = cache.insert(g0.clone(), 60, now);
+		// The second insert pushes the total to 120 > 100, evicting the LRU (g0).
+		let _t1 = cache.insert(g1.clone(), 60, now);
+
+		assert!(g0.is_aborted(), "least recently inserted group evicted");
+		assert!(!g1.is_aborted());
+	}
+
+	#[tokio::test]
+	async fn touch_updates_recency() {
+		tokio::time::pause();
+		let cache = Cache::new(Config::default().with_max_bytes(120));
+
+		let now = Instant::now();
+		let g0 = group(0);
+		let g1 = group(1);
+		let t0 = cache.insert(g0.clone(), 60, now);
+		let _t1 = cache.insert(g1.clone(), 60, now);
+
+		// Access g0 so it becomes most-recently-used; g1 is now the LRU victim.
+		tokio::time::advance(Duration::from_secs(1)).await;
+		let later = Instant::now();
+		cache.touch(t0, later);
+
+		// A third group pushes over budget; the least-recently-accessed (g1) is evicted.
+		let g2 = group(2);
+		let _t2 = cache.insert(g2.clone(), 60, later);
+
+		assert!(!g0.is_aborted(), "recently accessed group survives");
+		assert!(g1.is_aborted(), "least recently accessed group evicted");
+		assert!(!g2.is_aborted());
+	}
+
+	#[tokio::test]
+	async fn age_evicts_by_wall_clock() {
+		tokio::time::pause();
+		let cache = Cache::new(
+			Config::default()
+				.with_max_bytes(u64::MAX)
+				.with_max_age(Duration::from_secs(5)),
+		);
+
+		let now = Instant::now();
+		let g0 = group(0);
+		let _t0 = cache.insert(g0.clone(), 10, now);
+
+		tokio::time::advance(Duration::from_secs(6)).await;
+		cache.evict(Instant::now());
+		assert!(g0.is_aborted(), "group older than max_age is evicted");
+	}
+
+	#[tokio::test]
+	async fn remove_frees_budget_without_abort() {
+		tokio::time::pause();
+		let cache = Cache::new(Config::default().with_max_bytes(50));
+
+		let now = Instant::now();
+		let g0 = group(0);
+		let t0 = cache.insert(g0.clone(), 40, now);
+		cache.remove(t0);
+
+		// g0 is no longer counted, so a fresh 40-byte group fits without eviction.
+		let g1 = group(1);
+		let _t1 = cache.insert(g1.clone(), 40, now);
+		assert!(!g0.is_aborted());
+		assert!(!g1.is_aborted());
+	}
+}

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -212,6 +212,19 @@ impl GroupProducer {
 		state.offset + state.frames.len()
 	}
 
+	/// Total bytes currently buffered for this group (the sum of its cached frame sizes).
+	///
+	/// Used by the track cache to budget retained groups. Excludes frames already evicted
+	/// from the group's own per-group cache.
+	pub fn cached_size(&self) -> u64 {
+		self.state.read().cache
+	}
+
+	/// Whether the group has been aborted (e.g. evicted from the cache).
+	pub fn is_aborted(&self) -> bool {
+		self.state.read().abort.is_some()
+	}
+
 	/// Mark the group as complete; no more frames will be written.
 	pub fn finish(&mut self) -> Result<()> {
 		let mut state = modify(&self.state)?;

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -1,5 +1,6 @@
 mod bandwidth;
 mod broadcast;
+pub mod cache;
 mod frame;
 mod group;
 mod origin;
@@ -8,6 +9,7 @@ mod track;
 
 pub use bandwidth::*;
 pub use broadcast::*;
+pub use cache::Cache;
 pub use frame::*;
 pub use group::*;
 pub use origin::*;

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -8,7 +8,7 @@ use std::{
 use rand::RngExt;
 use web_async::Lock;
 
-use super::BroadcastConsumer;
+use super::{BroadcastConsumer, Cache};
 use crate::{
 	AsPath, Broadcast, BroadcastProducer, Path, PathOwned, PathPrefixes,
 	coding::{Decode, DecodeError, Encode, EncodeError},
@@ -686,6 +686,10 @@ pub struct OriginProducer {
 
 	// The prefix that is automatically stripped from all paths.
 	root: PathOwned,
+
+	// Shared cache cascaded onto broadcasts created via `create_broadcast` (and thus their
+	// tracks). A broadcast- or track-level cache overrides it. `None` keeps tracks latest-only.
+	cache: Option<Cache>,
 }
 
 impl std::ops::Deref for OriginProducer {
@@ -704,15 +708,29 @@ impl OriginProducer {
 			info,
 			nodes: OriginNodes::default(),
 			root: PathOwned::default(),
+			cache: None,
 		}
+	}
+
+	/// Attach a shared [`Cache`] cascaded onto broadcasts created via
+	/// [`create_broadcast`](Self::create_broadcast) (and in turn their tracks). A broadcast-level
+	/// [`BroadcastProducer::with_cache`] or track-level [`TrackProducer::with_cache`] overrides it.
+	/// Clone the same [`Cache`] across origins to share one budget. Returns `self` for chaining.
+	pub fn with_cache(mut self, cache: Cache) -> Self {
+		self.cache = Some(cache);
+		self
 	}
 
 	/// Create and publish a new broadcast, returning the producer.
 	///
 	/// This is a helper method when you only want to publish a broadcast to a single origin.
+	/// The broadcast inherits this origin's [`with_cache`](Self::with_cache) cache, if any.
 	/// Returns [None] if the broadcast is not allowed to be published.
 	pub fn create_broadcast(&self, path: impl AsPath) -> Option<BroadcastProducer> {
-		let broadcast = Broadcast::new().produce();
+		let mut broadcast = Broadcast::new().produce();
+		if let Some(cache) = &self.cache {
+			broadcast = broadcast.with_cache(cache.clone());
+		}
 		self.publish_broadcast(path, broadcast.consume()).then_some(broadcast)
 	}
 
@@ -764,6 +782,7 @@ impl OriginProducer {
 			info: self.info,
 			nodes: self.nodes.select(&prefixes)?,
 			root: self.root.clone(),
+			cache: self.cache.clone(),
 		})
 	}
 
@@ -795,6 +814,7 @@ impl OriginProducer {
 			info: self.info,
 			root: self.root.join(&prefix).to_owned(),
 			nodes: self.nodes.root(&prefix)?,
+			cache: self.cache.clone(),
 		})
 	}
 
@@ -1055,9 +1075,29 @@ impl OriginConsumer {
 
 #[cfg(test)]
 mod tests {
-	use crate::Broadcast;
+	use crate::{Broadcast, Track, cache};
+	use futures::FutureExt;
 
 	use super::*;
+
+	#[tokio::test]
+	async fn cache_cascades_to_created_broadcast() {
+		let cache = Cache::new(cache::Config::default().with_max_bytes(u64::MAX));
+		let origin = Origin::random().produce().with_cache(cache);
+
+		let mut broadcast = origin.create_broadcast("room").unwrap();
+		let mut track = broadcast.create_track(Track::new("video")).unwrap();
+
+		// The origin's cache cascaded through the broadcast onto the track, so a superseded
+		// group is retained instead of dropped.
+		track.append_group().unwrap(); // seq 0
+		track.append_group().unwrap(); // seq 1
+
+		assert!(
+			track.consume().get_group(0).now_or_never().unwrap().unwrap().is_some(),
+			"the origin's cache cascaded to the broadcast's track"
+		);
+	}
 
 	#[test]
 	fn origin_list_push_fails_at_limit() {

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -14,17 +14,13 @@
 
 use crate::{Error, Result, coding};
 
+use super::cache::{self, Cache};
 use super::{Group, GroupConsumer, GroupProducer};
 
 use std::{
 	collections::{HashSet, VecDeque},
 	task::{Poll, ready},
-	time::Duration,
 };
-
-/// Groups older than this are evicted from the track cache (unless they are the max_sequence group).
-// TODO: Replace with a configurable cache size.
-const MAX_GROUP_AGE: Duration = Duration::from_secs(5);
 
 /// A track is a collection of groups, delivered out-of-order until expired.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -51,15 +47,26 @@ impl Track {
 	}
 }
 
+/// A cached group plus its registration in the shared [`Cache`], if any. A group is registered
+/// only once it stops being the latest; the latest group is never handed to the cache.
+struct Cached {
+	group: GroupProducer,
+	token: Option<cache::Token>,
+}
+
 #[derive(Default)]
 struct State {
 	/// Groups in arrival order. `None` entries are tombstones for evicted groups.
-	groups: VecDeque<Option<(GroupProducer, tokio::time::Instant)>>,
+	groups: VecDeque<Option<Cached>>,
 	duplicates: HashSet<u64>,
 	offset: usize,
 	max_sequence: Option<u64>,
 	final_sequence: Option<u64>,
 	abort: Option<Error>,
+
+	/// Shared RAM cache governing retention of non-latest groups. `None` (the default) keeps
+	/// only the latest group: every superseded group is dropped at once.
+	cache: Option<Cache>,
 }
 
 impl State {
@@ -69,10 +76,12 @@ impl State {
 	fn poll_recv_group(&self, index: usize, min_sequence: u64) -> Poll<Result<Option<(GroupConsumer, usize)>>> {
 		let start = index.saturating_sub(self.offset);
 		for (i, slot) in self.groups.iter().enumerate().skip(start) {
-			if let Some((group, _)) = slot
-				&& group.sequence >= min_sequence
+			if let Some(cached) = slot
+				&& !cached.group.is_aborted()
+				&& cached.group.sequence >= min_sequence
 			{
-				return Poll::Ready(Ok(Some((group.consume(), self.offset + i))));
+				self.touch(cached);
+				return Poll::Ready(Ok(Some((cached.group.consume(), self.offset + i))));
 			}
 		}
 
@@ -98,8 +107,9 @@ impl State {
 		let start = index.saturating_sub(self.offset);
 		let mut pending_seen = false;
 		for (i, slot) in self.groups.iter().enumerate().skip(start) {
-			let Some((group, _)) = slot else { continue };
-			if group.sequence < next_sequence {
+			let Some(cached) = slot else { continue };
+			let group = &cached.group;
+			if group.is_aborted() || group.sequence < next_sequence {
 				continue;
 			}
 
@@ -131,10 +141,11 @@ impl State {
 	}
 
 	fn poll_get_group(&self, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
-		// Search for the group with the matching sequence, skipping tombstones.
-		for (group, _) in self.groups.iter().flatten() {
-			if group.sequence == sequence {
-				return Poll::Ready(Ok(Some(group.consume())));
+		// Search for the group with the matching sequence, skipping tombstones and evicted groups.
+		for cached in self.groups.iter().flatten() {
+			if cached.group.sequence == sequence && !cached.group.is_aborted() {
+				self.touch(cached);
+				return Poll::Ready(Ok(Some(cached.group.consume())));
 			}
 		}
 
@@ -162,32 +173,83 @@ impl State {
 		}
 	}
 
-	/// Evict groups older than MAX_GROUP_AGE, never evicting the max_sequence group.
+	/// Apply the retention policy after a group is added, then trim evicted slots.
 	///
-	/// Groups are in arrival order, so we can stop early when we hit a non-expired,
-	/// non-max_sequence group (everything after it arrived even later).
-	/// When max_sequence is at the front, we skip past it and tombstone expired groups
-	/// behind it.
-	fn evict_expired(&mut self, now: tokio::time::Instant) {
-		for slot in self.groups.iter_mut() {
-			let Some((group, created_at)) = slot else { continue };
+	/// The current max_sequence group is always kept (a live subscriber must be able to grab
+	/// it), so it is never handed to the shared cache. Every other live group is either dropped
+	/// at once (no cache: latest-only) or registered with the cache, which evicts by the shared
+	/// byte/age budget across all tracks. A group the cache has aborted (here or via another
+	/// track's insert) is tombstoned.
+	fn retain(&mut self, now: tokio::time::Instant) {
+		let max_sequence = self.max_sequence;
 
-			if Some(group.sequence) == self.max_sequence {
+		for slot in self.groups.iter_mut() {
+			let Some(cached) = slot else { continue };
+
+			// Never evict the current latest group.
+			if Some(cached.group.sequence) == max_sequence {
 				continue;
 			}
 
-			if now.duration_since(*created_at) <= MAX_GROUP_AGE {
-				break;
+			match &self.cache {
+				None => {
+					// Latest-only: a superseded group is dropped immediately.
+					self.duplicates.remove(&cached.group.sequence);
+					cached.group.abort(Error::Old).ok();
+					*slot = None;
+				}
+				Some(cache) => {
+					// Hand the group to the shared budget the first time it is superseded.
+					if cached.token.is_none() {
+						let bytes = cached.group.cached_size();
+						cached.token = Some(cache.insert(cached.group.clone(), bytes, now));
+					}
+				}
 			}
+		}
 
-			self.duplicates.remove(&group.sequence);
-			*slot = None;
+		// Run age eviction on the shared budget now, so an active track ages out stale groups
+		// (its own and its peers') even when no new group needed registering this round.
+		if let Some(cache) = &self.cache {
+			cache.evict(now);
+		}
+
+		// The shared cache may have aborted some of our (or another track's) groups; tombstone
+		// any that are now aborted so consumers skip them and the budget bookkeeping matches.
+		for slot in self.groups.iter_mut() {
+			if let Some(cached) = slot
+				&& cached.group.is_aborted()
+				&& Some(cached.group.sequence) != max_sequence
+			{
+				self.duplicates.remove(&cached.group.sequence);
+				*slot = None;
+			}
 		}
 
 		// Trim leading tombstones to advance the offset.
 		while let Some(None) = self.groups.front() {
 			self.groups.pop_front();
 			self.offset += 1;
+		}
+	}
+
+	/// Record a read of a cached group as a wall-clock access, so the shared cache treats it as
+	/// recently used. A no-op for the latest group (never in the cache) and when no cache is set.
+	fn touch(&self, cached: &Cached) {
+		if let (Some(cache), Some(token)) = (&self.cache, cached.token) {
+			cache.touch(token, tokio::time::Instant::now());
+		}
+	}
+
+	/// Drop this track's entries from the shared cache, freeing the budget without aborting the
+	/// groups (the track is going away on its own terms). Called when the track is cleared.
+	fn release_cache(&mut self) {
+		if let Some(cache) = &self.cache {
+			for cached in self.groups.iter_mut().flatten() {
+				if let Some(token) = cached.token.take() {
+					cache.remove(token);
+				}
+			}
 		}
 	}
 
@@ -225,6 +287,20 @@ impl TrackProducer {
 		}
 	}
 
+	/// Attach a shared [`Cache`] governing how much of this track's history is retained.
+	///
+	/// Without a cache, the track keeps only its latest group (a superseded group is dropped at
+	/// once). With one, superseded groups are retained in RAM up to the cache's shared byte and
+	/// age budget, evicted least-recently-accessed first. Clone the same [`Cache`] across tracks
+	/// to share one budget. Set this before producing groups; it takes effect on the next group.
+	/// Returns `self` for chaining.
+	pub fn with_cache(self, cache: Cache) -> Self {
+		if let Ok(mut state) = self.state.write() {
+			state.cache = Some(cache);
+		}
+		self
+	}
+
 	/// Create a new group with the given sequence number.
 	pub fn create_group(&mut self, info: Group) -> Result<GroupProducer> {
 		let group = info.produce();
@@ -242,8 +318,11 @@ impl TrackProducer {
 
 		let now = tokio::time::Instant::now();
 		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(group.sequence));
-		state.groups.push_back(Some((group.clone(), now)));
-		state.evict_expired(now);
+		state.groups.push_back(Some(Cached {
+			group: group.clone(),
+			token: None,
+		}));
+		state.retain(now);
 
 		Ok(group)
 	}
@@ -266,8 +345,11 @@ impl TrackProducer {
 		let now = tokio::time::Instant::now();
 		state.duplicates.insert(sequence);
 		state.max_sequence = Some(sequence);
-		state.groups.push_back(Some((group.clone(), now)));
-		state.evict_expired(now);
+		state.groups.push_back(Some(Cached {
+			group: group.clone(),
+			token: None,
+		}));
+		state.retain(now);
 
 		Ok(group)
 	}
@@ -322,6 +404,7 @@ impl TrackProducer {
 	/// own handle and can finish reading it.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
 		let mut guard = self.modify()?;
+		guard.release_cache();
 		guard.abort = Some(err);
 		guard.groups.clear();
 		guard.duplicates.clear();
@@ -408,6 +491,7 @@ impl Drop for TrackProducer {
 		if let Ok(mut state) = self.state.write()
 			&& state.final_sequence.is_none()
 		{
+			state.release_cache();
 			state.groups.clear();
 			state.duplicates.clear();
 		}
@@ -680,6 +764,7 @@ impl TrackConsumer {
 #[cfg(test)]
 mod test {
 	use super::*;
+	use std::time::Duration;
 
 	/// Helper: count non-tombstoned groups in state.
 	fn live_groups(state: &State) -> usize {
@@ -688,104 +773,187 @@ mod test {
 
 	/// Helper: get the sequence number of the first live group.
 	fn first_live_sequence(state: &State) -> u64 {
-		state.groups.iter().flatten().next().unwrap().0.sequence
+		state.groups.iter().flatten().next().unwrap().group.sequence
+	}
+
+	/// A cache large enough to retain many small groups, with no age bound.
+	fn unbounded_cache() -> Cache {
+		Cache::new(cache::Config::default().with_max_bytes(u64::MAX))
 	}
 
 	#[tokio::test]
-	async fn evict_expired_groups() {
-		tokio::time::pause();
-
+	async fn default_keeps_only_latest_group() {
 		let mut producer = Track::new("test").produce();
 
-		// Create 3 groups at time 0.
+		// Without a cache, each appended group supersedes the previous one immediately.
 		producer.append_group().unwrap(); // seq 0
 		producer.append_group().unwrap(); // seq 1
 		producer.append_group().unwrap(); // seq 2
 
-		{
-			let state = producer.state.read();
-			assert_eq!(live_groups(&state), 3);
-			assert_eq!(state.offset, 0);
-		}
-
-		// Advance time past the eviction threshold.
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
-
-		// Append a new group to trigger eviction.
-		producer.append_group().unwrap(); // seq 3
-
-		// Groups 0, 1, 2 are expired but seq 3 (max_sequence) is kept.
-		// Leading tombstones are trimmed, so only seq 3 remains.
-		{
-			let state = producer.state.read();
-			assert_eq!(live_groups(&state), 1);
-			assert_eq!(first_live_sequence(&state), 3);
-			assert_eq!(state.offset, 3);
-			assert!(!state.duplicates.contains(&0));
-			assert!(!state.duplicates.contains(&1));
-			assert!(!state.duplicates.contains(&2));
-			assert!(state.duplicates.contains(&3));
-		}
+		let state = producer.state.read();
+		assert_eq!(live_groups(&state), 1, "only the latest group is retained");
+		assert_eq!(first_live_sequence(&state), 2);
+		assert!(!state.duplicates.contains(&0));
+		assert!(!state.duplicates.contains(&1));
+		assert!(state.duplicates.contains(&2));
 	}
 
 	#[tokio::test]
-	async fn evict_keeps_max_sequence() {
-		tokio::time::pause();
+	async fn cache_retains_history_up_to_bytes() {
+		let mut producer = Track::new("test").produce().with_cache(unbounded_cache());
 
-		let mut producer = Track::new("test").produce();
-		producer.append_group().unwrap(); // seq 0
-
-		// Advance time past threshold.
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
-
-		// Append another group; seq 0 is expired and evicted.
-		producer.append_group().unwrap(); // seq 1
-
-		{
-			let state = producer.state.read();
-			assert_eq!(live_groups(&state), 1);
-			assert_eq!(first_live_sequence(&state), 1);
-			assert_eq!(state.offset, 1);
+		// With a cache, superseded groups stay retained.
+		for _ in 0..4 {
+			let mut g = producer.append_group().unwrap();
+			g.write_frame(bytes::Bytes::from_static(b"x")).unwrap();
 		}
+
+		let state = producer.state.read();
+		assert_eq!(live_groups(&state), 4, "cache retains every group within budget");
 	}
 
 	#[tokio::test]
-	async fn no_eviction_when_fresh() {
+	async fn cache_bytes_evicts_oldest() {
+		let mut producer = Track::new("test")
+			.produce()
+			.with_cache(Cache::new(cache::Config::default().with_max_bytes(20)));
+
+		// Each non-latest group costs 10 bytes; the 20-byte budget holds two of them plus the
+		// (uncounted) latest group.
+		for _ in 0..4 {
+			let mut g = producer.append_group().unwrap();
+			g.write_frame(bytes::Bytes::from(vec![0u8; 10])).unwrap();
+		}
+
+		let state = producer.state.read();
+		// seq 3 is the latest (not in the cache); seq 1 and 2 fit the budget; seq 0 is evicted.
+		assert!(
+			!state.duplicates.contains(&0),
+			"oldest group evicted under byte pressure"
+		);
+		assert!(state.duplicates.contains(&1));
+		assert!(state.duplicates.contains(&2));
+		assert!(state.duplicates.contains(&3));
+	}
+
+	#[tokio::test]
+	async fn cache_age_evicts_by_wall_clock() {
 		tokio::time::pause();
 
-		let mut producer = Track::new("test").produce();
-		producer.append_group().unwrap(); // seq 0
-		producer.append_group().unwrap(); // seq 1
+		let mut producer = Track::new("test").produce().with_cache(Cache::new(
+			cache::Config::default()
+				.with_max_bytes(u64::MAX)
+				.with_max_age(Duration::from_secs(5)),
+		));
+
+		producer.append_group().unwrap(); // seq 0 (will be cached once superseded)
+		producer.append_group().unwrap(); // seq 1, supersedes seq 0
+
+		// seq 0 is cached and fresh: still retained.
+		assert_eq!(live_groups(&producer.state.read()), 2);
+
+		// Advance past max_age, then append to trigger age eviction.
+		tokio::time::advance(Duration::from_secs(6)).await;
 		producer.append_group().unwrap(); // seq 2
 
-		{
-			let state = producer.state.read();
-			assert_eq!(live_groups(&state), 3);
-			assert_eq!(state.offset, 0);
+		let state = producer.state.read();
+		// seq 0 aged out; seq 1 was just superseded (fresh access at its own insert time) and
+		// kept; seq 2 is the latest.
+		assert!(!state.duplicates.contains(&0), "group older than max_age is evicted");
+		assert!(state.duplicates.contains(&2));
+	}
+
+	#[tokio::test]
+	async fn cache_access_keeps_group_alive() {
+		tokio::time::pause();
+
+		let mut producer = Track::new("test").produce().with_cache(Cache::new(
+			cache::Config::default()
+				.with_max_bytes(u64::MAX)
+				.with_max_age(Duration::from_secs(5)),
+		));
+
+		producer.append_group().unwrap(); // seq 0
+		producer.append_group().unwrap(); // seq 1, supersedes seq 0 (now cached)
+
+		let consumer = producer.consume();
+
+		// Keep accessing seq 0 so its last-access stays recent.
+		for _ in 0..4 {
+			tokio::time::advance(Duration::from_secs(2)).await;
+			assert!(consumer.get_group(0).now_or_never().unwrap().unwrap().is_some());
+			producer.append_group().unwrap(); // bump max_sequence + run eviction
 		}
+
+		// Despite total elapsed time well past max_age, seq 0 survived because it was accessed
+		// within every window.
+		assert!(
+			producer.state.read().duplicates.contains(&0),
+			"a recently accessed group is not aged out"
+		);
+	}
+
+	#[tokio::test]
+	async fn shared_cache_one_budget_across_tracks() {
+		let cache = Cache::new(cache::Config::default().with_max_bytes(20));
+
+		let mut track_a = Track::new("a").produce().with_cache(cache.clone());
+		let mut track_b = Track::new("b").produce().with_cache(cache.clone());
+
+		// Fill track A with two 10-byte non-latest groups (seq 0, 1) under the latest (seq 2).
+		// That alone is exactly the 20-byte budget across A.
+		let a0 = {
+			let mut g = track_a.append_group().unwrap(); // seq 0
+			g.write_frame(bytes::Bytes::from(vec![0u8; 10])).unwrap();
+			g
+		};
+		for _ in 0..2 {
+			let mut g = track_a.append_group().unwrap(); // seq 1, then 2
+			g.write_frame(bytes::Bytes::from(vec![0u8; 10])).unwrap();
+		}
+		assert!(!a0.is_aborted(), "A's oldest fits the budget so far");
+
+		// Producing on track B draws from the same 20-byte budget, evicting A's oldest first.
+		for _ in 0..2 {
+			let mut g = track_b.append_group().unwrap();
+			g.write_frame(bytes::Bytes::from(vec![0u8; 10])).unwrap();
+		}
+
+		// A's oldest group was aborted by the shared cache to make room for B's cached group.
+		assert!(a0.is_aborted(), "shared budget evicts across tracks");
+	}
+
+	#[tokio::test]
+	async fn cache_never_evicts_max_sequence() {
+		// A budget of 0 still keeps the latest group: it is never handed to the cache.
+		let mut producer = Track::new("test")
+			.produce()
+			.with_cache(Cache::new(cache::Config::default().with_max_bytes(0)));
+
+		let mut g = producer.append_group().unwrap();
+		g.write_frame(bytes::Bytes::from(vec![0u8; 1024])).unwrap();
+
+		let state = producer.state.read();
+		assert_eq!(live_groups(&state), 1, "the latest group survives a zero budget");
+		assert_eq!(first_live_sequence(&state), 0);
 	}
 
 	#[tokio::test]
 	async fn consumer_skips_evicted_groups() {
-		tokio::time::pause();
-
 		let mut producer = Track::new("test").produce();
 		producer.append_group().unwrap(); // seq 0
 
 		let mut consumer = producer.consume();
 
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
-		producer.append_group().unwrap(); // seq 1
+		producer.append_group().unwrap(); // seq 1, supersedes (and drops) seq 0
 
-		// Group 0 was evicted. Consumer should get group 1.
+		// Group 0 was evicted (latest-only). Consumer should get group 1.
 		let group = consumer.assert_group();
 		assert_eq!(group.sequence, 1);
 	}
 
 	#[tokio::test]
 	async fn out_of_order_max_sequence_at_front() {
-		tokio::time::pause();
-
 		let mut producer = Track::new("test").produce();
 
 		// Arrive out of order: seq 5 first, then 3, then 4.
@@ -793,26 +961,21 @@ mod test {
 		producer.create_group(Group { sequence: 3 }).unwrap();
 		producer.create_group(Group { sequence: 4 }).unwrap();
 
-		// max_sequence = 5, which is at the front of the VecDeque.
+		// max_sequence stays 5; without a cache every non-latest arrival is dropped at once.
 		{
 			let state = producer.state.read();
 			assert_eq!(state.max_sequence, Some(5));
+			assert_eq!(live_groups(&state), 1);
+			assert_eq!(first_live_sequence(&state), 5);
 		}
 
-		// Expire all three groups.
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
-
-		// Append seq 6 (becomes new max_sequence).
+		// Append seq 6 (becomes new max_sequence); seq 5 is now superseded and dropped.
 		producer.append_group().unwrap(); // seq 6
 
-		// Seq 3, 4, 5 are all expired. Seq 5 was the old max_sequence but now 6 is.
-		// All old groups are evicted.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 1);
 			assert_eq!(first_live_sequence(&state), 6);
-			assert!(!state.duplicates.contains(&3));
-			assert!(!state.duplicates.contains(&4));
 			assert!(!state.duplicates.contains(&5));
 			assert!(state.duplicates.contains(&6));
 		}
@@ -820,55 +983,33 @@ mod test {
 
 	#[tokio::test]
 	async fn max_sequence_at_front_blocks_trim() {
-		tokio::time::pause();
+		// With a cache, an out-of-order late arrival behind the protected max_sequence is
+		// retained and a consumer can read through to it.
+		let mut producer = Track::new("test").produce().with_cache(unbounded_cache());
 
-		let mut producer = Track::new("test").produce();
-
-		// Arrive: seq 5, then seq 3.
 		producer.create_group(Group { sequence: 5 }).unwrap();
-
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
-
-		// Seq 3 arrives late; max_sequence is still 5 (at front).
 		producer.create_group(Group { sequence: 3 }).unwrap();
-
-		// Seq 5 is max_sequence (protected). Seq 3 is not expired (just created).
-		// Nothing should be evicted.
-		{
-			let state = producer.state.read();
-			assert_eq!(live_groups(&state), 2);
-			assert_eq!(state.offset, 0);
-		}
-
-		// Expire seq 3 as well.
-		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
-
-		// Seq 2 arrives late, triggering eviction.
 		producer.create_group(Group { sequence: 2 }).unwrap();
 
-		// Seq 5 is still max_sequence (protected, at front, blocks trim).
-		// Seq 3 is expired → tombstoned.
-		// Seq 2 is fresh → kept.
-		// VecDeque: [Some(5), None, Some(2)]. Leading entry is Some, so offset stays.
 		{
 			let state = producer.state.read();
-			assert_eq!(live_groups(&state), 2);
+			// seq 5 is the protected latest; 3 and 2 are cached behind it.
+			assert_eq!(live_groups(&state), 3);
 			assert_eq!(state.offset, 0);
 			assert!(state.duplicates.contains(&5));
-			assert!(!state.duplicates.contains(&3));
+			assert!(state.duplicates.contains(&3));
 			assert!(state.duplicates.contains(&2));
 		}
 
-		// Consumer should still be able to read through the hole.
+		// consume() starts at index 0, first group in arrival order is seq 5.
 		let mut consumer = producer.consume();
-		let group = consumer.assert_group();
-		// consume() starts at index 0, first non-tombstoned group is seq 5.
-		assert_eq!(group.sequence, 5);
+		assert_eq!(consumer.assert_group().sequence, 5);
 	}
 
 	#[tokio::test]
 	async fn abort_clears_cached_groups() {
-		let mut producer = Track::new("test").produce();
+		// A cache retains both groups so we can verify abort drops them and releases the budget.
+		let mut producer = Track::new("test").produce().with_cache(unbounded_cache());
 		producer.append_group().unwrap();
 		producer.append_group().unwrap();
 
@@ -1017,7 +1158,8 @@ mod test {
 
 	#[tokio::test]
 	async fn next_group_returns_arrivals_in_order() {
-		let mut producer = Track::new("test").produce();
+		// A cache keeps both groups retained so the consumer sees the full arrival order.
+		let mut producer = Track::new("test").produce().with_cache(unbounded_cache());
 		let mut consumer = producer.consume();
 
 		// Seq 3 arrives first, then seq 5 — both should be returned in arrival order.
@@ -1043,7 +1185,8 @@ mod test {
 
 	#[tokio::test]
 	async fn recv_group_after_next_group_sees_late_arrivals() {
-		let mut producer = Track::new("test").produce();
+		// A cache retains the late seq 3 behind the protected latest seq 5.
+		let mut producer = Track::new("test").produce().with_cache(unbounded_cache());
 		let mut consumer = producer.consume();
 
 		producer.create_group(Group { sequence: 5 }).unwrap();
@@ -1065,7 +1208,8 @@ mod test {
 
 	#[tokio::test]
 	async fn read_frame_returns_single_frame_per_group() {
-		let mut producer = Track::new("test").produce();
+		// A cache retains both single-frame groups so the consumer can read each in turn.
+		let mut producer = Track::new("test").produce().with_cache(unbounded_cache());
 		let mut consumer = producer.consume();
 
 		producer.write_frame(b"hello".as_slice()).unwrap();
@@ -1112,7 +1256,8 @@ mod test {
 
 	#[tokio::test]
 	async fn read_frame_discards_rest_of_multi_frame_group() {
-		let mut producer = Track::new("test").produce();
+		// A cache retains group 0 so the consumer reads its first frame before group 1.
+		let mut producer = Track::new("test").produce().with_cache(unbounded_cache());
 		let mut consumer = producer.consume();
 
 		// Group 0 has two frames; only the first is returned.


### PR DESCRIPTION
## Summary

Adds a shared RAM LRU cache for groups, configurable at the origin, broadcast, or track level (cascading: track over broadcast over origin). It lets a track retain history beyond its latest group, bounded by a shared byte budget and a wall-clock age.

- **Shared handle.** `Cache` is a cheap, `Arc`-backed clone. Everything attached with the *same* handle draws from one `max_bytes`/`max_age` budget; two distinct `Cache` instances are independent. Clone the handle to share a budget across many tracks/broadcasts/origins.
- **LRU by wall-clock last-access.** The eviction key is the wall-clock instant a group was last *served* (read), not media timestamps or arrival order. A group is evicted when it exceeds `max_age` since last access, or when the shared total exceeds `max_bytes` (least-recently-accessed first). Uses `tokio::time::Instant` so `tokio::time::pause()` drives it deterministically in tests.
- **Default = latest group only.** With no `Cache` attached a track keeps only its current `max_sequence` group; every superseded group is dropped at once. This is the floor: even with a `Cache`, the current max_sequence group is never handed to the cache, so a live subscriber can always grab it.
- **Byte budget, not group count.** The per-handle limit is `max_bytes`, with `max_age` as the time bound.

### How it works

- A group is registered with the shared cache only once it stops being the latest (a newer group supersedes it). The cache holds a `GroupProducer` clone (keeping its frame buffers in RAM) and aborts it with `Error::Old` on eviction, so a parked reader unblocks instead of hanging. The owning track lazily tombstones aborted slots and skips them on read.
- Cross-track eviction is safe re: lock ordering: the track holds its own state lock, then the cache's internal mutex, then `GroupProducer::abort` (the group's own lock). No path takes those in the reverse order.
- A read (`recv_group`/`get_group` handing out a `GroupConsumer`) bumps the group's last-access time in the cache.

### Public API additions (all in `rs/moq-net`)

- `cache::Config` — `#[non_exhaustive]`, `Default` (empty/no-op budget: `max_bytes = 0`, `max_age = Duration::MAX`), with `with_max_bytes` / `with_max_age` setters. Fields `max_bytes: u64`, `max_age: Duration`.
- `Cache` (re-exported flat) — `Cache::new(Config)`, `Cache::is_clone(&self, &Self)`. Cheaply cloneable `Arc`-backed handle.
- `TrackProducer::with_cache(self, Cache) -> Self`
- `BroadcastProducer::with_cache(self, Cache) -> Self` (cascades to created and dynamically-served tracks)
- `OriginProducer::with_cache(self, Cache) -> Self` (cascades to `create_broadcast` and thence its tracks)
- `GroupProducer::cached_size(&self) -> u64` and `GroupProducer::is_aborted(&self) -> bool`

**Breaking / behavior change:** the no-cache default is now *latest-group-only* retention. Previously a track retained groups for a short arrival window. The wire `Track` shape is unchanged; `Cache` is a local-only policy object (nothing new on the wire). Per the Branch Targeting rules this is the kind of change that normally targets `dev` — see the note below.

### Branch targeting note

This worktree was based on `origin/main`, and the change is implemented against `main`'s moq-net model (`Track` / `Broadcast` / `MAX_GROUP_AGE`, `tokio::time::Instant`). `origin/dev` currently carries a divergent moq-net refactor (`TrackInfo` with a wire `cache: Duration` field, `BroadcastInfo`, `web_async::time::Instant`, `TrackDynamic`), so this commit does not rebase cleanly onto `dev` and would need reimplementing against that shape. The PR is opened against `main` to keep the diff clean and reviewable; please retarget or request a `dev` port as preferred. (CLAUDE.md: "when in doubt, target `main`; reviewers will redirect to `dev` if needed.")

### Cross-package sync

The Cross-Package Sync table maps `rs/moq-net` *wire/API* changes to `js/net` and `doc/concept`. This cache is **local-only policy** with **no wire change** (the `Track` shape is untouched, no new framing), so `js/net` and `doc/concept` need nothing. No other rows apply.

## Test plan

- [x] `cargo test -p moq-net --lib` — 358 passed
- [x] `cargo clippy -p moq-net --all-targets` — clean
- [x] `cargo fmt -p moq-net --check` — clean
- [x] `cargo check -p moq-net --no-default-features` — clean
- [x] `cargo check -p moq-relay` — builds
- [ ] `cargo check -p moq-cli` — not run: pulls `moq-video` → a git dependency (`nvidia-video-codec-sdk`) blocked by this environment's egress policy. Unrelated to this change (moq-net is additive).

New tests cover: default keeps only the latest group; a `Cache` retains history up to `max_bytes`; byte pressure evicts the oldest; `max_age` evicts by wall-clock; accessing an old group keeps it alive; a shared handle enforces one budget across two tracks (filling one evicts from the other); the max_sequence group is never evicted even under a zero budget; and the cache cascades origin → broadcast → track (including dynamically-served tracks). Existing track tests that relied on multiple retained groups now attach a `Cache` to reflect the latest-only default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EviJwrDw3XZ9ZgESJGua28

(Written by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EviJwrDw3XZ9ZgESJGua28)_