### PR TITLE
refactor(moq-net): broadcasts own tracks own groups own frames via inherited Arc<Info>

### DIFF
--- a/rs/hang/src/container/frame.rs
+++ b/rs/hang/src/container/frame.rs
@@ -59,7 +59,7 @@ impl Frame {
 			.timescale()
 			.map(|scale| self.timestamp.convert(scale))
 			.transpose()?;
-		let net_frame = moq_net::Frame {
+		let net_frame = moq_net::FrameInfo {
 			size,
 			timestamp: net_timestamp,
 		};

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -385,7 +385,10 @@ mod test {
 	use serde_json::json;
 
 	fn producer(config: Config) -> (Producer<Value>, moq_net::TrackSubscriber) {
-		let track = moq_net::TrackProducer::new("test", None);
+		let track = moq_net::BroadcastInfo::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
 		let consumer = track.subscribe(None);
 		(Producer::new(track, config), consumer)
 	}
@@ -541,7 +544,10 @@ mod test {
 			scte35: Option<u32>,
 		}
 
-		let track = moq_net::TrackProducer::new("test", None);
+		let track = moq_net::BroadcastInfo::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::<Doc>::new(track, Config::default());
 

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -52,6 +52,18 @@ mod test {
 
 	use super::*;
 
+	/// Mint a standalone track for tests via a throwaway broadcast, since tracks are
+	/// born from their broadcast (no public `TrackProducer::new`).
+	fn track_producer(
+		name: impl Into<std::sync::Arc<str>>,
+		info: impl Into<Option<moq_net::TrackInfo>>,
+	) -> moq_net::TrackProducer {
+		moq_net::BroadcastInfo::new()
+			.produce()
+			.create_track(name, info)
+			.unwrap()
+	}
+
 	// Build a base catalog distinguished by an audio rendition named `name`, plus its JSON payload.
 	fn catalog_payload(name: &str) -> (Catalog, String) {
 		let mut catalog = Catalog::default();
@@ -72,7 +84,7 @@ mod test {
 
 	#[test]
 	fn waits_for_pending_catalog_group_payload() {
-		let mut track = moq_net::TrackProducer::new(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
+		let mut track = track_producer(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
 		let mut consumer = Consumer::new(track.subscribe(None));
 		let mut group = track.append_group().expect("catalog group should append");
 
@@ -88,7 +100,7 @@ mod test {
 
 	#[test]
 	fn waits_for_pending_catalog_group_payload_after_track_finish() {
-		let mut track = moq_net::TrackProducer::new(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
+		let mut track = track_producer(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
 		let mut consumer = Consumer::new(track.subscribe(None));
 		let mut group = track.append_group().expect("catalog group should append");
 
@@ -106,7 +118,7 @@ mod test {
 
 	#[test]
 	fn returns_latest_complete_catalog_group() {
-		let mut track = moq_net::TrackProducer::new(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
+		let mut track = track_producer(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
 		let mut consumer = Consumer::new(track.subscribe(None));
 		let waiter = kio::Waiter::noop();
 
@@ -132,7 +144,7 @@ mod test {
 
 	#[test]
 	fn waits_for_newer_pending_group_instead_of_returning_older_ready_group() {
-		let mut track = moq_net::TrackProducer::new(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
+		let mut track = track_producer(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
 		let mut consumer = Consumer::new(track.subscribe(None));
 		let waiter = kio::Waiter::noop();
 
@@ -159,7 +171,7 @@ mod test {
 
 	#[test]
 	fn retained_pending_group_is_superseded_by_newer_group() {
-		let mut track = moq_net::TrackProducer::new(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
+		let mut track = track_producer(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
 		let mut consumer = Consumer::new(track.subscribe(None));
 		let waiter = kio::Waiter::noop();
 
@@ -189,7 +201,7 @@ mod test {
 
 	#[test]
 	fn returns_none_when_empty_track_finishes() {
-		let mut track = moq_net::TrackProducer::new(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
+		let mut track = track_producer(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info());
 		let mut consumer: Consumer = Consumer::new(track.subscribe(None));
 		let waiter = kio::Waiter::noop();
 

--- a/rs/moq-mux/src/codec/h264/export.rs
+++ b/rs/moq-mux/src/codec/h264/export.rs
@@ -285,14 +285,14 @@ mod tests {
 			.unwrap();
 
 		// Group 0 (keyframe-starting group): one IDR frame.
-		let mut g0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut g0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		write_length_prefixed(&mut g0, 0, &[idr]);
 		g0.finish().unwrap();
 
 		// Group 1 (next group): one P-slice. Consumer marks the first frame
 		// of every group as keyframe by protocol invariant, so the exporter
 		// MUST treat both group-starts as keyframes and inject SPS+PPS twice.
-		let mut g1 = track.create_group(moq_net::Group { sequence: 1 }).unwrap();
+		let mut g1 = track.create_group(moq_net::GroupInfo { sequence: 1 }).unwrap();
 		write_length_prefixed(&mut g1, 33_000, &[p_slice]);
 		g1.finish().unwrap();
 		track.finish().unwrap();

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -418,6 +418,18 @@ mod tests {
 
 	use bytes::Bytes;
 
+	/// Mint a standalone track for tests via a throwaway broadcast, since tracks are
+	/// born from their broadcast (no public `TrackProducer::new`).
+	fn track_producer(
+		name: impl Into<std::sync::Arc<str>>,
+		info: impl Into<Option<moq_net::TrackInfo>>,
+	) -> moq_net::TrackProducer {
+		moq_net::BroadcastInfo::new()
+			.produce()
+			.create_track(name, info)
+			.unwrap()
+	}
+
 	fn ts(micros: u64) -> Timestamp {
 		Timestamp::from_micros(micros).unwrap()
 	}
@@ -479,7 +491,7 @@ mod tests {
 
 	/// Write a finished group with explicit sequence and timestamps (Container::Legacy format).
 	fn write_group(track: &mut moq_net::TrackProducer, sequence: u64, timestamps: &[Timestamp]) {
-		let mut group = track.create_group(moq_net::Group { sequence }).unwrap();
+		let mut group = track.create_group(moq_net::GroupInfo { sequence }).unwrap();
 		for &timestamp in timestamps {
 			let frame = Frame {
 				timestamp,
@@ -513,7 +525,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn read_single_group() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -534,7 +546,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn read_multiple_frames_single_group() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -555,7 +567,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn read_multiple_groups_within_latency() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -577,7 +589,7 @@ mod tests {
 	#[tokio::test]
 	async fn latency_skip_delivers_recent_groups() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -585,7 +597,7 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		for f in 0..5u64 {
 			Container::Legacy
 				.write(
@@ -622,14 +634,14 @@ mod tests {
 	#[tokio::test]
 	async fn zero_latency_skips_aggressively() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::ZERO);
 
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -662,14 +674,14 @@ mod tests {
 	#[tokio::test]
 	async fn latency_skip_correctness() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -708,14 +720,14 @@ mod tests {
 	#[tokio::test]
 	async fn groups_delivered_in_sequence_order() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -747,7 +759,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn adjacent_group_flushed_immediately() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -768,7 +780,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn bframes_within_group() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -790,7 +802,7 @@ mod tests {
 	#[tokio::test]
 	async fn empty_track_returns_none() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -811,7 +823,7 @@ mod tests {
 	#[tokio::test]
 	async fn track_closed_with_error() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -836,7 +848,7 @@ mod tests {
 	#[tokio::test]
 	async fn closed_resolves_when_track_ends() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -862,7 +874,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn gap_in_group_sequence_recovery() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -883,7 +895,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn gap_at_start_of_sequence() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -909,7 +921,7 @@ mod tests {
 	/// group + the sequences after it evict, then it resumes).
 	#[tokio::test]
 	async fn evicted_group_with_gap_skips_to_live() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -917,7 +929,7 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: a frame the consumer reads, positioning it there.
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -955,7 +967,7 @@ mod tests {
 	/// higher group is buffered, and the track never finishes.
 	#[tokio::test]
 	async fn missing_sequence_skips_on_live_track() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -984,7 +996,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn frame_timestamp_and_index_decoding() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1007,7 +1019,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn frame_payload_preserved() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1015,7 +1027,7 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
-		let mut group = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group,
@@ -1048,14 +1060,14 @@ mod tests {
 	#[tokio::test]
 	async fn no_infinite_loop_with_buffered_frames() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
 
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1097,7 +1109,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn large_timestamps() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1116,7 +1128,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn set_latency_changes_behavior() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1137,7 +1149,7 @@ mod tests {
 	#[tokio::test]
 	async fn max_timestamp_tracks_through_bframes() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1146,7 +1158,7 @@ mod tests {
 		// to avoid the latency skip and test B-frame timestamp tracking.
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(110));
 
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		for &timestamp in &[ts(0), ts(66_000), ts(33_000)] {
 			Container::Legacy
 				.write(
@@ -1192,7 +1204,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_selects_earliest_group() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1202,7 +1214,7 @@ mod tests {
 		write_group(&mut track, 3, &[ts(0)]);
 		write_group(&mut track, 5, &[ts(150_000)]);
 
-		let mut group7 = track.create_group(moq_net::Group { sequence: 7 }).unwrap();
+		let mut group7 = track.create_group(moq_net::GroupInfo { sequence: 7 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group7,
@@ -1248,14 +1260,14 @@ mod tests {
 	#[tokio::test]
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
-		let _group5 = track.create_group(moq_net::Group { sequence: 5 }).unwrap();
+		let _group5 = track.create_group(moq_net::GroupInfo { sequence: 5 }).unwrap();
 		write_group(&mut track, 7, &[ts(210_000)]);
 		track.finish().unwrap();
 
@@ -1274,7 +1286,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn startup_single_group_mid_stream() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1291,14 +1303,14 @@ mod tests {
 	#[tokio::test]
 	async fn multiple_sequential_latency_skips() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(50));
 
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1330,14 +1342,14 @@ mod tests {
 	#[tokio::test]
 	async fn latency_skip_boundary_exact() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1371,7 +1383,7 @@ mod tests {
 	#[tokio::test]
 	async fn single_newer_group_triggers_skip() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1379,7 +1391,7 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: stalled at ts=0, NOT finished
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1412,7 +1424,7 @@ mod tests {
 	#[tokio::test]
 	async fn single_missing_sequence_near_eof_skips() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1431,14 +1443,14 @@ mod tests {
 
 	#[tokio::test]
 	async fn group_error_skips_to_next() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		group0.abort(moq_net::Error::Cancel).unwrap();
 
 		write_group(&mut track, 1, &[ts(30_000)]);
@@ -1451,7 +1463,7 @@ mod tests {
 	#[tokio::test]
 	async fn track_finishes_while_reading() {
 		tokio::time::pause();
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1483,14 +1495,14 @@ mod tests {
 
 	#[tokio::test]
 	async fn empty_group_advances() {
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		group0.finish().unwrap();
 
 		write_group(&mut track, 1, &[ts(30_000)]);
@@ -1506,7 +1518,7 @@ mod tests {
 	async fn video_container_legacy() {
 		tokio::time::pause();
 
-		let mut track = moq_net::TrackProducer::new(
+		let mut track = track_producer(
 			"video",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -1514,7 +1526,7 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		// Write frames using Container::Legacy encoding
-		let mut group = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		for i in 0..3u64 {
 			let frame = Frame {
 				timestamp: ts(i * 33_333),
@@ -1551,17 +1563,17 @@ mod tests {
 		tokio::time::pause();
 		// DurationWire is a test-only container that doesn't stamp moq_net frame
 		// timestamps; leave the track untimed so model-layer validation matches.
-		let mut track = moq_net::TrackProducer::new("test", None);
+		let mut track = track_producer("test", None);
 		let consumer_track = track.subscribe(None);
 		// Latency dwarfs the gap, so only duration coverage can trigger the skip.
 		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
 
 		// Group 0: one frame at ts=0 lasting 33ms, never finished.
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		write_duration_frame(&mut group0, ts(0), ts(33_000));
 
 		// Group 1: finished, starts exactly where group 0's frame ends.
-		let mut group1 = track.create_group(moq_net::Group { sequence: 1 }).unwrap();
+		let mut group1 = track.create_group(moq_net::GroupInfo { sequence: 1 }).unwrap();
 		write_duration_frame(&mut group1, ts(33_000), ts(33_000));
 		group1.finish().unwrap();
 
@@ -1592,16 +1604,16 @@ mod tests {
 	async fn duration_below_gap_does_not_skip() {
 		tokio::time::pause();
 		// DurationWire is untimed at the moq_net frame layer.
-		let mut track = moq_net::TrackProducer::new("test", None);
+		let mut track = track_producer("test", None);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
 
 		// Group 0: frame at ts=0 lasting only 10ms, far short of group 1 at 33ms.
-		let mut group0 = track.create_group(moq_net::Group { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
 		write_duration_frame(&mut group0, ts(0), ts(10_000));
 
 		// Group 1: finished at 33ms.
-		let mut group1 = track.create_group(moq_net::Group { sequence: 1 }).unwrap();
+		let mut group1 = track.create_group(moq_net::GroupInfo { sequence: 1 }).unwrap();
 		write_duration_frame(&mut group1, ts(33_000), ts(33_000));
 		group1.finish().unwrap();
 		track.finish().unwrap();

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -599,7 +599,7 @@ impl Import {
 					prev.finish()?;
 				}
 				match track.pending_sequence.take() {
-					Some(sequence) => track.track.create_group(moq_net::Group { sequence })?,
+					Some(sequence) => track.track.create_group(moq_net::GroupInfo { sequence })?,
 					None => track.track.append_group()?,
 				}
 			} else {
@@ -610,7 +610,7 @@ impl Import {
 			// in the track's native timescale. The relay reads it off the wire; the
 			// consumer still drives playback from the fragment's internal timing.
 			let timestamp = min_timestamp.ok_or(Error::MissingTrun)?;
-			let mut frame = g.create_frame(moq_net::Frame {
+			let mut frame = g.create_frame(moq_net::FrameInfo {
 				size: fragment_bytes.len() as u64,
 				timestamp: Some(timestamp),
 			})?;

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -90,7 +90,7 @@ impl<C: Container> Producer<C> {
 				return Err(super::MissingKeyframe.into());
 			}
 			self.group = Some(match self.pending_sequence.take() {
-				Some(sequence) => self.inner.create_group(moq_net::Group { sequence })?,
+				Some(sequence) => self.inner.create_group(moq_net::GroupInfo { sequence })?,
 				None => self.inner.append_group()?,
 			});
 		}
@@ -208,6 +208,18 @@ mod tests {
 	use crate::catalog::hang::Container;
 	use moq_net::Timestamp;
 
+	/// Mint a standalone track for tests via a throwaway broadcast, since tracks are
+	/// born from their broadcast (no public `TrackProducer::new`).
+	fn track_producer(
+		name: impl Into<std::sync::Arc<str>>,
+		info: impl Into<Option<moq_net::TrackInfo>>,
+	) -> moq_net::TrackProducer {
+		moq_net::BroadcastInfo::new()
+			.produce()
+			.create_track(name, info)
+			.unwrap()
+	}
+
 	fn frame(timestamp_us: u64, keyframe: bool) -> Frame {
 		Frame {
 			timestamp: Timestamp::from_micros(timestamp_us).unwrap(),
@@ -233,7 +245,7 @@ mod tests {
 	/// Explicit keyframe closes the current group and starts a new one.
 	#[tokio::test]
 	async fn keyframe_closes_group_immediately() {
-		let track = moq_net::TrackProducer::new(
+		let track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -252,7 +264,7 @@ mod tests {
 	/// `finish_group()` flushes the current group immediately; the next write must be a keyframe.
 	#[tokio::test]
 	async fn finish_group_closes_immediately() {
-		let track = moq_net::TrackProducer::new(
+		let track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -271,7 +283,7 @@ mod tests {
 	/// Writing a non-keyframe with no open group returns MissingKeyframe.
 	#[test]
 	fn first_frame_must_be_keyframe() {
-		let track = moq_net::TrackProducer::new(
+		let track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -293,7 +305,7 @@ mod tests {
 	/// `seek(n)` opens the next group at sequence `n`.
 	#[tokio::test]
 	async fn seek_uses_explicit_sequence() {
-		let track = moq_net::TrackProducer::new(
+		let track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -311,7 +323,7 @@ mod tests {
 	/// `seek` is consumed on the next group creation; subsequent groups auto-increment from there.
 	#[tokio::test]
 	async fn seek_clears_pending_after_use() {
-		let track = moq_net::TrackProducer::new(
+		let track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);
@@ -352,7 +364,7 @@ mod tests {
 	/// group's last frame, without buffering an extra frame.
 	#[tokio::test]
 	async fn keyframe_backfills_last_frame_duration() {
-		let track = moq_net::TrackProducer::new(
+		let track = track_producer(
 			"test",
 			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
 		);

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -136,7 +136,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	let mut group = track.append_group().expect("failed to append group");
 	for &us in &frames {
 		let payload = format!("frame@{us}").into_bytes();
-		let frame = moq_native::moq_net::Frame {
+		let frame = moq_native::moq_net::FrameInfo {
 			size: payload.len() as u64,
 			timestamp: Some(Timestamp::new(us, Timescale::MICRO).unwrap()),
 		};
@@ -252,7 +252,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	let mut group = track.append_group().expect("failed to append group"); // seq 0
 	for &us in &frames {
 		let payload = format!("frame@{us}").into_bytes();
-		let frame = moq_native::moq_net::Frame {
+		let frame = moq_native::moq_net::FrameInfo {
 			size: payload.len() as u64,
 			timestamp: Some(Timestamp::new(us, Timescale::MICRO).unwrap()),
 		};
@@ -357,8 +357,8 @@ async fn broadcast_moq_lite_05_fetch_webtransport() {
 async fn lite05_fetch_during_subscribe(scheme: &str) {
 	use moq_native::moq_net::{Timescale, Timestamp};
 
-	fn timestamped_frame(us: u64, payload: &str) -> moq_net::Frame {
-		moq_net::Frame {
+	fn timestamped_frame(us: u64, payload: &str) -> moq_net::FrameInfo {
+		moq_net::FrameInfo {
 			size: payload.len() as u64,
 			timestamp: Some(Timestamp::new(us, Timescale::MICRO).unwrap()),
 		}

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, hash_map::Entry};
 use std::sync::Arc;
 
 use crate::{
-	BroadcastDynamic, BroadcastInfo, Error, Frame, FrameProducer, Group, GroupProducer, OriginProducer, OriginPublish,
-	Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer, TrackRequest,
+	BroadcastDynamic, BroadcastInfo, Error, FrameInfo, FrameProducer, GroupInfo, GroupProducer, OriginProducer,
+	OriginPublish, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer, TrackRequest,
 	coding::{Reader, Stream},
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
 	model::BroadcastProducer,
@@ -521,8 +521,18 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	fn start_publish(&mut self, msg: &ietf::Publish<'_>) -> Result<(), Error> {
 		let request_id = msg.request_id;
+		let namespace = msg.track_namespace.to_owned();
 
-		let track = TrackProducer::new(msg.track_name.to_string(), None);
+		// Announce the broadcast first so the track is born from it (inheriting the
+		// broadcast's Arc<BroadcastInfo>). Undo the announce on any error path below.
+		let mut broadcast = self.start_announce(namespace.clone())?;
+		let track = match broadcast.create_track(msg.track_name.to_string(), None) {
+			Ok(track) => track,
+			Err(err) => {
+				let _ = self.stop_announce(namespace);
+				return Err(err);
+			}
+		};
 
 		let abs = self.origin.absolute(&msg.track_namespace).to_owned();
 		let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(&msg.track_name));
@@ -536,7 +546,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					stats: track_stats,
 				});
 			}
-			Entry::Occupied(_) => return Err(Error::Duplicate),
+			Entry::Occupied(_) => {
+				drop(state);
+				let _ = self.stop_announce(namespace);
+				return Err(Error::Duplicate);
+			}
 		};
 
 		match state.aliases.entry(msg.track_alias) {
@@ -545,14 +559,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 			Entry::Occupied(_) => {
 				state.subscribes.remove(&request_id);
+				drop(state);
+				let _ = self.stop_announce(namespace);
 				return Err(Error::Duplicate);
 			}
 		}
-		state.publishes.insert(request_id, msg.track_namespace.to_owned());
+		state.publishes.insert(request_id, namespace);
 		drop(state);
-
-		let mut broadcast = self.start_announce(msg.track_namespace.to_owned())?;
-		broadcast.insert_track(&track)?;
 
 		Ok(())
 	}
@@ -760,7 +773,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			};
 			let track = state.subscribes.get_mut(&request_id).ok_or(Error::NotFound)?;
 
-			let group_info = Group {
+			let group_info = GroupInfo {
 				sequence: group.group_id,
 			};
 			let producer = track.producer.create_group(group_info)?;
@@ -814,7 +827,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			if size == 0 {
 				let status: u64 = stream.decode().await?;
 				if status == 0 {
-					let mut frame = producer.create_frame(Frame {
+					let mut frame = producer.create_frame(FrameInfo {
 						size: 0,
 						timestamp: None,
 					})?;
@@ -828,7 +841,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			} else {
 				// `create_frame` is the allocation chokepoint and rejects an oversized
 				// `size` before allocating, so no pre-check is needed.
-				let mut frame = producer.create_frame(Frame { size, timestamp: None })?;
+				let mut frame = producer.create_frame(FrameInfo { size, timestamp: None })?;
 				track_stats.frame();
 
 				if let Err(err) = self.run_frame(stream, frame.clone(), &track_stats).await {

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -9,9 +9,9 @@
 //! The API is built around Producer/Consumer pairs, with the hierarchy:
 //! - [Origin]: A collection of [BroadcastConsumer]s, produced by one or more [Session]s.
 //! - [BroadcastConsumer]: A collection of [TrackConsumer]s, produced by a single publisher.
-//! - [TrackConsumer]: A collection of [Group]s, delivered out-of-order until expired.
-//! - [Group]: A collection of [Frame]s, delivered in order until cancelled.
-//! - [Frame]: Chunks of data with an upfront size.
+//! - [TrackConsumer]: A collection of [GroupInfo]s, delivered out-of-order until expired.
+//! - [GroupInfo]: A collection of [FrameInfo]s, delivered in order until cancelled.
+//! - [FrameInfo]: Chunks of data with an upfront size.
 //!
 //! ## Compatibility
 //! The API exposes the intersection of features supported by both protocols, intentionally

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -11,9 +11,10 @@ use futures::{StreamExt, stream::FuturesUnordered};
 use crate::util::{MaybeBoxedExt, MaybeSendBox};
 
 use crate::{
-	AsPath, BandwidthProducer, BroadcastDynamic, BroadcastInfo, Compression, Error, Frame, FrameProducer, Group,
-	GroupProducer, GroupRequest, MAX_FRAME_SIZE, OriginProducer, OriginPublish, Path, PathOwned, StatsHandle,
-	SubscriberStats, SubscriberTrack, Subscription, Timescale, Timestamp, TrackInfo, TrackProducer, TrackRequest,
+	AsPath, BandwidthProducer, BroadcastDynamic, BroadcastInfo, Compression, Error, FrameInfo, FrameProducer,
+	GroupInfo, GroupProducer, GroupRequest, MAX_FRAME_SIZE, OriginProducer, OriginPublish, Path, PathOwned,
+	StatsHandle, SubscriberStats, SubscriberTrack, Subscription, Timescale, Timestamp, TrackInfo, TrackProducer,
+	TrackRequest,
 	coding::{Reader, Stream},
 	lite,
 };
@@ -569,7 +570,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let mut subs = self.subscribes.lock();
 			let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
 
-			let group_info = Group { sequence: hdr.sequence };
+			let group_info = GroupInfo { sequence: hdr.sequence };
 			let group = entry.producer.create_group(group_info)?;
 			(
 				group,
@@ -647,7 +648,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				Compression::None => {
 					// `create_frame` is the allocation chokepoint and rejects an
 					// oversized `size` before allocating, so no pre-check is needed.
-					let mut frame = group.create_frame(Frame { size, timestamp })?;
+					let mut frame = group.create_frame(FrameInfo { size, timestamp })?;
 					track_stats.frame();
 
 					if let Err(err) = self.run_frame(stream, &mut frame, &track_stats).await {
@@ -671,7 +672,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					track_stats.bytes(size);
 
 					let payload = compression.decompress(&packed)?;
-					let mut frame = group.create_frame(Frame {
+					let mut frame = group.create_frame(FrameInfo {
 						size: payload.len() as u64,
 						timestamp,
 					})?;

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -129,11 +129,14 @@ impl BroadcastState {
 
 /// Manages tracks within a broadcast.
 ///
-/// Insert tracks statically with [Self::insert_track] / [Self::create_track],
-/// or handle on-demand requests via [Self::dynamic].
+/// Create tracks up front with [Self::create_track], reserve a name to fill in
+/// later with [Self::reserve_track], or handle on-demand consumer requests via
+/// [Self::dynamic].
 #[derive(Clone)]
 pub struct BroadcastProducer {
-	info: BroadcastInfo,
+	// Held behind an Arc so each track born from this broadcast can inherit a shared
+	// handle (threaded down by [`Self::create_track`] / [`Self::reserve_track`]).
+	info: Arc<BroadcastInfo>,
 	state: kio::Producer<BroadcastState>,
 }
 
@@ -141,25 +144,13 @@ impl BroadcastProducer {
 	/// Create a producer for the given broadcast metadata. Prefer [`BroadcastInfo::produce`].
 	pub fn new(info: BroadcastInfo) -> Self {
 		Self {
-			info,
+			info: Arc::new(info),
 			state: Default::default(),
 		}
 	}
 
 	pub fn info(&self) -> &BroadcastInfo {
 		&self.info
-	}
-
-	/// Insert a track into the lookup, returning an error on duplicate.
-	///
-	/// Stores a weak handle to the track. The caller (or the owner of the
-	/// track's [`TrackProducer`]) is responsible for keeping the track alive;
-	/// when all producers are dropped, the entry becomes closed and is
-	/// eventually evicted.
-	pub fn insert_track(&mut self, track: impl crate::Consume<TrackConsumer>) -> Result<(), Error> {
-		let track = track.consume();
-		let mut state = BroadcastState::modify(&self.state)?;
-		state.insert_track(track.weak())
 	}
 
 	/// Remove a track from the lookup.
@@ -179,7 +170,7 @@ impl BroadcastProducer {
 		info: impl Into<Option<TrackInfo>>,
 	) -> Result<TrackProducer, Error> {
 		let info = info.into().unwrap_or_default();
-		let track = TrackProducer::new(name, info);
+		let track = TrackProducer::new(self.info.clone(), name, info);
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(track.weak())?;
 		drop(state);
@@ -194,7 +185,7 @@ impl BroadcastProducer {
 	/// inspected the media, the same shape as a consumer-driven
 	/// [`BroadcastDynamic::requested_track`].
 	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<TrackRequest, Error> {
-		let request = TrackRequest::new(name);
+		let request = TrackRequest::new(self.info.clone(), name);
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(request.weak())?;
 		drop(state);
@@ -251,10 +242,6 @@ impl BroadcastProducer {
 	) -> TrackProducer {
 		self.create_track(name, info).expect("should not have errored")
 	}
-
-	pub fn assert_insert_track(&mut self, track: impl crate::Consume<TrackConsumer>) {
-		self.insert_track(track).expect("should not have errored")
-	}
 }
 
 /// Handles on-demand track creation for a broadcast.
@@ -265,7 +252,7 @@ impl BroadcastProducer {
 /// [`TrackRequest::reject`]s it. Dropped when no longer needed; pending requests
 /// are automatically aborted.
 pub struct BroadcastDynamic {
-	info: BroadcastInfo,
+	info: Arc<BroadcastInfo>,
 	state: kio::Producer<BroadcastState>,
 }
 
@@ -287,7 +274,7 @@ impl Clone for BroadcastDynamic {
 }
 
 impl BroadcastDynamic {
-	fn new(info: BroadcastInfo, state: kio::Producer<BroadcastState>) -> Self {
+	fn new(info: Arc<BroadcastInfo>, state: kio::Producer<BroadcastState>) -> Self {
 		if let Ok(mut state) = state.write() {
 			// If the broadcast is already closed, we can't handle any new requests.
 			state.dynamic += 1;
@@ -388,7 +375,7 @@ impl BroadcastDynamic {
 /// Subscribe to arbitrary broadcast/tracks.
 #[derive(Clone)]
 pub struct BroadcastConsumer {
-	info: BroadcastInfo,
+	info: Arc<BroadcastInfo>,
 	state: kio::Consumer<BroadcastState>,
 }
 
@@ -426,7 +413,7 @@ impl BroadcastConsumer {
 		// Allocate the name once and share the same Arc across the request, the
 		// requests map, and the FIFO order.
 		let name: Arc<str> = name.into();
-		let request = TrackRequest::new(name.clone());
+		let request = TrackRequest::new(self.info.clone(), name.clone());
 		let consumer = request.consume();
 
 		state.requests.insert(name.clone(), request);
@@ -495,10 +482,9 @@ mod test {
 	#[tokio::test]
 	async fn insert() {
 		let mut producer = BroadcastInfo::new().produce();
-		let mut track1 = TrackProducer::new("track1", None);
 
-		// Make sure we can insert before a consumer is created.
-		producer.assert_insert_track(&track1);
+		// Create the track before any consumer exists.
+		let mut track1 = producer.assert_create_track("track1", None);
 		track1.append_group().unwrap();
 
 		let consumer = producer.consume();
@@ -507,8 +493,7 @@ mod test {
 		let mut track1_sub = consumer.track("track1").unwrap().subscribe(None).await.unwrap();
 		track1_sub.assert_group();
 
-		let mut track2 = TrackProducer::new("track2", None);
-		producer.assert_insert_track(&track2);
+		let mut track2 = producer.assert_create_track("track2", None);
 
 		let consumer2 = producer.consume();
 		let mut track2_consumer = consumer2.track("track2").unwrap().subscribe(None).await.unwrap();

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -25,7 +25,7 @@ pub(crate) const MAX_FRAME_SIZE: u64 = 32 * 1024 * 1024;
 ///
 /// Note that this is just the header.
 /// You use [FrameProducer] and [FrameConsumer] to deal with the frame payload, potentially chunked.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FrameInfo {
 	/// Total payload size in bytes. Declared up front so consumers can preallocate.
@@ -44,13 +44,13 @@ impl FrameInfo {
 	/// Create an unparented producer for the frame.
 	///
 	/// Test-only: real frames are constructed via
-	/// [`crate::GroupProducer::create_frame`], which threads the parent group's
-	/// `Arc<GroupInfo>` down and validates the timestamp against the track's
+	/// [`crate::GroupProducer::create_frame`], which threads the parent
+	/// [`GroupInfo`] down and validates the timestamp against the track's
 	/// timescale. This helper defaults the parent group for in-crate tests. Returns
 	/// [`Error::FrameTooLarge`] if [`FrameInfo::size`] exceeds [`MAX_FRAME_SIZE`].
 	#[cfg(test)]
 	pub(crate) fn produce(self) -> Result<FrameProducer> {
-		FrameProducer::new(self, std::sync::Arc::new(GroupInfo { sequence: 0 }))
+		FrameProducer::new(self, GroupInfo { sequence: 0 })
 	}
 }
 
@@ -185,9 +185,9 @@ struct FrameState {
 pub struct FrameProducer {
 	info: FrameInfo,
 	// The parent group's info, inherited from [`crate::GroupProducer::create_frame`]
-	// so the ownership chain reaches the leaf. Carried for identity/debugging; the
-	// timestamp-vs-timescale check lives on the group.
-	group: Arc<GroupInfo>,
+	// so the ownership chain reaches the leaf. A small `Copy` value; carried for
+	// identity/debugging (the timestamp-vs-timescale check lives on the group).
+	group: GroupInfo,
 	state: kio::Producer<FrameState>,
 	buf: FrameBuf,
 }
@@ -206,7 +206,7 @@ impl FrameProducer {
 	/// The single allocation chokepoint: rejects a frame whose declared
 	/// [`FrameInfo::size`] exceeds [`MAX_FRAME_SIZE`] with [`Error::FrameTooLarge`]
 	/// before allocating the (untrusted) buffer.
-	pub(crate) fn new(info: FrameInfo, group: Arc<GroupInfo>) -> Result<Self> {
+	pub(crate) fn new(info: FrameInfo, group: GroupInfo) -> Result<Self> {
 		if info.size > MAX_FRAME_SIZE {
 			return Err(Error::FrameTooLarge);
 		}
@@ -263,7 +263,7 @@ impl FrameProducer {
 	/// Create a new consumer for the frame.
 	pub fn consume(&self) -> FrameConsumer {
 		FrameConsumer {
-			info: self.info.clone(),
+			info: self.info,
 			state: self.state.consume(),
 			buf: self.buf.clone(),
 			read_idx: 0,
@@ -339,8 +339,8 @@ unsafe impl BufMut for FrameProducer {
 impl Clone for FrameProducer {
 	fn clone(&self) -> Self {
 		Self {
-			info: self.info.clone(),
-			group: self.group.clone(),
+			info: self.info,
+			group: self.group,
 			state: self.state.clone(),
 			buf: self.buf.clone(),
 		}

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -5,14 +5,14 @@ use std::task::{Poll, ready};
 use bytes::buf::UninitSlice;
 use bytes::{BufMut, Bytes};
 
-use crate::{Error, Result, Timestamp};
+use crate::{Error, GroupInfo, Result, Timestamp};
 
 /// Maximum payload size accepted for a single frame.
 ///
 /// The receive path preallocates a buffer from the declared frame size, so an
 /// untrusted peer could otherwise request a multi-gigabyte allocation with a
 /// single varint. [`FrameProducer::new`] enforces this for every frame: it's the
-/// sole allocation chokepoint (reached via [`Frame::produce`] and
+/// sole allocation chokepoint (reached via [`FrameInfo::produce`] and
 /// [`crate::GroupProducer::create_frame`]) and rejects an oversized declared size
 /// with [`Error::FrameTooLarge`] before allocating.
 ///
@@ -27,7 +27,7 @@ pub(crate) const MAX_FRAME_SIZE: u64 = 32 * 1024 * 1024;
 /// You use [FrameProducer] and [FrameConsumer] to deal with the frame payload, potentially chunked.
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Frame {
+pub struct FrameInfo {
 	/// Total payload size in bytes. Declared up front so consumers can preallocate.
 	pub size: u64,
 	/// Presentation timestamp in the parent track's timescale.
@@ -40,19 +40,21 @@ pub struct Frame {
 	pub timestamp: Option<Timestamp>,
 }
 
-impl Frame {
-	/// Create a producer for the frame.
+impl FrameInfo {
+	/// Create an unparented producer for the frame.
 	///
-	/// Crate-private: frames are only constructed via
-	/// [`crate::GroupProducer::create_frame`], which validates the timestamp
-	/// against the parent track's timescale. Returns [`Error::FrameTooLarge`] if the
-	/// declared [`Frame::size`] exceeds [`MAX_FRAME_SIZE`].
+	/// Test-only: real frames are constructed via
+	/// [`crate::GroupProducer::create_frame`], which threads the parent group's
+	/// `Arc<GroupInfo>` down and validates the timestamp against the track's
+	/// timescale. This helper defaults the parent group for in-crate tests. Returns
+	/// [`Error::FrameTooLarge`] if [`FrameInfo::size`] exceeds [`MAX_FRAME_SIZE`].
+	#[cfg(test)]
 	pub(crate) fn produce(self) -> Result<FrameProducer> {
-		FrameProducer::new(self)
+		FrameProducer::new(self, std::sync::Arc::new(GroupInfo { sequence: 0 }))
 	}
 }
 
-impl From<usize> for Frame {
+impl From<usize> for FrameInfo {
 	fn from(size: usize) -> Self {
 		Self {
 			size: size as u64,
@@ -61,13 +63,13 @@ impl From<usize> for Frame {
 	}
 }
 
-impl From<u64> for Frame {
+impl From<u64> for FrameInfo {
 	fn from(size: u64) -> Self {
 		Self { size, timestamp: None }
 	}
 }
 
-impl From<u32> for Frame {
+impl From<u32> for FrameInfo {
 	fn from(size: u32) -> Self {
 		Self {
 			size: size as u64,
@@ -76,7 +78,7 @@ impl From<u32> for Frame {
 	}
 }
 
-impl From<u16> for Frame {
+impl From<u16> for FrameInfo {
 	fn from(size: u16) -> Self {
 		Self {
 			size: size as u64,
@@ -175,19 +177,23 @@ struct FrameState {
 
 /// Writes a frame's payload in one or more chunks.
 ///
-/// The total bytes written must exactly match [Frame::size].
+/// The total bytes written must exactly match [FrameInfo::size].
 /// Call [Self::finish] after writing all bytes to verify correctness.
 ///
 /// Implements [BufMut] so the receive path can write directly into the
 /// pre-allocated buffer (e.g. via `tokio::io::AsyncReadExt::read_buf`).
 pub struct FrameProducer {
-	info: Frame,
+	info: FrameInfo,
+	// The parent group's info, inherited from [`crate::GroupProducer::create_frame`]
+	// so the ownership chain reaches the leaf. Carried for identity/debugging; the
+	// timestamp-vs-timescale check lives on the group.
+	group: Arc<GroupInfo>,
 	state: kio::Producer<FrameState>,
 	buf: FrameBuf,
 }
 
 impl std::ops::Deref for FrameProducer {
-	type Target = Frame;
+	type Target = FrameInfo;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
@@ -198,18 +204,24 @@ impl FrameProducer {
 	/// Create a new frame producer for the given frame header.
 	///
 	/// The single allocation chokepoint: rejects a frame whose declared
-	/// [`Frame::size`] exceeds [`MAX_FRAME_SIZE`] with [`Error::FrameTooLarge`]
+	/// [`FrameInfo::size`] exceeds [`MAX_FRAME_SIZE`] with [`Error::FrameTooLarge`]
 	/// before allocating the (untrusted) buffer.
-	pub(crate) fn new(info: Frame) -> Result<Self> {
+	pub(crate) fn new(info: FrameInfo, group: Arc<GroupInfo>) -> Result<Self> {
 		if info.size > MAX_FRAME_SIZE {
 			return Err(Error::FrameTooLarge);
 		}
 		let buf = FrameBuf::new(info.size as usize);
 		Ok(Self {
 			info,
+			group,
 			state: kio::Producer::new(FrameState::default()),
 			buf,
 		})
+	}
+
+	/// The parent group this frame belongs to.
+	pub fn group(&self) -> &GroupInfo {
+		&self.group
 	}
 
 	/// Write a chunk of data to the frame.
@@ -228,7 +240,7 @@ impl FrameProducer {
 
 	/// Verify that all bytes have been written.
 	///
-	/// Returns [Error::WrongSize] if the bytes written don't match [Frame::size].
+	/// Returns [Error::WrongSize] if the bytes written don't match [FrameInfo::size].
 	pub fn finish(&mut self) -> Result<()> {
 		let written = self.buf.written(Ordering::Acquire);
 		if written != self.buf.capacity() {
@@ -328,6 +340,7 @@ impl Clone for FrameProducer {
 	fn clone(&self) -> Self {
 		Self {
 			info: self.info.clone(),
+			group: self.group.clone(),
 			state: self.state.clone(),
 			buf: self.buf.clone(),
 		}
@@ -337,7 +350,7 @@ impl Clone for FrameProducer {
 /// Used to consume a frame's worth of data, streaming as bytes arrive.
 #[derive(Clone)]
 pub struct FrameConsumer {
-	info: Frame,
+	info: FrameInfo,
 	state: kio::Consumer<FrameState>,
 	buf: FrameBuf,
 	// Byte offset into the buffer; cloned consumers inherit this offset and
@@ -346,7 +359,7 @@ pub struct FrameConsumer {
 }
 
 impl std::ops::Deref for FrameConsumer {
-	type Target = Frame;
+	type Target = FrameInfo;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
@@ -474,7 +487,7 @@ mod test {
 
 	#[test]
 	fn single_chunk_roundtrip() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 5,
 			timestamp: None,
 		}
@@ -490,7 +503,7 @@ mod test {
 
 	#[test]
 	fn multi_chunk_read_all() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 10,
 			timestamp: None,
 		}
@@ -507,7 +520,7 @@ mod test {
 
 	#[test]
 	fn read_chunk_sequential() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 10,
 			timestamp: None,
 		}
@@ -531,7 +544,7 @@ mod test {
 
 	#[test]
 	fn read_all_chunks() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 10,
 			timestamp: None,
 		}
@@ -549,7 +562,7 @@ mod test {
 
 	#[test]
 	fn finish_checks_remaining() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 5,
 			timestamp: None,
 		}
@@ -562,7 +575,7 @@ mod test {
 
 	#[test]
 	fn write_too_many_bytes() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 3,
 			timestamp: None,
 		}
@@ -576,7 +589,7 @@ mod test {
 	fn rejects_oversized_frame() {
 		// The allocation chokepoint refuses an oversized declared size before any
 		// buffer is allocated, so a single varint can't request a huge allocation.
-		let result = Frame {
+		let result = FrameInfo {
 			size: MAX_FRAME_SIZE + 1,
 			timestamp: None,
 		}
@@ -586,7 +599,7 @@ mod test {
 
 	#[test]
 	fn abort_propagates() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 5,
 			timestamp: None,
 		}
@@ -601,7 +614,7 @@ mod test {
 
 	#[test]
 	fn empty_frame() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 0,
 			timestamp: None,
 		}
@@ -616,7 +629,7 @@ mod test {
 
 	#[tokio::test]
 	async fn pending_then_ready() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 5,
 			timestamp: None,
 		}
@@ -637,7 +650,7 @@ mod test {
 	#[test]
 	fn buf_mut_roundtrip() {
 		// Exercise the BufMut path that the receive loop uses via `read_buf`.
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 12,
 			timestamp: None,
 		}
@@ -658,7 +671,7 @@ mod test {
 	#[test]
 	#[should_panic(expected = "advance_mut past frame.size")]
 	fn buf_mut_advance_past_capacity_panics() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 4,
 			timestamp: None,
 		}
@@ -670,7 +683,7 @@ mod test {
 
 	#[test]
 	fn read_chunk_streams_partial_writes() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 6,
 			timestamp: None,
 		}
@@ -695,7 +708,7 @@ mod test {
 
 	#[test]
 	fn cloned_consumer_independent_cursor() {
-		let mut producer = Frame {
+		let mut producer = FrameInfo {
 			size: 10,
 			timestamp: None,
 		}

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -8,7 +8,6 @@
 //!
 //! The stream is closed with [Error] when all writers or readers are dropped.
 use std::collections::VecDeque;
-use std::sync::Arc;
 use std::task::{Poll, ready};
 
 use bytes::Bytes;
@@ -28,7 +27,7 @@ const MAX_GROUP_FRAMES: usize = 1024;
 /// A group contains a sequence number because they can arrive out of order.
 ///
 /// You can use [crate::TrackProducer::append_group] if you just want to +1 the sequence number.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GroupInfo {
 	/// Per-track sequence number used to detect ordering and gaps. Higher numbers
@@ -44,7 +43,7 @@ impl GroupInfo {
 	/// tests that don't exercise timestamps.
 	#[cfg(test)]
 	pub(crate) fn produce(self) -> GroupProducer {
-		GroupProducer::new(self, Arc::new(TrackInfo::default()))
+		GroupProducer::new(self, TrackInfo::default())
 	}
 }
 
@@ -147,16 +146,16 @@ pub struct GroupProducer {
 	// Mutable stream state.
 	state: kio::Producer<GroupState>,
 
-	// The group header containing the sequence number. Held behind an Arc so each
-	// frame can inherit a shared handle (see [`Self::create_frame`]).
-	info: Arc<GroupInfo>,
+	// The group header containing the sequence number. A small `Copy` value,
+	// inherited by each frame (see [`Self::create_frame`]).
+	info: GroupInfo,
 
 	// The parent track's info, inherited rather than passed piecemeal. Its
 	// `timescale` drives per-frame timestamp validation in [`Self::append_frame`]:
 	// `None` means frames must have `FrameInfo::timestamp = None`; `Some(scale)`
 	// requires `FrameInfo::timestamp = Some(ts)` with `ts.scale() == scale`.
-	// Threaded down by [`crate::TrackProducer::create_group`] / `append_group`.
-	track: Arc<TrackInfo>,
+	// Threaded down by value from [`crate::TrackProducer::create_group`] / `append_group`.
+	track: TrackInfo,
 }
 
 impl std::ops::Deref for GroupProducer {
@@ -171,13 +170,13 @@ impl GroupProducer {
 	/// Create a group producer bound to its parent track's [`TrackInfo`].
 	///
 	/// Crate-private: groups are only constructed via [`crate::TrackProducer`],
-	/// which threads its `Arc<TrackInfo>` down so properties like the timescale are
+	/// which threads its [`TrackInfo`] down so properties like the timescale are
 	/// inherited rather than passed in. An untimed track (`timescale = None`)
 	/// requires every frame's `timestamp` to be `None`; a timed track requires
 	/// `Some(ts)` with `ts.scale()` matching the track's scale.
-	pub(crate) fn new(info: GroupInfo, track: Arc<TrackInfo>) -> Self {
+	pub(crate) fn new(info: GroupInfo, track: TrackInfo) -> Self {
 		Self {
-			info: Arc::new(info),
+			info,
 			state: kio::Producer::default(),
 			track,
 		}
@@ -205,7 +204,7 @@ impl GroupProducer {
 	/// Returns [`Error::FrameTooLarge`] if the declared size exceeds the per-frame
 	/// limit, refused before the buffer is allocated.
 	pub fn create_frame(&mut self, info: impl Into<FrameInfo>) -> Result<FrameProducer> {
-		let frame = FrameProducer::new(info.into(), self.info.clone())?;
+		let frame = FrameProducer::new(info.into(), self.info)?;
 		self.append_frame(frame.clone())?;
 		Ok(frame)
 	}
@@ -267,9 +266,9 @@ impl GroupProducer {
 	/// Create a new consumer for the group.
 	pub fn consume(&self) -> GroupConsumer {
 		GroupConsumer {
-			info: self.info.clone(),
+			info: self.info,
 			state: self.state.consume(),
-			track: self.track.clone(),
+			track: self.track,
 			index: 0,
 		}
 	}
@@ -292,9 +291,9 @@ impl GroupProducer {
 impl Clone for GroupProducer {
 	fn clone(&self) -> Self {
 		Self {
-			info: self.info.clone(),
+			info: self.info,
 			state: self.state.clone(),
-			track: self.track.clone(),
+			track: self.track,
 		}
 	}
 }
@@ -323,11 +322,11 @@ pub struct GroupConsumer {
 	state: kio::Consumer<GroupState>,
 
 	// Immutable stream state.
-	info: Arc<GroupInfo>,
+	info: GroupInfo,
 
 	// The parent track's info, inherited from the producer. Its `timescale` lets the
 	// wire publisher decide whether to emit per-frame timestamps for a fetched group.
-	track: Arc<TrackInfo>,
+	track: TrackInfo,
 
 	// The number of frames we've read.
 	// NOTE: Cloned readers inherit this offset, but then run in parallel.
@@ -700,7 +699,7 @@ mod test {
 	fn append_frame_rejects_timestamp_on_untimed_group() {
 		use crate::Timestamp;
 
-		let mut producer = GroupProducer::new(GroupInfo { sequence: 0 }, Arc::new(TrackInfo::default()));
+		let mut producer = GroupProducer::new(GroupInfo { sequence: 0 }, TrackInfo::default());
 		let frame = FrameInfo {
 			size: 3,
 			timestamp: Some(Timestamp::from_micros(42).unwrap()),
@@ -715,7 +714,7 @@ mod test {
 
 		let mut producer = GroupProducer::new(
 			GroupInfo { sequence: 0 },
-			Arc::new(TrackInfo::default().with_timescale(Timescale::MICRO)),
+			TrackInfo::default().with_timescale(Timescale::MICRO),
 		);
 		let frame = FrameInfo {
 			size: 3,
@@ -731,7 +730,7 @@ mod test {
 
 		let mut producer = GroupProducer::new(
 			GroupInfo { sequence: 0 },
-			Arc::new(TrackInfo::default().with_timescale(Timescale::MICRO)),
+			TrackInfo::default().with_timescale(Timescale::MICRO),
 		);
 		let frame = FrameInfo {
 			size: 3,
@@ -747,7 +746,7 @@ mod test {
 
 		let mut producer = GroupProducer::new(
 			GroupInfo { sequence: 0 },
-			Arc::new(TrackInfo::default().with_timescale(Timescale::MICRO)),
+			TrackInfo::default().with_timescale(Timescale::MICRO),
 		);
 		let frame = FrameInfo {
 			size: 1,

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -8,13 +8,14 @@
 //!
 //! The stream is closed with [Error] when all writers or readers are dropped.
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::task::{Poll, ready};
 
 use bytes::Bytes;
 
-use crate::{Error, Result, Timescale};
+use crate::{Error, Result, Timescale, TrackInfo};
 
-use super::{Frame, FrameConsumer, FrameProducer};
+use super::{FrameConsumer, FrameInfo, FrameProducer};
 
 /// Maximum total size of frames cached in a group before old frames are evicted.
 ///
@@ -29,25 +30,25 @@ const MAX_GROUP_FRAMES: usize = 1024;
 /// You can use [crate::TrackProducer::append_group] if you just want to +1 the sequence number.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Group {
+pub struct GroupInfo {
 	/// Per-track sequence number used to detect ordering and gaps. Higher numbers
 	/// supersede lower ones; consumers may skip late arrivals.
 	pub sequence: u64,
 }
 
-impl Group {
+impl GroupInfo {
 	/// Create an untimed producer for this group.
 	///
 	/// Test-only: real groups are created via [`crate::TrackProducer`], which
-	/// supplies the track's negotiated timescale. This helper exists for in-crate
+	/// supplies the parent track's [`TrackInfo`]. This helper exists for in-crate
 	/// tests that don't exercise timestamps.
 	#[cfg(test)]
 	pub(crate) fn produce(self) -> GroupProducer {
-		GroupProducer::new(self, None)
+		GroupProducer::new(self, Arc::new(TrackInfo::default()))
 	}
 }
 
-impl From<usize> for Group {
+impl From<usize> for GroupInfo {
 	fn from(sequence: usize) -> Self {
 		Self {
 			sequence: sequence as u64,
@@ -55,13 +56,13 @@ impl From<usize> for Group {
 	}
 }
 
-impl From<u64> for Group {
+impl From<u64> for GroupInfo {
 	fn from(sequence: u64) -> Self {
 		Self { sequence }
 	}
 }
 
-impl From<u32> for Group {
+impl From<u32> for GroupInfo {
 	fn from(sequence: u32) -> Self {
 		Self {
 			sequence: sequence as u64,
@@ -69,7 +70,7 @@ impl From<u32> for Group {
 	}
 }
 
-impl From<u16> for Group {
+impl From<u16> for GroupInfo {
 	fn from(sequence: u16) -> Self {
 		Self {
 			sequence: sequence as u64,
@@ -146,19 +147,20 @@ pub struct GroupProducer {
 	// Mutable stream state.
 	state: kio::Producer<GroupState>,
 
-	// The group header containing the sequence number.
-	info: Group,
+	// The group header containing the sequence number. Held behind an Arc so each
+	// frame can inherit a shared handle (see [`Self::create_frame`]).
+	info: Arc<GroupInfo>,
 
-	// Parent track's negotiated timescale, used by [`Self::create_frame`] to
-	// validate per-frame timestamps before they enter the stream. `None` means
-	// frames on this group must have `Frame::timestamp = None`; `Some(scale)`
-	// requires `Frame::timestamp = Some(ts)` with `ts.scale() == scale`.
-	// Populated by [`crate::TrackProducer::create_group`] / `append_group`.
-	timescale: Option<Timescale>,
+	// The parent track's info, inherited rather than passed piecemeal. Its
+	// `timescale` drives per-frame timestamp validation in [`Self::append_frame`]:
+	// `None` means frames must have `FrameInfo::timestamp = None`; `Some(scale)`
+	// requires `FrameInfo::timestamp = Some(ts)` with `ts.scale() == scale`.
+	// Threaded down by [`crate::TrackProducer::create_group`] / `append_group`.
+	track: Arc<TrackInfo>,
 }
 
 impl std::ops::Deref for GroupProducer {
-	type Target = Group;
+	type Target = GroupInfo;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
@@ -166,23 +168,24 @@ impl std::ops::Deref for GroupProducer {
 }
 
 impl GroupProducer {
-	/// Create a group producer bound to its parent track's timescale.
+	/// Create a group producer bound to its parent track's [`TrackInfo`].
 	///
 	/// Crate-private: groups are only constructed via [`crate::TrackProducer`],
-	/// which supplies the negotiated timescale. `None` means the parent track is
-	/// untimed and added frames must have `timestamp = None`; `Some(scale)`
-	/// requires every frame's `timestamp` to be `Some(ts)` with `ts.scale() == scale`.
-	pub(crate) fn new(info: Group, timescale: Option<Timescale>) -> Self {
+	/// which threads its `Arc<TrackInfo>` down so properties like the timescale are
+	/// inherited rather than passed in. An untimed track (`timescale = None`)
+	/// requires every frame's `timestamp` to be `None`; a timed track requires
+	/// `Some(ts)` with `ts.scale()` matching the track's scale.
+	pub(crate) fn new(info: GroupInfo, track: Arc<TrackInfo>) -> Self {
 		Self {
-			info,
+			info: Arc::new(info),
 			state: kio::Producer::default(),
-			timescale,
+			track,
 		}
 	}
 
 	/// The parent track's negotiated timescale, or `None` for untimed tracks.
 	pub fn timescale(&self) -> Option<Timescale> {
-		self.timescale
+		self.track.timescale
 	}
 
 	/// A helper method to write a frame from a single byte buffer.
@@ -201,8 +204,8 @@ impl GroupProducer {
 	///
 	/// Returns [`Error::FrameTooLarge`] if the declared size exceeds the per-frame
 	/// limit, refused before the buffer is allocated.
-	pub fn create_frame(&mut self, info: impl Into<Frame>) -> Result<FrameProducer> {
-		let frame = info.into().produce()?;
+	pub fn create_frame(&mut self, info: impl Into<FrameInfo>) -> Result<FrameProducer> {
+		let frame = FrameProducer::new(info.into(), self.info.clone())?;
 		self.append_frame(frame.clone())?;
 		Ok(frame)
 	}
@@ -216,7 +219,7 @@ impl GroupProducer {
 		// Catch the contract violation here, at the model layer, so peers that
 		// downstream-encode (e.g. the lite publisher's `serve_frame`) can rely
 		// on the invariant instead of re-validating per byte.
-		match (self.timescale, frame.timestamp) {
+		match (self.track.timescale, frame.timestamp) {
 			(Some(track_scale), Some(ts)) if ts.scale() == track_scale => {}
 			(None, None) => {}
 			_ => return Err(Error::TimestampMismatch),
@@ -266,7 +269,7 @@ impl GroupProducer {
 		GroupConsumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
-			timescale: self.timescale,
+			track: self.track.clone(),
 			index: 0,
 		}
 	}
@@ -291,7 +294,7 @@ impl Clone for GroupProducer {
 		Self {
 			info: self.info.clone(),
 			state: self.state.clone(),
-			timescale: self.timescale,
+			track: self.track.clone(),
 		}
 	}
 }
@@ -320,11 +323,11 @@ pub struct GroupConsumer {
 	state: kio::Consumer<GroupState>,
 
 	// Immutable stream state.
-	info: Group,
+	info: Arc<GroupInfo>,
 
-	// Parent track's negotiated timescale, copied from the producer. Lets the
+	// The parent track's info, inherited from the producer. Its `timescale` lets the
 	// wire publisher decide whether to emit per-frame timestamps for a fetched group.
-	timescale: Option<Timescale>,
+	track: Arc<TrackInfo>,
 
 	// The number of frames we've read.
 	// NOTE: Cloned readers inherit this offset, but then run in parallel.
@@ -332,7 +335,7 @@ pub struct GroupConsumer {
 }
 
 impl std::ops::Deref for GroupConsumer {
-	type Target = Group;
+	type Target = GroupInfo;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
@@ -342,7 +345,7 @@ impl std::ops::Deref for GroupConsumer {
 impl GroupConsumer {
 	/// The parent track's negotiated timescale, or `None` for untimed tracks.
 	pub fn timescale(&self) -> Option<Timescale> {
-		self.timescale
+		self.track.timescale
 	}
 
 	// A helper to automatically apply Dropped if the state is closed without an error.
@@ -455,7 +458,7 @@ mod test {
 
 	#[test]
 	fn basic_frame_reading() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		producer.write_frame(Bytes::from_static(b"frame0")).unwrap();
 		producer.write_frame(Bytes::from_static(b"frame1")).unwrap();
 		producer.finish().unwrap();
@@ -471,7 +474,7 @@ mod test {
 
 	#[test]
 	fn read_frame_all_at_once() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		producer.write_frame(Bytes::from_static(b"hello")).unwrap();
 		producer.finish().unwrap();
 
@@ -482,7 +485,7 @@ mod test {
 
 	#[test]
 	fn read_frame_chunks() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		let mut frame = producer.create_frame(10u64).unwrap();
 		frame.write(Bytes::from_static(b"hello")).unwrap();
 		frame.write(Bytes::from_static(b"world")).unwrap();
@@ -499,7 +502,7 @@ mod test {
 
 	#[test]
 	fn get_frame_by_index() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		producer.write_frame(Bytes::from_static(b"a")).unwrap();
 		producer.write_frame(Bytes::from_static(b"bb")).unwrap();
 		producer.finish().unwrap();
@@ -515,7 +518,7 @@ mod test {
 
 	#[test]
 	fn group_finish_returns_none() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
@@ -525,7 +528,7 @@ mod test {
 
 	#[test]
 	fn abort_propagates() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		let mut consumer = producer.consume();
 		producer.abort(crate::Error::Cancel).unwrap();
 
@@ -535,7 +538,7 @@ mod test {
 
 	#[test]
 	fn abort_clears_cached_frames() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		producer.write_frame(Bytes::from_static(b"data")).unwrap();
 
 		// A stale consumer that never reads must not pin the cached frames.
@@ -551,7 +554,7 @@ mod test {
 
 	#[test]
 	fn drop_unfinished_clears_cached_frames() {
-		let producer = Group { sequence: 0 }.produce();
+		let producer = GroupInfo { sequence: 0 }.produce();
 		let mut writer = producer.clone();
 		writer.write_frame(Bytes::from_static(b"data")).unwrap();
 
@@ -569,7 +572,7 @@ mod test {
 
 	#[test]
 	fn drop_finished_keeps_cached_frames() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		producer.write_frame(Bytes::from_static(b"data")).unwrap();
 		producer.finish().unwrap();
 
@@ -583,7 +586,7 @@ mod test {
 
 	#[tokio::test]
 	async fn pending_then_ready() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		let mut consumer = producer.consume();
 
 		// Consumer blocks because no frames yet.
@@ -598,7 +601,7 @@ mod test {
 
 	#[test]
 	fn eviction_drops_old_frames() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 
 		// Write frames that total more than MAX_GROUP_CACHE.
 		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
@@ -617,7 +620,7 @@ mod test {
 
 	#[test]
 	fn no_eviction_under_limit() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		producer.write_frame(Bytes::from_static(b"small")).unwrap();
 		producer.write_frame(Bytes::from_static(b"frames")).unwrap();
 		producer.finish().unwrap();
@@ -631,7 +634,7 @@ mod test {
 
 	#[test]
 	fn eviction_by_frame_count() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 
 		// Write more than MAX_GROUP_FRAMES frames.
 		for _ in 0..=MAX_GROUP_FRAMES {
@@ -655,7 +658,7 @@ mod test {
 
 	#[test]
 	fn next_frame_returns_cache_full_on_tombstone() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 
 		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
 		producer.write_frame(big.clone()).unwrap();
@@ -669,7 +672,7 @@ mod test {
 
 	#[test]
 	fn clone_consumer_independent() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		producer.write_frame(Bytes::from_static(b"a")).unwrap();
 
 		let mut c1 = producer.consume();
@@ -697,8 +700,8 @@ mod test {
 	fn append_frame_rejects_timestamp_on_untimed_group() {
 		use crate::Timestamp;
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, None);
-		let frame = Frame {
+		let mut producer = GroupProducer::new(GroupInfo { sequence: 0 }, Arc::new(TrackInfo::default()));
+		let frame = FrameInfo {
 			size: 3,
 			timestamp: Some(Timestamp::from_micros(42).unwrap()),
 		};
@@ -710,8 +713,11 @@ mod test {
 	fn append_frame_rejects_missing_timestamp_on_timed_group() {
 		use crate::Timescale;
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
-		let frame = Frame {
+		let mut producer = GroupProducer::new(
+			GroupInfo { sequence: 0 },
+			Arc::new(TrackInfo::default().with_timescale(Timescale::MICRO)),
+		);
+		let frame = FrameInfo {
 			size: 3,
 			timestamp: None,
 		};
@@ -723,8 +729,11 @@ mod test {
 	fn append_frame_rejects_scale_mismatch() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
-		let frame = Frame {
+		let mut producer = GroupProducer::new(
+			GroupInfo { sequence: 0 },
+			Arc::new(TrackInfo::default().with_timescale(Timescale::MICRO)),
+		);
+		let frame = FrameInfo {
 			size: 3,
 			timestamp: Some(Timestamp::from_millis(1).unwrap()), // millis, not micros
 		};
@@ -736,8 +745,11 @@ mod test {
 	fn append_frame_accepts_matching_scale() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
-		let frame = Frame {
+		let mut producer = GroupProducer::new(
+			GroupInfo { sequence: 0 },
+			Arc::new(TrackInfo::default().with_timescale(Timescale::MICRO)),
+		);
+		let frame = FrameInfo {
 			size: 1,
 			timestamp: Some(Timestamp::from_micros(7).unwrap()),
 		};
@@ -750,7 +762,7 @@ mod test {
 	/// it as FrameTooLarge before allocating the buffer.
 	#[test]
 	fn create_frame_rejects_oversized() {
-		let mut producer = Group { sequence: 0 }.produce();
+		let mut producer = GroupInfo { sequence: 0 }.produce();
 		let result = producer.create_frame(crate::MAX_FRAME_SIZE + 1);
 		assert!(matches!(result, Err(Error::FrameTooLarge)));
 	}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -33,7 +33,7 @@ pub const DEFAULT_CACHE: Duration = Duration::from_secs(5);
 /// while the track is alive. A subscriber learns them via
 /// [`crate::BroadcastConsumer::track`](crate::BroadcastConsumer::track),
 /// which returns the publisher's [`TrackInfo`] once the subscription is accepted.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrackInfo {
 	/// Hint that this track's frames are worth compressing (e.g. a JSON catalog).
@@ -156,9 +156,8 @@ impl TrackInfo {
 #[derive(Default)]
 struct TrackState {
 	// The info for the track; always Some for TrackSubscriber/TrackProducer.
-	// Held behind an Arc so each group can inherit a shared handle (and read the
-	// timescale) rather than being handed a copied-out value.
-	info: Option<Arc<TrackInfo>>,
+	// A small `Copy` value, inherited by each group it creates.
+	info: Option<TrackInfo>,
 
 	// Groups in arrival order. `None` entries are tombstones for evicted groups.
 	groups: VecDeque<Option<(GroupProducer, web_async::time::Instant)>>,
@@ -194,7 +193,7 @@ struct TrackState {
 impl TrackState {
 	fn poll_info(&self) -> Poll<Result<TrackInfo>> {
 		if let Some(info) = &self.info {
-			Poll::Ready(Ok((**info).clone()))
+			Poll::Ready(Ok(*info))
 		} else {
 			Poll::Pending
 		}
@@ -454,9 +453,9 @@ impl TrackState {
 		}
 
 		// Adopt the supplied info only if the track hasn't been accepted yet.
-		let info = self.info.get_or_insert_with(|| Arc::new(info.unwrap_or_default()));
+		let info = *self.info.get_or_insert_with(|| info.unwrap_or_default());
 
-		let group = GroupProducer::new(GroupInfo { sequence }, info.clone());
+		let group = GroupProducer::new(GroupInfo { sequence }, info);
 		let cache = info.cache;
 		let now = web_async::time::Instant::now();
 		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
@@ -494,7 +493,7 @@ impl TrackProducer {
 			name: name.into(),
 			broadcast,
 			state: kio::Producer::new(TrackState {
-				info: Some(Arc::new(info)),
+				info: Some(info),
 				..Default::default()
 			}),
 			prev_subscription: None,
@@ -519,7 +518,7 @@ impl TrackProducer {
 			return Err(Error::Closed);
 		}
 		let info = state.info.as_ref().unwrap();
-		let track = info.clone();
+		let track = *info;
 		let cache = info.cache;
 
 		let group = GroupProducer::new(group, track);
@@ -549,7 +548,7 @@ impl TrackProducer {
 		}
 
 		let info = state.info.as_ref().unwrap();
-		let track = info.clone();
+		let track = *info;
 		let cache = info.cache;
 
 		let group = GroupProducer::new(GroupInfo { sequence }, track);
@@ -699,7 +698,7 @@ impl TrackProducer {
 		let mut preferences = subscription.into().unwrap_or_default();
 
 		let mut state = self.modify().expect("track producer state is never closed");
-		let info = (**state.info.as_ref().expect("producer always has info")).clone();
+		let info = *state.info.as_ref().expect("producer always has info");
 		preferences.stale = info.clamp_stale(preferences.stale);
 		let subscription = kio::Producer::new(preferences);
 		state.subscriptions.push(subscription.consume());
@@ -1468,7 +1467,7 @@ impl TrackRequest {
 	/// The track's name must match [`Self::name`]. Returns [`Error::NotFound`] on
 	/// mismatch, or the broadcast's abort error if it closed while pending.
 	pub fn accept(self, info: impl Into<Option<TrackInfo>>) -> TrackProducer {
-		self.state.write().ok().unwrap().info = Some(Arc::new(info.into().unwrap_or_default()));
+		self.state.write().ok().unwrap().info = Some(info.into().unwrap_or_default());
 		TrackProducer {
 			name: self.name,
 			broadcast: self.broadcast,

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -13,9 +13,9 @@
 //!
 //! The track is closed with [Error] when all writers or readers are dropped.
 
-use crate::{Error, Result, Subscription, Timescale, coding};
+use crate::{BroadcastInfo, Error, Result, Subscription, Timescale, coding};
 
-use super::{Fetch, Group, GroupConsumer, GroupProducer};
+use super::{Fetch, GroupConsumer, GroupInfo, GroupProducer};
 
 use std::{
 	collections::{HashSet, VecDeque},
@@ -156,7 +156,9 @@ impl TrackInfo {
 #[derive(Default)]
 struct TrackState {
 	// The info for the track; always Some for TrackSubscriber/TrackProducer.
-	info: Option<TrackInfo>,
+	// Held behind an Arc so each group can inherit a shared handle (and read the
+	// timescale) rather than being handed a copied-out value.
+	info: Option<Arc<TrackInfo>>,
 
 	// Groups in arrival order. `None` entries are tombstones for evicted groups.
 	groups: VecDeque<Option<(GroupProducer, web_async::time::Instant)>>,
@@ -192,7 +194,7 @@ struct TrackState {
 impl TrackState {
 	fn poll_info(&self) -> Poll<Result<TrackInfo>> {
 		if let Some(info) = &self.info {
-			Poll::Ready(Ok(info.clone()))
+			Poll::Ready(Ok((**info).clone()))
 		} else {
 			Poll::Pending
 		}
@@ -452,9 +454,9 @@ impl TrackState {
 		}
 
 		// Adopt the supplied info only if the track hasn't been accepted yet.
-		let info = self.info.get_or_insert_with(|| info.unwrap_or_default());
+		let info = self.info.get_or_insert_with(|| Arc::new(info.unwrap_or_default()));
 
-		let group = GroupProducer::new(Group { sequence }, info.timescale);
+		let group = GroupProducer::new(GroupInfo { sequence }, info.clone());
 		let cache = info.cache;
 		let now = web_async::time::Instant::now();
 		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
@@ -468,18 +470,31 @@ impl TrackState {
 #[derive(Clone)]
 pub struct TrackProducer {
 	name: Arc<str>,
+	// The parent broadcast's info, inherited from [`crate::BroadcastProducer::create_track`].
+	// Top link of the ownership chain; carried for identity and future inheritance.
+	broadcast: Arc<BroadcastInfo>,
 	state: kio::Producer<TrackState>,
 	prev_subscription: Option<Subscription>,
 }
 
 impl TrackProducer {
 	/// Build a producer for the given track metadata.
-	pub fn new(name: impl Into<Arc<str>>, info: impl Into<Option<TrackInfo>>) -> Self {
+	///
+	/// Crate-private: tracks are born from their broadcast via
+	/// [`crate::BroadcastProducer::create_track`] (or served on demand through a
+	/// [`TrackRequest`]), which threads the broadcast's `Arc<BroadcastInfo>` down so
+	/// the broadcast owns the namespace and there's a single way to mint a track.
+	pub(crate) fn new(
+		broadcast: Arc<BroadcastInfo>,
+		name: impl Into<Arc<str>>,
+		info: impl Into<Option<TrackInfo>>,
+	) -> Self {
 		let info = info.into().unwrap_or_default();
 		Self {
 			name: name.into(),
+			broadcast,
 			state: kio::Producer::new(TrackState {
-				info: Some(info),
+				info: Some(Arc::new(info)),
 				..Default::default()
 			}),
 			prev_subscription: None,
@@ -490,8 +505,13 @@ impl TrackProducer {
 		&self.name
 	}
 
+	/// The parent broadcast this track belongs to.
+	pub fn broadcast(&self) -> &BroadcastInfo {
+		&self.broadcast
+	}
+
 	/// Create a new group with the given sequence number.
-	pub fn create_group(&mut self, group: Group) -> Result<GroupProducer> {
+	pub fn create_group(&mut self, group: GroupInfo) -> Result<GroupProducer> {
 		let mut state = self.modify()?;
 		if let Some(fin) = state.final_sequence
 			&& group.sequence >= fin
@@ -499,10 +519,10 @@ impl TrackProducer {
 			return Err(Error::Closed);
 		}
 		let info = state.info.as_ref().unwrap();
-		let timescale = info.timescale;
+		let track = info.clone();
 		let cache = info.cache;
 
-		let group = GroupProducer::new(group, timescale);
+		let group = GroupProducer::new(group, track);
 		if !state.duplicates.insert(group.sequence) {
 			return Err(Error::Duplicate);
 		}
@@ -529,10 +549,10 @@ impl TrackProducer {
 		}
 
 		let info = state.info.as_ref().unwrap();
-		let timescale = info.timescale;
+		let track = info.clone();
 		let cache = info.cache;
 
-		let group = GroupProducer::new(Group { sequence }, timescale);
+		let group = GroupProducer::new(GroupInfo { sequence }, track);
 
 		let now = web_async::time::Instant::now();
 		state.duplicates.insert(sequence);
@@ -679,7 +699,7 @@ impl TrackProducer {
 		let mut preferences = subscription.into().unwrap_or_default();
 
 		let mut state = self.modify().expect("track producer state is never closed");
-		let info = state.info.clone().expect("producer always has info");
+		let info = (**state.info.as_ref().expect("producer always has info")).clone();
 		preferences.stale = info.clamp_stale(preferences.stale);
 		let subscription = kio::Producer::new(preferences);
 		state.subscriptions.push(subscription.consume());
@@ -976,13 +996,6 @@ impl TrackConsumer {
 	/// The track name this handle is bound to.
 	pub fn name(&self) -> &str {
 		&self.name
-	}
-
-	pub(crate) fn weak(&self) -> TrackWeak {
-		TrackWeak {
-			name: self.name.clone(),
-			state: self.state.weak(),
-		}
 	}
 
 	/// Open a live subscription.
@@ -1397,6 +1410,8 @@ impl TrackSubscriber {
 
 pub struct TrackRequest {
 	name: Arc<str>,
+	// The parent broadcast's info, threaded into the [`TrackProducer`] on accept.
+	broadcast: Arc<BroadcastInfo>,
 	state: kio::Producer<TrackState>,
 
 	// The previous subscription that was combined, used to detect changes.
@@ -1410,12 +1425,13 @@ pub struct TrackRequest {
 }
 
 impl TrackRequest {
-	pub fn new(name: impl Into<Arc<str>>) -> Self {
+	pub(crate) fn new(broadcast: Arc<BroadcastInfo>, name: impl Into<Arc<str>>) -> Self {
 		let name = name.into();
 		let state = kio::Producer::<TrackState>::default();
 		let dynamic = TrackDynamic::new(name.clone(), state.clone());
 		Self {
 			name,
+			broadcast,
 			state,
 			prev_subscription: None,
 			_dynamic: dynamic,
@@ -1452,9 +1468,10 @@ impl TrackRequest {
 	/// The track's name must match [`Self::name`]. Returns [`Error::NotFound`] on
 	/// mismatch, or the broadcast's abort error if it closed while pending.
 	pub fn accept(self, info: impl Into<Option<TrackInfo>>) -> TrackProducer {
-		self.state.write().ok().unwrap().info = Some(info.into().unwrap_or_default());
+		self.state.write().ok().unwrap().info = Some(Arc::new(info.into().unwrap_or_default()));
 		TrackProducer {
 			name: self.name,
+			broadcast: self.broadcast,
 			state: self.state,
 			prev_subscription: None,
 		}
@@ -1562,6 +1579,12 @@ impl TrackSubscriber {
 mod test {
 	use super::*;
 
+	/// Mint a track for tests with a default parent broadcast, since tracks are
+	/// normally born from a [`crate::BroadcastProducer`].
+	fn track_producer(name: impl Into<Arc<str>>, info: impl Into<Option<TrackInfo>>) -> TrackProducer {
+		TrackProducer::new(Arc::new(BroadcastInfo::default()), name, info)
+	}
+
 	/// Helper: count non-tombstoned groups in state.
 	fn live_groups(state: &TrackState) -> usize {
 		state.groups.iter().flatten().count()
@@ -1576,7 +1599,7 @@ mod test {
 	async fn evict_expired_groups() {
 		tokio::time::pause();
 
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 
 		// Create 3 groups at time 0.
 		producer.append_group().unwrap(); // seq 0
@@ -1613,7 +1636,7 @@ mod test {
 	async fn evict_keeps_max_sequence() {
 		tokio::time::pause();
 
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		producer.append_group().unwrap(); // seq 0
 
 		// Advance time past threshold.
@@ -1634,7 +1657,7 @@ mod test {
 	async fn no_eviction_when_fresh() {
 		tokio::time::pause();
 
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		producer.append_group().unwrap(); // seq 0
 		producer.append_group().unwrap(); // seq 1
 		producer.append_group().unwrap(); // seq 2
@@ -1650,7 +1673,7 @@ mod test {
 	async fn consumer_skips_evicted_groups() {
 		tokio::time::pause();
 
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		producer.append_group().unwrap(); // seq 0
 
 		let mut consumer = producer.subscribe(None);
@@ -1668,7 +1691,7 @@ mod test {
 		tokio::time::pause();
 
 		// A shorter cache evicts sooner than the default.
-		let mut producer = TrackProducer::new("test", TrackInfo::default().with_cache(Duration::from_secs(1)));
+		let mut producer = track_producer("test", TrackInfo::default().with_cache(Duration::from_secs(1)));
 		producer.append_group().unwrap(); // seq 0
 
 		// Past the custom cache but well within DEFAULT_CACHE.
@@ -1683,7 +1706,7 @@ mod test {
 
 	#[test]
 	fn stale_clamped_to_cache() {
-		let producer = TrackProducer::new("test", TrackInfo::default().with_cache(Duration::from_secs(2)));
+		let producer = track_producer("test", TrackInfo::default().with_cache(Duration::from_secs(2)));
 
 		// A stale window beyond the cache is capped to the cache; a group can't be
 		// waited for longer than the publisher keeps it.
@@ -1702,12 +1725,12 @@ mod test {
 	async fn out_of_order_max_sequence_at_front() {
 		tokio::time::pause();
 
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 
 		// Arrive out of order: seq 5 first, then 3, then 4.
-		producer.create_group(Group { sequence: 5 }).unwrap();
-		producer.create_group(Group { sequence: 3 }).unwrap();
-		producer.create_group(Group { sequence: 4 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 4 }).unwrap();
 
 		// max_sequence = 5, which is at the front of the VecDeque.
 		{
@@ -1738,15 +1761,15 @@ mod test {
 	async fn max_sequence_at_front_blocks_trim() {
 		tokio::time::pause();
 
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 
 		// Arrive: seq 5, then seq 3.
-		producer.create_group(Group { sequence: 5 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
 
 		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 
 		// Seq 3 arrives late; max_sequence is still 5 (at front).
-		producer.create_group(Group { sequence: 3 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
 
 		// Seq 5 is max_sequence (protected). Seq 3 is not expired (just created).
 		// Nothing should be evicted.
@@ -1760,7 +1783,7 @@ mod test {
 		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 
 		// Seq 2 arrives late, triggering eviction.
-		producer.create_group(Group { sequence: 2 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 2 }).unwrap();
 
 		// Seq 5 is still max_sequence (protected, at front, blocks trim).
 		// Seq 3 is expired → tombstoned.
@@ -1784,7 +1807,7 @@ mod test {
 
 	#[tokio::test]
 	async fn abort_clears_cached_groups() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		producer.append_group().unwrap();
 		producer.append_group().unwrap();
 
@@ -1807,7 +1830,7 @@ mod test {
 
 	#[tokio::test]
 	async fn drop_unfinished_clears_cached_groups() {
-		let producer = TrackProducer::new("test", None);
+		let producer = track_producer("test", None);
 		let mut writer = producer.clone();
 		writer.append_group().unwrap();
 
@@ -1825,7 +1848,7 @@ mod test {
 
 	#[tokio::test]
 	async fn drop_finished_keeps_cached_groups() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		producer.append_group().unwrap();
 		producer.finish().unwrap();
 
@@ -1840,7 +1863,7 @@ mod test {
 
 	#[test]
 	fn append_finish_cannot_be_rewritten() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 
 		// Finishing an empty track is valid (fin = 0, total groups = 0).
 		assert!(producer.finish().is_ok());
@@ -1850,7 +1873,7 @@ mod test {
 
 	#[test]
 	fn finish_after_groups() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 
 		producer.append_group().unwrap();
 		assert!(producer.finish().is_ok());
@@ -1860,8 +1883,8 @@ mod test {
 
 	#[test]
 	fn insert_finish_validates_sequence_and_freezes_to_max() {
-		let mut producer = TrackProducer::new("test", None);
-		producer.create_group(Group { sequence: 5 }).unwrap();
+		let mut producer = track_producer("test", None);
+		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
 
 		assert!(producer.finish_at(4).is_err());
 		assert!(producer.finish_at(10).is_err());
@@ -1873,14 +1896,14 @@ mod test {
 		}
 
 		assert!(producer.finish_at(5).is_err());
-		assert!(producer.create_group(Group { sequence: 4 }).is_ok());
-		assert!(producer.create_group(Group { sequence: 5 }).is_err());
+		assert!(producer.create_group(GroupInfo { sequence: 4 }).is_ok());
+		assert!(producer.create_group(GroupInfo { sequence: 5 }).is_err());
 	}
 
 	#[tokio::test]
 	async fn recv_group_finishes_without_waiting_for_gaps() {
-		let mut producer = TrackProducer::new("test", None);
-		producer.create_group(Group { sequence: 1 }).unwrap();
+		let mut producer = track_producer("test", None);
+		producer.create_group(GroupInfo { sequence: 1 }).unwrap();
 		producer.finish_at(1).unwrap();
 
 		let mut consumer = producer.subscribe(None);
@@ -1896,11 +1919,11 @@ mod test {
 
 	#[tokio::test]
 	async fn next_group_skips_late_arrivals() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		// Seq 5 arrives first.
-		producer.create_group(Group { sequence: 5 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
 		let group = consumer
 			.next_group()
 			.now_or_never()
@@ -1910,11 +1933,11 @@ mod test {
 		assert_eq!(group.sequence, 5);
 
 		// Seq 3 arrives late — skipped because 3 <= 5.
-		producer.create_group(Group { sequence: 3 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
 		// Seq 4 arrives late — also skipped.
-		producer.create_group(Group { sequence: 4 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 4 }).unwrap();
 		// Seq 7 arrives — returned.
-		producer.create_group(Group { sequence: 7 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 7 }).unwrap();
 
 		let group = consumer
 			.next_group()
@@ -1933,12 +1956,12 @@ mod test {
 
 	#[tokio::test]
 	async fn next_group_returns_arrivals_in_order() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		// Seq 3 arrives first, then seq 5 — both should be returned in arrival order.
-		producer.create_group(Group { sequence: 3 }).unwrap();
-		producer.create_group(Group { sequence: 5 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
 
 		let group = consumer
 			.next_group()
@@ -1959,12 +1982,12 @@ mod test {
 
 	#[tokio::test]
 	async fn next_group_and_recv_group_use_independent_cursors() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		// Out-of-order arrivals: seq 5 first, then seq 3.
-		producer.create_group(Group { sequence: 5 }).unwrap();
-		producer.create_group(Group { sequence: 3 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
 
 		// next_group is sequence-ordered: it returns the smallest sequence first,
 		// regardless of arrival order.
@@ -1983,11 +2006,11 @@ mod test {
 
 	#[tokio::test]
 	async fn end_at_caps_next_group() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		for s in 0..6 {
-			producer.create_group(Group { sequence: s }).unwrap();
+			producer.create_group(GroupInfo { sequence: s }).unwrap();
 		}
 
 		consumer.end_at(2);
@@ -2015,11 +2038,11 @@ mod test {
 
 	#[tokio::test]
 	async fn end_at_release_drains_cached_groups() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		for s in 0..6 {
-			producer.create_group(Group { sequence: s }).unwrap();
+			producer.create_group(GroupInfo { sequence: s }).unwrap();
 		}
 
 		consumer.end_at(1);
@@ -2060,11 +2083,11 @@ mod test {
 
 	#[tokio::test]
 	async fn end_at_lower_than_cursor_parks_consumer() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		for s in 0..3 {
-			producer.create_group(Group { sequence: s }).unwrap();
+			producer.create_group(GroupInfo { sequence: s }).unwrap();
 		}
 
 		// Drain everything with no cap.
@@ -2083,8 +2106,8 @@ mod test {
 
 		// Lower the cap below the cursor. New groups beyond the cap are blocked.
 		consumer.end_at(1);
-		producer.create_group(Group { sequence: 3 }).unwrap();
-		producer.create_group(Group { sequence: 4 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 4 }).unwrap();
 		assert!(
 			consumer.next_group().now_or_never().is_none(),
 			"cap is below cursor; nothing returnable until cap rises"
@@ -2104,18 +2127,18 @@ mod test {
 
 	#[tokio::test]
 	async fn end_at_toggling_around_late_arrivals() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		consumer.end_at(5);
 
 		// Out-of-order arrivals all within the cap.
-		producer.create_group(Group { sequence: 2 }).unwrap();
-		producer.create_group(Group { sequence: 5 }).unwrap();
-		producer.create_group(Group { sequence: 3 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 2 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
 		// One beyond the cap; should be held even though it arrived in the middle.
-		producer.create_group(Group { sequence: 8 }).unwrap();
-		producer.create_group(Group { sequence: 4 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 8 }).unwrap();
+		producer.create_group(GroupInfo { sequence: 4 }).unwrap();
 
 		// next_group walks in sequence order through everything <= cap.
 		assert_eq!(
@@ -2147,7 +2170,7 @@ mod test {
 
 	#[tokio::test]
 	async fn read_frame_returns_single_frame_per_group() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		producer.write_frame(b"hello".as_slice()).unwrap();
@@ -2172,13 +2195,13 @@ mod test {
 
 	#[tokio::test]
 	async fn read_frame_skips_stalled_group_for_newer_ready_frame() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		// Seq 3: group open, no frame yet (stalled).
-		let _stalled = producer.create_group(Group { sequence: 3 }).unwrap();
+		let _stalled = producer.create_group(GroupInfo { sequence: 3 }).unwrap();
 		// Seq 5: fully-written group with a frame.
-		let mut g5 = producer.create_group(Group { sequence: 5 }).unwrap();
+		let mut g5 = producer.create_group(GroupInfo { sequence: 5 }).unwrap();
 		g5.write_frame(bytes::Bytes::from_static(b"later")).unwrap();
 		g5.finish().unwrap();
 
@@ -2194,11 +2217,11 @@ mod test {
 
 	#[tokio::test]
 	async fn read_frame_discards_rest_of_multi_frame_group() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		// Group 0 has two frames; only the first is returned.
-		let mut g0 = producer.create_group(Group { sequence: 0 }).unwrap();
+		let mut g0 = producer.create_group(GroupInfo { sequence: 0 }).unwrap();
 		g0.write_frame(bytes::Bytes::from_static(b"one")).unwrap();
 		g0.write_frame(bytes::Bytes::from_static(b"two")).unwrap();
 		g0.finish().unwrap();
@@ -2228,10 +2251,10 @@ mod test {
 	async fn read_frame_waits_for_pending_group_after_finish() {
 		// finish() sets final_sequence, but groups already created with lower sequences
 		// can still produce frames. read_frame must not return None prematurely.
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
-		let mut g0 = producer.create_group(Group { sequence: 0 }).unwrap();
+		let mut g0 = producer.create_group(GroupInfo { sequence: 0 }).unwrap();
 		producer.finish().unwrap();
 
 		// Track is finished but group 0 has no frame yet — must block, not return None.
@@ -2255,16 +2278,16 @@ mod test {
 	async fn read_frame_respects_start_at() {
 		// start_at sets min_sequence; read_frame must skip groups below it even though
 		// next_sequence is still 0.
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 		consumer.start_at(5);
 
 		// Seq 3 has a frame but is below min_sequence — must be skipped.
-		let mut g3 = producer.create_group(Group { sequence: 3 }).unwrap();
+		let mut g3 = producer.create_group(GroupInfo { sequence: 3 }).unwrap();
 		g3.write_frame(bytes::Bytes::from_static(b"skip-me")).unwrap();
 		g3.finish().unwrap();
 
-		let mut g5 = producer.create_group(Group { sequence: 5 }).unwrap();
+		let mut g5 = producer.create_group(GroupInfo { sequence: 5 }).unwrap();
 		g5.write_frame(bytes::Bytes::from_static(b"keep")).unwrap();
 		g5.finish().unwrap();
 
@@ -2279,7 +2302,7 @@ mod test {
 
 	#[tokio::test]
 	async fn read_frame_returns_none_when_finished() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
 		producer.write_frame(b"only".as_slice()).unwrap();
@@ -2303,8 +2326,8 @@ mod test {
 
 	#[tokio::test]
 	async fn get_group_finishes_without_waiting_for_gaps() {
-		let mut producer = TrackProducer::new("test", None);
-		producer.create_group(Group { sequence: 1 }).unwrap();
+		let mut producer = track_producer("test", None);
+		producer.create_group(GroupInfo { sequence: 1 }).unwrap();
 		producer.finish_at(1).unwrap();
 
 		let consumer = producer.subscribe(None);
@@ -2326,7 +2349,7 @@ mod test {
 
 	#[test]
 	fn append_group_returns_bounds_exceeded_on_sequence_overflow() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		{
 			let mut state = producer.state.write().ok().unwrap();
 			state.max_sequence = Some(u64::MAX);
@@ -2337,7 +2360,7 @@ mod test {
 
 	#[tokio::test]
 	async fn fetch_cache_hit() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 
 		// Produce a cached group.
 		let mut group = producer.append_group().unwrap(); // seq 0
@@ -2359,7 +2382,7 @@ mod test {
 
 	#[tokio::test]
 	async fn fetch_miss_signals_dynamic() {
-		let producer = TrackProducer::new("test", None);
+		let producer = track_producer("test", None);
 		let dynamic = producer.dynamic();
 		let consumer = producer.consume();
 
@@ -2392,7 +2415,7 @@ mod test {
 	async fn fetch_miss_no_dynamic_not_found() {
 		// A track with no `TrackDynamic` can't serve old content, so a cache miss
 		// resolves to NotFound instead of blocking forever.
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		producer.append_group().unwrap(); // seq 0, but we miss on seq 5
 		let consumer = producer.consume();
 		assert!(matches!(consumer.fetch_group(5, None).await, Err(Error::NotFound)));
@@ -2400,7 +2423,7 @@ mod test {
 
 	#[tokio::test]
 	async fn fetch_past_final_not_found() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		producer.append_group().unwrap(); // seq 0
 		producer.finish().unwrap(); // final_sequence = 1
 
@@ -2416,7 +2439,7 @@ mod test {
 
 	#[tokio::test]
 	async fn fetch_aborts_with_track() {
-		let mut producer = TrackProducer::new("test", None);
+		let mut producer = track_producer("test", None);
 		let dynamic = producer.dynamic();
 		let consumer = producer.consume();
 


### PR DESCRIPTION
Makes the moq-net model a strict ownership chain: a child is born only from its parent's `create_*`, and each level inherits its parent's `Arc<Info>` so properties (notably the track timescale) are **inherited rather than passed piecemeal**.

## Ownership: children are born only from parents

- `TrackProducer::new` and `TrackRequest::new` are now `pub(crate)`. The only public ways to mint a track are `BroadcastProducer::create_track` / `reserve_track`, or a dynamic `TrackRequest`.
- **`BroadcastProducer::insert_track` is removed.** Its one production user, the IETF `PUBLISH` path in `ietf/subscriber.rs`, now `start_announce`s the broadcast first and then `create_track`s the track from it (so the track is genuinely born from its broadcast), undoing the announce on the error paths.
- Standalone `BroadcastInfo::produce()` is kept, as agreed. Origin-owned broadcasts (`Arc<OriginInfo>`) remain a deliberate follow-up.

## Inherited `Arc<Info>` chain

- `BroadcastProducer` / `BroadcastConsumer` / `BroadcastDynamic` hold `Arc<BroadcastInfo>`, threaded into every track via `create_track` / `reserve_track` / `TrackRequest::accept`. Exposed as `TrackProducer::broadcast()`.
- `TrackState` holds `Option<Arc<TrackInfo>>`; each group inherits a shared `Arc<TrackInfo>` clone (replacing the copied-out `Option<Timescale>`), and `GroupProducer::timescale()` reads through it.
- `GroupProducer` / `GroupConsumer` hold `Arc<GroupInfo>`, threaded into every frame. Exposed as `FrameProducer::group()`.

## Rename

`Group` → `GroupInfo` and `Frame` → `FrameInfo`, matching the existing `BroadcastInfo` / `TrackInfo` convention. The wire types `lite::Group` / `ietf::Group` are unchanged.

## Cascade

The only breakage anywhere in the workspace was test-site callers of the now-private constructors (moq-mux ×3 files, moq-json, moq-native test) and qualified `moq_net::Group`/`Frame` refs (moq-mux, hang). No production code outside moq-net needed changes. Test sites were migrated to `create_track` (via a throwaway broadcast helper) and the renamed types.

## Public API changes (breaking, targets `dev`)

- `Group` renamed to `GroupInfo`; `Frame` renamed to `FrameInfo`.
- `TrackProducer::new`, `TrackRequest::new` demoted to `pub(crate)`.
- `BroadcastProducer::insert_track` removed.
- `BroadcastProducer`/`Consumer`/`Dynamic` now carry `Arc<BroadcastInfo>`; `GroupProducer`/`Consumer` carry `Arc<GroupInfo>`; `FrameProducer` carries `Arc<GroupInfo>`.
- New: `TrackProducer::broadcast()`, `FrameProducer::group()`.

## Testing

- `cargo test -p moq-net` → 398 lib + 4 doctests pass.
- **62 moq-native loopback broadcast tests pass** — validates the IETF publish reshape end-to-end.
- `moq-mux` / `moq-json` / `hang` / `moq-relay` libs pass.
- `cargo build --workspace --all-targets`, `clippy`, and `cargo fmt --check` (nix toolchain) all clean.

## Cross-package sync (follow-up)

- `js/net` mirror (`broadcast.ts` / `track.ts` / `group.ts`) and `doc/concept` are **not** in this PR; they're the tracked follow-up.
- `Arc<OriginInfo>` (origins owning broadcasts) intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)