### PR TITLE
feat(moq-native): unified client TLS verification + quiche backend support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1783,7 +1783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2283,7 +2283,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3287,7 +3287,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4442,7 +4442,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5981,7 +5981,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5994,7 +5994,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6053,7 +6053,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6074,7 +6074,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6289,7 +6289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6700,7 +6700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6924,7 +6924,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6933,7 +6933,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8100,9 +8100,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quiche"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4f79670e02d23e233f96f53a05d5cbaeb0dfcc37ee4175c93f10a8a5389ee4"
+checksum = "1c946eccf30928aa98aa0454d2929f48ad952e5335e2ecbf4d0eb6263f1f98ce"
 dependencies = [
  "boring",
  "bytes",
@@ -8211,7 +8211,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 default = ["quinn", "aws-lc-rs", "websocket", "tcp", "uds"]
 quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
 noq = ["dep:web-transport-noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
-quiche = ["dep:web-transport-quiche", "dep:rcgen"]
+quiche = ["dep:web-transport-quiche", "dep:rcgen", "dep:reqwest"]
 # Filesystem watcher for hot-reloading on-disk TLS certs/keys; the QUIC backends imply it.
 watch = ["dep:notify"]
 aws-lc-rs = ["rustls/aws-lc-rs", "rcgen?/aws_lc_rs", "quinn?/rustls-aws-lc-rs"]

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -119,6 +119,8 @@ type Result<T> = std::result::Result<T, Error>;
 pub(crate) struct NoqClient {
 	pub quic: noq::Endpoint,
 	pub transport: Arc<noq::TransportConfig>,
+	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
+	pub http_bootstrap: bool,
 	pub versions: moq_net::Versions,
 }
 
@@ -149,6 +151,7 @@ impl NoqClient {
 		Ok(Self {
 			quic,
 			transport,
+			http_bootstrap: config.tls.allows_http_bootstrap(),
 			versions: config.versions(),
 		})
 	}
@@ -172,25 +175,34 @@ impl NoqClient {
 		let ip = crate::util::pick_addr(addrs, local).ok_or(Error::NoDnsEntries)?;
 
 		if url.scheme() == "http" {
-			// Perform a HTTP request to fetch the certificate fingerprint.
-			let mut fingerprint = url.clone();
-			fingerprint.set_path("/certificate.sha256");
-			fingerprint.set_query(None);
-			fingerprint.set_fragment(None);
+			// Insecure per-connection bootstrap: only honored when no stronger
+			// verification is configured, so an attacker controlling the plaintext
+			// fetch can't weaken an explicit pin or re-enable disabled verification.
+			if self.http_bootstrap {
+				// Perform a HTTP request to fetch the certificate fingerprint.
+				let mut fingerprint = url.clone();
+				fingerprint.set_path("/certificate.sha256");
+				fingerprint.set_query(None);
+				fingerprint.set_fragment(None);
 
-			tracing::warn!(url = %fingerprint, "performing insecure HTTP request for certificate");
+				tracing::warn!(url = %fingerprint, "performing insecure HTTP request for certificate");
 
-			let resp = reqwest::get(fingerprint.as_str())
-				.await
-				.map_err(Error::FetchFingerprint)?
-				.error_for_status()
-				.map_err(Error::FingerprintStatus)?;
+				let resp = reqwest::get(fingerprint.as_str())
+					.await
+					.map_err(Error::FetchFingerprint)?
+					.error_for_status()
+					.map_err(Error::FingerprintStatus)?;
 
-			let fingerprint = resp.text().await.map_err(Error::ReadFingerprint)?;
-			let fingerprint = hex::decode(fingerprint.trim())?;
+				let fingerprint = resp.text().await.map_err(Error::ReadFingerprint)?;
+				let fingerprint = hex::decode(fingerprint.trim())?;
 
-			let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), vec![fingerprint]);
-			config.dangerous().set_certificate_verifier(Arc::new(verifier));
+				let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), vec![fingerprint]);
+				config.dangerous().set_certificate_verifier(Arc::new(verifier));
+			} else {
+				tracing::warn!(
+					"ignoring insecure http:// fingerprint bootstrap; using the configured TLS verification"
+				);
+			}
 
 			url.set_scheme("https").expect("failed to set scheme");
 		}

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -30,6 +30,9 @@ pub enum Error {
 	#[error("failed to fetch certificate fingerprint")]
 	FetchFingerprint(#[source] reqwest::Error),
 
+	#[error("certificate fingerprint request failed")]
+	FingerprintStatus(#[source] reqwest::Error),
+
 	#[error("failed to read certificate fingerprint")]
 	ReadFingerprint(#[source] reqwest::Error),
 
@@ -103,6 +106,8 @@ pub(crate) struct QuicheClient {
 	pub bind: net::SocketAddr,
 	/// Resolved server-verification policy, shared with the other backends.
 	pub verification: crate::tls::Verification,
+	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
+	pub http_bootstrap: bool,
 	pub max_streams: u64,
 	pub versions: moq_net::Versions,
 }
@@ -112,6 +117,7 @@ impl QuicheClient {
 		Ok(Self {
 			bind: config.bind,
 			verification: config.tls.verification()?,
+			http_bootstrap: config.tls.allows_http_bootstrap(),
 			max_streams: config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS),
 			versions: config.versions(),
 		})
@@ -124,19 +130,23 @@ impl QuicheClient {
 		let port = url.port().unwrap_or(443);
 
 		// `http://` fetches the relay's self-signed certificate fingerprint over
-		// an insecure request, then pins it. The URL is treated as https after,
-		// and the fetched pin forces pin mode for this connection (matching the
-		// quinn/noq backends), in addition to any configured fingerprints.
+		// an insecure request and pins it for this connection. It is only honored
+		// when no stronger verification is configured: an attacker who controls
+		// the plaintext fetch must not be able to weaken an explicit pin or
+		// re-enable verification we were told to skip.
 		let (url, verification) = if url.scheme() == "http" {
-			let pin = fetch_fingerprint(&url).await?;
 			let mut https = url.clone();
 			https.set_scheme("https").expect("https is a valid scheme");
 
-			let mut hashes = vec![pin];
-			if let Verification::Fingerprints(fps) = &self.verification {
-				hashes.extend_from_slice(fps);
+			if self.http_bootstrap {
+				let pin = fetch_fingerprint(&url).await?;
+				(https, Verification::Fingerprints(vec![pin]))
+			} else {
+				tracing::warn!(
+					"ignoring insecure http:// fingerprint bootstrap; using the configured TLS verification"
+				);
+				(https, self.verification.clone())
 			}
-			(https, Verification::Fingerprints(hashes))
 		} else {
 			(url, self.verification.clone())
 		};
@@ -228,7 +238,11 @@ async fn fetch_fingerprint(url: &Url) -> Result<[u8; 32]> {
 
 	tracing::warn!(url = %fp, "performing insecure HTTP request for certificate fingerprint");
 
-	let resp = reqwest::get(fp.as_str()).await.map_err(Error::FetchFingerprint)?;
+	let resp = reqwest::get(fp.as_str())
+		.await
+		.map_err(Error::FetchFingerprint)?
+		.error_for_status()
+		.map_err(Error::FingerprintStatus)?;
 	let text = resp.text().await.map_err(Error::ReadFingerprint)?;
 	let bytes = hex::decode(text.trim()).map_err(Error::InvalidFingerprint)?;
 	bytes.try_into().map_err(|v: Vec<u8>| Error::FingerprintLength(v.len()))

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -101,58 +101,44 @@ type Result<T> = std::result::Result<T, Error>;
 #[derive(Clone)]
 pub(crate) struct QuicheClient {
 	pub bind: net::SocketAddr,
-	pub disable_verify: bool,
-	/// SHA-256 pins from `--tls-fingerprint`; bypass the CA chain when present.
-	pub fingerprints: Vec<[u8; 32]>,
-	/// Trust roots (system + custom) used when not pinning by fingerprint.
-	pub roots: Vec<CertificateDer<'static>>,
+	/// Resolved server-verification policy, shared with the other backends.
+	pub verification: crate::tls::Verification,
 	pub max_streams: u64,
 	pub versions: moq_net::Versions,
 }
 
 impl QuicheClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
-		let disable_verify = config.tls.disable_verify.unwrap_or_default();
-		let fingerprints = config.tls.fingerprints()?;
-
-		// Roots are only consulted for standard verification, i.e. when we're
-		// neither skipping verification nor pinning by fingerprint.
-		let roots = if disable_verify || !fingerprints.is_empty() {
-			Vec::new()
-		} else {
-			let roots = config.tls.root_certs()?;
-			if roots.is_empty() {
-				return Err(crate::tls::Error::NoRoots.into());
-			}
-			roots
-		};
-
 		Ok(Self {
 			bind: config.bind,
-			disable_verify,
-			fingerprints,
-			roots,
+			verification: config.tls.verification()?,
 			max_streams: config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS),
 			versions: config.versions(),
 		})
 	}
 
 	pub async fn connect(&self, url: Url) -> Result<web_transport_quiche::Connection> {
+		use crate::tls::Verification;
+
 		let host = url.host().ok_or(Error::InvalidDnsName)?.to_string();
 		let port = url.port().unwrap_or(443);
 
-		// Per-connection cert pins start from the configured fingerprints.
-		let mut hashes = self.fingerprints.clone();
-
 		// `http://` fetches the relay's self-signed certificate fingerprint over
-		// an insecure request, then pins it. The URL is treated as https after.
-		let url = if url.scheme() == "http" {
-			hashes.push(fetch_fingerprint(&url).await?);
+		// an insecure request, then pins it. The URL is treated as https after,
+		// and the fetched pin forces pin mode for this connection (matching the
+		// quinn/noq backends), in addition to any configured fingerprints.
+		let (url, verification) = if url.scheme() == "http" {
+			let pin = fetch_fingerprint(&url).await?;
 			let mut https = url.clone();
 			https.set_scheme("https").expect("https is a valid scheme");
-			https
+
+			let mut hashes = vec![pin];
+			if let Verification::Fingerprints(fps) = &self.verification {
+				hashes.extend_from_slice(fps);
+			}
+			(https, Verification::Fingerprints(hashes))
 		} else {
-			url
+			(url, self.verification.clone())
 		};
 
 		let alpns: Vec<Vec<u8>> = match url.scheme() {
@@ -167,7 +153,7 @@ impl QuicheClient {
 		};
 
 		let mut settings = web_transport_quiche::Settings::default();
-		settings.verify_peer = !self.disable_verify;
+		settings.verify_peer = !matches!(verification, Verification::Disabled);
 		settings.alpn = alpns;
 		settings.initial_max_streams_bidi = self.max_streams;
 		settings.initial_max_streams_uni = self.max_streams;
@@ -176,12 +162,15 @@ impl QuicheClient {
 			.with_settings(settings)
 			.with_bind(self.bind)?;
 
-		// Fingerprint pinning bypasses the CA chain; otherwise verify against the
-		// resolved trust roots. `disable_verify` leaves both unset.
-		if !hashes.is_empty() {
-			builder = builder.with_server_certificate_hashes(hashes);
-		} else if !self.roots.is_empty() {
-			builder = builder.with_root_certificates(self.roots.clone());
+		match verification {
+			// No hook: tokio-quiche's default config with verify_peer = false.
+			Verification::Disabled => {}
+			Verification::Fingerprints(hashes) => {
+				builder = builder.with_server_certificate_hashes(hashes);
+			}
+			Verification::Roots(roots) => {
+				builder = builder.with_root_certificates(roots);
+			}
 		}
 
 		tracing::debug!(%url, "connecting via quiche");

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -21,6 +21,12 @@ pub enum Error {
 	#[error("invalid DNS name")]
 	InvalidDnsName,
 
+	/// No longer returned: the `http://` scheme now fetches and pins the
+	/// certificate fingerprint instead of failing.
+	#[deprecated(note = "fingerprint verification over http:// is now supported; this is never returned")]
+	#[error("fingerprint verification (http:// scheme) is not supported with the quiche backend")]
+	FingerprintUnsupported,
+
 	#[error("failed to fetch certificate fingerprint")]
 	FetchFingerprint(#[source] reqwest::Error),
 

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -21,8 +21,17 @@ pub enum Error {
 	#[error("invalid DNS name")]
 	InvalidDnsName,
 
-	#[error("fingerprint verification (http:// scheme) is not supported with the quiche backend")]
-	FingerprintUnsupported,
+	#[error("failed to fetch certificate fingerprint")]
+	FetchFingerprint(#[source] reqwest::Error),
+
+	#[error("failed to read certificate fingerprint")]
+	ReadFingerprint(#[source] reqwest::Error),
+
+	#[error("invalid certificate fingerprint")]
+	InvalidFingerprint(#[source] hex::FromHexError),
+
+	#[error("certificate fingerprint must be 32 bytes (SHA-256), got {0}")]
+	FingerprintLength(usize),
 
 	#[error("url scheme must be 'https', 'moqt', or 'moql'")]
 	InvalidScheme,
@@ -87,19 +96,36 @@ type Result<T> = std::result::Result<T, Error>;
 pub(crate) struct QuicheClient {
 	pub bind: net::SocketAddr,
 	pub disable_verify: bool,
+	/// SHA-256 pins from `--tls-fingerprint`; bypass the CA chain when present.
+	pub fingerprints: Vec<[u8; 32]>,
+	/// Trust roots (system + custom) used when not pinning by fingerprint.
+	pub roots: Vec<CertificateDer<'static>>,
 	pub max_streams: u64,
 	pub versions: moq_net::Versions,
 }
 
 impl QuicheClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
-		if !config.tls.root.is_empty() {
-			tracing::warn!("--tls-root is not supported with the quiche backend; system roots will be used");
-		}
+		let disable_verify = config.tls.disable_verify.unwrap_or_default();
+		let fingerprints = config.tls.fingerprints()?;
+
+		// Roots are only consulted for standard verification, i.e. when we're
+		// neither skipping verification nor pinning by fingerprint.
+		let roots = if disable_verify || !fingerprints.is_empty() {
+			Vec::new()
+		} else {
+			let roots = config.tls.root_certs()?;
+			if roots.is_empty() {
+				return Err(crate::tls::Error::NoRoots.into());
+			}
+			roots
+		};
 
 		Ok(Self {
 			bind: config.bind,
-			disable_verify: config.tls.disable_verify.unwrap_or_default(),
+			disable_verify,
+			fingerprints,
+			roots,
 			max_streams: config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS),
 			versions: config.versions(),
 		})
@@ -109,9 +135,19 @@ impl QuicheClient {
 		let host = url.host().ok_or(Error::InvalidDnsName)?.to_string();
 		let port = url.port().unwrap_or(443);
 
-		if url.scheme() == "http" {
-			return Err(Error::FingerprintUnsupported);
-		}
+		// Per-connection cert pins start from the configured fingerprints.
+		let mut hashes = self.fingerprints.clone();
+
+		// `http://` fetches the relay's self-signed certificate fingerprint over
+		// an insecure request, then pins it. The URL is treated as https after.
+		let url = if url.scheme() == "http" {
+			hashes.push(fetch_fingerprint(&url).await?);
+			let mut https = url.clone();
+			https.set_scheme("https").expect("https is a valid scheme");
+			https
+		} else {
+			url
+		};
 
 		let alpns: Vec<Vec<u8>> = match url.scheme() {
 			"https" => vec![web_transport_quiche::ALPN.as_bytes().to_vec()],
@@ -130,9 +166,17 @@ impl QuicheClient {
 		settings.initial_max_streams_bidi = self.max_streams;
 		settings.initial_max_streams_uni = self.max_streams;
 
-		let builder = web_transport_quiche::ez::ClientBuilder::default()
+		let mut builder = web_transport_quiche::ez::ClientBuilder::default()
 			.with_settings(settings)
 			.with_bind(self.bind)?;
+
+		// Fingerprint pinning bypasses the CA chain; otherwise verify against the
+		// resolved trust roots. `disable_verify` leaves both unset.
+		if !hashes.is_empty() {
+			builder = builder.with_server_certificate_hashes(hashes);
+		} else if !self.roots.is_empty() {
+			builder = builder.with_root_certificates(self.roots.clone());
+		}
 
 		tracing::debug!(%url, "connecting via quiche");
 
@@ -175,6 +219,24 @@ impl QuicheClient {
 			_ => unreachable!("unsupported URL scheme: {}", url.scheme()),
 		}
 	}
+}
+
+/// Fetch a relay's certificate SHA-256 over an insecure `http://` request.
+///
+/// This is the native equivalent of how a browser bootstraps trust for a
+/// self-signed relay: GET `/certificate.sha256` and pin the returned hash.
+async fn fetch_fingerprint(url: &Url) -> Result<[u8; 32]> {
+	let mut fp = url.clone();
+	fp.set_path("/certificate.sha256");
+	fp.set_query(None);
+	fp.set_fragment(None);
+
+	tracing::warn!(url = %fp, "performing insecure HTTP request for certificate fingerprint");
+
+	let resp = reqwest::get(fp.as_str()).await.map_err(Error::FetchFingerprint)?;
+	let text = resp.text().await.map_err(Error::ReadFingerprint)?;
+	let bytes = hex::decode(text.trim()).map_err(Error::InvalidFingerprint)?;
+	bytes.try_into().map_err(|v: Vec<u8>| Error::FingerprintLength(v.len()))
 }
 
 impl Error {

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -117,6 +117,8 @@ type Result<T> = std::result::Result<T, Error>;
 pub(crate) struct QuinnClient {
 	pub quic: quinn::Endpoint,
 	pub transport: Arc<quinn::TransportConfig>,
+	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
+	pub http_bootstrap: bool,
 	pub versions: moq_net::Versions,
 }
 
@@ -147,6 +149,7 @@ impl QuinnClient {
 		Ok(Self {
 			quic,
 			transport,
+			http_bootstrap: config.tls.allows_http_bootstrap(),
 			versions: config.versions(),
 		})
 	}
@@ -170,25 +173,34 @@ impl QuinnClient {
 		let ip = crate::util::pick_addr(addrs, local).ok_or(Error::NoDnsEntries)?;
 
 		if url.scheme() == "http" {
-			// Perform a HTTP request to fetch the certificate fingerprint.
-			let mut fingerprint = url.clone();
-			fingerprint.set_path("/certificate.sha256");
-			fingerprint.set_query(None);
-			fingerprint.set_fragment(None);
+			// Insecure per-connection bootstrap: only honored when no stronger
+			// verification is configured, so an attacker controlling the plaintext
+			// fetch can't weaken an explicit pin or re-enable disabled verification.
+			if self.http_bootstrap {
+				// Perform a HTTP request to fetch the certificate fingerprint.
+				let mut fingerprint = url.clone();
+				fingerprint.set_path("/certificate.sha256");
+				fingerprint.set_query(None);
+				fingerprint.set_fragment(None);
 
-			tracing::warn!(url = %fingerprint, "performing insecure HTTP request for certificate");
+				tracing::warn!(url = %fingerprint, "performing insecure HTTP request for certificate");
 
-			let resp = reqwest::get(fingerprint.as_str())
-				.await
-				.map_err(Error::FetchFingerprint)?
-				.error_for_status()
-				.map_err(Error::FingerprintStatus)?;
+				let resp = reqwest::get(fingerprint.as_str())
+					.await
+					.map_err(Error::FetchFingerprint)?
+					.error_for_status()
+					.map_err(Error::FingerprintStatus)?;
 
-			let fingerprint = resp.text().await.map_err(Error::ReadFingerprint)?;
-			let fingerprint = hex::decode(fingerprint.trim())?;
+				let fingerprint = resp.text().await.map_err(Error::ReadFingerprint)?;
+				let fingerprint = hex::decode(fingerprint.trim())?;
 
-			let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), vec![fingerprint]);
-			config.dangerous().set_certificate_verifier(Arc::new(verifier));
+				let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), vec![fingerprint]);
+				config.dangerous().set_certificate_verifier(Arc::new(verifier));
+			} else {
+				tracing::warn!(
+					"ignoring insecure http:// fingerprint bootstrap; using the configured TLS verification"
+				);
+			}
 
 			url.set_scheme("https").expect("failed to set scheme");
 		}

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -268,6 +268,45 @@ impl Client {
 
 		Ok(tls)
 	}
+
+	/// Resolve the trust roots as DER for backends that can't consume a
+	/// [rustls::ClientConfig] (e.g. quiche/BoringSSL).
+	///
+	/// Like [Client::build], system roots are included only when no custom root
+	/// is given unless `system_roots` is set explicitly.
+	pub(crate) fn root_certs(&self) -> Result<Vec<CertificateDer<'static>>> {
+		let system_roots = self.system_roots.unwrap_or(self.root.is_empty());
+
+		let mut out = Vec::new();
+		if system_roots {
+			let native = rustls_native_certs::load_native_certs();
+			for err in native.errors {
+				tracing::warn!(%err, "failed to load root cert");
+			}
+			out.extend(native.certs);
+		}
+		for root in &self.root {
+			let certs = read_certs(root)?;
+			if certs.is_empty() {
+				return Err(Error::EmptyRoots(root.clone()));
+			}
+			out.extend(certs);
+		}
+
+		Ok(out)
+	}
+
+	/// Parse the configured fingerprints into fixed-size SHA-256 digests, for
+	/// backends that pin by hash directly rather than via a rustls verifier.
+	pub(crate) fn fingerprints(&self) -> Result<Vec<[u8; 32]>> {
+		self.fingerprint
+			.iter()
+			.map(|fp| {
+				let bytes = hex::decode(fp.trim()).map_err(Error::Fingerprint)?;
+				bytes.try_into().map_err(|v: Vec<u8>| Error::FingerprintLength(v.len()))
+			})
+			.collect()
+	}
 }
 
 // ── Server ──────────────────────────────────────────────────────────

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -283,8 +283,8 @@ impl Client {
 
 	/// Build a [`rustls::ClientConfig`] from this configuration.
 	///
-	/// Resolves the [verification](Client::verification) policy, optionally
-	/// attaches a client identity for mTLS, and installs the matching verifier.
+	/// Resolves the verification policy, optionally attaches a client identity
+	/// for mTLS, and installs the matching verifier.
 	pub fn build(&self) -> Result<rustls::ClientConfig> {
 		let provider = crypto::provider();
 		let verification = self.verification()?;

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -46,6 +46,11 @@ pub enum Error {
 	#[error("invalid TLS fingerprint length: expected 32 bytes (SHA-256), got {0}")]
 	FingerprintLength(usize),
 
+	#[error(
+		"--tls-fingerprint cannot be combined with --tls-root or --tls-system-roots: fingerprint pinning bypasses CA verification"
+	)]
+	FingerprintWithRoots,
+
 	#[error("failed to add root certificate")]
 	AddRoot(#[source] rustls::Error),
 
@@ -180,45 +185,102 @@ pub struct Client {
 	pub disable_verify: Option<bool>,
 }
 
+/// The resolved server-certificate verification policy.
+///
+/// Computed once by [Client::verification] and shared by every backend (the
+/// rustls-based quinn/noq via [Client::build], and quiche directly) so they
+/// agree on precedence, the system-roots default, and which flag combinations
+/// are valid.
+#[derive(Clone)]
+pub(crate) enum Verification {
+	/// No verification at all. Insecure; only via `--tls-disable-verify`.
+	Disabled,
+
+	/// Pin the leaf certificate by SHA-256. The CA chain is not consulted, so
+	/// this is mutually exclusive with any roots.
+	Fingerprints(Vec<[u8; 32]>),
+
+	/// Standard verification against these roots (system and/or custom, already
+	/// resolved). The two sets are additive.
+	Roots(Vec<CertificateDer<'static>>),
+}
+
 impl Client {
-	/// Build a [`rustls::ClientConfig`] from this configuration.
+	/// Resolve the verification policy from the configured flags.
 	///
-	/// Trusts the configured roots plus the platform's native roots (the latter
-	/// gated by `system_roots`), optionally attaches a client identity for mTLS,
-	/// and swaps in fingerprint pinning or disabled verification when requested.
-	pub fn build(&self) -> Result<rustls::ClientConfig> {
-		let provider = crypto::provider();
+	/// Precedence and rules (shared by all backends):
+	/// - `--tls-disable-verify` wins and disables verification.
+	/// - `--tls-fingerprint` pins the leaf and bypasses the CA chain; combining
+	///   it with `--tls-root` or `--tls-system-roots` is rejected rather than
+	///   silently ignoring one of them.
+	/// - Otherwise, verify against the system roots (default) plus any custom
+	///   roots. The system roots are dropped once a custom root is given unless
+	///   `--tls-system-roots` re-enables them.
+	pub(crate) fn verification(&self) -> Result<Verification> {
+		if self.disable_verify.unwrap_or_default() {
+			return Ok(Verification::Disabled);
+		}
+
+		let fingerprints = self.fingerprints()?;
+		if !fingerprints.is_empty() {
+			if !self.root.is_empty() || self.system_roots == Some(true) {
+				return Err(Error::FingerprintWithRoots);
+			}
+			return Ok(Verification::Fingerprints(fingerprints));
+		}
 
 		// Default to system roots only when no custom root is given, so passing a
 		// root replaces them unless the system roots are explicitly re-enabled.
 		let system_roots = self.system_roots.unwrap_or(self.root.is_empty());
 
-		// fingerprint pinning and disable_verify swap in their own verifier below,
-		// so an empty root store is fine in those cases. Otherwise WebPKI needs at
-		// least one trusted root to ever succeed, so fail fast instead of producing
-		// confusing handshake errors later.
-		let custom_verifier = self.disable_verify.unwrap_or_default() || !self.fingerprint.is_empty();
-		if !system_roots && self.root.is_empty() && !custom_verifier {
-			return Err(Error::NoRoots);
-		}
-
-		let mut roots = rustls::RootCertStore::empty();
+		let mut roots = Vec::new();
 		if system_roots {
 			let native = rustls_native_certs::load_native_certs();
 			for err in native.errors {
 				tracing::warn!(%err, "failed to load root cert");
 			}
-			for cert in native.certs {
-				roots.add(cert).map_err(Error::AddRoot)?;
-			}
+			roots.extend(native.certs);
 		}
 		for root in &self.root {
 			let certs = read_certs(root)?;
 			if certs.is_empty() {
 				return Err(Error::EmptyRoots(root.clone()));
 			}
+			roots.extend(certs);
+		}
+
+		// WebPKI needs at least one trusted root to ever succeed, so fail fast
+		// instead of producing confusing handshake errors later.
+		if roots.is_empty() {
+			return Err(Error::NoRoots);
+		}
+
+		Ok(Verification::Roots(roots))
+	}
+
+	/// Parse the configured fingerprints into fixed-size SHA-256 digests.
+	fn fingerprints(&self) -> Result<Vec<[u8; 32]>> {
+		self.fingerprint
+			.iter()
+			.map(|fp| {
+				let bytes = hex::decode(fp.trim()).map_err(Error::Fingerprint)?;
+				bytes.try_into().map_err(|v: Vec<u8>| Error::FingerprintLength(v.len()))
+			})
+			.collect()
+	}
+
+	/// Build a [`rustls::ClientConfig`] from this configuration.
+	///
+	/// Resolves the [verification](Client::verification) policy, optionally
+	/// attaches a client identity for mTLS, and installs the matching verifier.
+	pub fn build(&self) -> Result<rustls::ClientConfig> {
+		let provider = crypto::provider();
+		let verification = self.verification()?;
+
+		let mut roots = rustls::RootCertStore::empty();
+		if let Verification::Roots(certs) = &verification {
 			for cert in certs {
-				roots.add(cert).map_err(Error::AddRoot)?;
+				roots.add(cert.clone()).map_err(Error::AddRoot)?;
 			}
 		}
 
@@ -245,67 +307,24 @@ impl Client {
 			_ => return Err(Error::IncompleteClientAuth),
 		};
 
-		if self.disable_verify.unwrap_or_default() {
-			tracing::warn!("TLS server certificate verification is disabled; A man-in-the-middle attack is possible.");
-			let noop = NoCertificateVerification(provider);
-			tls.dangerous().set_certificate_verifier(Arc::new(noop));
-		} else if !self.fingerprint.is_empty() {
-			let fingerprints = self
-				.fingerprint
-				.iter()
-				.map(|fp| {
-					let bytes = hex::decode(fp.trim()).map_err(Error::Fingerprint)?;
-					match bytes.len() {
-						32 => Ok(bytes),
-						len => Err(Error::FingerprintLength(len)),
-					}
-				})
-				.collect::<Result<Vec<_>>>()?;
-
-			let verifier = FingerprintVerifier::new(provider, fingerprints);
-			tls.dangerous().set_certificate_verifier(Arc::new(verifier));
+		match verification {
+			Verification::Disabled => {
+				tracing::warn!(
+					"TLS server certificate verification is disabled; A man-in-the-middle attack is possible."
+				);
+				tls.dangerous()
+					.set_certificate_verifier(Arc::new(NoCertificateVerification(provider)));
+			}
+			Verification::Fingerprints(fingerprints) => {
+				let fingerprints = fingerprints.into_iter().map(|fp| fp.to_vec()).collect();
+				let verifier = FingerprintVerifier::new(provider, fingerprints);
+				tls.dangerous().set_certificate_verifier(Arc::new(verifier));
+			}
+			// Roots are already in the store above; use the default WebPKI verifier.
+			Verification::Roots(_) => {}
 		}
 
 		Ok(tls)
-	}
-
-	/// Resolve the trust roots as DER for backends that can't consume a
-	/// [rustls::ClientConfig] (e.g. quiche/BoringSSL).
-	///
-	/// Like [Client::build], system roots are included only when no custom root
-	/// is given unless `system_roots` is set explicitly.
-	pub(crate) fn root_certs(&self) -> Result<Vec<CertificateDer<'static>>> {
-		let system_roots = self.system_roots.unwrap_or(self.root.is_empty());
-
-		let mut out = Vec::new();
-		if system_roots {
-			let native = rustls_native_certs::load_native_certs();
-			for err in native.errors {
-				tracing::warn!(%err, "failed to load root cert");
-			}
-			out.extend(native.certs);
-		}
-		for root in &self.root {
-			let certs = read_certs(root)?;
-			if certs.is_empty() {
-				return Err(Error::EmptyRoots(root.clone()));
-			}
-			out.extend(certs);
-		}
-
-		Ok(out)
-	}
-
-	/// Parse the configured fingerprints into fixed-size SHA-256 digests, for
-	/// backends that pin by hash directly rather than via a rustls verifier.
-	pub(crate) fn fingerprints(&self) -> Result<Vec<[u8; 32]>> {
-		self.fingerprint
-			.iter()
-			.map(|fp| {
-				let bytes = hex::decode(fp.trim()).map_err(Error::Fingerprint)?;
-				bytes.try_into().map_err(|v: Vec<u8>| Error::FingerprintLength(v.len()))
-			})
-			.collect()
 	}
 }
 
@@ -648,6 +667,30 @@ mod tests {
 			..Default::default()
 		};
 		assert!(config.build().is_ok());
+	}
+
+	#[test]
+	fn build_rejects_fingerprint_with_roots() {
+		let cert = self_signed();
+		let fingerprint = hex::encode(crypto::sha256(&crypto::provider(), cert.as_ref()));
+
+		// Fingerprint pinning bypasses the CA chain, so combining it with roots
+		// is rejected rather than silently ignoring one of them.
+		let with_system = Client {
+			fingerprint: vec![fingerprint.clone()],
+			system_roots: Some(true),
+			..Default::default()
+		};
+		assert!(matches!(with_system.build(), Err(Error::FingerprintWithRoots)));
+
+		// The conflict is detected before any root file is read, so the path
+		// need not exist.
+		let with_custom = Client {
+			fingerprint: vec![fingerprint],
+			root: vec![PathBuf::from("/does-not-exist.pem")],
+			..Default::default()
+		};
+		assert!(matches!(with_custom.build(), Err(Error::FingerprintWithRoots)));
 	}
 }
 

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -258,6 +258,18 @@ impl Client {
 		Ok(Verification::Roots(roots))
 	}
 
+	/// Whether an insecure `http://` certificate-fingerprint bootstrap may be
+	/// honored for a connection.
+	///
+	/// Only when no stronger verification is configured: an explicit
+	/// `--tls-fingerprint` must never be weakened by an attacker-controlled
+	/// plaintext fetch, and there is nothing to bootstrap when verification is
+	/// disabled. With CA roots (the default), `http://` is the deliberate
+	/// per-connection way to pin a self-signed relay, so it is allowed.
+	pub(crate) fn allows_http_bootstrap(&self) -> bool {
+		self.fingerprint.is_empty() && !self.disable_verify.unwrap_or_default()
+	}
+
 	/// Parse the configured fingerprints into fixed-size SHA-256 digests.
 	fn fingerprints(&self) -> Result<Vec<[u8; 32]>> {
 		self.fingerprint


### PR DESCRIPTION
## Summary

Brings the **quiche** QUIC backend up to TLS-verification parity with quinn/noq, and centralizes the verification policy so all three backends agree.

### Verification (shared)
`tls::Client::verification()` is the single source of truth, returning a `Verification` enum (`Disabled` / `Fingerprints` / `Roots`) consumed by the rustls backends (quinn/noq via `build()`) and quiche directly:

- **`--tls-fingerprint`** → pins the leaf by SHA-256 (native `serverCertificateHashes`), bypassing the CA chain.
- **`--tls-root` / `--tls-system-roots`** → verify against system and/or custom roots. System roots are on by default, dropped once a custom root is given unless re-enabled; the two sets are additive.
- **`http://` scheme** → fetch `/certificate.sha256` and pin it.

**Behavior fix (quinn/noq/quiche):** fingerprint + roots used to silently resolve to "fingerprint only" (roots dropped). It's now a hard error (`FingerprintWithRoots`) — pinning bypasses the CA chain, so combining it with roots is a misconfiguration. The quiche backend's previously-duplicated root/fingerprint resolution is gone; it now calls the shared `verification()`.

> Full additive verification (accept if pinned **or** chains to a root) was considered but not adopted: clean in rustls (a composite verifier), but in BoringSSL `set_custom_verify_callback` *replaces* standard verification and would require hand-rolling chain + hostname checks. Erroring keeps it safe and consistent.

### quiche backend
Wires the above into quiche (`with_server_certificate_hashes` / `with_root_certificates`, the `http://` fetch). `quiche::Error::FingerprintUnsupported` is kept as `#[deprecated]` (never constructed).

Backend pieces live in [moq-dev/web-transport#261](https://github.com/moq-dev/web-transport/pull/261), shipped as `web-transport-quiche` **0.4.2**, which this PR bumps to.

## API note (additive — safe for main)
`quiche::Error` gains fetch variants; `FingerprintUnsupported` is deprecated, not removed. `tls::Error` gains `FingerprintWithRoots`. No public removals.

## Test plan

- [x] `tls` unit tests incl. new `build_rejects_fingerprint_with_roots` (fingerprint + system/custom roots both error).
- [x] `cargo check`/`clippy` for `moq-native` (quinn default, `noq`, `quiche`) and `moq-cli`/`moq-relay` with `moq-native/quiche`, against published `web-transport-quiche` 0.4.2 — clean.
- [ ] End-to-end against a running relay (not yet done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)