### PR TITLE
refactor(moq-json): gate group rolls on already-written deltas

### DIFF
--- a/js/json/src/compression.test.ts
+++ b/js/json/src/compression.test.ts
@@ -25,6 +25,17 @@ async function firstFrame(track: Track): Promise<Uint8Array> {
 	return frame;
 }
 
+// Count the groups a (finished) track published, draining each so the reads terminate.
+async function groupCount(track: Track): Promise<number> {
+	let groups = 0;
+	for (;;) {
+		const group = await track.nextGroupOrdered();
+		if (!group) return groups;
+		groups++;
+		while ((await group.readFrame()) !== undefined) {}
+	}
+}
+
 test("compressed snapshot per group round-trips", async () => {
 	const track = new Track("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 0, compression: true });
@@ -113,4 +124,25 @@ test("compression shrinks a repetitive frame", async () => {
 	const plainLen = (await firstFrame(plain)).length;
 	const compressedLen = (await firstFrame(compressed)).length;
 	expect(compressedLen).toBeLessThan(plainLen);
+});
+
+test("compressed deltas roll on the compressed budget", async () => {
+	// With compression the budget is measured on compressed frame sizes: #snapshotLen and #deltaBytes
+	// are the written slice lengths, not the raw JSON. A tight ratio over many distinct updates must
+	// roll more than one group, and a late joiner must still rebuild the final value across the
+	// compressed group boundary. Guards against the budget regressing to raw lengths. Two identical
+	// producers (deterministic output) keep the group-count and reconstruction reads independent.
+	const fill = (track: Track) => {
+		const producer = new Producer<Value>(track, { deltaRatio: 2, compression: true });
+		for (let n = 0; n <= 40; n++) producer.update({ n });
+		producer.finish();
+	};
+
+	const layout = new Track("layout");
+	fill(layout);
+	expect(await groupCount(layout)).toBeGreaterThan(1);
+
+	const reconstruct = new Track("reconstruct");
+	fill(reconstruct);
+	expect((await drainCompressed(reconstruct)).at(-1)).toEqual({ n: 40 });
 });

--- a/js/json/src/json.test.ts
+++ b/js/json/src/json.test.ts
@@ -151,28 +151,31 @@ test("mutate removes a section", async () => {
 
 test("tight ratio rolls snapshots", async () => {
 	const track = new Track("test");
-	// A ratio of 1 admits deltas only up to the snapshot size: with equal 7-byte frames that is a
-	// single delta per group, so it rolls every other update.
+	// A ratio of 1 budgets deltas up to one snapshot (equal 7-byte frames => 7 bytes). The gate checks
+	// the deltas already written, so the delta that tips the group over budget still lands (a one-frame
+	// overshoot): group 0 takes two deltas (14 bytes) before the fourth update rolls group 1.
 	const producer = new Producer<Value>(track, { deltaRatio: 1 });
 	producer.update({ a: 1 }); // snapshot, group 0
-	producer.update({ a: 2 }); // delta, group 0
-	producer.update({ a: 3 }); // exceeds budget, rolls group 1
-	producer.update({ a: 4 }); // delta, group 1
+	producer.update({ a: 2 }); // delta, group 0 (deltas = 7)
+	producer.update({ a: 3 }); // delta, group 0 (deltas = 14, now over budget)
+	producer.update({ a: 4 }); // budget already exceeded, rolls group 1
 	producer.finish();
 
-	expect(await structure(track)).toEqual([2, 2]);
+	expect(await structure(track)).toEqual([3, 1]);
 });
 
 test("deltas stay within ratio times snapshot", async () => {
 	const track = new Track("test");
-	// The budget covers only the deltas, not the snapshot frame, measured against the current
-	// snapshot size. Single-digit values keep every frame at a constant 7 bytes (`{"n":N}`), so a
-	// ratio of 8 admits 8 deltas (8x the snapshot) on top of the snapshot before the 9th rolls.
+	// The budget covers only the deltas, not the snapshot frame, measured against the group's snapshot
+	// size. Single-digit values keep every frame at a constant 7 bytes (`{"n":N}`), so a ratio of 8
+	// budgets 56 bytes of deltas. The gate checks the deltas already written, so the group keeps filling
+	// until they first exceed 56 (nine deltas = 63 bytes) and the next update rolls (a one-frame
+	// overshoot past the 56-byte budget).
 	const producer = new Producer<Value>(track, { deltaRatio: 8 });
-	for (let n = 0; n <= 9; n++) producer.update({ n });
+	for (let n = 0; n <= 10; n++) producer.update({ n });
 	producer.finish();
 
-	expect(await structure(track)).toEqual([9, 1]);
+	expect(await structure(track)).toEqual([10, 1]);
 });
 
 test("array change is a wholesale delta", async () => {

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -18,9 +18,12 @@ export interface Config<T> {
 	// `0` disables deltas: every change is published as a new snapshot group.
 	//
 	// A positive number enables deltas: a delta is appended to the current group as long as the
-	// accumulated deltas (excluding the snapshot frame) stay within `deltaRatio` times the size of a
-	// fresh snapshot; otherwise a new snapshot group is started. So `1` allows deltas totalling up to
-	// one snapshot before rolling.
+	// accumulated deltas (excluding the snapshot frame) stay within `deltaRatio` times the snapshot
+	// size; otherwise a new snapshot group is started. So `1` allows deltas totalling up to one snapshot
+	// before rolling.
+	//
+	// When {@link compression} is on, both sides of the comparison are measured on the compressed frame
+	// sizes (the real wire cost).
 	//
 	// Defaults to `8` when unset.
 	deltaRatio?: number;
@@ -56,11 +59,13 @@ export class Producer<T> {
 	#track?: Moq.Track;
 	#group?: Moq.Group;
 	#last?: unknown;
-	// Bytes of deltas accumulated in the current group, excluding the snapshot frame. Always raw
-	// (uncompressed) sizes, even when compressing: the delta-vs-snapshot decision measures raw bytes,
-	// so a compressed producer rolls groups on raw sizes (still valid on the wire, just a touch sooner
-	// than the Rust producer, which measures compressed sizes).
+	// Bytes of deltas already written to the current group, excluding the snapshot frame. Compressed
+	// frame sizes when compressing, raw otherwise, matching {@link #snapshotLen} so the budget check is
+	// like-for-like (and identical to the Rust producer).
 	#deltaBytes = 0;
+	// Size of the current group's snapshot frame, the reference the delta budget is measured against.
+	// Compressed when compressing, raw otherwise.
+	#snapshotLen = 0;
 	#groupFrames = 0;
 
 	// Group-scoped `deflate-raw` compression. `#encoder` is the current group's stream, swapped for a
@@ -124,10 +129,9 @@ export class Producer<T> {
 		if (this.#last !== undefined && deepEqual(this.#last, json)) return;
 
 		const snapshot = new TextEncoder().encode(text);
-		const delta = this.#delta(json, snapshot.length);
+		const delta = this.#delta(json);
 		if (delta && this.#group) {
-			this.#writeDelta(this.#group, delta);
-			this.#deltaBytes += delta.length;
+			this.#deltaBytes += this.#writeDelta(this.#group, delta);
 			this.#groupFrames += 1;
 		} else {
 			this.#snapshot(this.#track, snapshot);
@@ -211,21 +215,24 @@ export class Producer<T> {
 		return this.#config.deltaRatio ?? DEFAULT_DELTA_RATIO;
 	}
 
-	#delta(json: unknown, snapshotLen: number): Uint8Array | undefined {
+	// Build a delta frame, or `undefined` to signal that a fresh snapshot should be published.
+	//
+	// The budget gate runs first, against the deltas already written, so rolling a new group costs no
+	// merge-patch work. Since the gate excludes the frame about to be written, the delta that tips the
+	// group past `ratio * snapshot` still lands: a group overshoots the budget by at most one delta.
+	#delta(json: unknown): Uint8Array | undefined {
 		const ratio = this.#deltaRatio;
 		if (ratio === 0) return undefined;
 		if (this.#last === undefined) return undefined;
 		if (!this.#group || this.#groupFrames >= MAX_DELTA_FRAMES) return undefined;
 
+		// Gate on the deltas accumulated so far (snapshot frame excluded), before computing the patch.
+		if (this.#deltaBytes > ratio * this.#snapshotLen) return undefined;
+
 		const result = diff(this.#last, json);
 		if (result.forcedSnapshot) return undefined;
 
-		const delta = new TextEncoder().encode(JSON.stringify(result.patch));
-
-		// Roll a snapshot once the deltas would outgrow the budget (snapshot frame excluded).
-		if (this.#deltaBytes + delta.length > ratio * snapshotLen) return undefined;
-
-		return delta;
+		return new TextEncoder().encode(JSON.stringify(result.patch));
 	}
 
 	#snapshot(track: Moq.Track, snapshot: Uint8Array): void {
@@ -233,7 +240,7 @@ export class Producer<T> {
 		this.#group?.close();
 
 		const group = track.appendGroup();
-		this.#writeSnapshot(group, snapshot);
+		this.#snapshotLen = this.#writeSnapshot(group, snapshot);
 		this.#deltaBytes = 0;
 		this.#groupFrames = 1;
 
@@ -247,24 +254,29 @@ export class Producer<T> {
 		}
 	}
 
-	// Write a group's snapshot (frame 0). On the compressed path this opens a fresh per-group encoder
-	// (cold window), so the snapshot and its deltas share one DEFLATE stream.
-	#writeSnapshot(group: Moq.Group, frame: Uint8Array): void {
+	// Write a group's snapshot (frame 0), returning the bytes written. On the compressed path this opens
+	// a fresh per-group encoder (cold window), so the snapshot and its deltas share one DEFLATE stream.
+	#writeSnapshot(group: Moq.Group, frame: Uint8Array): number {
 		if (!this.#compress) {
 			group.writeFrame(frame);
-			return;
+			return frame.length;
 		}
 		this.#encoder = new Encoder();
-		group.writeFrame(this.#encoder.frame(frame));
+		const slice = this.#encoder.frame(frame);
+		group.writeFrame(slice);
+		return slice.length;
 	}
 
-	// Write a delta frame, compressed against the current group's encoder when compressing.
-	#writeDelta(group: Moq.Group, frame: Uint8Array): void {
+	// Write a delta frame, compressed against the current group's encoder when compressing. Returns the
+	// bytes written.
+	#writeDelta(group: Moq.Group, frame: Uint8Array): number {
 		if (!this.#compress) {
 			group.writeFrame(frame);
-			return;
+			return frame.length;
 		}
 		if (!this.#encoder) throw new Error("compressed delta requires an open group");
-		group.writeFrame(this.#encoder.frame(frame));
+		const slice = this.#encoder.frame(frame);
+		group.writeFrame(slice);
+		return slice.length;
 	}
 }

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -17,10 +17,10 @@ export interface Config<T> {
 	//
 	// `0` disables deltas: every change is published as a new snapshot group.
 	//
-	// A positive number enables deltas: a delta is appended to the current group as long as the
-	// accumulated deltas (excluding the snapshot frame) stay within `deltaRatio` times the snapshot
-	// size; otherwise a new snapshot group is started. So `1` allows deltas totalling up to one snapshot
-	// before rolling.
+	// A positive number enables deltas: a new snapshot group is started once the deltas already written
+	// to the current group (excluding the snapshot frame) exceed `deltaRatio` times the snapshot size.
+	// The pending delta is excluded from that check, so the one that first crosses the budget still
+	// lands before the group rolls. So `1` allows roughly one snapshot's worth of deltas before rolling.
 	//
 	// When {@link compression} is on, both sides of the comparison are measured on the compressed frame
 	// sizes (the real wire cost).

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -263,7 +263,7 @@ impl Inner {
 			return Ok(());
 		}
 
-		match self.delta(&json, snapshot.len())? {
+		match self.delta(&json)? {
 			Some(slice) => {
 				let group = self.group.as_mut().expect("delta requires an open group");
 				let len = slice.len() as u64;
@@ -278,11 +278,14 @@ impl Inner {
 		Ok(())
 	}
 
-	/// Serialize (and, when compressing, compress) a delta if deltas are enabled and appending one
-	/// keeps the group within budget; otherwise `None`, signalling that a fresh snapshot should be
-	/// published instead. Returns the frame slice ready to write.
-	fn delta(&mut self, value: &Value, snapshot_len: usize) -> Result<Option<Bytes>> {
-		let ratio = self.config.delta_ratio;
+	/// Build a delta frame for `value`, or `None` to signal that a fresh snapshot should be published.
+	///
+	/// The budget gate runs first, against the deltas *already written*, so rolling a new group costs
+	/// no merge-patch or compression work. Because the gate doesn't include the frame about to be
+	/// written, the delta that tips the group past `ratio * snapshot` still lands: a group overshoots
+	/// the budget by at most one delta before rolling.
+	fn delta(&mut self, value: &Value) -> Result<Option<Bytes>> {
+		let ratio = self.config.delta_ratio as u64;
 		if ratio == 0 {
 			return Ok(None);
 		}
@@ -290,39 +293,28 @@ impl Inner {
 			return Ok(None);
 		}
 
-		let patch = {
-			let Some(last) = &self.last else {
-				return Ok(None);
-			};
-			let diff = diff(last, value);
-			if diff.forced_snapshot {
-				return Ok(None);
-			}
-			serde_json::to_vec(&diff.patch)?
-		};
-
-		match self.encoder.as_mut() {
-			// Compressed: measure the delta's *compressed* slice size (the real wire cost) against the
-			// group's anchoring snapshot, also compressed. Encoding advances the per-group window; if
-			// the delta doesn't fit we roll a new group with a fresh encoder, discarding this slice
-			// (the abandoned window has no effect on the new group).
-			Some(encoder) => {
-				let slice = encoder.frame(&patch);
-				let projected = self.delta_bytes + slice.len() as u64;
-				if projected > ratio as u64 * self.snapshot_len {
-					return Ok(None);
-				}
-				Ok(Some(slice))
-			}
-			// Uncompressed: raw delta bytes against a fresh snapshot of the current value.
-			None => {
-				let projected = self.delta_bytes + patch.len() as u64;
-				if projected > ratio as u64 * snapshot_len as u64 {
-					return Ok(None);
-				}
-				Ok(Some(Bytes::from(patch)))
-			}
+		// Gate on the deltas accumulated so far, measured against the group's snapshot frame. Both are
+		// compressed sizes when compressing and raw otherwise, so the comparison is always like-for-like.
+		// Cheap: no diff, no merge patch, no compression yet.
+		if self.delta_bytes > ratio * self.snapshot_len {
+			return Ok(None);
 		}
+
+		let Some(last) = &self.last else {
+			return Ok(None);
+		};
+		let diff = diff(last, value);
+		if diff.forced_snapshot {
+			return Ok(None);
+		}
+		let patch = serde_json::to_vec(&diff.patch)?;
+
+		// Compress into the per-group window only now, for a frame we are committed to writing.
+		let slice = match self.encoder.as_mut() {
+			Some(encoder) => encoder.frame(&patch),
+			None => Bytes::from(patch),
+		};
+		Ok(Some(slice))
 	}
 
 	/// Start a new group with a full snapshot as its first frame.
@@ -652,15 +644,16 @@ mod test {
 
 	#[test]
 	fn tight_ratio_rolls_snapshots() {
-		// A ratio of 1 admits deltas only up to the snapshot size: with equal 7-byte frames that is a
-		// single delta per group, so it rolls every other update. (Still distinct from 0, which would
-		// disable deltas entirely and never produce the group-0 delta below.)
+		// A ratio of 1 budgets deltas up to one snapshot (equal 7-byte frames => 7 bytes). The gate
+		// checks the deltas already written, so the delta that tips the group over budget still lands
+		// (a one-frame overshoot): group 0 takes two deltas (14 bytes) before the fourth update rolls
+		// group 1. (Still distinct from 0, which disables deltas entirely.)
 		let config = cfg(1);
 		let (mut producer, track) = producer(config);
 		producer.update(&json!({ "a": 1 })).unwrap(); // snapshot, group 0
-		producer.update(&json!({ "a": 2 })).unwrap(); // delta, group 0
-		producer.update(&json!({ "a": 3 })).unwrap(); // exceeds budget, rolls group 1
-		producer.update(&json!({ "a": 4 })).unwrap(); // delta, group 1
+		producer.update(&json!({ "a": 2 })).unwrap(); // delta, group 0 (deltas = 7)
+		producer.update(&json!({ "a": 3 })).unwrap(); // delta, group 0 (deltas = 14, now over budget)
+		producer.update(&json!({ "a": 4 })).unwrap(); // budget already exceeded, rolls group 1
 		producer.finish().unwrap();
 
 		assert_eq!(track.latest(), Some(1));
@@ -668,20 +661,21 @@ mod test {
 
 	#[test]
 	fn deltas_stay_within_ratio_times_snapshot() {
-		// The budget covers only the deltas, not the snapshot frame, measured against the current
-		// snapshot size. Single-digit values keep every frame at a constant 7 bytes (`{"n":N}`), so a
-		// `ratio = 8` admits 8 deltas (8x the snapshot, the inclusive limit) on top of the snapshot
-		// before the 9th delta rolls.
+		// The budget covers only the deltas, not the snapshot frame, measured against the group's
+		// snapshot size. Single-digit values keep every frame at a constant 7 bytes (`{"n":N}`), so
+		// `ratio = 8` budgets 56 bytes of deltas. The gate checks the deltas already written, so the
+		// group keeps filling until the accumulated deltas first exceed 56 (nine deltas = 63 bytes) and
+		// the next update rolls (a one-frame overshoot past the 56-byte budget).
 		let config = cfg(8);
 		let (mut producer, track) = producer(config);
-		for n in 0..=9 {
+		for n in 0..=10 {
 			producer.update(&json!({ "n": n })).unwrap();
 		}
 		producer.finish().unwrap();
 
-		// Group 0 carries the snapshot plus 8 deltas (9 frames); the 9th delta opens group 1.
+		// Group 0 carries the snapshot plus 9 deltas (10 frames); the 10th delta opens group 1.
 		assert_eq!(track.latest(), Some(1));
-		assert_eq!(drain(track).last().unwrap(), &json!({ "n": 9 }));
+		assert_eq!(drain(track).last().unwrap(), &json!({ "n": 10 }));
 	}
 
 	#[test]
@@ -768,7 +762,8 @@ mod test {
 
 	#[test]
 	fn newer_group_supersedes_in_progress_reconstruction() {
-		// A tight ratio lets one delta fit, then forces the next update into a new snapshot group.
+		// A tight ratio fills group 0 with a couple of deltas, then forces a later update into a new
+		// snapshot group (the gate overshoots the budget by one delta before rolling).
 		let config = cfg(1);
 		let (mut producer, track) = producer(config);
 		let observer = producer.consume();
@@ -781,8 +776,9 @@ mod test {
 			other => panic!("expected first value, got {other:?}"),
 		}
 
-		producer.update(&json!({ "a": 2 })).unwrap(); // delta in group 0
-		producer.update(&json!({ "a": 3 })).unwrap(); // exceeds budget, rolls group 1
+		producer.update(&json!({ "a": 2 })).unwrap(); // delta in group 0 (deltas = 7)
+		producer.update(&json!({ "a": 3 })).unwrap(); // delta in group 0 (deltas = 14, now over budget)
+		producer.update(&json!({ "a": 4 })).unwrap(); // budget already exceeded, rolls group 1
 		producer.finish().unwrap();
 		assert_eq!(observer.latest(), Some(1));
 
@@ -791,7 +787,7 @@ mod test {
 		while let Poll::Ready(Ok(Some(value))) = consumer.poll_next(&waiter) {
 			last = Some(value);
 		}
-		assert_eq!(last.unwrap(), json!({ "a": 3 }));
+		assert_eq!(last.unwrap(), json!({ "a": 4 }));
 	}
 
 	#[test]

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -69,10 +69,11 @@ pub struct ProducerConfig {
 	///
 	/// A ratio of `0` disables deltas: every change is published as a new snapshot group.
 	///
-	/// A positive ratio enables deltas. A delta is appended to the current group as long as the
-	/// accumulated deltas (excluding the snapshot frame) stay within `ratio` times the size of a
-	/// snapshot; otherwise a new snapshot group is started. So `1` allows deltas totalling up
-	/// to one snapshot before rolling, and a larger ratio tolerates more deltas per snapshot.
+	/// A positive ratio enables deltas. A new snapshot group is started once the deltas *already
+	/// written* to the current group (excluding the snapshot frame) exceed `ratio` times the snapshot
+	/// size. The pending delta is excluded from that check, so the one that first crosses the budget
+	/// still lands before the group rolls. So `1` allows roughly one snapshot's worth of deltas before
+	/// rolling, and a larger ratio tolerates more.
 	///
 	/// When [`compression`](Self::compression) is on, both sides of the comparison are measured on
 	/// the *compressed* frame sizes (the real wire cost).

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -925,6 +925,26 @@ mod test {
 	}
 
 	#[test]
+	fn compressed_deltas_roll_on_compressed_budget() {
+		// With compression the budget is measured on compressed frame sizes: `snapshot_len` and
+		// `delta_bytes` are the compressed slice lengths, not the raw JSON. A tight ratio over many
+		// distinct updates must therefore roll at least one group, and a late joiner must still rebuild
+		// the final value across the compressed group boundary (per-group decoder reset). Guards against
+		// the budget regressing to raw lengths.
+		let (mut producer, track) = producer(cfg_deflate(2));
+		for n in 0..=40 {
+			producer.update(&json!({ "n": n })).unwrap();
+		}
+		producer.finish().unwrap();
+
+		assert!(
+			track.latest().unwrap() > 0,
+			"a tight ratio should roll at least one compressed group"
+		);
+		assert_eq!(drain_with(deflate_consumer(track)).last().unwrap(), &json!({ "n": 40 }));
+	}
+
+	#[test]
 	fn compressed_cloned_consumer_reconstructs_mid_group() {
 		// A clone taken mid-group has no decoder window; it must rebuild from the retained slices.
 		let (mut producer, track) = producer(cfg_deflate(100));


### PR DESCRIPTION
## Summary

The snapshot/delta producer rolls a new group once accumulated deltas exceed `delta_ratio × snapshot`. The budget check ran *after* computing the merge patch (and, on the Rust compressed path, after compressing it into the per-group DEFLATE window), so a roll threw all of that work away.

This moves the gate **ahead** of the diff/patch/compression. It now compares only the deltas *already written* against `ratio × snapshot`, so rolling a new group costs no wasted CPU (no merge patch, no inflate).

Because the gate excludes the frame about to be written, the delta that tips a group past its budget still lands, so a group **overshoots by at most one delta** before rolling. That's negligible for the `8` default and stays well under the 256-frame cap.

## Why

The old compressed path had to run `encoder.frame(&patch)` purely to learn the delta's wire size, mutating the DEFLATE window *before* the decision and discarding it on a roll. Gating on the running total of frames we actually wrote removes that throwaway work entirely. The compressed measurement is kept (it's the right signal: later frames in a shared DEFLATE stream compress progressively smaller, which a raw-size heuristic would miss).

## Unifies Rust and JS

The two producers previously diverged on what they measured:

- Rust compressed → compressed sizes vs. the group snapshot
- Rust uncompressed → raw sizes vs. the *current value's* snapshot
- JS → raw sizes always, even when compressing (its own comment apologized for rolling "a touch sooner" than Rust)

Both now gate on the accumulated **written** bytes (compressed when compressing, raw otherwise) against the group's stored snapshot frame size. JS gains a `#snapshotLen` field mirroring Rust's `snapshot_len`, and its write helpers return the bytes actually written.

## Compatibility

- **No wire-format change.** Frames are byte-identical; only the timing of the roll decision shifts (by one frame).
- **No public API change.** `delta_ratio` / `deltaRatio` and their defaults are unchanged. Doc comments were tightened, and the JS `deltaRatio` doc gained the "compressed frame sizes" note to match Rust now that JS measures compressed too.
- Cross-Package Sync: `rs/moq-json` → `js/json` both updated.

## Test plan

- [x] `cargo test -p moq-json` — 32 pass (updated `tight_ratio_rolls_snapshots`, `deltas_stay_within_ratio_times_snapshot`, `newer_group_supersedes_in_progress_reconstruction` for the one-frame overshoot)
- [x] `bun run --filter='@moq/json' test` — 47 pass (mirrored test updates; the cross-impl `vectors.test.ts` fixture only covers diff/patch shape, unaffected)
- [x] clippy clean + `cargo fmt --check` (via nix)
- [x] `bun run --filter='@moq/json' check` (tsc + biome)

(Written by Claude)