### PR TITLE
feat(moq-net): two-phase accept exposing the SETUP request path (lite-05 + moq-transport 14-18)

### DIFF
--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -278,6 +278,15 @@ impl Client {
 		Ok(session)
 	}
 
+	/// The moq client builder, with `path` advertised in the SETUP if present.
+	#[cfg(any(feature = "tcp", feature = "uds"))]
+	fn moq_with_path(&self, path: Option<String>) -> moq_net::Client {
+		match path {
+			Some(path) => self.moq.clone().with_path(path),
+			None => self.moq.clone(),
+		}
+	}
+
 	#[cfg(any(
 		feature = "noq",
 		feature = "quinn",
@@ -287,15 +296,6 @@ impl Client {
 		feature = "tcp",
 		feature = "uds"
 	))]
-	/// The moq client builder, with `path` advertised in the lite-05 SETUP if present.
-	#[cfg(any(feature = "tcp", feature = "uds"))]
-	fn moq_with_path(&self, path: Option<String>) -> moq_net::Client {
-		match path {
-			Some(path) => self.moq.clone().with_path(path),
-			None => self.moq.clone(),
-		}
-	}
-
 	async fn connect_inner(&self, url: Url) -> crate::Result<moq_net::Session> {
 		// Plain TCP (qmux, no TLS). Explicit opt-in scheme; never raced against
 		// QUIC, which can't speak it. Use only on a trusted network.

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -287,21 +287,38 @@ impl Client {
 		feature = "tcp",
 		feature = "uds"
 	))]
+	/// The moq client builder, with `path` advertised in the lite-05 SETUP if present.
+	#[cfg(any(feature = "tcp", feature = "uds"))]
+	fn moq_with_path(&self, path: Option<String>) -> moq_net::Client {
+		match path {
+			Some(path) => self.moq.clone().with_path(path),
+			None => self.moq.clone(),
+		}
+	}
+
 	async fn connect_inner(&self, url: Url) -> crate::Result<moq_net::Session> {
 		// Plain TCP (qmux, no TLS). Explicit opt-in scheme; never raced against
 		// QUIC, which can't speak it. Use only on a trusted network.
+		//
+		// qmux carries no request URI, so the resource path travels in the lite-05
+		// SETUP. The URL path is the resource for `tcp://`.
 		#[cfg(feature = "tcp")]
 		if url.scheme() == "tcp" {
+			let path = setup_path(&url, false);
 			let session = crate::tcp::connect(url, &self.versions.alpns()).await?;
-			return Ok(self.moq.connect(session).await?);
+			return Ok(self.moq_with_path(path).connect(session).await?);
 		}
 
 		// Unix domain socket (qmux, no TLS). Same-host only; the server can
 		// authenticate us by uid/gid via SO_PEERCRED.
+		//
+		// The URL path is the socket location, so the resource path rides in the
+		// `?path=` query and travels in the lite-05 SETUP.
 		#[cfg(all(feature = "uds", unix))]
 		if url.scheme() == "unix" {
+			let path = setup_path(&url, true);
 			let session = crate::unix::connect(url, &self.versions.alpns()).await?;
-			return Ok(self.moq.connect(session).await?);
+			return Ok(self.moq_with_path(path).connect(session).await?);
 		}
 
 		#[cfg(feature = "iroh")]
@@ -395,6 +412,22 @@ impl Client {
 			TransportRace::Quic(quic) => Ok(self.moq.connect(quic).await?),
 			TransportRace::WebSocket(websocket) => Ok(self.moq.connect(websocket).await?),
 		}
+	}
+}
+
+/// The resource path to advertise in the lite-05 SETUP, derived from the dial URL.
+///
+/// When `path_is_address` (Unix sockets, whose URL path is the socket file), the
+/// resource path rides in the `?path=` query; otherwise the URL path is it.
+#[cfg(any(feature = "tcp", feature = "uds"))]
+fn setup_path(url: &Url, path_is_address: bool) -> Option<String> {
+	if path_is_address {
+		url.query_pairs()
+			.find(|(k, _)| k == "path")
+			.map(|(_, v)| v.into_owned())
+	} else {
+		let path = url.path();
+		(!path.is_empty()).then(|| path.to_string())
 	}
 }
 

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -239,6 +239,10 @@ impl Client {
 		let mut parameters = ietf::Parameters::default();
 		parameters.set_varint(ietf::ParameterVarInt::MaxRequestId, u32::MAX as u64);
 		parameters.set_bytes(ietf::ParameterBytes::Implementation, b"moq-lite-rs".to_vec());
+		// Advertise the request path in-band (draft 14-16), same as the lite-05 SETUP.
+		if let Some(path) = &self.setup_path {
+			parameters.set_bytes(ietf::ParameterBytes::Path, path.clone().into_bytes());
+		}
 		let parameters = parameters.encode_bytes(ietf_encoding)?;
 
 		let client = setup::Client {

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -171,6 +171,7 @@ impl Client {
 					self.stats.clone(),
 					lite::Version::Lite05Wip,
 					our_setup,
+					None,
 				)?;
 
 				// Block until the initial announce set has landed (Lite05 reports it
@@ -193,6 +194,7 @@ impl Client {
 					self.stats.clone(),
 					lite::Version::Lite04,
 					lite::Setup::default(),
+					None,
 				)?;
 
 				// Lite04 has no initial-set boundary, so this resolves immediately.
@@ -214,6 +216,7 @@ impl Client {
 					self.stats.clone(),
 					lite::Version::Lite03,
 					lite::Setup::default(),
+					None,
 				)?;
 
 				// Lite03 has no initial-set boundary, so this resolves immediately.
@@ -266,6 +269,7 @@ impl Client {
 					// This path only handles versions negotiated via the bidi SETUP exchange
 					// (pre-lite-05), which have no Setup Stream.
 					lite::Setup::default(),
+					None,
 				)?;
 
 				// Block until the initial announce set has landed (for versions that

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -95,6 +95,7 @@ impl Client {
 					.ok_or(Error::Version)?;
 
 				// Draft-17+: SETUP is exchanged in the background by the session.
+				// We advertise the request path in our SETUP for URL-less transports.
 				ietf::start(
 					session.clone(),
 					None,
@@ -104,6 +105,8 @@ impl Client {
 					self.subscribe.clone(),
 					self.stats.clone(),
 					ietf::Version::Draft18,
+					self.setup_path.clone(),
+					None,
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
@@ -116,6 +119,7 @@ impl Client {
 					.ok_or(Error::Version)?;
 
 				// Draft-17+: SETUP is exchanged in the background by the session.
+				// We advertise the request path in our SETUP for URL-less transports.
 				ietf::start(
 					session.clone(),
 					None,
@@ -125,6 +129,8 @@ impl Client {
 					self.subscribe.clone(),
 					self.stats.clone(),
 					ietf::Version::Draft17,
+					self.setup_path.clone(),
+					None,
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
@@ -290,6 +296,7 @@ impl Client {
 					.map(ietf::RequestId);
 
 				let stream = stream.with_version(v);
+				// Draft 14-16: the path rode in the bidi SETUP above, not the uni one.
 				ietf::start(
 					session.clone(),
 					Some(stream),
@@ -299,6 +306,8 @@ impl Client {
 					self.subscribe.clone(),
 					self.stats.clone(),
 					v,
+					None,
+					None,
 				)?;
 				None
 			}

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -68,12 +68,13 @@ impl Client {
 		self
 	}
 
-	/// Set the request path to advertise in the lite-05 SETUP message.
+	/// Set the request path to advertise in the SETUP (moq-lite-05 and moq-transport
+	/// 14-18).
 	///
 	/// Required on transports that carry no request URI (native QUIC, qmux over
 	/// TCP/TLS) so the server learns which path the client wants; omit it on bindings
-	/// that already carry a URI (WebTransport). Ignored by the IETF transport and by
-	/// pre-lite-05 versions, which have no SETUP message.
+	/// that already carry a URI (WebTransport). Ignored by versions with no in-band
+	/// request path (lite 01-04).
 	pub fn with_path(mut self, path: impl Into<String>) -> Self {
 		self.setup_path = Some(path.into());
 		self

--- a/rs/moq-net/src/ietf/parameters.rs
+++ b/rs/moq-net/src/ietf/parameters.rs
@@ -211,7 +211,6 @@ impl Parameters {
 		self.vars.insert(kind, value);
 	}
 
-	#[cfg(test)]
 	pub fn get_bytes(&self, kind: ParameterBytes) -> Option<&[u8]> {
 		self.bytes.get(&kind).map(|v| v.as_slice())
 	}

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -1,6 +1,6 @@
 use crate::{
 	Error, Origin, OriginConsumer, OriginProducer, StatsHandle,
-	coding::{Encode, Reader, Stream, Writer},
+	coding::{Decode, Encode, Reader, Stream, Writer},
 	ietf::{self, FetchHeader, RequestId},
 	setup,
 };
@@ -20,6 +20,13 @@ pub fn start<S: web_transport_trait::Session>(
 	// Tier-scoped stats handle. Pass [`StatsHandle::default`] to opt out.
 	stats: StatsHandle,
 	version: Version,
+	// The request path we advertise in our SETUP (draft-17+ clients on URL-less
+	// transports). A server passes `None`.
+	path: Option<String>,
+	// The peer's SETUP stream, when it was already read before `start` (a draft-17+
+	// server that gated on the client's path via [`accept_setup`]). It becomes the
+	// GOAWAY channel; `None` lets the uni loop read the SETUP itself.
+	peer_setup: Option<Reader<S::RecvStream, crate::Version>>,
 ) -> Result<(), Error> {
 	web_async::spawn(async move {
 		// moq-transport threads concrete origins through the publisher/subscriber.
@@ -71,7 +78,7 @@ pub fn start<S: web_transport_trait::Session>(
 				web_async::spawn({
 					let session = session.clone();
 					async move {
-						if let Err(err) = run_setup(session, version).await {
+						if let Err(err) = run_setup(session, version, path).await {
 							tracing::warn!(%err, "setup send error");
 						}
 					}
@@ -84,10 +91,21 @@ pub fn start<S: web_transport_trait::Session>(
 				let sub_ns_session = session.clone();
 				let mut sub_ns = subscriber.clone();
 
+				// When the peer's SETUP was pre-read (a gated server accept), monitor
+				// GOAWAY on that stream here; otherwise `run_unis` does it when the SETUP
+				// arrives on the wire.
+				let goaway = async move {
+					match peer_setup {
+						Some(reader) => run_goaway(reader.with_version(version), version).await,
+						None => std::future::pending().await,
+					}
+				};
+
 				tokio::select! {
 									Err(err) = run_unis(session.clone(), subscriber.clone(), version) => Err(err),
 									Err(err) = run_dispatch(session.clone(), publisher.clone(), subscriber.clone(), version) => Err(err),
 									Err(err) = publisher.run() => Err(err),
+									Err(err) = goaway => Err(err),
 									Err(err) = async {
 				let stream = Stream::open(&sub_ns_session, version).await?;
 										if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
@@ -118,8 +136,49 @@ pub fn start<S: web_transport_trait::Session>(
 	Ok(())
 }
 
+/// Server (draft-17+): read the peer's SETUP off its uni stream before starting the
+/// session, returning that stream (it becomes the GOAWAY channel) and the request
+/// path the peer advertised.
+///
+/// Blocks on the peer's Setup Stream; any other uni stream racing ahead of it is
+/// `STOP_SENDING`-ed and skipped (group data needs a prior subscribe, so nothing
+/// legitimate precedes the SETUP at connect). Pass the returned reader to [`start`]
+/// as its `peer_setup` so GOAWAY monitoring continues without re-reading it.
+pub async fn accept_setup<S: web_transport_trait::Session>(
+	session: &S,
+	version: Version,
+) -> Result<(Reader<S::RecvStream, crate::Version>, Option<String>), Error> {
+	let outer_version = crate::Version::Ietf(version);
+
+	loop {
+		let recv = session.accept_uni().await.map_err(Error::from_transport)?;
+		let mut reader: Reader<S::RecvStream, crate::Version> = Reader::new(recv, outer_version);
+
+		if reader.decode_peek::<u64>().await? != setup::SETUP_V17 {
+			// Not the SETUP (group data this early is unexpected). Reject and keep waiting.
+			reader.abort(&Error::UnexpectedStream);
+			continue;
+		}
+
+		let setup: setup::Setup = reader.decode().await?;
+		let mut bytes = setup.parameters;
+		let path = ietf::Parameters::decode(&mut bytes, version)?
+			.get_bytes(ietf::ParameterBytes::Path)
+			.map(|b| String::from_utf8_lossy(b).into_owned());
+
+		return Ok((reader, path));
+	}
+}
+
 /// Send our SETUP on a uni stream and keep it alive for potential GOAWAY.
-async fn run_setup<S: web_transport_trait::Session>(session: S, version: Version) -> Result<(), Error> {
+///
+/// `path` is the request path we advertise (clients on URL-less transports); a
+/// server passes `None`.
+async fn run_setup<S: web_transport_trait::Session>(
+	session: S,
+	version: Version,
+	path: Option<String>,
+) -> Result<(), Error> {
 	let outer_version = crate::Version::Ietf(version);
 
 	let send = session.open_uni().await.map_err(Error::from_transport)?;
@@ -127,6 +186,9 @@ async fn run_setup<S: web_transport_trait::Session>(session: S, version: Version
 
 	let mut parameters = ietf::Parameters::default();
 	parameters.set_bytes(ietf::ParameterBytes::Implementation, b"moq-lite-rs".to_vec());
+	if let Some(path) = path {
+		parameters.set_bytes(ietf::ParameterBytes::Path, path.into_bytes());
+	}
 	let parameters = parameters.encode_bytes(version)?;
 
 	writer.encode(&setup::Setup { parameters }).await?;

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -1,10 +1,38 @@
 use crate::{
 	BandwidthConsumer, BandwidthProducer, Error, Origin, OriginConsumer, OriginProducer, StatsHandle,
-	coding::{Stream, Writer},
+	coding::{Reader, Stream, Writer},
 	lite::SessionInfo,
 };
 
-use super::{Connecting, PeerSetup, Publisher, PublisherConfig, Setup, Subscriber, SubscriberConfig, Version};
+use super::{
+	Connecting, DataType, PeerSetup, Publisher, PublisherConfig, Setup, Subscriber, SubscriberConfig, Version,
+};
+
+/// Server: read the peer's single SETUP message off its Setup Stream before starting
+/// the session, so the caller can inspect the advertised path (and gate on it) before
+/// serving. lite-05+ only.
+///
+/// Blocks on the peer's Setup Stream, which every lite-05 endpoint opens at startup.
+/// Almost always the first unidirectional stream; any other uni stream that races
+/// ahead of it is `STOP_SENDING`-ed and skipped (we don't support proactive uni
+/// PUBLISH, so nothing legitimate precedes the SETUP today). The eventual home for
+/// out-of-order tolerance is the full session loop with deferred origin binding.
+///
+/// Pass the returned [`Setup`] to [`start`] as its `peer_setup` so PROBE gating still
+/// resolves without re-reading the (consumed) stream.
+pub async fn accept_setup<S: web_transport_trait::Session>(session: &S, version: Version) -> Result<Setup, Error> {
+	loop {
+		let stream = session.accept_uni().await.map_err(Error::from_transport)?;
+		let mut reader = Reader::new(stream, version);
+
+		match reader.decode::<DataType>().await? {
+			DataType::Setup => return reader.decode::<Setup>().await,
+			// A non-SETUP uni stream this early is unexpected (GROUP needs a prior
+			// subscribe). Reject it and keep waiting rather than failing the session.
+			_ => reader.abort(&Error::UnexpectedStream),
+		}
+	}
+}
 
 /// Start a lite session.
 ///
@@ -12,6 +40,9 @@ use super::{Connecting, PeerSetup, Publisher, PublisherConfig, Setup, Subscriber
 /// becomes ready once the initial announce set has been inserted into the subscribe
 /// origin, letting `connect()` block past the startup race. It is ready immediately
 /// when there is nothing to wait on (a version without an initial-set boundary).
+// Internal entry point wiring a session together; the knobs are all distinct and
+// positional clarity beats a one-off config struct here.
+#[allow(clippy::too_many_arguments)]
 pub fn start<S: web_transport_trait::Session>(
 	session: S,
 	// The stream used to set up the session, after exchanging setup messages.
@@ -28,6 +59,10 @@ pub fn start<S: web_transport_trait::Session>(
 	// The capabilities (and optional request path) we advertise in our SETUP message.
 	// Only sent on versions with a Setup Stream (lite-05+); ignored otherwise.
 	our_setup: Setup,
+	// The peer's SETUP, when it was already read before `start` (e.g. a server that
+	// gated on the client's path via [`accept_setup`]). Seeds the peer-setup slot so
+	// the Setup Stream isn't expected again. `None` reads it from the wire as usual.
+	peer_setup: Option<Setup>,
 ) -> Result<(Option<BandwidthConsumer>, Connecting), Error> {
 	let recv_bw = BandwidthProducer::new();
 
@@ -69,7 +104,13 @@ pub fn start<S: web_transport_trait::Session>(
 	// Required for cross-session cluster loop detection.
 	// Shared slot for the peer's SETUP (lite-05+). The subscriber writes it when it
 	// reads the peer's Setup stream; capability-gated streams (PROBE) wait on it.
-	let peer_setup = PeerSetup::default();
+	// When the caller already read it (a gated server accept), seed the slot so the
+	// Setup stream isn't expected on the wire again.
+	let peer_setup_slot = PeerSetup::default();
+	if let Some(setup) = peer_setup {
+		peer_setup_slot.set(setup);
+	}
+	let peer_setup = peer_setup_slot;
 
 	// Advertise our own capabilities on a uni Setup Stream, then FIN. Best-effort:
 	// a failure here just means the peer falls back to "no capabilities" for us.

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -65,50 +65,49 @@ impl Server {
 		self
 	}
 
-	/// Perform the MoQ handshake as a server for the given session.
+	/// Perform the MoQ handshake as a server, returning the established [`Session`].
+	///
+	/// Convenience wrapper over [`accept_request`](Self::accept_request) that
+	/// completes the handshake immediately. Use `accept_request` when you need to
+	/// inspect the client's advertised path before deciding what to serve.
 	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
+		self.accept_request(session).await?.ok().await
+	}
+
+	/// Two-phase accept: negotiate the version and, for lite-05, read the client's
+	/// SETUP so [`Request::path`] is available before the caller commits to
+	/// [`Request::ok`] or [`Request::close`]. Mirrors the WebTransport-level
+	/// `Request` in moq-native.
+	///
+	/// Every regime defers its session start to `ok()`, so origins set on the
+	/// Request (after inspecting the path) always take effect. The path is surfaced
+	/// for lite-05, whose Setup Stream carries it; other versions report `None`.
+	pub async fn accept_request<S: web_transport_trait::Session>(&self, session: S) -> Result<Request<S>, Error> {
+		// Regimes without a path to read defer to `ok()` without surfacing one.
+		let deferred = |handshake| Request {
+			server: self.clone(),
+			path: None,
+			handshake,
+		};
+
 		let (encoding, supported) = match session.protocol() {
 			Some(ALPN_18) => {
-				let v = self
-					.versions
+				self.versions
 					.select(Version::Ietf(ietf::Version::Draft18))
 					.ok_or(Error::Version)?;
-
-				// Draft-17+: SETUP is exchanged in the background by the session.
-				ietf::start(
-					session.clone(),
-					None,
-					None,
-					false,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
-					ietf::Version::Draft18,
-				)?;
-
-				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None));
+				return Ok(deferred(Handshake::IetfModern {
+					session,
+					version: ietf::Version::Draft18,
+				}));
 			}
 			Some(ALPN_17) => {
-				let v = self
-					.versions
+				self.versions
 					.select(Version::Ietf(ietf::Version::Draft17))
 					.ok_or(Error::Version)?;
-
-				// Draft-17+: SETUP is exchanged in the background by the session.
-				ietf::start(
-					session.clone(),
-					None,
-					None,
-					false,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
-					ietf::Version::Draft17,
-				)?;
-
-				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None));
+				return Ok(deferred(Handshake::IetfModern {
+					session,
+					version: ietf::Version::Draft17,
+				}));
 			}
 			Some(ALPN_16) => {
 				let v = self
@@ -136,59 +135,33 @@ impl Server {
 					.select(Version::Lite(lite::Version::Lite05Wip))
 					.ok_or(Error::Version)?;
 
-				// We report send bitrate; a server never advertises a request Path.
-				let our_setup = lite::Setup {
-					probe: lite::ProbeLevel::Report,
-					path: None,
-				};
-
-				// Server side never blocks on the initial set; discard the synced receiver.
-				let (recv_bw, _connecting) = lite::start(
-					session.clone(),
-					None,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
-					lite::Version::Lite05Wip,
-					our_setup,
-				)?;
-
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
+				// Gate on the client's SETUP: read it before serving so the caller can
+				// scope by the advertised path. Seeded back into `start` on `ok()` so
+				// PROBE gating resolves without re-reading the (consumed) Setup Stream.
+				let client_setup = lite::accept_setup(&session, lite::Version::Lite05Wip).await?;
+				return Ok(Request {
+					server: self.clone(),
+					path: client_setup.path.clone(),
+					handshake: Handshake::Lite05 { session, client_setup },
+				});
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions
 					.select(Version::Lite(lite::Version::Lite04))
 					.ok_or(Error::Version)?;
-
-				let (recv_bw, _connecting) = lite::start(
-					session.clone(),
-					None,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
-					lite::Version::Lite04,
-					lite::Setup::default(),
-				)?;
-
-				return Ok(Session::new(session, lite::Version::Lite04.into(), recv_bw));
+				return Ok(deferred(Handshake::LiteBare {
+					session,
+					version: lite::Version::Lite04,
+				}));
 			}
 			Some(ALPN_LITE_03) => {
 				self.versions
 					.select(Version::Lite(lite::Version::Lite03))
 					.ok_or(Error::Version)?;
-
-				// Starting with draft-03, there's no more SETUP control stream.
-				let (recv_bw, _connecting) = lite::start(
-					session.clone(),
-					None,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
-					lite::Version::Lite03,
-					lite::Setup::default(),
-				)?;
-
-				return Ok(Session::new(session, lite::Version::Lite03.into(), recv_bw));
+				return Ok(deferred(Handshake::LiteBare {
+					session,
+					version: lite::Version::Lite03,
+				}));
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -197,17 +170,159 @@ impl Server {
 			Some(p) => return Err(Error::UnknownAlpn(p.to_string())),
 		};
 
+		// Legacy bidi SETUP exchange (IETF 14-16, lite 01/02). Read the client's
+		// SETUP to choose the version; `ok()` sends the server SETUP and starts.
 		let mut stream = Stream::accept(&session, encoding).await?;
-
 		let mut client: setup::Client = stream.reader.decode().await?;
 
-		// Choose the version to use
 		let version = client
 			.versions
 			.iter()
 			.flat_map(|v| Version::try_from(*v).ok())
 			.find(|v| supported.contains(v))
 			.ok_or(Error::Version)?;
+
+		// Pull the client's max request ID out now (IETF only) so `ok()` doesn't
+		// re-decode the consumed parameters.
+		let request_id_max = match version {
+			Version::Ietf(v) => ietf::Parameters::decode(&mut client.parameters, v)?
+				.get_varint(ietf::ParameterVarInt::MaxRequestId)
+				.map(ietf::RequestId),
+			Version::Lite(_) => None,
+		};
+
+		Ok(Request {
+			server: self.clone(),
+			path: None,
+			handshake: Handshake::Legacy {
+				session,
+				stream,
+				version,
+				request_id_max,
+			},
+		})
+	}
+}
+
+/// A paused server-side handshake.
+///
+/// Returned by [`Server::accept_request`] once the peer's advertised
+/// [`path`](Self::path) is known but before the session is granted anything. Set
+/// the origins to serve, then call [`ok`](Self::ok) to complete the handshake, or
+/// [`close`](Self::close) to reject it. Modeled on the WebTransport `Request` in
+/// moq-native.
+pub struct Request<S: web_transport_trait::Session> {
+	server: Server,
+	path: Option<String>,
+	handshake: Handshake<S>,
+}
+
+/// The handshake state captured at the pause point. Every variant defers its
+/// session start to [`Request::ok`] so origins set on the Request still apply.
+enum Handshake<S: web_transport_trait::Session> {
+	/// Modern IETF (17/18): no readable client SETUP (exchanged in the background).
+	IetfModern { session: S, version: ietf::Version },
+	/// moq-lite 03/04: no Setup Stream.
+	LiteBare { session: S, version: lite::Version },
+	/// Legacy IETF (draft 14-16) and lite 01/02: the client SETUP has been read off
+	/// the bidi stream but the server SETUP hasn't been sent. `ok()` finishes it.
+	Legacy {
+		session: S,
+		stream: Stream<S, Version>,
+		version: Version,
+		request_id_max: Option<ietf::RequestId>,
+	},
+	/// moq-lite 05+: the client's Setup Stream has been read. `ok()` starts the
+	/// session, seeding the SETUP back so PROBE gating resolves.
+	Lite05 { session: S, client_setup: lite::Setup },
+}
+
+impl<S: web_transport_trait::Session> Request<S> {
+	/// The request path the client advertised in its SETUP, if any.
+	///
+	/// Populated for moq-lite 05+ (its Setup Stream carries it). `None` on other
+	/// versions; see the note on [`Server::accept_request`].
+	pub fn path(&self) -> Option<&str> {
+		self.path.as_deref()
+	}
+
+	/// Publish to the connected client. Overrides any value from the [`Server`]
+	/// builder; typically set after inspecting [`path`](Self::path).
+	pub fn with_publisher(mut self, publish: impl Consume<OriginConsumer>) -> Self {
+		self.server.publish = Some(publish.consume());
+		self
+	}
+
+	/// Subscribe to the connected client. Overrides any value from the [`Server`] builder.
+	pub fn with_subscriber(mut self, subscribe: OriginProducer) -> Self {
+		self.server.subscribe = Some(subscribe);
+		self
+	}
+
+	/// Set the tier-scoped stats handle. Overrides any value from the [`Server`] builder.
+	pub fn with_stats(mut self, stats: StatsHandle) -> Self {
+		self.server.stats = stats;
+		self
+	}
+
+	/// Accept the session, completing the handshake.
+	pub async fn ok(self) -> Result<Session, Error> {
+		let server = self.server;
+
+		let (session, mut stream, version, request_id_max) = match self.handshake {
+			Handshake::IetfModern { session, version } => {
+				// Draft-17+: SETUP is exchanged in the background by the session.
+				ietf::start(
+					session.clone(),
+					None,
+					None,
+					false,
+					server.publish,
+					server.subscribe,
+					server.stats,
+					version,
+				)?;
+				tracing::debug!(?version, "connected");
+				return Ok(Session::new(session, version.into(), None));
+			}
+			Handshake::LiteBare { session, version } => {
+				let (recv_bw, _connecting) = lite::start(
+					session.clone(),
+					None,
+					server.publish,
+					server.subscribe,
+					server.stats,
+					version,
+					lite::Setup::default(),
+					None,
+				)?;
+				return Ok(Session::new(session, version.into(), recv_bw));
+			}
+			Handshake::Lite05 { session, client_setup } => {
+				// We report send bitrate; a server never advertises a request Path.
+				let our_setup = lite::Setup {
+					probe: lite::ProbeLevel::Report,
+					path: None,
+				};
+				let (recv_bw, _connecting) = lite::start(
+					session.clone(),
+					None,
+					server.publish,
+					server.subscribe,
+					server.stats,
+					lite::Version::Lite05Wip,
+					our_setup,
+					Some(client_setup),
+				)?;
+				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
+			}
+			Handshake::Legacy {
+				session,
+				stream,
+				version,
+				request_id_max,
+			} => (session, stream, version, request_id_max),
+		};
 
 		// Encode parameters using the version-appropriate type.
 		let parameters = match version {
@@ -220,44 +335,38 @@ impl Server {
 			Version::Lite(v) => lite::Parameters::default().encode_bytes(v)?,
 		};
 
-		let server = setup::Server {
+		let server_setup = setup::Server {
 			version: version.into(),
 			parameters,
 		};
-		stream.writer.encode(&server).await?;
+		stream.writer.encode(&server_setup).await?;
 
 		let recv_bw = match version {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
+				// Pre-lite-05: no Setup Stream, so nothing to advertise or seed.
 				let (recv_bw, _connecting) = lite::start(
 					session.clone(),
 					Some(stream),
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					server.publish,
+					server.subscribe,
+					server.stats,
 					v,
-					// This path only handles versions negotiated via the bidi SETUP exchange
-					// (pre-lite-05), which have no Setup Stream.
 					lite::Setup::default(),
+					None,
 				)?;
 				recv_bw
 			}
 			Version::Ietf(v) => {
-				// Decode the client's parameters to get their max request ID.
-				let parameters = ietf::Parameters::decode(&mut client.parameters, v)?;
-				let request_id_max = parameters
-					.get_varint(ietf::ParameterVarInt::MaxRequestId)
-					.map(ietf::RequestId);
-
 				let stream = stream.with_version(v);
 				ietf::start(
 					session.clone(),
 					Some(stream),
 					request_id_max,
 					false,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					server.publish,
+					server.subscribe,
+					server.stats,
 					v,
 				)?;
 				None
@@ -265,5 +374,183 @@ impl Server {
 		};
 
 		Ok(Session::new(session, version, recv_bw))
+	}
+
+	/// Reject the session, closing the transport with `err`'s wire code.
+	pub fn close(self, err: Error) {
+		let session = match self.handshake {
+			Handshake::IetfModern { session, .. } => session,
+			Handshake::LiteBare { session, .. } => session,
+			Handshake::Legacy { session, .. } => session,
+			Handshake::Lite05 { session, .. } => session,
+		};
+		session.close(err.to_code(), &err.to_string());
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::{
+		collections::VecDeque,
+		sync::{Arc, Mutex},
+	};
+
+	use crate::ALPN_LITE_05_WIP;
+	use bytes::Bytes;
+
+	#[derive(Debug, Clone, Default)]
+	struct FakeError;
+	impl std::fmt::Display for FakeError {
+		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			write!(f, "fake transport error")
+		}
+	}
+	impl std::error::Error for FakeError {}
+	impl web_transport_trait::Error for FakeError {
+		fn session_error(&self) -> Option<(u32, String)> {
+			Some((0, "closed".to_string()))
+		}
+	}
+
+	/// A session that replays a queue of unidirectional streams (each a `Vec<u8>`) in
+	/// order from `accept_uni`; everything else is inert.
+	#[derive(Clone)]
+	struct FakeSession {
+		protocol: Option<&'static str>,
+		uni: Arc<Mutex<VecDeque<Vec<u8>>>>,
+	}
+
+	impl FakeSession {
+		fn new(protocol: &'static str, uni: impl IntoIterator<Item = Vec<u8>>) -> Self {
+			Self {
+				protocol: Some(protocol),
+				uni: Arc::new(Mutex::new(uni.into_iter().collect())),
+			}
+		}
+	}
+
+	impl web_transport_trait::Session for FakeSession {
+		type SendStream = FakeSend;
+		type RecvStream = FakeRecv;
+		type Error = FakeError;
+
+		async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
+			// Drop the guard before any await so the future stays Send.
+			let data = self.uni.lock().unwrap().pop_front();
+			match data {
+				Some(data) => Ok(FakeRecv { data: data.into() }),
+				None => std::future::pending().await,
+			}
+		}
+		async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+			std::future::pending().await
+		}
+		async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+			std::future::pending().await
+		}
+		async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
+			std::future::pending().await
+		}
+		fn send_datagram(&self, _payload: Bytes) -> Result<(), Self::Error> {
+			Ok(())
+		}
+		async fn recv_datagram(&self) -> Result<Bytes, Self::Error> {
+			std::future::pending().await
+		}
+		fn max_datagram_size(&self) -> usize {
+			1200
+		}
+		fn protocol(&self) -> Option<&str> {
+			self.protocol
+		}
+		fn close(&self, _code: u32, _reason: &str) {}
+		async fn closed(&self) -> Self::Error {
+			std::future::pending().await
+		}
+	}
+
+	#[derive(Clone, Default)]
+	struct FakeSend;
+	impl web_transport_trait::SendStream for FakeSend {
+		type Error = FakeError;
+		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+			Ok(buf.len())
+		}
+		fn set_priority(&mut self, _order: u8) {}
+		fn finish(&mut self) -> Result<(), Self::Error> {
+			Ok(())
+		}
+		fn reset(&mut self, _code: u32) {}
+		async fn closed(&mut self) -> Result<(), Self::Error> {
+			Ok(())
+		}
+	}
+
+	struct FakeRecv {
+		data: VecDeque<u8>,
+	}
+	impl web_transport_trait::RecvStream for FakeRecv {
+		type Error = FakeError;
+		async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+			if self.data.is_empty() {
+				return Ok(None);
+			}
+			let size = dst.len().min(self.data.len());
+			for slot in dst.iter_mut().take(size) {
+				*slot = self.data.pop_front().unwrap();
+			}
+			Ok(Some(size))
+		}
+		fn stop(&mut self, _code: u32) {}
+		async fn closed(&mut self) -> Result<(), Self::Error> {
+			Ok(())
+		}
+	}
+
+	/// Encode a lite-05 Setup Stream: the `DataType::Setup` tag then the SETUP message.
+	fn lite05_setup(path: Option<&str>) -> Vec<u8> {
+		let v = lite::Version::Lite05Wip;
+		let mut buf = Vec::new();
+		lite::DataType::Setup.encode(&mut buf, v).unwrap();
+		lite::Setup {
+			probe: lite::ProbeLevel::None,
+			path: path.map(str::to_string),
+		}
+		.encode(&mut buf, v)
+		.unwrap();
+		buf
+	}
+
+	/// Encode a lite-05 GROUP uni stream header (just the `DataType::Group` tag).
+	fn lite05_group() -> Vec<u8> {
+		let mut buf = Vec::new();
+		lite::DataType::Group
+			.encode(&mut buf, lite::Version::Lite05Wip)
+			.unwrap();
+		buf
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn accept_request_reads_lite05_path() {
+		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_setup(Some("/team/room"))]);
+		let request = Server::new().accept_request(session).await.unwrap();
+		assert_eq!(request.path(), Some("/team/room"));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn accept_request_lite05_without_path_is_none() {
+		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_setup(None)]);
+		let request = Server::new().accept_request(session).await.unwrap();
+		assert_eq!(request.path(), None);
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn accept_request_skips_uni_stream_before_setup() {
+		// A GROUP racing ahead of the SETUP is STOP_SENDING-ed and skipped; the gate
+		// keeps reading until it finds the SETUP.
+		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_group(), lite05_setup(Some("/team/room"))]);
+		let request = Server::new().accept_request(session).await.unwrap();
+		assert_eq!(request.path(), Some("/team/room"));
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,7 +1,7 @@
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Consume,
 	Error, NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
-	coding::{Decode, Encode, Stream},
+	coding::{Decode, Encode, Reader, Stream},
 	ietf, lite, setup,
 };
 
@@ -82,9 +82,8 @@ impl Server {
 	/// serve, and call [`ok`](Request::ok) or [`close`](Request::close). Session start
 	/// is deferred to `ok()`, so origins set on the `Request` always take effect.
 	///
-	/// The path is surfaced for moq-lite-05 and the legacy moq-transport drafts
-	/// (14-16). draft-17/18 also send a path, but the server reads their SETUP in the
-	/// background and doesn't surface it yet, so it reports `None` there for now.
+	/// The path is surfaced for moq-lite-05 and every moq-transport draft (14-18);
+	/// it's `None` on versions with no in-band request path (e.g. lite 01-04).
 	pub async fn accept_request<S: web_transport_trait::Session>(&self, session: S) -> Result<Request<S>, Error> {
 		// Regimes without a path to read defer to `ok()` without surfacing one.
 		let deferred = |handshake| Request {
@@ -98,19 +97,13 @@ impl Server {
 				self.versions
 					.select(Version::Ietf(ietf::Version::Draft18))
 					.ok_or(Error::Version)?;
-				return Ok(deferred(Handshake::IetfModern {
-					session,
-					version: ietf::Version::Draft18,
-				}));
+				return self.accept_ietf_modern(session, ietf::Version::Draft18).await;
 			}
 			Some(ALPN_17) => {
 				self.versions
 					.select(Version::Ietf(ietf::Version::Draft17))
 					.ok_or(Error::Version)?;
-				return Ok(deferred(Handshake::IetfModern {
-					session,
-					version: ietf::Version::Draft17,
-				}));
+				return self.accept_ietf_modern(session, ietf::Version::Draft17).await;
 			}
 			Some(ALPN_16) => {
 				let v = self
@@ -213,6 +206,25 @@ impl Server {
 			},
 		})
 	}
+
+	/// Read a draft-17/18 client's SETUP (with its request path) off its uni stream,
+	/// then pause. `ok()` starts the session and hands the stream back for GOAWAY.
+	async fn accept_ietf_modern<S: web_transport_trait::Session>(
+		&self,
+		session: S,
+		version: ietf::Version,
+	) -> Result<Request<S>, Error> {
+		let (peer_setup, path) = ietf::accept_setup(&session, version).await?;
+		Ok(Request {
+			server: self.clone(),
+			path,
+			handshake: Handshake::IetfModern {
+				session,
+				version,
+				peer_setup,
+			},
+		})
+	}
 }
 
 /// A paused server-side handshake.
@@ -231,10 +243,14 @@ pub struct Request<S: web_transport_trait::Session> {
 /// The handshake state captured at the pause point. Every variant defers its
 /// session start to [`Request::ok`] so origins set on the Request still apply.
 enum Handshake<S: web_transport_trait::Session> {
-	/// Modern IETF (17/18): the client's SETUP (with its path) is read in the
-	/// background by `ietf::start`, so it isn't surfaced here yet. TODO: read it
-	/// before serving like lite-05 / legacy IETF so `path()` works on 17/18 too.
-	IetfModern { session: S, version: ietf::Version },
+	/// Modern IETF (17/18): the client's SETUP (with its request path) has been read
+	/// off its uni stream; `ok()` starts the session, handing that stream back for
+	/// GOAWAY monitoring.
+	IetfModern {
+		session: S,
+		version: ietf::Version,
+		peer_setup: Reader<S::RecvStream, Version>,
+	},
 	/// moq-lite 03/04: no Setup Stream.
 	LiteBare { session: S, version: lite::Version },
 	/// Legacy IETF (draft 14-16) and lite 01/02: the client SETUP has been read off
@@ -254,9 +270,8 @@ enum Handshake<S: web_transport_trait::Session> {
 impl<S: web_transport_trait::Session> Request<S> {
 	/// The request path the client advertised in its SETUP, if any.
 	///
-	/// Populated for moq-lite-05 and the legacy moq-transport drafts (14-16);
-	/// `None` on draft-17/18 (not surfaced yet) and versions without an in-band
-	/// path. See the note on [`Server::accept_request`].
+	/// Populated for moq-lite-05 and moq-transport 14-18; `None` on versions without
+	/// an in-band request path. See the note on [`Server::accept_request`].
 	pub fn path(&self) -> Option<&str> {
 		self.path.as_deref()
 	}
@@ -286,9 +301,13 @@ impl<S: web_transport_trait::Session> Request<S> {
 		let path = self.path;
 
 		let (session, mut stream, version, request_id_max) = match self.handshake {
-			Handshake::IetfModern { session, version } => {
-				// Draft-17+: both SETUPs are exchanged in the background by the session.
-				// TODO: read the client's first so its request path reaches `path()`.
+			Handshake::IetfModern {
+				session,
+				version,
+				peer_setup,
+			} => {
+				// The client's SETUP was read in `accept_request`; hand the stream back
+				// for GOAWAY. A server never advertises a path, hence `None`.
 				ietf::start(
 					session.clone(),
 					None,
@@ -298,9 +317,11 @@ impl<S: web_transport_trait::Session> Request<S> {
 					server.subscribe,
 					server.stats,
 					version,
+					None,
+					Some(peer_setup),
 				)?;
 				tracing::debug!(?version, "connected");
-				return Ok(Session::new(session, version.into(), None));
+				return Ok(Session::new(session, version.into(), None).with_path(path));
 			}
 			Handshake::LiteBare { session, version } => {
 				let (recv_bw, _connecting) = lite::start(
@@ -376,6 +397,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 			}
 			Version::Ietf(v) => {
 				let stream = stream.with_version(v);
+				// Draft 14-16: path came in the bidi SETUP, no uni SETUP to hand back.
 				ietf::start(
 					session.clone(),
 					Some(stream),
@@ -385,6 +407,8 @@ impl<S: web_transport_trait::Session> Request<S> {
 					server.subscribe,
 					server.stats,
 					v,
+					None,
+					None,
 				)?;
 				None
 			}

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -304,6 +304,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					probe: lite::ProbeLevel::Report,
 					path: None,
 				};
+				let path = client_setup.path.clone();
 				let (recv_bw, _connecting) = lite::start(
 					session.clone(),
 					None,
@@ -314,7 +315,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					our_setup,
 					Some(client_setup),
 				)?;
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
+				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw).with_path(path));
 			}
 			Handshake::Legacy {
 				session,
@@ -552,5 +553,13 @@ mod tests {
 		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_group(), lite05_setup(Some("/team/room"))]);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.path(), Some("/team/room"));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn established_session_carries_lite05_path() {
+		// The path survives `ok()` onto the established session.
+		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_setup(Some("/team/room"))]);
+		let session = Server::new().accept(session).await.unwrap();
+		assert_eq!(session.path(), Some("/team/room"));
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -298,7 +298,6 @@ impl<S: web_transport_trait::Session> Request<S> {
 	/// Accept the session, completing the handshake.
 	pub async fn ok(self) -> Result<Session, Error> {
 		let server = self.server;
-		let path = self.path;
 
 		let (session, mut stream, version, request_id_max) = match self.handshake {
 			Handshake::IetfModern {
@@ -321,7 +320,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					Some(peer_setup),
 				)?;
 				tracing::debug!(?version, "connected");
-				return Ok(Session::new(session, version.into(), None).with_path(path));
+				return Ok(Session::new(session, version.into(), None));
 			}
 			Handshake::LiteBare { session, version } => {
 				let (recv_bw, _connecting) = lite::start(
@@ -352,7 +351,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					our_setup,
 					Some(client_setup),
 				)?;
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw).with_path(path));
+				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
 			}
 			Handshake::Legacy {
 				session,
@@ -414,7 +413,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 			}
 		};
 
-		Ok(Session::new(session, version, recv_bw).with_path(path))
+		Ok(Session::new(session, version, recv_bw))
 	}
 
 	/// Reject the session, closing the transport with `err`'s wire code.
@@ -593,13 +592,5 @@ mod tests {
 		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_group(), lite05_setup(Some("/team/room"))]);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.path(), Some("/team/room"));
-	}
-
-	#[tokio::test(start_paused = true)]
-	async fn established_session_carries_lite05_path() {
-		// The path survives `ok()` onto the established session.
-		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_setup(Some("/team/room"))]);
-		let session = Server::new().accept(session).await.unwrap();
-		assert_eq!(session.path(), Some("/team/room"));
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -74,14 +74,17 @@ impl Server {
 		self.accept_request(session).await?.ok().await
 	}
 
-	/// Two-phase accept: negotiate the version and, for lite-05, read the client's
-	/// SETUP so [`Request::path`] is available before the caller commits to
-	/// [`Request::ok`] or [`Request::close`]. Mirrors the WebTransport-level
-	/// `Request` in moq-native.
+	/// Begin the MoQ handshake, pausing once the client's request path is known so
+	/// the caller can authorize/scope before serving.
 	///
-	/// Every regime defers its session start to `ok()`, so origins set on the
-	/// Request (after inspecting the path) always take effect. The path is surfaced
-	/// for lite-05, whose Setup Stream carries it; other versions report `None`.
+	/// Reads the client's SETUP (the in-band path lives there on URL-less transports),
+	/// then returns a [`Request`]: inspect [`path`](Request::path), set the origins to
+	/// serve, and call [`ok`](Request::ok) or [`close`](Request::close). Session start
+	/// is deferred to `ok()`, so origins set on the `Request` always take effect.
+	///
+	/// The path is surfaced for moq-lite-05 and the legacy moq-transport drafts
+	/// (14-16). draft-17/18 also send a path, but the server reads their SETUP in the
+	/// background and doesn't surface it yet, so it reports `None` there for now.
 	pub async fn accept_request<S: web_transport_trait::Session>(&self, session: S) -> Result<Request<S>, Error> {
 		// Regimes without a path to read defer to `ok()` without surfacing one.
 		let deferred = |handshake| Request {
@@ -182,18 +185,26 @@ impl Server {
 			.find(|v| supported.contains(v))
 			.ok_or(Error::Version)?;
 
-		// Pull the client's max request ID out now (IETF only) so `ok()` doesn't
-		// re-decode the consumed parameters.
-		let request_id_max = match version {
-			Version::Ietf(v) => ietf::Parameters::decode(&mut client.parameters, v)?
-				.get_varint(ietf::ParameterVarInt::MaxRequestId)
-				.map(ietf::RequestId),
-			Version::Lite(_) => None,
+		// Pull the request path and max request ID out now (IETF only) so `ok()`
+		// doesn't re-decode the consumed parameters. moq-transport carries the path
+		// in its SETUP just like lite-05.
+		let (path, request_id_max) = match version {
+			Version::Ietf(v) => {
+				let params = ietf::Parameters::decode(&mut client.parameters, v)?;
+				let path = params
+					.get_bytes(ietf::ParameterBytes::Path)
+					.map(|b| String::from_utf8_lossy(b).into_owned());
+				let request_id_max = params
+					.get_varint(ietf::ParameterVarInt::MaxRequestId)
+					.map(ietf::RequestId);
+				(path, request_id_max)
+			}
+			Version::Lite(_) => (None, None),
 		};
 
 		Ok(Request {
 			server: self.clone(),
-			path: None,
+			path,
 			handshake: Handshake::Legacy {
 				session,
 				stream,
@@ -220,12 +231,15 @@ pub struct Request<S: web_transport_trait::Session> {
 /// The handshake state captured at the pause point. Every variant defers its
 /// session start to [`Request::ok`] so origins set on the Request still apply.
 enum Handshake<S: web_transport_trait::Session> {
-	/// Modern IETF (17/18): no readable client SETUP (exchanged in the background).
+	/// Modern IETF (17/18): the client's SETUP (with its path) is read in the
+	/// background by `ietf::start`, so it isn't surfaced here yet. TODO: read it
+	/// before serving like lite-05 / legacy IETF so `path()` works on 17/18 too.
 	IetfModern { session: S, version: ietf::Version },
 	/// moq-lite 03/04: no Setup Stream.
 	LiteBare { session: S, version: lite::Version },
 	/// Legacy IETF (draft 14-16) and lite 01/02: the client SETUP has been read off
-	/// the bidi stream but the server SETUP hasn't been sent. `ok()` finishes it.
+	/// the bidi stream (including its request path) but the server SETUP hasn't been
+	/// sent. `ok()` finishes it.
 	Legacy {
 		session: S,
 		stream: Stream<S, Version>,
@@ -240,8 +254,9 @@ enum Handshake<S: web_transport_trait::Session> {
 impl<S: web_transport_trait::Session> Request<S> {
 	/// The request path the client advertised in its SETUP, if any.
 	///
-	/// Populated for moq-lite 05+ (its Setup Stream carries it). `None` on other
-	/// versions; see the note on [`Server::accept_request`].
+	/// Populated for moq-lite-05 and the legacy moq-transport drafts (14-16);
+	/// `None` on draft-17/18 (not surfaced yet) and versions without an in-band
+	/// path. See the note on [`Server::accept_request`].
 	pub fn path(&self) -> Option<&str> {
 		self.path.as_deref()
 	}
@@ -268,10 +283,12 @@ impl<S: web_transport_trait::Session> Request<S> {
 	/// Accept the session, completing the handshake.
 	pub async fn ok(self) -> Result<Session, Error> {
 		let server = self.server;
+		let path = self.path;
 
 		let (session, mut stream, version, request_id_max) = match self.handshake {
 			Handshake::IetfModern { session, version } => {
-				// Draft-17+: SETUP is exchanged in the background by the session.
+				// Draft-17+: both SETUPs are exchanged in the background by the session.
+				// TODO: read the client's first so its request path reaches `path()`.
 				ietf::start(
 					session.clone(),
 					None,
@@ -304,7 +321,6 @@ impl<S: web_transport_trait::Session> Request<S> {
 					probe: lite::ProbeLevel::Report,
 					path: None,
 				};
-				let path = client_setup.path.clone();
 				let (recv_bw, _connecting) = lite::start(
 					session.clone(),
 					None,
@@ -374,7 +390,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 			}
 		};
 
-		Ok(Session::new(session, version, recv_bw))
+		Ok(Session::new(session, version, recv_bw).with_path(path))
 	}
 
 	/// Reject the session, closing the transport with `err`'s wire code.

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -52,6 +52,7 @@ pub struct ConnectionStats {
 pub struct Session {
 	session: Arc<dyn SessionInner>,
 	version: Version,
+	path: Option<String>,
 	send_bandwidth: Option<BandwidthConsumer>,
 	recv_bandwidth: Option<BandwidthConsumer>,
 	closed: bool,
@@ -81,15 +82,34 @@ impl Session {
 		Self {
 			session: Arc::new(session),
 			version,
+			path: None,
 			send_bandwidth,
 			recv_bandwidth,
 			closed: false,
 		}
 	}
 
+	/// Attach the request path the peer advertised in its SETUP (lite-05 over a
+	/// URL-less transport). Set by [`crate::Server::accept`] / the accept request.
+	pub(super) fn with_path(mut self, path: Option<String>) -> Self {
+		self.path = path;
+		self
+	}
+
 	/// Returns the negotiated protocol version.
 	pub fn version(&self) -> Version {
 		self.version
+	}
+
+	/// The request path the peer addressed, or `None` if it provided none.
+	///
+	/// On URL-less transports (native QUIC, qmux over TCP/TLS/UDS) this is the path the
+	/// client advertised in the lite-05 SETUP. URL-carrying transports (WebTransport,
+	/// WebSocket) put the path in the connection URL, which is not visible at this layer
+	/// yet, so this currently returns `None` for them; read the URL from the transport
+	/// instead until `web-transport` surfaces it here.
+	pub fn path(&self) -> Option<&str> {
+		self.path.as_deref()
 	}
 
 	/// Returns a consumer for the estimated send bitrate (from the congestion controller).

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -52,7 +52,6 @@ pub struct ConnectionStats {
 pub struct Session {
 	session: Arc<dyn SessionInner>,
 	version: Version,
-	path: Option<String>,
 	send_bandwidth: Option<BandwidthConsumer>,
 	recv_bandwidth: Option<BandwidthConsumer>,
 	closed: bool,
@@ -82,34 +81,15 @@ impl Session {
 		Self {
 			session: Arc::new(session),
 			version,
-			path: None,
 			send_bandwidth,
 			recv_bandwidth,
 			closed: false,
 		}
 	}
 
-	/// Attach the request path the peer advertised in its SETUP (lite-05 over a
-	/// URL-less transport). Set by [`crate::Server::accept`] / the accept request.
-	pub(super) fn with_path(mut self, path: Option<String>) -> Self {
-		self.path = path;
-		self
-	}
-
 	/// Returns the negotiated protocol version.
 	pub fn version(&self) -> Version {
 		self.version
-	}
-
-	/// The request path the peer addressed, or `None` if it provided none.
-	///
-	/// On URL-less transports (native QUIC, qmux over TCP/TLS/UDS) this is the path the
-	/// client advertised in the lite-05 SETUP. URL-carrying transports (WebTransport,
-	/// WebSocket) put the path in the connection URL, which is not visible at this layer
-	/// yet, so this currently returns `None` for them; read the URL from the transport
-	/// instead until `web-transport` surfaces it here.
-	pub fn path(&self) -> Option<&str> {
-		self.path.as_deref()
 	}
 
 	/// Returns a consumer for the estimated send bitrate (from the congestion controller).

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -221,27 +221,31 @@ fn spawn_session<S>(session: S, cluster: Cluster, tier: moq_net::Tier)
 where
 	S: web_transport_trait::Session,
 {
-	// Full access to everything under the empty root.
-	let token = AuthToken::unrestricted(moq_net::Path::new("").to_owned());
-	let publish = cluster.publisher(&token);
-	let subscribe = cluster.subscriber(&token);
-	let stats = cluster.stats.tier(tier);
-
 	let serve = async move {
+		// Read the SETUP first so a trusted worker can scope its grant to a path
+		// (e.g. `tcp://relay/team`). No path means the empty root: everything.
+		let request = moq_net::Server::new().accept_request(session).await?;
+		let root = moq_net::Path::new(request.path().unwrap_or_default()).to_owned();
+
+		// Full access within `root`.
+		let token = AuthToken::unrestricted(root.clone());
+		let publish = cluster.publisher(&token);
+		let subscribe = cluster.subscriber(&token);
+
 		// subscribe/publish look backwards on purpose: see connection.rs. We publish
 		// the tracks the client may subscribe to, and subscribe to what it may publish.
 		// Only set the side the token grants; moq-net defaults the unset side to a
 		// fresh no-op origin.
-		let mut server = moq_net::Server::new().with_stats(stats);
+		let mut request = request.with_stats(cluster.stats.tier(tier));
 		if let Some(subscribe) = subscribe {
-			server = server.with_publisher(&subscribe);
+			request = request.with_publisher(&subscribe);
 		}
 		if let Some(publish) = publish {
-			server = server.with_subscriber(publish);
+			request = request.with_subscriber(publish);
 		}
-		let session = server.accept(session).await?;
+		let session = request.ok().await?;
 
-		tracing::info!(version = %session.version(), "negotiated");
+		tracing::info!(version = %session.version(), %root, "negotiated");
 		session.closed().await?;
 		anyhow::Ok(())
 	};

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -92,10 +92,18 @@ async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
 }
 
 fn client() -> moq_native::Client {
+	client_version(None)
+}
+
+/// A client pinned to a single MoQ version, or all versions when `None`.
+fn client_version(version: Option<moq_net::Version>) -> moq_native::Client {
 	let mut config = moq_native::ClientConfig::default();
 	config.tls.disable_verify = Some(true);
 	// Zero head start so the WebSocket path runs immediately.
 	config.websocket.delay = None;
+	if let Some(version) = version {
+		config.version = vec![version];
+	}
 	config.init().expect("client init")
 }
 
@@ -516,11 +524,23 @@ async fn internal_unix_round_trip() {
 	handle.abort();
 }
 
-/// Publisher and subscriber that announce/observe `broadcast` over the internal
-/// listener at `pub_url` / `sub_url`. Returns the path the subscriber sees the
-/// publisher's broadcast announced at, proving whether the request path reached
-/// the server (it scopes the publisher's grant to that root).
-async fn path_round_trip(pub_url: url::Url, sub_url: url::Url, broadcast: &str) -> String {
+/// The versions whose SETUP carries a request path that the server reads today:
+/// moq-lite-05 (Setup Stream) and the legacy moq-transport drafts (14-16, in-band
+/// SETUP parameter). draft-17/18 send the path too but the server doesn't surface
+/// it yet (the SETUP is read in the background), so they're left out for now.
+fn path_versions() -> Vec<moq_net::Version> {
+	["moq-lite-05-wip", "moq-transport-14"]
+		.iter()
+		.map(|alpn| alpn.parse().expect("parse version alpn"))
+		.collect()
+}
+
+/// Publisher and subscriber (both pinned to `version`) that announce/observe
+/// `broadcast` over the internal listener at `pub_url` / `sub_url`. Returns the
+/// path the subscriber sees the publisher's broadcast announced at, proving
+/// whether the request path reached the server (it scopes the publisher's grant
+/// to that root).
+async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: url::Url, broadcast: &str) -> String {
 	let pub_origin = Origin::random().produce();
 	let mut bc = pub_origin.create_broadcast(broadcast).expect("create broadcast");
 	let mut track = bc.create_track("video", None).expect("create track");
@@ -528,14 +548,16 @@ async fn path_round_trip(pub_url: url::Url, sub_url: url::Url, broadcast: &str) 
 	group.write_frame_now(b"hello".as_ref()).expect("write frame");
 	group.finish().expect("finish group");
 
-	let pub_session = tokio::time::timeout(TIMEOUT, client().with_publisher(pub_origin.consume()).connect(pub_url))
+	let pub_client = client_version(Some(version)).with_publisher(pub_origin.consume());
+	let pub_session = tokio::time::timeout(TIMEOUT, pub_client.connect(pub_url))
 		.await
 		.expect("publisher connect timeout")
 		.expect("publisher connect failed");
 
 	let sub_origin = Origin::random().produce();
 	let mut announcements = sub_origin.consume().announced();
-	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(sub_url))
+	let sub_client = client_version(Some(version)).with_subscriber(sub_origin);
+	let sub_session = tokio::time::timeout(TIMEOUT, sub_client.connect(sub_url))
 		.await
 		.expect("subscriber connect timeout")
 		.expect("subscriber connect failed");
@@ -554,7 +576,8 @@ async fn path_round_trip(pub_url: url::Url, sub_url: url::Url, broadcast: &str) 
 
 /// A `tcp://host:port/<path>` client advertises `<path>` in the SETUP; the relay
 /// scopes its grant to that root, so the publisher's broadcast lands prefixed.
-/// Proves the request path can be specified and reaches the server over plain TCP.
+/// Proves the request path can be specified and reaches the server over plain TCP,
+/// across every version whose SETUP carries a path.
 #[tokio::test]
 async fn internal_tcp_path_reaches_server() {
 	let (port, handle) = spawn_internal_relay().await;
@@ -563,18 +586,20 @@ async fn internal_tcp_path_reaches_server() {
 	let pub_url: url::Url = format!("tcp://127.0.0.1:{port}/room").parse().expect("parse url");
 	let sub_url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
-	let announced = path_round_trip(pub_url, sub_url, "test").await;
-	assert_eq!(
-		announced, "room/test",
-		"the SETUP path should scope the publisher's grant"
-	);
+	for version in path_versions() {
+		let announced = path_round_trip(version, pub_url.clone(), sub_url.clone(), "test").await;
+		assert_eq!(
+			announced, "room/test",
+			"the SETUP path should scope the publisher's grant ({version})"
+		);
+	}
 
 	handle.abort();
 }
 
 /// `unix://<socket>` carries no resource path in its URL (that's the socket), so
-/// the request path rides in the `?path=` query. Same assertion as TCP: the path
-/// reaches the server and scopes the publisher's grant.
+/// the request path rides in the `?path=` query. Same assertion as TCP, across
+/// every version whose SETUP carries a path.
 #[cfg(unix)]
 #[tokio::test]
 async fn internal_unix_path_reaches_server() {
@@ -585,11 +610,13 @@ async fn internal_unix_path_reaches_server() {
 		.expect("parse url");
 	let sub_url: url::Url = format!("unix://{}", path.display()).parse().expect("parse url");
 
-	let announced = path_round_trip(pub_url, sub_url, "test").await;
-	assert_eq!(
-		announced, "room/test",
-		"the SETUP path should scope the publisher's grant"
-	);
+	for version in path_versions() {
+		let announced = path_round_trip(version, pub_url.clone(), sub_url.clone(), "test").await;
+		assert_eq!(
+			announced, "room/test",
+			"the SETUP path should scope the publisher's grant ({version})"
+		);
+	}
 
 	handle.abort();
 }

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -524,15 +524,21 @@ async fn internal_unix_round_trip() {
 	handle.abort();
 }
 
-/// The versions whose SETUP carries a request path that the server reads today:
-/// moq-lite-05 (Setup Stream) and the legacy moq-transport drafts (14-16, in-band
-/// SETUP parameter). draft-17/18 send the path too but the server doesn't surface
-/// it yet (the SETUP is read in the background), so they're left out for now.
+/// Every version whose SETUP carries a request path the server reads: moq-lite-05
+/// (Setup Stream) and moq-transport 14-18 (the `Path` SETUP parameter, in-band on
+/// the bidi stream for 14-16 and the uni Setup Stream for 17-18).
 fn path_versions() -> Vec<moq_net::Version> {
-	["moq-lite-05-wip", "moq-transport-14"]
-		.iter()
-		.map(|alpn| alpn.parse().expect("parse version alpn"))
-		.collect()
+	[
+		"moq-lite-05-wip",
+		"moq-transport-14",
+		"moq-transport-15",
+		"moq-transport-16",
+		"moq-transport-17",
+		"moq-transport-18",
+	]
+	.iter()
+	.map(|alpn| alpn.parse().expect("parse version alpn"))
+	.collect()
 }
 
 /// Publisher and subscriber (both pinned to `version`) that announce/observe

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -420,8 +420,11 @@ async fn spawn_internal_unix_relay() -> (std::path::PathBuf, tokio::task::JoinHa
 	let cluster = Cluster::new(ClusterConfig::default()).expect("cluster init");
 
 	// Keep the path short: macOS caps AF_UNIX paths around 104 bytes, and the
-	// system temp dir is long. /tmp is fine on macOS and Linux.
-	let path = std::path::PathBuf::from(format!("/tmp/moq-internal-{}.sock", std::process::id()));
+	// system temp dir is long. /tmp is fine on macOS and Linux. A per-call counter
+	// keeps concurrent tests in the same process off each other's socket.
+	static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+	let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+	let path = std::path::PathBuf::from(format!("/tmp/moq-internal-{}-{seq}.sock", std::process::id()));
 
 	let mut internal = InternalConfig::default();
 	internal.uds.listen = Some(path.clone());
@@ -510,6 +513,84 @@ async fn internal_unix_round_trip() {
 	drop(broadcast);
 	drop(pub_session);
 	drop(sub_session);
+	handle.abort();
+}
+
+/// Publisher and subscriber that announce/observe `broadcast` over the internal
+/// listener at `pub_url` / `sub_url`. Returns the path the subscriber sees the
+/// publisher's broadcast announced at, proving whether the request path reached
+/// the server (it scopes the publisher's grant to that root).
+async fn path_round_trip(pub_url: url::Url, sub_url: url::Url, broadcast: &str) -> String {
+	let pub_origin = Origin::random().produce();
+	let mut bc = pub_origin.create_broadcast(broadcast).expect("create broadcast");
+	let mut track = bc.create_track("video", None).expect("create track");
+	let mut group = track.append_group().expect("append group");
+	group.write_frame_now(b"hello".as_ref()).expect("write frame");
+	group.finish().expect("finish group");
+
+	let pub_session = tokio::time::timeout(TIMEOUT, client().with_publisher(pub_origin.consume()).connect(pub_url))
+		.await
+		.expect("publisher connect timeout")
+		.expect("publisher connect failed");
+
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume().announced();
+	let sub_session = tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(sub_url))
+		.await
+		.expect("subscriber connect timeout")
+		.expect("subscriber connect failed");
+
+	let (path, _) = tokio::time::timeout(TIMEOUT, announcements.next())
+		.await
+		.expect("announcement timeout")
+		.expect("origin closed");
+
+	drop(track);
+	drop(bc);
+	drop(pub_session);
+	drop(sub_session);
+	path.as_str().to_string()
+}
+
+/// A `tcp://host:port/<path>` client advertises `<path>` in the SETUP; the relay
+/// scopes its grant to that root, so the publisher's broadcast lands prefixed.
+/// Proves the request path can be specified and reaches the server over plain TCP.
+#[tokio::test]
+async fn internal_tcp_path_reaches_server() {
+	let (port, handle) = spawn_internal_relay().await;
+
+	// Publisher addresses `/room`; subscriber addresses the bare root.
+	let pub_url: url::Url = format!("tcp://127.0.0.1:{port}/room").parse().expect("parse url");
+	let sub_url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
+
+	let announced = path_round_trip(pub_url, sub_url, "test").await;
+	assert_eq!(
+		announced, "room/test",
+		"the SETUP path should scope the publisher's grant"
+	);
+
+	handle.abort();
+}
+
+/// `unix://<socket>` carries no resource path in its URL (that's the socket), so
+/// the request path rides in the `?path=` query. Same assertion as TCP: the path
+/// reaches the server and scopes the publisher's grant.
+#[cfg(unix)]
+#[tokio::test]
+async fn internal_unix_path_reaches_server() {
+	let (path, handle) = spawn_internal_unix_relay().await;
+
+	let pub_url: url::Url = format!("unix://{}?path=room", path.display())
+		.parse()
+		.expect("parse url");
+	let sub_url: url::Url = format!("unix://{}", path.display()).parse().expect("parse url");
+
+	let announced = path_round_trip(pub_url, sub_url, "test").await;
+	assert_eq!(
+		announced, "room/test",
+		"the SETUP path should scope the publisher's grant"
+	);
+
 	handle.abort();
 }
 


### PR DESCRIPTION
## Summary

A server can learn the client's request path on transports that have no request URI (raw QUIC, qmux over TCP/TLS/UDS), by reading it from the MoQ SETUP before deciding what to serve.

- **moq-net** — `Server::accept_request` returns a `Request` handle. The handshake pauses after the client's SETUP is read; you inspect `Request::path()`, set the origins to serve, then `ok()` (or `close()`). `accept()` is a thin `accept_request().ok()` wrapper, so existing callers are untouched.
- **moq-native** — `tcp://` advertises `url.path()`; `unix://` advertises the `?path=` query (the socket stays in the URL path), threaded through `moq_net::Client::with_path`.
- **moq-relay** — the internal tcp/uds listener reads `request.path()` and scopes the trusted grant's root to it. No path still means the empty root (everything), so behavior is unchanged when no path is sent.

The path is read across **moq-lite-05 and every moq-transport draft (14-18)**:
- lite-05 and moq-transport 17/18 carry it on a unidirectional Setup Stream — `accept_setup` blocks on that stream and `STOP_SENDING`s any uni stream that races ahead (group data needs a prior subscribe, so nothing legitimate precedes the SETUP), then hands the stream back to `start` so it keeps serving (PROBE for lite, GOAWAY for IETF).
- moq-transport 14-16 carry it as an in-band parameter on the bidi SETUP, read synchronously.

We bite the bullet on blocking the lite-05 / IETF-17-18 accept on the SETUP; in the common flow it's in the client's first post-handshake flight, so it isn't a full extra round-trip.

## Why no `Session::path()`

An established `Session` deliberately has no `path()`. It could only ever return the in-band SETUP path, so it'd be `None` for WebTransport/WebSocket (whose path is in the connection URL) — a confusing half-truth. The path is surfaced where you act on it: the `accept_request` -> `Request::path()` flow.

## Public API changes

All additive; no breaking signature changes. `mod lite` / `mod ietf` are private, so their `accept_setup` / `start` / `Setup` items are crate-internal, not public surface.

**`moq-net` (`pub use server::*`)**
- **New** `Server::accept_request(&self, session) -> Result<Request<S>, Error>`.
- **New** `pub struct Request<S: web_transport_trait::Session>` with `path()`, `with_publisher()`, `with_subscriber()`, `with_stats()`, `async ok()`, `close()`.
- **Behavior change (no signature change)** `Server::accept`: now `accept_request().ok()`, and on lite-05 / moq-transport-17-18 it blocks on the client SETUP before returning.

**`moq-native`** / **`moq-relay`** — none public.

Targets **dev** (SETUP/behavior change).

## Test plan
- [x] `cargo test -p moq-net -p moq-native -p moq-relay`
  - moq-net: `accept_request_reads_lite05_path`, `..._without_path_is_none`, `accept_request_skips_uni_stream_before_setup`
  - moq-relay smoke: `internal_tcp_path_reaches_server`, `internal_unix_path_reaches_server` — a client pins each of **moq-lite-05 and moq-transport 14/15/16/17/18**, publishes under `/room`, and a no-path subscriber sees `room/test`, proving the path reaches the server on every version over both qmux transports.
- [x] `cargo build --workspace`
- [x] `cargo clippy` clean
- [x] `cargo fmt` via nix
- [ ] e2e against a live relay over `tcp://` / `unix://`

## Follow-ups
- `doc/concept` note on the SETUP path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)