### PR TITLE
revert(moq-net): encode Hop ID as a 62-bit varint again, not fixed-width 64-bit

### DIFF
--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -2,7 +2,7 @@ import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
 import { type Origin, OriginSchema } from "./origin.ts";
-import { hasBroadcastEpoch, hopsFixedWidth, Version } from "./version.ts";
+import { hasBroadcastEpoch, Version } from "./version.ts";
 
 // Must match the MAX_HOPS in Rust's model/origin.rs. Broadcasts with longer
 // hop chains are rejected; this keeps loop-detection bounded and rejects
@@ -68,15 +68,10 @@ export class AnnounceBroadcast {
 				await w.u53(this.hops.length);
 				break;
 			default:
-				// Lite04+: hop count + individual Hop IDs. Lite05+ carries each id
-				// fixed-width (64-bit); Lite04 used a 62-bit varint.
+				// Lite04+: hop count + individual Origin varints.
 				await w.u53(this.hops.length);
 				for (const origin of this.hops) {
-					if (hopsFixedWidth(version)) {
-						await w.u64(origin);
-					} else {
-						await w.u62(origin);
-					}
+					await w.u62(origin);
 				}
 				break;
 		}
@@ -104,13 +99,12 @@ export class AnnounceBroadcast {
 				break;
 			}
 			default: {
-				// Lite04+: hop count + individual Hop IDs. Lite05+ carries each id
-				// fixed-width (64-bit); Lite04 used a 62-bit varint.
+				// Lite04+: hop count + individual Origin varints.
 				const count = await r.u53();
 				if (count > MAX_HOPS) throw new Error(`hop count ${count} exceeds maximum ${MAX_HOPS}`);
 				hops = [];
 				for (let i = 0; i < count; i++) {
-					hops.push(OriginSchema.parse(hopsFixedWidth(version) ? await r.u64() : await r.u62()));
+					hops.push(OriginSchema.parse(await r.u62()));
 				}
 				break;
 			}
@@ -138,8 +132,8 @@ export class AnnounceBroadcast {
  */
 export class AnnounceRequest {
 	prefix: Path.Valid;
-	// Hop ID of the peer asking for announces. Zero means "no exclusion".
-	// Must be a bigint: peer origins are up to 64 bits and overflow u53.
+	// 62-bit Origin id of the peer asking for announces. Zero means "no exclusion".
+	// Must be a bigint: peer origins are up to 62 bits and overflow u53.
 	excludeHop: bigint;
 
 	constructor(prefix: Path.Valid, excludeHop: bigint = 0n) {
@@ -155,12 +149,8 @@ export class AnnounceRequest {
 			case Version.DRAFT_03:
 				break;
 			default:
-				// Lite04+: exclude_hop Hop ID. Lite05+ fixed-width (64-bit); Lite04 a 62-bit varint.
-				if (hopsFixedWidth(version)) {
-					await w.u64(this.excludeHop);
-				} else {
-					await w.u62(this.excludeHop);
-				}
+				// Lite04+: exclude_hop field (u62 varint).
+				await w.u62(this.excludeHop);
 				break;
 		}
 	}
@@ -174,7 +164,7 @@ export class AnnounceRequest {
 			case Version.DRAFT_03:
 				break;
 			default:
-				excludeHop = hopsFixedWidth(version) ? await r.u64() : await r.u62();
+				excludeHop = await r.u62();
 				break;
 		}
 		return new AnnounceRequest(prefix, excludeHop);
@@ -261,13 +251,12 @@ export class AnnounceOk {
 	}
 
 	async #encode(w: Writer) {
-		// lite-05 carries the Hop ID fixed-width (64-bit).
-		await w.u64(this.origin);
+		await w.u62(this.origin);
 		await w.u53(this.active);
 	}
 
 	static async #decode(r: Reader): Promise<AnnounceOk> {
-		const raw = await r.u64();
+		const raw = await r.u62();
 		// A zero responder id is never legitimate; it would stamp a placeholder onto chains.
 		if (raw === 0n) throw new Error("announce ok origin must be non-zero");
 		const origin = OriginSchema.parse(raw);

--- a/js/net/src/lite/origin.ts
+++ b/js/net/src/lite/origin.ts
@@ -1,18 +1,16 @@
 import * as z from "zod/mini";
 
 /**
- * A relay origin id (Hop ID), randomly assigned and carried in the hop chain.
+ * A relay origin id, encoded as a 62-bit varint on the wire.
  *
- * On the wire lite-05+ encodes it as a fixed-width 64-bit integer (the full
- * 64-bit space); older versions used a 62-bit varint. The {@link OriginSchema}
- * validates any incoming value and brands it so the type system enforces "only
- * validated origins flow into hop lists." Internal code that synthesizes an id
- * (e.g. {@link randomOrigin}) uses `OriginSchema.parse(...)` to produce a
- * branded value from the raw bigint.
+ * The {@link OriginSchema} validates any incoming value and brands it so the
+ * type system enforces "only validated origins flow into hop lists." Internal
+ * code that synthesizes an id (e.g. {@link randomOrigin}) uses
+ * `OriginSchema.parse(...)` to produce a branded value from the raw bigint.
  */
 export const OriginSchema = z
 	.bigint()
-	.check(z.refine((value) => value >= 0n && value < 1n << 64n, "Origin must be a non-negative 64-bit integer"))
+	.check(z.refine((value) => value >= 0n && value < 1n << 62n, "Origin must be a non-negative 62-bit integer"))
 	.brand("Origin");
 
 export type Origin = z.infer<typeof OriginSchema>;

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -11,23 +11,6 @@ export const Version = {
 
 export type Version = (typeof Version)[keyof typeof Version];
 
-/// Whether Hop IDs (ANNOUNCE / ANNOUNCE_OK) and `Exclude Hop` (ANNOUNCE_INTEREST) are
-/// carried as fixed-width 64-bit integers rather than varints. Added in lite-05: Hop IDs
-/// are randomly assigned, so a varint would almost never be shorter, and the fixed width
-/// buys the full 64-bit space (a varint caps at 62 bits).
-export function hopsFixedWidth(version: Version): boolean {
-	// Explicitly list older versions so future versions default to fixed-width.
-	switch (version) {
-		case Version.DRAFT_01:
-		case Version.DRAFT_02:
-		case Version.DRAFT_03:
-		case Version.DRAFT_04:
-			return false;
-		default:
-			return true;
-	}
-}
-
 /// Whether ANNOUNCE_BROADCAST carries a per-broadcast Epoch varint (after the suffix,
 /// before the hop chain). Added in lite-05 so a consumer can tell a newer instance of a
 /// broadcast from an older one. Older versions omit the field.

--- a/js/net/src/stream.test.ts
+++ b/js/net/src/stream.test.ts
@@ -206,34 +206,6 @@ test("Reader u62 varint decoding", async () => {
 	expect(await reader.done()).toBe(true);
 });
 
-test("Reader u64 fixed-width decoding", async () => {
-	// Fixed-width always uses 8 bytes, including the full 64-bit space a varint can't reach.
-	const testValues = [0n, 1n, 63n, 1n << 53n, (1n << 62n) - 1n, 1n << 62n, (1n << 64n) - 1n];
-
-	const { stream, written } = createTestWritableStream();
-	const testWriter = new Writer(stream);
-
-	for (const value of testValues) {
-		await testWriter.u64(value);
-	}
-
-	testWriter.close();
-	await testWriter.closed;
-
-	const data = concatChunks(written);
-	// Every value occupies exactly 8 bytes.
-	expect(data.byteLength).toBe(testValues.length * 8);
-
-	const reader = new Reader(undefined, data);
-
-	for (const expectedValue of testValues) {
-		const actualValue = await reader.u64();
-		expect(actualValue).toBe(expectedValue);
-	}
-
-	expect(await reader.done()).toBe(true);
-});
-
 test("Reader string decoding", async () => {
 	const testStrings = ["hello", "🎉", "", "world with spaces", "multi\nline\nstring"];
 

--- a/js/net/src/stream.ts
+++ b/js/net/src/stream.ts
@@ -170,16 +170,6 @@ export class Reader {
 		return result;
 	}
 
-	// Fixed-width big-endian 64-bit integer (8 bytes), as opposed to the variable-length
-	// u62 varint. Used for randomly-assigned Hop IDs on lite-05+, where a varint would
-	// almost never be shorter and the fixed width buys the full 64-bit space.
-	async u64(): Promise<bigint> {
-		await this.#fillTo(8);
-		const slice = this.#slice(8);
-		const view = new DataView(slice.buffer, slice.byteOffset, slice.byteLength);
-		return view.getBigUint64(0);
-	}
-
 	// Returns a Number using 53-bits, the max Javascript can use for integer math.
 	// Values > 2^53-1 are coerced to a Number (precision is lost) and logged. We
 	// downgrade overflow from throw to warn so a stray u64 field on the wire (e.g.
@@ -304,11 +294,6 @@ export class Writer {
 		await this.write(setUint16(this.#scratch, v));
 	}
 
-	// Fixed-width big-endian 64-bit integer (8 bytes); counterpart to {@link Reader.u64}.
-	async u64(v: bigint) {
-		await this.write(setBigUint64(this.#scratch, v));
-	}
-
 	async i32(v: number) {
 		if (Math.abs(v) > MAX_U31) {
 			throw new Error(`overflow, value larger than 32-bits: ${v.toString()}`);
@@ -385,12 +370,6 @@ function setUint16(dst: ArrayBuffer, v: number): Uint8Array {
 function setInt32(dst: ArrayBuffer, v: number): Uint8Array {
 	const view = new DataView(dst, 0, 4);
 	view.setInt32(0, v);
-	return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
-}
-
-function setBigUint64(dst: ArrayBuffer, v: bigint): Uint8Array {
-	const view = new DataView(dst, 0, 8);
-	view.setBigUint64(0, BigInt.asUintN(64, v));
 	return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
 }
 

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -358,7 +358,7 @@ impl Server {
 							let noq = super::noq::NoqRequest::accept(_conn, alpns).await?;
 							Ok(Request {
 								server,
-								kind: RequestKind::Noq(noq),
+								kind: RequestKind::Noq(Box::new(noq)),
 							})
 						}.boxed());
 					}
@@ -384,7 +384,7 @@ impl Server {
 							let quiche = super::quiche::QuicheRequest::accept(_conn, alpns).await?;
 							Ok(Request {
 								server,
-								kind: RequestKind::Quiche(quiche),
+								kind: RequestKind::Quiche(Box::new(quiche)),
 							})
 						}.boxed());
 					}
@@ -483,11 +483,11 @@ impl Server {
 /// An incoming connection that can be accepted or rejected.
 pub(crate) enum RequestKind {
 	#[cfg(feature = "noq")]
-	Noq(crate::noq::NoqRequest),
+	Noq(Box<crate::noq::NoqRequest>),
 	#[cfg(feature = "quinn")]
 	Quinn(Box<crate::quinn::QuinnRequest>),
 	#[cfg(feature = "quiche")]
-	Quiche(crate::quiche::QuicheRequest),
+	Quiche(Box<crate::quiche::QuicheRequest>),
 	#[cfg(feature = "iroh")]
 	Iroh(crate::iroh::Request),
 	#[cfg(feature = "websocket")]

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -124,7 +124,6 @@ pub struct AnnounceRequest<'a> {
 	// Request tracks with this prefix.
 	pub prefix: Path<'a>,
 	// If non-zero, the publisher SHOULD skip announces whose hop IDs contain this value.
-	// Carried as a Hop ID (varint on Lite04, fixed-width 64-bit on Lite05+); 0 means no exclusion.
 	pub exclude_hop: u64,
 }
 
@@ -133,8 +132,7 @@ impl Message for AnnounceRequest<'_> {
 		let prefix = Path::decode(r, version)?;
 		let exclude_hop = match version {
 			Version::Lite01 | Version::Lite02 | Version::Lite03 => 0,
-			// Decode as a Hop ID so the fixed-width vs varint choice tracks the version.
-			_ => Origin::decode(r, version)?.id,
+			_ => u64::decode(r, version)?,
 		};
 		Ok(Self { prefix, exclude_hop })
 	}
@@ -144,7 +142,7 @@ impl Message for AnnounceRequest<'_> {
 		match version {
 			Version::Lite01 | Version::Lite02 | Version::Lite03 => {}
 			_ => {
-				Origin::from(self.exclude_hop).encode(w, version)?;
+				self.exclude_hop.encode(w, version)?;
 			}
 		}
 
@@ -350,49 +348,6 @@ mod tests {
 		assert_eq!(round_trip(&msg), msg);
 	}
 
-	#[test]
-	fn announce_ok_full_64_bit_origin() {
-		// lite-05 carries the Hop ID fixed-width, so the full 64-bit space round-trips
-		// (a value a 62-bit varint could not hold).
-		let msg = AnnounceOk {
-			origin: Origin { id: u64::MAX },
-			active: 1,
-		};
-		assert_eq!(round_trip(&msg), msg);
-	}
-
-	#[test]
-	fn announce_ok_origin_is_fixed_width() {
-		let mut buf = bytes::BytesMut::new();
-		AnnounceOk {
-			origin: Origin { id: 1 },
-			active: 0,
-		}
-		.encode(&mut buf, Version::Lite05Wip)
-		.unwrap();
-		// size(1) + origin(8 fixed) + active(1 varint) = 10 bytes; a varint origin id of 1
-		// would have been a single byte, giving 3.
-		assert_eq!(buf.len(), 10);
-	}
-
-	#[test]
-	fn announce_request_exclude_hop_round_trip() {
-		// A value above the old 62-bit varint ceiling only survives the fixed-width lite-05 path.
-		for &exclude_hop in &[0u64, 7, 1u64 << 53, u64::MAX] {
-			let msg = AnnounceRequest {
-				prefix: Path::new("foo/bar"),
-				exclude_hop,
-			};
-			let mut buf = bytes::BytesMut::new();
-			msg.encode(&mut buf, Version::Lite05Wip).unwrap();
-			let mut slice = &buf[..];
-			let got = AnnounceRequest::decode(&mut slice, Version::Lite05Wip).unwrap();
-			assert!(slice.is_empty(), "trailing bytes after decode");
-			assert_eq!(got.exclude_hop, exclude_hop);
-			assert_eq!(got.prefix, msg.prefix);
-		}
-	}
-
 	fn broadcast_round_trip(msg: &AnnounceBroadcast, version: Version) -> AnnounceBroadcast<'static> {
 		let mut buf = bytes::BytesMut::new();
 		msg.encode(&mut buf, version).unwrap();
@@ -470,13 +425,11 @@ mod tests {
 		}
 		.encode(&mut buf, Version::Lite05Wip)
 		.unwrap();
-		// origin sits right after the size prefix; rewrite it to 0.
+		// origin id 1 sits right after the size prefix; rewrite it to 0.
 		let bytes = &buf[..];
 		let mut patched = bytes.to_vec();
-		// size(1 byte) | origin fixed-width 64-bit (8 bytes) | active varint(1 byte)
-		for b in &mut patched[1..9] {
-			*b = 0x00;
-		}
+		// size(1 byte) | origin varint(1 byte = 0x01) | active varint(1 byte)
+		patched[1] = 0x00;
 		let mut slice = &patched[..];
 		assert!(matches!(
 			AnnounceOk::decode(&mut slice, Version::Lite05Wip),

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -30,20 +30,6 @@ impl Version {
 		}
 	}
 
-	/// Whether Hop IDs (ANNOUNCE / ANNOUNCE_OK) and `Exclude Hop` (ANNOUNCE_INTEREST)
-	/// are carried as fixed-width 64-bit integers rather than varints. Added in lite-05:
-	/// Hop IDs are randomly assigned, so a varint would almost never be shorter than its
-	/// fixed-width equivalent, and the fixed width buys the full 64-bit space (a varint
-	/// caps at 62 bits).
-	#[allow(clippy::match_like_matches_macro)]
-	pub fn hops_fixed_width(self) -> bool {
-		// Match form so future versions default forward (CLAUDE.md convention).
-		match self {
-			Self::Lite01 | Self::Lite02 | Self::Lite03 | Self::Lite04 => false,
-			_ => true,
-		}
-	}
-
 	/// Whether ANNOUNCE_BROADCAST carries a per-broadcast Epoch varint (after the
 	/// suffix, before the hop chain). Added in lite-05 so a consumer can tell a newer
 	/// instance of a broadcast from an older one. Older versions omit the field.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -14,23 +14,23 @@ use crate::{
 	coding::{Decode, DecodeError, Encode, EncodeError},
 };
 
-/// A relay origin (Hop ID), a randomly-assigned identifier carried in the hop chain.
+/// A relay origin, identified by a 62-bit varint on the wire.
 ///
 /// `id` must be non-zero for a real origin; `id == 0` is reserved as a
 /// placeholder for Lite03-style hops where the actual value isn't carried.
-/// On the wire lite-05+ encodes the id as a fixed-width 64-bit integer (the full
-/// 64-bit space), while older versions used a 62-bit varint. [`Origin::random`]
-/// picks a random nonzero id.
+/// Encoding a value outside the 62-bit range (>= 2^62) will fail at the
+/// varint layer; [`Origin::random`] picks a valid random nonzero id.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Origin {
-	/// Non-zero identifier. Encoded as a fixed-width 64-bit integer on the wire (lite-05+).
+	/// Non-zero 62-bit identifier. Encoded as a QUIC varint on the wire.
 	pub id: u64,
 }
 
 impl Origin {
 	/// Placeholder for hop entries whose actual id is not on the wire (Lite03).
-	/// Never encoded for Lite04+: violates the non-zero invariant and would fail to round-trip.
+	/// `0` is a legal wire value and round-trips through the codec; we reserve it
+	/// as the "unknown" marker rather than hand it to a real origin.
 	pub(crate) const UNKNOWN: Self = Self { id: 0 };
 
 	/// Generate a fresh origin with a random non-zero id. Use this for any
@@ -65,36 +65,25 @@ impl fmt::Display for Origin {
 	}
 }
 
-impl Encode<crate::lite::Version> for Origin {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: crate::lite::Version) -> Result<(), EncodeError> {
-		if version.hops_fixed_width() {
-			// lite-05+: fixed-width 64-bit. Hop IDs are random, so a varint would almost
-			// never be shorter, and the fixed width buys the full 64-bit space.
-			if w.remaining_mut() < 8 {
-				return Err(EncodeError::Short);
-			}
-			w.put_u64(self.id);
-			Ok(())
-		} else {
-			self.id.encode(w, version)
-		}
+impl<V: Copy> Encode<V> for Origin
+where
+	u64: Encode<V>,
+{
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) -> Result<(), EncodeError> {
+		self.id.encode(w, version)
 	}
 }
 
-impl Decode<crate::lite::Version> for Origin {
-	fn decode<R: bytes::Buf>(r: &mut R, version: crate::lite::Version) -> Result<Self, DecodeError> {
-		if version.hops_fixed_width() {
-			if r.remaining() < 8 {
-				return Err(DecodeError::Short);
-			}
-			// Fixed-width carries the full 64-bit space.
-			Ok(Self { id: r.get_u64() })
-		} else {
-			// A lite varint is QUIC-encoded, so it already caps at 62 bits.
-			Ok(Self {
-				id: u64::decode(r, version)?,
-			})
+impl<V: Copy> Decode<V> for Origin
+where
+	u64: Decode<V>,
+{
+	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
+		let id = u64::decode(r, version)?;
+		if id >= 1u64 << 62 {
+			return Err(DecodeError::InvalidValue);
 		}
+		Ok(Self { id })
 	}
 }
 
@@ -1720,6 +1709,19 @@ mod tests {
 		}
 		assert_eq!(list.len(), MAX_HOPS);
 		assert_eq!(list.push(Origin::random()), Err(TooManyOrigins));
+	}
+
+	#[test]
+	fn origin_zero_round_trips() {
+		// `0` is the reserved UNKNOWN placeholder; it must stay a legal wire value.
+		let mut buf = bytes::BytesMut::new();
+		Origin::UNKNOWN
+			.encode(&mut buf, crate::lite::Version::Lite05Wip)
+			.unwrap();
+		let mut slice = &buf[..];
+		let got = Origin::decode(&mut slice, crate::lite::Version::Lite05Wip).unwrap();
+		assert!(slice.is_empty());
+		assert_eq!(got, Origin::UNKNOWN);
 	}
 
 	#[test]


### PR DESCRIPTION
Reverts the lite-05 fixed-width 64-bit Hop ID encoding from [#1788](https://github.com/moq-dev/moq/pull/1788), restoring the **62-bit varint** on the wire. Targets `dev` (wire-protocol change).

## What changed

**`rs/moq-net`**
- `Origin` goes back to the generic varint `Encode`/`Decode` (with the `>= 2^62` range check on decode).
- Removed `Version::hops_fixed_width()`.
- `AnnounceRequest.exclude_hop` and the `AnnounceOk` responder origin encode/decode as `u64` varints again.
- Removed the fixed-width-only tests; restored the single-byte patch in `announce_ok_rejects_zero_origin`.

**`js/net`** (wire pairing)
- `OriginSchema` bound back to `1n << 62n`.
- Removed `hopsFixedWidth`; hops, `excludeHop`, and `AnnounceOk.origin` back to `u62`.
- Removed the now-unused `Reader.u64`/`Writer.u64`/`setBigUint64` helpers and their test.

**`0` is a legal "unknown" value**
- The `UNKNOWN` placeholder (`id == 0`) round-trips through the varint codec. Added `origin_zero_round_trips` to lock that in, and corrected the misleading `UNKNOWN` doc comment that claimed it "would fail to round-trip".

**`rs/moq-native` (CI unblock, unrelated to the revert)**
- Boxed `RequestKind::Noq` and `Quiche` to clear a pre-existing `clippy::large_enum_variant` error. It's workspace-wide under `-D warnings`, so it gates *any* `rs/` PR; the fix mirrors the already-boxed `Quinn`/`WebSocket` variants. Flagged and approved to handle inline rather than in a separate PR.

## Test plan
- [x] `cargo test -p moq-net` (401 pass, incl. new `origin_zero_round_trips`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- [x] `cargo test --workspace --all-targets --all-features`
- [x] `just js check`

(Written by Claude)