### PR TITLE
feat(moq-net): add OriginProducer::dynamic + infallible OriginConsumer::request_broadcast

### DIFF
--- a/rs/kio/src/consumer.rs
+++ b/rs/kio/src/consumer.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
 	Counts, State, Weak,
 	lock::*,
-	producer::{Producer, Ref},
+	producer::{Mut, Producer, Ref},
 	waiter::*,
 };
 
@@ -49,6 +49,21 @@ impl<T> Consumer<T> {
 		waiter.register(&mut state.waiters_value);
 
 		Poll::Pending
+	}
+
+	/// Acquire write access to the shared state from the consumer side.
+	///
+	/// Unlike [`poll`](Self::poll), this never registers a waiter; it simply locks the
+	/// state for mutation. Returns `Err(`[`Ref`]`)` if the channel is already closed.
+	/// Mirrors [`Producer::write`], for the rare case where a consumer also feeds shared
+	/// state back to producers (e.g. a request queue).
+	pub fn write(&self) -> Result<Mut<'_, T>, Ref<'_, T>> {
+		let state = self.state.lock();
+		if state.closed {
+			Err(Ref { state })
+		} else {
+			Ok(Mut::new(state))
+		}
 	}
 
 	/// Poll for channel closure, registering the waiter if still open.

--- a/rs/kio/src/future.rs
+++ b/rs/kio/src/future.rs
@@ -1,0 +1,146 @@
+use std::{
+	ops::{Deref, DerefMut},
+	pin::Pin,
+	task::{Context, Poll},
+};
+
+use crate::Waiter;
+
+/// A pollable computation backed by kio channels.
+///
+/// Implementors write only [`Self::poll`], registering the [`Waiter`] with the
+/// channels they read. Wrap the value in [`Pending`] to get a real
+/// [`std::future::Future`].
+///
+/// This exists because a kio [`Waiter`] holds the strong `Arc<Waker>` while the
+/// channel's [`crate::WaiterList`] keeps only a `Weak`. A bare
+/// [`std::future::Future`] would have to stash the strong `Waiter` in a field and
+/// replace it every poll (or lose its wakeup); [`Pending`] does that once so each
+/// implementor doesn't have to.
+pub trait Future: Unpin {
+	type Output;
+
+	/// Poll for the output, registering `waiter` with the relevant channels if not
+	/// yet ready.
+	///
+	/// Takes `&self`: kio channels poll immutably, so a pollable can be driven
+	/// through a shared borrow (e.g. while it lives inside an `&self`-borrowed enum).
+	/// Carry any per-poll mutable state in a kio channel or a [`std::cell`] type.
+	fn poll(&self, waiter: &Waiter) -> Poll<Self::Output>;
+}
+
+/// Adapts a kio [`Future`] into a [`std::future::Future`], retaining the strong
+/// [`Waiter`] between polls so its weak registration stays live.
+///
+/// Derefs to the inner value, so any inherent methods you define on it are
+/// reachable through the pending handle (e.g. a non-blocking `poll`, or an
+/// `update`).
+pub struct Pending<F> {
+	inner: F,
+	// Retain the previous waiter so its Weak registration survives until the next
+	// poll replaces it (see [`crate::WaiterList`]).
+	waiter: Option<Waiter>,
+}
+
+impl<F> Pending<F> {
+	/// Wrap a [`Future`] so it can be `.await`ed.
+	pub fn new(inner: F) -> Self {
+		Self { inner, waiter: None }
+	}
+
+	/// Consume the wrapper, returning the inner value.
+	pub fn into_inner(self) -> F {
+		self.inner
+	}
+}
+
+impl<F> Deref for Pending<F> {
+	type Target = F;
+
+	fn deref(&self) -> &F {
+		&self.inner
+	}
+}
+
+impl<F> DerefMut for Pending<F> {
+	fn deref_mut(&mut self) -> &mut F {
+		&mut self.inner
+	}
+}
+
+impl<F: Future> std::future::Future for Pending<F> {
+	type Output = F::Output;
+
+	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
+		// Replacing drops the previous waiter, killing its Weak ref in the list so
+		// the inner poll's register call can recycle the slot (see `WaiterList`).
+		// `Pending<F>` is `Unpin` (F is, via the trait bound), so this deref is sound.
+		let this = &mut *self;
+		this.waiter = Some(Waiter::new(cx.waker().clone()));
+		Future::poll(&this.inner, this.waiter.as_ref().unwrap())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::Producer;
+
+	/// A pollable that waits for the channel value to reach a threshold, with an
+	/// inherent method reachable through `Pending`'s `DerefMut`.
+	struct AtLeast {
+		consumer: crate::Consumer<u64>,
+		threshold: u64,
+	}
+
+	impl AtLeast {
+		fn bump_threshold(&mut self) {
+			self.threshold += 1;
+		}
+	}
+
+	impl Future for AtLeast {
+		type Output = u64;
+
+		fn poll(&self, waiter: &Waiter) -> Poll<u64> {
+			let threshold = self.threshold;
+			match self.consumer.poll(waiter, |v| {
+				let current = **v;
+				if current >= threshold {
+					Poll::Ready(current)
+				} else {
+					Poll::Pending
+				}
+			}) {
+				Poll::Ready(Ok(v)) => Poll::Ready(v),
+				_ => Poll::Pending,
+			}
+		}
+	}
+
+	#[test]
+	fn pending_derefs_and_drives() {
+		use std::task::Waker;
+
+		let producer = Producer::new(0u64);
+		let mut pending = Pending::new(AtLeast {
+			consumer: producer.consume(),
+			threshold: 5,
+		});
+
+		// Inherent method on the inner reached via DerefMut.
+		pending.bump_threshold(); // threshold now 6
+
+		// The kio-level poll (reached through Deref) is pending until the value catches up.
+		assert!(Future::poll(&*pending, &Waiter::noop()).is_pending());
+
+		if let Ok(mut v) = producer.write() {
+			*v = 6;
+		}
+
+		// The std Future resolves once the threshold is met.
+		let mut cx = Context::from_waker(Waker::noop());
+		let mut pending = std::pin::pin!(pending);
+		assert_eq!(std::future::Future::poll(pending.as_mut(), &mut cx), Poll::Ready(6));
+	}
+}

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -14,6 +14,7 @@ mod lock;
 mod waiter;
 
 mod consumer;
+mod future;
 mod producer;
 mod weak;
 
@@ -21,6 +22,7 @@ mod weak;
 mod tests;
 
 pub use consumer::Consumer;
+pub use future::{Future, Pending};
 pub use producer::{Mut, Producer, Ref};
 pub use waiter::{Waiter, WaiterList, wait};
 pub use weak::Weak;

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -49,6 +49,11 @@ pub enum Error {
 	#[error("not found")]
 	NotFound,
 
+	/// A broadcast was requested that is neither announced nor served by a dynamic
+	/// router, so there is no route to it.
+	#[error("unroutable")]
+	Unroutable,
+
 	#[error("wrong frame size")]
 	WrongSize,
 
@@ -123,6 +128,9 @@ impl Error {
 			Self::Closed => 25,
 			Self::CacheFull => 26,
 			Self::FrameTooLarge => 27,
+			// 28 (Decompress) and 29 (TimestampMismatch) are reserved on the dev branch;
+			// keep Unroutable at 30 so the wire code is identical across branches.
+			Self::Unroutable => 30,
 			Self::App(app) => *app as u32 + 64,
 			Self::Remote(code) => *code,
 		}

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -10,7 +10,7 @@ use web_async::Lock;
 
 use super::BroadcastConsumer;
 use crate::{
-	AsPath, Broadcast, BroadcastProducer, Path, PathOwned, PathPrefixes,
+	AsPath, Broadcast, BroadcastProducer, Error, Path, PathOwned, PathPrefixes,
 	coding::{Decode, DecodeError, Encode, EncodeError},
 };
 
@@ -686,6 +686,11 @@ pub struct OriginProducer {
 
 	// The prefix that is automatically stripped from all paths.
 	root: PathOwned,
+
+	// Fallback request queue, shared with every derived consumer. Separate from
+	// `nodes` because dynamic broadcasts are never announced: they only resolve a
+	// consumer's `request_broadcast` when no live announcement exists.
+	dynamic: kio::Producer<OriginDynamicState>,
 }
 
 impl std::ops::Deref for OriginProducer {
@@ -704,6 +709,7 @@ impl OriginProducer {
 			info,
 			nodes: OriginNodes::default(),
 			root: PathOwned::default(),
+			dynamic: kio::Producer::default(),
 		}
 	}
 
@@ -764,12 +770,25 @@ impl OriginProducer {
 			info: self.info,
 			nodes: self.nodes.select(&prefixes)?,
 			root: self.root.clone(),
+			dynamic: self.dynamic.clone(),
 		})
+	}
+
+	/// Create a dynamic handler that picks up [`OriginConsumer::request_broadcast`]
+	/// calls for paths that are not announced.
+	///
+	/// This is the origin-level analogue of [`BroadcastProducer::dynamic`]: it serves
+	/// broadcasts on demand rather than tracks. Crucially the served broadcasts are
+	/// *not* announced, so [`OriginConsumer::announced`] never sees them; they exist
+	/// only as a fallback for a consumer that asks for an exact path with no live
+	/// announcement. Drop the handler (and every clone) to reject pending requests.
+	pub fn dynamic(&self) -> OriginDynamic {
+		OriginDynamic::new(self.info, self.root.clone(), self.dynamic.clone())
 	}
 
 	/// Subscribe to all announced broadcasts.
 	pub fn consume(&self) -> OriginConsumer {
-		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone())
+		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.consume())
 	}
 
 	/// Get a broadcast by path if it has *already* been published.
@@ -795,6 +814,7 @@ impl OriginProducer {
 			info: self.info,
 			root: self.root.join(&prefix).to_owned(),
 			nodes: self.nodes.root(&prefix)?,
+			dynamic: self.dynamic.clone(),
 		})
 	}
 
@@ -830,6 +850,10 @@ pub struct OriginConsumer {
 
 	// A prefix that is automatically stripped from all paths.
 	root: PathOwned,
+
+	// Shared fallback request queue, fed to any `OriginDynamic` handler on the
+	// producer side. Used only by `request_broadcast`; announced lookups ignore it.
+	dynamic: kio::Consumer<OriginDynamicState>,
 }
 
 impl std::ops::Deref for OriginConsumer {
@@ -841,7 +865,7 @@ impl std::ops::Deref for OriginConsumer {
 }
 
 impl OriginConsumer {
-	fn new(info: Origin, root: PathOwned, nodes: OriginNodes) -> Self {
+	fn new(info: Origin, root: PathOwned, nodes: OriginNodes, dynamic: kio::Consumer<OriginDynamicState>) -> Self {
 		let state = kio::Producer::<OriginConsumerState>::default();
 		let id = ConsumerId::new();
 
@@ -859,6 +883,7 @@ impl OriginConsumer {
 			nodes,
 			state,
 			root,
+			dynamic,
 		}
 	}
 
@@ -963,6 +988,7 @@ impl OriginConsumer {
 			self.info,
 			self.root.clone(),
 			self.nodes.select(&prefixes)?,
+			self.dynamic.clone(),
 		))
 	}
 
@@ -977,7 +1003,57 @@ impl OriginConsumer {
 			self.info,
 			self.root.join(&prefix).to_owned(),
 			self.nodes.root(&prefix)?,
+			self.dynamic.clone(),
 		))
+	}
+
+	/// Get a broadcast by path, falling back to a dynamic request when it is not announced.
+	///
+	/// Returns a [`kio::Pending`] future (resolved synchronously for an announced broadcast,
+	/// otherwise once a handler serves it). The lookup order is: an already-announced broadcast
+	/// resolves immediately; otherwise, if an [`OriginDynamic`] handler is live (see
+	/// [`OriginProducer::dynamic`]), a fallback request is registered and the future resolves
+	/// when the handler [`accept`](BroadcastRequest::accept)s it (or errors if it
+	/// [`reject`](BroadcastRequest::reject)s or every handler drops). Concurrent requests for
+	/// the same unannounced path coalesce onto one handler request.
+	///
+	/// The returned future resolves to [`Error::Unroutable`] when the path is not announced and no
+	/// dynamic handler exists, or [`Error::Dropped`] once the origin is gone. A request that is
+	/// registered while a handler is live but then loses every handler before being served also
+	/// resolves to [`Error::Unroutable`]. Unlike an announced broadcast, a dynamically served one
+	/// is never visible to [`Self::announced`].
+	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<BroadcastRequested> {
+		let path = path.as_path();
+
+		// Prefer a live announcement when one is present; the dynamic queue is only a fallback.
+		if let Some(broadcast) = self.get_broadcast(&path) {
+			return kio::Pending::new(BroadcastRequested::ready(broadcast));
+		}
+
+		// Key requests by absolute path so a scoped/rooted consumer and the handler
+		// (which may have a different root) agree on the same entry.
+		let absolute = self.root.join(&path).to_owned();
+
+		let Ok(mut state) = self.dynamic.write() else {
+			return kio::Pending::new(BroadcastRequested::failed(Error::Dropped));
+		};
+
+		// Coalesce onto a queued request for the same path; otherwise register a new one.
+		let consumer = if let Some(producer) = state.requests.get(&absolute) {
+			producer.consume()
+		} else {
+			if state.dynamic == 0 {
+				return kio::Pending::new(BroadcastRequested::failed(Error::Unroutable));
+			}
+
+			let producer = kio::Producer::<PendingBroadcast>::default();
+			let consumer = producer.consume();
+			state.requests.insert(absolute.clone(), producer);
+			state.request_order.push_back(absolute);
+			consumer
+		};
+
+		kio::Pending::new(BroadcastRequested::pending(consumer))
 	}
 
 	/// Returns the prefix that is automatically stripped from all paths.
@@ -1007,7 +1083,253 @@ impl Drop for OriginConsumer {
 
 impl Clone for OriginConsumer {
 	fn clone(&self) -> Self {
-		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone())
+		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.clone())
+	}
+}
+
+/// Shared fallback request queue for an origin.
+///
+/// Lives off to the side of the announce tree because dynamically served broadcasts
+/// are never announced. Mirrors the `dynamic`/`requests`/`request_order` fields of the
+/// broadcast and track models.
+#[derive(Default)]
+struct OriginDynamicState {
+	// Result channels for queued requests, keyed by absolute path. Concurrent
+	// `request_broadcast` calls for the same path coalesce onto the same channel while
+	// it is queued. The producer is moved out (and the entry removed) when the handler
+	// picks the request up via [`OriginDynamic::requested_broadcast`].
+	requests: HashMap<PathOwned, kio::Producer<PendingBroadcast>>,
+
+	// Requested paths in FIFO order for the handler to drain.
+	request_order: VecDeque<PathOwned>,
+
+	// The number of live `OriginDynamic` handlers. While zero, `request_broadcast`
+	// fails fast with `Unroutable` rather than queueing a request nobody will serve.
+	dynamic: usize,
+}
+
+impl OriginDynamicState {
+	/// Drop every queued request, closing its result channel so awaiting requesters
+	/// resolve to an error. Called when the last handler goes away.
+	fn reject_requests(&mut self) {
+		self.requests.clear();
+		self.request_order.clear();
+	}
+}
+
+/// One-shot result of a dynamic broadcast request.
+///
+/// Stays `None` until a handler [`accept`](BroadcastRequest::accept)s (yielding the served
+/// broadcast) or [`reject`](BroadcastRequest::reject)s (yielding an error). The producer is
+/// dropped right after writing, closing the channel; kio checks the value before the closed
+/// flag, so an awaiting requester still observes the final result.
+#[derive(Default)]
+struct PendingBroadcast {
+	resolved: Option<Result<BroadcastConsumer, Error>>,
+}
+
+/// Picks up [`OriginConsumer::request_broadcast`] calls for paths that are not announced.
+///
+/// The origin-level analogue of [`crate::BroadcastDynamic`]: where that serves tracks on
+/// demand within a broadcast, this serves whole broadcasts on demand within an origin. A
+/// relay uses it as a fallback router, fetching a broadcast from upstream only when a
+/// downstream consumer asks for an exact path that nobody announced.
+///
+/// Served broadcasts are deliberately *not* announced, so they never appear in
+/// [`OriginConsumer::announced`]. Drop this handle (and every clone) to reject the
+/// requests still waiting to be served.
+pub struct OriginDynamic {
+	info: Origin,
+	root: PathOwned,
+	state: kio::Producer<OriginDynamicState>,
+}
+
+impl Clone for OriginDynamic {
+	fn clone(&self) -> Self {
+		// Mirror `new`: bump `dynamic` so each live handle is counted. Without this,
+		// dropping a clone would decrement past `new`'s increment and prematurely flip
+		// `dynamic` to zero, making future `request_broadcast` calls return `Unroutable`.
+		if let Ok(mut state) = self.state.write() {
+			state.dynamic += 1;
+		}
+
+		Self {
+			info: self.info,
+			root: self.root.clone(),
+			state: self.state.clone(),
+		}
+	}
+}
+
+impl OriginDynamic {
+	fn new(info: Origin, root: PathOwned, state: kio::Producer<OriginDynamicState>) -> Self {
+		if let Ok(mut state) = state.write() {
+			state.dynamic += 1;
+		}
+
+		Self { info, root, state }
+	}
+
+	/// The origin this handler belongs to.
+	pub fn info(&self) -> &Origin {
+		&self.info
+	}
+
+	// Gate readiness on a queued request; mutate through the returned `Mut`.
+	fn poll<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, OriginDynamicState>, Error>>
+	where
+		F: FnMut(&kio::Ref<'_, OriginDynamicState>) -> Poll<()>,
+	{
+		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
+			Ok(state) => Ok(state),
+			Err(_) => Err(Error::Dropped),
+		})
+	}
+
+	/// Poll for the next requested broadcast, without blocking.
+	pub fn poll_requested_broadcast(&mut self, waiter: &kio::Waiter) -> Poll<Result<BroadcastRequest, Error>> {
+		let mut state = ready!(self.poll(waiter, |state| {
+			if state.request_order.is_empty() {
+				Poll::Pending
+			} else {
+				Poll::Ready(())
+			}
+		}))?;
+
+		let path = state.request_order.pop_front().expect("predicate guaranteed a request");
+		let producer = state.requests.remove(&path).expect("request_order out of sync");
+		Poll::Ready(Ok(BroadcastRequest { path, producer }))
+	}
+
+	/// Block until a consumer requests an unannounced broadcast, returning a
+	/// [`BroadcastRequest`] to serve.
+	pub async fn requested_broadcast(&mut self) -> Result<BroadcastRequest, Error> {
+		kio::wait(|waiter| self.poll_requested_broadcast(waiter)).await
+	}
+
+	/// Returns the prefix that is automatically stripped from requested paths.
+	pub fn root(&self) -> &Path<'_> {
+		&self.root
+	}
+}
+
+impl Drop for OriginDynamic {
+	fn drop(&mut self) {
+		if let Ok(mut state) = self.state.write() {
+			// Saturating sub so `OriginProducer::dynamic` can stay infallible.
+			state.dynamic = state.dynamic.saturating_sub(1);
+			if state.dynamic == 0 {
+				// No handlers left to fulfill queued requests; close them.
+				state.reject_requests();
+			}
+		}
+	}
+}
+
+/// A pending request for a broadcast that was not announced.
+///
+/// Yielded by [`OriginDynamic::requested_broadcast`]. The requester is awaiting inside
+/// [`OriginConsumer::request_broadcast`]; [`accept`](Self::accept) resolves it with a live
+/// broadcast (which the handler keeps producing into) and [`reject`](Self::reject) resolves
+/// it with an error. Dropping the request without either rejects it.
+pub struct BroadcastRequest {
+	// Absolute path that was requested.
+	path: PathOwned,
+
+	// Result channel back to the awaiting requester(s). Writing `resolved` and dropping
+	// this wakes them with the outcome.
+	producer: kio::Producer<PendingBroadcast>,
+}
+
+impl BroadcastRequest {
+	/// The absolute path that was requested.
+	pub fn path(&self) -> &Path<'_> {
+		&self.path
+	}
+
+	/// Accept the request, resolving every awaiting requester with `broadcast`.
+	///
+	/// The caller keeps producing into `broadcast` (e.g. a relay proxying tracks from
+	/// upstream); the requesters receive a consumer for it. The broadcast is *not*
+	/// announced.
+	pub fn accept(self, broadcast: BroadcastConsumer) {
+		if let Ok(mut state) = self.producer.write() {
+			state.resolved = Some(Ok(broadcast));
+		}
+		// `self.producer` drops here, closing the channel; the value is still observable.
+	}
+
+	/// Reject the request, resolving every awaiting requester with `err`.
+	pub fn reject(self, err: Error) {
+		if let Ok(mut state) = self.producer.write() {
+			state.resolved = Some(Err(err));
+		}
+	}
+}
+
+/// The pollable result of [`OriginConsumer::request_broadcast`].
+///
+/// Awaited via the [`kio::Pending`] wrapper; resolves to the [`BroadcastConsumer`]
+/// immediately when the broadcast was already announced, or once an [`OriginDynamic`]
+/// handler serves the request. Resolves to an error if the request is rejected or every
+/// handler drops before serving it.
+pub struct BroadcastRequested {
+	inner: Requested,
+}
+
+enum Requested {
+	// Already announced: resolves immediately with a clone of this broadcast.
+	Ready(BroadcastConsumer),
+	// Unroutable at request time, or the origin was already dropped: resolves immediately
+	// with this error. Baked in so `request_broadcast` itself stays infallible.
+	Failed(Error),
+	// Awaiting a handler: resolves when the request's result channel is written.
+	Pending(kio::Consumer<PendingBroadcast>),
+}
+
+impl BroadcastRequested {
+	fn ready(broadcast: BroadcastConsumer) -> Self {
+		Self {
+			inner: Requested::Ready(broadcast),
+		}
+	}
+
+	fn failed(error: Error) -> Self {
+		Self {
+			inner: Requested::Failed(error),
+		}
+	}
+
+	fn pending(consumer: kio::Consumer<PendingBroadcast>) -> Self {
+		Self {
+			inner: Requested::Pending(consumer),
+		}
+	}
+
+	/// Poll for the requested broadcast without blocking.
+	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<BroadcastConsumer, Error>> {
+		match &self.inner {
+			Requested::Ready(broadcast) => Poll::Ready(Ok(broadcast.clone())),
+			Requested::Failed(error) => Poll::Ready(Err(error.clone())),
+			Requested::Pending(consumer) => Poll::Ready(
+				match ready!(consumer.poll(waiter, |state| match &state.resolved {
+					Some(result) => Poll::Ready(result.clone()),
+					None => Poll::Pending,
+				})) {
+					Ok(result) => result,
+					// Every handler dropped without resolving: nobody could route it.
+					Err(_closed) => Err(Error::Unroutable),
+				},
+			),
+		}
+	}
+}
+
+impl kio::Future for BroadcastRequested {
+	type Output = Result<BroadcastConsumer, Error>;
+
+	fn poll(&self, waiter: &kio::Waiter) -> Poll<Self::Output> {
+		self.poll_ok(waiter)
 	}
 }
 
@@ -1055,6 +1377,8 @@ impl OriginConsumer {
 
 #[cfg(test)]
 mod tests {
+	use futures::FutureExt;
+
 	use crate::Broadcast;
 
 	use super::*;
@@ -2212,6 +2536,166 @@ mod tests {
 		assert!(
 			collected.iter().all(|(path, _)| path == &Path::new("test")),
 			"unexpected path in pending updates",
+		);
+	}
+
+	// With no OriginDynamic handler, an unannounced path resolves to Unroutable.
+	#[tokio::test]
+	async fn dynamic_request_unroutable_without_handler() {
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+		assert!(matches!(
+			consumer.request_broadcast("missing").await,
+			Err(Error::Unroutable)
+		));
+	}
+
+	// A dynamically served broadcast resolves the requester, but is never announced.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_served_not_announced() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		// A separate announce cursor must never observe the dynamic broadcast.
+		let mut announced = origin.consume();
+		announced.assert_next_wait();
+
+		// Request a path that nobody announced; the future stays pending until served.
+		// Registration happens up front, so the handler sees the request immediately.
+		let request_fut = consumer.request_broadcast("fallback");
+
+		// The handler serves it with a live broadcast it keeps producing into.
+		let served = Broadcast::new().produce();
+
+		let request = dynamic.requested_broadcast().await.unwrap();
+		assert_eq!(request.path(), &Path::new("fallback"));
+		request.accept(served.consume());
+
+		let broadcast = request_fut.await.unwrap();
+		assert!(broadcast.is_clone(&served.consume()));
+
+		// Still nothing announced.
+		announced.assert_next_wait();
+	}
+
+	// Concurrent requests for the same queued path coalesce onto one handler request.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_coalesces() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		// Both register before the handler drains either.
+		let f1 = consumer.request_broadcast("dup");
+		let f2 = consumer.request_broadcast("dup");
+
+		// Exactly one request reaches the handler.
+		let request = dynamic.requested_broadcast().await.unwrap();
+		assert_eq!(request.path(), &Path::new("dup"));
+		assert!(
+			dynamic.requested_broadcast().now_or_never().is_none(),
+			"a coalesced request must not be served twice"
+		);
+
+		// Accepting resolves both awaiting requesters with the same broadcast.
+		let served = Broadcast::new().produce();
+		request.accept(served.consume());
+		assert!(f1.await.unwrap().is_clone(&served.consume()));
+		assert!(f2.await.unwrap().is_clone(&served.consume()));
+	}
+
+	// Rejecting a request resolves the requester with the error.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_rejected() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let request_fut = consumer.request_broadcast("fallback");
+
+		let request = dynamic.requested_broadcast().await.unwrap();
+		request.reject(Error::Cancel);
+
+		assert!(matches!(request_fut.await, Err(Error::Cancel)));
+	}
+
+	// Dropping the last handler resolves queued requests with an error and reverts to
+	// resolving Unroutable.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_handler_dropped() {
+		let origin = Origin::random().produce();
+		let dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let request_fut = consumer.request_broadcast("fallback");
+		drop(dynamic);
+		assert!(matches!(request_fut.await, Err(Error::Unroutable)));
+
+		// With no handler left, a fresh request resolves Unroutable.
+		assert!(matches!(
+			consumer.request_broadcast("again").await,
+			Err(Error::Unroutable)
+		));
+	}
+
+	// `accept` is decoupled from the dynamic count: once a handler has picked a request up,
+	// it can still serve it even if every handler (including itself) drops first, flipping the
+	// count to zero. The in-flight request must not be rejected as `Unroutable`.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_accept_after_handler_dropped() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let request_fut = consumer.request_broadcast("fallback");
+
+		// The handler picks the request up, then every handler drops (count -> 0).
+		let request = dynamic.requested_broadcast().await.unwrap();
+		drop(dynamic);
+
+		// Accept still resolves the awaiting requester with the served broadcast.
+		let served = Broadcast::new().produce();
+		request.accept(served.consume());
+		assert!(request_fut.await.unwrap().is_clone(&served.consume()));
+	}
+
+	// A live announcement wins over the dynamic fallback; no request is queued.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_prefers_announced() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let broadcast = Broadcast::new().produce();
+		assert!(origin.publish_broadcast("live", broadcast.consume()));
+
+		let got = consumer.request_broadcast("live").await.unwrap();
+		assert!(
+			got.is_clone(&broadcast.consume()),
+			"should return the announced broadcast"
+		);
+		assert!(
+			dynamic.requested_broadcast().now_or_never().is_none(),
+			"an announced path must not queue a fallback request"
+		);
+	}
+
+	// Cloning a handler and dropping the clone must not flip the count to zero.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_clone_keeps_alive() {
+		let origin = Origin::random().produce();
+		let dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		drop(dynamic.clone());
+
+		// The original handle is still live, so the request registers (stays pending)
+		// instead of resolving Unroutable.
+		let request_fut = consumer.request_broadcast("fallback");
+		assert!(
+			request_fut.now_or_never().is_none(),
+			"request should stay pending until served"
 		);
 	}
 }


### PR DESCRIPTION
## Summary

Ports the origin-level dynamic-fallback API from `dev` to `main`: `OriginProducer::dynamic()` (from [#1772](https://github.com/moq-dev/moq/pull/1772)) and an infallible `OriginConsumer::request_broadcast` (from [#1890](https://github.com/moq-dev/moq/pull/1890)).

On `dev` these ride on a chain of disruptive reshapes that are deliberately quarantined there (`TrackInfo`/`TrackConsumer` [#1631](https://github.com/moq-dev/moq/pull/1631), RAII `OriginPublish` [#1640](https://github.com/moq-dev/moq/pull/1640), lite-05 wire [#1847](https://github.com/moq-dev/moq/pull/1847)). Rather than drag those into `main`, this **reimplements the feature additively** against `main`'s existing primitives. It turned out the dynamic machinery is self-contained on `kio` + `OriginNodes`, so the port is small and touches no existing API — `subscribe_track` and the rest of the origin/track surface are unchanged.

## What changed

**moq-net**
- `OriginProducer::dynamic() -> OriginDynamic` — serves whole broadcasts on demand. Served broadcasts are **never announced**, so they only resolve a consumer's exact-path request when no live announcement exists (the origin-level analogue of `BroadcastProducer::dynamic`).
- `OriginConsumer::request_broadcast(path) -> kio::Pending<BroadcastRequested>` — looks up an announced broadcast (resolves immediately), else registers a fallback request that resolves once an `OriginDynamic` handler `accept`s it. Concurrent requests for the same path coalesce.
- New types: `OriginDynamic`, `BroadcastRequest`, `BroadcastRequested`.
- `Error::Unroutable` at wire code `30` (matches `dev`; codes 28/29 stay reserved for dev's compression/timestamp errors so the wire code is identical across branches).

**kio** (additive)
- `Future` + `Pending` (`future.rs`, ported verbatim — depends only on `Waiter`).
- `Consumer::write()`, so the requester can enqueue into the shared dynamic queue (mirrors `Producer::write`).

## Infallibility

`request_broadcast` is infallible on its own terms — it returns a `kio::Pending` future, not a `Result`. An announced path resolves immediately; an unannounced path stays *pending* until served, then resolves to the broadcast or to `Error::Unroutable` (no route) / `Error::Dropped` (origin gone). This required **no** change to `subscribe_track`, which stays `-> Result<...>` as on `main`.

## API notes

This adds new **public** `moq-net` surface but is purely additive (no existing signature changes), so it's `main`-appropriate per Branch Targeting. New public items: `OriginProducer::dynamic`, `OriginConsumer::request_broadcast`, `OriginDynamic`, `BroadcastRequest`, `BroadcastRequested`, `Error::Unroutable`, `kio::{Future, Pending}`, `kio::Consumer::write`.

One deliberate divergence from `dev`: `BroadcastRequest::accept` takes a `BroadcastConsumer` directly instead of dev's `Consume<T>` trait. That trait is part of the #1640 RAII reshape and pulling it in would change `publish_broadcast`'s signature, which is out of scope here.

## Follow-ups (Cross-Package Sync) — intentionally not in this PR

- `js/net` mirror + `doc/concept`
- FFI/libmoq + `py`/`swift`/`kt`/`go` wrapper surface (dev's #1772 mirrored this)
- relay wiring to use the dynamic fallback router

## Test plan

- [x] `cargo test -p kio -p moq-net` — passes, including 8 new `dynamic_*` tests (ported and adapted to main's API) and the kio `Pending` test
- [x] `cargo fmt` + `cargo clippy -p kio -p moq-net` (via nix) clean
- [x] reverse-deps compile: `moq-relay`, `moq-native`, `hang`, `moq-mux`, `moq-ffi`, `moq-cli`
- [ ] full `just check` (JS + native matrix) not run — change is Rust-only and additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)