### PR TITLE
fix(nix): give moq-relay's check phase a CA bundle via cacert

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -46,6 +46,12 @@ let
     # jemalloc's configure uses -O0 test builds, which conflict with
     # Nix's _FORTIFY_SOURCE hardening (requires -O).
     hardeningDisable = [ "fortify" ];
+    # Auth::new builds a rustls client config up front, which loads native
+    # roots and now errors when none are found. The build sandbox has no
+    # system trust store, so point rustls-native-certs at cacert's bundle
+    # for the check phase (even the http-only auth tests hit this path).
+    nativeBuildInputs = [ final.cacert ];
+    SSL_CERT_FILE = "${final.cacert}/etc/ssl/certs/ca-bundle.crt";
   };
 
   moqCliArgs = crateInfo ../rs/moq-cli/Cargo.toml // {


### PR DESCRIPTION
## Summary

`nix build .#moq-relay` fails during its check phase (`doCheck = true`) in the relay auth tests. The root cause:

- `Auth::new` always builds a rustls client config up front ([auth.rs:688](https://github.com/moq-dev/moq/blob/main/rs/moq-relay/src/auth.rs#L688)).
- That TLS builder defaults to loading native system roots and now hard-errors when none are found ([tls.rs:323](https://github.com/moq-dev/moq/blob/main/rs/moq-native/src/tls.rs#L323)).
- The Nix build sandbox has no system trust store, so `rustls-native-certs` returns no roots and the tests blow up, including plain-`http://` wiremock helpers (e.g. `key_dir: Some(format!("{}/keys/", server.uri()))`) that never make a TLS connection.

This wires a CA bundle into the `moq-relay` crane build so the check phase passes:

```nix
nativeBuildInputs = [ final.cacert ];
SSL_CERT_FILE = "${final.cacert}/etc/ssl/certs/ca-bundle.crt";
```

## Notes for reviewers

- Scoped to `moq-relay` since it's the only crane package that constructs a TLS client during tests. `moq-cli`/`moq-token-cli` also run `doCheck = true` but don't hit this path.
- The cross `x86_64-apple-darwin` relay output inherits these args but sets `doCheck = false`, so the extra env is inert there.
- The `nativeBuildInputs` entry is redundant given the explicit `SSL_CERT_FILE`, but keeps the cacert dependency visible/idiomatic.

## Test plan

- [x] `nixfmt` clean, flake still evaluates (`nix eval .#moq-relay.drvPath`).
- [x] Verified the derivation env now carries `SSL_CERT_FILE=…/nss-cacert-3.123/etc/ssl/certs/ca-bundle.crt`, `nss-cacert` in `nativeBuildInputs`, and `doCheck=1` with `cargo test -p moq-relay` in the check phase.
- [ ] Full `nix build .#moq-relay` (not run locally; long source build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)