### PR TITLE
[codex] remove moq-lite broadcast epoch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ When making changes to the codebase:
 
 1. Pick the base branch per [Branch Targeting](#branch-targeting) above. **When creating a new worktree, base it on the freshly-fetched remote branch** (`git fetch origin` first, then branch off `origin/main` / `origin/dev`), not on whatever local `main`/`dev` the repo happens to be sitting on. A local branch can lag the remote by many commits (or carry a stale local merge), which produces a massive conflicting PR diff against the real base at merge time.
 2. Make your code changes
-3. Run `just fix` to auto-format and fix linting issues
+3. Run `just fix` before committing to auto-format and fix linting issues
 4. Run `just check` to verify everything passes
 5. Walk the Cross-Package Sync table; update paired packages and docs in the same PR
 6. Add tests where they're easy to write

--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -69,9 +69,6 @@ The [moq-relay clustering](/bin/relay/cluster) feature actually uses this to dis
 The peer first replies with the set of broadcasts that are currently live, then streams updates as they change.
 This initial set is a discrete batch: the latest draft reports how many entries to expect up front, so a freshly connected session can wait until that snapshot has fully arrived before listing what's available, rather than racing the gossip.
 
-Each broadcast also carries an **epoch** identifying its instance.
-When the same broadcast is announced over multiple routes (or republished after going away), the epoch lets everyone converge on the newest instance instead of picking arbitrarily.
-
 ### Subscriptions
 
 All data transfers are initiated by subscriptions.

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -32,33 +32,16 @@ async function roundTrip(msg: AnnounceBroadcast, version: Version): Promise<Anno
 	return AnnounceBroadcast.decode(reader, version);
 }
 
-test("AnnounceBroadcast epoch round-trips on draft-05", async () => {
+test("AnnounceBroadcast round-trips on draft-05", async () => {
 	const hops = [OriginSchema.parse(7n)];
-	// 1_700_000_000_000 is ~ms since 2020 in 2023; the others probe the edges of u53.
-	for (const epoch of [0, 1, 1_700_000_000_000, 2 ** 52]) {
-		const active = new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: true, epoch, hops });
-		const gotActive = await roundTrip(active, Version.DRAFT_05_WIP);
-		expect(gotActive.active).toBe(true);
-		expect(gotActive.epoch).toBe(epoch);
-		expect(gotActive.suffix).toBe(Path.from("room/cam"));
-		expect(gotActive.hops).toEqual(hops);
+	const active = new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: true, hops });
+	const gotActive = await roundTrip(active, Version.DRAFT_05_WIP);
+	expect(gotActive.active).toBe(true);
+	expect(gotActive.suffix).toBe(Path.from("room/cam"));
+	expect(gotActive.hops).toEqual(hops);
 
-		const ended = new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: false, epoch });
-		const gotEnded = await roundTrip(ended, Version.DRAFT_05_WIP);
-		expect(gotEnded.active).toBe(false);
-		expect(gotEnded.epoch).toBe(epoch);
-	}
-});
-
-test("AnnounceBroadcast epoch is omitted before draft-05", async () => {
-	// Pre-lite-05 carries no epoch on the wire, so a nonzero epoch decodes back as 0.
-	const msg = new AnnounceBroadcast({
-		suffix: Path.from("room/cam"),
-		active: true,
-		epoch: 42,
-		hops: [OriginSchema.parse(7n)],
-	});
-	const got = await roundTrip(msg, Version.DRAFT_04);
-	expect(got.epoch).toBe(0);
-	expect(got.suffix).toBe(Path.from("room/cam"));
+	const ended = new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: false });
+	const gotEnded = await roundTrip(ended, Version.DRAFT_05_WIP);
+	expect(gotEnded.active).toBe(false);
+	expect(gotEnded.suffix).toBe(Path.from("room/cam"));
 });

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -2,7 +2,7 @@ import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
 import { type Origin, OriginSchema } from "./origin.ts";
-import { hasBroadcastEpoch, Version } from "./version.ts";
+import { Version } from "./version.ts";
 
 // Must match the MAX_HOPS in Rust's model/origin.rs. Broadcasts with longer
 // hop chains are rejected; this keeps loop-detection bounded and rejects
@@ -10,41 +10,18 @@ import { hasBroadcastEpoch, Version } from "./version.ts";
 export const MAX_HOPS = 32;
 
 /**
- * Seconds between the Unix epoch and 2020-01-01T00:00:00 UTC.
- *
- * Broadcast epochs ride the wire as milliseconds since this base (smaller than a
- * Unix-epoch value, and good past the year 2500 in a varint). See {@link epochNow}.
- */
-export const EPOCH_BASE_SECONDS = 1_577_836_800;
-
-/**
- * The current wall clock as a broadcast epoch: whole milliseconds since
- * 2020-01-01 UTC (the wire value). Saturates to `0` for a clock before the base.
- */
-export function epochNow(): number {
-	return Math.max(0, Math.floor(Date.now() - EPOCH_BASE_SECONDS * 1000));
-}
-
-/**
  * ANNOUNCE_BROADCAST: sent by the publisher to advertise (or retract) a broadcast.
  *
- * Carries the broadcast path suffix, its instance {@link epoch} (lite-05+), and the
- * hop chain. Renamed from `Announce` in lite-05.
+ * Carries the broadcast path suffix and the hop chain. Renamed from `Announce` in lite-05.
  */
 export class AnnounceBroadcast {
 	suffix: Path.Valid;
 	active: boolean;
-	/**
-	 * Broadcast instance epoch: milliseconds since 2020-01-01 UTC (see {@link epochNow}).
-	 * Only carried on the wire for lite-05+; `0` on older versions.
-	 */
-	epoch: number;
 	hops: Origin[];
 
-	constructor(props: { suffix: Path.Valid; active: boolean; epoch?: number; hops?: Origin[] }) {
+	constructor(props: { suffix: Path.Valid; active: boolean; hops?: Origin[] }) {
 		this.suffix = props.suffix;
 		this.active = props.active;
-		this.epoch = props.epoch ?? 0;
 		this.hops = props.hops ?? [];
 		if (this.hops.length > MAX_HOPS) {
 			throw new Error(`hop count ${this.hops.length} exceeds maximum ${MAX_HOPS}`);
@@ -54,11 +31,6 @@ export class AnnounceBroadcast {
 	async #encode(w: Writer, version: Version) {
 		await w.bool(this.active);
 		await w.string(this.suffix);
-
-		// Lite05+: the epoch varint sits after the suffix and before the hop chain.
-		if (hasBroadcastEpoch(version)) {
-			await w.u53(this.epoch);
-		}
 
 		switch (version) {
 			case Version.DRAFT_01:
@@ -80,9 +52,6 @@ export class AnnounceBroadcast {
 	static async #decode(r: Reader, version: Version): Promise<AnnounceBroadcast> {
 		const active = await r.bool();
 		const suffix = Path.from(await r.string());
-
-		// Lite05+ carries the epoch after the suffix; older versions default it to 0.
-		const epoch = hasBroadcastEpoch(version) ? await r.u53() : 0;
 
 		let hops: Origin[] = [];
 		switch (version) {
@@ -110,7 +79,7 @@ export class AnnounceBroadcast {
 			}
 		}
 
-		return new AnnounceBroadcast({ suffix, active, epoch, hops });
+		return new AnnounceBroadcast({ suffix, active, hops });
 	}
 
 	async encode(w: Writer, version: Version): Promise<void> {

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -7,7 +7,7 @@ import { type Stream, Writer } from "../stream.ts";
 import { Timescale } from "../time.ts";
 import type { TrackSubscriber } from "../track.ts";
 import { error } from "../util/error.ts";
-import { AnnounceBroadcast, AnnounceInit, AnnounceOk, type AnnounceRequest, epochNow } from "./announce.ts";
+import { AnnounceBroadcast, AnnounceInit, AnnounceOk, type AnnounceRequest } from "./announce.ts";
 import { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
 import { Probe } from "./probe.ts";
@@ -66,13 +66,6 @@ export class Publisher {
 	// It's a signal so we can live update any announce streams.
 	#broadcasts = new Signal<Map<Path.Valid, Broadcast> | undefined>(new Map());
 
-	// Per-broadcast epoch (ms since 2020-01-01 UTC), stamped when the instance is
-	// published. Mirrors the Rust `BroadcastInfo.epoch` (SystemTime::now at creation):
-	// a newer instance of the same path carries a later epoch, so a consumer can prefer
-	// the newest route. Sent in every ANNOUNCE_BROADCAST (lite-05+), including the
-	// unannounce, so the peer can match the instance that ended.
-	#epochs = new Map<Path.Valid, number>();
-
 	// TRACK_INFO is immutable per track, so resolve it from the application once
 	// (via a throwaway subscribe whose info() resolves when the app calls accept)
 	// and reuse it for every later TRACK request of the same track. Keyed by
@@ -98,27 +91,17 @@ export class Publisher {
 	 * @param name - The broadcast to publish
 	 */
 	publish(path: Path.Valid, broadcast: Broadcast) {
-		// Stamp the instance epoch at publish time (mirrors Rust's SystemTime::now default).
-		this.#epochs.set(path, epochNow());
 		this.#broadcasts.mutate((broadcasts) => {
 			if (!broadcasts) throw new Error("closed");
 			broadcasts.set(path, broadcast);
 		});
 
-		// Remove the broadcast from the lookup when it's closed. Keep the epoch around:
-		// the unannounce announce (sent from the per-stream diff loop after the map change)
-		// still needs it to identify the instance that ended. It's overwritten on the next
-		// publish to the same path, so it can't go stale.
+		// Remove the broadcast from the lookup when it's closed.
 		void broadcast.closed.finally(() => {
 			this.#broadcasts.mutate((broadcasts) => {
 				broadcasts?.delete(path);
 			});
 		});
-	}
-
-	// The epoch of the broadcast published at `path`, or 0 if it was never seen.
-	#epoch(path: Path.Valid): number {
-		return this.#epochs.get(path) ?? 0;
 	}
 
 	/**
@@ -157,8 +140,7 @@ export class Publisher {
 				const ok = new AnnounceOk(this.origin, active.size);
 				await ok.encode(stream.writer, this.version);
 				for (const suffix of active) {
-					const epoch = this.#epoch(Path.join(msg.prefix, suffix));
-					const wire = new AnnounceBroadcast({ suffix, active: true, epoch });
+					const wire = new AnnounceBroadcast({ suffix, active: true });
 					await wire.encode(stream.writer, this.version);
 				}
 				break;
@@ -199,18 +181,15 @@ export class Publisher {
 			for (const added of newActive.difference(active)) {
 				console.debug(`announce: broadcast=${added} active=true`);
 				const hops = this.version === Version.DRAFT_05_WIP ? [] : [this.origin];
-				const epoch = this.#epoch(Path.join(msg.prefix, added));
-				const wire = new AnnounceBroadcast({ suffix: added, active: true, epoch, hops });
+				const wire = new AnnounceBroadcast({ suffix: added, active: true, hops });
 				await wire.encode(stream.writer, this.version);
 			}
 
 			// Announce any removed broadcasts.
-			// Ended announces don't need hops — the peer matches on path only.
-			// They carry the epoch of the instance that ended so the peer can match it.
+			// Ended announces don't need hops. The peer matches on path only.
 			for (const removed of active.difference(newActive)) {
 				console.debug(`announce: broadcast=${removed} active=false`);
-				const epoch = this.#epoch(Path.join(msg.prefix, removed));
-				const wire = new AnnounceBroadcast({ suffix: removed, active: false, epoch });
+				const wire = new AnnounceBroadcast({ suffix: removed, active: false });
 				await wire.encode(stream.writer, this.version);
 			}
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -50,7 +50,7 @@ function supportsTrackStream(version: Version): boolean {
 export interface AnnouncedOptions {
 	/**
 	 * If true, skip announcements whose hop chain contains this connection's
-	 * own origin id — useful for meshes that reflect announces back. Defaults
+	 * own origin id. Useful for meshes that reflect announces back. Defaults
 	 * to false for backwards compatibility: existing code (notably hang.live)
 	 * relies on seeing its own publishes as the signal that a namespace
 	 * published successfully.
@@ -202,11 +202,7 @@ export class Subscriber {
 
 				const path = Path.join(prefix, announce.suffix);
 
-				// `announce.epoch` (lite-05+) identifies the broadcast instance. The Rust
-				// origin uses it to prefer the newest of several routes to the same path; the
-				// JS side has no multi-route origin tree (the announced queue is flat), so
-				// there is nothing to tie-break here and the epoch is currently unused.
-				console.debug(`announced: broadcast=${path} active=${announce.active} epoch=${announce.epoch}`);
+				console.debug(`announced: broadcast=${path} active=${announce.active}`);
 				announced.append({ path, active: announce.active });
 			}
 

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -11,22 +11,6 @@ export const Version = {
 
 export type Version = (typeof Version)[keyof typeof Version];
 
-/// Whether ANNOUNCE_BROADCAST carries a per-broadcast Epoch varint (after the suffix,
-/// before the hop chain). Added in lite-05 so a consumer can tell a newer instance of a
-/// broadcast from an older one. Older versions omit the field.
-export function hasBroadcastEpoch(version: Version): boolean {
-	// Explicitly list older versions so future versions default to carrying the epoch.
-	switch (version) {
-		case Version.DRAFT_01:
-		case Version.DRAFT_02:
-		case Version.DRAFT_03:
-		case Version.DRAFT_04:
-			return false;
-		default:
-			return true;
-	}
-}
-
 /// Whether the session opens a unidirectional Setup Stream carrying a single SETUP message
 /// (capabilities + optional Path). Added in lite-05; older drafts have no Setup Stream.
 export function hasSetupStream(version: Version): boolean {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -460,8 +460,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let mut hops = crate::OriginList::new();
 				hops.push(self.session_origin)
 					.expect("an empty hop chain has room for one entry");
-				// moq-transport carries no broadcast epoch on the wire; stamp the current
-				// time so the instance is still ordered against any future re-announce.
 				let broadcast = BroadcastInfo {
 					hops,
 					..Default::default()

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -460,11 +460,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let mut hops = crate::OriginList::new();
 				hops.push(self.session_origin)
 					.expect("an empty hop chain has room for one entry");
-				let broadcast = BroadcastInfo {
-					hops,
-					..Default::default()
-				}
-				.produce();
+				let broadcast = BroadcastInfo { hops }.produce();
 
 				// Create the dynamic handler BEFORE publishing so consumers see
 				// dynamic >= 1 the moment they receive the announce. Otherwise a

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -18,23 +18,18 @@ pub fn restart_supported(version: Version) -> bool {
 
 /// ANNOUNCE_BROADCAST: sent by the publisher to advertise (or retract) a broadcast.
 ///
-/// Carries the broadcast path suffix, its instance [`epoch`](crate::BroadcastInfo::epoch)
-/// (lite-05+), and the hop chain. Renamed from ANNOUNCE in lite-05.
+/// Carries the broadcast path suffix and the hop chain. Renamed from ANNOUNCE in lite-05.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AnnounceBroadcast<'a> {
 	Active {
 		#[cfg_attr(feature = "serde", serde(borrow))]
 		suffix: Path<'a>,
-		/// Broadcast instance epoch (lite-05+); `0` on older versions.
-		epoch: u64,
 		hops: OriginList,
 	},
 	Ended {
 		#[cfg_attr(feature = "serde", serde(borrow))]
 		suffix: Path<'a>,
-		/// Epoch of the instance that ended (lite-05+); `0` on older versions.
-		epoch: u64,
 		hops: OriginList,
 	},
 }
@@ -43,11 +38,10 @@ impl Message for AnnounceBroadcast<'_> {
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let status = AnnounceStatus::decode(r, version)?;
 		let suffix = Path::decode(r, version)?;
-		let epoch = decode_epoch(r, version)?;
 		let hops = match version {
 			Version::Lite01 | Version::Lite02 => OriginList::new(),
 			Version::Lite03 => {
-				// Lite03 sends only a hop count, not individual ids — fill with UNKNOWN placeholders.
+				// Lite03 sends only a hop count, not individual ids. Fill with UNKNOWN placeholders.
 				// push() enforces MAX_HOPS and `?` lifts the overflow to DecodeError::BoundsExceeded.
 				let count = u64::decode(r, version)? as usize;
 				let mut list = OriginList::new();
@@ -60,52 +54,33 @@ impl Message for AnnounceBroadcast<'_> {
 		};
 
 		Ok(match status {
-			AnnounceStatus::Active => Self::Active { suffix, epoch, hops },
-			AnnounceStatus::Ended => Self::Ended { suffix, epoch, hops },
+			AnnounceStatus::Active => Self::Active { suffix, hops },
+			AnnounceStatus::Ended => Self::Ended { suffix, hops },
 			// We encode a restart as a duplicate ANNOUNCE (a second `Active`), but on versions that
 			// support restart we also accept the draft's explicit `restart` status and treat it the
 			// same. For an already-announced path the subscriber turns it into a restart; for an
 			// unknown path it's a fresh announce. Older versions never defined this status, so it's
 			// an invalid value there.
-			AnnounceStatus::Restart if restart_supported(version) => Self::Active { suffix, epoch, hops },
+			AnnounceStatus::Restart if restart_supported(version) => Self::Active { suffix, hops },
 			AnnounceStatus::Restart => return Err(DecodeError::InvalidValue),
 		})
 	}
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
 		match self {
-			Self::Active { suffix, epoch, hops } => {
+			Self::Active { suffix, hops } => {
 				AnnounceStatus::Active.encode(w, version)?;
 				suffix.encode(w, version)?;
-				encode_epoch(w, version, *epoch)?;
 				encode_hops(w, version, hops)?;
 			}
-			Self::Ended { suffix, epoch, hops } => {
+			Self::Ended { suffix, hops } => {
 				AnnounceStatus::Ended.encode(w, version)?;
 				suffix.encode(w, version)?;
-				encode_epoch(w, version, *epoch)?;
 				encode_hops(w, version, hops)?;
 			}
 		}
 
 		Ok(())
-	}
-}
-
-/// Encode the broadcast Epoch varint, present only on versions that carry it (lite-05+).
-fn encode_epoch<W: bytes::BufMut>(w: &mut W, version: Version, epoch: u64) -> Result<(), EncodeError> {
-	if version.has_broadcast_epoch() {
-		epoch.encode(w, version)?;
-	}
-	Ok(())
-}
-
-/// Decode the broadcast Epoch varint, defaulting to `0` on versions that omit it.
-fn decode_epoch<R: bytes::Buf>(r: &mut R, version: Version) -> Result<u64, DecodeError> {
-	if version.has_broadcast_epoch() {
-		u64::decode(r, version)
-	} else {
-		Ok(0)
 	}
 }
 
@@ -276,7 +251,6 @@ mod tests {
 		let mut buf = bytes::BytesMut::new();
 		AnnounceBroadcast::Active {
 			suffix: Path::new("foo/bar"),
-			epoch: 0,
 			hops: OriginList::new(),
 		}
 		.encode(&mut buf, version)
@@ -356,50 +330,32 @@ mod tests {
 		assert!(slice.is_empty(), "trailing bytes after decode");
 		// Decode borrows from `buf`; re-own so the value can outlive this frame.
 		match got {
-			AnnounceBroadcast::Active { suffix, epoch, hops } => AnnounceBroadcast::Active {
+			AnnounceBroadcast::Active { suffix, hops } => AnnounceBroadcast::Active {
 				suffix: suffix.to_owned(),
-				epoch,
 				hops,
 			},
-			AnnounceBroadcast::Ended { suffix, epoch, hops } => AnnounceBroadcast::Ended {
+			AnnounceBroadcast::Ended { suffix, hops } => AnnounceBroadcast::Ended {
 				suffix: suffix.to_owned(),
-				epoch,
 				hops,
 			},
 		}
 	}
 
 	#[test]
-	fn announce_broadcast_epoch_round_trip_on_lite05() {
+	fn announce_broadcast_round_trip_on_lite05() {
 		let mut hops = OriginList::new();
 		hops.push(Origin { id: 7 }).unwrap();
-		for epoch in [0u64, 1, 1_700_000_000_000, u64::MAX >> 2] {
-			let msg = AnnounceBroadcast::Active {
-				suffix: Path::new("room/cam"),
-				epoch,
-				hops: hops.clone(),
-			};
-			assert_eq!(broadcast_round_trip(&msg, Version::Lite05Wip), msg);
-
-			let ended = AnnounceBroadcast::Ended {
-				suffix: Path::new("room/cam"),
-				epoch,
-				hops: OriginList::new(),
-			};
-			assert_eq!(broadcast_round_trip(&ended, Version::Lite05Wip), ended);
-		}
-	}
-
-	#[test]
-	fn announce_broadcast_epoch_omitted_before_lite05() {
-		// Pre-lite-05 carries no epoch on the wire, so a nonzero epoch decodes back as 0.
 		let msg = AnnounceBroadcast::Active {
 			suffix: Path::new("room/cam"),
-			epoch: 42,
+			hops: hops.clone(),
+		};
+		assert_eq!(broadcast_round_trip(&msg, Version::Lite05Wip), msg);
+
+		let ended = AnnounceBroadcast::Ended {
+			suffix: Path::new("room/cam"),
 			hops: OriginList::new(),
 		};
-		let got = broadcast_round_trip(&msg, Version::Lite04);
-		assert!(matches!(got, AnnounceBroadcast::Active { epoch: 0, .. }));
+		assert_eq!(broadcast_round_trip(&ended, Version::Lite05Wip), ended);
 	}
 
 	#[test]

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -211,12 +211,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let mut stats_guards: std::collections::HashMap<crate::PathOwned, crate::PublisherStats> =
 			std::collections::HashMap::new();
 
-		// Last advertised epoch per active path (wire value). An ANNOUNCE_BROADCAST
-		// `ended` carries the epoch of the instance that ended, but the origin's Ended
-		// event doesn't carry the broadcast, so we stash it here on every Active/Restart
-		// and read it back when the path goes away.
-		let mut epochs: std::collections::HashMap<crate::PathOwned, u64> = std::collections::HashMap::new();
-
 		match version {
 			Version::Lite01 | Version::Lite02 => {
 				let mut init = Vec::new();
@@ -252,10 +246,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			}
 			Version::Lite05Wip => {
 				// Drain the current active set synchronously (like the Lite01/02 path),
-				// stashing suffix+epoch+hops so we can both COUNT them for AnnounceOk and
-				// re-send them afterward. The receiver stamps our origin onto each hop chain,
-				// so we forward the stored chain as-is (no self push here).
-				let mut initial: Vec<(crate::PathOwned, u64, OriginList)> = Vec::new();
+				// stashing suffix+hops so we can both COUNT them for AnnounceOk and re-send
+				// them afterward. The receiver stamps our origin onto each hop chain, so we
+				// forward the stored chain as-is (no self push here).
+				let mut initial: Vec<(crate::PathOwned, OriginList)> = Vec::new();
 				while let Some((path, event)) = announced.try_next() {
 					let suffix = path
 						.strip_prefix(&prefix)
@@ -275,20 +269,17 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							if hops.contains(&self_origin) {
 								continue;
 							}
-							let epoch = info.epoch_wire();
 							tracing::debug!(broadcast = %absolute, "announce");
 							let guard = stats.broadcast(&absolute).publisher();
 							stats_guards.entry(absolute.clone()).or_insert(guard);
-							epochs.insert(absolute, epoch);
-							initial.retain(|(s, _, _)| s != &suffix);
-							initial.push((suffix, epoch, hops.clone()));
+							initial.retain(|(s, _)| s != &suffix);
+							initial.push((suffix, hops.clone()));
 						}
 						None => {
 							// A potential race: a just-announced path already unannounced.
 							tracing::debug!(broadcast = %absolute, "unannounce");
 							stats_guards.remove(&absolute);
-							epochs.remove(&absolute);
-							initial.retain(|(s, _, _)| s != &suffix);
+							initial.retain(|(s, _)| s != &suffix);
 						}
 					}
 				}
@@ -301,10 +292,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				};
 				stream.writer.encode(&ok).await?;
 
-				for (suffix, epoch, hops) in initial {
+				for (suffix, hops) in initial {
 					stream
 						.writer
-						.encode(&lite::AnnounceBroadcast::Active { suffix, epoch, hops })
+						.encode(&lite::AnnounceBroadcast::Active { suffix, hops })
 						.await?;
 				}
 			}
@@ -333,13 +324,11 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								let Some(hops) = Self::prepare_active_hops(&info.hops, self_origin, exclude_hop, version, &absolute) else {
 									continue;
 								};
-								let epoch = info.epoch_wire();
 								tracing::debug!(broadcast = %absolute, "announce");
 								let guard = stats.broadcast(&absolute).publisher();
 								let prev = stats_guards.insert(absolute.clone(), guard);
 								debug_assert!(prev.is_none(), "origin announced a path that was already active");
-								epochs.insert(absolute, epoch);
-								stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, epoch, hops }).await?;
+								stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, hops }).await?;
 							}
 							crate::Announced::Restart(active) => {
 								// On lite-05+ a restart travels as a duplicate ANNOUNCE (a second
@@ -348,30 +337,26 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								let info = active.info();
 								match Self::prepare_active_hops(&info.hops, self_origin, exclude_hop, version, &absolute) {
 									Some(hops) => {
-										let epoch = info.epoch_wire();
 										tracing::debug!(broadcast = %absolute, "restart");
-										epochs.insert(absolute.clone(), epoch);
 										// Continuity: keep the existing stats guard (no close + reopen).
 										if lite::restart_supported(version) {
-											stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, epoch, hops }).await?;
+											stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, hops }).await?;
 										} else {
 											stream
 												.writer
 												.encode(&lite::AnnounceBroadcast::Ended {
 													suffix: suffix.clone(),
-													epoch,
 													hops: OriginList::new(),
 												})
 												.await?;
-											stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, epoch, hops }).await?;
+											stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, hops }).await?;
 										}
 									}
 									None => {
 										// The replacement loops back to us; from this peer's view the broadcast is gone.
 										tracing::debug!(broadcast = %absolute, "restart replacement looped; unannouncing");
 										stats_guards.remove(&absolute);
-										let epoch = epochs.remove(&absolute).unwrap_or(0);
-										stream.writer.encode(&lite::AnnounceBroadcast::Ended { suffix, epoch, hops: OriginList::new() }).await?;
+										stream.writer.encode(&lite::AnnounceBroadcast::Ended { suffix, hops: OriginList::new() }).await?;
 									}
 								}
 							}
@@ -379,9 +364,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								tracing::debug!(broadcast = %absolute, "unannounce");
 								stats_guards.remove(&absolute);
 								// An ended announce doesn't need hops; the receiver matches on path only.
-								// It carries the epoch of the instance that ended (0 if never seen).
-								let epoch = epochs.remove(&absolute).unwrap_or(0);
-								stream.writer.encode(&lite::AnnounceBroadcast::Ended { suffix, epoch, hops: OriginList::new() }).await?;
+								stream.writer.encode(&lite::AnnounceBroadcast::Ended { suffix, hops: OriginList::new() }).await?;
 							}
 						}
 					}
@@ -805,7 +788,7 @@ async fn write_fetch_frame<W: web_transport_trait::SendStream>(
 	Ok(())
 }
 
-/// Shared per-subscription state for the publisher side. Cloned (cheaply — every
+/// Shared per-subscription state for the publisher side. Cloned cheaply. Every
 /// field is either small or already Arc-backed) for each spawned serve_group task
 /// so each in-flight group reads the latest SUBSCRIBE_UPDATE priority via its own
 /// watch::Receiver.
@@ -895,7 +878,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 				// read primitives (see Reader::decode_maybe doc).
 				upd = reader.decode_maybe::<lite::SubscribeUpdate>() => {
 					let Some(upd) = upd? else {
-						// Peer FIN'd — they're done with this subscription. Drop any
+						// Peer FIN'd. They're done with this subscription. Drop any
 						// in-flight serve_group tasks (don't drain) so half-sent
 						// groups get cancelled rather than completed pointlessly.
 						return Ok(());

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -234,15 +234,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				for suffix in msg.suffixes {
 					let path = prefix.join(&suffix);
 					let abs = self.origin.absolute(&path).to_owned();
-					// Lite01/02 don't carry hop information or an epoch; the broadcast starts with
-					// an empty chain and a zero epoch (decoded as the 2020 base instant).
-					if self.start_announce(
-						path.clone(),
-						crate::OriginList::new(),
-						0,
-						responder_origin,
-						&mut producers,
-					)? {
+					// Lite01/02 don't carry hop information; the broadcast starts with
+					// an empty chain.
+					if self.start_announce(path.clone(), crate::OriginList::new(), responder_origin, &mut producers)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
 				}
@@ -274,14 +268,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		while let Some(announce) = stream.reader.decode_maybe::<lite::AnnounceBroadcast>().await? {
 			match announce {
-				lite::AnnounceBroadcast::Active { suffix, epoch, hops } => {
+				lite::AnnounceBroadcast::Active { suffix, hops } => {
 					let path = prefix.join(&suffix);
 					let abs = self.origin.absolute(&path).to_owned();
 					if lite::restart_supported(self.version) && producers.contains_key(&path) {
 						// lite-05+ only: a duplicate ANNOUNCE for an already-announced path is a RESTART;
 						// atomically replace the broadcast. Older versions fall through to start_announce,
 						// which rejects the duplicate (Error::Duplicate).
-						if self.restart_announce(path.clone(), hops, epoch, responder_origin, &mut producers)? {
+						if self.restart_announce(path.clone(), hops, responder_origin, &mut producers)? {
 							// Continuity: keep the existing stats guard if present.
 							stats_guards
 								.entry(abs.clone())
@@ -289,7 +283,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						} else {
 							stats_guards.remove(&abs);
 						}
-					} else if self.start_announce(path.clone(), hops, epoch, responder_origin, &mut producers)? {
+					} else if self.start_announce(path.clone(), hops, responder_origin, &mut producers)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
 					// The first `initial_count` Active messages are the initial set; once
@@ -388,8 +382,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		path: PathOwned,
 		mut hops: crate::OriginList,
-		// Broadcast instance epoch from ANNOUNCE_BROADCAST (wire value, 0 on pre-lite-05).
-		epoch: u64,
 		// Lite05+: the announce sender's origin id (from AnnounceOk). The sender no
 		// longer stamps itself onto the chain, so we append it here to reconstruct
 		// the full `[src...sender]` chain Lite04 stored. None for older versions,
@@ -398,7 +390,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		producers: &mut HashMap<PathOwned, OriginPublish>,
 	) -> Result<bool, Error> {
 		if let Some(responder) = responder_origin {
-			// If the chain is already full, drop the announce — the same decision
+			// If the chain is already full, drop the announce. This is the same decision
 			// the Lite04 sender makes at its push site.
 			if hops.push(responder).is_err() {
 				tracing::warn!(
@@ -409,7 +401,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		}
 
-		// Drop announces that already passed through us — this connection is
+		// Drop announces that already passed through us. This connection is
 		// a reflection, not a new path. Peers should be filtering via
 		// AnnounceInterest.exclude_hop, but Lite03 peers can't, so this is
 		// the authoritative cluster-loop check on the receiver.
@@ -446,11 +438,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "announce");
 
-		let broadcast = BroadcastInfo {
-			hops,
-			epoch: BroadcastInfo::epoch_from_wire(epoch),
-		}
-		.produce();
+		let broadcast = BroadcastInfo { hops }.produce();
 
 		// Create the dynamic handler BEFORE publishing, so that consumers
 		// see dynamic >= 1 immediately when they receive the announcement.
@@ -482,8 +470,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		path: PathOwned,
 		mut hops: crate::OriginList,
-		// Broadcast instance epoch from ANNOUNCE_BROADCAST (wire value, 0 on pre-lite-05).
-		epoch: u64,
 		// Lite05+: the announce sender's origin id (from AnnounceOk), appended here to
 		// rebuild the full chain since the sender no longer stamps itself. None for older
 		// versions. See `start_announce`.
@@ -504,11 +490,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
 
-		let broadcast = BroadcastInfo {
-			hops,
-			epoch: BroadcastInfo::epoch_from_wire(epoch),
-		}
-		.produce();
+		let broadcast = BroadcastInfo { hops }.produce();
 		let dynamic = broadcast.dynamic();
 
 		// Publish the replacement first so the origin restarts atomically; the old broadcast is
@@ -697,7 +679,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		track_stats: &SubscriberTrack,
 	) -> Result<(), Error> {
 		// FrameProducer impls BufMut over its pre-allocated per-frame buffer, so
-		// read_buf writes QUIC stream bytes directly into the frame — no
+		// read_buf writes QUIC stream bytes directly into the frame. No
 		// intermediate Bytes allocations, and quinn's reassembly arena is freed
 		// as we drain it.
 		while bytes::BufMut::has_remaining_mut(frame) {

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -30,18 +30,6 @@ impl Version {
 		}
 	}
 
-	/// Whether ANNOUNCE_BROADCAST carries a per-broadcast Epoch varint (after the
-	/// suffix, before the hop chain). Added in lite-05 so a consumer can tell a newer
-	/// instance of a broadcast from an older one. Older versions omit the field.
-	#[allow(clippy::match_like_matches_macro)]
-	pub fn has_broadcast_epoch(self) -> bool {
-		// Match form so future versions default forward (CLAUDE.md convention).
-		match self {
-			Self::Lite01 | Self::Lite02 | Self::Lite03 | Self::Lite04 => false,
-			_ => true,
-		}
-	}
-
 	/// Whether the session opens a unidirectional Setup Stream carrying a single SETUP
 	/// message (capabilities + optional Path). Added in lite-05; the older bidirectional
 	/// setup exchange (Lite01/02) and the no-setup drafts (Lite03/04) don't use it.

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -2,17 +2,11 @@ use std::{
 	collections::{HashMap, VecDeque, hash_map},
 	sync::Arc,
 	task::{Poll, ready},
-	time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use crate::{Error, TrackConsumer, TrackProducer, TrackRequest, TrackWeak};
 
 use super::{OriginList, TrackInfo};
-
-/// Wall-clock base for the broadcast epoch: 2020-01-01T00:00:00 UTC, expressed as
-/// seconds since the Unix epoch. The wire carries milliseconds since this base
-/// (smaller than a Unix-epoch value, and good past the year 2500 in a varint).
-const EPOCH_BASE_SECS: u64 = 1_577_836_800;
 
 /// A collection of media tracks that can be published and subscribed to.
 ///
@@ -23,58 +17,20 @@ pub struct BroadcastInfo {
 	/// [`crate::Origin`] when forwarding, so the list is used for loop detection and
 	/// shortest-path preference.
 	pub hops: OriginList,
-
-	/// Wall-clock instant identifying this instance of the broadcast.
-	///
-	/// A newer instance of the same broadcast carries a later time than an older one,
-	/// so a consumer can prefer the newest when the same broadcast is advertised over
-	/// multiple routes. Defaults to [`SystemTime::now`] (the moment the broadcast was
-	/// created). Origin-assigned and forwarded unchanged by relays. On the wire
-	/// (ANNOUNCE_BROADCAST, lite-05+) it is encoded as milliseconds since 2020-01-01 UTC.
-	pub epoch: SystemTime,
 }
 
 impl Default for BroadcastInfo {
 	fn default() -> Self {
 		Self {
 			hops: OriginList::new(),
-			// A fresh broadcast instance is stamped with the current wall clock.
-			epoch: SystemTime::now(),
 		}
 	}
 }
 
 impl BroadcastInfo {
-	/// Create a new broadcast with an empty hop chain and an epoch of [`SystemTime::now`].
+	/// Create a new broadcast with an empty hop chain.
 	pub fn new() -> Self {
 		Self::default()
-	}
-
-	/// Set the broadcast instance epoch, returning `self` for chaining.
-	///
-	/// A newer instance of the same broadcast must use a later time. See [`Self::epoch`].
-	pub fn with_epoch(mut self, epoch: SystemTime) -> Self {
-		self.epoch = epoch;
-		self
-	}
-
-	/// The epoch as the wire value: whole milliseconds since 2020-01-01 UTC.
-	///
-	/// Saturates to `0` for any instant at or before the base (e.g. a skewed clock).
-	pub(crate) fn epoch_wire(&self) -> u64 {
-		self.epoch
-			.duration_since(Self::epoch_base())
-			.map(|d| d.as_millis() as u64)
-			.unwrap_or(0)
-	}
-
-	/// Reconstruct an epoch [`SystemTime`] from the wire value (ms since 2020-01-01 UTC).
-	pub(crate) fn epoch_from_wire(wire: u64) -> SystemTime {
-		Self::epoch_base() + Duration::from_millis(wire)
-	}
-
-	fn epoch_base() -> SystemTime {
-		UNIX_EPOCH + Duration::from_secs(EPOCH_BASE_SECS)
 	}
 
 	/// Consume this [BroadcastInfo] to create a producer that carries its metadata
@@ -634,7 +590,7 @@ mod test {
 		);
 
 		// While the producer is still alive, re-subscribing to the same name reuses
-		// it (no new request) — this is what lets the relay linger upstream
+		// it (no new request). This is what lets the relay linger upstream
 		// subscriptions across transient consumer churn.
 		let consumer3 = bc.track("unknown_track").unwrap().subscribe(None).await.unwrap();
 		consumer3.assert_is_clone(&producer1.subscribe(None));

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1878,7 +1878,6 @@ mod tests {
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = BroadcastInfo {
 			hops: OriginList::try_from(vec![Origin::from(1u64)]).unwrap(),
-			..Default::default()
 		}
 		.produce();
 		let b = BroadcastInfo::new().produce();
@@ -1900,7 +1899,6 @@ mod tests {
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = BroadcastInfo {
 			hops: OriginList::try_from(vec![Origin::from(1u64)]).unwrap(),
-			..Default::default()
 		}
 		.produce();
 		let b = BroadcastInfo::new().produce();

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -247,13 +247,12 @@ struct OriginBroadcast {
 /// Ordering key used to pick the active route among broadcasts at the same path.
 ///
 /// Lower wins. Shorter hop chains sort first (routing prefers the shortest path);
-/// among equal-length chains the newer broadcast instance (larger
-/// [`epoch`](BroadcastInfo::epoch)) wins, and any remaining ties break on a
-/// deterministic hash of the broadcast name and hop chain. Every node in the cluster,
-/// given the same candidate routes, converges on the same winner: the epoch and hops
-/// are forwarded unchanged, and the hash is build-stable. Mixing the name in spreads
-/// equal routes across different upstreams rather than funneling onto one.
-fn route_key(name: &Path, info: &BroadcastInfo) -> (usize, std::cmp::Reverse<u64>, u64) {
+/// remaining ties break on a deterministic hash of the broadcast name and hop
+/// chain. Every node in the cluster, given the same candidate routes, converges
+/// on the same winner: the hops are forwarded unchanged, and the hash is
+/// build-stable. Mixing the name in spreads equal routes across different
+/// upstreams rather than funneling onto one.
+fn route_key(name: &Path, info: &BroadcastInfo) -> (usize, u64) {
 	// FNV-1a, not the std hasher: its output is fixed across Rust versions and
 	// builds, which matters when nodes run mismatched binaries during a rolling
 	// deploy and still need to agree on the same route. SEED is a custom basis
@@ -272,8 +271,7 @@ fn route_key(name: &Path, info: &BroadcastInfo) -> (usize, std::cmp::Reverse<u64
 		}
 	}
 
-	// Reverse the epoch so a larger (newer) instance sorts lower, i.e. wins.
-	(info.hops.len(), std::cmp::Reverse(info.epoch_wire()), hash)
+	(info.hops.len(), hash)
 }
 
 /// One coalesced update queued for an `AnnounceConsumer`.
@@ -1945,15 +1943,9 @@ mod tests {
 	async fn test_deterministic_tiebreak() {
 		tokio::time::pause();
 
-		// Build a broadcast carrying a specific hop chain. All routes share one epoch so
-		// this test isolates the hash tie-break (a differing epoch would decide first).
 		fn route(ids: &[u64]) -> BroadcastProducer {
 			let hops = OriginList::try_from(ids.iter().copied().map(Origin::from).collect::<Vec<_>>()).unwrap();
-			BroadcastInfo {
-				hops,
-				epoch: BroadcastInfo::epoch_from_wire(0),
-			}
-			.produce()
+			BroadcastInfo { hops }.produce()
 		}
 
 		// Resolve the active route for "test" after publishing both routes in the given order.
@@ -2645,7 +2637,7 @@ mod tests {
 		let origin = Origin::random().produce();
 		let broadcast = BroadcastInfo::new().produce();
 
-		// "demo" and "demo/foo" — "demo/foo" is redundant, only "demo" should remain
+		// "demo" and "demo/foo". "demo/foo" is redundant, only "demo" should remain
 		let producer = origin
 			.scope(&["demo".into(), "demo/foo".into()])
 			.expect("should create producer");
@@ -2663,7 +2655,7 @@ mod tests {
 		let origin = Origin::random().produce();
 		let broadcast = BroadcastInfo::new().produce();
 
-		// Both "demo" and "demo/foo" are requested — should only have one node
+		// Both "demo" and "demo/foo" are requested. Should only have one node
 		let producer = origin
 			.scope(&["demo".into(), "demo/foo".into()])
 			.expect("should create producer");
@@ -2741,7 +2733,7 @@ mod tests {
 
 		tokio::task::yield_now().await;
 
-		// Publish an unrelated broadcast first — announced_broadcast should skip it.
+		// Publish an unrelated broadcast first. announced_broadcast should skip it.
 		origin.publish_broadcast_spawn("other", other.consume());
 		tokio::task::yield_now().await;
 		assert!(!wait.is_finished(), "must not resolve on unrelated path");
@@ -2768,7 +2760,7 @@ mod tests {
 
 		tokio::task::yield_now().await;
 
-		// "foo/bar" is under the prefix scope, but it's not the exact path — skip it.
+		// "foo/bar" is under the prefix scope, but it's not the exact path. Skip it.
 		origin.publish_broadcast_spawn("foo/bar", nested.consume());
 		tokio::task::yield_now().await;
 		assert!(!wait.is_finished(), "must not resolve on a nested path");
@@ -2786,7 +2778,7 @@ mod tests {
 			.scope(&["allowed".into()])
 			.expect("should create limited");
 
-		// Path is outside allowed prefixes — should return None immediately.
+		// Path is outside allowed prefixes. Should return None immediately.
 		assert!(limited.announced_broadcast("notallowed").await.is_none());
 	}
 


### PR DESCRIPTION
## Summary

- Remove the moq-lite-05-wip broadcast epoch field from Rust and JS ANNOUNCE_BROADCAST encoding.
- Drop Rust `BroadcastInfo` epoch state and switch duplicate-route selection to hop count plus the existing deterministic hash.
- Remove JS epoch stamping/logging and update the moq-lite concept doc.
- Document that agents should run `just fix` before committing, and clean up the Clippy warnings exposed by that pass.

## Why

Epoch is being removed from moq-lite-05-wip, while the linked draft text still contains stale references to it. Keeping it in the implementation would leave Rust and JS speaking a wider wire format than intended.

## Validation

- `just fix`
- `cargo test -p moq-net`
- `cargo clippy -p moq-net --all-targets`
- `cargo test -p moq-net model::origin::tests::test_restart`
- `bun run --cwd js/net check`
- `bun test js/net/src/lite/announce.test.ts`
- `cargo fmt --check`
- `bunx biome check js/net/src/lite/announce.ts js/net/src/lite/announce.test.ts js/net/src/lite/publisher.ts js/net/src/lite/subscriber.ts js/net/src/lite/version.ts`

Note: `bun run --cwd js/net test` still fails in the pre-existing compression tests because Bun in this environment does not define `CompressionStream`; the lite-05 integration path and focused announce test pass.

(Written by Codex)