### PR TITLE
[codex] fix moq-srt negative pacing offsets

### DIFF
--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -372,7 +372,10 @@ fn pace(
 	ts: moq_mux::container::Timestamp,
 	now: Instant,
 ) -> Paced {
-	let send_at = anchor + Duration::from(ts).saturating_sub(Duration::from(base));
+	let send_at = match ts.checked_sub(base) {
+		Ok(offset) => anchor + Duration::from(offset),
+		Err(_) => anchor.checked_sub(Duration::from(base - ts)).unwrap_or(anchor),
+	};
 	if send_at > now {
 		// Media outran wall-clock: re-anchor so this newest frame is the live edge.
 		Paced {
@@ -469,6 +472,21 @@ mod tests {
 			jittered.anchor, edge.anchor,
 			"no re-anchor when media is behind wall-clock"
 		);
+
+		// A reordered B-frame can carry a PTS before the re-anchored live edge. Keep
+		// that earlier media instant instead of flattening it onto the anchor.
+		let reordered = pace(
+			edge.anchor,
+			edge.base,
+			ms(4_099),
+			edge.anchor + Duration::from_millis(20),
+		);
+		assert_eq!(
+			reordered.send_at,
+			edge.anchor - Duration::from_millis(33),
+			"a reordered frame can pace before the anchor"
+		);
+		assert_eq!(reordered.anchor, edge.anchor, "no re-anchor when media trails the edge");
 	}
 
 	fn sid(s: &str) -> StreamId {


### PR DESCRIPTION
## Summary

- Fix `moq-srt` egress pacing so frames with presentation timestamps before the current media anchor pace before the anchor instead of collapsing onto it.
- Keep the unavoidable startup/`Instant` underflow case panic-free by saturating only that boundary condition.
- Add a regression assertion for a reordered B-frame whose PTS trails the re-anchored live edge.

## Root Cause

`pace()` computed `anchor + Duration::from(ts).saturating_sub(Duration::from(base))`. When `ts < base`, that flattened the negative media offset to zero, so reordered frames could be stamped at the live edge instead of their earlier media instant.

## Validation

- `cargo test -p moq-srt pace_re_anchors_to_live_edge`
- `cargo check -p moq-srt`
- `cargo fmt --package moq-srt`
- `git diff --check`

Refs #1917.

(Written by Codex)