### PR TITLE
[codex] Backport relay web embedding

### DIFF
--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -842,6 +842,19 @@ impl Auth {
 		AuthParams::from_url(url, &self.domains)
 	}
 
+	/// Build a full-access token for a peer already authenticated by mTLS.
+	///
+	/// The HTTPS/QUIC layer verifies the client certificate before calling this.
+	/// This method applies the relay's canonical alias resolution and internal
+	/// tier decision, so embedded HTTP handlers get the same authorization scope
+	/// as the built-in relay routes.
+	pub async fn verify_mtls(&self, path: &str) -> Result<AuthToken, AuthError> {
+		let (root, internal) = self.resolve_mtls(path).await?;
+		let mut token = AuthToken::unrestricted(Path::new(&root).to_owned());
+		token.internal = internal;
+		Ok(token)
+	}
+
 	/// Resolve the canonical root and billing tier for an mTLS peer via the
 	/// unified `--auth-api`. mTLS peers are already trusted (the cert is the
 	/// credential), so this only fetches the alias + tier.
@@ -856,7 +869,7 @@ impl Auth {
 	/// canonical root (e.g. `x7k2qp`), producing a zombie session: the publisher
 	/// believes it is connected and never reconnects, but nothing is ever served.
 	/// Failing closed lets the client retry and self-heal once the API recovers.
-	pub(crate) async fn resolve_mtls(&self, path: &str) -> Result<(String, bool), AuthError> {
+	async fn resolve_mtls(&self, path: &str) -> Result<(String, bool), AuthError> {
 		let Some((base, client)) = &self.auth_api else {
 			return Ok((path.to_string(), true));
 		};

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -2,7 +2,6 @@ use crate::{Auth, AuthError, AuthParams, AuthToken, Cluster};
 
 use axum::http;
 use moq_native::Request;
-use moq_net::Path;
 
 /// An error carrying the HTTP status to send when closing the request.
 ///
@@ -136,9 +135,7 @@ impl Connection {
 			// vanity alias lands on the same tree a JWT would; cluster peers dial
 			// "/", which the API resolves (typically to an unscoped root). The API
 			// also returns the billing tier (defaulting to internal for trusted peers).
-			let (root, internal) = self.auth.resolve_mtls(&params.path).await?;
-			let mut token = AuthToken::unrestricted(Path::new(&root).to_owned());
-			token.internal = internal;
+			let mut token = self.auth.verify_mtls(&params.path).await?;
 			// Close the session when the client certificate expires, mirroring
 			// the JWT `exp` handling. Validated once at the TLS handshake otherwise.
 			token.expires = identity.expiry();

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -28,7 +28,7 @@ use tokio_rustls::server::TlsStream;
 use tower_http::cors::{Any, CorsLayer};
 use tower_service::Service;
 
-use crate::{Auth, AuthParams, AuthToken, Cluster};
+use crate::{Auth, AuthParams, Cluster};
 
 /// Configuration for the HTTP/HTTPS web server.
 #[derive(Parser, Clone, Debug, serde::Deserialize, serde::Serialize, Default)]
@@ -113,17 +113,47 @@ pub struct WebState {
 
 /// Run a HTTP server using Axum
 pub struct Web {
-	state: WebState,
+	state: Arc<WebState>,
 	config: WebConfig,
 }
 
 impl Web {
+	/// Create a web server from shared relay state and listener config.
 	pub fn new(state: WebState, config: WebConfig) -> Self {
-		Self { state, config }
+		Self {
+			state: Arc::new(state),
+			config,
+		}
 	}
 
-	/// Runs the HTTP and/or HTTPS listeners until they shut down.
-	pub async fn run(self) -> anyhow::Result<()> {
+	/// Create a web server from its relay parts.
+	pub fn from_parts(
+		auth: Auth,
+		cluster: Cluster,
+		tls_info: Arc<std::sync::RwLock<moq_native::tls::Info>>,
+		config: WebConfig,
+	) -> Self {
+		Self::new(
+			WebState {
+				auth,
+				cluster,
+				tls_info,
+				conn_id: AtomicU64::new(0),
+			},
+			config,
+		)
+	}
+
+	/// Return the shared state used by the default web routes.
+	pub fn state(&self) -> Arc<WebState> {
+		self.state.clone()
+	}
+
+	/// Build the default relay web router.
+	///
+	/// The returned router already has relay state applied, so embedders can
+	/// merge in their own state-applied routers before calling [`serve`](Self::serve).
+	pub fn routes(&self) -> Router {
 		let app = Router::new()
 			.route("/health", get(serve_health))
 			.route("/certificate.sha256", get(serve_fingerprint))
@@ -146,11 +176,17 @@ impl Web {
 			false => app,
 		};
 
-		let app = app
-			.fallback(serve_landing)
-			.layer(CorsLayer::new().allow_origin(Any).allow_methods([Method::GET]))
-			.with_state(Arc::new(self.state))
-			.into_make_service();
+		app.layer(CorsLayer::new().allow_origin(Any).allow_methods([Method::GET]))
+			.with_state(self.state.clone())
+	}
+
+	/// Serve `app` on the configured HTTP/HTTPS listeners until they shut down.
+	///
+	/// This owns the listener and TLS machinery, including optional HTTPS mTLS
+	/// extraction. Embedders usually call [`routes`](Self::routes), merge extra
+	/// routes, then pass the result here.
+	pub async fn serve(self, app: Router) -> anyhow::Result<()> {
+		let app = app.fallback(serve_landing).into_make_service();
 
 		let http = if let Some(listen) = self.config.http.listen {
 			// Dual-stack so the cert endpoint + WebSocket fallback answer over IPv4
@@ -193,6 +229,12 @@ impl Web {
 		};
 
 		Ok(())
+	}
+
+	/// Runs the default router on the configured listeners until they shut down.
+	pub async fn run(self) -> anyhow::Result<()> {
+		let app = self.routes();
+		self.serve(app).await
 	}
 }
 
@@ -290,12 +332,13 @@ async fn reload_https_config(config: RustlsConfig, cert: PathBuf, key: PathBuf, 
 	}
 }
 
-/// Marker inserted as a request extension when rustls verified a client cert
-/// against the configured mTLS CA. We don't carry the cert bytes. "Verified
-/// by our CA" is the entire signal we need (mirrors `peer_identity` on
-/// the QUIC side).
+/// Marker inserted as a request extension after HTTPS mTLS verifies a client certificate.
+///
+/// Embedded routes can extract `Option<Extension<MtlsPeer>>` to mirror the
+/// built-in relay handlers, then call [`Auth::verify_mtls`] with their route
+/// path when the marker is present.
 #[derive(Clone, Debug)]
-pub(crate) struct MtlsPeer;
+pub struct MtlsPeer;
 
 /// Wraps [`RustlsAcceptor`] so that, after the TLS handshake, we extract the
 /// peer cert presence from rustls's `ServerConnection` and attach it to every
@@ -483,11 +526,7 @@ async fn serve_announced(
 		jwt: query.jwt,
 	};
 	let token = if mtls.is_some() {
-		// mTLS peers: the API returns the canonical root and the billing tier.
-		let (root, internal) = state.auth.resolve_mtls(&params.path).await?;
-		let mut token = AuthToken::unrestricted(moq_net::Path::new(&root).to_owned());
-		token.internal = internal;
-		token
+		state.auth.verify_mtls(&params.path).await?
 	} else {
 		state.auth.verify(&params).await?
 	};
@@ -527,11 +566,7 @@ async fn serve_fetch(
 		jwt: params.auth.jwt,
 	};
 	let token = if mtls.is_some() {
-		// mTLS peers: the API returns the canonical root and the billing tier.
-		let (root, internal) = state.auth.resolve_mtls(&auth.path).await?;
-		let mut token = AuthToken::unrestricted(moq_net::Path::new(&root).to_owned());
-		token.internal = internal;
-		token
+		state.auth.verify_mtls(&auth.path).await?
 	} else {
 		state.auth.verify(&auth).await?
 	};

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -16,7 +16,7 @@ use axum::{
 };
 use moq_net::{OriginConsumer, OriginProducer, StatsHandle, Tier};
 
-use crate::{AuthParams, AuthToken, WebState, web::AuthQuery, web::MtlsPeer, web::landing_response};
+use crate::{AuthParams, WebState, web::AuthQuery, web::MtlsPeer, web::landing_response};
 
 pub(crate) async fn serve_ws(
 	ws: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
@@ -43,11 +43,7 @@ pub(crate) async fn serve_ws(
 
 	let params = AuthParams { path, jwt: query.jwt };
 	let token = if mtls.is_some() {
-		// mTLS peers: the API returns the canonical root and the billing tier.
-		let (root, internal) = state.auth.resolve_mtls(&params.path).await?;
-		let mut token = AuthToken::unrestricted(moq_net::Path::new(&root).to_owned());
-		token.internal = internal;
-		token
+		state.auth.verify_mtls(&params.path).await?
 	} else {
 		state.auth.verify(&params).await?
 	};

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -84,13 +84,21 @@ fn free_tcp_port() -> u16 {
 	port
 }
 
-async fn wait_for_http(port: u16) {
+async fn wait_for_http(port: u16, server_result: &mut tokio::sync::oneshot::Receiver<anyhow::Result<()>>) {
 	// Wait for axum_server to bind. A short poll is more reliable than a
 	// fixed sleep when CI is slow.
 	let deadline = std::time::Instant::now() + Duration::from_secs(5);
 	loop {
 		if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
 			break;
+		}
+		match server_result.try_recv() {
+			Ok(Ok(())) => panic!("relay web server exited before listening"),
+			Ok(Err(err)) => panic!("relay web server failed before listening: {err:#}"),
+			Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {}
+			Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+				panic!("relay web server task ended before listening")
+			}
 		}
 		if std::time::Instant::now() >= deadline {
 			panic!("relay http listener never became ready on port {port}");
@@ -106,12 +114,13 @@ async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
 	let port = free_tcp_port();
 	let web = build_web(port, true).await;
 
+	let (server_result_tx, mut server_result_rx) = tokio::sync::oneshot::channel();
 	let handle = tokio::spawn(async move {
 		// `Web::run` only returns on error; in tests we abort it at teardown.
-		let _ = web.run().await;
+		let _ = server_result_tx.send(web.run().await);
 	});
 
-	wait_for_http(port).await;
+	wait_for_http(port, &mut server_result_rx).await;
 
 	(port, handle)
 }
@@ -202,17 +211,19 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 
 #[tokio::test]
 async fn relay_web_serves_merged_routes() {
+	tokio::time::pause();
 	let port = free_tcp_port();
 	let web = build_web(port, false).await;
 	let app = web
 		.routes()
 		.route("/embedded", axum::routing::get(|| async { "embedded\n" }));
 
+	let (server_result_tx, mut server_result_rx) = tokio::sync::oneshot::channel();
 	let handle = tokio::spawn(async move {
-		let _ = web.serve(app).await;
+		let _ = server_result_tx.send(web.serve(app).await);
 	});
 
-	wait_for_http(port).await;
+	wait_for_http(port, &mut server_result_rx).await;
 
 	let body = reqwest::get(format!("http://127.0.0.1:{port}/embedded"))
 		.await

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -31,10 +31,7 @@ fn newest_lite_version() -> moq_net::Version {
 		.expect("parse newest lite ALPN as a Version")
 }
 
-/// The shared bootstrap: stand up a relay listening on `127.0.0.1:<free-port>`
-/// with fully public auth, and return the port plus an abort handle for the
-/// spawned web server.
-async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
+async fn build_web(port: u16, ws: bool) -> Web {
 	// Crypto provider is process-global; reinstalls after the first one are
 	// no-ops, but the test binary may run before any other moq code does.
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
@@ -61,19 +58,11 @@ async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
 	server_config.tls.generate = vec!["localhost".into()];
 	let server = server_config.init().expect("server init");
 
-	// Pick a free port for HTTP, then immediately drop the probe listener
-	// so axum_server can bind it. There's a tiny race window where the
-	// kernel could hand the same port to another process, but on localhost
-	// in a single-test process it's safe in practice.
-	let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
-	let port = probe.local_addr().expect("local addr").port();
-	drop(probe);
-
 	let mut web_config = WebConfig::default();
-	web_config.ws = true;
+	web_config.ws = ws;
 	web_config.http.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
 
-	let web = Web::new(
+	Web::new(
 		WebState {
 			auth,
 			cluster,
@@ -81,13 +70,21 @@ async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
 			conn_id: AtomicU64::new(0),
 		},
 		web_config,
-	);
+	)
+}
 
-	let handle = tokio::spawn(async move {
-		// `Web::run` only returns on error; in tests we abort it at teardown.
-		let _ = web.run().await;
-	});
+fn free_tcp_port() -> u16 {
+	// Pick a free port for HTTP, then immediately drop the probe listener
+	// so axum_server can bind it. There's a tiny race window where the
+	// kernel could hand the same port to another process, but on localhost
+	// in a single-test process it's safe in practice.
+	let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
+	let port = probe.local_addr().expect("local addr").port();
+	drop(probe);
+	port
+}
 
+async fn wait_for_http(port: u16) {
 	// Wait for axum_server to bind. A short poll is more reliable than a
 	// fixed sleep when CI is slow.
 	let deadline = std::time::Instant::now() + Duration::from_secs(5);
@@ -100,6 +97,21 @@ async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
 		}
 		tokio::time::sleep(Duration::from_millis(25)).await;
 	}
+}
+
+/// The shared bootstrap: stand up a relay listening on `127.0.0.1:<free-port>`
+/// with fully public auth, and return the port plus an abort handle for the
+/// spawned web server.
+async fn spawn_relay() -> (u16, tokio::task::JoinHandle<()>) {
+	let port = free_tcp_port();
+	let web = build_web(port, true).await;
+
+	let handle = tokio::spawn(async move {
+		// `Web::run` only returns on error; in tests we abort it at teardown.
+		let _ = web.run().await;
+	});
+
+	wait_for_http(port).await;
 
 	(port, handle)
 }
@@ -186,6 +198,31 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	drop(pub_session);
 	drop(sub_session);
 	web_handle.abort();
+}
+
+#[tokio::test]
+async fn relay_web_serves_merged_routes() {
+	let port = free_tcp_port();
+	let web = build_web(port, false).await;
+	let app = web
+		.routes()
+		.route("/embedded", axum::routing::get(|| async { "embedded\n" }));
+
+	let handle = tokio::spawn(async move {
+		let _ = web.serve(app).await;
+	});
+
+	wait_for_http(port).await;
+
+	let body = reqwest::get(format!("http://127.0.0.1:{port}/embedded"))
+		.await
+		.expect("fetch embedded route")
+		.text()
+		.await
+		.expect("read embedded response");
+	assert_eq!(body, "embedded\n");
+
+	handle.abort();
 }
 
 /// A client that dials a bare `host:port` with no path must still get a


### PR DESCRIPTION
## Summary

- Add `Web::routes()` and `Web::serve(app)` so embedders can mount extra axum routes on the relay web listener.
- Expose `MtlsPeer` and add `Auth::verify_mtls(path)` so embedded HTTPS handlers can use the relay's mTLS alias resolution and internal-tier decision.
- Route built-in mTLS paths through the new helper and add smoke coverage for serving merged routes.

## Validation

- `cargo fmt -p moq-relay`
- `cargo check -p moq-relay`
- `cargo test -p moq-relay`

(Written by Claude)