### PR TITLE
[codex] expose moq-rtc session runner

### DIFF
--- a/rs/moq-rtc/src/client/whep.rs
+++ b/rs/moq-rtc/src/client/whep.rs
@@ -66,7 +66,8 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::Broadcas
 	let inbound = session::spawn_socket_reader(socket.clone());
 	let session = session::Session::ingest(rtc, socket, candidates, inbound, sink);
 	tokio::spawn(async move {
-		session::log_session_end("whep client", session.run().await);
+		let result = session.run().await;
+		session::log_session_end("whep client", &result);
 	});
 
 	Ok(())

--- a/rs/moq-rtc/src/client/whip.rs
+++ b/rs/moq-rtc/src/client/whip.rs
@@ -72,7 +72,8 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::Broadcas
 	let inbound = session::spawn_socket_reader(socket.clone());
 	let session = session::Session::egress(rtc, socket, candidates, inbound, source);
 	tokio::spawn(async move {
-		session::log_session_end("whip client", session.run().await);
+		let result = session.run().await;
+		session::log_session_end("whip client", &result);
 	});
 
 	Ok(())

--- a/rs/moq-rtc/src/lib.rs
+++ b/rs/moq-rtc/src/lib.rs
@@ -30,7 +30,8 @@
 //! the request path. To own the HTTP route and authorize requests yourself
 //! (resolving the broadcast name from a verified token), skip the routers and
 //! call [`whip::accept`] (ingest) / [`whep::accept`] (egress) from your own
-//! handler.
+//! handler. Return the [`Response::answer`] in your HTTP response, then run
+//! [`Response::run`] to drive the media session for its lifetime.
 //!
 //! ## Bitstream gotcha
 //!

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -18,85 +18,110 @@ use std::sync::{Arc, Mutex};
 use axum::Router;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use tokio::sync::{Notify, OnceCell, oneshot};
+use tokio::sync::{OnceCell, oneshot};
 
 use crate::{Error, Result};
 use mux::Mux;
 
 /// The result of a WHIP/WHEP [`whip::accept`] / [`whep::accept`]: the SDP answer
 /// to return to the client, plus an opaque resource id for the `Location` header
-/// (the RFC 9725 session resource URL), and a handle that resolves when the
-/// media session ends.
-#[derive(Clone, Debug)]
+/// (the RFC 9725 session resource URL).
 pub struct Response {
 	/// Opaque id identifying the negotiated session, for the `Location` header.
 	pub resource_id: String,
 	/// The SDP answer body (`Content-Type: application/sdp`).
 	pub answer: String,
-	/// Completion handle for the negotiated media session.
-	pub session: SessionHandle,
+	session: AcceptedSession,
 }
 
-/// Cloneable handle used to await a negotiated WHIP/WHEP session ending.
-#[derive(Clone, Debug)]
-pub struct SessionHandle {
-	inner: Arc<SessionState>,
-}
-
-#[derive(Debug, Default)]
-struct SessionState {
-	result: Mutex<Option<SessionResult>>,
-	notify: Notify,
-}
-
-/// Terminal result for a negotiated WHIP/WHEP session.
-pub type SessionResult = std::result::Result<(), Arc<Error>>;
-
-impl SessionHandle {
-	/// Returns a new open session handle.
-	pub fn new() -> Self {
+impl Response {
+	/// Build a negotiated session response.
+	pub(crate) fn new(
+		server: Server,
+		resource_id: String,
+		answer: String,
+		session: crate::session::Session,
+		registration: mux::Registration,
+		cancel: oneshot::Receiver<()>,
+		role: &'static str,
+	) -> Self {
 		Self {
-			inner: Arc::new(SessionState::default()),
+			resource_id: resource_id.clone(),
+			answer,
+			session: AcceptedSession {
+				server,
+				resource_id,
+				session: Some(session),
+				registration: Some(registration),
+				cancel: Some(cancel),
+				role,
+			},
 		}
 	}
 
-	/// Wait until the negotiated media session ends.
-	pub async fn closed(&self) -> SessionResult {
-		loop {
-			let notified = self.inner.notify.notified();
-			if let Some(result) = self.result() {
-				return result;
-			}
-			notified.await;
-		}
-	}
-
-	/// Return the terminal result if the session has already ended.
-	pub fn result(&self) -> Option<SessionResult> {
-		self.inner.result.lock().unwrap().clone()
-	}
-
-	/// Returns true once the session has ended.
-	pub fn is_closed(&self) -> bool {
-		self.result().is_some()
-	}
-
-	pub(crate) fn close(&self, result: Result<()>) {
-		let result = match result {
-			Ok(()) | Err(Error::SessionClosed) => Ok(()),
-			Err(err) => Err(Arc::new(err)),
-		};
-		let mut state = self.inner.result.lock().unwrap();
-		if state.is_none() {
-			*state = Some(result);
-			self.inner.notify.notify_waiters();
-		}
+	/// Run the negotiated media session until the peer disconnects, DELETE terminates it, or it errors.
+	pub async fn run(self) -> Result<()> {
+		self.session.run().await
 	}
 }
 
-impl Default for SessionHandle {
-	fn default() -> Self {
-		Self::new()
+impl std::fmt::Debug for Response {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Response")
+			.field("resource_id", &self.resource_id)
+			.field("answer", &self.answer)
+			.finish_non_exhaustive()
+	}
+}
+
+struct AcceptedSession {
+	server: Server,
+	resource_id: String,
+	session: Option<crate::session::Session>,
+	registration: Option<mux::Registration>,
+	cancel: Option<oneshot::Receiver<()>>,
+	role: &'static str,
+}
+
+impl AcceptedSession {
+	async fn run(mut self) -> Result<()> {
+		let Some(session) = self.session.take() else {
+			return Ok(());
+		};
+		let Some(registration) = self.registration.take() else {
+			return Ok(());
+		};
+		let Some(cancel) = self.cancel.take() else {
+			return Ok(());
+		};
+
+		let result = {
+			let _registration = registration;
+			tokio::select! {
+				res = session.run() => {
+					crate::session::log_session_end(self.role, &res);
+					res
+				}
+				_ = cancel => {
+					tracing::debug!(role = self.role, "webrtc session terminated by DELETE");
+					Ok(())
+				}
+			}
+		};
+		normalize_session_result(result)
+	}
+}
+
+impl Drop for AcceptedSession {
+	fn drop(&mut self) {
+		self.server.unregister_session(&self.resource_id);
+	}
+}
+
+fn normalize_session_result(result: Result<()>) -> Result<()> {
+	match result {
+		Ok(()) | Err(Error::SessionClosed) => Ok(()),
+		Err(err) => Err(err),
 	}
 }
 
@@ -205,9 +230,9 @@ impl Server {
 		&self.inner.subscriber
 	}
 
-	/// Register a session under its resource id, returning the cancel receiver
-	/// the session task selects on. Called by [`whip::accept`] / [`whep::accept`]
-	/// before spawning the session.
+	/// Register a session under its resource id, returning the cancel receiver.
+	/// Called by [`whip::accept`] / [`whep::accept`] before returning the
+	/// negotiated session runner.
 	pub(crate) fn register_session(&self, resource_id: String) -> oneshot::Receiver<()> {
 		let (tx, rx) = oneshot::channel();
 		self.inner.sessions.lock().unwrap().insert(resource_id, tx);
@@ -278,25 +303,8 @@ mod tests {
 		assert!(!server.terminate(id), "unregistered session can't be terminated");
 	}
 
-	#[tokio::test]
-	async fn session_handle_reports_terminal_result() {
-		let session = SessionHandle::new();
-		assert!(!session.is_closed());
-		assert!(session.result().is_none());
-
-		let waiter = session.clone();
-		let task = tokio::spawn(async move { waiter.closed().await });
-
-		session.close(Ok(()));
-		assert!(session.is_closed());
-		assert!(session.result().expect("terminal result").is_ok());
-		assert!(task.await.expect("waiter task").is_ok());
-	}
-
 	#[test]
-	fn session_handle_treats_peer_close_as_success() {
-		let session = SessionHandle::new();
-		session.close(Err(Error::SessionClosed));
-		assert!(session.result().expect("terminal result").is_ok());
+	fn peer_close_is_a_successful_session_result() {
+		assert!(normalize_session_result(Err(Error::SessionClosed)).is_ok());
 	}
 }

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -85,15 +85,12 @@ struct AcceptedSession {
 
 impl AcceptedSession {
 	async fn run(mut self) -> Result<()> {
-		let Some(session) = self.session.take() else {
-			return Ok(());
-		};
-		let Some(registration) = self.registration.take() else {
-			return Ok(());
-		};
-		let Some(cancel) = self.cancel.take() else {
-			return Ok(());
-		};
+		let session = self.session.take().expect("accepted session missing driver");
+		let registration = self
+			.registration
+			.take()
+			.expect("accepted session missing mux registration");
+		let cancel = self.cancel.take().expect("accepted session missing cancel receiver");
 
 		let result = {
 			let _registration = registration;

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use axum::Router;
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderValue, StatusCode, Uri};
 use tokio::sync::{OnceCell, oneshot};
 
 use crate::{Error, Result};
@@ -120,6 +120,16 @@ fn normalize_session_result(result: Result<()>) -> Result<()> {
 		Ok(()) | Err(Error::SessionClosed) => Ok(()),
 		Err(err) => Err(err),
 	}
+}
+
+pub(crate) fn session_location(uri: &Uri, resource_id: &str) -> Option<HeaderValue> {
+	let base = uri.path().trim_end_matches('/');
+	let path = if base.is_empty() {
+		format!("/{resource_id}")
+	} else {
+		format!("{base}/{resource_id}")
+	};
+	HeaderValue::from_str(&path).ok()
 }
 
 /// Configuration shared by both `server publish` and `server subscribe`.
@@ -303,5 +313,12 @@ mod tests {
 	#[test]
 	fn peer_close_is_a_successful_session_result() {
 		assert!(normalize_session_result(Err(Error::SessionClosed)).is_ok());
+	}
+
+	#[test]
+	fn session_location_preserves_mount_path() {
+		let uri: Uri = "/whip/live/cam0?token=secret".parse().unwrap();
+		let location = session_location(&uri, "session-id").expect("header value");
+		assert_eq!(location, "/whip/live/cam0/session-id");
 	}
 }

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -18,20 +18,86 @@ use std::sync::{Arc, Mutex};
 use axum::Router;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use tokio::sync::{OnceCell, oneshot};
+use tokio::sync::{Notify, OnceCell, oneshot};
 
-use crate::Result;
+use crate::{Error, Result};
 use mux::Mux;
 
 /// The result of a WHIP/WHEP [`whip::accept`] / [`whep::accept`]: the SDP answer
 /// to return to the client, plus an opaque resource id for the `Location` header
-/// (the RFC 9725 session resource URL).
+/// (the RFC 9725 session resource URL), and a handle that resolves when the
+/// media session ends.
 #[derive(Clone, Debug)]
 pub struct Response {
 	/// Opaque id identifying the negotiated session, for the `Location` header.
 	pub resource_id: String,
 	/// The SDP answer body (`Content-Type: application/sdp`).
 	pub answer: String,
+	/// Completion handle for the negotiated media session.
+	pub session: SessionHandle,
+}
+
+/// Cloneable handle used to await a negotiated WHIP/WHEP session ending.
+#[derive(Clone, Debug)]
+pub struct SessionHandle {
+	inner: Arc<SessionState>,
+}
+
+#[derive(Debug, Default)]
+struct SessionState {
+	result: Mutex<Option<SessionResult>>,
+	notify: Notify,
+}
+
+/// Terminal result for a negotiated WHIP/WHEP session.
+pub type SessionResult = std::result::Result<(), Arc<Error>>;
+
+impl SessionHandle {
+	/// Returns a new open session handle.
+	pub fn new() -> Self {
+		Self {
+			inner: Arc::new(SessionState::default()),
+		}
+	}
+
+	/// Wait until the negotiated media session ends.
+	pub async fn closed(&self) -> SessionResult {
+		loop {
+			let notified = self.inner.notify.notified();
+			if let Some(result) = self.result() {
+				return result;
+			}
+			notified.await;
+		}
+	}
+
+	/// Return the terminal result if the session has already ended.
+	pub fn result(&self) -> Option<SessionResult> {
+		self.inner.result.lock().unwrap().clone()
+	}
+
+	/// Returns true once the session has ended.
+	pub fn is_closed(&self) -> bool {
+		self.result().is_some()
+	}
+
+	pub(crate) fn close(&self, result: Result<()>) {
+		let result = match result {
+			Ok(()) | Err(Error::SessionClosed) => Ok(()),
+			Err(err) => Err(Arc::new(err)),
+		};
+		let mut state = self.inner.result.lock().unwrap();
+		if state.is_none() {
+			*state = Some(result);
+			self.inner.notify.notify_waiters();
+		}
+	}
+}
+
+impl Default for SessionHandle {
+	fn default() -> Self {
+		Self::new()
+	}
 }
 
 /// Configuration shared by both `server publish` and `server subscribe`.
@@ -210,5 +276,27 @@ mod tests {
 		let _cancel = server.register_session(id.to_string());
 		server.unregister_session(id);
 		assert!(!server.terminate(id), "unregistered session can't be terminated");
+	}
+
+	#[tokio::test]
+	async fn session_handle_reports_terminal_result() {
+		let session = SessionHandle::new();
+		assert!(!session.is_closed());
+		assert!(session.result().is_none());
+
+		let waiter = session.clone();
+		let task = tokio::spawn(async move { waiter.closed().await });
+
+		session.close(Ok(()));
+		assert!(session.is_closed());
+		assert!(session.result().expect("terminal result").is_ok());
+		assert!(task.await.expect("waiter task").is_ok());
+	}
+
+	#[test]
+	fn session_handle_treats_peer_close_as_success() {
+		let session = SessionHandle::new();
+		session.close(Err(Error::SessionClosed));
+		assert!(session.result().expect("terminal result").is_ok());
 	}
 }

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -6,7 +6,7 @@
 use axum::{
 	Router,
 	body::Bytes,
-	extract::{Path, State},
+	extract::{OriginalUri, Path, State},
 	http::{HeaderMap, HeaderValue, StatusCode, header},
 	response::{IntoResponse, Response as HttpResponse},
 	routing::post,
@@ -24,7 +24,13 @@ pub fn router(server: Server) -> Router {
 		.with_state(server)
 }
 
-async fn handle(server: State<Server>, path: Path<String>, headers: HeaderMap, body: Bytes) -> HttpResponse {
+async fn handle(
+	server: State<Server>,
+	path: Path<String>,
+	OriginalUri(uri): OriginalUri,
+	headers: HeaderMap,
+	body: Bytes,
+) -> HttpResponse {
 	let (server, path) = (server.0, path.0);
 	match accept_offer(&server, &path, &headers, body).await {
 		Ok(response) => {
@@ -35,7 +41,7 @@ async fn handle(server: State<Server>, path: Path<String>, headers: HeaderMap, b
 			} = response;
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
-			if let Ok(loc) = HeaderValue::from_str(&format!("/{path}/{resource_id}")) {
+			if let Some(loc) = crate::server::session_location(&uri, &resource_id) {
 				response_headers.insert(header::LOCATION, loc);
 			}
 			tokio::spawn(async move {

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -28,15 +28,18 @@ async fn handle(server: State<Server>, path: Path<String>, headers: HeaderMap, b
 	let (server, path) = (server.0, path.0);
 	match accept_offer(&server, &path, &headers, body).await {
 		Ok(response) => {
-			let resource_id = response.resource_id.clone();
-			let answer = response.answer.clone();
+			let Response {
+				resource_id,
+				answer,
+				session,
+			} = response;
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
 			if let Ok(loc) = HeaderValue::from_str(&format!("/{path}/{resource_id}")) {
 				response_headers.insert(header::LOCATION, loc);
 			}
 			tokio::spawn(async move {
-				let _ = response.run().await;
+				let _ = session.run().await;
 			});
 			(StatusCode::CREATED, response_headers, answer).into_response()
 		}

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -27,7 +27,9 @@ pub fn router(server: Server) -> Router {
 async fn handle(server: State<Server>, path: Path<String>, headers: HeaderMap, body: Bytes) -> HttpResponse {
 	let (server, path) = (server.0, path.0);
 	match accept_offer(&server, &path, &headers, body).await {
-		Ok(Response { resource_id, answer }) => {
+		Ok(Response {
+			resource_id, answer, ..
+		}) => {
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
 			if let Ok(loc) = HeaderValue::from_str(&format!("/{path}/{resource_id}")) {
@@ -117,21 +119,33 @@ pub async fn accept(
 	// Register before spawning so a DELETE that races startup still finds the
 	// session; the task unregisters itself when it ends.
 	let cancel = server.register_session(resource_id.clone());
+	let session_handle = crate::server::SessionHandle::new();
 	let task_server = server.clone();
 	let task_resource = resource_id.clone();
+	let task_session = session_handle.clone();
 	tokio::spawn(async move {
-		// Hold the mux registration for the session's lifetime (unregisters on exit).
-		let _registration = registration;
-		tokio::select! {
-			res = session.run() => session::log_session_end("whep server", res),
-			_ = cancel => tracing::debug!("whep session terminated by DELETE"),
-		}
+		let result = {
+			// Hold the mux registration for the session's lifetime (unregisters on exit).
+			let _registration = registration;
+			tokio::select! {
+				res = session.run() => {
+					session::log_session_end("whep server", &res);
+					res
+				}
+				_ = cancel => {
+					tracing::debug!("whep session terminated by DELETE");
+					Ok(())
+				}
+			}
+		};
 		task_server.unregister_session(&task_resource);
+		task_session.close(result);
 	});
 
 	Ok(Response {
 		resource_id,
 		answer: sdp::render_answer(&answer),
+		session: session_handle,
 	})
 }
 

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -27,14 +27,17 @@ pub fn router(server: Server) -> Router {
 async fn handle(server: State<Server>, path: Path<String>, headers: HeaderMap, body: Bytes) -> HttpResponse {
 	let (server, path) = (server.0, path.0);
 	match accept_offer(&server, &path, &headers, body).await {
-		Ok(Response {
-			resource_id, answer, ..
-		}) => {
+		Ok(response) => {
+			let resource_id = response.resource_id.clone();
+			let answer = response.answer.clone();
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
 			if let Ok(loc) = HeaderValue::from_str(&format!("/{path}/{resource_id}")) {
 				response_headers.insert(header::LOCATION, loc);
 			}
+			tokio::spawn(async move {
+				let _ = response.run().await;
+			});
 			(StatusCode::CREATED, response_headers, answer).into_response()
 		}
 		Err(err) => {
@@ -65,9 +68,10 @@ async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: By
 /// enforced by moq-net exactly as for a native session; the bundled [`router`]
 /// passes the server's own (unauthenticated) consumer. It parses the offer,
 /// resolves the broadcast on `subscriber`, restricts the answer to the codecs the
-/// catalog actually has, registers a media session on the shared mux, spawns the
-/// MoQ->RTP session, and returns the SDP answer plus an opaque `resource_id` for
-/// the WHEP `Location` header. Mirrors [`whip::accept`](super::whip::accept).
+/// catalog actually has, registers a media session on the shared mux, and
+/// returns the SDP answer plus an opaque `resource_id` for the WHEP `Location`
+/// header. The caller must run the returned [`Response`] to drive the MoQ->RTP
+/// session. Mirrors [`whip::accept`](super::whip::accept).
 ///
 /// `offer` is the raw SDP body; the caller is responsible for checking the
 /// `Content-Type: application/sdp` request header. Fails with [`Error::InvalidSdp`]
@@ -116,37 +120,19 @@ pub async fn accept(
 	let resource_id = sdp::new_resource_id();
 	let session = session::Session::egress(rtc, mux.socket(), mux.candidates().to_vec(), inbound, source);
 
-	// Register before spawning so a DELETE that races startup still finds the
-	// session; the task unregisters itself when it ends.
+	// Register before returning so a DELETE that races startup still finds the
+	// session; Response::run unregisters itself when it ends.
 	let cancel = server.register_session(resource_id.clone());
-	let session_handle = crate::server::SessionHandle::new();
-	let task_server = server.clone();
-	let task_resource = resource_id.clone();
-	let task_session = session_handle.clone();
-	tokio::spawn(async move {
-		let result = {
-			// Hold the mux registration for the session's lifetime (unregisters on exit).
-			let _registration = registration;
-			tokio::select! {
-				res = session.run() => {
-					session::log_session_end("whep server", &res);
-					res
-				}
-				_ = cancel => {
-					tracing::debug!("whep session terminated by DELETE");
-					Ok(())
-				}
-			}
-		};
-		task_server.unregister_session(&task_resource);
-		task_session.close(result);
-	});
 
-	Ok(Response {
+	Ok(Response::new(
+		server.clone(),
 		resource_id,
-		answer: sdp::render_answer(&answer),
-		session: session_handle,
-	})
+		sdp::render_answer(&answer),
+		session,
+		registration,
+		cancel,
+		"whep server",
+	))
 }
 
 fn is_sdp(headers: &HeaderMap) -> bool {

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -32,7 +32,9 @@ async fn handle(
 	body: Bytes,
 ) -> HttpResponse {
 	match accept_offer(&server, &path, &headers, body).await {
-		Ok(Response { resource_id, answer }) => {
+		Ok(Response {
+			resource_id, answer, ..
+		}) => {
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
 			if let Ok(loc) = HeaderValue::from_str(&format!("/{path}/{resource_id}")) {
@@ -121,21 +123,33 @@ pub async fn accept(
 	// Register before spawning so a DELETE that races the first packet still
 	// finds the session; the task unregisters itself when it ends.
 	let cancel = server.register_session(resource_id.clone());
+	let session_handle = crate::server::SessionHandle::new();
 	let task_server = server.clone();
 	let task_resource = resource_id.clone();
+	let task_session = session_handle.clone();
 	tokio::spawn(async move {
-		// Hold the mux registration for the session's lifetime; it unregisters on exit.
-		let _registration = registration;
-		tokio::select! {
-			res = session.run() => session::log_session_end("whip server", res),
-			_ = cancel => tracing::debug!("whip session terminated by DELETE"),
-		}
+		let result = {
+			// Hold the mux registration for the session's lifetime; it unregisters on exit.
+			let _registration = registration;
+			tokio::select! {
+				res = session.run() => {
+					session::log_session_end("whip server", &res);
+					res
+				}
+				_ = cancel => {
+					tracing::debug!("whip session terminated by DELETE");
+					Ok(())
+				}
+			}
+		};
 		task_server.unregister_session(&task_resource);
+		task_session.close(result);
 	});
 
 	Ok(Response {
 		resource_id,
 		answer: sdp::render_answer(&answer),
+		session: session_handle,
 	})
 }
 

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -7,7 +7,7 @@
 use axum::{
 	Router,
 	body::Bytes,
-	extract::{Path, State},
+	extract::{OriginalUri, Path, State},
 	http::{HeaderMap, HeaderValue, StatusCode, header},
 	response::{IntoResponse, Response as HttpResponse},
 	routing::post,
@@ -28,6 +28,7 @@ pub fn router(server: Server) -> Router {
 async fn handle(
 	State(server): State<Server>,
 	Path(path): Path<String>,
+	OriginalUri(uri): OriginalUri,
 	headers: HeaderMap,
 	body: Bytes,
 ) -> HttpResponse {
@@ -40,7 +41,7 @@ async fn handle(
 			} = response;
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
-			if let Ok(loc) = HeaderValue::from_str(&format!("/{path}/{resource_id}")) {
+			if let Some(loc) = crate::server::session_location(&uri, &resource_id) {
 				response_headers.insert(header::LOCATION, loc);
 			}
 			tokio::spawn(async move {

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -33,15 +33,18 @@ async fn handle(
 ) -> HttpResponse {
 	match accept_offer(&server, &path, &headers, body).await {
 		Ok(response) => {
-			let resource_id = response.resource_id.clone();
-			let answer = response.answer.clone();
+			let Response {
+				resource_id,
+				answer,
+				session,
+			} = response;
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
 			if let Ok(loc) = HeaderValue::from_str(&format!("/{path}/{resource_id}")) {
 				response_headers.insert(header::LOCATION, loc);
 			}
 			tokio::spawn(async move {
-				let _ = response.run().await;
+				let _ = session.run().await;
 			});
 			(StatusCode::CREATED, response_headers, answer).into_response()
 		}

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -32,14 +32,17 @@ async fn handle(
 	body: Bytes,
 ) -> HttpResponse {
 	match accept_offer(&server, &path, &headers, body).await {
-		Ok(Response {
-			resource_id, answer, ..
-		}) => {
+		Ok(response) => {
+			let resource_id = response.resource_id.clone();
+			let answer = response.answer.clone();
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
 			if let Ok(loc) = HeaderValue::from_str(&format!("/{path}/{resource_id}")) {
 				response_headers.insert(header::LOCATION, loc);
 			}
+			tokio::spawn(async move {
+				let _ = response.run().await;
+			});
 			(StatusCode::CREATED, response_headers, answer).into_response()
 		}
 		Err(err) => {
@@ -71,8 +74,9 @@ async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: By
 /// [`router`] passes the server's own (unauthenticated) producer. It parses the
 /// offer, registers the broadcast (so a fast subscriber doesn't 404 in the gap
 /// before the first RTP packet), registers a media session on the shared mux,
-/// spawns the RTP->MoQ session, and returns the SDP answer plus an opaque
-/// `resource_id` for the WHIP `Location` header.
+/// and returns the SDP answer plus an opaque `resource_id` for the WHIP
+/// `Location` header. The caller must run the returned [`Response`] to drive the
+/// RTP->MoQ session.
 ///
 /// `offer` is the raw SDP body; the caller is responsible for checking the
 /// `Content-Type: application/sdp` request header. Fails with
@@ -120,37 +124,19 @@ pub async fn accept(
 	let resource_id = sdp::new_resource_id();
 	let session = session::Session::ingest(rtc, mux.socket(), mux.candidates().to_vec(), inbound, sink);
 
-	// Register before spawning so a DELETE that races the first packet still
-	// finds the session; the task unregisters itself when it ends.
+	// Register before returning so a DELETE that races the first packet still
+	// finds the session; Response::run unregisters itself when it ends.
 	let cancel = server.register_session(resource_id.clone());
-	let session_handle = crate::server::SessionHandle::new();
-	let task_server = server.clone();
-	let task_resource = resource_id.clone();
-	let task_session = session_handle.clone();
-	tokio::spawn(async move {
-		let result = {
-			// Hold the mux registration for the session's lifetime; it unregisters on exit.
-			let _registration = registration;
-			tokio::select! {
-				res = session.run() => {
-					session::log_session_end("whip server", &res);
-					res
-				}
-				_ = cancel => {
-					tracing::debug!("whip session terminated by DELETE");
-					Ok(())
-				}
-			}
-		};
-		task_server.unregister_session(&task_resource);
-		task_session.close(result);
-	});
 
-	Ok(Response {
+	Ok(Response::new(
+		server.clone(),
 		resource_id,
-		answer: sdp::render_answer(&answer),
-		session: session_handle,
-	})
+		sdp::render_answer(&answer),
+		session,
+		registration,
+		cancel,
+		"whip server",
+	))
 }
 
 fn is_sdp(headers: &HeaderMap) -> bool {

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -330,7 +330,7 @@ impl IngestClock {
 /// ([`Error::SessionClosed`]) is debug, a genuine failure is a warning. Keeps
 /// normal WebRTC churn out of the warning stream. `role` labels the path
 /// (e.g. `"whip server"`).
-pub(crate) fn log_session_end(role: &str, result: Result<()>) {
+pub(crate) fn log_session_end(role: &str, result: &Result<()>) {
 	match result {
 		Ok(()) | Err(Error::SessionClosed) => tracing::debug!(role, "session ended"),
 		Err(err) => tracing::warn!(%err, role, "session ended"),


### PR DESCRIPTION
## Summary

- Change `moq_rtc::server::Response` into an owned session runner with `Response::run()`.
- Keep WHIP/WHEP accept functions focused on SDP negotiation and resource registration, while bundled routers explicitly spawn the returned runner after preparing the HTTP answer.
- Move session unregister and DELETE cancellation handling into the runner so embedders can await the exact WebRTC session lifetime.
- Build WHIP/WHEP `Location` headers from `OriginalUri` so nested routers preserve their mount prefix.

## Root Cause

`whip::accept` and `whep::accept` previously spawned `Session::run()` internally and returned only the SDP response data. The WebRTC task knew when the peer disconnected, but embedders had no handle to await, so external session accounting had to guess.

The bundled handlers also built `Location` from the wildcard path, which dropped route mount prefixes such as `/whip` or `/whep`.

## Public API Changes

- `moq_rtc::server::Response` is no longer `Clone`.
- `moq_rtc::server::Response` adds public `async fn run(self) -> Result<()>`.
- `whip::accept` and `whep::accept` now return a `Response` that must be run by the caller to drive the negotiated media session.

This is a breaking API change in `rs/moq-rtc`, but `moq-rtc` is currently version `0.0.1` and not listed in the branch-targeting breaking-change set.

## Validation

- `cargo test -p moq-rtc`
- `cargo check -p moq-rtc`
- `git diff --check`

(Written by Claude)
