### PR TITLE
[codex] support relay HTTPS cert arrays

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ The rename/removal rationale lives in the commit message and PR description, not
 
 ## AI Attribution
 
-LLM-authored prose visible to humans (PR descriptions, PR comments, review replies) should end with `(Written by Claude)` or similar. Do **not** tag code comments, doc comments, or `/doc` pages: source markers rot. Commit attribution lives in the `Co-Authored-By` trailer, not the commit body.
+LLM-authored prose visible to humans (PR descriptions, PR comments, review replies) should end with the agent model, e.g. `(Written by GPT-5)`. Do **not** tag code comments, doc comments, or `/doc` pages: source markers rot. Commit attribution lives in the `Co-Authored-By` trailer, not the commit body.
 
 ## Refactor As You Go
 
@@ -205,4 +205,4 @@ Update them with `gh pr edit <num> --title "..." --body "..."` whenever the scop
 - Bullet points in the "Summary" section that describe behavior the latest commits have changed or removed.
 - The test-plan checklist getting out of date as new tests are added.
 
-When you edit a PR description you authored, keep the `(Written by Claude)` marker so reviewers still know the body wasn't human-authored.
+When you edit a PR description you authored, keep the agent model marker so reviewers still know the body wasn't human-authored.

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -231,7 +231,7 @@ Client certificate presentation is **optional**: connections without a
 certificate fall through to the normal JWT path unchanged.
 
 ```toml
-[tls]
+[server.tls]
 cert = ["/etc/moq/server.pem"]
 key  = ["/etc/moq/server.key"]
 # One or more PEM files containing the CAs trusted to sign peer certificates.

--- a/doc/bin/relay/index.md
+++ b/doc/bin/relay/index.md
@@ -70,7 +70,7 @@ Create a `relay.toml` configuration file:
 [server]
 bind = "[::]:4443"  # Listen on all interfaces, port 4443
 
-[tls]
+[server.tls]
 cert = "/path/to/cert.pem"  # TLS certificate
 key = "/path/to/key.pem"    # TLS private key
 
@@ -109,7 +109,7 @@ sudo certbot certonly --standalone -d relay.example.com
 Update `relay.toml`:
 
 ```toml
-[tls]
+[server.tls]
 cert = "/etc/letsencrypt/live/relay.example.com/fullchain.pem"
 key = "/etc/letsencrypt/live/relay.example.com/privkey.pem"
 ```

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 default = ["quinn", "aws-lc-rs", "websocket", "tcp", "uds"]
 quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
 noq = ["dep:web-transport-noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
-quiche = ["dep:web-transport-quiche", "dep:rcgen", "dep:reqwest"]
+quiche = ["dep:web-transport-quiche", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki"]
 # Filesystem watcher for hot-reloading on-disk TLS certs/keys; the QUIC backends imply it.
 watch = ["dep:notify"]
 aws-lc-rs = ["rustls/aws-lc-rs", "rcgen?/aws_lc_rs", "quinn?/rustls-aws-lc-rs"]

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -329,7 +329,7 @@ impl QuicheServer {
 			.collect();
 
 		let info = Arc::new(RwLock::new(crate::tls::Info {
-			#[cfg(any(feature = "noq", feature = "quinn"))]
+			#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 			certs: Vec::new(),
 			fingerprints,
 		}));

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -480,7 +480,10 @@ pub struct Server {
 	/// and can be used by the application to grant elevated access. Clients that
 	/// do not present a certificate are unaffected.
 	///
-	/// Only supported by the Quinn and noq backends.
+	/// Client certificate reporting is only supported by the Quinn and noq QUIC
+	/// backends. Plain-TLS listeners built via [`Self::server_config`] also use
+	/// these roots for optional mTLS when the feature set includes quinn, noq, or
+	/// quiche.
 	#[arg(
 		long = "server-tls-root",
 		id = "server-tls-root",

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -5,9 +5,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fs, io};
 
-#[cfg(any(feature = "quinn", feature = "noq"))]
+#[cfg(all(
+	any(feature = "quinn", feature = "noq", feature = "quiche"),
+	any(feature = "aws-lc-rs", feature = "ring")
+))]
 use rustls::pki_types::PrivatePkcs8KeyDer;
-#[cfg(any(feature = "quinn", feature = "noq"))]
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 use std::sync::RwLock;
 
 /// Errors loading or generating TLS certificates and keys.
@@ -77,7 +80,7 @@ pub enum Error {
 	#[error(transparent)]
 	Rustls(#[from] rustls::Error),
 
-	#[cfg(any(feature = "quinn", feature = "noq"))]
+	#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 	#[error("failed to build client certificate verifier")]
 	ClientVerifier(#[source] rustls::server::VerifierBuilderError),
 
@@ -513,14 +516,14 @@ impl Server {
 	/// `alpn` sets the advertised ALPN protocols (e.g.
 	/// `vec![b"h2".to_vec(), b"http/1.1".to_vec()]`); pass an empty list for a
 	/// protocol like RTMPS that doesn't use ALPN.
-	#[cfg(any(feature = "noq", feature = "quinn"))]
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	pub fn server_config(&self, alpn: Vec<Vec<u8>>) -> Result<Arc<rustls::ServerConfig>> {
 		server_config(self, alpn)
 	}
 }
 
 /// Build a [`rustls::ServerConfig`] from a [`Server`] for a plain-TLS listener.
-#[cfg(any(feature = "noq", feature = "quinn"))]
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 fn server_config(config: &Server, alpn: Vec<Vec<u8>>) -> Result<Arc<rustls::ServerConfig>> {
 	let provider = crypto::provider();
 
@@ -591,7 +594,7 @@ impl PeerIdentity {
 /// TLS certificate information including fingerprints.
 #[derive(Debug)]
 pub struct Info {
-	#[cfg(any(feature = "noq", feature = "quinn"))]
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	pub(crate) certs: Vec<Arc<rustls::sign::CertifiedKey>>,
 	pub fingerprints: Vec<String>,
 }
@@ -841,14 +844,14 @@ mod tests {
 
 // ── ServeCerts ──────────────────────────────────────────────────────
 
-#[cfg(any(feature = "quinn", feature = "noq"))]
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 #[derive(Debug)]
 pub(crate) struct ServeCerts {
 	pub info: Arc<RwLock<Info>>,
 	provider: crypto::Provider,
 }
 
-#[cfg(any(feature = "quinn", feature = "noq"))]
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 impl ServeCerts {
 	pub fn new(provider: crypto::Provider) -> Self {
 		Self {
@@ -973,7 +976,7 @@ impl ServeCerts {
 	}
 }
 
-#[cfg(any(feature = "quinn", feature = "noq"))]
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 impl rustls::server::ResolvesServerCert for ServeCerts {
 	fn resolve(&self, client_hello: rustls::server::ClientHello<'_>) -> Option<Arc<rustls::sign::CertifiedKey>> {
 		if let Some(cert) = self.best_certificate(&client_hello) {

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -206,6 +206,50 @@ preferred_v6 = "[2001:db8::1]:443"
 		);
 	}
 
+	/// Serializes tests that touch `MOQ_WEB_HTTPS_*`. Same rationale as
+	/// `STATS_ENV_LOCK`.
+	static WEB_HTTPS_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	#[test]
+	fn cli_does_not_clobber_toml_web_https_cert_arrays() {
+		let _guard = WEB_HTTPS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: WEB_HTTPS_ENV_LOCK ensures no other test in this binary
+		// touches these env vars concurrently.
+		unsafe {
+			std::env::remove_var("MOQ_WEB_HTTPS_CERT");
+			std::env::remove_var("MOQ_WEB_HTTPS_KEY");
+		}
+
+		let toml = r#"
+[web.https]
+listen = "127.0.0.1:4443"
+cert = ["cdn.pem", "moq-pro.pem"]
+key = ["cdn.key", "moq-pro.key"]
+"#;
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("web-https-certs-toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(
+			config.web.https.cert,
+			vec![
+				std::path::PathBuf::from("cdn.pem"),
+				std::path::PathBuf::from("moq-pro.pem")
+			]
+		);
+		assert_eq!(
+			config.web.https.key,
+			vec![
+				std::path::PathBuf::from("cdn.key"),
+				std::path::PathBuf::from("moq-pro.key")
+			]
+		);
+	}
+
 	/// Explicit CLI flag must still override TOML. Belt-and-suspenders for the
 	/// fix above: making `enabled: Option<bool>` shouldn't break the override
 	/// path.

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -61,7 +61,7 @@ pub struct HttpConfig {
 	pub listen: Option<net::SocketAddr>,
 }
 
-/// HTTPS listener configuration with TLS certificate and key.
+/// HTTPS listener configuration with TLS certificates and keys.
 #[serde_with::serde_as]
 #[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields, default)]
@@ -71,13 +71,32 @@ pub struct HttpsConfig {
 	#[arg(long = "web-https-listen", id = "web-https-listen", env = "MOQ_WEB_HTTPS_LISTEN", requires_all = ["web-https-cert", "web-https-key"])]
 	pub listen: Option<net::SocketAddr>,
 
-	/// Load the given certificate from disk.
-	#[arg(long = "web-https-cert", id = "web-https-cert", env = "MOQ_WEB_HTTPS_CERT")]
-	pub cert: Option<PathBuf>,
+	/// Load the given certificate chain files from disk.
+	///
+	/// In config files, accepts either a single string or a TOML array.
+	#[arg(
+		long = "web-https-cert",
+		id = "web-https-cert",
+		value_delimiter = ',',
+		env = "MOQ_WEB_HTTPS_CERT"
+	)]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde_as(as = "serde_with::OneOrMany<_>")]
+	pub cert: Vec<PathBuf>,
 
-	/// Load the given key from disk.
-	#[arg(long = "web-https-key", id = "web-https-key", env = "MOQ_WEB_HTTPS_KEY")]
-	pub key: Option<PathBuf>,
+	/// Load the given private key files from disk.
+	///
+	/// Each key is paired with the certificate chain at the same index.
+	/// In config files, accepts either a single string or a TOML array.
+	#[arg(
+		long = "web-https-key",
+		id = "web-https-key",
+		value_delimiter = ',',
+		env = "MOQ_WEB_HTTPS_KEY"
+	)]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde_as(as = "serde_with::OneOrMany<_>")]
+	pub key: Vec<PathBuf>,
 
 	/// PEM file(s) of root CAs for validating optional client certificates (mTLS).
 	///
@@ -199,12 +218,12 @@ impl Web {
 		};
 
 		let https = if let Some(listen) = self.config.https.listen {
-			let cert = self.config.https.cert.expect("missing https.cert");
-			let key = self.config.https.key.expect("missing https.key");
+			let cert = self.config.https.cert.clone();
+			let key = self.config.https.key.clone();
 			let root = self.config.https.root.clone();
 
-			let config = build_https_config(&cert, &key, &root).await?;
-			let rustls_config = RustlsConfig::from_config(Arc::new(config));
+			let config = build_https_config(&cert, &key, &root)?;
+			let rustls_config = RustlsConfig::from_config(config);
 
 			tokio::spawn(reload_https_config(rustls_config.clone(), cert, key, root));
 
@@ -240,66 +259,20 @@ impl Web {
 
 /// Build a [`rustls::ServerConfig`] for the HTTPS listener.
 ///
-/// When `root` is non-empty, installs a [`WebPkiClientVerifier`] with
-/// `.allow_unauthenticated()` so JWT-only callers still complete the
-/// handshake without presenting a cert. When empty, falls back to
-/// [`with_no_client_auth`]. ALPN is set to `h2`, `http/1.1` to match
-/// axum-server's defaults.
-///
 /// TLS version is left at the rustls default (1.2 + 1.3) so older clients
 /// can still hit the HTTPS API; the QUIC server separately forces 1.3.
-async fn build_https_config(
-	cert: &std::path::Path,
-	key: &std::path::Path,
+fn build_https_config(
+	cert: &[PathBuf],
+	key: &[PathBuf],
 	root: &[PathBuf],
-) -> anyhow::Result<rustls::ServerConfig> {
-	use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
-	use rustls::server::WebPkiClientVerifier;
+) -> anyhow::Result<Arc<rustls::ServerConfig>> {
+	let mut tls = moq_native::tls::Server::default();
+	tls.cert = cert.to_vec();
+	tls.key = key.to_vec();
+	tls.root = root.to_vec();
 
-	let cert_chain: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(cert)
-		.context("failed to open https cert")?
-		.collect::<Result<_, _>>()
-		.context("failed to parse https cert")?;
-	let key_der = PrivateKeyDer::from_pem_file(key).context("failed to parse https key")?;
-
-	let provider = rustls::crypto::CryptoProvider::get_default()
-		.cloned()
-		.expect("no default crypto provider installed");
-
-	let builder =
-		rustls::ServerConfig::builder_with_provider(provider.clone()).with_safe_default_protocol_versions()?;
-
-	let mut config = if root.is_empty() {
-		builder
-			.with_no_client_auth()
-			.with_single_cert(cert_chain, key_der)
-			.context("invalid https cert/key pair")?
-	} else {
-		// Build the CA root store inline; `moq_native::tls::Server` is
-		// `non_exhaustive`, so we can't construct one to call its `load_roots`.
-		let mut root_store = rustls::RootCertStore::empty();
-		for path in root {
-			let mut found = false;
-			for cert in CertificateDer::pem_file_iter(path).context("failed to open mTLS client CA")? {
-				let cert = cert.context("failed to parse mTLS client CA PEM")?;
-				root_store.add(cert).context("failed to add mTLS client CA")?;
-				found = true;
-			}
-			anyhow::ensure!(found, "no certificates found in mTLS client CA: {}", path.display());
-		}
-		let verifier = WebPkiClientVerifier::builder_with_provider(Arc::new(root_store), provider)
-			.allow_unauthenticated()
-			.build()
-			.context("failed to build https client cert verifier")?;
-
-		builder
-			.with_client_cert_verifier(verifier)
-			.with_single_cert(cert_chain, key_der)
-			.context("invalid https cert/key pair")?
-	};
-
-	config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-	Ok(config)
+	tls.server_config(vec![b"h2".to_vec(), b"http/1.1".to_vec()])
+		.context("failed to build https TLS config")
 }
 
 /// Reload the HTTPS cert/key/root whenever they change on disk.
@@ -307,9 +280,11 @@ async fn build_https_config(
 /// `RustlsConfig::reload_from_pem_file` would rebuild with `with_no_client_auth`
 /// (silently stripping mTLS when configured), so we always rebuild via the full
 /// [`build_https_config`] path.
-async fn reload_https_config(config: RustlsConfig, cert: PathBuf, key: PathBuf, root: Vec<PathBuf>) {
-	let paths: Vec<PathBuf> = std::iter::once(cert.clone())
-		.chain(std::iter::once(key.clone()))
+async fn reload_https_config(config: RustlsConfig, cert: Vec<PathBuf>, key: Vec<PathBuf>, root: Vec<PathBuf>) {
+	let paths: Vec<PathBuf> = cert
+		.iter()
+		.cloned()
+		.chain(key.iter().cloned())
 		.chain(root.iter().cloned())
 		.collect();
 
@@ -325,8 +300,8 @@ async fn reload_https_config(config: RustlsConfig, cert: PathBuf, key: PathBuf, 
 		watcher.changed().await;
 		tracing::info!("reloading web certificate");
 
-		match build_https_config(&cert, &key, &root).await {
-			Ok(new) => config.reload_from_config(Arc::new(new)),
+		match build_https_config(&cert, &key, &root) {
+			Ok(new) => config.reload_from_config(new),
 			Err(err) => tracing::warn!(%err, "failed to reload web certificate"),
 		}
 	}
@@ -720,9 +695,13 @@ mod tests {
 	use std::io::Write;
 	use tempfile::TempDir;
 
+	fn make_certs(dir: &TempDir) -> (PathBuf, PathBuf, PathBuf) {
+		make_named_certs(dir, "server", "localhost")
+	}
+
 	/// Generate a CA + server cert/key on disk and return the temp paths.
 	/// Modeled after `auth.rs::mtls_fixture`.
-	fn make_certs(dir: &TempDir) -> (PathBuf, PathBuf, PathBuf) {
+	fn make_named_certs(dir: &TempDir, name: &str, hostname: &str) -> (PathBuf, PathBuf, PathBuf) {
 		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
 		let ca_kp = KeyPair::generate().unwrap();
@@ -733,15 +712,15 @@ mod tests {
 		let ca_issuer = rcgen::Issuer::from_params(&ca_params, &ca_kp);
 
 		let server_kp = KeyPair::generate().unwrap();
-		let mut server_params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+		let mut server_params = CertificateParams::new(vec![hostname.to_string()]).unwrap();
 		server_params
 			.distinguished_name
-			.push(rcgen::DnType::CommonName, "test-server");
+			.push(rcgen::DnType::CommonName, format!("test-{name}"));
 		let server_cert = server_params.signed_by(&server_kp, &ca_issuer).unwrap();
 
-		let ca_path = dir.path().join("ca.pem");
-		let cert_path = dir.path().join("server.cert.pem");
-		let key_path = dir.path().join("server.key.pem");
+		let ca_path = dir.path().join(format!("{name}.ca.pem"));
+		let cert_path = dir.path().join(format!("{name}.cert.pem"));
+		let key_path = dir.path().join(format!("{name}.key.pem"));
 		std::fs::write(&ca_path, ca_cert.pem()).unwrap();
 		std::fs::write(&cert_path, server_cert.pem()).unwrap();
 		std::fs::write(&key_path, server_kp.serialize_pem()).unwrap();
@@ -754,9 +733,8 @@ mod tests {
 		let dir = TempDir::new().unwrap();
 		let (ca_path, cert_path, key_path) = make_certs(&dir);
 
-		let config = build_https_config(&cert_path, &key_path, &[ca_path])
-			.await
-			.expect("build_https_config should succeed");
+		let config =
+			build_https_config(&[cert_path], &[key_path], &[ca_path]).expect("build_https_config should succeed");
 
 		// ALPN must include h2 + http/1.1; otherwise reqwest's h2 attempt
 		// would silently downgrade or fail. Mirrors axum_server's default.
@@ -774,11 +752,22 @@ mod tests {
 
 		// Empty root is the JWT-only path; should still produce a valid
 		// config with ALPN set so axum-server's hyper layer can negotiate h2.
-		let config = build_https_config(&cert_path, &key_path, &[])
-			.await
-			.expect("no-CA path should still build a usable config");
+		let config =
+			build_https_config(&[cert_path], &[key_path], &[]).expect("no-CA path should still build a usable config");
 
 		assert_eq!(config.alpn_protocols, vec![b"h2".to_vec(), b"http/1.1".to_vec()],);
+	}
+
+	#[tokio::test]
+	async fn build_https_config_accepts_multiple_cert_pairs() {
+		let dir = TempDir::new().unwrap();
+		let (_ca_a, cert_a, key_a) = make_named_certs(&dir, "cdn", "cdn.moq.dev");
+		let (_ca_b, cert_b, key_b) = make_named_certs(&dir, "pro", "moq.pro");
+
+		let config = build_https_config(&[cert_a, cert_b], &[key_a, key_b], &[])
+			.expect("multiple HTTPS cert/key pairs should build");
+
+		assert_eq!(config.alpn_protocols, vec![b"h2".to_vec(), b"http/1.1".to_vec()]);
 	}
 
 	#[tokio::test]
@@ -787,7 +776,7 @@ mod tests {
 		let (_ca_path, cert_path, key_path) = make_certs(&dir);
 
 		let bogus = dir.path().join("does-not-exist.pem");
-		let res = build_https_config(&cert_path, &key_path, &[bogus]).await;
+		let res = build_https_config(&[cert_path], &[key_path], &[bogus]);
 		assert!(res.is_err(), "missing CA file should be a hard error");
 	}
 
@@ -800,7 +789,7 @@ mod tests {
 		let mut f = std::fs::File::create(&empty).unwrap();
 		writeln!(f, "# no certs here").unwrap();
 
-		let res = build_https_config(&cert_path, &key_path, &[empty]).await;
+		let res = build_https_config(&[cert_path], &[key_path], &[empty]);
 		assert!(
 			res.is_err(),
 			"empty PEM must be rejected to avoid a silently disabled verifier"

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -266,6 +266,15 @@ fn build_https_config(
 	key: &[PathBuf],
 	root: &[PathBuf],
 ) -> anyhow::Result<Arc<rustls::ServerConfig>> {
+	anyhow::ensure!(
+		!cert.is_empty(),
+		"web.https.cert must include at least one certificate when web.https.listen is configured"
+	);
+	anyhow::ensure!(
+		cert.len() == key.len(),
+		"web.https.cert and web.https.key must have the same number of entries"
+	);
+
 	let mut tls = moq_native::tls::Server::default();
 	tls.cert = cert.to_vec();
 	tls.key = key.to_vec();
@@ -778,6 +787,21 @@ mod tests {
 		let bogus = dir.path().join("does-not-exist.pem");
 		let res = build_https_config(&[cert_path], &[key_path], &[bogus]);
 		assert!(res.is_err(), "missing CA file should be a hard error");
+	}
+
+	#[tokio::test]
+	async fn build_https_config_rejects_empty_cert_list() {
+		let res = build_https_config(&[], &[], &[]);
+		assert!(res.is_err(), "HTTPS must require at least one cert/key pair");
+	}
+
+	#[tokio::test]
+	async fn build_https_config_rejects_mismatched_cert_key_lists() {
+		let dir = TempDir::new().unwrap();
+		let (_ca_path, cert_path, _key_path) = make_certs(&dir);
+
+		let res = build_https_config(&[cert_path], &[], &[]);
+		assert!(res.is_err(), "HTTPS cert/key lists must be paired");
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

- Let the relay HTTPS listener accept cert/key arrays, matching the existing QUIC TLS config shape.
- Reuse the shared moq-native certificate resolver so HTTPS can select certificates by the client hello.
- Add coverage for TOML array preservation and HTTPS TLS config construction with multiple cert/key pairs.
- Fix relay docs snippets that still used the old top-level `[tls]` table.
- Update agent attribution guidance to use the agent model marker.

## Validation

- `cargo check -p moq-relay`
- `cargo check -p moq-relay --no-default-features --features quiche`
- `cargo check -p moq-native --no-default-features --features quiche`
- `cargo test -p moq-relay --lib`

(Written by GPT-5)
