### PR TITLE
[codex] add fmp4 track selection for hls

### DIFF
--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -80,7 +80,7 @@ impl Publish {
 				PublishDecoder::Avc3(Box::new(avc3))
 			}
 			PublishFormat::Fmp4 => {
-				let fmp4 = fmp4::Import::new(broadcast.clone(), catalog.clone());
+				let fmp4 = fmp4::Import::new(broadcast.clone(), catalog.clone(), Default::default());
 				PublishDecoder::Fmp4(Box::new(fmp4))
 			}
 			PublishFormat::Ts => unreachable!("TS is handled above with the mpegts catalog extension"),

--- a/rs/moq-hls/bin/moq-hls.rs
+++ b/rs/moq-hls/bin/moq-hls.rs
@@ -101,11 +101,9 @@ async fn main() -> anyhow::Result<()> {
 			let subscriber_consumer = subscriber.consume();
 			let reconnect = client.with_consume(subscriber).reconnect(relay.clone());
 
-			let config = moq_hls::export::Config {
-				part_target,
-				window,
-				..Default::default()
-			};
+			let mut config = moq_hls::export::Config::default();
+			config.part_target = part_target;
+			config.window = window;
 			let server = Server::new(subscriber_consumer, config);
 			let app = server
 				.router()

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -27,6 +27,7 @@ const CATALOG_RETRY: Duration = Duration::from_millis(250);
 
 /// Export tuning shared across renditions.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Config {
 	/// LL-HLS part target duration (also the exporter's fragment cap).
 	pub part_target: Duration,

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -15,7 +15,7 @@ use m3u8_rs::{
 	AlternativeMedia, AlternativeMediaType, Map, MasterPlaylist, MediaPlaylist, MediaSegment, Resolution, VariantStream,
 };
 use moq_mux::catalog::Producer as CatalogProducer;
-use moq_mux::container::fmp4::Import as Fmp4;
+use moq_mux::container::fmp4::{Import as Fmp4, ImportConfig, TrackSelection};
 use reqwest::Client;
 use tracing::{debug, info, warn};
 use url::Url;
@@ -31,6 +31,7 @@ const ERROR_BACKOFF: Duration = Duration::from_secs(1);
 
 /// Configuration for the single-rendition HLS import loop.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct Config {
 	/// The master or media playlist URL or file path to import.
 	pub playlist: String,
@@ -107,15 +108,19 @@ enum TrackKind {
 
 struct TrackState {
 	playlist: Url,
+	tracks: TrackSelection,
 	next_sequence: Option<u64>,
+	next_discontinuity: Option<u64>,
 	init_ready: bool,
 }
 
 impl TrackState {
-	fn new(playlist: Url) -> Self {
+	fn new(playlist: Url, tracks: TrackSelection) -> Self {
 		Self {
 			playlist,
+			tracks,
 			next_sequence: None,
+			next_discontinuity: None,
 			init_ready: false,
 		}
 	}
@@ -309,24 +314,31 @@ impl Import {
 				return Err(Error::NoVariants);
 			}
 
-			// Create a video track state for every usable variant.
-			for variant in &variants {
-				let video_url = resolve_uri(&self.base_url, &variant.uri)?;
-				self.video.push(TrackState::new(video_url));
-			}
-
 			// Choose an audio rendition based on the first variant with an audio group.
 			if let Some(group_id) = variants.iter().find_map(|v| v.audio.as_deref()) {
 				if let Some(audio_tag) = select_audio(&master, group_id) {
 					if let Some(uri) = &audio_tag.uri {
 						let audio_url = resolve_uri(&self.base_url, uri)?;
-						self.audio = Some(TrackState::new(audio_url));
+						self.audio = Some(TrackState::new(audio_url, TrackSelection::Audio));
 					} else {
 						warn!(%group_id, "audio rendition missing URI");
 					}
 				} else {
 					warn!(%group_id, "audio group not found in master playlist");
 				}
+			}
+
+			// Create a video track state for every usable variant. If there is a
+			// separate audio rendition, variants contribute only video; otherwise they
+			// may be muxed A/V and should publish every track they carry.
+			let variant_tracks = if self.audio.is_some() {
+				TrackSelection::Video
+			} else {
+				TrackSelection::All
+			};
+			for variant in &variants {
+				let video_url = resolve_uri(&self.base_url, &variant.uri)?;
+				self.video.push(TrackState::new(video_url, variant_tracks));
 			}
 
 			let audio_url = self.audio.as_ref().map(|a| a.playlist.to_string());
@@ -340,7 +352,8 @@ impl Import {
 		}
 
 		// Fallback: treat the provided URL as a single media playlist.
-		self.video.push(TrackState::new(self.base_url.clone()));
+		self.video
+			.push(TrackState::new(self.base_url.clone(), TrackSelection::All));
 		Ok(())
 	}
 
@@ -407,8 +420,18 @@ impl Import {
 
 		if to_process > 0 {
 			let base_seq = playlist_seq + skip as u64;
+			let mut discontinuity_sequence = playlist.discontinuity_sequence;
+			for segment in &playlist.segments[..skip] {
+				if segment.discontinuity {
+					discontinuity_sequence += 1;
+				}
+			}
 			for (i, segment) in playlist.segments[skip..skip + to_process].iter().enumerate() {
-				self.push_segment(kind, track, segment, base_seq + i as u64).await?;
+				if segment.discontinuity {
+					discontinuity_sequence += 1;
+				}
+				self.push_segment(kind, track, segment, base_seq + i as u64, discontinuity_sequence)
+					.await?;
 			}
 			info!(?kind, consumed = to_process, "consumed HLS segments");
 		} else {
@@ -433,7 +456,7 @@ impl Import {
 		let url = resolve_uri(&track.playlist, &map.uri)?;
 		let bytes = self.fetch_bytes(url).await?;
 		let importer = match kind {
-			TrackKind::Video(index) => self.ensure_video_importer_for(index),
+			TrackKind::Video(index) => self.ensure_video_importer_for(index, track.tracks),
 			TrackKind::Audio => self.ensure_audio_importer(),
 		};
 
@@ -453,6 +476,7 @@ impl Import {
 		track: &mut TrackState,
 		segment: &MediaSegment,
 		sequence: u64,
+		discontinuity_sequence: u64,
 	) -> Result<()> {
 		if segment.uri.is_empty() {
 			return Err(Error::EmptySegmentUri);
@@ -464,12 +488,21 @@ impl Import {
 		// `consume_segments` always runs `ensure_init_segment` before reaching here, so
 		// the importer is already initialized.
 		let importer = match kind {
-			TrackKind::Video(index) => self.ensure_video_importer_for(index),
+			TrackKind::Video(index) => self.ensure_video_importer_for(index, track.tracks),
 			TrackKind::Audio => self.ensure_audio_importer(),
 		};
 
+		// HLS media sequence names the live window, while discontinuity sequence
+		// names a new media timeline. Feed both into the MoQ group sequence whenever
+		// we join, skip ahead, or cross a discontinuity so consumers do not wait on
+		// groups that HLS has explicitly moved past.
+		if track.next_sequence != Some(sequence) || track.next_discontinuity != Some(discontinuity_sequence) {
+			importer.seek(moq_sequence(discontinuity_sequence, sequence)?)?;
+		}
+
 		importer.decode(&bytes)?;
 		track.next_sequence = Some(sequence + 1);
+		track.next_discontinuity = Some(discontinuity_sequence);
 
 		Ok(())
 	}
@@ -495,9 +528,9 @@ impl Import {
 	///
 	/// Each video variant gets its own importer so that their tracks remain
 	/// independent while still contributing to the same shared catalog.
-	fn ensure_video_importer_for(&mut self, index: usize) -> &mut Fmp4 {
+	fn ensure_video_importer_for(&mut self, index: usize, tracks: TrackSelection) -> &mut Fmp4 {
 		while self.video_importers.len() <= index {
-			let importer = Fmp4::new(self.broadcast.clone(), self.catalog.clone());
+			let importer = Fmp4::new(self.broadcast.clone(), self.catalog.clone(), fmp4_config(tracks));
 			self.video_importers.push(importer);
 		}
 
@@ -506,8 +539,13 @@ impl Import {
 
 	/// Create or retrieve the fMP4 importer for the audio rendition.
 	fn ensure_audio_importer(&mut self) -> &mut Fmp4 {
-		self.audio_importer
-			.get_or_insert_with(|| Fmp4::new(self.broadcast.clone(), self.catalog.clone()))
+		self.audio_importer.get_or_insert_with(|| {
+			Fmp4::new(
+				self.broadcast.clone(),
+				self.catalog.clone(),
+				fmp4_config(TrackSelection::Audio),
+			)
+		})
 	}
 
 	#[cfg(test)]
@@ -628,6 +666,32 @@ fn resolve_uri(base: &Url, value: &str) -> std::result::Result<Url, url::ParseEr
 	base.join(value)
 }
 
+fn fmp4_config(tracks: TrackSelection) -> ImportConfig {
+	let mut config = ImportConfig::default();
+	config.tracks = tracks;
+	config
+}
+
+/// Pack HLS discontinuity + media sequence into a single MoQ group sequence.
+///
+/// HLS media sequence alone can rewind after an upstream reset; discontinuity
+/// sequence alone cannot order segments inside the same epoch. The lower 48 bits
+/// leave enough room for realistic HLS media sequence values while the upper bits
+/// make discontinuities sort after earlier epochs.
+fn moq_sequence(discontinuity_sequence: u64, media_sequence: u64) -> Result<u64> {
+	const MEDIA_BITS: u32 = 48;
+	const MEDIA_MASK: u64 = (1u64 << MEDIA_BITS) - 1;
+	const DISCONTINUITY_MASK: u64 = u64::MAX >> MEDIA_BITS;
+
+	if media_sequence > MEDIA_MASK {
+		return Err(anyhow::anyhow!("HLS media sequence {media_sequence} exceeds {MEDIA_BITS} bits").into());
+	}
+	if discontinuity_sequence > DISCONTINUITY_MASK {
+		return Err(anyhow::anyhow!("HLS discontinuity sequence {discontinuity_sequence} is too large").into());
+	}
+	Ok((discontinuity_sequence << MEDIA_BITS) | media_sequence)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -658,5 +722,24 @@ mod tests {
 
 		assert!(!hls.has_video_importer());
 		assert!(!hls.has_audio_importer());
+	}
+
+	#[test]
+	fn moq_sequence_orders_discontinuities_after_media_sequence() {
+		let before = moq_sequence(0, 42).unwrap();
+		let after = moq_sequence(1, 0).unwrap();
+		assert!(after > before);
+	}
+
+	#[test]
+	fn moq_sequence_rejects_unrepresentable_media_sequence() {
+		let err = moq_sequence(0, 1u64 << 48).unwrap_err();
+		assert!(err.to_string().contains("media sequence"));
+	}
+
+	#[test]
+	fn moq_sequence_rejects_unrepresentable_discontinuity_sequence() {
+		let err = moq_sequence(1u64 << 16, 0).unwrap_err();
+		assert!(err.to_string().contains("discontinuity sequence"));
 	}
 }

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -470,7 +470,7 @@ async fn cmaf_source_to_cmaf_export_passthrough() {
 	let consumer = producer.consume();
 
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = crate::container::fmp4::Import::new(producer, catalog);
+	let mut importer = crate::container::fmp4::Import::new(producer, catalog, Default::default());
 	let buf = BytesMut::from(data.as_slice());
 	let _ = importer.decode(&buf);
 

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -1,11 +1,42 @@
 use bytes::{Bytes, BytesMut};
 use hang::catalog::{AAC, AudioCodec, AudioConfig, Container, H264, H265, VP9, VideoCodec, VideoConfig};
 use mp4_atom::{Any, Atom, DecodeMaybe, Encode, Mdat, Moof, Moov, Trak};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::Error;
 use crate::Result;
 use crate::container::Timestamp;
+
+/// Configuration for fMP4/CMAF import.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct ImportConfig {
+	/// Which track roles to publish from the source.
+	pub tracks: TrackSelection,
+}
+
+/// Which fMP4 tracks should be imported.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TrackSelection {
+	/// Import every supported media track.
+	#[default]
+	All,
+	/// Import only video tracks.
+	Video,
+	/// Import only audio tracks.
+	Audio,
+}
+
+impl TrackSelection {
+	fn accepts(self, kind: TrackKind) -> bool {
+		match self {
+			TrackSelection::All => true,
+			TrackSelection::Video => kind == TrackKind::Video,
+			TrackSelection::Audio => kind == TrackKind::Audio,
+		}
+	}
+}
 
 /// Converts fMP4/CMAF files into MoQ broadcast streams using CMAF passthrough.
 ///
@@ -25,6 +56,8 @@ use crate::container::Timestamp;
 /// - AAC (MP4A)
 /// - Opus
 pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
+	config: ImportConfig,
+
 	/// The broadcast being produced
 	broadcast: moq_net::BroadcastProducer,
 
@@ -33,6 +66,7 @@ pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 
 	// A lookup to tracks in the broadcast
 	tracks: HashMap<u32, Fmp4Track>,
+	skipped_tracks: HashSet<u32>,
 
 	// The moov atom at the start of the file.
 	moov: Option<Moov>,
@@ -46,7 +80,7 @@ pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	buffer: BytesMut,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 enum TrackKind {
 	Video,
 	Audio,
@@ -75,10 +109,16 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// Create a new CMAF importer that will write to the given broadcast.
 	///
 	/// The broadcast will be populated with tracks as they're discovered in the fMP4 file.
-	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(
+		broadcast: moq_net::BroadcastProducer,
+		catalog: crate::catalog::Producer<E>,
+		config: ImportConfig,
+	) -> Self {
 		Self {
+			config,
 			catalog,
 			tracks: HashMap::default(),
+			skipped_tracks: HashSet::default(),
 			moov: None,
 			moof: None,
 			moof_size: 0,
@@ -156,30 +196,46 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			let handler = &trak.mdia.hdlr.handler;
 			let suffix = ".m4s";
 
+			let kind = match handler.as_ref() {
+				b"vide" => TrackKind::Video,
+				b"soun" => TrackKind::Audio,
+				b"sbtl" if self.config.tracks == TrackSelection::All => return Err(Error::UnsupportedSubtitle.into()),
+				b"sbtl" => {
+					self.skipped_tracks.insert(track_id);
+					continue;
+				}
+				handler => {
+					if self.config.tracks != TrackSelection::All {
+						self.skipped_tracks.insert(track_id);
+						continue;
+					}
+					let mut buf = [0u8; 4];
+					buf[..handler.len().min(4)].copy_from_slice(&handler[..handler.len().min(4)]);
+					return Err(Error::UnknownTrackHandler(buf).into());
+				}
+			};
+
+			if !self.config.tracks.accepts(kind) {
+				self.skipped_tracks.insert(track_id);
+				continue;
+			}
+
 			// Declare the track at the fMP4's native timescale. Frame timestamps are
 			// emitted at this same scale (see below), so they satisfy the track's
 			// timescale invariant and ride the wire for the relay, redundant with the
 			// timing already inside each CMAF fragment.
 			let track = self.broadcast.unique_track(suffix)?;
 
-			let kind = match handler.as_ref() {
-				b"vide" => {
+			match kind {
+				TrackKind::Video => {
 					let config = self.init_video(trak, &moov)?;
 					catalog.video.renditions.insert(track.name().to_string(), config);
-					TrackKind::Video
 				}
-				b"soun" => {
+				TrackKind::Audio => {
 					let config = self.init_audio(trak, &moov)?;
 					catalog.audio.renditions.insert(track.name().to_string(), config);
-					TrackKind::Audio
 				}
-				b"sbtl" => return Err(Error::UnsupportedSubtitle.into()),
-				handler => {
-					let mut buf = [0u8; 4];
-					buf[..handler.len().min(4)].copy_from_slice(&handler[..handler.len().min(4)]);
-					return Err(Error::UnknownTrackHandler(buf).into());
-				}
-			};
+			}
 
 			self.tracks.insert(
 				track_id,
@@ -410,7 +466,12 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		// Loop over all of the traf boxes in the moof.
 		for traf in &moof.traf {
 			let track_id = traf.tfhd.track_id;
-			let track = self.tracks.get_mut(&track_id).ok_or(Error::UnknownTrack(track_id))?;
+			let Some(track) = self.tracks.get_mut(&track_id) else {
+				if self.skipped_tracks.contains(&track_id) {
+					continue;
+				}
+				return Err(Error::UnknownTrack(track_id).into());
+			};
 
 			// Find the track information in the moov
 			let trak = moov

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -14,10 +14,14 @@ fn drain_group_sequences(consumer: &mut moq_net::TrackConsumer) -> Vec<u64> {
 }
 
 fn run_fmp4(data: &[u8]) -> crate::catalog::hang::Catalog {
+	run_fmp4_with_config(data, Default::default())
+}
+
+fn run_fmp4_with_config(data: &[u8], config: crate::container::fmp4::ImportConfig) -> crate::catalog::hang::Catalog {
 	let mut broadcast = moq_net::Broadcast::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
-	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone());
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone(), config);
 
 	let buf = bytes::BytesMut::from(data);
 	// Ignore errors from incomplete/malformed trailing fragments in test files.
@@ -52,6 +56,34 @@ fn test_bbb_catalog() {
 	assert_eq!(audio.sample_rate, 44100);
 	assert_eq!(audio.channel_count, 2);
 	assert!(matches!(audio.container, Container::Cmaf { .. }));
+}
+
+#[test]
+fn test_track_selection_video_only() {
+	let data = include_bytes!("test_data/bbb.mp4");
+	let catalog = run_fmp4_with_config(
+		data,
+		crate::container::fmp4::ImportConfig {
+			tracks: crate::container::fmp4::TrackSelection::Video,
+		},
+	);
+
+	assert_eq!(catalog.video.renditions.len(), 1);
+	assert_eq!(catalog.audio.renditions.len(), 0);
+}
+
+#[test]
+fn test_track_selection_audio_only() {
+	let data = include_bytes!("test_data/bbb.mp4");
+	let catalog = run_fmp4_with_config(
+		data,
+		crate::container::fmp4::ImportConfig {
+			tracks: crate::container::fmp4::TrackSelection::Audio,
+		},
+	);
+
+	assert_eq!(catalog.video.renditions.len(), 0);
+	assert_eq!(catalog.audio.renditions.len(), 1);
 }
 
 #[test]
@@ -149,7 +181,7 @@ async fn test_seek_sets_initial_sequence() {
 	let mut broadcast = moq_net::Broadcast::new().produce();
 	let broadcast_consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone());
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone(), Default::default());
 
 	let data = include_bytes!("test_data/bbb.mp4");
 
@@ -212,7 +244,7 @@ async fn test_msf_catalog_roundtrip() {
 	// MSF catalog track has been created by `catalog::Producer::new`.
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog);
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog, Default::default());
 
 	let data = include_bytes!("test_data/bbb.mp4");
 	let buf = bytes::BytesMut::from(&data[..]);

--- a/rs/moq-mux/src/container/hls/import.rs
+++ b/rs/moq-mux/src/container/hls/import.rs
@@ -464,7 +464,7 @@ impl Import {
 	/// independent while still contributing to the same shared catalog.
 	fn ensure_video_importer_for(&mut self, index: usize) -> &mut Fmp4 {
 		while self.video_importers.len() <= index {
-			let importer = Fmp4::new(self.broadcast.clone(), self.catalog.clone());
+			let importer = Fmp4::new(self.broadcast.clone(), self.catalog.clone(), Default::default());
 			self.video_importers.push(importer);
 		}
 
@@ -474,7 +474,7 @@ impl Import {
 	/// Create or retrieve the fMP4 importer for the audio rendition.
 	fn ensure_audio_importer(&mut self) -> &mut Fmp4 {
 		self.audio_importer
-			.get_or_insert_with(|| Fmp4::new(self.broadcast.clone(), self.catalog.clone()))
+			.get_or_insert_with(|| Fmp4::new(self.broadcast.clone(), self.catalog.clone(), Default::default()))
 	}
 
 	#[cfg(test)]

--- a/rs/moq-mux/src/import/container.rs
+++ b/rs/moq-mux/src/import/container.rs
@@ -20,7 +20,11 @@ enum ContainerImpl<E: crate::container::ts::catalog::Catalog = ()> {
 
 impl<E: crate::container::ts::catalog::Catalog> ContainerImpl<E> {
 	fn fmp4(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
-		ContainerImpl::Fmp4(Box::new(crate::container::fmp4::Import::new(broadcast, catalog)))
+		ContainerImpl::Fmp4(Box::new(crate::container::fmp4::Import::new(
+			broadcast,
+			catalog,
+			Default::default(),
+		)))
 	}
 
 	fn mkv(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {


### PR DESCRIPTION
## Summary
- add fMP4 import config with `TrackSelection::{All, Video, Audio}` so callers can select tracks before catalog publication
- use track selection from HLS import so master variants with separate audio publish video-only while standalone and muxed playlists still import all tracks
- preserve HLS media and discontinuity sequence through fMP4 seek and make HLS configs non-exhaustive

## Public API Changes
- Breaking: `moq_mux::container::fmp4::Import::new` now takes `ImportConfig` as a third argument.
- New public `moq_mux::container::fmp4::ImportConfig` and `TrackSelection`.
- `moq_hls::import::Config` and `moq_hls::export::Config` are now `#[non_exhaustive]`.

## Validation
- `cargo test -p moq-mux container::fmp4`
- `cargo test -p moq-hls`
- `cargo check -p moq-cli`

(Written by Claude)
