### PR TITLE
moq-hls: preserve discontinuity sequence through fMP4 import

### DIFF
--- a/rs/moq-hls/src/error.rs
+++ b/rs/moq-hls/src/error.rs
@@ -40,6 +40,15 @@ pub enum Error {
 	#[error("encountered segment with empty URI")]
 	EmptySegmentUri,
 
+	/// An HLS media or discontinuity sequence was too large to pack into a MoQ group sequence.
+	#[error("HLS {kind} sequence {value} is too large to encode")]
+	SequenceOverflow {
+		/// Which sequence overflowed: `"media"` or `"discontinuity"`.
+		kind: &'static str,
+		/// The offending sequence value.
+		value: u64,
+	},
+
 	/// A playlist or segment URI could not be resolved against its base.
 	#[error(transparent)]
 	UrlParse(#[from] url::ParseError),

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -445,13 +445,13 @@ impl Import {
 			let mut discontinuity_seq = playlist.discontinuity_sequence;
 			for segment in &playlist.segments[..skip] {
 				if segment.discontinuity {
-					discontinuity_seq += 1;
+					discontinuity_seq = bump_discontinuity(discontinuity_seq)?;
 				}
 			}
 
 			for (i, segment) in playlist.segments[skip..skip + to_process].iter().enumerate() {
 				if segment.discontinuity {
-					discontinuity_seq += 1;
+					discontinuity_seq = bump_discontinuity(discontinuity_seq)?;
 				}
 				self.push_segment(kind, track, segment, base_seq + i as u64, discontinuity_seq)
 					.await?;
@@ -518,9 +518,12 @@ impl Import {
 		// HLS media sequence names the live window, while discontinuity sequence names a
 		// new media timeline. Whenever we join, skip ahead, or cross a discontinuity, anchor
 		// the MoQ group sequence to both so consumers do not wait on groups HLS has moved
-		// past. Contiguous segments let the importer auto-increment instead.
+		// past. Contiguous segments let the importer auto-increment instead; we still pack
+		// (and so validate) the sequence on that path so media sequence can't silently
+		// auto-increment into the discontinuity bits.
+		let group_sequence = moq_sequence(discontinuity_sequence, sequence)?;
 		if track.next_sequence != Some(sequence) || track.next_discontinuity != Some(discontinuity_sequence) {
-			importer.seek(moq_sequence(discontinuity_sequence, sequence)?)?;
+			importer.seek(group_sequence)?;
 		}
 
 		importer.decode(&bytes)?;
@@ -685,6 +688,14 @@ fn resolve_uri(base: &Url, value: &str) -> std::result::Result<Url, url::ParseEr
 	}
 
 	base.join(value)
+}
+
+/// Advance the running discontinuity sequence, rejecting a u64 wrap on absurd input.
+fn bump_discontinuity(sequence: u64) -> Result<u64> {
+	sequence.checked_add(1).ok_or(Error::SequenceOverflow {
+		kind: "discontinuity",
+		value: sequence,
+	})
 }
 
 /// Pack HLS discontinuity + media sequence into a single MoQ group sequence.

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -112,6 +112,7 @@ struct TrackState {
 	// separate audio rendition publishes video only).
 	select: select::Broadcast,
 	next_sequence: Option<u64>,
+	next_discontinuity: Option<u64>,
 	init_ready: bool,
 }
 
@@ -121,6 +122,7 @@ impl TrackState {
 			playlist,
 			select,
 			next_sequence: None,
+			next_discontinuity: None,
 			init_ready: false,
 		}
 	}
@@ -436,8 +438,23 @@ impl Import {
 
 		if to_process > 0 {
 			let base_seq = playlist_seq + skip as u64;
+
+			// Discontinuity sequence names a fresh media timeline; the tag count for the
+			// skipped prefix gets us to the discontinuity sequence of the first segment
+			// we actually push.
+			let mut discontinuity_seq = playlist.discontinuity_sequence;
+			for segment in &playlist.segments[..skip] {
+				if segment.discontinuity {
+					discontinuity_seq += 1;
+				}
+			}
+
 			for (i, segment) in playlist.segments[skip..skip + to_process].iter().enumerate() {
-				self.push_segment(kind, track, segment, base_seq + i as u64).await?;
+				if segment.discontinuity {
+					discontinuity_seq += 1;
+				}
+				self.push_segment(kind, track, segment, base_seq + i as u64, discontinuity_seq)
+					.await?;
 			}
 			info!(?kind, consumed = to_process, "consumed HLS segments");
 		} else {
@@ -482,6 +499,7 @@ impl Import {
 		track: &mut TrackState,
 		segment: &MediaSegment,
 		sequence: u64,
+		discontinuity_sequence: u64,
 	) -> Result<()> {
 		if segment.uri.is_empty() {
 			return Err(Error::EmptySegmentUri);
@@ -497,8 +515,17 @@ impl Import {
 			TrackKind::Audio => self.ensure_audio_importer(&track.select),
 		};
 
+		// HLS media sequence names the live window, while discontinuity sequence names a
+		// new media timeline. Whenever we join, skip ahead, or cross a discontinuity, anchor
+		// the MoQ group sequence to both so consumers do not wait on groups HLS has moved
+		// past. Contiguous segments let the importer auto-increment instead.
+		if track.next_sequence != Some(sequence) || track.next_discontinuity != Some(discontinuity_sequence) {
+			importer.seek(moq_sequence(discontinuity_sequence, sequence)?)?;
+		}
+
 		importer.decode(&bytes)?;
 		track.next_sequence = Some(sequence + 1);
+		track.next_discontinuity = Some(discontinuity_sequence);
 
 		Ok(())
 	}
@@ -660,6 +687,33 @@ fn resolve_uri(base: &Url, value: &str) -> std::result::Result<Url, url::ParseEr
 	base.join(value)
 }
 
+/// Pack HLS discontinuity + media sequence into a single MoQ group sequence.
+///
+/// HLS media sequence alone can rewind after an upstream reset, and discontinuity
+/// sequence alone cannot order segments inside the same epoch. The lower 48 bits hold
+/// the media sequence (ample for realistic playlists) while the upper 16 bits hold the
+/// discontinuity sequence, so a new epoch always sorts after every segment of the last.
+fn moq_sequence(discontinuity_sequence: u64, media_sequence: u64) -> Result<u64> {
+	const MEDIA_BITS: u32 = 48;
+	const MEDIA_MASK: u64 = (1u64 << MEDIA_BITS) - 1;
+	const DISCONTINUITY_MASK: u64 = u64::MAX >> MEDIA_BITS;
+
+	if media_sequence > MEDIA_MASK {
+		return Err(Error::SequenceOverflow {
+			kind: "media",
+			value: media_sequence,
+		});
+	}
+	if discontinuity_sequence > DISCONTINUITY_MASK {
+		return Err(Error::SequenceOverflow {
+			kind: "discontinuity",
+			value: discontinuity_sequence,
+		});
+	}
+
+	Ok((discontinuity_sequence << MEDIA_BITS) | media_sequence)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -741,5 +795,36 @@ mod tests {
 		assert_eq!(hls.video.len(), 1);
 		assert!(hls.video[0].select.has_video() && hls.video[0].select.has_audio());
 		assert!(hls.audio.is_none());
+	}
+
+	#[test]
+	fn moq_sequence_orders_discontinuities_after_media_sequence() {
+		// A new epoch outranks every segment of the previous one, even a higher media seq.
+		let last_of_epoch_0 = moq_sequence(0, u64::from(u32::MAX)).unwrap();
+		let first_of_epoch_1 = moq_sequence(1, 0).unwrap();
+		assert!(first_of_epoch_1 > last_of_epoch_0);
+	}
+
+	#[test]
+	fn moq_sequence_preserves_media_order_within_epoch() {
+		assert!(moq_sequence(3, 10).unwrap() > moq_sequence(3, 9).unwrap());
+	}
+
+	#[test]
+	fn moq_sequence_rejects_unrepresentable_media_sequence() {
+		let err = moq_sequence(0, 1u64 << 48).unwrap_err();
+		assert!(matches!(err, Error::SequenceOverflow { kind: "media", .. }));
+	}
+
+	#[test]
+	fn moq_sequence_rejects_unrepresentable_discontinuity_sequence() {
+		let err = moq_sequence(1u64 << 16, 0).unwrap_err();
+		assert!(matches!(
+			err,
+			Error::SequenceOverflow {
+				kind: "discontinuity",
+				..
+			}
+		));
 	}
 }


### PR DESCRIPTION
## Summary

Picks up the **discontinuity-sequence half of #1940**, which was intentionally deferred. The track-selection half already landed in `68c9ebd48` ("unify rendition selection behind `select::Broadcast`"); that commit's message notes the discontinuity change was left for a separate PR. This is it.

HLS *media* sequence names the live window, while *discontinuity* sequence names a fresh media timeline. The import side only tracked media sequence, so a consumer joining mid-stream (or after an upstream reset that rewinds media sequence) could wait on groups HLS has explicitly moved past.

- Count `EXT-X-DISCONTINUITY` tags while consuming segments and thread the running discontinuity sequence into `push_segment`.
- Pack both values into one MoQ group sequence: discontinuity in the upper 16 bits, media in the lower 48, so a new epoch always sorts after every segment of the previous one (`moq_sequence`). Overflow of either field is a typed `Error::SequenceOverflow` rather than a silent wrap.
- Anchor the importer with `seek()` whenever we join, skip ahead, or cross a discontinuity; contiguous segments still let the fMP4 importer auto-increment.

## Public API Changes

- `moq_hls::Error` (already `#[non_exhaustive]`) gains a `SequenceOverflow { kind, value }` variant. Additive, non-breaking.
- No change to `moq-mux`, `moq-net`, or any wire/catalog format. `Fmp4::seek()` already existed.

## Test / Git LFS note

The sequence packing is pure and tested without any media (epoch ordering, intra-epoch order, and both overflow guards), so this needs **no** new test fixture. The existing fMP4 unit fixtures are tiny (`bbb.mp4` is 2.5K) and committed via `include_bytes!`, and the demo-only large-media path already caches downloads, so no Git LFS is warranted here.

## Validation

- `cargo test -p moq-hls` (14 passing, including 4 new `moq_sequence_*` tests)
- `just check` clean for all Rust crates / fmt / clippy / remark (the only failure is shellcheck flagging the gitignored local `.direnv/bin/nix-direnv-reload`, unrelated to this change)

(Written by Claude Opus 4.8)