### PR TITLE
demo/web: focus the watch tab instead of stats on `just web`

### DIFF
--- a/demo/web/vite.config.ts
+++ b/demo/web/vite.config.ts
@@ -14,8 +14,9 @@ export default defineConfig({
 		solidPlugin(),
 		workletInline(),
 		consoleOverlay(),
-		// Open the watch, publish, and stats demos each in their own tab.
-		openTabs(["watch.html", "publish.html", "stats.html"]),
+		// Open the stats, publish, and watch demos each in their own tab.
+		// Order matters: the browser focuses the last tab, so watch ends up in front.
+		openTabs(["stats.html", "publish.html", "watch.html"]),
 	],
 	build: {
 		target: "esnext",


### PR DESCRIPTION
## Summary

`just web` opens the watch, publish, and stats demos each in their own browser tab. Browsers focus the **last** tab opened, so listing `stats.html` last left the stats demo in front, which is a confusing landing view.

This reorders the tab list so `stats.html` opens first and `watch.html` opens last (and gets focus). The stats page is still opened, just no longer the foreground tab.

## Changes

- `demo/web/vite.config.ts`: reorder `openTabs([...])` to `["stats.html", "publish.html", "watch.html"]` and note why order matters.

## Notes for reviewers

- Dev-only change (the `openTabs` plugin only applies on `serve`); no effect on builds or production.
- If we'd rather not open stats at all, dropping `"stats.html"` from the array is the alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)