### PR TITLE
ci: retire self-hosted A1 runner, move all jobs back to GitHub-hosted

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,0 @@
-# Custom labels for the moq-dev self-hosted A1 runner, so actionlint accepts
-# `runs-on: [self-hosted, nix]`. `self-hosted` is built in; `nix` is ours.
-self-hosted-runner:
-  labels:
-    - nix

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -28,10 +28,8 @@ jobs:
             runs-on: ubuntu-latest
           - os: macos-latest # aarch64-darwin
             runs-on: macos-latest
-          # aarch64-linux on the moq-dev self-hosted A1 (warm /nix/store). Tag
-          # pushes are trusted, so no fork concern.
           - os: aarch64-linux
-            runs-on: [self-hosted, nix]
+            runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -53,17 +51,7 @@ jobs:
           fi
           echo "name=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
 
-      # The cachix action and `nix build` below run `nix` directly, so put it on
-      # PATH. A login shell resolves it via /etc/profile.d regardless of the
-      # box's install path. Self-hosted only; the hosted runners get Nix from
-      # the installer step.
-      - name: Add Nix to PATH
-        if: runner.environment == 'self-hosted'
-        shell: bash -leo pipefail {0}
-        run: dirname "$(command -v nix)" >> "$GITHUB_PATH"
-
-      - if: runner.environment == 'github-hosted'
-        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
 
@@ -71,11 +59,6 @@ jobs:
         with:
           name: kixelated
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          # The self-hosted box's runner user isn't a Nix trusted-user and the
-          # box deliberately substitutes only from its warm local store, so
-          # don't let `cachix use` rewrite nix.conf there. Push auth (above)
-          # still works; this leg only pushes.
-          skipAddingSubstituter: ${{ runner.environment == 'self-hosted' }}
 
       - name: Build and cache
         env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,19 +22,13 @@ jobs:
     # Skip the actual work on close/merge: this run exists only to cancel the
     # superseded in-flight build via the concurrency group above.
     if: github.event.action != 'closed'
-    # Trusted events run on the moq-dev self-hosted A1 runner (warm /nix/store +
-    # persistent CARGO_TARGET_DIR). Fork PRs fall back to GitHub-hosted ARM so
-    # untrusted code never runs on the box.
-    runs-on: ${{ github.event.pull_request.head.repo.fork && fromJSON('["ubuntu-24.04-arm"]') || fromJSON('["self-hosted", "nix"]') }}
+    runs-on: ubuntu-24.04-arm
     # Backstop a hang (e.g. a wedged test) instead of holding the runner for the
     # 6-hour default. Generous enough for a cold first build.
     timeout-minutes: 60
 
     steps:
-      # GitHub-hosted fallback only: the self-hosted box already has disk space,
-      # Determinate Nix, and a warm store.
       - name: Free disk space
-        if: runner.environment == 'github-hosted'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: false
@@ -46,27 +40,16 @@ jobs:
           # Full history so `just changed` can diff against origin/$GITHUB_BASE_REF.
           fetch-depth: 0
 
-      - if: runner.environment == 'github-hosted'
-        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - if: runner.environment == 'github-hosted'
-        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
-      - if: runner.environment == 'github-hosted'
-        uses: DeterminateSystems/flake-checker-action@a0f068d37b542f3150564fbf1164fec2d958ee11 # main
+      - uses: DeterminateSystems/flake-checker-action@a0f068d37b542f3150564fbf1164fec2d958ee11 # main
 
-      # GitHub-hosted fallback caches Rust via the Actions cache. The self-hosted
-      # box runs the heavy Rust CI (clippy/doc/test) as plain cargo, reusing a
-      # persistent CARGO_TARGET_DIR set in the runner environment (not here), so
-      # unchanged crates are reused across jobs; the checkout's ./target is unused.
+      # Cache Rust dependencies and build artifacts via the Actions cache.
       - name: Rust Cache
-        if: runner.environment == 'github-hosted'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
 
       # `just ci` calls `just changed` internally to skip unchanged scopes.
-      # Login shell so /etc/profile.d puts Nix on PATH; Actions shells don't by
-      # default. Harmless on the hosted fallback.
       - run: nix develop --command just ci
-        shell: bash -leo pipefail {0}

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -18,9 +18,7 @@ concurrency:
 jobs:
   release:
     name: Release JS Packages
-    # Trusted push to main, so run on the moq-dev self-hosted A1 runner (warm
-    # /nix/store).
-    runs-on: [self-hosted, nix]
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'moq-dev'
 
     steps:
@@ -28,16 +26,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        with:
+          determinate: false
+
       - name: Setup npm registry
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           registry-url: 'https://registry.npmjs.org'
 
-      # Login shell so /etc/profile.d puts Nix on PATH; Actions shells don't by
-      # default.
       - name: Install dependencies
         run: nix develop --command bun install --frozen-lockfile
-        shell: bash -leo pipefail {0}
 
       - name: Release packages
         # Web-component packages register custom elements via global type
@@ -46,4 +45,3 @@ jobs:
         env:
           JSR_ALLOW_SLOW_TYPES: "true"
         run: nix develop --command bun --filter '*' release
-        shell: bash -leo pipefail {0}

--- a/.github/workflows/release-py.yml
+++ b/.github/workflows/release-py.yml
@@ -31,10 +31,7 @@ concurrency:
 jobs:
   build:
     name: Build wheel + sdist
-    # Trusted push to main and the wrapper wheel is pure-python (arch
-    # independent), so run on the moq-dev self-hosted A1 runner (warm
-    # /nix/store).
-    runs-on: [self-hosted, nix]
+    runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'moq-dev' }}
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -59,11 +56,12 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: .github/scripts/release.sh pypi-exists moq-rs "$VERSION"
 
-      # Login shell so /etc/profile.d puts Nix on PATH; Actions shells don't by
-      # default.
+      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        with:
+          determinate: false
+
       - name: Build
         run: nix develop --command just py package
-        shell: bash -leo pipefail {0}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release-rs.yml
+++ b/.github/workflows/release-rs.yml
@@ -18,9 +18,7 @@ jobs:
   release:
     name: Plz
 
-    # Trusted push to main, so run on the moq-dev self-hosted A1 runner (warm
-    # /nix/store + persistent CARGO_TARGET_DIR).
-    runs-on: [self-hosted, nix]
+    runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'moq-dev' }}
 
     steps:
@@ -39,16 +37,13 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 
-      # Persist the cargo target outside the workspace (checkout clean wipes the
-      # workspace, not $HOME). Scope per runner so a second service on the box
-      # gets its own dir instead of racing on a shared one.
-      - run: echo "CARGO_TARGET_DIR=$HOME/cargo-target/moq-$RUNNER_NAME" >> "$GITHUB_ENV"
+      # Install Nix for system dependencies (e.g. ffmpeg).
+      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        with:
+          determinate: false
 
-      # Login shell so /etc/profile.d puts Nix on PATH; Actions shells don't by
-      # default.
       - name: Release
         run: nix develop --command just rs release
-        shell: bash -leo pipefail {0}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -50,7 +50,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # main
 
       # Reuse ~/.cargo + ./target across nightly runs so only changed crates
       # recompile (the relay, cli, moq-ffi, and libmoq all build from source).

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -12,21 +12,16 @@ on:
 jobs:
   update-flake:
     name: Update flake.lock
-    # Run on the moq-dev self-hosted A1 runner (already has Nix); fork dispatches
-    # have no such runner, so guard on the owner to avoid queueing forever.
-    runs-on: [self-hosted, nix]
-    if: ${{ github.repository_owner == 'moq-dev' }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      # The update-flake-lock action runs `nix` directly (not through a shell),
-      # so put Nix on GITHUB_PATH. A login shell resolves it via /etc/profile.d
-      # regardless of the box's install path.
-      - name: Add Nix to PATH
-        shell: bash -leo pipefail {0}
-        run: dirname "$(command -v nix)" >> "$GITHUB_PATH"
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        with:
+          determinate: false
 
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@fd9359ac79d0e912f1b4b947a48470b3e2799b56 # main

--- a/rs/justfile
+++ b/rs/justfile
@@ -42,24 +42,20 @@ ci FILES="":
     cargo shear
     cargo deny check --show-stats
 
-    # Compiles. The all-features clippy / doc / test were crane derivations built
-    # by `nix flake check`; they now run here as plain cargo (flake.nix `checks`
-    # is unwired). Each full-workspace compile below is expensive on the 4-core A1
-    # runner, so we run the minimum set that still covers every feature edge:
+    # Compiles. The all-features clippy / doc / test run as plain cargo (flake.nix
+    # `checks` is unwired). Each full-workspace compile below is expensive, so we
+    # run the minimum set that still covers every feature edge:
     #   - clippy --all-targets --all-features is the gate and a superset of a plain
     #     `cargo check --all-targets` (default features), so that redundant check
     #     pass is intentionally omitted -- one fewer full workspace compile.
     #   - --no-default-features stays: it's the only pass that exercises code behind
     #     `#[cfg(not(feature = ...))]`, which the all-features run never compiles.
-    # The self-hosted runner sets a persistent CARGO_TARGET_DIR (in its env, not
-    # here), so unchanged crates are reused across jobs and a Cargo.lock change
-    # recompiles only the changed crate + its reverse-deps. (Local devs still get
-    # the full cargo loop via `just rs check`.)
+    # (Local devs still get the full cargo loop via `just rs check`.)
     cargo check --workspace --no-default-features
     cargo clippy --workspace --all-targets --all-features -- -D warnings
     RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
     # nextest compiles + runs the test binaries with real parallelism (faster than
-    # `cargo test`'s serial harness on the 4-core box). It does not build or run
+    # `cargo test`'s serial harness). It does not build or run
     # doctests, so the `/// ```` examples are no longer compile-checked in CI -- an
     # accepted trade for speed (they still render in `cargo doc` output).
     cargo nextest run --workspace --all-targets --all-features


### PR DESCRIPTION
## Summary

Retire the moq-dev self-hosted ARM (Oracle A1) runner and run all CI/release jobs on GitHub-hosted runners again. This reverts the [#1793](https://github.com/moq-dev/moq/pull/1793) migration that moved the Nix workflows onto the box.

| Workflow | Before | After |
|---|---|---|
| `check.yml` | `self-hosted` (forks → `ubuntu-24.04-arm`) | `ubuntu-24.04-arm`, dropped the fork conditional and all `runner.environment` `if:` guards |
| `cachix.yml` | aarch64-linux on `self-hosted` | aarch64-linux on `ubuntu-24.04-arm` (coverage kept), removed the PATH/substituter conditionals |
| `release-rs.yml` | `self-hosted` + persistent `CARGO_TARGET_DIR` | `ubuntu-latest` + nix-installer |
| `release-js.yml` | `self-hosted` | `ubuntu-latest` + nix-installer |
| `release-py.yml` | `self-hosted` | `ubuntu-latest` + nix-installer |
| `update-flake.yml` | `self-hosted` + owner guard | `ubuntu-latest` + nix-installer |

ARM is kept where arch matters (`check`, since the A1 was ARM so trusted PRs already ran on ARM; and the `aarch64-linux` cachix leg) using GitHub's GA `ubuntu-24.04-arm` runners. The arch-independent publish jobs go back to their original `ubuntu-latest`.

Also deleted `.github/actionlint.yaml` (it only existed to whitelist the `nix` runner label) and cleaned the stale "4-core A1" / persistent-target comments out of `rs/justfile`.

## Caching: dropped dead `magic-nix-cache`

While restoring the pre-self-hosted caching, removed `DeterminateSystems/magic-nix-cache-action` from `check.yml` and `smoke.yml`. It was sunset upstream (now gated behind FlakeHub registration, failing every Nix job with a "FlakeHub registration required" annotation) and was already deliberately dropped in [#1769](https://github.com/moq-dev/moq/pull/1769); it crept back via the self-hosted fallback and the [#1871](https://github.com/moq-dev/moq/pull/1871) smoke workflow.

It added near-zero value here: the devShell is all prebuilt nixpkgs + rust-overlay binaries, so `cache.nixos.org` covers the Nix store for free, and Rust is cached by `Swatinem/rust-cache` (retained). This matches the proven post-#1769 setup.

## Notes for reviewers

- No public API or wire changes; CI-only, targets `main`.
- The self-hosted A1 instance itself (the `~/work/oci` OpenTofu config) is a separate teardown — this PR only removes the repo's *use* of the runner.
- The `dev` branch may still reference the self-hosted runner in its workflow files until this propagates via a main → dev merge.
- All six modified workflows + `smoke.yml` pass `actionlint`.

(Written by Claude Opus 4.8)