### PR TITLE
chore(js): bump versions for packages with unreleased changes

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/json",
 	"type": "module",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Snapshot/delta JSON publishing over MoQ tracks using RFC 7396 JSON Merge Patch.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"jsr": false,
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/msf",
 	"type": "module",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "MSF (MOQT Streaming Format) catalog types for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.15",
+	"version": "0.2.16",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/signals",
 	"type": "module",
-	"version": "0.1.9",
+	"version": "0.1.10",
 	"description": "Reactive and safe signals",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

The JS release workflow publishes each package's current `package.json` version on push to `main`, skipping any version already on the registry. Several packages have had source changes merged since their currently published version, so their next release would be skipped as "already published" and the merged work would never ship.

This bumps the patch version for each package whose published version already matches `main` but whose `src/` has changed since the last release:

| Package | Bump | Notable change since release |
|---|---|---|
| `@moq/net` | 0.1.5 → 0.1.6 | `Group.state` encapsulation, refactors |
| `@moq/hang` | 0.2.11 → 0.2.12 | compressed catalog track (`catalog.json.z`) |
| `@moq/watch` | 0.2.17 → 0.2.18 | HLS routing, compressed catalog |
| `@moq/publish` | 0.2.15 → 0.2.16 | new public `CATALOG_TRACK_COMPRESSED` |
| `@moq/json` | 0.1.0 → 0.1.1 | group roll refactor |
| `@moq/msf` | 0.1.2 → 0.1.3 | moq-mux backport |
| `@moq/signals` | 0.1.9 → 0.1.10 | `CreateOptions` type fix |
| `@moq/boy` | 0.2.10 → 0.2.11 | source updates |

Patch increments follow the repo's established cadence (the last bump in #1846 was patch-level across the board).

### Left unchanged
- `@moq/loc`, `@moq/token`: only a devDependency (TypeScript) changed, no `src/` change, so the published artifact is unaffected.
- `@moq/clock`: `"private": true`, never published.
- `@moq/flate`: at `0.1.0` but not yet on npm/JSR. Its first release is still pending and it has no changes, so it stays at `0.1.0`.

## Test plan

- [x] All eight edited `package.json` files remain valid JSON.
- [x] Diff is exactly the eight `version` lines, nothing else.
- [x] `bun install --frozen-lockfile` validates the lockfile (internal deps use `workspace:*`/`workspace:^`, so no lockfile regen needed). Full `just check` could not run in this environment because a native dependency's postinstall needs git access that the sandbox blocks; this is unrelated to the version-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMHkwcjhvK7NgZMmuvtUVT)_