### PR TITLE
fix(moq-native): defer TLS root resolution so http:// fingerprint bootstrap works without roots

### DIFF
--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -97,7 +97,17 @@ pub struct Client {
 	backoff: Backoff,
 	#[cfg(feature = "websocket")]
 	websocket: crate::websocket::Client,
-	tls: rustls::ClientConfig,
+	/// Prebuilt rustls config for the resolved verification policy, or `None` when
+	/// no CA roots resolved. Left unresolved so a per-connection `http://`
+	/// fingerprint bootstrap can still connect without roots; any other connection
+	/// then surfaces [`crate::tls::Error::NoRoots`] at connect time.
+	tls: Option<rustls::ClientConfig>,
+	/// The TLS config itself, kept to build a freshly pinned rustls config per
+	/// connection when bootstrapping a self-signed relay over `http://`. Only the
+	/// rustls-based quinn/noq backends rebuild from it; quiche carries its own
+	/// resolved policy.
+	#[cfg(any(feature = "quinn", feature = "noq"))]
+	tls_config: crate::tls::Client,
 	#[cfg(feature = "noq")]
 	noq: Option<crate::noq::NoqClient>,
 	#[cfg(feature = "quinn")]
@@ -153,7 +163,14 @@ impl Client {
 			panic!("no QUIC backend compiled; enable noq, quinn, or quiche feature");
 		});
 
-		let tls = config.tls.build()?;
+		// Resolve the verification policy once. Building the rustls config is
+		// deferred to `None` when no roots resolved, so construction doesn't fail
+		// before a per-connection `http://` bootstrap gets a chance to pin a cert.
+		let tls = config
+			.tls
+			.verification()?
+			.map(|v| config.tls.build_with(v))
+			.transpose()?;
 
 		#[cfg(feature = "noq")]
 		#[allow(unreachable_patterns)]
@@ -183,6 +200,8 @@ impl Client {
 			#[cfg(feature = "websocket")]
 			websocket: config.websocket,
 			tls,
+			#[cfg(any(feature = "quinn", feature = "noq"))]
+			tls_config: config.tls,
 			#[cfg(feature = "noq")]
 			noq,
 			#[cfg(feature = "quinn")]
@@ -302,9 +321,12 @@ impl Client {
 
 		#[cfg(feature = "noq")]
 		if let Some(noq) = self.noq.as_ref() {
-			let tls = self.tls.clone();
 			let quic_url = url.clone();
-			let quic_handle = async { noq.connect(&tls, quic_url).await.map_err(Error::from) };
+			let quic_handle = async {
+				noq.connect(self.tls.as_ref(), &self.tls_config, quic_url)
+					.await
+					.map_err(Error::from)
+			};
 
 			#[cfg(feature = "websocket")]
 			{
@@ -320,9 +342,13 @@ impl Client {
 
 		#[cfg(feature = "quinn")]
 		if let Some(quinn) = self.quinn.as_ref() {
-			let tls = self.tls.clone();
 			let quic_url = url.clone();
-			let quic_handle = async { quinn.connect(&tls, quic_url).await.map_err(Error::from) };
+			let quic_handle = async {
+				quinn
+					.connect(self.tls.as_ref(), &self.tls_config, quic_url)
+					.await
+					.map_err(Error::from)
+			};
 
 			#[cfg(feature = "websocket")]
 			{
@@ -356,7 +382,7 @@ impl Client {
 		#[cfg(feature = "websocket")]
 		{
 			let alpns = self.versions.alpns();
-			let session = crate::websocket::connect(&self.websocket, &self.tls, url, &alpns).await?;
+			let session = crate::websocket::connect(&self.websocket, self.tls.as_ref(), url, &alpns).await?;
 			return Ok(self.moq.connect(session).await?);
 		}
 
@@ -374,7 +400,7 @@ impl Client {
 		let ws_config = self.websocket.clone();
 		let ws_tls = self.tls.clone();
 		let websocket = async move {
-			crate::websocket::race_handle(&ws_config, &ws_tls, url, &alpns)
+			crate::websocket::race_handle(&ws_config, ws_tls.as_ref(), url, &alpns)
 				.await
 				.map(|res| res.map_err(Error::from))
 		};
@@ -523,6 +549,22 @@ mod tests {
 	fn test_cli_no_disable_verify() {
 		let config = ClientConfig::parse_from(["test"]);
 		assert_eq!(config.tls.disable_verify, None);
+	}
+
+	#[cfg(feature = "quinn")]
+	#[tokio::test]
+	async fn init_defers_no_roots() {
+		// Regression: a roots-less config (system roots off, no custom root, no
+		// fingerprint) used to fail construction with NoRoots before any URL scheme
+		// was known. It now builds, so a per-connection http:// fingerprint
+		// bootstrap can still connect; other schemes surface NoRoots at connect time.
+		let mut tls = crate::tls::Client::default();
+		tls.system_roots = Some(false);
+		let config = ClientConfig {
+			tls,
+			..Default::default()
+		};
+		assert!(config.init().is_ok());
 	}
 
 	#[test]

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -13,6 +13,11 @@
 /// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
 pub(crate) const DEFAULT_MAX_STREAMS: u64 = 1024;
 
+/// Overall timeout for the insecure `http://` certificate-fingerprint fetch, so a
+/// stalled `/certificate.sha256` response can't block connect indefinitely.
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
+pub(crate) const FINGERPRINT_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 pub mod bind;
 mod client;
 mod connect;

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -50,6 +50,7 @@ pub enum Error {
 	#[error("invalid fingerprint")]
 	InvalidFingerprint(#[from] hex::FromHexError),
 
+	/// The fetched `http://` certificate fingerprint didn't decode to a 32-byte SHA-256 digest.
 	#[error("certificate fingerprint must be 32 bytes (SHA-256), got {0}")]
 	FingerprintLength(usize),
 
@@ -159,6 +160,13 @@ impl NoqClient {
 		})
 	}
 
+	/// Connect to `url`, resolving TLS now that the scheme is known.
+	///
+	/// `base` is the prebuilt config for the resolved verification policy, or
+	/// `None` when no roots resolved. An eligible `http://` URL fetches
+	/// `/certificate.sha256`, pins it (rebuilding from `tls_config`, no roots
+	/// needed), and upgrades to `https://`; any other scheme reuses `base` and
+	/// surfaces [`crate::tls::Error::NoRoots`] when it is `None`.
 	pub async fn connect(
 		&self,
 		base: Option<&rustls::ClientConfig>,
@@ -186,9 +194,11 @@ impl NoqClient {
 		// needed); anything else reuses the resolved policy, surfacing the
 		// deferred `NoRoots` when none was configured.
 		let mut config = if url.scheme() == "http" && self.http_bootstrap {
-			// Insecure per-connection bootstrap: only honored when no stronger
-			// verification is configured, so an attacker controlling the plaintext
-			// fetch can't weaken an explicit pin or re-enable disabled verification.
+			// Insecure per-connection bootstrap: an `http://` URL is a deliberate
+			// opt-in to replace CA validation with a freshly fetched pin for this
+			// connection. It's refused for an explicit `--client-tls-fingerprint`
+			// or disabled verification, so an attacker controlling the plaintext
+			// fetch can't weaken a stronger choice the user already made.
 			let pin = fetch_fingerprint(&url).await?;
 			tls_config.build_with(crate::tls::Verification::Fingerprints(vec![pin]))?
 		} else {
@@ -267,7 +277,13 @@ async fn fetch_fingerprint(url: &Url) -> Result<[u8; 32]> {
 
 	tracing::warn!(url = %fp, "performing insecure HTTP request for certificate");
 
-	let resp = reqwest::get(fp.as_str())
+	// Bound the fetch so a stalled response can't block connect indefinitely.
+	let resp = reqwest::Client::builder()
+		.timeout(crate::FINGERPRINT_FETCH_TIMEOUT)
+		.build()
+		.map_err(Error::FetchFingerprint)?
+		.get(fp.as_str())
+		.send()
 		.await
 		.map_err(Error::FetchFingerprint)?
 		.error_for_status()

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -1,6 +1,6 @@
 use crate::client::ClientConfig;
 use crate::server::{ServerConfig, ServerId};
-use crate::tls::{FingerprintVerifier, ServeCerts};
+use crate::tls::ServeCerts;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::{net, time};
@@ -49,6 +49,9 @@ pub enum Error {
 
 	#[error("invalid fingerprint")]
 	InvalidFingerprint(#[from] hex::FromHexError),
+
+	#[error("certificate fingerprint must be 32 bytes (SHA-256), got {0}")]
+	FingerprintLength(usize),
 
 	#[error("url scheme must be 'https', 'moqt', or 'moql'")]
 	InvalidScheme,
@@ -156,9 +159,13 @@ impl NoqClient {
 		})
 	}
 
-	pub async fn connect(&self, tls: &rustls::ClientConfig, url: Url) -> Result<web_transport_noq::Session> {
+	pub async fn connect(
+		&self,
+		base: Option<&rustls::ClientConfig>,
+		tls_config: &crate::tls::Client,
+		url: Url,
+	) -> Result<web_transport_noq::Session> {
 		let mut url = url;
-		let mut config = tls.clone();
 
 		let host = url.host().ok_or(Error::InvalidDnsName)?.to_string();
 		let port = url.port().unwrap_or(443);
@@ -174,36 +181,26 @@ impl NoqClient {
 			.map_err(Error::DnsLookup)?;
 		let ip = crate::util::pick_addr(addrs, local).ok_or(Error::NoDnsEntries)?;
 
-		if url.scheme() == "http" {
+		// Resolve the per-connection rustls config now that the scheme is known.
+		// An `http://` bootstrap pins a freshly fetched fingerprint (no roots
+		// needed); anything else reuses the resolved policy, surfacing the
+		// deferred `NoRoots` when none was configured.
+		let mut config = if url.scheme() == "http" && self.http_bootstrap {
 			// Insecure per-connection bootstrap: only honored when no stronger
 			// verification is configured, so an attacker controlling the plaintext
 			// fetch can't weaken an explicit pin or re-enable disabled verification.
-			if self.http_bootstrap {
-				// Perform a HTTP request to fetch the certificate fingerprint.
-				let mut fingerprint = url.clone();
-				fingerprint.set_path("/certificate.sha256");
-				fingerprint.set_query(None);
-				fingerprint.set_fragment(None);
-
-				tracing::warn!(url = %fingerprint, "performing insecure HTTP request for certificate");
-
-				let resp = reqwest::get(fingerprint.as_str())
-					.await
-					.map_err(Error::FetchFingerprint)?
-					.error_for_status()
-					.map_err(Error::FingerprintStatus)?;
-
-				let fingerprint = resp.text().await.map_err(Error::ReadFingerprint)?;
-				let fingerprint = hex::decode(fingerprint.trim())?;
-
-				let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), vec![fingerprint]);
-				config.dangerous().set_certificate_verifier(Arc::new(verifier));
-			} else {
+			let pin = fetch_fingerprint(&url).await?;
+			tls_config.build_with(crate::tls::Verification::Fingerprints(vec![pin]))?
+		} else {
+			if url.scheme() == "http" {
 				tracing::warn!(
 					"ignoring insecure http:// fingerprint bootstrap; using the configured TLS verification"
 				);
 			}
+			base.cloned().ok_or(crate::tls::Error::NoRoots)?
+		};
 
+		if url.scheme() == "http" {
 			url.set_scheme("https").expect("failed to set scheme");
 		}
 
@@ -257,6 +254,27 @@ impl NoqClient {
 
 		Ok(session)
 	}
+}
+
+/// Fetch a relay's certificate SHA-256 over an insecure `http://` request and
+/// return it as a pin. Mirrors the browser's self-signed bootstrap: GET
+/// `/certificate.sha256` and pin the returned hash.
+async fn fetch_fingerprint(url: &Url) -> Result<[u8; 32]> {
+	let mut fp = url.clone();
+	fp.set_path("/certificate.sha256");
+	fp.set_query(None);
+	fp.set_fragment(None);
+
+	tracing::warn!(url = %fp, "performing insecure HTTP request for certificate");
+
+	let resp = reqwest::get(fp.as_str())
+		.await
+		.map_err(Error::FetchFingerprint)?
+		.error_for_status()
+		.map_err(Error::FingerprintStatus)?;
+	let text = resp.text().await.map_err(Error::ReadFingerprint)?;
+	let bytes = hex::decode(text.trim())?;
+	bytes.try_into().map_err(|v: Vec<u8>| Error::FingerprintLength(v.len()))
 }
 
 impl Error {

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -105,7 +105,9 @@ type Result<T> = std::result::Result<T, Error>;
 pub(crate) struct QuicheClient {
 	pub bind: net::SocketAddr,
 	/// Resolved server-verification policy, shared with the other backends.
-	pub verification: crate::tls::Verification,
+	/// `None` when no CA roots resolved: deferred so an `http://` bootstrap can
+	/// still pin a fetched fingerprint, while other schemes surface `NoRoots`.
+	pub verification: Option<crate::tls::Verification>,
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
 	pub max_streams: u64,
@@ -145,10 +147,10 @@ impl QuicheClient {
 				tracing::warn!(
 					"ignoring insecure http:// fingerprint bootstrap; using the configured TLS verification"
 				);
-				(https, self.verification.clone())
+				(https, self.verification.clone().ok_or(crate::tls::Error::NoRoots)?)
 			}
 		} else {
-			(url, self.verification.clone())
+			(url, self.verification.clone().ok_or(crate::tls::Error::NoRoots)?)
 		};
 
 		let alpns: Vec<Vec<u8>> = match url.scheme() {

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -240,7 +240,13 @@ async fn fetch_fingerprint(url: &Url) -> Result<[u8; 32]> {
 
 	tracing::warn!(url = %fp, "performing insecure HTTP request for certificate fingerprint");
 
-	let resp = reqwest::get(fp.as_str())
+	// Bound the fetch so a stalled response can't block connect indefinitely.
+	let resp = reqwest::Client::builder()
+		.timeout(crate::FINGERPRINT_FETCH_TIMEOUT)
+		.build()
+		.map_err(Error::FetchFingerprint)?
+		.get(fp.as_str())
+		.send()
 		.await
 		.map_err(Error::FetchFingerprint)?
 		.error_for_status()

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -1,6 +1,6 @@
 use crate::client::ClientConfig;
 use crate::server::{ServerConfig, ServerId};
-use crate::tls::{FingerprintVerifier, ServeCerts};
+use crate::tls::ServeCerts;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::{net, time};
@@ -47,6 +47,9 @@ pub enum Error {
 
 	#[error("invalid fingerprint")]
 	InvalidFingerprint(#[from] hex::FromHexError),
+
+	#[error("certificate fingerprint must be 32 bytes (SHA-256), got {0}")]
+	FingerprintLength(usize),
 
 	#[error("url scheme must be 'https', 'moqt', or 'moql'")]
 	InvalidScheme,
@@ -154,9 +157,13 @@ impl QuinnClient {
 		})
 	}
 
-	pub async fn connect(&self, tls: &rustls::ClientConfig, url: Url) -> Result<web_transport_quinn::Session> {
+	pub async fn connect(
+		&self,
+		base: Option<&rustls::ClientConfig>,
+		tls_config: &crate::tls::Client,
+		url: Url,
+	) -> Result<web_transport_quinn::Session> {
 		let mut url = url;
-		let mut config = tls.clone();
 
 		let host = url.host().ok_or(Error::InvalidDnsName)?.to_string();
 		let port = url.port().unwrap_or(443);
@@ -172,36 +179,26 @@ impl QuinnClient {
 			.map_err(Error::DnsLookup)?;
 		let ip = crate::util::pick_addr(addrs, local).ok_or(Error::NoDnsEntries)?;
 
-		if url.scheme() == "http" {
+		// Resolve the per-connection rustls config now that the scheme is known.
+		// An `http://` bootstrap pins a freshly fetched fingerprint (no roots
+		// needed); anything else reuses the resolved policy, surfacing the
+		// deferred `NoRoots` when none was configured.
+		let mut config = if url.scheme() == "http" && self.http_bootstrap {
 			// Insecure per-connection bootstrap: only honored when no stronger
 			// verification is configured, so an attacker controlling the plaintext
 			// fetch can't weaken an explicit pin or re-enable disabled verification.
-			if self.http_bootstrap {
-				// Perform a HTTP request to fetch the certificate fingerprint.
-				let mut fingerprint = url.clone();
-				fingerprint.set_path("/certificate.sha256");
-				fingerprint.set_query(None);
-				fingerprint.set_fragment(None);
-
-				tracing::warn!(url = %fingerprint, "performing insecure HTTP request for certificate");
-
-				let resp = reqwest::get(fingerprint.as_str())
-					.await
-					.map_err(Error::FetchFingerprint)?
-					.error_for_status()
-					.map_err(Error::FingerprintStatus)?;
-
-				let fingerprint = resp.text().await.map_err(Error::ReadFingerprint)?;
-				let fingerprint = hex::decode(fingerprint.trim())?;
-
-				let verifier = FingerprintVerifier::new(config.crypto_provider().clone(), vec![fingerprint]);
-				config.dangerous().set_certificate_verifier(Arc::new(verifier));
-			} else {
+			let pin = fetch_fingerprint(&url).await?;
+			tls_config.build_with(crate::tls::Verification::Fingerprints(vec![pin]))?
+		} else {
+			if url.scheme() == "http" {
 				tracing::warn!(
 					"ignoring insecure http:// fingerprint bootstrap; using the configured TLS verification"
 				);
 			}
+			base.cloned().ok_or(crate::tls::Error::NoRoots)?
+		};
 
+		if url.scheme() == "http" {
 			url.set_scheme("https").expect("failed to set scheme");
 		}
 
@@ -255,6 +252,27 @@ impl QuinnClient {
 
 		Ok(session)
 	}
+}
+
+/// Fetch a relay's certificate SHA-256 over an insecure `http://` request and
+/// return it as a pin. Mirrors the browser's self-signed bootstrap: GET
+/// `/certificate.sha256` and pin the returned hash.
+async fn fetch_fingerprint(url: &Url) -> Result<[u8; 32]> {
+	let mut fp = url.clone();
+	fp.set_path("/certificate.sha256");
+	fp.set_query(None);
+	fp.set_fragment(None);
+
+	tracing::warn!(url = %fp, "performing insecure HTTP request for certificate");
+
+	let resp = reqwest::get(fp.as_str())
+		.await
+		.map_err(Error::FetchFingerprint)?
+		.error_for_status()
+		.map_err(Error::FingerprintStatus)?;
+	let text = resp.text().await.map_err(Error::ReadFingerprint)?;
+	let bytes = hex::decode(text.trim())?;
+	bytes.try_into().map_err(|v: Vec<u8>| Error::FingerprintLength(v.len()))
 }
 
 impl Error {

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -48,6 +48,7 @@ pub enum Error {
 	#[error("invalid fingerprint")]
 	InvalidFingerprint(#[from] hex::FromHexError),
 
+	/// The fetched `http://` certificate fingerprint didn't decode to a 32-byte SHA-256 digest.
 	#[error("certificate fingerprint must be 32 bytes (SHA-256), got {0}")]
 	FingerprintLength(usize),
 
@@ -157,6 +158,13 @@ impl QuinnClient {
 		})
 	}
 
+	/// Connect to `url`, resolving TLS now that the scheme is known.
+	///
+	/// `base` is the prebuilt config for the resolved verification policy, or
+	/// `None` when no roots resolved. An eligible `http://` URL fetches
+	/// `/certificate.sha256`, pins it (rebuilding from `tls_config`, no roots
+	/// needed), and upgrades to `https://`; any other scheme reuses `base` and
+	/// surfaces [`crate::tls::Error::NoRoots`] when it is `None`.
 	pub async fn connect(
 		&self,
 		base: Option<&rustls::ClientConfig>,
@@ -184,9 +192,11 @@ impl QuinnClient {
 		// needed); anything else reuses the resolved policy, surfacing the
 		// deferred `NoRoots` when none was configured.
 		let mut config = if url.scheme() == "http" && self.http_bootstrap {
-			// Insecure per-connection bootstrap: only honored when no stronger
-			// verification is configured, so an attacker controlling the plaintext
-			// fetch can't weaken an explicit pin or re-enable disabled verification.
+			// Insecure per-connection bootstrap: an `http://` URL is a deliberate
+			// opt-in to replace CA validation with a freshly fetched pin for this
+			// connection. It's refused for an explicit `--client-tls-fingerprint`
+			// or disabled verification, so an attacker controlling the plaintext
+			// fetch can't weaken a stronger choice the user already made.
 			let pin = fetch_fingerprint(&url).await?;
 			tls_config.build_with(crate::tls::Verification::Fingerprints(vec![pin]))?
 		} else {
@@ -265,7 +275,13 @@ async fn fetch_fingerprint(url: &Url) -> Result<[u8; 32]> {
 
 	tracing::warn!(url = %fp, "performing insecure HTTP request for certificate");
 
-	let resp = reqwest::get(fp.as_str())
+	// Bound the fetch so a stalled response can't block connect indefinitely.
+	let resp = reqwest::Client::builder()
+		.timeout(crate::FINGERPRINT_FETCH_TIMEOUT)
+		.build()
+		.map_err(Error::FetchFingerprint)?
+		.get(fp.as_str())
+		.send()
 		.await
 		.map_err(Error::FetchFingerprint)?
 		.error_for_status()

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -386,9 +386,9 @@ impl Client {
 	///
 	/// Resolves the verification policy, optionally attaches a client identity
 	/// for mTLS, and installs the matching verifier. Errors with [`Error::NoRoots`]
-	/// when standard verification is selected but no roots resolved; use
-	/// [`Self::verification`] + [`Self::build_with`] to defer that decision per
-	/// connection instead.
+	/// when standard verification is selected but no roots resolved (the native
+	/// client defers that decision per connection so an `http://` bootstrap can
+	/// still pin a cert).
 	pub fn build(&self) -> Result<rustls::ClientConfig> {
 		let verification = self.verification()?.ok_or(Error::NoRoots)?;
 		self.build_with(verification)

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -238,10 +238,11 @@ struct Deprecated {
 
 /// The resolved server-certificate verification policy.
 ///
-/// Computed once by [Client::verification] and shared by every backend (the
-/// rustls-based quinn/noq via [Client::build], and quiche directly) so they
+/// Resolved once by [Client::verification] and reused by every backend (the
+/// rustls-based quinn/noq via [Client::build_with], and quiche directly) so they
 /// agree on precedence, the system-roots default, and which flag combinations
-/// are valid.
+/// are valid. A per-connection `http://` bootstrap substitutes its own
+/// [`Verification::Fingerprints`] without touching the resolved policy.
 #[derive(Clone)]
 pub(crate) enum Verification {
 	/// No verification at all. Insecure; only via `--client-tls-disable-verify`.
@@ -308,11 +309,16 @@ impl Client {
 	/// - Otherwise, verify against the system roots (default) plus any custom
 	///   roots. The system roots are dropped once a custom root is given unless
 	///   `--client-tls-system-roots` re-enables them.
-	pub(crate) fn verification(&self) -> Result<Verification> {
+	///
+	/// Returns `Ok(None)` when standard root verification is selected but no roots
+	/// resolved: WebPKI needs at least one trusted root, but the caller may still
+	/// connect if a per-connection `http://` fingerprint bootstrap replaces
+	/// verification. Callers that can't bootstrap map `None` to [`Error::NoRoots`].
+	pub(crate) fn verification(&self) -> Result<Option<Verification>> {
 		self.warn_deprecated();
 
 		if self.effective_disable_verify().unwrap_or_default() {
-			return Ok(Verification::Disabled);
+			return Ok(Some(Verification::Disabled));
 		}
 
 		let fingerprints = self.fingerprints()?;
@@ -320,7 +326,7 @@ impl Client {
 			if !self.effective_root().is_empty() || self.effective_system_roots() == Some(true) {
 				return Err(Error::FingerprintWithRoots);
 			}
-			return Ok(Verification::Fingerprints(fingerprints));
+			return Ok(Some(Verification::Fingerprints(fingerprints)));
 		}
 
 		let root = self.effective_root();
@@ -344,13 +350,13 @@ impl Client {
 			roots.extend(certs);
 		}
 
-		// WebPKI needs at least one trusted root to ever succeed, so fail fast
-		// instead of producing confusing handshake errors later.
+		// No roots resolved: defer to the caller, which may still bootstrap a pin
+		// over `http://` for a single connection.
 		if roots.is_empty() {
-			return Err(Error::NoRoots);
+			return Ok(None);
 		}
 
-		Ok(Verification::Roots(roots))
+		Ok(Some(Verification::Roots(roots)))
 	}
 
 	/// Whether an insecure `http://` certificate-fingerprint bootstrap may be
@@ -379,10 +385,24 @@ impl Client {
 	/// Build a [`rustls::ClientConfig`] from this configuration.
 	///
 	/// Resolves the verification policy, optionally attaches a client identity
-	/// for mTLS, and installs the matching verifier.
+	/// for mTLS, and installs the matching verifier. Errors with [`Error::NoRoots`]
+	/// when standard verification is selected but no roots resolved; use
+	/// [`Self::verification`] + [`Self::build_with`] to defer that decision per
+	/// connection instead.
 	pub fn build(&self) -> Result<rustls::ClientConfig> {
+		let verification = self.verification()?.ok_or(Error::NoRoots)?;
+		self.build_with(verification)
+	}
+
+	/// Build a [`rustls::ClientConfig`] for an already-resolved verification policy.
+	///
+	/// Lets the native client resolve [`Self::verification`] once, then build a
+	/// config per connection: an `http://` URL can swap in a freshly fetched pin
+	/// without any configured roots, while other connections reuse the resolved
+	/// policy. Optionally attaches a client identity for mTLS and installs the
+	/// matching verifier.
+	pub(crate) fn build_with(&self, verification: Verification) -> Result<rustls::ClientConfig> {
 		let provider = crypto::provider();
-		let verification = self.verification()?;
 
 		let mut roots = rustls::RootCertStore::empty();
 		if let Verification::Roots(certs) = &verification {
@@ -797,6 +817,18 @@ mod tests {
 			..Default::default()
 		};
 		assert!(matches!(config.build(), Err(Error::NoRoots)));
+	}
+
+	#[test]
+	fn verification_defers_no_roots() {
+		// Same roots-less config: resolution defers (Ok(None)) instead of erroring
+		// so a per-connection http:// bootstrap can still pin a fetched cert. The
+		// eager build() above is what maps that None to NoRoots.
+		let config = Client {
+			system_roots: Some(false),
+			..Default::default()
+		};
+		assert!(matches!(config.verification(), Ok(None)));
 	}
 
 	#[test]

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -39,6 +39,7 @@ pub enum Error {
 	#[error("WebSocket accept failed")]
 	Accept(#[source] qmux::Error),
 
+	/// TLS resolution failed for a secure (`wss://`) connection, e.g. no roots were configured.
 	#[error(transparent)]
 	Tls(#[from] crate::tls::Error),
 }

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -38,6 +38,9 @@ pub enum Error {
 
 	#[error("WebSocket accept failed")]
 	Accept(#[source] qmux::Error),
+
+	#[error(transparent)]
+	Tls(#[from] crate::tls::Error),
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -85,7 +88,7 @@ impl Default for Client {
 
 pub(crate) async fn race_handle(
 	config: &Client,
-	tls: &rustls::ClientConfig,
+	tls: Option<&rustls::ClientConfig>,
 	url: Url,
 	alpns: &[&str],
 ) -> Option<Result<qmux::Session>> {
@@ -109,7 +112,7 @@ pub(crate) async fn race_handle(
 
 pub(crate) async fn connect(
 	config: &Client,
-	tls: &rustls::ClientConfig,
+	tls: Option<&rustls::ClientConfig>,
 	mut url: Url,
 	alpns: &[&str],
 ) -> Result<qmux::Session> {
@@ -154,8 +157,11 @@ pub(crate) async fn connect(
 
 	tracing::debug!(%url, "connecting via WebSocket");
 
-	// Use the existing TLS config (which respects tls-disable-verify) for secure connections.
+	// Use the existing TLS config (which respects tls-disable-verify) for secure
+	// connections. Plaintext `ws://` needs no roots, so only a secure scheme
+	// surfaces the deferred [`crate::tls::Error::NoRoots`] when none resolved.
 	let connector = if needs_tls {
+		let tls = tls.ok_or(crate::tls::Error::NoRoots)?;
 		tokio_tungstenite::Connector::Rustls(Arc::new(tls.clone()))
 	} else {
 		tokio_tungstenite::Connector::Plain


### PR DESCRIPTION
Fixes #1907.

## Problem

A roots-less client configuration (`--client-tls-system-roots=false` with no `--client-tls-root` and no `--client-tls-fingerprint`) failed at **construction**, before any `connect()` could see the URL scheme:

- `client.rs::new()` called `config.tls.build()` (→ `tls::Client::verification()`) eagerly for every backend.
- `QuicheClient::new()` resolved `verification()` too.

Both returned `NoRoots` and aborted construction, even though an `http://` URL would fetch `/certificate.sha256` and pin it for that connection (bypassing CA roots). Net effect: the `http://` insecure-bootstrap path was unusable when no system/custom roots were configured. Fail-closed and niche, but a real functional limitation, consistent across quinn/noq/quiche.

## Fix

Resolve the verification policy once but defer the "no roots" decision until the URL scheme is known:

- `tls::Client::verification()` now returns `Ok(None)` for the no-roots case instead of `Err(NoRoots)`. The eager public `build()` keeps its contract by mapping `None → NoRoots`; a new `pub(crate) build_with(verification)` builds a rustls config from an already-resolved policy.
- `moq-native::Client` stores the prebuilt rustls config as `Option` (`None` = deferred) plus the `tls::Client` to rebuild a pinned config per connection.
- quinn / noq / quiche build their per-connection config once the scheme is known: an `http://` bootstrap pins a freshly fetched fingerprint (no roots needed), anything else reuses the resolved policy and surfaces `NoRoots` **at connect time**.
- The fingerprint fetch stays on the QUIC side, so the WebSocket race can still fall back over plaintext `ws://` if the fetch fails.
- The WebSocket path only needs roots for secure `wss://`; plaintext `ws://` connects without them (deferred `NoRoots` only on a secure scheme).

The fingerprint-fetch helper, previously duplicated inline in quinn/noq, is now a small `fetch_fingerprint()` in each backend returning a length-validated `[u8; 32]` (matching quiche).

## Public API

No public breaking changes. Additive only:

- `quinn::Error` / `noq::Error`: new `FingerprintLength(usize)` variant (both `#[non_exhaustive]`).
- `websocket::Error`: new `Tls(#[from] tls::Error)` variant (`#[non_exhaustive]`).

`tls::Client::build()` (used by `moq-relay`) is unchanged in signature and behavior. `verification()` / `build_with()` are `pub(crate)`.

## Test plan

- [x] `cargo test -p moq-native` (57 integration + 46 lib) green.
- [x] New `tls::verification_defers_no_roots` (resolution returns `Ok(None)`, `build()` still `NoRoots`).
- [x] New `client::init_defers_no_roots` (roots-less `init()` now succeeds instead of erroring at construction).
- [x] `cargo check`/`clippy` across default, noq, and quiche feature sets; `cargo check -p moq-relay`.
- [ ] Not e2e-tested against a live self-signed relay over `http://`.

(Written by Claude Opus 4.8)
