### PR TITLE
moq-rtc: abort sessions that never receive ICE candidates

### DIFF
--- a/rs/moq-rtc/src/error.rs
+++ b/rs/moq-rtc/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
 	#[error("session closed")]
 	SessionClosed,
 
+	#[error("ICE did not connect before the establishment deadline")]
+	IceTimeout,
+
 	#[error("io error: {0}")]
 	Io(#[from] std::io::Error),
 

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -13,7 +13,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use str0m::{Event, IceConnectionState, Input, Output, Rtc, net::Receive};
 use tokio::net::UdpSocket;
@@ -38,6 +38,22 @@ pub(crate) const SESSION_INBOX: usize = 256;
 /// large keyframe and the rest of the current group via NACK; see
 /// [`rtc_config_with_codecs`].
 const EGRESS_SEND_BUFFER_VIDEO: usize = 3000;
+
+/// Backstop deadline for a session to reach a connected ICE state, covering the one
+/// case str0m's ICE agent deliberately never times out: a peer that answers the SDP
+/// but provides NO remote candidates and sends nothing (an abandoned WHIP/WHEP
+/// offer, or a probe that only exercises signalling). str0m DOES end a connection
+/// whose candidate pairs were tried and exhausted -- the agent goes to
+/// `IceConnectionState::Disconnected` (handled in `handle_event`) after
+/// ~`StunTiming::timeout()` (~21s at the defaults). But when `remote_candidates`
+/// stays empty the agent treats the session as "still possible" forever (trickle
+/// ICE: more candidates could arrive), so it sits in `Checking` indefinitely,
+/// pinning this task, its broadcast announcement, and its mux registration. Nothing
+/// upstream ends it, so we do. Set ABOVE str0m's ~21s pair-exhaustion so a
+/// connection that actually started checks is ended by str0m's native path (and a
+/// slow-but-real TURN/lossy peer isn't clipped); this only fires for the
+/// never-any-candidate case.
+const ICE_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Receives `MediaData` events from str0m and dispatches to the right codec
 /// [`Bridge`](codec::Bridge). Used as the per-session sink in [`Session::run`]
@@ -144,6 +160,8 @@ impl Session {
 	}
 
 	pub async fn run(mut self) -> Result<()> {
+		let started = Instant::now();
+		let mut connected = false;
 		loop {
 			// A dead Rtc (DTLS/SDP failure, explicit disconnect) makes poll_output
 			// return a never-firing timeout instead of erroring, which would hang
@@ -151,6 +169,12 @@ impl Session {
 			// registration. Bail so those release.
 			if !self.rtc.is_alive() {
 				return Err(Error::SessionClosed);
+			}
+
+			// Abort a session that never finishes connecting (see
+			// ICE_ESTABLISH_TIMEOUT); once connected, str0m's own timeouts take over.
+			if !connected && started.elapsed() >= ICE_ESTABLISH_TIMEOUT {
+				return Err(Error::IceTimeout);
 			}
 
 			let timeout = match self.rtc.poll_output().map_err(Error::Rtc)? {
@@ -162,13 +186,21 @@ impl Session {
 					continue;
 				}
 				Output::Event(event) => {
+					if let Event::IceConnectionStateChange(state) = &event {
+						connected |= state.is_connected();
+					}
 					self.handle_event(event)?;
 					continue;
 				}
 			};
 
 			let now = Instant::now();
-			let duration = timeout.saturating_duration_since(now);
+			let mut duration = timeout.saturating_duration_since(now);
+			// While still connecting, never sleep past the establishment deadline, so
+			// the check above fires on time even if str0m scheduled a far-off timeout.
+			if !connected {
+				duration = duration.min(ICE_ESTABLISH_TIMEOUT.saturating_sub(started.elapsed()));
+			}
 			if duration.is_zero() {
 				self.rtc.handle_input(Input::Timeout(now)).map_err(Error::Rtc)?;
 				continue;
@@ -333,6 +365,9 @@ impl IngestClock {
 pub(crate) fn log_session_end(role: &str, result: Result<()>) {
 	match result {
 		Ok(()) | Err(Error::SessionClosed) => tracing::debug!(role, "session ended"),
+		// An abandoned offer (peer answered but never connected) is normal churn, not
+		// a failure: keep it out of the warning stream.
+		Err(Error::IceTimeout) => tracing::debug!(role, "session ended: ICE never connected"),
 		Err(err) => tracing::warn!(%err, role, "session ended"),
 	}
 }


### PR DESCRIPTION
## Problem

str0m already ends a WebRTC connection whose candidate pairs were tried and failed: once every pair exhausts its STUN retransmits the ICE agent (`is`) transitions to `IceConnectionState::Disconnected` (~21s at the default `StunTiming`), which `Session::run` maps to `SessionClosed`.

What it does **not** end -- deliberately, for trickle ICE -- is a session that never received any remote candidate. `evaluate_state` forces `any_still_possible = true` whenever `remote_candidates` is empty ("more candidates may yet arrive"), so a peer that answers the SDP and then sends nothing -- an abandoned WHIP/WHEP offer, or a probe that only exercises the signalling contract -- sits in `Checking` forever. The task lives indefinitely holding its broadcast announcement + mux registration; accumulated stuck sessions peg the CPU. (str0m's own `chat.rs`/`http-post.rs` examples have the same gap -- they only react to `Disconnected` -- so the application is expected to bound this.)

## Fix

Add a backstop: track whether ICE ever connected and bail with a new `Error::IceTimeout` if not within `ICE_ESTABLISH_TIMEOUT`. Set it (30s) **above** str0m's ~21s pair-exhaustion so a connection that actually started checks is still ended by str0m's native `Disconnected` path (and a slow-but-real TURN/lossy peer isn't clipped) -- this only fires for the never-any-candidate case. Clamp the `select` sleep to the deadline so the check fires even when str0m scheduled a far-off timeout. Logged as ordinary churn (debug).

## Verification

`cargo build`/`clippy`/`test -p moq-rtc` clean. Against a live dev edge: six abandoned WHIP offers + three WHEP offers were each torn down with `session ended: ICE never connected` ~the deadline after creation; before the change they never ended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)