### PR TITLE
fix(moq-js/watch): improve fullscreen media layout and touch controls

### DIFF
--- a/js/watch/src/ui/element.ts
+++ b/js/watch/src/ui/element.ts
@@ -83,12 +83,71 @@ export default class MoqWatchUi extends HTMLElement {
 		player.append(scrimTop, center, chrome, panel);
 		DOM.render(effect, this.#root, player);
 
-		this.#wireChrome(effect, watch, state, player);
+		this.#fitMedia(effect, watch, player);
+		this.#wireChrome(effect, watch, state, player, chrome, panel);
+	}
+
+	#fullscreen(player: HTMLElement): boolean {
+		const doc = document as Document & { webkitFullscreenElement?: Element | null };
+		// Firefox reports shadow fullscreen on the shadow root.
+		const root = this.#root as ShadowRoot & { fullscreenElement?: Element | null };
+		return (
+			root.fullscreenElement === player ||
+			document.fullscreenElement === player ||
+			doc.webkitFullscreenElement === player ||
+			player.classList.contains("player--pseudo-fullscreen")
+		);
+	}
+
+	#fitMedia(effect: Effect, watch: MoqWatch, player: HTMLElement) {
+		const apply = () => {
+			const media = watch.querySelector("canvas, video") as HTMLElement | null;
+			if (!media) return;
+			const fullscreen = this.#fullscreen(player);
+
+			watch.style.width = "100%";
+			watch.style.height = fullscreen ? "100%" : "";
+
+			media.style.width = "100%";
+			media.style.height = fullscreen ? "100%" : "auto";
+			media.style.maxWidth = "100%";
+			media.style.maxHeight = "100%";
+			media.style.objectFit = "contain";
+		};
+
+		const observer = new MutationObserver(apply);
+		observer.observe(watch, { childList: true, subtree: true });
+
+		const playerObserver = new MutationObserver(apply);
+		playerObserver.observe(player, { attributes: true, attributeFilter: ["class"] });
+
+		effect.cleanup(() => observer.disconnect());
+		effect.cleanup(() => playerObserver.disconnect());
+
+		effect.event(document, "fullscreenchange", apply);
+		effect.event(document, "webkitfullscreenchange", apply);
+		effect.event(this.#root, "fullscreenchange", apply);
+		apply();
 	}
 
 	// Show the chrome on activity, auto-hide while playing once the pointer
 	// settles. Stays pinned while paused or when the settings panel is open.
-	#wireChrome(effect: Effect, watch: MoqWatch, state: UiState, player: HTMLElement) {
+	#wireChrome(
+		effect: Effect,
+		watch: MoqWatch,
+		state: UiState,
+		player: HTMLElement,
+		chrome: HTMLElement,
+		panel: HTMLElement,
+	) {
+		// Mobile devices don't support hover, so the controls remain visible in non-fullscreen mode.
+		// In fullscreen mode, tap the video to toggle the controls.
+		const touchUi = window.matchMedia("(pointer: coarse)").matches || window.matchMedia("(hover: none)").matches;
+		if (touchUi) {
+			this.#wireTouchChrome(effect, state, player, chrome, panel);
+			return;
+		}
+
 		// Bump on any pointer/focus activity to re-arm the auto-hide.
 		const activity = new Signal(0);
 		const bump = () => activity.update((n) => n + 1);
@@ -113,6 +172,31 @@ export default class MoqWatchUi extends HTMLElement {
 			if (pinned()) return;
 			state.chrome.set(false);
 		});
+
+		effect.run((e) => {
+			player.classList.toggle("player--chrome", e.get(state.chrome));
+		});
+	}
+
+	#wireTouchChrome(effect: Effect, state: UiState, player: HTMLElement, chrome: HTMLElement, panel: HTMLElement) {
+		state.chrome.set(true);
+
+		const interactive = (event: Event) =>
+			event.composedPath().some((target) => target === chrome || target === panel);
+
+		effect.event(player, "pointerdown", (event) => {
+			if (interactive(event)) return;
+			if (this.#fullscreen(player)) {
+				state.chrome.update((shown) => !shown);
+			} else {
+				state.chrome.set(true);
+			}
+		});
+
+		const showChrome = () => state.chrome.set(true);
+		effect.event(document, "fullscreenchange", showChrome);
+		effect.event(document, "webkitfullscreenchange", showChrome);
+		effect.event(this.#root, "fullscreenchange", showChrome);
 
 		effect.run((e) => {
 			player.classList.toggle("player--chrome", e.get(state.chrome));

--- a/js/watch/src/ui/styles/player.css
+++ b/js/watch/src/ui/styles/player.css
@@ -5,6 +5,9 @@
 
 .player {
 	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: 100%;
 	overflow: hidden;
 	border-radius: var(--spacing-8);
@@ -16,6 +19,7 @@
 .player ::slotted(moq-watch) {
 	display: block;
 	width: 100%;
+	line-height: 0;
 }
 
 /* Hide the cursor along with the chrome while playing. */
@@ -47,10 +51,19 @@
 	z-index: 2147483647;
 }
 
+/* Avoid mobile browser bars overlapping pseudo fullscreen controls. */
+@supports (height: 100dvh) {
+	.player--pseudo-fullscreen {
+		height: 100dvh;
+	}
+}
+
 .player:fullscreen ::slotted(moq-watch),
 /* stylelint-disable-next-line selector-no-vendor-prefix -- Safari/iPadOS fallback */
 .player:-webkit-full-screen ::slotted(moq-watch),
 .player--pseudo-fullscreen ::slotted(moq-watch) {
+	width: 100%;
+	height: 100%;
 	max-height: 100%;
 }
 


### PR DESCRIPTION
## Summary

- Fit watch media with `object-fit: contain` during fullscreen and pseudo-fullscreen playback.
- Keep watch controls visible on touch devices so they can be tapped reliably on mobile phone.
- Allow tapping the video area to show or hide controls while fullscreen.
- Use `100dvh` for pseudo fullscreen when supported, with the existing `100vh` fallback.

## Why

Mobile screen capture streams can have portrait or near-portrait resolutions. In fullscreen playback, these streams could be stretched or clipped. This change keeps the layout fix scoped to fullscreen media fitting, so the normal watch layout is left mostly unchanged.

Touch devices also do not have the same hover behavior as desktop browsers. The existing chrome behavior could make the controls hard to reveal and tap. To keep the change small, touch devices keep the controls visible outside fullscreen. In fullscreen, tapping the video area toggles the controls, while taps inside the control bar or settings panel continue to work normally.

## Test 
I checked fullscreen video fitting in Chrome, Firefox, and Safari on desktop,and checked the touch control behavior on iOS Safari and iOS Chrome, including showing/hiding the controls and entering fullscreen.


safari
<img width="1280" height="2774" alt="37adce8ea465227f9ae6614fa66e75be" src="https://github.com/user-attachments/assets/c9d380a2-9fec-49b6-84f6-3d6fc90d7f48" />
<img width="1280" height="2774" alt="b5a8739d2ac6013a4575a2d1a8586197" src="https://github.com/user-attachments/assets/6ad90ecd-c4f5-42a2-a1a2-f757dd4cdc27" />

chrome
<img width="1280" height="2774" alt="6d8d5f1b6dad941dc3dbe0aa4e934084" src="https://github.com/user-attachments/assets/7b17aa74-e647-46a9-9c68-9129d531b65b" />
<img width="1280" height="2774" alt="8936b45137d3a531084e28af0710ec03" src="https://github.com/user-attachments/assets/f75f87e6-0b4c-4e16-bbd9-55f3c52c7eaa" />

safari
<img width="1280" height="2774" alt="c0032a18871a087e20cba1f68f8b1272" src="https://github.com/user-attachments/assets/6cccc517-0c3e-4891-a5c0-20ca807581ff" />
<img width="1280" height="2774" alt="5589c60ef330314832a92825e2eec60e" src="https://github.com/user-attachments/assets/a484b6d0-3e7d-4b45-a291-629ac9abd4a2" />


