### PR TITLE
fix(js/net): bump @moq/qmux to 0.1.3 to fix reconnect hang

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "moq",
@@ -178,7 +179,7 @@
       "name": "@moq/net",
       "version": "0.1.5",
       "dependencies": {
-        "@moq/qmux": "^0.0.6",
+        "@moq/qmux": "^0.1.3",
         "@moq/signals": "workspace:*",
         "async-mutex": "^0.5.0",
       },
@@ -577,7 +578,7 @@
 
     "@moq/publish": ["@moq/publish@workspace:js/publish"],
 
-    "@moq/qmux": ["@moq/qmux@0.0.6", "", {}, "sha512-ISuGz05lUvf1hzHW3Aw3VnsGRJe1w9Qdog3LQ66KS+l+5mzQsPANvW8yOioEe1Z9dJO2G3sAHoGPnzwnsY9SIQ=="],
+    "@moq/qmux": ["@moq/qmux@0.1.3", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.0" } }, "sha512-naGmMMOxCSMeLyEATrLiY9RGyeZENC4dHFVVNWNcA17LXE9NwM3aQrQY218xXypWahYIgIkl/ZCutIP2xHibgA=="],
 
     "@moq/signals": ["@moq/signals@workspace:js/signals"],
 
@@ -588,6 +589,8 @@
     "@moq/token": ["@moq/token@workspace:js/token"],
 
     "@moq/watch": ["@moq/watch@workspace:js/watch"],
+
+    "@moq/web-socket-stream": ["@moq/web-socket-stream@0.1.0", "", {}, "sha512-VxPaJZvZ8qgFmTjG9XhTH0bQoQE9pExvlS/R0fH1aNcpqCnZdbYS2kvB2ypO5SyFTf6oH+4eWvgElDzW6yiqFQ=="],
 
     "@moq/web-transport": ["@moq/web-transport@0.1.3", "", { "optionalDependencies": { "@moq/web-transport-darwin-arm64": "0.1.3", "@moq/web-transport-darwin-x64": "0.1.3", "@moq/web-transport-linux-arm64-gnu": "0.1.3", "@moq/web-transport-linux-x64-gnu": "0.1.3", "@moq/web-transport-win32-x64-msvc": "0.1.3" } }, "sha512-hg3mKWUJaEwtJDGf8Ck62XP8ya+7wyMV/9ycV1A+M3iVly3xBOTPHpT8BrpOLomsBIB9iXQY6Z85MjknhUJW8w=="],
 

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -17,7 +17,7 @@
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {
-		"@moq/qmux": "^0.0.6",
+		"@moq/qmux": "^0.1.3",
 		"@moq/signals": "workspace:*",
 		"async-mutex": "^0.5.0"
 	},

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -424,30 +424,14 @@ async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>):
 
 	const quic = new Session(url);
 
-	// Race connecting against losing the cancel race or closing before we ever
-	// opened. A rejected `ready` (refused/failed) maps to "closed" so the cleanup
-	// path still runs; the separate `closed` arm covers Session versions that
-	// resolve `closed` but never reject `ready`, which would otherwise hang here
-	// forever and stop the caller from retrying.
-	const result = await Promise.race([
-		quic.ready.then(
-			() => "ready" as const,
-			() => "closed" as const,
-		),
-		quic.closed.then(
-			() => "closed" as const,
-			() => "closed" as const,
-		),
-		cancel.then(() => "cancel" as const),
-	]);
-	if (result === "ready") return quic;
+	// Wait for the WebSocket to connect, or for the cancel promise to resolve.
+	// `ready` rejects on a refused/failed connection, so a throw here is the caller's
+	// cue to retry; a lost cancel race instead resolves and we close the loser.
+	const loaded = await Promise.race([quic.ready.then(() => true), cancel]);
+	if (!loaded) {
+		quic.close();
+		return undefined;
+	}
 
-	quic.close();
-
-	// Lost the race to another transport: return undefined so the winner proceeds.
-	if (result === "cancel") return undefined;
-
-	// Genuine failure: throw so `Promise.any` ignores us and waits on (or fails
-	// alongside) the other transport, letting the reconnect loop retry.
-	throw new Error("WebSocket closed before connecting");
+	return quic;
 }

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -425,11 +425,15 @@ async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>):
 	const quic = new Session(url);
 
 	// Race connecting against losing the cancel race or closing before we ever
-	// opened. The `closed` arm matters because some Session versions resolve
-	// `closed` but never reject `ready` on a refused connection; without it a
-	// failed attempt would hang here forever and the caller could never retry.
+	// opened. A rejected `ready` (refused/failed) maps to "closed" so the cleanup
+	// path still runs; the separate `closed` arm covers Session versions that
+	// resolve `closed` but never reject `ready`, which would otherwise hang here
+	// forever and stop the caller from retrying.
 	const result = await Promise.race([
-		quic.ready.then(() => "ready" as const),
+		quic.ready.then(
+			() => "ready" as const,
+			() => "closed" as const,
+		),
 		quic.closed.then(
 			() => "closed" as const,
 			() => "closed" as const,

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -424,13 +424,26 @@ async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>):
 
 	const quic = new Session(url);
 
-	// Wait for the WebSocket to connect, or for the cancel promise to resolve.
-	// Close the connection if we lost the race.
-	const loaded = await Promise.race([quic.ready.then(() => true), cancel]);
-	if (!loaded) {
-		quic.close();
-		return undefined;
-	}
+	// Race connecting against losing the cancel race or closing before we ever
+	// opened. The `closed` arm matters because some Session versions resolve
+	// `closed` but never reject `ready` on a refused connection; without it a
+	// failed attempt would hang here forever and the caller could never retry.
+	const result = await Promise.race([
+		quic.ready.then(() => "ready" as const),
+		quic.closed.then(
+			() => "closed" as const,
+			() => "closed" as const,
+		),
+		cancel.then(() => "cancel" as const),
+	]);
+	if (result === "ready") return quic;
 
-	return quic;
+	quic.close();
+
+	// Lost the race to another transport: return undefined so the winner proceeds.
+	if (result === "cancel") return undefined;
+
+	// Genuine failure: throw so `Promise.any` ignores us and waits on (or fails
+	// alongside) the other transport, letting the reconnect loop retry.
+	throw new Error("WebSocket closed before connecting");
 }


### PR DESCRIPTION
## Summary

A browser client pointed at a relay that is down tried to connect **exactly once** and then sat idle, never retrying, despite `Reload`'s exponential-backoff loop.

Root cause: the pinned `@moq/qmux@0.0.6` never *rejects* its `Session.ready` promise on a refused connection — its `#close()` only resolves `closed`, leaving `ready` pending forever. So the WebSocket fallback's `await quic.ready` hung. When the relay is down the WebTransport attempt rejects promptly (the `certificate.sha256` fetch fails with `ERR_CONNECTION_REFUSED`), leaving the hung WebSocket as the only outstanding arm of `connect()`'s `Promise.any`, which therefore never settled → `connect()` never rejected → the reconnect loop never fired.

## Fix

Bump `@moq/qmux` `0.0.6` → `^0.1.3`. qmux 0.1.3 rejects `ready` on a failed connection, fixing the hang at the source. (It only became installable once its `@moq/web-socket-stream` dependency was published — see [moq-dev/web-transport#272](https://github.com/moq-dev/web-transport/pull/272).)

With qmux behaving correctly, `connectWebSocket` keeps its simple `Promise.race([ready, cancel])` shape: a rejected `ready` throws, which `connect()`'s `Promise.any` ignores so it waits on (or fails alongside) the WebTransport attempt, letting `Reload` retry with backoff. The only `connect.ts` change is a clarifying comment documenting that we now rely on `ready` rejecting.

> Earlier iterations of this PR added a defensive `quic.closed` race in `connectWebSocket` to tolerate the buggy 0.0.6 behavior. That's now unnecessary — the bump fixes it properly — so the workaround was reverted in favor of trusting the dependency.

## Public API

No public API or wire changes. `@moq/qmux` is an internal transport dependency of `@moq/net`.

## Test plan

- [x] `tsc --noEmit` clean on `js/net` against qmux 0.1.3
- [x] `bun test` — 153 pass / 0 fail
- [x] `biome check` clean
- [ ] Manual: watch against a down relay keeps retrying with backoff (instead of stopping after one attempt); bring the relay up and confirm it connects.

(Written by Claude Opus 4.8)