### PR TITLE
docs(moq-native): fix rustdoc links to quinn-gated items under default features

### DIFF
--- a/rs/moq-native/src/error.rs
+++ b/rs/moq-native/src/error.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 /// Errors produced while configuring or establishing native MoQ connections.
 ///
 /// Backend-specific failures live in per-backend error types ([`crate::tls::Error`],
-/// [`crate::quinn::Error`], etc.). They're wrapped in `Arc` here so the aggregate
+/// the per-backend `Error` types, etc.). They're wrapped in `Arc` here so the aggregate
 /// stays `Clone` even though the underlying transport/IO errors are not.
 #[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -281,7 +281,7 @@ impl Server {
 
 	/// Returns the next partially established QUIC or WebTransport session.
 	///
-	/// This returns a [Request] instead of a [web_transport_quinn::Session]
+	/// This returns a [Request] instead of an established `web_transport` session
 	/// so the connection can be rejected early on an invalid path or missing auth.
 	///
 	/// The [Request] is either a WebTransport or a raw QUIC request.


### PR DESCRIPTION
## Summary

`cargo doc -p moq-native --no-deps` with default features fails under `RUSTDOCFLAGS="-D warnings"` because two doc comments link to items that only exist behind the non-default `quinn` feature. Dev commit ec405f552 made the `noq` backend the default and gated `pub mod quinn` behind `#[cfg(feature = "quinn")]`, so the links no longer resolve under default features.

This makes the local inner-loop `just check` (which docs the workspace with default features, `rs/justfile:20`) red even on a clean `dev`. CI's `just rs ci` uses `--all-features`, so it stayed green there.

Broken links:
- `rs/moq-native/src/error.rs` — `` [`crate::quinn::Error`] `` in the `Error` enum doc.
- `rs/moq-native/src/server.rs` — `[web_transport_quinn::Session]` in `accept`'s doc.

Both are reworded to plain backtick text so nothing needs the `quinn` feature to resolve.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-native --no-deps` passes (previously failed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-native --no-deps --all-features` still passes

No public API or wire change; documentation-only.

(Written by Claude Opus 4.8)