### PR TITLE
moq-rtc: emit a valid rejected m-line in SDP answers

### DIFF
--- a/rs/moq-rtc/src/sdp.rs
+++ b/rs/moq-rtc/src/sdp.rs
@@ -18,7 +18,7 @@ pub fn parse_offer(body: &str) -> Result<str0m::change::SdpOffer> {
 ///
 /// str0m can emit a *rejected* media line (port 0) with an EMPTY format list,
 /// e.g. `m=audio 0 UDP/TLS/RTP/SAVPF `. This happens when we restrict the
-/// `CodecConfig` (see [`session::rtc_config_with_codecs`]) and the peer's offer
+/// `CodecConfig` (see [`crate::session::rtc_config_with_codecs`]) and the peer's offer
 /// carries a codec the broadcast can't egress -- the classic case being AAC
 /// audio over WHEP, which we can't carry, so the audio m-line comes back
 /// rejected with no payload. An m-line with no `<fmt>` violates RFC 4566, and a

--- a/rs/moq-rtc/src/sdp.rs
+++ b/rs/moq-rtc/src/sdp.rs
@@ -74,8 +74,14 @@ mod tests {
 	#[test]
 	fn rejected_mline_with_no_format_gets_placeholder() {
 		// str0m's malformed rejected audio line.
-		assert_eq!(ensure_media_format("m=audio 0 UDP/TLS/RTP/SAVPF "), "m=audio 0 UDP/TLS/RTP/SAVPF 0");
-		assert_eq!(ensure_media_format("m=audio 0 UDP/TLS/RTP/SAVPF"), "m=audio 0 UDP/TLS/RTP/SAVPF 0");
+		assert_eq!(
+			ensure_media_format("m=audio 0 UDP/TLS/RTP/SAVPF "),
+			"m=audio 0 UDP/TLS/RTP/SAVPF 0"
+		);
+		assert_eq!(
+			ensure_media_format("m=audio 0 UDP/TLS/RTP/SAVPF"),
+			"m=audio 0 UDP/TLS/RTP/SAVPF 0"
+		);
 	}
 
 	#[test]

--- a/rs/moq-rtc/src/sdp.rs
+++ b/rs/moq-rtc/src/sdp.rs
@@ -4,6 +4,7 @@
 //! request/response bodies. The only thing we add on top of str0m's offer/answer
 //! parse/serialize is a tiny wrapper to keep the call sites readable.
 
+use std::borrow::Cow;
 use std::str::FromStr;
 
 use crate::{Error, Result};
@@ -14,8 +15,39 @@ pub fn parse_offer(body: &str) -> Result<str0m::change::SdpOffer> {
 }
 
 /// Serialize an SDP answer for the `application/sdp` response body.
+///
+/// str0m can emit a *rejected* media line (port 0) with an EMPTY format list,
+/// e.g. `m=audio 0 UDP/TLS/RTP/SAVPF `. This happens when we restrict the
+/// `CodecConfig` (see [`session::rtc_config_with_codecs`]) and the peer's offer
+/// carries a codec the broadcast can't egress -- the classic case being AAC
+/// audio over WHEP, which we can't carry, so the audio m-line comes back
+/// rejected with no payload. An m-line with no `<fmt>` violates RFC 4566, and a
+/// browser rejects the WHOLE answer in `setRemoteDescription`, killing playback
+/// of the media (e.g. video) that WAS negotiated. So we give any such line a
+/// placeholder static payload; the media stays rejected (port 0), so the
+/// placeholder is never used.
 pub fn render_answer(answer: &str0m::change::SdpAnswer) -> String {
-	answer.to_sdp_string()
+	// SDP uses CRLF line endings (RFC 4566); splitting and rejoining on "\r\n"
+	// round-trips exactly, including the trailing CRLF.
+	answer
+		.to_sdp_string()
+		.split("\r\n")
+		.map(ensure_media_format)
+		.collect::<Vec<Cow<str>>>()
+		.join("\r\n")
+}
+
+/// Give an `m=` line a placeholder format payload when it has none (see
+/// [`render_answer`]); every other line passes through untouched.
+fn ensure_media_format(line: &str) -> Cow<'_, str> {
+	if !line.starts_with("m=") {
+		return Cow::Borrowed(line);
+	}
+	// m=<media> <port> <proto> <fmt>...; fewer than 4 tokens means no <fmt>.
+	if line.split_whitespace().count() >= 4 {
+		return Cow::Borrowed(line);
+	}
+	Cow::Owned(format!("{} 0", line.trim_end()))
 }
 
 /// Build a stable WHIP/WHEP resource identifier from a UUID v4.
@@ -33,4 +65,24 @@ pub fn parse_resource_id(path: &str) -> Result<uuid::Uuid> {
 		.find(|s| !s.is_empty())
 		.ok_or_else(|| Error::InvalidSdp("missing resource id".into()))?;
 	uuid::Uuid::from_str(last).map_err(|err| Error::InvalidSdp(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::ensure_media_format;
+
+	#[test]
+	fn rejected_mline_with_no_format_gets_placeholder() {
+		// str0m's malformed rejected audio line.
+		assert_eq!(ensure_media_format("m=audio 0 UDP/TLS/RTP/SAVPF "), "m=audio 0 UDP/TLS/RTP/SAVPF 0");
+		assert_eq!(ensure_media_format("m=audio 0 UDP/TLS/RTP/SAVPF"), "m=audio 0 UDP/TLS/RTP/SAVPF 0");
+	}
+
+	#[test]
+	fn well_formed_lines_are_untouched() {
+		let video = "m=video 9 UDP/TLS/RTP/SAVPF 96 97";
+		assert_eq!(ensure_media_format(video), video);
+		let attr = "a=ice-ufrag:abcd";
+		assert_eq!(ensure_media_format(attr), attr);
+	}
 }


### PR DESCRIPTION
## Problem

When `moq-rtc` restricts the `CodecConfig` to the codecs a broadcast can egress (`session::rtc_config_with_codecs`) and the peer's offer carries one we can't carry, str0m answers with that media line **rejected** (port 0) but with an **empty format list**, e.g.:

```
m=audio 0 UDP/TLS/RTP/SAVPF
```

The classic trigger is AAC audio over WHEP (we can't carry AAC), so a player offering audio+video gets the audio m-line rejected. An m-line with no `<fmt>` violates RFC 4566, and browsers reject the **whole** answer in `setRemoteDescription` — killing playback of the media (e.g. video) that *was* negotiated. In practice this means a WHEP player gets nothing instead of video-only.

## Fix

`render_answer` now gives any format-less m-line a placeholder static payload (`0`). The media stays rejected (port 0), so the placeholder is never used — the answer just parses. This is the single serialization chokepoint shared by both WHEP and WHIP, so it covers both.

Unit-tested (malformed line gets the placeholder; well-formed lines untouched).

## Verification

Confirmed against a running gateway: a WHEP player offering audio+video for an AAC-audio broadcast now receives `m=audio 0 UDP/TLS/RTP/SAVPF 0` and `setRemoteDescription` succeeds (video negotiates), where before the browser threw `Failed to parse SessionDescription`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)