### PR TITLE
moq-mux/moq-rtc: report + drop incompatible egress renditions

### DIFF
--- a/rs/moq-mux/src/compat.rs
+++ b/rs/moq-mux/src/compat.rs
@@ -1,0 +1,216 @@
+//! Codec compatibility helpers shared by the egress muxers and the RTP egress.
+//!
+//! Each egress format (MPEG-TS, FLV/RTMP, WebRTC) can only carry a subset of the
+//! codecs a hang catalog might contain. When a broadcast carries a codec a given
+//! format can't, that rendition is *dropped*: the rest still egresses, and the
+//! gateway reports the drop so the dashboard can flag the incompatibility (e.g.
+//! "AAC audio can't go over WebRTC, use Opus").
+
+use std::time::Duration;
+
+use anyhow::Context;
+use hang::catalog::{AudioCodec, VideoCodec};
+
+use crate::catalog::hang::{Catalog, CatalogExt};
+
+/// An egress protocol, used to pick the codec set it can carry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Protocol {
+	/// WebRTC / WHEP.
+	Webrtc,
+	/// FLV / RTMP (enhanced-RTMP FourCCs included).
+	Flv,
+	/// MPEG-TS (SRT).
+	Ts,
+}
+
+/// Whether `protocol` can carry this audio codec on egress.
+pub fn carries_audio(protocol: Protocol, codec: &AudioCodec) -> bool {
+	match protocol {
+		Protocol::Webrtc => matches!(codec, AudioCodec::Opus),
+		Protocol::Flv => matches!(
+			codec,
+			AudioCodec::AAC(_) | AudioCodec::Opus | AudioCodec::Ac3 | AudioCodec::Ec3
+		),
+		Protocol::Ts => matches!(
+			codec,
+			AudioCodec::AAC(_) | AudioCodec::Mp2 | AudioCodec::Ac3 | AudioCodec::Ec3
+		),
+	}
+}
+
+/// Whether `protocol` can carry this video codec on egress.
+pub fn carries_video(protocol: Protocol, codec: &VideoCodec) -> bool {
+	match protocol {
+		Protocol::Webrtc => matches!(
+			codec,
+			VideoCodec::H264(_) | VideoCodec::H265(_) | VideoCodec::VP8 | VideoCodec::VP9(_) | VideoCodec::AV1(_)
+		),
+		Protocol::Flv => matches!(
+			codec,
+			VideoCodec::H264(_) | VideoCodec::H265(_) | VideoCodec::AV1(_) | VideoCodec::VP9(_)
+		),
+		Protocol::Ts => matches!(codec, VideoCodec::H264(_) | VideoCodec::H265(_)),
+	}
+}
+
+/// Renditions in `catalog` that `protocol` can't carry.
+pub fn classify<E: CatalogExt>(catalog: &Catalog<E>, protocol: Protocol) -> Vec<DroppedTrack> {
+	let mut out = Vec::new();
+	for r in catalog.audio.renditions.values() {
+		if !carries_audio(protocol, &r.codec) {
+			out.push(DroppedTrack::audio(&r.codec));
+		}
+	}
+	for r in catalog.video.renditions.values() {
+		if !carries_video(protocol, &r.codec) {
+			out.push(DroppedTrack::video(&r.codec));
+		}
+	}
+	out
+}
+
+/// Resolve the broadcast at `path`, read its catalog, and report the renditions
+/// `protocol` can't carry. Best-effort and bounded: if the broadcast or its
+/// catalog doesn't resolve quickly, returns empty rather than blocking egress.
+///
+/// For egress paths that hand the muxer/peer back the dropped set directly (WHEP's
+/// `Response::dropped`, the TS exporter's `Export::dropped`), prefer that. This is
+/// for the RTMP path, whose serve owns the exporter and can't surface it mid-session.
+pub async fn dropped_for(origin: &moq_net::OriginConsumer, path: &str, protocol: Protocol) -> Vec<DroppedTrack> {
+	let fetch = async {
+		let broadcast = origin
+			.request_broadcast(path)
+			.await
+			.context("resolve broadcast for compat check")?;
+		let track = broadcast.subscribe_track(&moq_net::Track::new(hang::Catalog::DEFAULT_NAME))?;
+		let mut consumer = crate::catalog::hang::Consumer::<()>::new(track);
+		let catalog = consumer.next().await?.context("catalog closed before snapshot")?;
+		anyhow::Ok(classify(&catalog, protocol))
+	};
+	match tokio::time::timeout(Duration::from_secs(3), fetch).await {
+		Ok(Ok(dropped)) => dropped,
+		Ok(Err(err)) => {
+			tracing::debug!(%err, "compat check skipped");
+			Vec::new()
+		}
+		Err(_) => {
+			tracing::debug!("compat check timed out");
+			Vec::new()
+		}
+	}
+}
+
+/// Which half of the catalog a dropped track came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrackKind {
+	Audio,
+	Video,
+}
+
+/// A catalog rendition an egress format can't carry, surfaced for reporting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DroppedTrack {
+	pub kind: TrackKind,
+	/// Friendly codec label, e.g. "AAC", "Opus", "VP8".
+	pub codec: String,
+}
+
+impl DroppedTrack {
+	pub fn audio(codec: &AudioCodec) -> Self {
+		Self {
+			kind: TrackKind::Audio,
+			codec: audio_codec_name(codec),
+		}
+	}
+
+	pub fn video(codec: &VideoCodec) -> Self {
+		Self {
+			kind: TrackKind::Video,
+			codec: video_codec_name(codec),
+		}
+	}
+}
+
+/// Short human label for an audio codec (for incompatibility messages).
+pub fn audio_codec_name(codec: &AudioCodec) -> String {
+	match codec {
+		AudioCodec::AAC(_) => "AAC".into(),
+		AudioCodec::Opus => "Opus".into(),
+		AudioCodec::Mp2 => "MP2".into(),
+		AudioCodec::Ac3 => "AC-3".into(),
+		AudioCodec::Ec3 => "E-AC-3".into(),
+		AudioCodec::Unknown(s) => s.clone(),
+		_ => "unknown audio".into(),
+	}
+}
+
+/// Short human label for a video codec (for incompatibility messages).
+pub fn video_codec_name(codec: &VideoCodec) -> String {
+	match codec {
+		VideoCodec::H264(_) => "H.264".into(),
+		VideoCodec::H265(_) => "H.265".into(),
+		VideoCodec::VP8 => "VP8".into(),
+		VideoCodec::VP9(_) => "VP9".into(),
+		VideoCodec::AV1(_) => "AV1".into(),
+		VideoCodec::Unknown(s) => s.clone(),
+		_ => "unknown video".into(),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::str::FromStr;
+
+	use super::*;
+
+	fn aac() -> AudioCodec {
+		AudioCodec::from_str("mp4a.40.2").unwrap()
+	}
+	fn h264() -> VideoCodec {
+		VideoCodec::from_str("avc1.42001f").unwrap()
+	}
+	fn h265() -> VideoCodec {
+		VideoCodec::from_str("hvc1.1.6.L93.B0").unwrap()
+	}
+	fn av1() -> VideoCodec {
+		VideoCodec::from_str("av01.0.04M.08").unwrap()
+	}
+
+	#[test]
+	fn protocol_codec_support_matrix() {
+		// The case that motivated this: AAC can't go over WebRTC, but can over RTMP/SRT.
+		assert!(!carries_audio(Protocol::Webrtc, &aac()));
+		assert!(carries_audio(Protocol::Flv, &aac()));
+		assert!(carries_audio(Protocol::Ts, &aac()));
+
+		// Opus: WebRTC + RTMP yes, MPEG-TS no.
+		assert!(carries_audio(Protocol::Webrtc, &AudioCodec::Opus));
+		assert!(carries_audio(Protocol::Flv, &AudioCodec::Opus));
+		assert!(!carries_audio(Protocol::Ts, &AudioCodec::Opus));
+
+		// MP2: only MPEG-TS.
+		assert!(!carries_audio(Protocol::Flv, &AudioCodec::Mp2));
+		assert!(carries_audio(Protocol::Ts, &AudioCodec::Mp2));
+
+		// VP8: only WebRTC. AV1: WebRTC + RTMP, not TS.
+		assert!(carries_video(Protocol::Webrtc, &VideoCodec::VP8));
+		assert!(!carries_video(Protocol::Flv, &VideoCodec::VP8));
+		assert!(!carries_video(Protocol::Ts, &VideoCodec::VP8));
+		assert!(carries_video(Protocol::Flv, &av1()));
+		assert!(!carries_video(Protocol::Ts, &av1()));
+
+		// H.264/H.265: everyone.
+		for p in [Protocol::Webrtc, Protocol::Flv, Protocol::Ts] {
+			assert!(carries_video(p, &h264()));
+			assert!(carries_video(p, &h265()));
+		}
+	}
+
+	#[test]
+	fn dropped_track_labels() {
+		assert_eq!(DroppedTrack::audio(&aac()).codec, "AAC");
+		assert_eq!(DroppedTrack::video(&VideoCodec::VP8).codec, "VP8");
+		assert_eq!(DroppedTrack::audio(&AudioCodec::Opus).kind, TrackKind::Audio);
+	}
+}

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -9,7 +9,8 @@
 //! avcC/hvcC (parsing inline avc3/hev1 parameter sets when needed) and hands the
 //! other codecs through unchanged. FLV carries a single video and a single audio
 //! stream, so only the first rendition of each kind is muxed; extra renditions
-//! and any unsupported codec are rejected.
+//! and any rendition whose codec FLV can't carry (VP8, MP2, ...) are dropped, so
+//! a supported track still exports (see [`Export::dropped`]).
 
 use std::task::Poll;
 use std::time::Duration;
@@ -25,6 +26,7 @@ use super::{
 	VIDEO_PACKET_SEQUENCE_START,
 };
 use crate::catalog::{CatalogFormat, Stream};
+use crate::compat::{self, DroppedTrack};
 use crate::container::{ExportSource, Frame};
 
 /// Which FLV payload shape a bound track is muxed as: a legacy CodecID
@@ -79,6 +81,10 @@ pub struct Export {
 	video: Option<FlvTrack>,
 	audio: Option<FlvTrack>,
 
+	/// Renditions whose codec FLV/RTMP can't carry, dropped so the rest still
+	/// exports. Surfaced via [`Self::dropped`] for incompatibility reporting.
+	dropped: Vec<DroppedTrack>,
+
 	/// True once the file header and sequence headers have been emitted.
 	header_emitted: bool,
 }
@@ -118,6 +124,7 @@ impl Export {
 			latency: Duration::ZERO,
 			video: None,
 			audio: None,
+			dropped: Vec::new(),
 			header_emitted: false,
 		})
 	}
@@ -126,6 +133,13 @@ impl Export {
 	pub fn with_latency(mut self, latency: Duration) -> Self {
 		self.latency = latency;
 		self
+	}
+
+	/// Renditions from the source catalog that FLV/RTMP can't carry and were
+	/// dropped. Populated once the catalog is known (after the first `next`); a
+	/// gateway reports these so the dashboard can flag the incompatibility.
+	pub fn dropped(&self) -> &[DroppedTrack] {
+		&self.dropped
 	}
 
 	/// Get the next byte chunk.
@@ -223,7 +237,12 @@ impl Export {
 		self.video.is_some() || self.audio.is_some()
 	}
 
-	fn update_catalog(&mut self, catalog: Catalog) -> anyhow::Result<()> {
+	fn update_catalog(&mut self, mut catalog: Catalog) -> anyhow::Result<()> {
+		// Drop renditions FLV/RTMP can't carry (it does H.264/H.265/AV1/VP9 video and
+		// AAC/Opus/AC-3/E-AC-3 audio) so a supported track still exports instead of the
+		// session hard-failing; the dropped set is reported for incompatibility flagging.
+		self.dropped = retain_flv_supported(&mut catalog);
+
 		// FLV carries one video and one audio stream. Bind to the first rendition of
 		// each kind and ignore the rest; a layout change once bound is rejected.
 		if self.video.is_none()
@@ -430,6 +449,29 @@ fn ensure_legacy(container: &Container, kind: &str, name: &str) -> anyhow::Resul
 		Container::Legacy | Container::Loc => Ok(()),
 		Container::Cmaf { .. } => anyhow::bail!("FLV export does not support CMAF {kind} track '{name}'"),
 	}
+}
+
+/// Remove renditions FLV/RTMP can't carry, returning them as [`DroppedTrack`]s.
+/// FLV does H.264/H.265/AV1/VP9 video (enhanced-RTMP FourCCs) and
+/// AAC/Opus/AC-3/E-AC-3 audio; VP8, MP2, and unknown codecs are dropped so the
+/// supported tracks still export.
+fn retain_flv_supported(catalog: &mut Catalog) -> Vec<DroppedTrack> {
+	let mut dropped = Vec::new();
+	catalog.video.renditions.retain(|_, c| {
+		let ok = compat::carries_video(compat::Protocol::Flv, &c.codec);
+		if !ok {
+			dropped.push(DroppedTrack::video(&c.codec));
+		}
+		ok
+	});
+	catalog.audio.renditions.retain(|_, c| {
+		let ok = compat::carries_audio(compat::Protocol::Flv, &c.codec);
+		if !ok {
+			dropped.push(DroppedTrack::audio(&c.codec));
+		}
+		ok
+	});
+	dropped
 }
 
 fn video_flavor(config: &hang::catalog::VideoConfig) -> anyhow::Result<Flavor> {

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -31,6 +31,7 @@ use mpeg2ts::ts::{
 
 use crate::catalog::hang::{Catalog, CatalogExt};
 use crate::catalog::{CatalogFormat, Stream};
+use crate::compat::{self, DroppedTrack};
 use crate::codec::annexb;
 use crate::container::{ExportSource, Frame, Timestamp};
 
@@ -57,6 +58,9 @@ pub struct Export<E: CatalogExt = ()> {
 	latency: Duration,
 
 	tracks: HashMap<String, Track>,
+	/// Renditions whose codec MPEG-TS can't carry, dropped from the program so the
+	/// rest still exports. Surfaced via [`Self::dropped`] for incompatibility reporting.
+	dropped: Vec<DroppedTrack>,
 	/// Continuity counter per PID (PAT, PMT, and each elementary stream).
 	counters: HashMap<u16, ContinuityCounter>,
 	/// PMT program-level descriptors captured on import, re-emitted in the PMT.
@@ -183,6 +187,7 @@ impl<E: CatalogExt> Export<E> {
 			catalog: Some(catalog),
 			latency: Duration::ZERO,
 			tracks: HashMap::new(),
+			dropped: Vec::new(),
 			counters: HashMap::new(),
 			program_descriptors: Vec::new(),
 			psi: None,
@@ -195,6 +200,14 @@ impl<E: CatalogExt> Export<E> {
 	pub fn with_latency(mut self, latency: Duration) -> Self {
 		self.latency = latency;
 		self
+	}
+
+	/// Renditions from the source catalog that MPEG-TS can't carry and were
+	/// dropped from the program. Populated once the catalog is known (after the
+	/// first `poll_next`); a gateway reports these so the dashboard can flag the
+	/// incompatibility.
+	pub fn dropped(&self) -> &[DroppedTrack] {
+		&self.dropped
 	}
 
 	/// Get the next muxed frame.
@@ -324,6 +337,11 @@ impl<E: CatalogExt> Export<E> {
 		// empty default: no verbatim streams, no preserved PIDs/descriptors).
 		let mpegts = catalog::mpegts_mut(&mut catalog).cloned().unwrap_or_default();
 		self.program_descriptors = mpegts.program_descriptors.clone();
+
+		// Drop renditions MPEG-TS can't carry (it does H.264/H.265 video and
+		// AAC/MP2/AC-3/E-AC-3 audio) so the rest still exports instead of the whole
+		// session hard-failing; the dropped set is reported for incompatibility flagging.
+		self.dropped = retain_ts_supported(&mut catalog);
 
 		// The desired track set: media renditions plus the verbatim streams.
 		let mut active: HashMap<String, ()> = HashMap::new();
@@ -923,6 +941,28 @@ fn to_ticks(timestamp: Timestamp) -> u64 {
 fn to_ts_timestamp(timestamp: Timestamp) -> anyhow::Result<TsTimestamp> {
 	// Continuous 90 kHz ticks, wrapped into the 33-bit field.
 	TsTimestamp::new(to_ticks(timestamp) & TS_TIMESTAMP_MASK).map_err(anyhow::Error::msg)
+}
+
+/// Remove renditions MPEG-TS can't carry, returning them as [`DroppedTrack`]s.
+/// TS does H.264/H.265 video and AAC/MP2/AC-3/E-AC-3 audio; everything else
+/// (Opus, VP8/VP9/AV1, unknown) is dropped so the supported tracks still export.
+fn retain_ts_supported<E: CatalogExt>(catalog: &mut Catalog<E>) -> Vec<DroppedTrack> {
+	let mut dropped = Vec::new();
+	catalog.video.renditions.retain(|_, c| {
+		let ok = compat::carries_video(compat::Protocol::Ts, &c.codec);
+		if !ok {
+			dropped.push(DroppedTrack::video(&c.codec));
+		}
+		ok
+	});
+	catalog.audio.renditions.retain(|_, c| {
+		let ok = compat::carries_audio(compat::Protocol::Ts, &c.codec);
+		if !ok {
+			dropped.push(DroppedTrack::audio(&c.codec));
+		}
+		ok
+	});
+	dropped
 }
 
 fn video_kind(config: &VideoConfig, name: &str) -> anyhow::Result<Kind> {

--- a/rs/moq-mux/src/lib.rs
+++ b/rs/moq-mux/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod catalog;
 mod clock;
 pub mod codec;
+pub mod compat;
 pub mod container;
 mod error;
 pub mod import;

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 use bytes::Bytes;
 use hang::catalog::{AudioCodec, VideoCodec};
 use moq_mux::catalog::hang::Catalog;
+use moq_mux::compat::DroppedTrack;
 use str0m::format::Codec;
 use str0m::media::{Frequency, MediaTime, Mid, Pt};
 use tokio::sync::mpsc;
@@ -100,6 +101,12 @@ impl EgressSource {
 			pump(mid, pt, clock_rate, track, tx).await;
 		});
 		Ok(())
+	}
+
+	/// Catalog renditions WebRTC can't egress (audio that isn't Opus, or an
+	/// unknown video codec), surfaced so a gateway can report the incompatibility.
+	pub fn dropped(&self) -> Vec<DroppedTrack> {
+		moq_mux::compat::classify(&self.catalog, moq_mux::compat::Protocol::Webrtc)
 	}
 
 	/// Codecs present in the catalog, used by the SDP-offer side

--- a/rs/moq-rtc/src/sdp.rs
+++ b/rs/moq-rtc/src/sdp.rs
@@ -4,6 +4,7 @@
 //! request/response bodies. The only thing we add on top of str0m's offer/answer
 //! parse/serialize is a tiny wrapper to keep the call sites readable.
 
+use std::borrow::Cow;
 use std::str::FromStr;
 
 use crate::{Error, Result};
@@ -14,8 +15,39 @@ pub fn parse_offer(body: &str) -> Result<str0m::change::SdpOffer> {
 }
 
 /// Serialize an SDP answer for the `application/sdp` response body.
+///
+/// str0m can emit a *rejected* media line (port 0) with an EMPTY format list,
+/// e.g. `m=audio 0 UDP/TLS/RTP/SAVPF `. This happens when we restrict the
+/// `CodecConfig` (see [`session::rtc_config_with_codecs`]) and the peer's offer
+/// carries a codec the broadcast can't egress -- the classic case being AAC
+/// audio over WHEP, which we can't carry, so the audio m-line comes back
+/// rejected with no payload. An m-line with no `<fmt>` violates RFC 4566, and a
+/// browser rejects the WHOLE answer in `setRemoteDescription`, killing playback
+/// of the media (e.g. video) that WAS negotiated. So we give any such line a
+/// placeholder static payload; the media stays rejected (port 0), so the
+/// placeholder is never used.
 pub fn render_answer(answer: &str0m::change::SdpAnswer) -> String {
-	answer.to_sdp_string()
+	// SDP uses CRLF line endings (RFC 4566); splitting and rejoining on "\r\n"
+	// round-trips exactly, including the trailing CRLF.
+	answer
+		.to_sdp_string()
+		.split("\r\n")
+		.map(ensure_media_format)
+		.collect::<Vec<Cow<str>>>()
+		.join("\r\n")
+}
+
+/// Give an `m=` line a placeholder format payload when it has none (see
+/// [`render_answer`]); every other line passes through untouched.
+fn ensure_media_format(line: &str) -> Cow<'_, str> {
+	if !line.starts_with("m=") {
+		return Cow::Borrowed(line);
+	}
+	// m=<media> <port> <proto> <fmt>...; fewer than 4 tokens means no <fmt>.
+	if line.split_whitespace().count() >= 4 {
+		return Cow::Borrowed(line);
+	}
+	Cow::Owned(format!("{} 0", line.trim_end()))
 }
 
 /// Build a stable WHIP/WHEP resource identifier from a UUID v4.
@@ -33,4 +65,24 @@ pub fn parse_resource_id(path: &str) -> Result<uuid::Uuid> {
 		.find(|s| !s.is_empty())
 		.ok_or_else(|| Error::InvalidSdp("missing resource id".into()))?;
 	uuid::Uuid::from_str(last).map_err(|err| Error::InvalidSdp(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::ensure_media_format;
+
+	#[test]
+	fn rejected_mline_with_no_format_gets_placeholder() {
+		// str0m's malformed rejected audio line.
+		assert_eq!(ensure_media_format("m=audio 0 UDP/TLS/RTP/SAVPF "), "m=audio 0 UDP/TLS/RTP/SAVPF 0");
+		assert_eq!(ensure_media_format("m=audio 0 UDP/TLS/RTP/SAVPF"), "m=audio 0 UDP/TLS/RTP/SAVPF 0");
+	}
+
+	#[test]
+	fn well_formed_lines_are_untouched() {
+		let video = "m=video 9 UDP/TLS/RTP/SAVPF 96 97";
+		assert_eq!(ensure_media_format(video), video);
+		let attr = "a=ice-ufrag:abcd";
+		assert_eq!(ensure_media_format(attr), attr);
+	}
 }

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -31,6 +31,9 @@ pub struct Response {
 	pub resource_id: String,
 	/// The SDP answer body (`Content-Type: application/sdp`).
 	pub answer: String,
+	/// Source renditions this egress couldn't carry (incompatible codec), for
+	/// the caller to report. Always empty for ingest (WHIP).
+	pub dropped: Vec<moq_mux::compat::DroppedTrack>,
 	session: AcceptedSession,
 }
 
@@ -44,10 +47,12 @@ impl Response {
 		registration: mux::Registration,
 		cancel: oneshot::Receiver<()>,
 		role: &'static str,
+		dropped: Vec<moq_mux::compat::DroppedTrack>,
 	) -> Self {
 		Self {
 			resource_id: resource_id.clone(),
 			answer,
+			dropped,
 			session: AcceptedSession {
 				server,
 				resource_id,

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -38,6 +38,7 @@ async fn handle(
 				resource_id,
 				answer,
 				session,
+				..
 			} = response;
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
@@ -127,6 +128,8 @@ pub async fn accept(
 
 	let answer = rtc.sdp_api().accept_offer(offer).map_err(Error::Rtc)?;
 	let resource_id = sdp::new_resource_id();
+	// Capture incompatible renditions before the source moves into the session.
+	let dropped = source.dropped();
 	let session = session::Session::egress(rtc, mux.socket(), mux.candidates().to_vec(), inbound, source);
 
 	// Register before returning so a DELETE that races startup still finds the
@@ -141,6 +144,7 @@ pub async fn accept(
 		registration,
 		cancel,
 		"whep server",
+		dropped,
 	))
 }
 

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -38,6 +38,7 @@ async fn handle(
 				resource_id,
 				answer,
 				session,
+				..
 			} = response;
 			let mut response_headers = HeaderMap::new();
 			response_headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/sdp"));
@@ -140,6 +141,7 @@ pub async fn accept(
 		registration,
 		cancel,
 		"whip server",
+		Vec::new(), // ingest: no egress renditions to drop
 	))
 }
 


### PR DESCRIPTION
Stacked on #1964.

## Problem

Each egress format carries only a subset of the codecs a catalog can hold. Today an unsupported codec either:
- **hard-fails the whole session** — FLV/MPEG-TS export `bail!`s on the first codec it can't carry, so e.g. an Opus-audio broadcast can't be played over SRT *at all*, even though its H.264 video could; or
- **vanishes silently** — WHEP drops the track with only a `tracing::warn!` (the AAC-over-WebRTC case).

Either way the user gets no signal about *what* was incompatible.

## Change

Supported tracks now still egress, and the dropped ones are surfaced so a caller can flag the incompatibility.

- **`moq-mux::compat`** (new): the codec-support matrix in one place — `carries_audio` / `carries_video` per `Protocol` (Webrtc / Flv / Ts), `classify` (catalog → `Vec<DroppedTrack>`), `DroppedTrack` with friendly labels ("AAC", "VP8", …), and `dropped_for` (resolve a broadcast, read its catalog, report drops). `dropped_for` is for serve paths that own the exporter and can't surface it mid-session (RTMP/SRT sealed `accept`).
- **FLV + MPEG-TS export**: filter renditions the format can't carry out of the catalog snapshot at ingest (`bail!` → partial), so a supported track still exports; expose the dropped set via `Export::dropped`. FLV carries H.264/H.265/AV1/VP9 + AAC/Opus/AC-3/E-AC-3; TS carries H.264/H.265 + AAC/MP2/AC-3/E-AC-3. Verbatim (`mpegts`) passthrough streams are untouched.
- **moq-rtc WHEP**: `Response::dropped` carries the renditions WebRTC can't egress.

## Tests

New unit tests for the support matrix + labels. All 314 existing `moq-mux` tests (incl. FLV/TS export round-trips) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)