### PR TITLE
feat(moq-mux): add MP3 audio support for FLV/RTMP

### DIFF
--- a/doc/bin/rtmp.md
+++ b/doc/bin/rtmp.md
@@ -22,10 +22,11 @@ each message as an FLV tag and feeds it to `moq-mux`'s FLV demuxer; on egress it
 muxes the broadcast back to FLV with `moq-mux` and sends the tags out as RTMP
 messages. It's the sibling of `moq-srt` (SRT/MPEG-TS) and `moq-rtc` (WHIP/WHEP).
 
-Both **legacy RTMP** (H.264 + AAC) and **enhanced RTMP** (E-RTMP: the HEVC, AV1,
-VP9, Opus, and AC-3 FourCC payloads) are supported in each direction, because all
-codec handling lives in the `moq-mux` FLV demuxer/muxer. Legacy players that speak
-only H.264 + AAC will reject the E-RTMP codecs on the play path.
+Both **legacy RTMP** (H.264 + AAC, plus MP3) and **enhanced RTMP** (E-RTMP: the
+HEVC, AV1, VP9, Opus, AC-3, and MP3 FourCC payloads) are supported in each
+direction, because all codec handling lives in the `moq-mux` FLV demuxer/muxer.
+Legacy players that speak only H.264 + AAC will reject the E-RTMP codecs on the
+play path.
 
 ## CLI shape
 
@@ -127,8 +128,9 @@ be pulled back out over RTMP.
   `Server::with_tls`) with a `rustls::ServerConfig`, or accept the connection and
   finish the TLS handshake by hand and hand the stream to `moq_rtmp::accept_stream`
   (which works over any `AsyncRead + AsyncWrite` transport).
-- **Codecs.** FLAC and MP3 enhanced-audio payloads are dropped (no MoQ catalog
-  codec); everything else (H.264/HEVC/AV1/VP9 video, AAC/Opus/AC-3/E-AC-3 audio)
-  is supported.
+- **Codecs.** FLAC enhanced-audio payloads are dropped (no MoQ catalog codec);
+  everything else (H.264/HEVC/AV1/VP9 video, AAC/MP3/Opus/AC-3/E-AC-3 audio) is
+  supported. MP3 is accepted as both the legacy SoundFormat 2 tag and the E-RTMP
+  `.mp3` FourCC, and re-muxed as the legacy tag on export.
 
 (Written by Claude)

--- a/js/watch/src/audio/source.ts
+++ b/js/watch/src/audio/source.ts
@@ -167,5 +167,11 @@ function defaultAudioJitter(config: Catalog.AudioConfig): number | undefined {
 		return Math.ceil((1024 / config.sampleRate) * 1000);
 	}
 
+	if (config.codec === "mp3") {
+		// 1152 samples per frame for MPEG-1 Layer III; MPEG-2/2.5 use 576.
+		const samples = config.sampleRate >= 32000 ? 1152 : 576;
+		return Math.ceil((samples / config.sampleRate) * 1000);
+	}
+
 	return undefined;
 }

--- a/rs/hang/src/catalog/audio/codec.rs
+++ b/rs/hang/src/catalog/audio/codec.rs
@@ -15,6 +15,13 @@ pub enum AudioCodec {
 	#[display("opus")]
 	Opus,
 
+	/// MPEG-1/2 Audio Layer III (MP3). Configuration is carried in band in each
+	/// frame header, so there is no out-of-band description. Browsers decode it
+	/// via WebCodecs (`AudioDecoder` codec string `"mp3"`), so unlike the legacy
+	/// codecs below it gets its own [`AudioCodecKind`].
+	#[display("mp3")]
+	Mp3,
+
 	/// MPEG-1/2 Audio Layer II. Legacy broadcast codec, carried verbatim by the
 	/// MPEG-TS bridge for TS gear. WebCodecs cannot decode it, so browsers should
 	/// skip this rendition. Do not use it for new content.
@@ -45,6 +52,7 @@ pub enum AudioCodec {
 pub enum AudioCodecKind {
 	AAC,
 	Opus,
+	Mp3,
 	Unknown,
 }
 
@@ -54,6 +62,7 @@ impl AudioCodec {
 		match self {
 			Self::AAC(_) => AudioCodecKind::AAC,
 			Self::Opus => AudioCodecKind::Opus,
+			Self::Mp3 => AudioCodecKind::Mp3,
 			// Legacy TS-bridge codecs aren't WebCodecs-decodable, so they share the
 			// coarse Unknown family for tag-only matching.
 			Self::Mp2 | Self::Ac3 | Self::Ec3 => AudioCodecKind::Unknown,
@@ -70,6 +79,8 @@ impl FromStr for AudioCodec {
 			return AAC::from_str(s).map(Into::into);
 		} else if s == "opus" {
 			return Ok(Self::Opus);
+		} else if s == "mp3" {
+			return Ok(Self::Mp3);
 		} else if s == "mp2" {
 			return Ok(Self::Mp2);
 		} else if s == "ac-3" {

--- a/rs/moq-mux/src/codec/mod.rs
+++ b/rs/moq-mux/src/codec/mod.rs
@@ -15,6 +15,7 @@ pub mod h264;
 pub mod h265;
 pub(crate) mod legacy;
 pub(crate) mod mp2;
+pub mod mp3;
 pub mod opus;
 pub mod vp8;
 pub mod vp9;

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -1,0 +1,137 @@
+//! MP3 (MPEG-1/2/2.5 Audio Layer III).
+//!
+//! Audio carried verbatim: each frame is published whole. The header is parsed
+//! only for the catalog config (sample rate, channels); the audio is never
+//! decoded and there is no out-of-band configuration record.
+
+/// MP3 parsing errors.
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+	/// The buffer was shorter than the 4-byte MPEG audio frame header.
+	#[error("MP3 frame header must be at least 4 bytes")]
+	HeaderTooShort,
+
+	/// The 11-bit frame sync (`0xFFE`) was missing.
+	#[error("missing MP3 frame sync")]
+	MissingSync,
+
+	/// The MPEG version field was the reserved value `01`.
+	#[error("reserved MPEG version")]
+	ReservedVersion,
+
+	/// The layer field was not Layer III, so this is not an MP3 frame (Layer I/II
+	/// are MP1/MP2, the reserved value is invalid).
+	#[error("not an MPEG Layer III (MP3) frame")]
+	NotLayer3,
+
+	/// The sample-rate index was the reserved value `11`.
+	#[error("reserved MP3 sample rate")]
+	ReservedSampleRate,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Typed MP3 configuration parsed from an MPEG audio frame header.
+pub struct Config {
+	/// Sampling frequency in Hz.
+	pub sample_rate: u32,
+	/// Channel count (1 for the mono channel mode, 2 otherwise).
+	pub channel_count: u32,
+}
+
+impl Config {
+	/// Parse the catalog config from the start of an MPEG Layer III frame.
+	///
+	/// Reads the 4-byte frame header (ISO/IEC 11172-3 §2.4.1.2): verifies the
+	/// frame sync and that the layer is III, then derives the sample rate from
+	/// the version + sample-rate index and the channel count from the channel
+	/// mode. The buffer is not advanced; the frame is published whole.
+	pub fn parse(data: &[u8]) -> Result<Self> {
+		if data.len() < 4 {
+			return Err(Error::HeaderTooShort);
+		}
+
+		// 11-bit frame sync: all of byte 0 plus the top 3 bits of byte 1.
+		if data[0] != 0xFF || (data[1] & 0xE0) != 0xE0 {
+			return Err(Error::MissingSync);
+		}
+
+		let version = (data[1] >> 3) & 0x03;
+		let layer = (data[1] >> 1) & 0x03;
+		// Layer is encoded inverted: 0b01 == Layer III.
+		if layer != 0b01 {
+			return Err(Error::NotLayer3);
+		}
+
+		let sr_index = ((data[2] >> 2) & 0x03) as usize;
+		if sr_index == 0b11 {
+			return Err(Error::ReservedSampleRate);
+		}
+
+		let sample_rate = match version {
+			0b11 => [44100, 48000, 32000][sr_index], // MPEG-1
+			0b10 => [22050, 24000, 16000][sr_index], // MPEG-2
+			0b00 => [11025, 12000, 8000][sr_index],  // MPEG-2.5
+			_ => return Err(Error::ReservedVersion),
+		};
+
+		// Channel mode 0b11 is single channel (mono); the rest are two-channel.
+		let channel_count = if (data[3] >> 6) & 0x03 == 0b11 { 1 } else { 2 };
+
+		Ok(Self {
+			sample_rate,
+			channel_count,
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parses_mpeg1_stereo() {
+		// MPEG-1 Layer III, 128 kbps, 44.1 kHz, joint stereo.
+		let header = [0xFF, 0xFB, 0x90, 0x44];
+		let cfg = Config::parse(&header).unwrap();
+		assert_eq!(cfg.sample_rate, 44100);
+		assert_eq!(cfg.channel_count, 2);
+	}
+
+	#[test]
+	fn parses_mpeg1_mono() {
+		// Same header but channel mode 0b11 (mono) in the top bits of byte 3.
+		let header = [0xFF, 0xFB, 0x90, 0xC4];
+		let cfg = Config::parse(&header).unwrap();
+		assert_eq!(cfg.channel_count, 1);
+	}
+
+	#[test]
+	fn parses_mpeg2_sample_rate() {
+		// MPEG-2 (version 0b10), Layer III, sample-rate index 0 -> 22.05 kHz.
+		let header = [0xFF, 0xF3, 0x90, 0x44];
+		let cfg = Config::parse(&header).unwrap();
+		assert_eq!(cfg.sample_rate, 22050);
+	}
+
+	#[test]
+	fn rejects_layer2() {
+		// Layer II is 0b10, i.e. an MP2 (not MP3) frame.
+		let header = [0xFF, 0xFD, 0x90, 0x44];
+		assert!(matches!(Config::parse(&header), Err(Error::NotLayer3)));
+	}
+
+	#[test]
+	fn rejects_missing_sync() {
+		assert!(matches!(
+			Config::parse(&[0x00, 0x00, 0x00, 0x00]),
+			Err(Error::MissingSync)
+		));
+	}
+
+	#[test]
+	fn rejects_short() {
+		assert!(matches!(Config::parse(&[0xFF, 0xFB]), Err(Error::HeaderTooShort)));
+	}
+}

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -2,9 +2,9 @@
 //!
 //! [`Export`] subscribes to a MoQ broadcast and produces a single FLV byte
 //! stream: the file header, the video/audio sequence headers, then one tag per
-//! media frame interleaved by timestamp. Legacy H.264 + AAC are muxed as the
-//! classic CodecID tags; HEVC, AV1, VP9, Opus, AC-3, and E-AC-3 are muxed as the
-//! enhanced-RTMP (E-RTMP) FourCC payloads. Frames flow through [`ExportSource`],
+//! media frame interleaved by timestamp. Legacy H.264 + AAC + MP3 are muxed as
+//! the classic CodecID tags; HEVC, AV1, VP9, Opus, AC-3, and E-AC-3 are muxed as
+//! the enhanced-RTMP (E-RTMP) FourCC payloads. Frames flow through [`ExportSource`],
 //! which normalizes H.264/H.265 to length-prefixed NALU plus a resolved
 //! avcC/hvcC (parsing inline avc3/hev1 parameter sets when needed) and hands the
 //! other codecs through unchanged. FLV carries a single video and a single audio
@@ -20,8 +20,8 @@ use hang::catalog::{AV1, AudioCodec, Catalog, Container, VideoCodec};
 
 use super::{
 	AAC_AUDIO_TAG_HEADER, AAC_RAW, AAC_SEQUENCE_HEADER, AUDIO_FORMAT_EX, AUDIO_PACKET_CODED_FRAMES,
-	AUDIO_PACKET_SEQUENCE_START, AVC_NALU, AVC_SEQUENCE_HEADER, FRAME_TYPE_INTER, FRAME_TYPE_KEY, TAG_AUDIO,
-	TAG_HEADER_LEN, TAG_VIDEO, VIDEO_CODEC_AVC, VIDEO_EX_HEADER, VIDEO_PACKET_CODED_FRAMES,
+	AUDIO_PACKET_SEQUENCE_START, AVC_NALU, AVC_SEQUENCE_HEADER, FRAME_TYPE_INTER, FRAME_TYPE_KEY, MP3_AUDIO_TAG_HEADER,
+	TAG_AUDIO, TAG_HEADER_LEN, TAG_VIDEO, VIDEO_CODEC_AVC, VIDEO_EX_HEADER, VIDEO_PACKET_CODED_FRAMES,
 	VIDEO_PACKET_SEQUENCE_START,
 };
 use crate::catalog::{CatalogFormat, Stream};
@@ -36,6 +36,7 @@ enum Flavor {
 	Av1,
 	Vp9,
 	Aac,
+	Mp3,
 	Opus,
 	Ac3,
 	Eac3,
@@ -43,7 +44,7 @@ enum Flavor {
 
 impl Flavor {
 	/// The enhanced-RTMP FourCC for this codec, or `None` for the legacy
-	/// (CodecID-signaled) AVC and AAC shapes.
+	/// (CodecID-signaled) AVC, AAC, and MP3 shapes.
 	fn fourcc(self) -> Option<[u8; 4]> {
 		match self {
 			Flavor::Hevc => Some(*b"hvc1"),
@@ -52,7 +53,7 @@ impl Flavor {
 			Flavor::Opus => Some(*b"Opus"),
 			Flavor::Ac3 => Some(*b"ac-3"),
 			Flavor::Eac3 => Some(*b"ec-3"),
-			Flavor::Avc | Flavor::Aac => None,
+			Flavor::Avc | Flavor::Aac | Flavor::Mp3 => None,
 		}
 	}
 }
@@ -387,12 +388,17 @@ impl Export {
 		} else {
 			let flavor = self.audio.as_ref().expect("audio frame without an audio track").flavor;
 			let mut body = BytesMut::with_capacity(5 + frame.payload.len());
-			match flavor.fourcc() {
-				None => {
+			match flavor {
+				// Legacy AAC: tag header + AACPacketType (raw frame follows).
+				Flavor::Aac => {
 					body.put_u8(AAC_AUDIO_TAG_HEADER);
 					body.put_u8(AAC_RAW);
 				}
-				Some(fourcc) => {
+				// Legacy MP3: tag header only; the raw frame carries its own config.
+				Flavor::Mp3 => body.put_u8(MP3_AUDIO_TAG_HEADER),
+				// Enhanced FourCC CodedFrames.
+				_ => {
+					let fourcc = flavor.fourcc().expect("enhanced audio flavor missing FourCC");
 					body.put_u8((AUDIO_FORMAT_EX << 4) | AUDIO_PACKET_CODED_FRAMES);
 					body.put_slice(&fourcc);
 				}
@@ -445,6 +451,7 @@ fn video_flavor(config: &hang::catalog::VideoConfig) -> anyhow::Result<Flavor> {
 fn audio_flavor(config: &hang::catalog::AudioConfig) -> anyhow::Result<Flavor> {
 	match &config.codec {
 		AudioCodec::AAC(_) => Ok(Flavor::Aac),
+		AudioCodec::Mp3 => Ok(Flavor::Mp3),
 		AudioCodec::Opus => Ok(Flavor::Opus),
 		AudioCodec::Ac3 => Ok(Flavor::Ac3),
 		AudioCodec::Ec3 => Ok(Flavor::Eac3),
@@ -481,13 +488,15 @@ fn video_sequence_header(track: &FlvTrack) -> anyhow::Result<Option<BytesMut>> {
 		}
 		// VP9 configures the decoder from the key frame; no sequence header tag.
 		Flavor::Vp9 => return Ok(None),
-		Flavor::Aac | Flavor::Opus | Flavor::Ac3 | Flavor::Eac3 => unreachable!("audio flavor on a video track"),
+		Flavor::Aac | Flavor::Mp3 | Flavor::Opus | Flavor::Ac3 | Flavor::Eac3 => {
+			unreachable!("audio flavor on a video track")
+		}
 	}
 	Ok(Some(body))
 }
 
 /// Build the FLV audio sequence-header tag body, or `None` for codecs that carry
-/// their config in band (AC-3 / E-AC-3).
+/// their config in band (MP3 / AC-3 / E-AC-3).
 fn audio_sequence_header(track: &FlvTrack) -> anyhow::Result<Option<BytesMut>> {
 	let mut body = BytesMut::new();
 	match track.flavor {
@@ -506,8 +515,8 @@ fn audio_sequence_header(track: &FlvTrack) -> anyhow::Result<Option<BytesMut>> {
 			body.put_slice(b"Opus");
 			body.put_slice(head);
 		}
-		// AC-3 / E-AC-3 carry their config in each sync frame; no sequence header tag.
-		Flavor::Ac3 | Flavor::Eac3 => return Ok(None),
+		// MP3 / AC-3 / E-AC-3 carry their config in each frame; no sequence header tag.
+		Flavor::Mp3 | Flavor::Ac3 | Flavor::Eac3 => return Ok(None),
 		Flavor::Avc | Flavor::Hevc | Flavor::Av1 | Flavor::Vp9 => unreachable!("video flavor on an audio track"),
 	}
 	Ok(Some(body))

--- a/rs/moq-mux/src/container/flv/export_test.rs
+++ b/rs/moq-mux/src/container/flv/export_test.rs
@@ -276,6 +276,57 @@ async fn export_roundtrips_enhanced() {
 	));
 }
 
+/// Legacy MP3 audio survives an import -> export -> import round trip, muxed back
+/// out as the legacy SoundFormat 2 tag with the config still in band.
+#[tokio::test(start_paused = true)]
+async fn export_roundtrips_mp3() {
+	// MPEG-1 Layer III, 44.1 kHz, joint stereo.
+	let mut mp3 = vec![0xFF, 0xFB, 0x90, 0x44];
+	mp3.resize(417, 0xAA);
+
+	let mut flv = Vec::new();
+	flv.extend_from_slice(b"FLV");
+	flv.push(1);
+	flv.push(0x04); // audio only
+	flv.extend_from_slice(&9u32.to_be_bytes());
+	flv.extend_from_slice(&0u32.to_be_bytes());
+	let mut tag = vec![super::MP3_AUDIO_TAG_HEADER];
+	tag.extend_from_slice(&mp3);
+	write_tag(&mut flv, super::TAG_AUDIO, 0, &tag);
+
+	let mut producer = moq_net::Broadcast::new().produce();
+	let consumer = producer.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(flv.as_slice())).unwrap();
+	catalog.finish().unwrap();
+
+	let exporter = Export::new(consumer).unwrap();
+	let exported = drain_export(exporter, importer).await;
+
+	// The audio is muxed as a legacy SoundFormat 2 (MP3) tag, no sequence header.
+	let tags = parse_tags(&exported);
+	assert!(
+		tags.iter()
+			.any(|t| t.tag_type == super::TAG_AUDIO && (t.body[0] >> 4) == super::AUDIO_FORMAT_MP3),
+		"expected a legacy MP3 audio tag"
+	);
+
+	// Re-import and confirm the codec rebuilds.
+	let mut bcast2 = moq_net::Broadcast::new().produce();
+	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
+	let mut imp2 = Import::new(bcast2, cat2.clone());
+	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
+	imp2.finish().unwrap();
+
+	let snap = cat2.snapshot();
+	let a = snap.audio.renditions.values().next().unwrap();
+	assert!(matches!(a.codec, AudioCodec::Mp3));
+	assert_eq!(a.sample_rate, 44100);
+	assert_eq!(a.channel_count, 2);
+}
+
 struct ParsedTag {
 	tag_type: u8,
 	timestamp: u32,

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -9,20 +9,22 @@
 //! - **Enhanced RTMP (E-RTMP)**: the FourCC-signaled payloads OBS and ffmpeg emit
 //!   for HEVC (`hvc1`), AV1 (`av01`), VP9 (`vp09`), and the legacy AVC FourCC
 //!   (`avc1`); plus enhanced audio for Opus (`Opus`), AC-3 (`ac-3`), E-AC-3
-//!   (`ec-3`), and AAC (`mp4a`).
+//!   (`ec-3`), AAC (`mp4a`), and MP3 (`.mp3`).
+//!
+//! MP3 is also accepted as the legacy SoundFormat 2 audio tag.
 //!
 //! Each codec's out-of-band config record (avcC / hvcC / av1C / `AudioSpecificConfig`
 //! / `OpusHead`) becomes the catalog `description`; VP9 and the verbatim audio
-//! codecs (AC-3 / E-AC-3) carry their config in band, so they configure from the
-//! first frame instead. Sample bytes already match the [`Legacy`](crate::catalog::hang::Container)
-//! container, so no codec transform is needed. FLAC (`fLaC`) and MP3 (`.mp3`)
-//! enhanced audio, and any other codec, are logged and dropped.
+//! codecs (MP3 / AC-3 / E-AC-3) carry their config in band, so they configure from
+//! the first frame instead. Sample bytes already match the [`Legacy`](crate::catalog::hang::Container)
+//! container, so no codec transform is needed. FLAC (`fLaC`) enhanced audio, and
+//! any other codec, are logged and dropped.
 
 use bytes::{Buf, Bytes, BytesMut};
 use hang::catalog::{AAC, AudioCodec, AudioConfig, Container, H264, VideoConfig};
 
 use super::{
-	AAC_RAW, AAC_SEQUENCE_HEADER, AUDIO_FORMAT_AAC, AUDIO_FORMAT_EX, AUDIO_PACKET_CODED_FRAMES,
+	AAC_RAW, AAC_SEQUENCE_HEADER, AUDIO_FORMAT_AAC, AUDIO_FORMAT_EX, AUDIO_FORMAT_MP3, AUDIO_PACKET_CODED_FRAMES,
 	AUDIO_PACKET_MULTICHANNEL_CONFIG, AUDIO_PACKET_SEQUENCE_END, AUDIO_PACKET_SEQUENCE_START, AVC_NALU,
 	AVC_SEQUENCE_HEADER, FILE_HEADER_LEN, FRAME_TYPE_KEY, PREV_TAG_SIZE_LEN, TAG_AUDIO, TAG_HEADER_LEN, TAG_SCRIPT,
 	TAG_VIDEO, VIDEO_CODEC_AVC, VIDEO_EX_HEADER, VIDEO_PACKET_CODED_FRAMES, VIDEO_PACKET_CODED_FRAMES_X,
@@ -233,6 +235,15 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		if sound_format == AUDIO_FORMAT_EX {
 			return self.handle_audio_enhanced(first, body, timestamp);
 		}
+		if sound_format == AUDIO_FORMAT_MP3 {
+			// Legacy MP3: the raw frame follows the one-byte tag header, with the
+			// config in band. Configure from the first frame, then write it.
+			let frame = &body[1..];
+			if self.audio.is_none() {
+				self.init_audio(config_from_mp3(frame)?)?;
+			}
+			return self.write_audio(frame, timestamp);
+		}
 		if sound_format != AUDIO_FORMAT_AAC {
 			tracing::warn!(sound_format, "unsupported FLV audio format, dropping");
 			return Ok(());
@@ -261,7 +272,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				let config = match &fourcc {
 					b"Opus" => config_from_opus_head(payload)?,
 					b"mp4a" => config_from_asc(payload)?,
-					// AC-3 / E-AC-3 are verbatim with no sequence header; they
+					// MP3 / AC-3 / E-AC-3 are verbatim with no sequence header; they
 					// configure from the first frame. Anything else is unsupported.
 					other => {
 						tracing::warn!(fourcc = ?other, "unsupported enhanced FLV audio codec, dropping");
@@ -271,10 +282,11 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				self.init_audio(config)
 			}
 			AUDIO_PACKET_CODED_FRAMES => {
-				// AC-3 / E-AC-3 carry their config in the frame header, so configure
-				// from the first frame when no sequence header preceded it.
+				// MP3 / AC-3 / E-AC-3 carry their config in the frame header, so
+				// configure from the first frame when no sequence header preceded it.
 				if self.audio.is_none() {
 					let config = match &fourcc {
+						b".mp3" => Some(config_from_mp3(payload)?),
 						b"ac-3" => Some(config_from_ac3(payload)?),
 						b"ec-3" => Some(config_from_eac3(payload)?),
 						_ => None,
@@ -457,6 +469,14 @@ fn config_from_opus_head(head: &[u8]) -> anyhow::Result<AudioConfig> {
 	let cfg = crate::codec::opus::Config::parse(&mut cursor)?;
 	let mut config = AudioConfig::new(AudioCodec::Opus, cfg.sample_rate, cfg.channel_count);
 	config.description = Some(Bytes::copy_from_slice(head));
+	config.container = Container::Legacy;
+	Ok(config)
+}
+
+/// Build an audio config for MP3 from a frame header (config is in band).
+fn config_from_mp3(frame: &[u8]) -> anyhow::Result<AudioConfig> {
+	let cfg = crate::codec::mp3::Config::parse(frame)?;
+	let mut config = AudioConfig::new(AudioCodec::Mp3, cfg.sample_rate, cfg.channel_count);
 	config.container = Container::Legacy;
 	Ok(config)
 }

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -225,6 +225,41 @@ async fn import_enhanced_opus() {
 	assert_eq!(a.description.as_ref().map(|b| b.as_ref()), Some(head.as_ref()));
 }
 
+/// Legacy SoundFormat 2 MP3 configures from the first frame's in-band header and
+/// carries the frame through verbatim.
+#[tokio::test(start_paused = true)]
+async fn import_legacy_mp3() {
+	// MPEG-1 Layer III, 128 kbps, 44.1 kHz, joint stereo, padded to a plausible frame.
+	let mut mp3 = vec![0xFF, 0xFB, 0x90, 0x44];
+	mp3.resize(417, 0xAA);
+
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1);
+	out.push(0x04); // audio only
+	out.extend_from_slice(&9u32.to_be_bytes());
+	out.extend_from_slice(&0u32.to_be_bytes());
+
+	// Legacy audio tag: SoundFormat 2 (MP3) header byte, then the raw frame.
+	let mut tag = vec![super::MP3_AUDIO_TAG_HEADER];
+	tag.extend_from_slice(&mp3);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &tag);
+
+	let mut producer = moq_net::Broadcast::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	assert_eq!(snap.audio.renditions.len(), 1);
+	let a = snap.audio.renditions.values().next().unwrap();
+	assert!(matches!(a.codec, AudioCodec::Mp3));
+	assert_eq!(a.sample_rate, 44100);
+	assert_eq!(a.channel_count, 2);
+	assert!(a.description.is_none(), "MP3 config is in band");
+}
+
 #[tokio::test(start_paused = true)]
 async fn import_rejects_non_flv() {
 	let mut producer = moq_net::Broadcast::new().produce();

--- a/rs/moq-mux/src/container/flv/mod.rs
+++ b/rs/moq-mux/src/container/flv/mod.rs
@@ -10,12 +10,15 @@
 //! - **Enhanced RTMP (E-RTMP)**: the FourCC payloads for HEVC (`hvc1`), AV1
 //!   (`av01`), VP9 (`vp09`), Opus (`Opus`), AC-3 (`ac-3`), and E-AC-3 (`ec-3`).
 //!
+//! MP3 is handled in both generations: the legacy SoundFormat 2 tag and the
+//! E-RTMP `.mp3` FourCC on import, and the legacy SoundFormat 2 tag on export.
+//!
 //! Each codec's config record passes straight through as the catalog
-//! `description` (or, for the in-band codecs VP9 / AC-3 / E-AC-3, is read from the
-//! frame), and the sample bytes already match the
+//! `description` (or, for the in-band codecs VP9 / MP3 / AC-3 / E-AC-3, is read
+//! from the frame), and the sample bytes already match the
 //! [`Legacy`](crate::catalog::hang::Container) container, so no codec transform is
-//! needed. Other legacy codecs (VP6, MP3, Speex, …) and the E-RTMP FLAC / MP3
-//! audio are logged and dropped on import, and rejected on export.
+//! needed. Other legacy codecs (VP6, Speex, …) and the E-RTMP FLAC audio are
+//! logged and dropped on import, and rejected on export.
 
 mod export;
 mod import;
@@ -46,6 +49,8 @@ const FILE_HEADER_LEN: usize = 9;
 const VIDEO_CODEC_AVC: u8 = 7;
 /// SoundFormat for AAC (high nibble of an audio tag's first byte).
 const AUDIO_FORMAT_AAC: u8 = 10;
+/// SoundFormat for MP3 (high nibble of an audio tag's first byte).
+const AUDIO_FORMAT_MP3: u8 = 2;
 
 /// Video FrameType for a keyframe.
 const FRAME_TYPE_KEY: u8 = 1;
@@ -66,6 +71,11 @@ const AAC_RAW: u8 = 1;
 /// (44 kHz flag), SoundSize 1 (16-bit), SoundType 1 (stereo). The real rate and
 /// channel layout live in the `AudioSpecificConfig`, so these bits are nominal.
 const AAC_AUDIO_TAG_HEADER: u8 = (AUDIO_FORMAT_AAC << 4) | (3 << 2) | (1 << 1) | 1;
+
+/// First byte of an MP3 audio tag: SoundFormat 2, with the same nominal
+/// SoundRate / SoundSize / SoundType bits as AAC. The real rate and channel
+/// layout live in the MP3 frame header that follows, so these bits are nominal.
+const MP3_AUDIO_TAG_HEADER: u8 = (AUDIO_FORMAT_MP3 << 4) | (3 << 2) | (1 << 1) | 1;
 
 /// Enhanced-RTMP (E-RTMP) video signaling: a set high bit on a video tag's
 /// first byte switches from a legacy CodecID to a FourCC codec + packet type.

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -47,6 +47,10 @@ pub enum Error {
 	#[error("opus: {0}")]
 	Opus(#[from] crate::codec::opus::Error),
 
+	/// Error parsing MP3.
+	#[error("mp3: {0}")]
+	Mp3(#[from] crate::codec::mp3::Error),
+
 	/// Error parsing H.264.
 	#[error("h264: {0}")]
 	H264(#[from] crate::codec::h264::Error),

--- a/rs/moq-rtmp/src/lib.rs
+++ b/rs/moq-rtmp/src/lib.rs
@@ -14,11 +14,11 @@
 //!   [`moq_net::OriginConsumer`], mux it back to FLV with [`moq_mux`], and stream
 //!   the tags down as RTMP. The counterpart to `moq-cli hls export`.
 //!
-//! Both legacy RTMP (H.264 + AAC) and enhanced RTMP (E-RTMP: the HEVC, AV1, VP9,
-//! Opus, and AC-3 FourCC payloads) are supported in each direction, because the
-//! codec handling lives entirely in the [`moq_mux`] FLV demuxer/muxer; this crate
-//! only translates the RTMP transport. Legacy players that speak only H.264 + AAC
-//! will of course reject the E-RTMP codecs on the play path.
+//! Both legacy RTMP (H.264 + AAC, plus MP3) and enhanced RTMP (E-RTMP: the HEVC,
+//! AV1, VP9, Opus, AC-3, and MP3 FourCC payloads) are supported in each direction,
+//! because the codec handling lives entirely in the [`moq_mux`] FLV demuxer/muxer;
+//! this crate only translates the RTMP transport. Legacy players that speak only
+//! H.264 + AAC will of course reject the E-RTMP codecs on the play path.
 //!
 //! Two entry points, depending on how much control you need over each request:
 //!


### PR DESCRIPTION
## Summary

Adds **MP3** as a first-class, WebCodecs-decodable audio codec, wired end-to-end through **FLV/RTMP ingest + egress + browser playback**. Unlike the existing legacy `Mp2`/`Ac3`/`Ec3` codecs (TS-bridge only, not browser-decodable), MP3 decodes natively in Chrome's `AudioDecoder` (`"mp3"`), so it gets its own catalog codec rather than the `Unknown` bucket.

This is Phase 1 of broader MP3 support; fMP4, MPEG-TS, and MKV/GStreamer are follow-ups.

## Changes

- **`rs/hang` catalog** — `AudioCodec::Mp3` (displays `"mp3"`), its own `AudioCodecKind::Mp3`, and the `kind()` + `from_str` arms.
- **`rs/moq-mux` `codec::mp3`** (new) — `Config::parse` reading the MPEG-1/2/2.5 Layer III frame header (sample rate + channel count). MP3 carries its config in band, so there is no out-of-band `description`. Rejects MP2 / non-Layer-III input.
- **FLV import** — accepts both the legacy SoundFormat 2 tag and the E-RTMP `.mp3` FourCC, configuring from the first frame.
- **FLV export** — muxes MP3 back out as the legacy SoundFormat 2 tag (most player-compatible).
- **`js/watch`** — MP3 jitter default (1152/576 samples per frame). Browser playback otherwise needs no change: the decoder already handles a `None` description and MP3 decodes natively.
- **Docs (Cross-Package Sync)** — `doc/bin/rtmp.md` and `rs/moq-rtmp` now list MP3 as supported instead of "dropped".

## Public API changes

- `hang::catalog::AudioCodec::Mp3` (new variant; enum is `#[non_exhaustive]`)
- `hang::catalog::AudioCodecKind::Mp3` (new variant; enum is `#[non_exhaustive]`)
- `moq_mux::codec::mp3::{Config, Error}` (new module)
- `moq_mux::Error::Mp3` (new variant; enum is `#[non_exhaustive]`)

All additive on `#[non_exhaustive]` types — **not breaking**. The catalog codec is a wire string (`"mp3"`), already wire-compatible, so there is no wire/format change. Targets **main** per Branch Targeting.

## Test plan

- [x] `codec::mp3::Config::parse` unit tests (MPEG-1/2 stereo/mono, rejects MP2 / bad sync / short)
- [x] FLV `import_legacy_mp3` (SoundFormat 2 → `AudioCodec::Mp3`)
- [x] FLV `export_roundtrips_mp3` (import → export → re-import round-trip)
- [x] `cargo clippy` (moq-mux/hang/moq-rtmp), `cargo fmt --check`, `biome`, `tsc` (js/watch), `ruff`, `remark` all clean
- [ ] Not yet exercised against a live RTMP encoder pushing real MP3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)