### PR TITLE
feat(moq-mux,moq-gst): MP3 support for MKV and GStreamer

### DIFF
--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -225,6 +225,7 @@ The first pad of each kind is always `video_0` / `audio_0` regardless of catalog
 | Video | VP8   | `video/x-vp8`         |
 | Video | VP9   | `video/x-vp9`         |
 | Audio | AAC   | `audio/mpeg` (v4)     |
+| Audio | MP3   | `audio/mpeg` (v1/v2, layer 3) |
 | Audio | Opus  | `audio/x-opus`        |
 
 ### moqsrc (subscribe)

--- a/doc/lib/rs/crate/moq-mux.md
+++ b/doc/lib/rs/crate/moq-mux.md
@@ -52,6 +52,7 @@ See the [moq-cli source](https://github.com/moq-dev/moq/tree/main/rs/moq-cli) fo
 
 - AAC
 - Opus
+- MP3
 - MP2 (MPEG-TS only, carried verbatim)
 - AC-3 (MPEG-TS only, carried verbatim)
 - E-AC-3 (MPEG-TS only, carried verbatim)

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -232,6 +232,13 @@ impl ElementImpl for MoqSink {
 					.field("stream-format", "raw")
 					.build(),
 			);
+			// MP3 (MPEG-1/2 Layer III). The frame header carries the config in band.
+			caps.merge(
+				gst::Caps::builder("audio/mpeg")
+					.field("mpegversion", gst::List::new([1i32, 2i32]))
+					.field("layer", 3i32)
+					.build(),
+			);
 			caps.merge(gst::Caps::builder("audio/x-opus").build());
 
 			let sink =

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -92,8 +92,9 @@ impl Pad {
 
 		// MP3 is handled before the shared `make` closure borrows `broadcast`. Unlike the other
 		// codecs it has no config blob to parse (the config lives in each frame header), so it builds
-		// its importer straight from the caps rate/channels. The pad template pins layer=3.
-		if structure.name() == "audio/mpeg" && structure.get::<i32>("mpegversion").ok() != Some(4) {
+		// its importer straight from the caps rate/channels. Keyed on `layer == 3`, which positively
+		// identifies Layer III: AAC (`audio/mpeg`, no layer field) and MP2 (`layer=2`) both fall through.
+		if structure.name() == "audio/mpeg" && structure.get::<i32>("layer").ok() == Some(3) {
 			let rate: i32 = structure.get("rate").context("MP3 caps missing rate")?;
 			let channels: i32 = structure.get("channels").context("MP3 caps missing channels")?;
 			ensure!(rate > 0, "MP3 caps has non-positive sample rate {rate}");

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -90,6 +90,25 @@ impl Pad {
 		let mut broadcast = broadcast.clone();
 		let catalog = catalog.clone();
 
+		// MP3 is handled before the shared `make` closure borrows `broadcast`. Unlike the other
+		// codecs it has no config blob to parse (the config lives in each frame header), so it builds
+		// its importer straight from the caps rate/channels. The pad template pins layer=3.
+		if structure.name() == "audio/mpeg" && structure.get::<i32>("mpegversion").ok() != Some(4) {
+			let rate: i32 = structure.get("rate").context("MP3 caps missing rate")?;
+			let channels: i32 = structure.get("channels").context("MP3 caps missing channels")?;
+			ensure!(rate > 0, "MP3 caps has non-positive sample rate {rate}");
+			ensure!(channels > 0, "MP3 caps has non-positive channel count {channels}");
+			let config = moq_mux::codec::mp3::Config {
+				sample_rate: rate as u32,
+				channel_count: channels as u32,
+			};
+			let track = import::unique_track(&mut broadcast, ".mp3")?;
+			let import = moq_mux::codec::mp3::Import::new(track, catalog, config)?;
+			self.framed = Some(import.into());
+			self.caps = Some(caps.clone());
+			return Ok(());
+		}
+
 		// Mint a track for a single codec and hand it to the importer. Every codec converges on one
 		// `import::Track`; only the caps -> (format, init) construction differs. The pad template fixes
 		// the structural fields (h264/h265 byte-stream/au, AAC mpegversion=4/stream-format=raw), so

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -685,6 +685,12 @@ fn audio_caps(config: &hang::catalog::AudioConfig) -> Result<gst::Caps> {
 			}
 			builder.build()
 		}
+		hang::catalog::AudioCodec::Mp3 => gst::Caps::builder("audio/mpeg")
+			.field("mpegversion", 1)
+			.field("layer", 3)
+			.field("rate", config.sample_rate)
+			.field("channels", config.channel_count)
+			.build(),
 		other => bail!("unsupported audio codec: {other:?}"),
 	};
 	Ok(caps)

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -2,7 +2,11 @@
 //!
 //! Audio carried verbatim: each frame is published whole. The header is parsed
 //! only for the catalog config (sample rate, channels); the audio is never
-//! decoded and there is no out-of-band configuration record.
+//! decoded and there is no out-of-band configuration record. [`Import`] publishes
+//! raw MP3 frames to a moq broadcast.
+
+use crate::catalog::hang::CatalogExt;
+use crate::container::{Frame, Timestamp};
 
 /// MP3 parsing errors.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -83,6 +87,73 @@ impl Config {
 			sample_rate,
 			channel_count,
 		})
+	}
+}
+
+/// MP3 importer.
+///
+/// Publishes raw MP3 frames to a single moq track. Build it with [`new`](Self::new),
+/// passing the track producer and the [`catalog::Producer`](crate::catalog::Producer)
+/// it publishes its rendition into.
+///
+/// Each frame handed to [`decode`](Self::decode) is published in its own group so the
+/// relay can forward it immediately. MP3 carries its config in band, so the rendition
+/// has no out-of-band description.
+pub struct Import<E: CatalogExt = ()> {
+	track: crate::container::Producer<crate::catalog::hang::Container>,
+	rendition: crate::catalog::AudioTrack<E>,
+}
+
+impl<E: CatalogExt> Import<E> {
+	/// Publish on an existing track producer, registering the rendition in `catalog`.
+	pub fn new(
+		track: moq_net::TrackProducer,
+		catalog: crate::catalog::Producer<E>,
+		config: Config,
+	) -> crate::Result<Self> {
+		let mut audio =
+			hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Mp3, config.sample_rate, config.channel_count);
+		audio.container = hang::catalog::Container::Legacy;
+
+		tracing::debug!(name = ?track.name(), config = ?audio, "starting track");
+
+		let mut rendition = catalog.audio_track(track.name());
+		rendition.set(audio);
+
+		Ok(Self {
+			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
+			rendition,
+		})
+	}
+
+	/// A watch-only handle to this track's subscriber demand.
+	pub fn demand(&self) -> moq_net::TrackDemand {
+		self.track.track().demand()
+	}
+
+	/// Finish the track, flushing the current group.
+	pub fn finish(&mut self) -> crate::Result<()> {
+		self.track.finish()?;
+		Ok(())
+	}
+
+	/// Close the current group and open the next one at `sequence`.
+	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
+		self.track.seek(sequence)?;
+		Ok(())
+	}
+
+	/// Publish one MP3 frame as its own group, stamping `pts` or a wall clock when absent.
+	pub fn decode(&mut self, frame: &[u8], pts: Option<Timestamp>) -> crate::Result<()> {
+		let timestamp = self.rendition.timestamp(pts)?;
+		self.track.write(Frame {
+			timestamp,
+			payload: bytes::Bytes::copy_from_slice(frame),
+			keyframe: true,
+			duration: None,
+		})?;
+		self.track.finish_group()?;
+		Ok(())
 	}
 }
 

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -596,20 +596,24 @@ fn build_audio_track_entry(track_number: u64, config: &AudioConfig) -> Result<Ma
 					.to_vec(),
 			),
 		),
+		// MP3 carries its config in band, so there's no codec private.
+		AudioCodec::Mp3 => ("A_MPEG/L3", None),
 		other => return Err(Error::UnsupportedAudioExport(format!("{:?}", other)).into()),
 	};
 
-	let entry = vec![
+	let mut entry = vec![
 		MatroskaSpec::TrackNumber(track_number),
 		MatroskaSpec::TrackUID(track_number),
 		MatroskaSpec::TrackType(2),
 		MatroskaSpec::CodecID(codec_id.to_string()),
-		MatroskaSpec::CodecPrivate(codec_private.unwrap()),
-		MatroskaSpec::Audio(Master::Full(vec![
-			MatroskaSpec::SamplingFrequency(config.sample_rate as f64),
-			MatroskaSpec::Channels(config.channel_count as u64),
-		])),
 	];
+	if let Some(cp) = codec_private {
+		entry.push(MatroskaSpec::CodecPrivate(cp));
+	}
+	entry.push(MatroskaSpec::Audio(Master::Full(vec![
+		MatroskaSpec::SamplingFrequency(config.sample_rate as f64),
+		MatroskaSpec::Channels(config.channel_count as u64),
+	])));
 
 	Ok(MatroskaSpec::TrackEntry(Master::Full(entry)))
 }

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -138,6 +138,87 @@ async fn export_header_roundtrip_vp9_opus() {
 	assert_eq!(a.sample_rate, 48000);
 }
 
+/// MP3 (config in band, no codec private) survives an import -> export -> re-import
+/// round trip as the `A_MPEG/L3` track entry.
+#[tokio::test(start_paused = true)]
+async fn export_header_roundtrip_mp3() {
+	let import_bytes = synth_matroska_mp3();
+
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = crate::container::mkv::Import::new(producer, catalog.clone());
+	importer
+		.decode(&bytes::BytesMut::from(import_bytes.as_slice()))
+		.unwrap();
+	importer.finish().unwrap();
+
+	let catalog_stream =
+		crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang).expect("catalog consumer");
+	let mut exporter = crate::container::mkv::Export::new(consumer, catalog_stream);
+
+	let header = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
+		.await
+		.expect("exporter timed out")
+		.expect("exporter result")
+		.expect("expected header bytes");
+
+	// Re-import the exported header and confirm the codec rebuilds.
+	let mut broadcast2 = moq_net::Broadcast::new().produce();
+	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
+	let mut importer2 = crate::container::mkv::Import::new(broadcast2, catalog2.clone());
+	importer2.decode(&bytes::BytesMut::from(header.as_ref())).unwrap();
+
+	let snap = catalog2.snapshot();
+	assert_eq!(snap.audio.renditions.len(), 1);
+	let a = snap.audio.renditions.values().next().unwrap();
+	assert!(matches!(a.codec, AudioCodec::Mp3));
+	assert_eq!(a.sample_rate, 44100);
+	assert_eq!(a.channel_count, 2);
+}
+
+/// Build a small Matroska with a single MP3 audio track (no codec private).
+fn synth_matroska_mp3() -> Vec<u8> {
+	use webm_iterable::WebmWriter;
+
+	let tags: Vec<MatroskaSpec> = vec![
+		MatroskaSpec::Ebml(Master::Full(vec![
+			MatroskaSpec::DocType("matroska".to_string()),
+			MatroskaSpec::DocTypeVersion(2),
+			MatroskaSpec::DocTypeReadVersion(2),
+		])),
+		MatroskaSpec::Segment(Master::Start),
+		MatroskaSpec::Info(Master::Full(vec![MatroskaSpec::TimestampScale(1_000_000)])),
+		MatroskaSpec::Tracks(Master::Full(vec![MatroskaSpec::TrackEntry(Master::Full(vec![
+			MatroskaSpec::TrackNumber(1),
+			MatroskaSpec::TrackUID(1),
+			MatroskaSpec::TrackType(2),
+			MatroskaSpec::CodecID("A_MPEG/L3".to_string()),
+			MatroskaSpec::Audio(Master::Full(vec![
+				MatroskaSpec::SamplingFrequency(44100.0),
+				MatroskaSpec::Channels(2),
+			])),
+		]))])),
+		MatroskaSpec::Cluster(Master::Start),
+		MatroskaSpec::Timestamp(0),
+		SimpleBlock::new_uncheked(b"mp3-frame", 1, 0, false, None, false, true).into(),
+		MatroskaSpec::Cluster(Master::End),
+		MatroskaSpec::Segment(Master::End),
+	];
+
+	let mut dest = Cursor::new(Vec::new());
+	{
+		let mut writer = WebmWriter::new(&mut dest);
+		for tag in &tags {
+			writer.write(tag).unwrap();
+		}
+		writer.flush().unwrap();
+	}
+	dest.into_inner()
+}
+
 /// A mid-stream subscriber may poll the exporter before the catalog track has
 /// arrived. With `tracks` empty, `header_ready()` must not be vacuously true and
 /// drive `build_header` into a "no catalog snapshot" error; it should stay

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -34,8 +34,9 @@ const DEFAULT_TIMESTAMP_SCALE_NS: u64 = 1_000_000;
 /// **Audio:**
 /// - AAC (`A_AAC`)
 /// - Opus (`A_OPUS`)
+/// - MP3 (`A_MPEG/L3`)
 ///
-/// Unsupported codecs (e.g. Vorbis, AC3, MP3, subtitles) are logged and dropped.
+/// Unsupported codecs (e.g. Vorbis, AC3, subtitles) are logged and dropped.
 pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	broadcast: moq_net::BroadcastProducer,
 	catalog: crate::catalog::Producer<E>,
@@ -529,6 +530,13 @@ fn build_audio_config(
 				},
 			);
 			config.description = Some(priv_data.clone());
+			config.container = Container::Legacy;
+			Ok(config)
+		}
+		"A_MPEG/L3" => {
+			// MP3 carries its config in band, so there's no codec private; the track
+			// header's SamplingFrequency/Channels are the only config source.
+			let mut config = AudioConfig::new(AudioCodec::Mp3, sample_rate, channels);
 			config.container = Container::Legacy;
 			Ok(config)
 		}

--- a/rs/moq-mux/src/container/mkv/import_test.rs
+++ b/rs/moq-mux/src/container/mkv/import_test.rs
@@ -121,6 +121,20 @@ fn track_entry_audio_opus(number: u64, sample_rate: f64, channels: u64) -> Matro
 	]))
 }
 
+fn track_entry_audio_mp3(number: u64, sample_rate: f64, channels: u64) -> MatroskaSpec {
+	// MP3 has no codec private; config comes from the track header.
+	MatroskaSpec::TrackEntry(Master::Full(vec![
+		MatroskaSpec::TrackNumber(number),
+		MatroskaSpec::TrackUID(number),
+		MatroskaSpec::TrackType(2),
+		MatroskaSpec::CodecID("A_MPEG/L3".to_string()),
+		MatroskaSpec::Audio(Master::Full(vec![
+			MatroskaSpec::SamplingFrequency(sample_rate),
+			MatroskaSpec::Channels(channels),
+		])),
+	]))
+}
+
 fn track_entry_video_vp9(number: u64, width: u64, height: u64) -> MatroskaSpec {
 	MatroskaSpec::TrackEntry(Master::Full(vec![
 		MatroskaSpec::TrackNumber(number),
@@ -198,6 +212,26 @@ fn test_vp9_opus_catalog() {
 	assert!(matches!(a.codec, AudioCodec::Opus));
 	assert_eq!(a.sample_rate, 48000);
 	assert_eq!(a.channel_count, 2);
+}
+
+#[test]
+fn test_mp3_catalog() {
+	let data = MkvBuilder::new()
+		.header("matroska")
+		.segment_start()
+		.info(1_000_000)
+		.tracks(vec![track_entry_audio_mp3(1, 44100.0, 2)])
+		.cluster(0, || vec![simple_block(1, 0, true, b"mp3-frame")])
+		.segment_end()
+		.build();
+
+	let catalog = run(&data);
+	assert_eq!(catalog.audio.renditions.len(), 1);
+	let a = catalog.audio.renditions.values().next().unwrap();
+	assert!(matches!(a.codec, AudioCodec::Mp3));
+	assert_eq!(a.sample_rate, 44100);
+	assert_eq!(a.channel_count, 2);
+	assert!(a.description.is_none(), "MP3 config is in band");
 }
 
 #[test]

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -200,6 +200,7 @@ impl_importer_direct!(crate::codec::vp8::Import<E>);
 impl_importer_direct!(crate::codec::vp9::Import<E>);
 impl_importer_direct!(crate::codec::aac::Import<E>);
 impl_importer_direct!(crate::codec::opus::Import<E>);
+impl_importer_direct!(crate::codec::mp3::Import<E>);
 
 /// An av1C config record (ISO/IEC 14496-15) starts with a 0x81 marker and is at
 /// least 16 bytes; raw OBUs never look like this.
@@ -385,6 +386,18 @@ impl<E: CatalogExt> From<crate::codec::aac::Import<E>> for Track<E> {
 	fn from(aac: crate::codec::aac::Import<E>) -> Self {
 		Self {
 			inner: Box::new(aac),
+			_ext: PhantomData,
+		}
+	}
+}
+
+// Lift an already-built mp3 importer into a `Track` so callers that build their
+// config out-of-band (e.g. moq-gst, which reads rate/channels from gstreamer caps
+// rather than parsing a frame header) can keep using `.into()`.
+impl<E: CatalogExt> From<crate::codec::mp3::Import<E>> for Track<E> {
+	fn from(mp3: crate::codec::mp3::Import<E>) -> Self {
+		Self {
+			inner: Box::new(mp3),
 			_ext: PhantomData,
 		}
 	}


### PR DESCRIPTION
## Summary

Phase 2 of MP3 support: extends the FLV/RTMP work in #1967 (now merged to `main`) to the **Matroska/WebM** container and the **GStreamer** plugin. Targets `main`.

## Changes

- **MKV import** ([`mkv/import.rs`](rs/moq-mux/src/container/mkv/import.rs)) — `A_MPEG/L3` → `AudioCodec::Mp3`, config from the track header (MP3 has no codec private).
- **MKV export** ([`mkv/export.rs`](rs/moq-mux/src/container/mkv/export.rs)) — `AudioCodec::Mp3` → `A_MPEG/L3`; `CodecPrivate` is now emitted conditionally (MP3 has none), matching the video branch.
- **`mp3::Import`** ([`codec/mp3.rs`](rs/moq-mux/src/codec/mp3.rs)) — publishes raw MP3 frames one-per-group (mirrors `opus::Import`), plus the `impl_importer_direct!` + `From<mp3::Import> for Track` wiring in [`import/track.rs`](rs/moq-mux/src/import/track.rs).
- **GStreamer `moqsrc`** ([`source/imp.rs`](rs/moq-gst/src/source/imp.rs)) — `AudioCodec::Mp3` → `audio/mpeg, mpegversion=1/2, layer=3`.
- **GStreamer `moqsink`** ([`sink/pad.rs`](rs/moq-gst/src/sink/pad.rs), [`sink/imp.rs`](rs/moq-gst/src/sink/imp.rs)) — pad template admits `audio/mpeg, layer=3`; the handler builds `mp3::Import` from the caps rate/channels, keyed on `layer == 3` (positively identifies Layer III; AAC and MP2 fall through).
- **Docs** — `gstreamer.md` codec table + `moq-mux` crate doc list MP3.

## Public API changes

- `moq_mux::codec::mp3::Import` (new) + `From<mp3::Import<E>> for moq_mux::import::Track<E>` (new impl)

Additive only. No wire/format change. Targets `main`.

## Test plan

- [x] MKV `test_mp3_catalog` (import `A_MPEG/L3` → `AudioCodec::Mp3`)
- [x] MKV `export_header_roundtrip_mp3` (import → export → re-import)
- [x] Full `moq-mux` suite green (322 tests)
- [x] `cargo clippy` (moq-mux + moq-gst) + `cargo fmt --check` clean; moq-gst compiles against system GStreamer
- [x] Multi-agent review pass: keyed MP3 caps detection on `layer == 3` (was `mpegversion != 4`)
- [ ] Not yet exercised end-to-end through a real GStreamer pipeline pushing/pulling MP3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)