### PR TITLE
feat(moq-ffi): expose TLS system root trust control

### DIFF
--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -54,6 +54,21 @@ mod tests {
 			MoqError::Forbidden
 		));
 	}
+
+	#[test]
+	fn sets_tls_system_roots() {
+		let client = MoqClient::new();
+
+		client.set_tls_system_roots(true);
+		{
+			let state = client.task.lock().expect("client state should be available");
+			assert_eq!(state.config.tls.system_roots, Some(true));
+		}
+
+		client.set_tls_system_roots(false);
+		let state = client.task.lock().expect("client state should be available");
+		assert_eq!(state.config.tls.system_roots, Some(false));
+	}
 }
 
 #[derive(uniffi::Object)]
@@ -90,6 +105,17 @@ impl MoqClient {
 	pub fn set_tls_roots(&self, paths: Vec<String>) {
 		if let Some(mut state) = self.task.lock() {
 			state.config.tls.root = paths.into_iter().map(Into::into).collect();
+		}
+	}
+
+	/// Configure whether to also trust the platform's native root certificates.
+	///
+	/// By default, system roots are trusted only when no custom roots are configured.
+	/// Set this to `true` to trust system roots in addition to roots from
+	/// `set_tls_roots`, or `false` to trust only custom roots.
+	pub fn set_tls_system_roots(&self, system_roots: bool) {
+		if let Some(mut state) = self.task.lock() {
+			state.config.tls.system_roots = Some(system_roots);
 		}
 	}
 


### PR DESCRIPTION
Allow native callers to choose whether platform roots are trusted alongside custom TLS roots, or disabled when only pinned custom roots should apply.