### PR TITLE
[codex] default watch reload to enabled

### DIFF
--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -106,7 +106,6 @@ function createTile(name: string): WatchTile {
 	// `broadcast`/`backend`, so the shared inspector panel reflects the active tile.
 	const watch = document.createElement("moq-watch") as MoqWatch;
 	watch.name = name;
-	watch.reload = true; // wait for (re)announcement; survives publisher restarts
 	watch.muted = true; // unmuted only while active (see below)
 	// Default to a fixed 100ms jitter buffer (instead of adaptive "real-time") so
 	// the latency visualization has something to show. Drag it in the panel.

--- a/doc/lib/js/@moq/watch.md
+++ b/doc/lib/js/@moq/watch.md
@@ -70,6 +70,7 @@ a real bundler (the examples below).
 - `paused`: Pause playback (boolean)
 - `muted`: Mute audio (boolean)
 - `volume`: Audio volume (0 to 1, default: 1)
+- `reload`: Wait for (re)announcement before subscribing (default: true). Defaults off for `mediaoverquic.com` relays until they support broadcast discovery.
 - `latency`: Latency target. `"real-time"` (default) derives it from RTT, or a number sets a fixed jitter buffer in ms. Collapses `latency-min` and `latency-max` to one value (minimize latency).
 - `latency-min`: Latency floor (the jitter/startup buffer). Same units as `latency`; leaves the ceiling untouched.
 - `latency-max`: Latency ceiling. `"real-time"` (default) minimizes latency; a number caps at that many ms. A ceiling above the floor enables [buffered playback](#buffered-playback): build up a buffer from future-dated frames instead of skipping ahead.
@@ -273,8 +274,10 @@ const broadcast = new Watch.Broadcast({
     connection,
     enabled: true,
     name: "alice.hang",
-    reload: true,
 });
+
+// Disable the announcement gate for relays without broadcast discovery.
+broadcast.reload.set(false);
 ```
 
 ## Related Packages

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -72,6 +72,7 @@ The simplest way to watch a stream:
 | `muted`   | boolean                             | false    | Mute audio                               |
 | `visible` | never, distance, or always          | `0px`    | When to download video (see below)       |
 | `volume`  | number                              | 0.5      | Audio volume (0-1)                       |
+| `reload`  | boolean                             | true     | Wait for (re)announcement before subscribing. Defaults off for `mediaoverquic.com` relays until they support broadcast discovery. |
 
 The `visible` attribute controls when the video track is downloaded, based on the canvas
 position relative to the viewport:

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -24,7 +24,8 @@ export function parseCatalogFormat(value: string | null): CatalogFormat | undefi
 export interface BroadcastProps {
 	connection?: Moq.Connection.Established | Signal<Moq.Connection.Established | undefined>;
 
-	// All actively announced broadcast paths from the connection.
+	// All actively announced broadcast paths from the connection. If omitted, reload skips the
+	// announcement gate and subscribes immediately.
 	announced?: Getter<Set<Moq.Path.Valid>>;
 
 	// Whether to start downloading the broadcast.
@@ -35,7 +36,7 @@ export interface BroadcastProps {
 	name?: Moq.Path.Valid | Signal<Moq.Path.Valid>;
 
 	// Whether to reload the broadcast when it goes offline.
-	// Defaults to false; pass true to wait for an announcement before subscribing.
+	// Defaults to true; pass false to subscribe immediately without waiting for an announcement.
 	reload?: boolean | Signal<boolean>;
 
 	// Which catalog format to use. When `undefined` (the default), the format is
@@ -73,7 +74,7 @@ export class Broadcast {
 	catalog: Signal<Catalog.Root | undefined>;
 
 	// All actively announced broadcast paths from the connection.
-	#announced: Getter<Set<Moq.Path.Valid>>;
+	#announced?: Getter<Set<Moq.Path.Valid>>;
 
 	// Whether `name` is currently in the announced set (or skipping the check).
 	// Derived in its own effect so that flaps for unrelated broadcasts don't
@@ -86,11 +87,11 @@ export class Broadcast {
 		this.connection = Signal.from(props?.connection);
 		this.name = Signal.from(props?.name ?? Path.empty());
 		this.enabled = Signal.from(props?.enabled ?? false);
-		this.reload = Signal.from(props?.reload ?? false);
+		this.reload = Signal.from(props?.reload ?? true);
 		this.catalogFormat = Signal.from<CatalogFormat | undefined>(props?.catalogFormat);
 		this.catalog = Signal.from(props?.catalog);
 
-		this.#announced = props?.announced ?? new Signal(new Set());
+		this.#announced = props?.announced;
 
 		this.signals.run(this.#runAnnouncedNow.bind(this));
 		this.signals.run(this.#runBroadcast.bind(this));
@@ -104,12 +105,15 @@ export class Broadcast {
 			return;
 		}
 
+		if (!this.#announced) {
+			this.#announcedNow.set(true);
+			return;
+		}
+
 		// Cloudflare's relay does not yet support announcement subscriptions,
-		// so an announcement will never arrive. Fall back to subscribing
-		// immediately (reload=false behaviour) instead of waiting forever.
+		// so default to subscribing immediately instead of waiting forever.
 		const conn = effect.get(this.connection);
 		if (conn?.url.hostname.endsWith("mediaoverquic.com")) {
-			console.warn("Cloudflare relay does not support broadcast discovery yet; ignoring reload signal.");
 			this.#announcedNow.set(true);
 			return;
 		}

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -36,6 +36,12 @@ function parseVisible(value: string | null): Visible {
 	return "0px";
 }
 
+function parseBoolean(value: string | null, defaultValue: boolean): boolean {
+	if (value === null) return defaultValue;
+	const normalized = value.trim().toLowerCase();
+	return normalized !== "false" && normalized !== "0";
+}
+
 // Close everything when this element is garbage collected.
 // This is primarily to avoid a console.warn that we didn't close() before GC.
 // There's no destructor for web components so this is the best we can do.
@@ -223,7 +229,7 @@ export default class MoqWatch extends HTMLElement {
 		} else if (name === "visible") {
 			this.backend.visible.set(parseVisible(newValue));
 		} else if (name === "reload") {
-			this.broadcast.reload.set(newValue !== null);
+			this.broadcast.reload.set(parseBoolean(newValue, true));
 		} else if (name === "latency") {
 			// Sugar: collapse the floor and ceiling to a single value.
 			this.latency = this.#parseBound(newValue);


### PR DESCRIPTION
## Summary

- Default `@moq/watch` broadcasts to wait for announcements before subscribing.
- Let `<moq-watch reload="false">` opt out explicitly, while `mediaoverquic.com` relays still default to immediate subscribe until they support broadcast discovery.
- Update the watch docs and demo now that `reload=true` is implicit.

## Validation

- `just js check`
- `bun remark js/watch/README.md doc/lib/js/@moq/watch.md --quiet --frail`
- `just check` reached JS and Rust checks successfully, then failed on the existing repo-wide `justfile` formatting check.

(Written by GPT-5)
